### PR TITLE
[Workspace][Page header] Integrate new page header for workspace pages

### DIFF
--- a/changelogs/fragments/7697.yml
+++ b/changelogs/fragments/7697.yml
@@ -1,0 +1,2 @@
+feat:
+- Integrate new page header for workspace pages ([#7697](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7697))

--- a/src/plugins/management/opensearch_dashboards.json
+++ b/src/plugins/management/opensearch_dashboards.json
@@ -4,5 +4,6 @@
   "server": true,
   "ui": true,
   "optionalPlugins": ["home", "managementOverview"],
-  "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils"]
+  "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils"],
+  "requiredPlugins": ["navigation"]
 }

--- a/src/plugins/management/public/components/feature_cards/__snapshots__/feature_cards.test.tsx.snap
+++ b/src/plugins/management/public/components/feature_cards/__snapshots__/feature_cards.test.tsx.snap
@@ -3,22 +3,6 @@
 exports[`<FeatureCards /> render with complex navLinks 1`] = `
 <div>
   <div
-    class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusNone euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--borderRadiusNone"
-    role="main"
-  >
-    <header
-      class="euiPageHeader euiPageHeader--responsive euiPageHeader--center"
-    >
-      <div
-        class="euiPageHeaderSection"
-      >
-        <h1
-          class="euiTitle euiTitle--large"
-        />
-      </div>
-    </header>
-  </div>
-  <div
     class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent"
     role="main"
   >

--- a/src/plugins/management/public/components/feature_cards/feature_cards.test.tsx
+++ b/src/plugins/management/public/components/feature_cards/feature_cards.test.tsx
@@ -7,12 +7,18 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { FeatureCards } from './feature_cards';
 import { AppCategory, ChromeNavLink } from 'opensearch-dashboards/public';
+import { navigationPluginMock } from '../../../../navigation/public/mocks';
+import { coreMock } from '../../../../../../src/core/public/mocks';
 
 const mockCategory: AppCategory = {
   id: 'dashboard',
   label: 'Dashboard',
   order: 2,
 };
+
+const mockSetAppDescriptionControls = coreMock.createStart().application.setAppDescriptionControls;
+const mockNavigationUI = navigationPluginMock.createStartContract().ui;
+mockNavigationUI.HeaderControl = () => null;
 
 const navLinks: ChromeNavLink[] = [
   {
@@ -85,7 +91,13 @@ const navLinks: ChromeNavLink[] = [
 describe('<FeatureCards />', () => {
   it('render with empty navLinks', () => {
     const { container } = render(
-      <FeatureCards getStartedCards={[]} pageTitle="" navLinks={[]} navigateToApp={jest.fn()} />
+      <FeatureCards
+        pageDescription=""
+        navLinks={[]}
+        navigateToApp={jest.fn()}
+        setAppDescriptionControls={mockSetAppDescriptionControls}
+        navigationUI={mockNavigationUI}
+      />
     );
     expect(container).toMatchSnapshot();
   });
@@ -93,10 +105,11 @@ describe('<FeatureCards />', () => {
   it('render with complex navLinks', () => {
     const { container, getAllByTestId } = render(
       <FeatureCards
-        getStartedCards={[]}
-        pageTitle=""
+        pageDescription=""
         navLinks={navLinks}
         navigateToApp={jest.fn()}
+        setAppDescriptionControls={mockSetAppDescriptionControls}
+        navigationUI={mockNavigationUI}
       />
     );
     expect(container).toMatchSnapshot();
@@ -107,10 +120,11 @@ describe('<FeatureCards />', () => {
     const mockedNavigateToApp = jest.fn();
     const { getByTestId } = render(
       <FeatureCards
-        getStartedCards={[]}
-        pageTitle=""
+        pageDescription=""
         navLinks={navLinks}
         navigateToApp={mockedNavigateToApp}
+        setAppDescriptionControls={mockSetAppDescriptionControls}
+        navigationUI={mockNavigationUI}
       />
     );
     fireEvent.click(getByTestId('landingPageFeature_1'));

--- a/src/plugins/management/public/components/feature_cards/feature_cards.tsx
+++ b/src/plugins/management/public/components/feature_cards/feature_cards.tsx
@@ -3,42 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { i18n } from '@osd/i18n';
 import {
   EuiCard,
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPageContent,
-  EuiPageHeader,
-  EuiPageHeaderSection,
-  EuiPanel,
   EuiSpacer,
   EuiTitle,
 } from '@elastic/eui';
 import { AppCategory, ChromeNavLink, CoreStart } from 'opensearch-dashboards/public';
 import React, { useMemo } from 'react';
+import { NavigationPublicPluginStart } from '../../../../../../src/plugins/navigation/public';
 
 export interface FeatureCardsProps {
-  pageTitle: string;
+  pageDescription: string;
   navLinks: ChromeNavLink[];
   navigateToApp: CoreStart['application']['navigateToApp'];
-  getStartedCards: Array<{
-    id: string;
-    title: string;
-    description: string;
-  }>;
+  setAppDescriptionControls: CoreStart['application']['setAppDescriptionControls'];
+  navigationUI: NavigationPublicPluginStart['ui'];
 }
-
-const getStartedTitle = i18n.translate('management.gettingStarted.label', {
-  defaultMessage: 'Get started',
-});
 
 export const FeatureCards = ({
   navLinks,
   navigateToApp,
-  pageTitle,
-  getStartedCards,
+  setAppDescriptionControls,
+  pageDescription,
+  navigationUI: { HeaderControl },
 }: FeatureCardsProps) => {
   const itemsPerRow = 4;
   const groupedCardForDisplay = useMemo(() => {
@@ -65,41 +55,14 @@ export const FeatureCards = ({
   }
   return (
     <>
-      <EuiPageContent borderRadius="none">
-        <EuiPageHeader>
-          <EuiPageHeaderSection>
-            <EuiTitle size="l">
-              <h1>{pageTitle}</h1>
-            </EuiTitle>
-          </EuiPageHeaderSection>
-        </EuiPageHeader>
-        {getStartedCards.length ? (
-          <>
-            <EuiSpacer size="s" />
-            <EuiTitle>
-              <h3>{getStartedTitle}</h3>
-            </EuiTitle>
-            <EuiFlexGrid columns={4}>
-              {getStartedCards.map((card) => {
-                return (
-                  <EuiFlexItem>
-                    <EuiPanel>
-                      <EuiCard
-                        title={card.title}
-                        description={card.description}
-                        data-test-subj={`getStartedCard_${card.id}`}
-                        textAlign="left"
-                        onClick={() => navigateToApp(card.id)}
-                        titleSize="xs"
-                      />
-                    </EuiPanel>
-                  </EuiFlexItem>
-                );
-              })}
-            </EuiFlexGrid>
-          </>
-        ) : null}
-      </EuiPageContent>
+      <HeaderControl
+        controls={[
+          {
+            description: pageDescription,
+          },
+        ]}
+        setMountPoint={setAppDescriptionControls}
+      />
       <EuiPageContent hasShadow={false} hasBorder={false} color="transparent">
         {groupedCardForDisplay.map((group) => (
           <div key={group.category?.id}>

--- a/src/plugins/management/public/landing_page_application.test.tsx
+++ b/src/plugins/management/public/landing_page_application.test.tsx
@@ -4,6 +4,8 @@
  */
 
 import { renderApp } from './landing_page_application';
+import { navigationPluginMock } from '../../navigation/public/mocks';
+import { coreMock } from '../../../../src/core/public/mocks';
 
 describe('Landing page application', () => {
   it('renders and unmount without crashing', () => {
@@ -13,6 +15,9 @@ describe('Landing page application', () => {
         props: {
           navigateToApp: jest.fn(),
           navLinks: [],
+          navigationUI: navigationPluginMock.createStartContract().ui,
+          setAppDescriptionControls: coreMock.createStart().application.setAppDescriptionControls,
+          pageDescription: '',
         },
       });
 

--- a/src/plugins/management/public/plugin.ts
+++ b/src/plugins/management/public/plugin.ts
@@ -46,7 +46,6 @@ import {
   AppNavLinkStatus,
   DEFAULT_NAV_GROUPS,
   WorkspaceAvailability,
-  ChromeNavLink,
 } from '../../../core/public';
 
 import { MANAGEMENT_APP_ID } from '../common/contants';
@@ -62,13 +61,17 @@ import {
   LinkItemType,
   getSortedNavLinks,
 } from '../../../core/public';
+import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
 interface ManagementSetupDependencies {
   home?: HomePublicPluginSetup;
   managementOverview?: ManagementOverViewPluginSetup;
 }
-
-export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart> {
+interface ManagementStartDependencies {
+  navigation: NavigationPublicPluginStart;
+}
+export class ManagementPlugin
+  implements Plugin<ManagementSetup, ManagementStart, {}, ManagementStartDependencies> {
   private readonly managementSections = new ManagementSectionsService();
 
   private readonly appUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
@@ -81,7 +84,10 @@ export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart
     defaultMessage: 'Dashboards Management',
   });
 
-  public setup(core: CoreSetup, { home, managementOverview }: ManagementSetupDependencies) {
+  public setup(
+    core: CoreSetup<ManagementStartDependencies>,
+    { home, managementOverview }: ManagementSetupDependencies
+  ) {
     const opensearchDashboardsVersion = this.initializerContext.env.packageInfo.version;
 
     core.application.register({
@@ -111,15 +117,30 @@ export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart
     const settingsLandingPageId = 'settings_landing';
 
     const settingsLandingPageTitle = i18n.translate('management.settings.landingPage.title', {
-      defaultMessage: 'Settings and setup',
+      defaultMessage: 'Settings and setup overview',
     });
+
+    const settingsLandingPageDescription = i18n.translate(
+      'management.settings.landingPage.description',
+      {
+        defaultMessage:
+          'Customize the appearance of the application, change feature behavior, and more.',
+      }
+    );
 
     const dataAdministrationLandingPageId = 'data_administration_landing';
 
     const dataAdministrationPageTitle = i18n.translate(
       'management.dataAdministration.landingPage.title',
       {
-        defaultMessage: 'Data administration',
+        defaultMessage: 'Data administration overview',
+      }
+    );
+
+    const dataAdministrationPageDescription = i18n.translate(
+      'management.dataAdministration.landingPage.description',
+      {
+        defaultMessage: 'Configure automation and access control policies to manage your data.',
       }
     );
 
@@ -186,18 +207,24 @@ export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
       mount: async (params: AppMountParameters) => {
         const { renderApp } = await import('./landing_page_application');
-        const [coreStart] = await core.getStartServices();
+        const [coreStart, { navigation }] = await core.getStartServices();
         const navLinks = (
           await getNavLinksByNavGroupId(DEFAULT_NAV_GROUPS.settingsAndSetup.id)
         ).filter((navLink) => navLink.id !== settingsLandingPageId);
 
+        coreStart.chrome.setBreadcrumbs([
+          {
+            text: settingsLandingPageTitle,
+          },
+        ]);
         return renderApp({
           mountElement: params.element,
           props: {
             navigateToApp: coreStart.application.navigateToApp,
+            setAppDescriptionControls: coreStart.application.setAppDescriptionControls,
             navLinks,
-            pageTitle: settingsLandingPageTitle,
-            getStartedCards: [],
+            pageDescription: settingsLandingPageDescription,
+            navigationUI: navigation.ui,
           },
         });
       },
@@ -213,18 +240,25 @@ export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
       mount: async (params: AppMountParameters) => {
         const { renderApp } = await import('./landing_page_application');
-        const [coreStart] = await core.getStartServices();
+        const [coreStart, { navigation }] = await core.getStartServices();
         const navLinks = (
           await getNavLinksByNavGroupId(DEFAULT_NAV_GROUPS.dataAdministration.id)
         ).filter((navLink) => navLink.id !== dataAdministrationLandingPageId);
+
+        coreStart.chrome.setBreadcrumbs([
+          {
+            text: dataAdministrationPageTitle,
+          },
+        ]);
 
         return renderApp({
           mountElement: params.element,
           props: {
             navigateToApp: coreStart.application.navigateToApp,
             navLinks,
-            pageTitle: dataAdministrationPageTitle,
-            getStartedCards: [],
+            pageDescription: dataAdministrationPageDescription,
+            navigationUI: navigation.ui,
+            setAppDescriptionControls: coreStart.application.setAppDescriptionControls,
           },
         });
       },

--- a/src/plugins/workspace/opensearch_dashboards.json
+++ b/src/plugins/workspace/opensearch_dashboards.json
@@ -5,7 +5,8 @@
   "ui": true,
   "requiredPlugins": [
     "savedObjects",
-    "opensearchDashboardsReact"
+    "opensearchDashboardsReact",
+    "navigation"
   ],
   "optionalPlugins": ["savedObjectsManagement","management","dataSourceManagement","contentManagement"],
   "requiredBundles": ["opensearchDashboardsReact", "home","dataSource"]

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -91,6 +91,9 @@ const WorkspaceCreator = ({
         },
       },
       dataSourceManagement: {},
+      navigationUI: {
+        HeaderControl: () => null,
+      },
     },
   });
   const registeredUseCases$ = new BehaviorSubject([

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -4,13 +4,7 @@
  */
 
 import React, { useCallback } from 'react';
-import {
-  EuiPage,
-  EuiPageBody,
-  EuiPageHeader,
-  EuiPageContent,
-  euiPaletteColorBlind,
-} from '@elastic/eui';
+import { EuiPage, EuiPageBody, EuiPageContent, euiPaletteColorBlind } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { useObservable } from 'react-use';
 import { BehaviorSubject } from 'rxjs';
@@ -25,6 +19,7 @@ import { DataSource } from '../../../common/types';
 import { DataSourceManagementPluginSetup } from '../../../../../plugins/data_source_management/public';
 import { WorkspaceUseCase } from '../../types';
 import { WorkspaceFormData } from '../workspace_form/types';
+import { NavigationPublicPluginStart } from '../../../../../plugins/navigation/public';
 
 export interface WorkspaceCreatorProps {
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
@@ -39,10 +34,12 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
       workspaceClient,
       savedObjects,
       dataSourceManagement,
+      navigationUI: { HeaderControl },
     },
   } = useOpenSearchDashboards<{
     workspaceClient: WorkspaceClient;
     dataSourceManagement?: DataSourceManagementPluginSetup;
+    navigationUI: NavigationPublicPluginStart['ui'];
   }>();
 
   const defaultWorkspaceFormValues: Partial<WorkspaceFormData> = {
@@ -102,8 +99,17 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
 
   return (
     <EuiPage>
+      <HeaderControl
+        controls={[
+          {
+            description: i18n.translate('workspace.creator.description', {
+              defaultMessage: 'Organize collaborative projects in use-case-specific workspaces.',
+            }),
+          },
+        ]}
+        setMountPoint={application?.setAppDescriptionControls}
+      />
       <EuiPageBody>
-        <EuiPageHeader pageTitle="Create a workspace" />
         <EuiPageContent
           verticalPosition="center"
           paddingSize="none"

--- a/src/plugins/workspace/public/components/workspace_creator_app.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator_app.tsx
@@ -12,21 +12,28 @@ import { WorkspaceCreatorProps } from './workspace_creator/workspace_creator';
 
 export const WorkspaceCreatorApp = (props: WorkspaceCreatorProps) => {
   const {
-    services: { chrome },
+    services: { chrome, application },
   } = useOpenSearchDashboards();
 
   /**
    * set breadcrumbs to chrome
    */
   useEffect(() => {
+    const homeBreadcrumb = {
+      text: i18n.translate('core.breadcrumbs.homeTitle', { defaultMessage: 'Home' }),
+      onClick: () => {
+        application?.navigateToApp('home');
+      },
+    };
     chrome?.setBreadcrumbs([
+      homeBreadcrumb,
       {
         text: i18n.translate('workspace.workspaceCreateTitle', {
           defaultMessage: 'Create a workspace',
         }),
       },
     ]);
-  }, [chrome]);
+  }, [chrome, application]);
 
   return (
     <I18nProvider>

--- a/src/plugins/workspace/public/components/workspace_detail/__snapshots__/workspace_detail.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_detail/__snapshots__/workspace_detail.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`WorkspaceDetail render workspace detail page normally 1`] = `
 <div>
   <div
-    class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusNone euiPanel--plain euiPanel--noShadow euiPanel--noBorder"
-  >
-    <header
-      class="euiPageHeader euiPageHeader--responsive euiPageHeader--center"
-    >
-      <div
-        class="euiPageHeaderContent"
-      >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive euiPageHeaderContent__top"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <h1
-              class="euiTitle euiTitle--large"
-            >
-              <div
-                class="euiFlexGroup euiFlexGroup--alignItemsBaseline euiFlexGroup--directionRow euiFlexGroup--responsive"
-              >
-                <div
-                  class="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  foo
-                </div>
-              </div>
-            </h1>
-          </div>
-        </div>
-      </div>
-    </header>
-  </div>
-  <div
     class="euiPage euiPage--paddingLarge euiPage--grow"
   >
     <div

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx
@@ -95,7 +95,7 @@ describe('WorkspaceDetail', () => {
   it('default selected tab is overview', async () => {
     const workspaceService = createWorkspacesSetupContractMockWithValue(workspaceObject);
     render(WorkspaceDetailPage({ workspacesService: workspaceService }));
-    expect(screen.queryByText('foo')).not.toBeNull();
+    expect(screen.queryByTestId('workspaceTabs')).not.toBeNull();
     expect(document.querySelector('#overview')).toHaveClass('euiTab-isSelected');
   });
 

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_detail.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_detail.tsx
@@ -4,15 +4,7 @@
  */
 
 import React from 'react';
-import {
-  EuiPage,
-  EuiPageBody,
-  EuiPageHeader,
-  EuiFlexItem,
-  EuiTabbedContent,
-  EuiFlexGroup,
-  EuiPanel,
-} from '@elastic/eui';
+import { EuiPage, EuiPageBody, EuiTabbedContent } from '@elastic/eui';
 
 import { useObservable } from 'react-use';
 import { i18n } from '@osd/i18n';
@@ -39,12 +31,6 @@ export const WorkspaceDetail = (props: WorkspaceDetailProps) => {
   if (!currentWorkspace) {
     return null;
   }
-
-  const pageTitle = (
-    <EuiFlexGroup gutterSize="none" alignItems="baseline" justifyContent="flexStart">
-      <EuiFlexItem grow={false}>{currentWorkspace?.name}</EuiFlexItem>
-    </EuiFlexGroup>
-  );
 
   const detailTabs = [
     {
@@ -86,9 +72,6 @@ export const WorkspaceDetail = (props: WorkspaceDetailProps) => {
 
   return (
     <>
-      <EuiPanel paddingSize="l" borderRadius="none" hasShadow={false} hasBorder={false}>
-        <EuiPageHeader pageTitle={pageTitle} />
-      </EuiPanel>
       <EuiPage paddingSize="l">
         <EuiPageBody>
           <EuiTabbedContent

--- a/src/plugins/workspace/public/components/workspace_detail_app.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail_app.tsx
@@ -36,7 +36,9 @@ export const WorkspaceDetailApp = (props: WorkspaceDetailProps) => {
         text: currentWorkspace.name,
       });
       breadcrumbs.push({
-        text: i18n.translate('workspace.detail.breadcrumb', { defaultMessage: 'Workspace Detail' }),
+        text: `${currentWorkspace.name} ${i18n.translate('workspace.detail.title', {
+          defaultMessage: 'settings',
+        })}`,
       });
     }
     chrome?.setBreadcrumbs(breadcrumbs);

--- a/src/plugins/workspace/public/components/workspace_detail_app.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail_app.tsx
@@ -36,9 +36,12 @@ export const WorkspaceDetailApp = (props: WorkspaceDetailProps) => {
         text: currentWorkspace.name,
       });
       breadcrumbs.push({
-        text: `${currentWorkspace.name} ${i18n.translate('workspace.detail.title', {
-          defaultMessage: 'settings',
-        })}`,
+        text: i18n.translate('workspace.detail.title', {
+          defaultMessage: '{name} settings',
+          values: {
+            name: currentWorkspace.name,
+          },
+        }),
       });
     }
     chrome?.setBreadcrumbs(breadcrumbs);

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -5,41 +5,30 @@ exports[`WorkspaceList should render title and table normally 1`] = `
   <div
     class="euiPage euiPage--grow"
   >
+    Organize collaborative projects with use-case-specific workspaces.
+    <button
+      class="euiButton euiButton--primary euiButton--small"
+      data-test-subj="workspaceList-create-workspace"
+      type="button"
+    >
+      <span
+        class="euiButtonContent euiButton__content"
+      >
+        <span
+          class="euiButtonContent__icon"
+          color="inherit"
+          data-euiicon-type="plus"
+        />
+        <span
+          class="euiButton__text"
+        >
+          Create workspace
+        </span>
+      </span>
+    </button>
     <div
       class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusNone euiPanel--plain euiPanel--hasShadow euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
     >
-      <header
-        class="euiPageHeader euiPageHeader--responsive euiPage--restrictWidth-default euiPageHeader--center"
-        style="padding-bottom: 0px; border-bottom: 0;"
-      >
-        <div
-          class="euiPageHeaderContent"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive euiPageHeaderContent__top"
-          >
-            <div
-              class="euiFlexItem"
-            >
-              <h1
-                class="euiTitle euiTitle--large"
-              >
-                Workspaces
-              </h1>
-              <div
-                class="euiSpacer euiSpacer--l"
-              />
-              <div
-                class="euiText euiText--medium euiText--constrainedWidth"
-              >
-                <p>
-                  Workspace allow you to save and organize library items, such as index patterns, visualizations, dashboards, saved searches, and share them with other OpenSearch Dashboards users. You can control which features are visible in each workspace, and which users and groups have read and write access to the library items in the workspace.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
         role="main"
@@ -253,25 +242,498 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                 </thead>
                 <tbody>
                   <tr
-                    class="euiTableRow"
+                    class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
                   >
                     <td
-                      class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                      colspan="5"
+                      class="euiTableRowCell"
                     >
                       <div
-                        class="euiTableCellContent euiTableCellContent--alignCenter"
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--overflowingContent"
+                      >
+                        <span
+                          class=""
+                        >
+                          <button
+                            class="euiLink euiLink--primary"
+                            type="button"
+                          >
+                            name1
+                          </button>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        ID
+                      </div>
+                      <div
+                        class="euiTableCellContent"
                       >
                         <span
                           class="euiTableCellContent__text"
                         >
-                          No items found
+                          id1
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Description
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--truncateText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Use case
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--overflowingContent"
+                      >
+                        Analytics (All)
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell euiTableRowCell--hasActions"
+                    >
+                      <div
+                        class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                      >
+                        <span
+                          class="euiToolTipAnchor"
+                        >
+                          <button
+                            aria-labelledby="generated-id"
+                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                            data-test-subj="workspace-list-edit-icon"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="pencil"
+                            />
+                          </button>
+                          <span
+                            class="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            Edit
+                          </span>
+                        </span>
+                        <span
+                          class="euiToolTipAnchor"
+                        >
+                          <button
+                            aria-labelledby="generated-id"
+                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                            data-test-subj="workspace-list-delete-icon"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="trash"
+                            />
+                          </button>
+                          <span
+                            class="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            Delete
+                          </span>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--overflowingContent"
+                      >
+                        <span
+                          class=""
+                        >
+                          <button
+                            class="euiLink euiLink--primary"
+                            type="button"
+                          >
+                            name2
+                          </button>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        ID
+                      </div>
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          id2
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Description
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--truncateText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Use case
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--overflowingContent"
+                      />
+                    </td>
+                    <td
+                      class="euiTableRowCell euiTableRowCell--hasActions"
+                    >
+                      <div
+                        class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                      >
+                        <span
+                          class="euiToolTipAnchor"
+                        >
+                          <button
+                            aria-labelledby="generated-id"
+                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                            data-test-subj="workspace-list-edit-icon"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="pencil"
+                            />
+                          </button>
+                          <span
+                            class="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            Edit
+                          </span>
+                        </span>
+                        <span
+                          class="euiToolTipAnchor"
+                        >
+                          <button
+                            aria-labelledby="generated-id"
+                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                            data-test-subj="workspace-list-delete-icon"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="trash"
+                            />
+                          </button>
+                          <span
+                            class="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            Delete
+                          </span>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--overflowingContent"
+                      >
+                        <span
+                          class=""
+                        >
+                          <button
+                            class="euiLink euiLink--primary"
+                            type="button"
+                          >
+                            name3
+                          </button>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        ID
+                      </div>
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          id3
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Description
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--truncateText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Use case
+                      </div>
+                      <div
+                        class="euiTableCellContent euiTableCellContent--overflowingContent"
+                      >
+                        Observability
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell euiTableRowCell--hasActions"
+                    >
+                      <div
+                        class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                      >
+                        <span
+                          class="euiToolTipAnchor"
+                        >
+                          <button
+                            aria-labelledby="generated-id"
+                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                            data-test-subj="workspace-list-edit-icon"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="pencil"
+                            />
+                          </button>
+                          <span
+                            class="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            Edit
+                          </span>
+                        </span>
+                        <span
+                          class="euiToolTipAnchor"
+                        >
+                          <button
+                            aria-labelledby="generated-id"
+                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                            data-test-subj="workspace-list-delete-icon"
+                            type="button"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="trash"
+                            />
+                          </button>
+                          <span
+                            class="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            Delete
+                          </span>
                         </span>
                       </div>
                     </td>
                   </tr>
                 </tbody>
               </table>
+            </div>
+            <div>
+              <div
+                class="euiSpacer euiSpacer--m"
+              />
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+              >
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <div
+                    class="euiPopover euiPopover--anchorUpRight"
+                  >
+                    <div
+                      class="euiPopover__anchor"
+                    >
+                      <button
+                        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                        data-test-subj="tablePaginationPopoverButton"
+                        type="button"
+                      >
+                        <span
+                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        >
+                          <span
+                            class="euiButtonContent__icon"
+                            color="inherit"
+                            data-euiicon-type="arrowDown"
+                          />
+                          <span
+                            class="euiButtonEmpty__text"
+                          >
+                            Rows per page
+                            : 
+                            5
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <nav
+                    class="euiPagination"
+                  >
+                    <button
+                      aria-label="Previous page"
+                      class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                      data-test-subj="pagination-button-previous"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="arrowLeft"
+                      />
+                    </button>
+                    <ul
+                      class="euiPagination__list"
+                    >
+                      <li
+                        class="euiPagination__item"
+                      >
+                        <button
+                          aria-controls="__table_generated-id"
+                          aria-current="true"
+                          aria-label="Page 1 of 1"
+                          class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                          data-test-subj="pagination-button-0"
+                          disabled=""
+                          type="button"
+                        >
+                          <span
+                            class="euiButtonContent euiButtonEmpty__content"
+                          >
+                            <span
+                              class="euiButtonEmpty__text"
+                            >
+                              1
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    </ul>
+                    <button
+                      aria-label="Next page"
+                      class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                      data-test-subj="pagination-button-next"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="euiButtonIcon__icon"
+                        color="inherit"
+                        data-euiicon-type="arrowRight"
+                      />
+                    </button>
+                  </nav>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`WorkspaceList should render title and table normally 1`] = `
 <div>
   <div
-    class="euiPage euiPage--grow"
+    class="euiPage euiPage--paddingMedium euiPage--grow"
   >
     Organize collaborative projects with use-case-specific workspaces.
     <button
@@ -27,712 +27,707 @@ exports[`WorkspaceList should render title and table normally 1`] = `
       </span>
     </button>
     <div
-      class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusNone euiPanel--plain euiPanel--hasShadow euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
+      role="main"
     >
-      <div
-        class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
-        role="main"
-        style="width: 100%; max-width: 1000px;"
-      >
-        <div>
+      <div>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+        >
           <div
-            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+            class="euiFlexItem euiSearchBar__searchHolder"
           >
             <div
-              class="euiFlexItem euiSearchBar__searchHolder"
+              class="euiFormControlLayout euiFormControlLayout--fullWidth"
             >
               <div
-                class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                class="euiFormControlLayout__childrenWrapper"
               >
+                <input
+                  aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                  class="euiFieldSearch euiFieldSearch--fullWidth"
+                  placeholder="Search..."
+                  type="search"
+                  value=""
+                />
                 <div
-                  class="euiFormControlLayout__childrenWrapper"
+                  class="euiFormControlLayoutIcons"
                 >
-                  <input
-                    aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
-                    class="euiFieldSearch euiFieldSearch--fullWidth"
-                    placeholder="Search..."
-                    type="search"
-                    value=""
-                  />
-                  <div
-                    class="euiFormControlLayoutIcons"
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
                   >
                     <span
-                      class="euiFormControlLayoutCustomIcon"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="euiFormControlLayoutCustomIcon__icon"
-                        data-euiicon-type="search"
-                      />
-                    </span>
-                  </div>
+                      aria-hidden="true"
+                      class="euiFormControlLayoutCustomIcon__icon"
+                      data-euiicon-type="search"
+                    />
+                  </span>
                 </div>
               </div>
             </div>
           </div>
-          <div
-            class="euiSpacer euiSpacer--l"
-          />
-          <div
-            class="euiBasicTable"
-          >
-            <div>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiBasicTable"
+        >
+          <div>
+            <div
+              class="euiTableHeaderMobile"
+            >
               <div
-                class="euiTableHeaderMobile"
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
               >
                 <div
-                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                />
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
                   <div
-                    class="euiFlexItem euiFlexItem--flexGrowZero"
-                  />
-                  <div
-                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                    class="euiTableSortMobile"
                   >
                     <div
-                      class="euiTableSortMobile"
+                      class="euiPopover euiPopover--anchorDownRight"
                     >
                       <div
-                        class="euiPopover euiPopover--anchorDownRight"
+                        class="euiPopover__anchor"
                       >
-                        <div
-                          class="euiPopover__anchor"
+                        <button
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                          type="button"
                         >
-                          <button
-                            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                            type="button"
+                          <span
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <span
-                              class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                              class="euiButtonContent__icon"
+                              color="inherit"
+                              data-euiicon-type="arrowDown"
+                            />
+                            <span
+                              class="euiButtonEmpty__text"
                             >
-                              <span
-                                class="euiButtonContent__icon"
-                                color="inherit"
-                                data-euiicon-type="arrowDown"
-                              />
-                              <span
-                                class="euiButtonEmpty__text"
-                              >
-                                Sorting
-                              </span>
+                              Sorting
                             </span>
-                          </button>
-                        </div>
+                          </span>
+                        </button>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <table
-                class="euiTable euiTable--responsive"
-                id="__table_generated-id"
-                tabindex="-1"
-              >
-                <caption
-                  class="euiScreenReaderOnly euiTableCaption"
-                />
-                <thead>
-                  <tr>
-                    <th
-                      aria-live="polite"
-                      aria-sort="ascending"
-                      class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_name_0"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <button
-                        class="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                        data-test-subj="tableHeaderSortButton"
-                        type="button"
-                      >
-                        <span
-                          class="euiTableCellContent"
-                        >
-                          <span
-                            class="euiTableCellContent__text"
-                            title="Name"
-                          >
-                            Name
-                          </span>
-                          <span
-                            class="euiTableSortIcon"
-                            data-euiicon-type="sortUp"
-                          />
-                        </span>
-                      </button>
-                    </th>
-                    <th
-                      aria-live="polite"
-                      aria-sort="none"
-                      class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_id_1"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <button
-                        class="euiTableHeaderButton"
-                        data-test-subj="tableHeaderSortButton"
-                        type="button"
-                      >
-                        <span
-                          class="euiTableCellContent"
-                        >
-                          <span
-                            class="euiTableCellContent__text"
-                            title="ID"
-                          >
-                            ID
-                          </span>
-                        </span>
-                      </button>
-                    </th>
-                    <th
-                      class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_description_2"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <span
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                          title="Description"
-                        >
-                          Description
-                        </span>
-                      </span>
-                    </th>
-                    <th
-                      class="euiTableHeaderCell"
-                      data-test-subj="tableHeaderCell_features_3"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <span
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                          title="Use case"
-                        >
-                          Use case
-                        </span>
-                      </span>
-                    </th>
-                    <th
-                      class="euiTableHeaderCell"
-                      role="columnheader"
-                      scope="col"
-                    >
-                      <span
-                        class="euiTableCellContent euiTableCellContent--alignRight"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                          title="Actions"
-                        >
-                          Actions
-                        </span>
-                      </span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                  >
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Name
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--overflowingContent"
-                      >
-                        <span
-                          class=""
-                        >
-                          <button
-                            class="euiLink euiLink--primary"
-                            type="button"
-                          >
-                            name1
-                          </button>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        ID
-                      </div>
-                      <div
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        >
-                          id1
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Description
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--truncateText"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Use case
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--overflowingContent"
-                      >
-                        Analytics (All)
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell euiTableRowCell--hasActions"
-                    >
-                      <div
-                        class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                      >
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <button
-                            aria-labelledby="generated-id"
-                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                            data-test-subj="workspace-list-edit-icon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="pencil"
-                            />
-                          </button>
-                          <span
-                            class="euiScreenReaderOnly"
-                            id="generated-id"
-                          >
-                            Edit
-                          </span>
-                        </span>
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <button
-                            aria-labelledby="generated-id"
-                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                            data-test-subj="workspace-list-delete-icon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="trash"
-                            />
-                          </button>
-                          <span
-                            class="euiScreenReaderOnly"
-                            id="generated-id"
-                          >
-                            Delete
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr
-                    class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                  >
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Name
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--overflowingContent"
-                      >
-                        <span
-                          class=""
-                        >
-                          <button
-                            class="euiLink euiLink--primary"
-                            type="button"
-                          >
-                            name2
-                          </button>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        ID
-                      </div>
-                      <div
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        >
-                          id2
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Description
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--truncateText"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Use case
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--overflowingContent"
-                      />
-                    </td>
-                    <td
-                      class="euiTableRowCell euiTableRowCell--hasActions"
-                    >
-                      <div
-                        class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                      >
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <button
-                            aria-labelledby="generated-id"
-                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                            data-test-subj="workspace-list-edit-icon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="pencil"
-                            />
-                          </button>
-                          <span
-                            class="euiScreenReaderOnly"
-                            id="generated-id"
-                          >
-                            Edit
-                          </span>
-                        </span>
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <button
-                            aria-labelledby="generated-id"
-                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                            data-test-subj="workspace-list-delete-icon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="trash"
-                            />
-                          </button>
-                          <span
-                            class="euiScreenReaderOnly"
-                            id="generated-id"
-                          >
-                            Delete
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr
-                    class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                  >
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Name
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--overflowingContent"
-                      >
-                        <span
-                          class=""
-                        >
-                          <button
-                            class="euiLink euiLink--primary"
-                            type="button"
-                          >
-                            name3
-                          </button>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        ID
-                      </div>
-                      <div
-                        class="euiTableCellContent"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        >
-                          id3
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Description
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--truncateText"
-                      >
-                        <span
-                          class="euiTableCellContent__text"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
-                    >
-                      <div
-                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                      >
-                        Use case
-                      </div>
-                      <div
-                        class="euiTableCellContent euiTableCellContent--overflowingContent"
-                      >
-                        Observability
-                      </div>
-                    </td>
-                    <td
-                      class="euiTableRowCell euiTableRowCell--hasActions"
-                    >
-                      <div
-                        class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                      >
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <button
-                            aria-labelledby="generated-id"
-                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                            data-test-subj="workspace-list-edit-icon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="pencil"
-                            />
-                          </button>
-                          <span
-                            class="euiScreenReaderOnly"
-                            id="generated-id"
-                          >
-                            Edit
-                          </span>
-                        </span>
-                        <span
-                          class="euiToolTipAnchor"
-                        >
-                          <button
-                            aria-labelledby="generated-id"
-                            class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                            data-test-subj="workspace-list-delete-icon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="trash"
-                            />
-                          </button>
-                          <span
-                            class="euiScreenReaderOnly"
-                            id="generated-id"
-                          >
-                            Delete
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
             </div>
-            <div>
-              <div
-                class="euiSpacer euiSpacer--m"
+            <table
+              class="euiTable euiTable--responsive"
+              id="__table_generated-id"
+              tabindex="-1"
+            >
+              <caption
+                class="euiScreenReaderOnly euiTableCaption"
               />
-              <div
-                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-              >
-                <div
-                  class="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorUpRight"
-                  >
-                    <div
-                      class="euiPopover__anchor"
-                    >
-                      <button
-                        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                        data-test-subj="tablePaginationPopoverButton"
-                        type="button"
-                      >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                        >
-                          <span
-                            class="euiButtonContent__icon"
-                            color="inherit"
-                            data-euiicon-type="arrowDown"
-                          />
-                          <span
-                            class="euiButtonEmpty__text"
-                          >
-                            Rows per page
-                            : 
-                            5
-                          </span>
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <nav
-                    class="euiPagination"
+              <thead>
+                <tr>
+                  <th
+                    aria-live="polite"
+                    aria-sort="ascending"
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_name_0"
+                    role="columnheader"
+                    scope="col"
                   >
                     <button
-                      aria-label="Previous page"
-                      class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                      data-test-subj="pagination-button-previous"
-                      disabled=""
+                      class="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                      data-test-subj="tableHeaderSortButton"
                       type="button"
                     >
                       <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="arrowLeft"
-                      />
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                          title="Name"
+                        >
+                          Name
+                        </span>
+                        <span
+                          class="euiTableSortIcon"
+                          data-euiicon-type="sortUp"
+                        />
+                      </span>
                     </button>
-                    <ul
-                      class="euiPagination__list"
+                  </th>
+                  <th
+                    aria-live="polite"
+                    aria-sort="none"
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_id_1"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <button
+                      class="euiTableHeaderButton"
+                      data-test-subj="tableHeaderSortButton"
+                      type="button"
                     >
-                      <li
-                        class="euiPagination__item"
+                      <span
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                          title="ID"
+                        >
+                          ID
+                        </span>
+                      </span>
+                    </button>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_description_2"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Description"
+                      >
+                        Description
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_features_3"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Use case"
+                      >
+                        Use case
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      class="euiTableCellContent euiTableCellContent--alignRight"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Actions"
+                      >
+                        Actions
+                      </span>
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+                >
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Name
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    >
+                      <span
+                        class=""
                       >
                         <button
-                          aria-controls="__table_generated-id"
-                          aria-current="true"
-                          aria-label="Page 1 of 1"
-                          class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                          data-test-subj="pagination-button-0"
-                          disabled=""
+                          class="euiLink euiLink--primary"
+                          type="button"
+                        >
+                          name1
+                        </button>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      ID
+                    </div>
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      >
+                        id1
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Description
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--truncateText"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Use case
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    >
+                      Analytics (All)
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell euiTableRowCell--hasActions"
+                  >
+                    <div
+                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                    >
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <button
+                          aria-labelledby="generated-id"
+                          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                          data-test-subj="workspace-list-edit-icon"
                           type="button"
                         >
                           <span
-                            class="euiButtonContent euiButtonEmpty__content"
-                          >
-                            <span
-                              class="euiButtonEmpty__text"
-                            >
-                              1
-                            </span>
-                          </span>
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="pencil"
+                          />
                         </button>
-                      </li>
-                    </ul>
+                        <span
+                          class="euiScreenReaderOnly"
+                          id="generated-id"
+                        >
+                          Edit
+                        </span>
+                      </span>
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <button
+                          aria-labelledby="generated-id"
+                          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                          data-test-subj="workspace-list-delete-icon"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="trash"
+                          />
+                        </button>
+                        <span
+                          class="euiScreenReaderOnly"
+                          id="generated-id"
+                        >
+                          Delete
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+                >
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Name
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    >
+                      <span
+                        class=""
+                      >
+                        <button
+                          class="euiLink euiLink--primary"
+                          type="button"
+                        >
+                          name2
+                        </button>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      ID
+                    </div>
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      >
+                        id2
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Description
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--truncateText"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Use case
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    />
+                  </td>
+                  <td
+                    class="euiTableRowCell euiTableRowCell--hasActions"
+                  >
+                    <div
+                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                    >
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <button
+                          aria-labelledby="generated-id"
+                          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                          data-test-subj="workspace-list-edit-icon"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="pencil"
+                          />
+                        </button>
+                        <span
+                          class="euiScreenReaderOnly"
+                          id="generated-id"
+                        >
+                          Edit
+                        </span>
+                      </span>
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <button
+                          aria-labelledby="generated-id"
+                          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                          data-test-subj="workspace-list-delete-icon"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="trash"
+                          />
+                        </button>
+                        <span
+                          class="euiScreenReaderOnly"
+                          id="generated-id"
+                        >
+                          Delete
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+                >
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Name
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    >
+                      <span
+                        class=""
+                      >
+                        <button
+                          class="euiLink euiLink--primary"
+                          type="button"
+                        >
+                          name3
+                        </button>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      ID
+                    </div>
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      >
+                        id3
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Description
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--truncateText"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--isExpander"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Use case
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    >
+                      Observability
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell euiTableRowCell--hasActions"
+                  >
+                    <div
+                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                    >
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <button
+                          aria-labelledby="generated-id"
+                          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                          data-test-subj="workspace-list-edit-icon"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="pencil"
+                          />
+                        </button>
+                        <span
+                          class="euiScreenReaderOnly"
+                          id="generated-id"
+                        >
+                          Edit
+                        </span>
+                      </span>
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <button
+                          aria-labelledby="generated-id"
+                          class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                          data-test-subj="workspace-list-delete-icon"
+                          type="button"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="trash"
+                          />
+                        </button>
+                        <span
+                          class="euiScreenReaderOnly"
+                          id="generated-id"
+                        >
+                          Delete
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+            >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <div
+                  class="euiPopover euiPopover--anchorUpRight"
+                >
+                  <div
+                    class="euiPopover__anchor"
+                  >
                     <button
-                      aria-label="Next page"
-                      class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                      data-test-subj="pagination-button-next"
-                      disabled=""
+                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                      data-test-subj="tablePaginationPopoverButton"
                       type="button"
                     >
                       <span
-                        aria-hidden="true"
-                        class="euiButtonIcon__icon"
-                        color="inherit"
-                        data-euiicon-type="arrowRight"
-                      />
+                        class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                      >
+                        <span
+                          class="euiButtonContent__icon"
+                          color="inherit"
+                          data-euiicon-type="arrowDown"
+                        />
+                        <span
+                          class="euiButtonEmpty__text"
+                        >
+                          Rows per page
+                          : 
+                          5
+                        </span>
+                      </span>
                     </button>
-                  </nav>
+                  </div>
                 </div>
+              </div>
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <nav
+                  class="euiPagination"
+                >
+                  <button
+                    aria-label="Previous page"
+                    class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                    data-test-subj="pagination-button-previous"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="arrowLeft"
+                    />
+                  </button>
+                  <ul
+                    class="euiPagination__list"
+                  >
+                    <li
+                      class="euiPagination__item"
+                    >
+                      <button
+                        aria-controls="__table_generated-id"
+                        aria-current="true"
+                        aria-label="Page 1 of 1"
+                        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                        data-test-subj="pagination-button-0"
+                        disabled=""
+                        type="button"
+                      >
+                        <span
+                          class="euiButtonContent euiButtonEmpty__content"
+                        >
+                          <span
+                            class="euiButtonEmpty__text"
+                          >
+                            1
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                  </ul>
+                  <button
+                    aria-label="Next page"
+                    class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                    data-test-subj="pagination-button-next"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="arrowRight"
+                    />
+                  </button>
+                </nav>
               </div>
             </div>
           </div>

--- a/src/plugins/workspace/public/components/workspace_list/index.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.test.tsx
@@ -39,10 +39,17 @@ function getWrapWorkspaceListInContext(
     },
   };
 
+  const mockHeaderControl = ({ controls }) => {
+    return controls?.[0].description ?? controls?.[0].renderComponent ?? null;
+  };
+
   const services = {
     ...coreStartMock,
     workspaces: {
       workspaceList$: of(workspaceList),
+    },
+    navigationUI: {
+      HeaderControl: mockHeaderControl,
     },
   };
 
@@ -59,12 +66,10 @@ function getWrapWorkspaceListInContext(
 
 describe('WorkspaceList', () => {
   it('should render title and table normally', () => {
-    const { getByText, getByRole, container } = render(
-      <WorkspaceList
-        registeredUseCases$={new BehaviorSubject([WORKSPACE_USE_CASES.observability])}
-      />
-    );
-    expect(getByText('Workspaces')).toBeInTheDocument();
+    const { getByText, getByRole, container } = render(getWrapWorkspaceListInContext());
+    expect(
+      getByText('Organize collaborative projects with use-case-specific workspaces.')
+    ).toBeInTheDocument();
     expect(getByRole('table')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -6,7 +6,6 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import {
   EuiPage,
-  EuiPageBody,
   EuiPageContent,
   EuiLink,
   EuiSmallButton,
@@ -23,7 +22,6 @@ import { navigateToWorkspaceDetail } from '../utils/workspace';
 
 import { WORKSPACE_CREATE_APP_ID } from '../../../common/constants';
 
-import { cleanWorkspaceId } from '../../../../../core/public';
 import { DeleteWorkspaceModal } from '../delete_workspace_modal';
 import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
 import { WorkspaceUseCase } from '../../types';
@@ -91,7 +89,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
     });
     if (!appUrl) return '';
 
-    return cleanWorkspaceId(appUrl);
+    return appUrl;
   }, [application]);
 
   const renderCreateWorkspaceButton = () => {
@@ -198,7 +196,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
   };
 
   return (
-    <EuiPage paddingSize="none">
+    <EuiPage paddingSize="m">
       <HeaderControl
         controls={[
           {
@@ -210,36 +208,33 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
         setMountPoint={application?.setAppDescriptionControls}
       />
       {isDashboardAdmin && renderCreateWorkspaceButton()}
-      <EuiPageBody panelled>
-        <EuiPageContent
-          verticalPosition="center"
-          horizontalPosition="center"
-          paddingSize="m"
-          panelPaddingSize="l"
-          hasShadow={false}
-          style={{ width: '100%', maxWidth: 1000 }}
-        >
-          <EuiInMemoryTable
-            items={searchResult}
-            columns={columns}
-            itemId="id"
-            onTableChange={({ page: { index, size } }) =>
-              setPagination((prev) => {
-                return { ...prev, pageIndex: index, pageSize: size };
-              })
-            }
-            pagination={pagination}
-            sorting={{
-              sort: {
-                field: initialSortField,
-                direction: initialSortDirection,
-              },
-            }}
-            isSelectable={true}
-            search={search}
-          />
-        </EuiPageContent>
-      </EuiPageBody>
+      <EuiPageContent
+        verticalPosition="center"
+        horizontalPosition="center"
+        paddingSize="m"
+        panelPaddingSize="l"
+        hasShadow={false}
+      >
+        <EuiInMemoryTable
+          items={searchResult}
+          columns={columns}
+          itemId="id"
+          onTableChange={({ page: { index, size } }) =>
+            setPagination((prev) => {
+              return { ...prev, pageIndex: index, pageSize: size };
+            })
+          }
+          pagination={pagination}
+          sorting={{
+            sort: {
+              field: initialSortField,
+              direction: initialSortDirection,
+            },
+          }}
+          isSelectable={true}
+          search={search}
+        />
+      </EuiPageContent>
       {deletedWorkspace && (
         <DeleteWorkspaceModal
           selectedWorkspace={deletedWorkspace}

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -82,7 +82,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
   }, [workspaceList, queryInput]);
 
   const workspaceCreateUrl = useMemo(() => {
-    if (!application || !http) {
+    if (!application) {
       return '';
     }
 
@@ -92,10 +92,9 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
     if (!appUrl) return '';
 
     return cleanWorkspaceId(appUrl);
-  }, [application, http]);
+  }, [application]);
 
   const renderCreateWorkspaceButton = () => {
-    if (!isDashboardAdmin) return null;
     const button = (
       <EuiSmallButton
         href={workspaceCreateUrl}
@@ -210,7 +209,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
         ]}
         setMountPoint={application?.setAppDescriptionControls}
       />
-      {renderCreateWorkspaceButton()}
+      {isDashboardAdmin && renderCreateWorkspaceButton()}
       <EuiPageBody panelled>
         <EuiPageContent
           verticalPosition="center"

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -53,6 +53,7 @@ import { UseCaseService } from './services/use_case_service';
 import { WorkspaceListCard } from './components/service_card';
 import { UseCaseFooter } from './components/home_get_start_card';
 import { HOME_CONTENT_AREAS } from '../../home/public';
+import { NavigationPublicPluginStart } from '../../../plugins/navigation/public';
 
 type WorkspaceAppType = (
   params: AppMountParameters,
@@ -68,6 +69,7 @@ interface WorkspacePluginSetupDeps {
 
 export interface WorkspacePluginStartDeps {
   contentManagement: ContentManagementPluginStart;
+  navigation: NavigationPublicPluginStart;
 }
 
 export class WorkspacePlugin
@@ -235,7 +237,7 @@ export class WorkspacePlugin
   }
 
   public async setup(
-    core: CoreSetup,
+    core: CoreSetup<WorkspacePluginStartDeps>,
     { savedObjectsManagement, management, dataSourceManagement }: WorkspacePluginSetupDeps
   ) {
     const workspaceClient = new WorkspaceClient(core.http, core.workspaces);
@@ -295,11 +297,13 @@ export class WorkspacePlugin
     }
 
     const mountWorkspaceApp = async (params: AppMountParameters, renderApp: WorkspaceAppType) => {
-      const [coreStart] = await core.getStartServices();
+      const [coreStart, { navigation }] = await core.getStartServices();
+
       const services = {
         ...coreStart,
         workspaceClient,
         dataSourceManagement,
+        navigationUI: navigation.ui,
       };
 
       return renderApp(params, services, {
@@ -431,7 +435,7 @@ export class WorkspacePlugin
     });
   }
 
-  public start(core: CoreStart, { contentManagement }: WorkspacePluginStartDeps) {
+  public start(core: CoreStart, { contentManagement, navigation }: WorkspacePluginStartDeps) {
     this.coreStart = core;
 
     this.currentWorkspaceIdSubscription = this._changeSavedObjectCurrentWorkspace();

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -6,10 +6,12 @@
 import { CoreStart } from '../../../core/public';
 import { WorkspaceClient } from './workspace_client';
 import { DataSourceManagementPluginSetup } from '../../../plugins/data_source_management/public';
+import { NavigationPublicPluginStart } from '../../../plugins/navigation/public';
 
 export type Services = CoreStart & {
   workspaceClient: WorkspaceClient;
   dataSourceManagement?: DataSourceManagementPluginSetup;
+  navigationUI?: NavigationPublicPluginStart['ui'];
 };
 
 export interface WorkspaceUseCase {


### PR DESCRIPTION
### Description

Integrate new page header for workspace pages, including
1. workspace create page
2. workspace list page
3. workspace detail page header
4. settings and setup landing page
5. data administration page

This is first phase of integration, the integration of remaining pages will be proposed in later PRs.

## Screenshot

![image](https://github.com/user-attachments/assets/94aec9bc-d660-417a-935b-2e26c38f3664)
![image](https://github.com/user-attachments/assets/05b8343f-9f25-4e58-9d90-53d4b596e06d)
![image](https://github.com/user-attachments/assets/83089033-3f2f-48d7-96b6-996a96098405)
![image](https://github.com/user-attachments/assets/97eb849f-3fb6-455e-8966-8b9315f88ac0)
![image](https://github.com/user-attachments/assets/17718cf5-7f92-4060-8d90-283fb1d55914)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- feat: Integrate new page header for workspace pages


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
