### PR TITLE
[WorkSpace] Refractor homepage assets list section

### DIFF
--- a/changelogs/fragments/7702.yml
+++ b/changelogs/fragments/7702.yml
@@ -1,0 +1,2 @@
+feat:
+- Refractor the homepage assets list section ([#7702](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7702))

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.test.tsx
@@ -10,6 +10,7 @@ import { RecentWork } from './recent_work';
 import { coreMock } from '../../../../core/public/mocks';
 import { ChromeRecentlyAccessedHistoryItem } from 'opensearch-dashboards/public';
 import { SavedObjectWithMetadata } from '../types';
+import { APP_ID } from '../plugin';
 
 const mockedRecentItems: ChromeRecentlyAccessedHistoryItem[] = [
   {
@@ -94,5 +95,18 @@ describe('<RecentWork />', () => {
     expect(allCardsAfterSort[0].querySelector('.euiCard__titleAnchor')?.textContent).toEqual(
       mockedRecentItems[1].label.charAt(0).toUpperCase() + mockedRecentItems[1].label.slice(1)
     );
+  });
+
+  it('should be able to show view all button', () => {
+    const { getByText } = render(<RecentWork core={getStartMockForRecentWork()} />);
+    expect(getByText('View all')).toBeInTheDocument();
+  });
+
+  it('shoule be able to be linked to the expected page when clicking View all button', () => {
+    const coreStartMock = getStartMockForRecentWork();
+    const { getByText } = render(<RecentWork core={coreStartMock} />);
+    const mockedViewAllButton = getByText('View all');
+    fireEvent.click(mockedViewAllButton);
+    expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith(APP_ID);
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.test.tsx
@@ -60,7 +60,7 @@ const getStartMockForRecentWork = () => {
 describe('<RecentWork />', () => {
   it('render with emty recent work', async () => {
     const { findByText } = render(<RecentWork core={getStartMockForRecentWork()} />);
-    await findByText('No recent work');
+    await findByText('No assets found');
   });
 
   it('render with recent works', async () => {
@@ -85,14 +85,14 @@ describe('<RecentWork />', () => {
     const allCards = await findAllByTestId('recentlyCard');
     expect(allCards.length).toBe(2);
     expect(allCards[0].querySelector('.euiCard__titleAnchor')?.textContent).toEqual(
-      mockedRecentItems[0].label
+      mockedRecentItems[0].label.charAt(0).toUpperCase() + mockedRecentItems[0].label.slice(1)
     );
 
     // click the filter button
-    fireEvent.click(getByTestId('filterButton-recently%20updated'));
+    fireEvent.click(getByTestId('filterButton-Recently%20updated'));
     const allCardsAfterSort = await findAllByTestId('recentlyCard');
     expect(allCardsAfterSort[0].querySelector('.euiCard__titleAnchor')?.textContent).toEqual(
-      mockedRecentItems[1].label
+      mockedRecentItems[1].label.charAt(0).toUpperCase() + mockedRecentItems[1].label.slice(1)
     );
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
@@ -9,14 +9,18 @@ import {
   EuiFlexItem,
   EuiCard,
   EuiPanel,
-  EuiSpacer,
+  EuiFlexGrid,
   EuiFlexGroup,
   EuiTitle,
   EuiFilterGroup,
   EuiFilterButton,
   EuiComboBox,
   EuiIcon,
+  EuiLink,
   EuiEmptyPrompt,
+  EuiToolTip,
+  EuiSpacer,
+  EuiText,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import {
@@ -26,18 +30,19 @@ import {
 } from 'opensearch-dashboards/public';
 import { useObservable } from 'react-use';
 import { SavedObjectWithMetadata } from 'src/plugins/saved_objects_management/common';
+import { APP_ID } from '../plugin';
 import { createRecentNavLink } from '../../../../core/public';
 
 const allOption = i18n.translate('savedObjectsManagement.recentWorkSection.all.items', {
-  defaultMessage: 'all items',
+  defaultMessage: 'All items',
 });
 
 const recentlyViewed = i18n.translate('savedObjectsManagement.recentWorkSection.recentlyViewed', {
-  defaultMessage: 'recently viewed',
+  defaultMessage: 'Recently viewed',
 });
 
 const recentlyUpdated = i18n.translate('savedObjectsManagement.recentWorkSection.recentlyUpdated', {
-  defaultMessage: 'recently updated',
+  defaultMessage: 'Recently updated',
 });
 
 const sortKeyMap = {
@@ -102,9 +107,9 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
     const options: string[] = [allOption];
     detailedSavedObjects
       .filter((item) => !item.error)
-      .forEach((recentAccessItem: ChromeRecentlyAccessedHistoryItem) => {
-        if (recentAccessItem.meta?.type && options.indexOf(recentAccessItem.meta.type) === -1) {
-          options.push(recentAccessItem.meta.type);
+      .forEach((recentAccessItem) => {
+        if (recentAccessItem?.type && options.indexOf(recentAccessItem?.type) === -1) {
+          options.push(recentAccessItem?.type);
         }
       });
     return options.map((option: string) => ({ label: option, value: option }));
@@ -156,22 +161,36 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
     <EuiPanel>
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem>
-          <EuiTitle>
-            <h5>
-              {i18n.translate('savedObjectsManagement.recentWorkSection.title', {
-                defaultMessage: 'Assets',
-              })}
-            </h5>
-          </EuiTitle>
+          <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiTitle>
+                <h3>
+                  {i18n.translate('savedObjectsManagement.recentWorkSection.title', {
+                    defaultMessage: 'Assets',
+                  })}
+                </h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                display="inlineBlock"
+                position="right"
+                content="Dashboards, visualizations, saved queries, and other assets within your Worksapces."
+                data-test-subj="assetsTooltip"
+              >
+                <EuiIcon type="iInCircle" />
+              </EuiToolTip>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFilterGroup>
+              <EuiFilterGroup style={{ borderRadius: '5px' }}>
                 {[recentlyViewed, recentlyUpdated].map((item) => (
                   <EuiFilterButton
+                    hasActiveFilters={selectedSort === item}
                     key={item}
-                    hasActiveFilters={item === selectedSort}
                     onClick={() => setSelectedSort(item)}
                     data-test-subj={`filterButton-${encodeURIComponent(item)}`}
                   >
@@ -208,47 +227,81 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
                 core.http.basePath,
                 core.application.navigateToUrl
               );
+
               content = (
                 <EuiCard
-                  title={recentAccessItem.label}
-                  titleSize="xs"
-                  data-test-subj="recentlyCard"
-                  description=""
-                  textAlign="left"
-                  href={recentNavLink.href}
-                  footer={
-                    <>
-                      <div>
+                  title={
+                    <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="none">
+                      <EuiFlexItem grow={false}>
                         <EuiIcon
                           style={{ marginRight: widthForRightMargin }}
                           type={recentAccessItem.meta.icon || 'apps'}
                         />
-                        {recentAccessItem.type}
-                      </div>
-                      <EuiSpacer size="s" />
-                      <div>
-                        {selectedSort === recentlyViewed
-                          ? i18n.translate('savedObjectsManagement.recentWorkSection.viewedAt', {
-                              defaultMessage: 'Viewed',
-                            })
-                          : i18n.translate('savedObjectsManagement.recentWorkSection.updatedAt', {
-                              defaultMessage: 'Updated',
-                            })}
-                        :{' '}
-                        <b>
-                          {selectedSort === recentlyViewed
-                            ? moment(recentAccessItem?.lastAccessedTime).fromNow()
-                            : moment(recentAccessItem?.updatedAt).fromNow()}
-                        </b>
-                      </div>
-                      {workspaceEnabled && (
-                        <div>
-                          {i18n.translate('savedObjectsManagement.recentWorkSection.workspace', {
-                            defaultMessage: 'Workspace',
-                          })}
-                          : <b>{recentAccessItem.workspaceName || 'N/A'}</b>
-                        </div>
-                      )}
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="xs" color="subdued">
+                          {recentAccessItem.type.charAt(0).toUpperCase() +
+                            recentAccessItem.type.slice(1)}
+                        </EuiText>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  data-test-subj="recentlyCard"
+                  description={<h3>{recentAccessItem.label}</h3>}
+                  textAlign="left"
+                  href={recentNavLink.href}
+                  footer={
+                    <>
+                      <EuiFlexGrid columns={2} gutterSize="s">
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="xs" color="default">
+                            {selectedSort === recentlyViewed
+                              ? i18n.translate(
+                                  'savedObjectsManagement.recentWorkSection.viewedAt',
+                                  {
+                                    defaultMessage: 'Viewed',
+                                  }
+                                )
+                              : i18n.translate(
+                                  'savedObjectsManagement.recentWorkSection.updatedAt',
+                                  {
+                                    defaultMessage: 'Updated',
+                                  }
+                                )}
+                            :{' '}
+                          </EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
+                          <EuiText size="xs" color="default">
+                            <b>
+                              {selectedSort === recentlyViewed
+                                ? moment(recentAccessItem?.lastAccessedTime).fromNow()
+                                : moment(recentAccessItem?.updatedAt).fromNow()}
+                            </b>
+                          </EuiText>
+                        </EuiFlexItem>
+
+                        {workspaceEnabled && (
+                          <>
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="xs" color="default">
+                                {i18n.translate(
+                                  'savedObjectsManagement.recentWorkSection.workspace',
+                                  {
+                                    defaultMessage: 'Workspace',
+                                  }
+                                )}
+                                :
+                              </EuiText>
+                            </EuiFlexItem>
+                            <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
+                              <EuiText size="xs" color="default">
+                                <b>{recentAccessItem.workspaceName || 'N/A'} </b>
+                              </EuiText>
+                            </EuiFlexItem>
+                          </>
+                        )}
+                      </EuiFlexGrid>
                     </>
                   }
                   onClick={recentNavLink.onClick}
@@ -262,15 +315,27 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
         </EuiFlexGroup>
       ) : (
         <EuiEmptyPrompt
+          icon={<EuiIcon size="l" type="layers" />}
           title={
             <h2>
               {i18n.translate('savedObjectsManagement.recentWorkSection.empty.title', {
-                defaultMessage: 'No recent work',
+                defaultMessage: 'No assets found',
               })}
             </h2>
           }
+          body={i18n.translate('savedObjectsManagement.recentWorkSection.empty.body', {
+            defaultMessage: "Asset's you've recently viewed or updated will appear here.",
+          })}
         />
       )}
+      <EuiSpacer size="m" />
+      <EuiLink target="_blank" onClick={() => core.application.navigateToApp(APP_ID)}>
+        <EuiText size="s" className="eui-displayInline">
+          {i18n.translate('home.list.card.view_all', {
+            defaultMessage: 'View all',
+          })}
+        </EuiText>
+      </EuiLink>
     </EuiPanel>
   );
 };

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
@@ -324,7 +324,7 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
             </h2>
           }
           body={i18n.translate('savedObjectsManagement.recentWorkSection.empty.body', {
-            defaultMessage: "Asset's you've recently viewed or updated will appear here.",
+            defaultMessage: "Assets you've recently viewed or updated will appear here.",
           })}
         />
       )}

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
@@ -175,7 +175,10 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
               <EuiToolTip
                 display="inlineBlock"
                 position="right"
-                content="Dashboards, visualizations, saved queries, and other assets within your Worksapces."
+                content={i18n.translate('savedObjectsManagement.recentWorkSection.assetsInfo', {
+                  defaultMessage:
+                    'Dashboards, visualizations, saved queries, and other assets within your Worksapces.',
+                })}
                 data-test-subj="assetsTooltip"
               >
                 <EuiIcon type="iInCircle" />

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
@@ -115,6 +115,10 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
     return options.map((option: string) => ({ label: option, value: option }));
   }, [detailedSavedObjects]);
 
+  const capitalTheFirstLetter = function (recentAccessItem: DetailedRecentlyAccessedItem) {
+    return recentAccessItem.type.charAt(0).toUpperCase() + recentAccessItem.type.slice(1);
+  };
+
   const itemsForDisplay = useMemo(() => {
     const sortedResult = [...detailedSavedObjects]
       .filter((item) => !item.error)
@@ -189,7 +193,7 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
         <EuiFlexItem grow={false}>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFilterGroup style={{ borderRadius: '5px' }}>
+              <EuiFilterGroup>
                 {[recentlyViewed, recentlyUpdated].map((item) => (
                   <EuiFilterButton
                     hasActiveFilters={selectedSort === item}
@@ -243,8 +247,7 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiText size="xs" color="subdued">
-                          {recentAccessItem.type.charAt(0).toUpperCase() +
-                            recentAccessItem.type.slice(1)}
+                          {capitalTheFirstLetter(recentAccessItem)}
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/src/plugins/saved_objects_management/public/plugin.ts
+++ b/src/plugins/saved_objects_management/public/plugin.ts
@@ -68,6 +68,8 @@ import { RecentWork } from './management_section/recent_work';
 import { HOME_CONTENT_AREAS } from '../../../plugins/home/public';
 import { getScopedBreadcrumbs } from '../../opensearch_dashboards_react/public';
 
+export const APP_ID = 'objects';
+
 export interface SavedObjectsManagementPluginSetup {
   actions: SavedObjectsManagementActionServiceSetup;
   columns: SavedObjectsManagementColumnServiceSetup;
@@ -141,7 +143,7 @@ export class SavedObjectsManagementPlugin
 
     const opensearchDashboardsSection = management.sections.section.opensearchDashboards;
     opensearchDashboardsSection.registerApp({
-      id: 'objects',
+      id: APP_ID,
       title: i18n.translate('savedObjectsManagement.managementSectionLabel', {
         defaultMessage: 'Saved objects',
       }),
@@ -160,7 +162,7 @@ export class SavedObjectsManagementPlugin
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
       core.application.register({
-        id: 'objects',
+        id: APP_ID,
         title: i18n.translate('savedObjectsManagement.assets.label', {
           defaultMessage: 'Assets',
         }),
@@ -187,14 +189,14 @@ export class SavedObjectsManagementPlugin
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
       {
-        id: 'objects',
+        id: APP_ID,
         order: 300,
       },
     ]);
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
       {
-        id: 'objects',
+        id: APP_ID,
         category: DEFAULT_APP_CATEGORIES.manage,
         order: 300,
       },
@@ -202,7 +204,7 @@ export class SavedObjectsManagementPlugin
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
       {
-        id: 'objects',
+        id: APP_ID,
         category: DEFAULT_APP_CATEGORIES.manage,
         order: 300,
       },
@@ -210,7 +212,7 @@ export class SavedObjectsManagementPlugin
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
       {
-        id: 'objects',
+        id: APP_ID,
         category: DEFAULT_APP_CATEGORIES.manage,
         order: 300,
       },
@@ -218,7 +220,7 @@ export class SavedObjectsManagementPlugin
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.essentials, [
       {
-        id: 'objects',
+        id: APP_ID,
         category: DEFAULT_APP_CATEGORIES.manage,
         order: 300,
       },
@@ -226,7 +228,7 @@ export class SavedObjectsManagementPlugin
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
       {
-        id: 'objects',
+        id: APP_ID,
         category: DEFAULT_APP_CATEGORIES.manage,
         order: 300,
       },


### PR DESCRIPTION
### Description

In this pr, I refractor the assets list in the homepage.

## Screenshot
1. empty state
![Screenshot 2024-08-14 at 14 46 45](https://github.com/user-attachments/assets/8b309299-56ac-4cc1-b54f-a4a58668cfec)

2. Look
![Screenshot 2024-08-14 at 14 47 35](https://github.com/user-attachments/assets/395dcaad-3785-445a-82e0-c0b562d32f57)

3. filtering
![Screenshot 2024-08-14 at 14 47 38](https://github.com/user-attachments/assets/879c138b-4e88-4b11-a8e7-a06d516d902c)
![Screenshot 2024-08-14 at 14 47 41](https://github.com/user-attachments/assets/76853926-cf33-409c-8e3e-dff0b23ae1b0)
![Screenshot 2024-08-14 at 14 47 43](https://github.com/user-attachments/assets/33c8f288-362e-4661-bd8b-e1dc60ffa924)

4. Title tooltip
![Screenshot 2024-08-14 at 14 46 48](https://github.com/user-attachments/assets/b2a1bd5a-29f4-44a5-8d14-bf6b14cc53fc)

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: refractor the homepage assets list section

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
