### PR TITLE
Simplify `TopNavControlDescriptionData` to to be followed by links

### DIFF
--- a/changelogs/fragments/7723.yml
+++ b/changelogs/fragments/7723.yml
@@ -1,0 +1,2 @@
+feat:
+- Simplify `TopNavControlDescriptionData` to to be followed by links ([#7723](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7723))

--- a/src/core/public/chrome/ui/header/header_controls_container.scss
+++ b/src/core/public/chrome/ui/header/header_controls_container.scss
@@ -16,6 +16,7 @@
 
   &.headerBottomControl {
     padding: $euiSizeM;
+    max-width: 725px;
   }
 
   &:empty {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_control_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_control_data.tsx
@@ -78,6 +78,7 @@ export interface TopNavControlTextData {
 
 export interface TopNavControlDescriptionData {
   description: string;
+  links?: TopNavControlLinkData | TopNavControlLinkData[];
 }
 
 export interface TopNavControlComponentData {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_control_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_control_item.tsx
@@ -46,9 +46,14 @@ export function TopNavControlItem(props: TopNavControlData) {
   }
 
   if ('description' in props) {
+    const links = props.links && [props.links].flat();
+
     return (
       <EuiText className="descriptionHeaderControl" size="s">
         {props.description}
+        {links?.map((linkProps) => (
+          <TopNavControlItem {...linkProps} />
+        ))}
       </EuiText>
     );
   }


### PR DESCRIPTION
### Description

Simplify `TopNavControlDescriptionData` to to be followed by links


## Changelog
- feat: Simplify `TopNavControlDescriptionData` to to be followed by links

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
