### PR TITLE
Update Recent popover to always render breadcrumbs with full length

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -8613,7 +8613,6 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                         }
                       }
                       buttonSize="s"
-                      headerVariant="application"
                       navLinks$={
                         BehaviorSubject {
                           "_isScalar": false,
@@ -8867,6 +8866,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                               "thrownError": null,
                             }
                           }
+                          renderFullLength={true}
                           useUpdatedHeader={true}
                         />
                       }
@@ -17371,6 +17371,7 @@ exports[`Header renders page header with application title 1`] = `
                               "thrownError": null,
                             }
                           }
+                          renderFullLength={true}
                           useUpdatedHeader={true}
                         />
                       }

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -209,12 +209,13 @@ export function Header({
     />
   );
 
-  const renderBreadcrumbs = () => (
+  const renderBreadcrumbs = (renderFullLength?: boolean) => (
     <HeaderBreadcrumbs
       appTitle$={observables.appTitle$}
       breadcrumbs$={observables.breadcrumbs$}
       breadcrumbsEnricher$={observables.breadcrumbsEnricher$}
       useUpdatedHeader={useUpdatedHeader}
+      renderFullLength={renderFullLength}
     />
   );
 
@@ -355,8 +356,7 @@ export function Header({
         navigateToUrl={application.navigateToUrl}
         navLinks$={observables.navLinks$}
         basePath={basePath}
-        headerVariant={headerVariant}
-        renderBreadcrumbs={renderBreadcrumbs()}
+        renderBreadcrumbs={renderBreadcrumbs(true)}
         buttonSize={useApplicationHeader ? 's' : 'xs'}
       />
     </EuiHeaderSectionItem>

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -41,6 +41,7 @@ interface Props {
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
   breadcrumbsEnricher$: Observable<ChromeBreadcrumbEnricher | undefined>;
   useUpdatedHeader?: boolean;
+  renderFullLength?: boolean;
 }
 
 export function HeaderBreadcrumbs({
@@ -48,6 +49,7 @@ export function HeaderBreadcrumbs({
   breadcrumbs$,
   breadcrumbsEnricher$,
   useUpdatedHeader,
+  renderFullLength,
 }: Props) {
   const appTitle = useObservable(appTitle$, 'OpenSearch Dashboards');
   const breadcrumbs = useObservable(breadcrumbs$, []);
@@ -87,7 +89,7 @@ export function HeaderBreadcrumbs({
 
   return (
     <EuiHeaderBreadcrumbs
-      breadcrumbs={remainingCrumbs}
+      breadcrumbs={renderFullLength ? crumbs : remainingCrumbs}
       max={10}
       data-test-subj="breadcrumbs"
       className={className}

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -17,7 +17,7 @@ import {
   EuiHeaderSectionItemButtonProps,
 } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
-import { ChromeRecentlyAccessedHistoryItem, HeaderVariant } from '../..';
+import { ChromeRecentlyAccessedHistoryItem } from '../..';
 import { WorkspaceObject } from '../../../workspace';
 import { createRecentNavLink } from './nav_link';
 import { HttpStart } from '../../../http';
@@ -30,7 +30,6 @@ export interface Props {
   navigateToUrl: (url: string) => Promise<void>;
   basePath: HttpStart['basePath'];
   navLinks$: Rx.Observable<ChromeNavLink[]>;
-  headerVariant?: HeaderVariant;
   renderBreadcrumbs: React.JSX.Element;
   buttonSize?: EuiHeaderSectionItemButtonProps['size'];
 }
@@ -41,7 +40,6 @@ export const RecentItems = ({
   navigateToUrl,
   navLinks$,
   basePath,
-  headerVariant,
   renderBreadcrumbs,
   buttonSize = 's',
 }: Props) => {
@@ -69,8 +67,6 @@ export const RecentItems = ({
     setIsPopoverOpen(false);
   };
 
-  const appendBreadcrumbs = Boolean(headerVariant === HeaderVariant.APPLICATION);
-
   return (
     <EuiPopover
       button={
@@ -95,12 +91,8 @@ export const RecentItems = ({
       initialFocus={false}
       panelPaddingSize="s"
     >
-      {appendBreadcrumbs ? (
-        <>
-          {renderBreadcrumbs}
-          <EuiSpacer size="s" />
-        </>
-      ) : null}
+      {renderBreadcrumbs}
+      <EuiSpacer size="s" />
 
       <EuiTitle size="xxs">
         <h4>Recents</h4>


### PR DESCRIPTION
### Description
Update Recent popover to always render breadcrumbs with full length, no matter of header variants. While for page header, also keep the existing breadcrumbs on the top, with last leaf cut off
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/0c4c32e6-5668-4566-8225-89a698de4ce5


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
