### PR TITLE
[1.3][CVE-2024-28849] Bump follow-redirects from `1.15.2` to `1.15.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "**/ejs": "^3.1.6",
     "**/express": "^4.18.0",
     "**/flat": "^5.0.2",
-    "**/follow-redirects": "^1.15.2",
+    "**/follow-redirects": "^1.15.6",
     "**/front-matter": "^4.0.2",
     "**/glob-parent": "^6.0.2",
     "**/highlight.js": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9743,10 +9743,10 @@ focus-trap@^2.0.1:
   dependencies:
     tabbable "^1.0.3"
 
-follow-redirects@1.12.1, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.9, follow-redirects@^1.15.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+follow-redirects@1.12.1, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.9, follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 font-awesome@4.7.0:
   version "4.7.0"


### PR DESCRIPTION
### Issues Resolved
CVE-2024-28849

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
