### PR TITLE
[discover] update interfaces and move dataset manager

### DIFF
--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -138,7 +138,7 @@ export enum DATA_STRUCTURE_META_TYPES {
 /**
  * Metadata for a data structure, used for additional properties like icons or tooltips.
  */
-export interface DataStructureFeatureMeta extends DataSourceMeta {
+export interface DataStructureFeatureMeta extends DataStructureMeta {
   type: DATA_STRUCTURE_META_TYPES.FEATURE;
   icon: string;
   tooltip: string;

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -36,7 +36,7 @@ export interface DataSourceMeta {
  * const openSearchCluster: DataStructure = {
  *   id: "b18e5f58-cf71-11ee-ad92-2468ce360004",
  *   title: "Production Cluster",
- *   type: "OPENSEARCH",
+ *   type: "DATA-SOURCE",
  *   children: [
  *     {
  *       id: "b18e5f58-cf71-11ee-ad92-2468ce360004::logs-2023.05",
@@ -58,7 +58,7 @@ export interface DataSourceMeta {
  * const s3DataSource: DataStructure = {
  *   id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003",
  *   title: "mys3",
- *   type: "S3,
+ *   type: "DATA-SOURCE",
  *   children: [
  *     {
  *       id: "mys3.defaultDb",

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -31,52 +31,74 @@ export interface DataSourceMeta {
  * Represents the hierarchical structure of data within a data source.
  *
  * @example
- * Example of an OpenSearch cluster with indices
  *
  * const openSearchCluster: DataStructure = {
  *   id: "b18e5f58-cf71-11ee-ad92-2468ce360004",
- *   title: "Production Cluster",
- *   type: "DATA-SOURCE",
+ *   title: "Data Cluster1",
+ *   type: "DATA_SOURCE",
  *   children: [
  *     {
  *       id: "b18e5f58-cf71-11ee-ad92-2468ce360004::logs-2023.05",
  *       title: "logs-2023.05",
  *       type: "INDEX",
- *       parent: { id: "b18e5f58-cf71-11ee-ad92-2468ce360004", title: "Production Cluster", type: "OPENSEARCH" }
+ *       parent: { id: "b18e5f58-cf71-11ee-ad92-2468ce360004", title: "Data Cluster1", type: "DATA_SOURCE" },
+ *       meta: {
+ *         type: 'FEATURE',
+ *         icon: 'indexIcon',
+ *         tooltip: 'Logs from May 2023'
+ *       }
  *     },
  *     {
  *       id: "b18e5f58-cf71-11ee-ad92-2468ce360004::logs-2023.06",
  *       title: "logs-2023.06",
  *       type: "INDEX",
- *       parent: { id: "b18e5f58-cf71-11ee-ad92-2468ce360004", title: "Production Cluster", type: "OPENSEARCH" }
+ *       parent: { id: "b18e5f58-cf71-11ee-ad92-2468ce360004", title: "Data Cluster1", type: "DATA_SOURCE" },
+ *       meta: {
+ *         type: 'FEATURE',
+ *         icon: 'indexIcon',
+ *         tooltip: 'Logs from June 2023'
+ *       }
  *     }
- *   ]
+ *   ],
+ *   meta: {
+ *     type: 'FEATURE',
+ *     icon: 'clusterIcon',
+ *     tooltip: 'OpenSearch Cluster'
+ *   }
  * };
  *
- * Example of an S3 data source with a database and tables:
+ * Example of an S3 data source with a connection, database, and tables:
  *
  * const s3DataSource: DataStructure = {
  *   id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003",
- *   title: "mys3",
- *   type: "DATA-SOURCE",
+ *   title: "Flint MDS cluster name",
+ *   type: "DATA_SOURCE",
  *   children: [
  *     {
- *       id: "mys3.defaultDb",
- *       title: "defaultDb",
- *       type: "DATABASE",
- *       parent: { id: "myS3", title: "My S3 Bucket", type: "S3" },
+ *       id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3",
+ *       title: "mys3",
+ *       type: "CONNECTION",
+ *       parent: { id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003", title: "Flint MDS cluster name", type: "DATA_SOURCE" },
  *       children: [
  *         {
- *           id: "mys3.defaultDb.table1",
- *           title: "table1",
- *           type: "TABLE",
- *           parent: { id: "sales-db", title: "Sales Database", type: "DATABASE" }
- *         },
- *         {
- *           id: "mys3.defaultDb.table2",
- *           title: "table2",
- *           type: "TABLE",
- *           parent: { id: "sales-db", title: "Sales Database", type: "DATABASE" }
+ *           id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3.defaultDb",
+ *           title: "defaultDb",
+ *           type: "DATABASE",
+ *           parent: { id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3", title: "mys3", type: "CONNECTION" },
+ *           children: [
+ *             {
+ *               id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3.defaultDb.table1",
+ *               title: "table1",
+ *               type: "TABLE",
+ *               parent: { id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3.defaultDb", title: "defaultDb", type: "DATABASE" }
+ *             },
+ *             {
+ *               id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3.defaultDb.table2",
+ *               title: "table2",
+ *               type: "TABLE",
+ *               parent: { id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003::mys3.defaultDb", title: "defaultDb", type: "DATABASE" }
+ *             }
+ *           ]
  *         }
  *       ]
  *     }
@@ -88,12 +110,69 @@ export interface DataStructure {
   id: string;
   /** Human-readable name of the data structure */
   title: string;
-  /** The type of the data structure, registered by other classes */
+  /** The type of the data structure */
   type: string;
   /** Optional reference to the parent data structure */
   parent?: DataStructure;
   /** Optional array of child data structures */
   children?: DataStructure[];
+  /** Optional metadata for the data structure */
+  meta?: DataStructureMeta;
+}
+
+/**
+ * Metadata for a data structure, used for additional properties like icons or tooltips.
+ */
+export interface DataStructureMeta {
+  type: DATA_STRUCTURE_META_TYPES;
+}
+
+/**
+ * DataStructureMeta types
+ */
+export enum DATA_STRUCTURE_META_TYPES {
+  FEATURE = 'FEATURE',
+  CUSTOM = 'CUSTOM',
+}
+
+/**
+ * Metadata for a data structure, used for additional properties like icons or tooltips.
+ */
+export interface DataStructureFeatureMeta extends DataSourceMeta {
+  type: DATA_STRUCTURE_META_TYPES.FEATURE;
+  icon: string;
+  tooltip: string;
+}
+
+/**
+ * Metadata for a data structure with CUSTOM type, allowing any additional fields.
+ */
+export interface DataStructureCustomMeta extends DataStructureMeta {
+  type: DATA_STRUCTURE_META_TYPES.CUSTOM;
+  [key: string]: any;
+}
+
+/**
+ * Represents a cached version of DataStructure with string references instead of object references.
+ *
+ * @example
+ *
+ * const cachedOpenSearchCluster: CachedDataStructure = {
+ *   id: "b18e5f58-cf71-11ee-ad92-2468ce360004",
+ *   title: "Data Cluster1",
+ *   type: "DATA_SOURCE",
+ *   parent: "",
+ *   children: [
+ *     "b18e5f58-cf71-11ee-ad92-2468ce360004::logs-2023.05",
+ *     "b18e5f58-cf71-11ee-ad92-2468ce360004::logs-2023.06"
+ *   ]
+ * };
+ */
+export interface CachedDataStructure extends Omit<DataStructure, 'parent' | 'children' | 'meta'> {
+  /** ID of the parent data structure */
+  parent: string;
+  /** Array of child data structure IDs */
+  children: string[];
 }
 
 /**
@@ -103,7 +182,7 @@ export interface DataStructure {
  * have similar titles and the data plugin assumes unique data set IDs.
  *
  * @example
- * Example of a Dataset for an OpenSearch index
+ * Example of a Dataset for an OpenSearch index pattern
  * const logsIndexDataset: Dataset = {
  *   id: "2e1b1b80-9c4d-11ee-8c90-0242ac120001",
  *   title: "logs-*",
@@ -112,7 +191,7 @@ export interface DataStructure {
  *   dataSource: {
  *     id: "main-cluster",
  *     title: "Main OpenSearch Cluster",
- *     type: "DEFAULT"
+ *     type: "OPENSEARCH"
  *   },
  * };
  *
@@ -126,7 +205,7 @@ export interface DataStructure {
  *   dataSource: {
  *     id: "7d5c3e1c-ae5f-11ee-9c91-1357bd240003",
  *     title: "My S3 Connect",
- *     type: "EXAMPLE_DATASOURCE"
+ *     type: "S3_GLUE"
  *   },
  * };
  */

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -462,8 +462,6 @@ export {
   QueryState,
   getDefaultQuery,
   FilterManager,
-  DataSetManager,
-  DataSetContract,
   SavedQuery,
   SavedQueryService,
   SavedQueryTimeFilter,

--- a/src/plugins/data/public/query/index.tsx
+++ b/src/plugins/data/public/query/index.tsx
@@ -32,7 +32,7 @@ export * from './lib';
 
 export * from './query_service';
 export * from './filter_manager';
-export * from './dataset_manager';
+export * from './query_string/dataset_manager';
 export * from './timefilter';
 export * from './saved_query';
 export * from './persisted_log';

--- a/src/plugins/data/public/query/mocks.ts
+++ b/src/plugins/data/public/query/mocks.ts
@@ -33,7 +33,7 @@ import { QueryService, QuerySetup, QueryStart } from '.';
 import { timefilterServiceMock } from './timefilter/timefilter_service.mock';
 import { createFilterManagerMock } from './filter_manager/filter_manager.mock';
 import { queryStringManagerMock } from './query_string/query_string_manager.mock';
-import { dataSetManagerMock } from './dataset_manager/dataset_manager.mock';
+import { dataSetManagerMock } from './query_string/dataset_manager/dataset_manager.mock';
 
 type QueryServiceClientContract = PublicMethodsOf<QueryService>;
 

--- a/src/plugins/data/public/query/query_service.ts
+++ b/src/plugins/data/public/query/query_service.ts
@@ -37,7 +37,6 @@ import { TimefilterService, TimefilterSetup } from './timefilter';
 import { createSavedQueryService } from './saved_query/saved_query_service';
 import { createQueryStateObservable } from './state_sync/create_global_query_observable';
 import { QueryStringManager, QueryStringContract } from './query_string';
-import { DataSetContract, DataSetManager } from './dataset_manager';
 import { buildOpenSearchQuery, getOpenSearchQueryConfig, IndexPatternsService } from '../../common';
 import { getUiSettings } from '../services';
 import { IndexPattern } from '..';
@@ -63,7 +62,6 @@ export class QueryService {
   filterManager!: FilterManager;
   timefilter!: TimefilterSetup;
   queryStringManager!: QueryStringContract;
-  dataSetManager!: DataSetContract;
 
   state$!: ReturnType<typeof createQueryStateObservable>;
 
@@ -77,20 +75,19 @@ export class QueryService {
     });
 
     this.queryStringManager = new QueryStringManager(storage, uiSettings);
-    this.dataSetManager = new DataSetManager(uiSettings);
 
     this.state$ = createQueryStateObservable({
       filterManager: this.filterManager,
       timefilter: this.timefilter,
       queryString: this.queryStringManager,
-      dataSetManager: this.dataSetManager,
+      datasetManager: this.queryStringManager.getDatasetManager(),
     }).pipe(share());
 
     return {
       filterManager: this.filterManager,
       timefilter: this.timefilter,
       queryString: this.queryStringManager,
-      dataSetManager: this.dataSetManager,
+      datasetManager: this.queryStringManager.getDatasetManager(),
       state$: this.state$,
     };
   }
@@ -101,7 +98,7 @@ export class QueryService {
     uiSettings,
     indexPatterns,
   }: QueryServiceStartDependencies) {
-    this.dataSetManager.init(indexPatterns);
+    this.queryStringManager.getDatasetManager().init(indexPatterns);
     return {
       addToQueryLog: createAddToQueryLog({
         storage,
@@ -109,7 +106,7 @@ export class QueryService {
       }),
       filterManager: this.filterManager,
       queryString: this.queryStringManager,
-      dataSetManager: this.dataSetManager,
+      dataSetManager: this.queryStringManager.getDatasetManager(),
       savedQueries: createSavedQueryService(savedObjectsClient),
       state$: this.state$,
       timefilter: this.timefilter,

--- a/src/plugins/data/public/query/query_string/dataset_manager/dataset_manager.mock.ts
+++ b/src/plugins/data/public/query/query_string/dataset_manager/dataset_manager.mock.ts
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DataSetContract } from '.';
+import { DatasetContract } from '.';
 
 const createSetupContractMock = () => {
-  const dataSetManagerMock: jest.Mocked<DataSetContract> = {
+  const datasetManagerMock: jest.Mocked<DatasetContract> = {
     init: jest.fn(),
-    getDataSet: jest.fn(),
-    setDataSet: jest.fn(),
+    getDataset: jest.fn(),
+    setDataset: jest.fn(),
     getUpdates$: jest.fn(),
-    getDefaultDataSet: jest.fn(),
-    fetchDefaultDataSet: jest.fn(),
+    getDefaultDataset: jest.fn(),
+    fetchDefaultDataset: jest.fn(),
     initWithIndexPattern: jest.fn(),
   };
-  return dataSetManagerMock;
+  return datasetManagerMock;
 };
 
-export const dataSetManagerMock = {
+export const datasetManagerMock = {
   createSetupContract: createSetupContractMock,
   createStartContract: createSetupContractMock,
 };

--- a/src/plugins/data/public/query/query_string/dataset_manager/dataset_manager.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_manager/dataset_manager.test.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DataSetManager } from './dataset_manager';
-import { coreMock } from '../../../../../core/public/mocks';
-import { Dataset } from '../../../common';
+import { DatasetManager } from './dataset_manager';
+import { coreMock } from '../../../../../../core/public/mocks';
+import { Dataset } from '../../../../common';
 
 describe('DatasetManager', () => {
-  let service: DataSetManager;
+  let service: DatasetManager;
 
   beforeEach(() => {
     const uiSettingsMock = coreMock.createSetup().uiSettings;
     uiSettingsMock.get.mockReturnValue(true);
-    service = new DataSetManager(uiSettingsMock);
+    service = new DatasetManager(uiSettingsMock);
   });
 
   test('getUpdates$ is a cold emits only after dataset changes', () => {
@@ -25,16 +25,16 @@ describe('DatasetManager', () => {
     expect(emittedValues).toHaveLength(0);
     expect(emittedValues[0]).toEqual(undefined);
 
-    const newDataSet: Dataset = {
+    const newDataset: Dataset = {
       id: 'test_dataset',
       title: 'Test Dataset',
       type: 'INDEX_PATTERN',
     };
-    service.setDataSet(newDataSet);
+    service.setDataset(newDataset);
     expect(emittedValues).toHaveLength(1);
-    expect(emittedValues[0]).toEqual(newDataSet);
+    expect(emittedValues[0]).toEqual(newDataset);
 
-    service.setDataSet({ ...newDataSet });
+    service.setDataset({ ...newDataset });
     expect(emittedValues).toHaveLength(2);
   });
 });

--- a/src/plugins/data/public/query/query_string/dataset_manager/dataset_manager.ts
+++ b/src/plugins/data/public/query/query_string/dataset_manager/dataset_manager.ts
@@ -6,22 +6,22 @@
 import { BehaviorSubject } from 'rxjs';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { skip } from 'rxjs/operators';
-import { DEFAULT_QUERY, Dataset, DataSource, IndexPattern, UI_SETTINGS } from '../../../common';
-import { IndexPatternsContract } from '../../index_patterns';
+import { DEFAULT_QUERY, Dataset, DataSource, IndexPattern, UI_SETTINGS } from '../../../../common';
+import { IndexPatternsContract } from '../../../index_patterns';
 
-export class DataSetManager {
-  private dataSet$: BehaviorSubject<Dataset | undefined>;
+export class DatasetManager {
+  private dataset$: BehaviorSubject<Dataset | undefined>;
   private indexPatterns?: IndexPatternsContract;
-  private defaultDataSet?: Dataset;
+  private defaultDataset?: Dataset;
 
   constructor(private readonly uiSettings: CoreStart['uiSettings']) {
-    this.dataSet$ = new BehaviorSubject<Dataset | undefined>(undefined);
+    this.dataset$ = new BehaviorSubject<Dataset | undefined>(undefined);
   }
 
   public init = async (indexPatterns: IndexPatternsContract) => {
     if (!this.uiSettings.get(UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED)) return;
     this.indexPatterns = indexPatterns;
-    this.defaultDataSet = await this.fetchDefaultDataSet();
+    this.defaultDataset = await this.fetchDefaultDataset();
   };
 
   public initWithIndexPattern = (indexPattern: IndexPattern | null) => {
@@ -30,7 +30,7 @@ export class DataSetManager {
       return undefined;
     }
 
-    this.defaultDataSet = {
+    this.defaultDataset = {
       id: indexPattern.id,
       title: indexPattern.title,
       type: DEFAULT_QUERY.DATASET_TYPE,
@@ -48,27 +48,27 @@ export class DataSetManager {
   };
 
   public getUpdates$ = () => {
-    return this.dataSet$.asObservable().pipe(skip(1));
+    return this.dataset$.asObservable().pipe(skip(1));
   };
 
-  public getDataSet = () => {
-    return this.dataSet$.getValue();
+  public getDataset = () => {
+    return this.dataset$.getValue();
   };
 
   /**
    * Updates the query.
    * @param {Query} query
    */
-  public setDataSet = (dataSet: Dataset | undefined) => {
+  public setDataset = (dataSet: Dataset | undefined) => {
     if (!this.uiSettings.get(UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED)) return;
-    this.dataSet$.next(dataSet);
+    this.dataset$.next(dataSet);
   };
 
-  public getDefaultDataSet = () => {
-    return this.defaultDataSet;
+  public getDefaultDataset = () => {
+    return this.defaultDataset;
   };
 
-  public fetchDefaultDataSet = async (): Promise<Dataset | undefined> => {
+  public fetchDefaultDataset = async (): Promise<Dataset | undefined> => {
     const defaultIndexPatternId = this.uiSettings.get('defaultIndex');
     if (!defaultIndexPatternId) {
       return undefined;
@@ -97,4 +97,4 @@ export class DataSetManager {
   };
 }
 
-export type DataSetContract = PublicMethodsOf<DataSetManager>;
+export type DatasetContract = PublicMethodsOf<DatasetManager>;

--- a/src/plugins/data/public/query/query_string/dataset_manager/index.ts
+++ b/src/plugins/data/public/query/query_string/dataset_manager/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { DataSetContract, DataSetManager } from './dataset_manager';
+export { DatasetContract, DatasetManager } from './dataset_manager';

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -33,15 +33,18 @@ import { skip } from 'rxjs/operators';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { IStorageWrapper } from 'src/plugins/opensearch_dashboards_utils/public';
 import { Query, UI_SETTINGS } from '../../../common';
+import { DatasetContract, DatasetManager } from './dataset_manager';
 
 export class QueryStringManager {
   private query$: BehaviorSubject<Query>;
+  private datasetManager!: DatasetContract;
 
   constructor(
     private readonly storage: IStorageWrapper,
     private readonly uiSettings: CoreStart['uiSettings']
   ) {
     this.query$ = new BehaviorSubject<Query>(this.getDefaultQuery());
+    this.datasetManager = new DatasetManager(uiSettings);
   }
 
   private getDefaultQueryString() {
@@ -100,6 +103,42 @@ export class QueryStringManager {
   public clearQuery = () => {
     this.setQuery(this.getDefaultQuery());
   };
+
+  /**
+   * TODO: verify if we want to just access the dataset manager directly or access each function
+   */
+  public getDatasetManager = () => {
+    return this.datasetManager;
+  };
+
+  // TODO: uncomment or use based on decision above
+  // public initDataset = async (indexPatterns: IndexPatternsContract) => {
+  //   return this.datasetManager.init(indexPatterns);
+  // };
+
+  // public initDatasetWithIndexPattern = (indexPattern: IndexPattern | null) => {
+  //   return this.datasetManager.initWithIndexPattern(indexPattern);
+  // };
+
+  // public getDatasetUpdates$ = () => {
+  //   return this.datasetManager.getUpdates$();
+  // };
+
+  // public getDataset = () => {
+  //   return this.datasetManager.getDataset();
+  // };
+
+  // public setDataset = (dataset: Dataset | undefined) => {
+  //   return this.datasetManager.setDataset(dataset);
+  // };
+
+  // public getDefaultDataset = () => {
+  //   return this.datasetManager.getDefaultDataset();
+  // };
+
+  // public fetchDefaultDataset = async (): Promise<Dataset | undefined> => {
+  //   return this.datasetManager.fetchDefaultDataset();
+  // };
 }
 
 export type QueryStringContract = PublicMethodsOf<QueryStringManager>;

--- a/src/plugins/data/public/query/state_sync/types.ts
+++ b/src/plugins/data/public/query/state_sync/types.ts
@@ -38,6 +38,8 @@ export interface QueryState {
   refreshInterval?: RefreshInterval;
   filters?: Filter[];
   query?: Query;
+  // TODO: remove once query object correctly has dataset
+  dataset?: Dataset;
 }
 
 type QueryStateChangePartial = {


### PR DESCRIPTION
Updating the discover interfaces and move dataset manager into the proper location within the querystring manager.

![datastructure](https://github.com/user-attachments/assets/28eeb397-59a4-45c8-b580-d20abb7cd4f6)

![cached-datastructure](https://github.com/user-attachments/assets/824b66db-5ee9-46d4-8cd2-aebdcefbba48)

