### PR TITLE
[Workspace]fix the parameter misalignment error in the workspace_detail_page

### DIFF
--- a/changelogs/fragments/7768.yml
+++ b/changelogs/fragments/7768.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix the parameter misalignment in the workspace_detail_page ([#7768](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7768))

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_detail.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_detail.tsx
@@ -187,7 +187,7 @@ export const WorkspaceDetail = (props: WorkspaceDetailProps) => {
         </EuiPageBody>
         {deletedWorkspace && (
           <DeleteWorkspaceModal
-            selectedWorkspace={deletedWorkspace}
+            selectedWorkspaces={[deletedWorkspace]}
             onClose={() => setDeletedWorkspace(null)}
             onDeleteSuccess={() => {
               window.setTimeout(() => {


### PR DESCRIPTION
### Description
This pr address the bug in the workspace_detail_page, which due to the change of parameter declaration in delete_workspace_modal

## Changelog
- fix: fix the parameter misalignment in the workspace_detail_page

<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
