### PR TITLE
Support overriding theme through URL search parameter

### DIFF
--- a/changelogs/fragments/7791.yml
+++ b/changelogs/fragments/7791.yml
@@ -1,0 +1,2 @@
+feat:
+- Support overriding theme through URL search parameter ([#7791](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7791))

--- a/src/legacy/ui/ui_render/bootstrap/startup.js.hbs
+++ b/src/legacy/ui/ui_render/bootstrap/startup.js.hbs
@@ -14,12 +14,7 @@ try {
   if (!urlThemeParam && window.location.hash.includes('?')) {
     urlThemeParam = new URLSearchParams(window.location.hash.split('?')[1]).get('theme');
   }
-  if (
-    urlThemeParam !== null &&
-    urlThemeParam !== 'dark' &&
-    urlThemeParam !== 'light' &&
-    urlThemeParam !== 'browser'
-  ) {
+  if (![null, 'dark', 'light', 'browser'].includes(urlThemeParam)) {
     throw new Error('theme must be "browser", "light", or "dark", received ' + urlThemeParam);
     urlThemeParam = null;
   }

--- a/src/legacy/ui/ui_render/bootstrap/startup.js.hbs
+++ b/src/legacy/ui/ui_render/bootstrap/startup.js.hbs
@@ -7,16 +7,41 @@ try {
   window.console.log(error);
 }
 
-var useBrowserColorScheme = window.localStorage.getItem('useBrowserColorScheme') === 'true' || false;
+/** @type {'browser' | 'light' | 'dark' | null} */
+var urlThemeParam = null;
+try {
+  urlThemeParam = new URLSearchParams(window.location.search).get('theme');
+  if (!urlThemeParam && window.location.hash.includes('?')) {
+    urlThemeParam = new URLSearchParams(window.location.hash.split('?')[1]).get('theme');
+  }
+  if (
+    urlThemeParam !== null &&
+    urlThemeParam !== 'dark' &&
+    urlThemeParam !== 'light' &&
+    urlThemeParam !== 'browser'
+  ) {
+    throw new Error('theme must be "browser", "light", or "dark", received ' + urlThemeParam);
+    urlThemeParam = null;
+  }
+} catch (error) {
+  window.console.warn('Failed to parse "theme" parameter in URL', error);
+}
 
-var browserDarkMode = uiSettings['theme:darkMode'] || {};
+var useBrowserColorScheme =
+  urlThemeParam === 'browser' ||
+  window.localStorage.getItem('useBrowserColorScheme') === 'true' ||
+  false;
+
+var browserDarkMode = urlThemeParam
+  ? { userValue: urlThemeParam === 'dark' }
+  : uiSettings['theme:darkMode'] || {};
 var browserThemeVersion = uiSettings['theme:version'] || {};
 
 var rawDarkMode = typeof browserDarkMode.userValue !== 'boolean' ? {{configDarkMode}} : browserDarkMode.userValue;
 
 var rawThemeVersion = browserThemeVersion.userValue || '{{configThemeVersion}}'
 
-if ({{configEnableUserControl}}) {
+if (urlThemeParam || {{configEnableUserControl}}) {
   if (useBrowserColorScheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches !==
   rawDarkMode) {
     uiSettings['theme:darkMode'] = window.matchMedia('(prefers-color-scheme: dark)').matches;


### PR DESCRIPTION
### Description

This PR allows theme to be overridden by search parameter.

- If `theme` is `dark`, OSD sets theme to dark. 
- If `theme` is `browser`, OSD sets theme to match browser. 
- If `theme` is `light`, OSD sets theme to light. 
- If `theme` is absent or any other value, OSD behavior does not change.

Theme can be a search param in either `location.search` or `location.hash`. For example

- `http://localhost:5601/app/home#/?theme=dark`
- `http://localhost:5601/app/management?theme=light`
- `http://localhost:5601/app/home?theme=browser#/?theme=dark`
  - it will prioritize the value in search param over hash, so theme will be browser

This override will only be in-effect if the parameter is present in the URL. It only changes the actual theme and does not change theme selection on UI. This is more for the `embed`ed use case and not a user facing feature.

This PR depends on #5652. The handlebars files don't seem to have tests, will add tests for 5652 in general later.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: support overriding theme through URL search parameter

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
