### PR TITLE
Fix new header allowing their single-child's overflowing

### DIFF
--- a/changelogs/fragments/7796.yml
+++ b/changelogs/fragments/7796.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix new header allowing their single-child's overflowing ([#7796](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7796))

--- a/src/core/public/chrome/ui/header/header.scss
+++ b/src/core/public/chrome/ui/header/header.scss
@@ -49,6 +49,10 @@
   & > .euiHeaderSection {
     gap: $euiSizeS;
 
+    &:only-child {
+      width: 100%;
+    }
+
     // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
     & > .euiHeaderSectionItem:empty {
       display: none;


### PR DESCRIPTION
### Description

Fix new header allowing their single-child's overflowing


## Changelog
- fix: Fix new header allowing their single-child's overflowing

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
