### PR TITLE
[Workspace] Refactor the style of recent items card in the header

### DIFF
--- a/changelogs/fragments/7805.yml
+++ b/changelogs/fragments/7805.yml
@@ -1,0 +1,2 @@
+feat:
+- Refractor the style of recent items card ([#7805](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7805))

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -43,7 +43,6 @@ import {
 } from 'rxjs';
 import { flatMap, map, takeUntil } from 'rxjs/operators';
 import { EuiLink } from '@elastic/eui';
-import { CoreStart } from 'opensearch-dashboards/public';
 import { mountReactNode } from '../utils/mount';
 import { InternalApplicationStart } from '../application';
 import { DocLinksStart } from '../doc_links';
@@ -116,7 +115,6 @@ export interface StartDeps {
   application: InternalApplicationStart;
   docLinks: DocLinksStart;
   http: HttpStart;
-  // core: CoreStart;
   injectedMetadata: InjectedMetadataStart;
   notifications: NotificationsStart;
   uiSettings: IUiSettingsClient;

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -43,6 +43,7 @@ import {
 } from 'rxjs';
 import { flatMap, map, takeUntil } from 'rxjs/operators';
 import { EuiLink } from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
 import { mountReactNode } from '../utils/mount';
 import { InternalApplicationStart } from '../application';
 import { DocLinksStart } from '../doc_links';
@@ -115,6 +116,7 @@ export interface StartDeps {
   application: InternalApplicationStart;
   docLinks: DocLinksStart;
   http: HttpStart;
+  // core: CoreStart;
   injectedMetadata: InjectedMetadataStart;
   notifications: NotificationsStart;
   uiSettings: IUiSettingsClient;
@@ -349,6 +351,7 @@ export class ChromeService {
 
       getHeaderComponent: () => (
         <Header
+          http={http}
           loadingCount$={http.getLoadingCount$()}
           application={application}
           appTitle$={appTitle$.pipe(takeUntil(this.stop$))}

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -1397,6 +1397,34 @@ exports[`Header handles visibility and lock changes 1`] = `
     }
   }
   homeHref="/"
+  http={
+    Object {
+      "addLoadingCountSource": [MockFunction],
+      "anonymousPaths": Object {
+        "isAnonymous": [MockFunction],
+        "register": [MockFunction],
+      },
+      "basePath": BasePath {
+        "basePath": "/test",
+        "clientBasePath": "",
+        "get": [Function],
+        "getBasePath": [Function],
+        "prepend": [Function],
+        "remove": [Function],
+        "serverBasePath": "/test",
+      },
+      "delete": [MockFunction],
+      "fetch": [MockFunction],
+      "get": [MockFunction],
+      "getLoadingCount$": [MockFunction],
+      "head": [MockFunction],
+      "intercept": [MockFunction],
+      "options": [MockFunction],
+      "patch": [MockFunction],
+      "post": [MockFunction],
+      "put": [MockFunction],
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -7759,6 +7787,34 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
     }
   }
   homeHref="/"
+  http={
+    Object {
+      "addLoadingCountSource": [MockFunction],
+      "anonymousPaths": Object {
+        "isAnonymous": [MockFunction],
+        "register": [MockFunction],
+      },
+      "basePath": BasePath {
+        "basePath": "/test",
+        "clientBasePath": "",
+        "get": [Function],
+        "getBasePath": [Function],
+        "prepend": [Function],
+        "remove": [Function],
+        "serverBasePath": "/test",
+      },
+      "delete": [MockFunction],
+      "fetch": [MockFunction],
+      "get": [MockFunction],
+      "getLoadingCount$": [MockFunction],
+      "head": [MockFunction],
+      "intercept": [MockFunction],
+      "options": [MockFunction],
+      "patch": [MockFunction],
+      "post": [MockFunction],
+      "put": [MockFunction],
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -8234,43 +8290,6 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
           "syncErrorThrown": false,
           "syncErrorValue": null,
         },
-        Subscriber {
-          "_parentOrParents": null,
-          "_subscriptions": Array [
-            SubjectSubscription {
-              "_parentOrParents": [Circular],
-              "_subscriptions": null,
-              "closed": false,
-              "subject": [Circular],
-              "subscriber": [Circular],
-            },
-          ],
-          "closed": false,
-          "destination": SafeSubscriber {
-            "_complete": undefined,
-            "_context": [Circular],
-            "_error": undefined,
-            "_next": [Function],
-            "_parentOrParents": null,
-            "_parentSubscriber": [Circular],
-            "_subscriptions": null,
-            "closed": false,
-            "destination": Object {
-              "closed": true,
-              "complete": [Function],
-              "error": [Function],
-              "next": [Function],
-            },
-            "isStopped": false,
-            "syncErrorThrowable": false,
-            "syncErrorThrown": false,
-            "syncErrorValue": null,
-          },
-          "isStopped": false,
-          "syncErrorThrowable": true,
-          "syncErrorThrown": false,
-          "syncErrorValue": null,
-        },
       ],
       "thrownError": null,
     }
@@ -8605,102 +8624,33 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                     className="euiHeaderSectionItem"
                   >
                     <RecentItems
-                      basePath={
-                        BasePath {
-                          "basePath": "/test",
-                          "clientBasePath": "",
-                          "get": [Function],
-                          "getBasePath": [Function],
-                          "prepend": [Function],
-                          "remove": [Function],
-                          "serverBasePath": "/test",
-                        }
-                      }
                       buttonSize="s"
-                      navLinks$={
-                        BehaviorSubject {
-                          "_isScalar": false,
-                          "_value": Array [],
-                          "closed": false,
-                          "hasError": false,
-                          "isStopped": false,
-                          "observers": Array [
-                            Subscriber {
-                              "_parentOrParents": null,
-                              "_subscriptions": Array [
-                                SubjectSubscription {
-                                  "_parentOrParents": [Circular],
-                                  "_subscriptions": null,
-                                  "closed": false,
-                                  "subject": [Circular],
-                                  "subscriber": [Circular],
-                                },
-                              ],
-                              "closed": false,
-                              "destination": SafeSubscriber {
-                                "_complete": undefined,
-                                "_context": [Circular],
-                                "_error": undefined,
-                                "_next": [Function],
-                                "_parentOrParents": null,
-                                "_parentSubscriber": [Circular],
-                                "_subscriptions": null,
-                                "closed": false,
-                                "destination": Object {
-                                  "closed": true,
-                                  "complete": [Function],
-                                  "error": [Function],
-                                  "next": [Function],
-                                },
-                                "isStopped": false,
-                                "syncErrorThrowable": false,
-                                "syncErrorThrown": false,
-                                "syncErrorValue": null,
-                              },
-                              "isStopped": false,
-                              "syncErrorThrowable": true,
-                              "syncErrorThrown": false,
-                              "syncErrorValue": null,
-                            },
-                            Subscriber {
-                              "_parentOrParents": null,
-                              "_subscriptions": Array [
-                                SubjectSubscription {
-                                  "_parentOrParents": [Circular],
-                                  "_subscriptions": null,
-                                  "closed": false,
-                                  "subject": [Circular],
-                                  "subscriber": [Circular],
-                                },
-                              ],
-                              "closed": false,
-                              "destination": SafeSubscriber {
-                                "_complete": undefined,
-                                "_context": [Circular],
-                                "_error": undefined,
-                                "_next": [Function],
-                                "_parentOrParents": null,
-                                "_parentSubscriber": [Circular],
-                                "_subscriptions": null,
-                                "closed": false,
-                                "destination": Object {
-                                  "closed": true,
-                                  "complete": [Function],
-                                  "error": [Function],
-                                  "next": [Function],
-                                },
-                                "isStopped": false,
-                                "syncErrorThrowable": false,
-                                "syncErrorThrown": false,
-                                "syncErrorValue": null,
-                              },
-                              "isStopped": false,
-                              "syncErrorThrowable": true,
-                              "syncErrorThrown": false,
-                              "syncErrorValue": null,
-                            },
-                          ],
-                          "thrownError": null,
+                      http={
+                        Object {
+                          "addLoadingCountSource": [MockFunction],
+                          "anonymousPaths": Object {
+                            "isAnonymous": [MockFunction],
+                            "register": [MockFunction],
+                          },
+                          "basePath": BasePath {
+                            "basePath": "/test",
+                            "clientBasePath": "",
+                            "get": [Function],
+                            "getBasePath": [Function],
+                            "prepend": [Function],
+                            "remove": [Function],
+                            "serverBasePath": "/test",
+                          },
+                          "delete": [MockFunction],
+                          "fetch": [MockFunction],
+                          "get": [MockFunction],
+                          "getLoadingCount$": [MockFunction],
+                          "head": [MockFunction],
+                          "intercept": [MockFunction],
+                          "options": [MockFunction],
+                          "patch": [MockFunction],
+                          "post": [MockFunction],
+                          "put": [MockFunction],
                         }
                       }
                       navigateToUrl={[MockFunction]}
@@ -8928,7 +8878,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                         anchorPosition="downCenter"
                         button={
                           <EuiToolTip
-                            content="Recents"
+                            content="Recent"
                             delay="long"
                             position="bottom"
                           >
@@ -8951,7 +8901,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                         initialFocus={false}
                         isOpen={false}
                         ownFocus={true}
-                        panelPaddingSize="s"
+                        panelPaddingSize="m"
                         repositionOnScroll={true}
                       >
                         <div
@@ -8961,7 +8911,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                             className="euiPopover__anchor"
                           >
                             <EuiToolTip
-                              content="Recents"
+                              content="Recent"
                               delay="long"
                               position="bottom"
                             >
@@ -9511,43 +9461,6 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -11048,6 +10961,34 @@ exports[`Header renders condensed header 1`] = `
     }
   }
   homeHref="/"
+  http={
+    Object {
+      "addLoadingCountSource": [MockFunction],
+      "anonymousPaths": Object {
+        "isAnonymous": [MockFunction],
+        "register": [MockFunction],
+      },
+      "basePath": BasePath {
+        "basePath": "/test",
+        "clientBasePath": "",
+        "get": [Function],
+        "getBasePath": [Function],
+        "prepend": [Function],
+        "remove": [Function],
+        "serverBasePath": "/test",
+      },
+      "delete": [MockFunction],
+      "fetch": [MockFunction],
+      "get": [MockFunction],
+      "getLoadingCount$": [MockFunction],
+      "head": [MockFunction],
+      "intercept": [MockFunction],
+      "options": [MockFunction],
+      "patch": [MockFunction],
+      "post": [MockFunction],
+      "put": [MockFunction],
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -16023,6 +15964,34 @@ exports[`Header renders page header with application title 1`] = `
     }
   }
   homeHref="/"
+  http={
+    Object {
+      "addLoadingCountSource": [MockFunction],
+      "anonymousPaths": Object {
+        "isAnonymous": [MockFunction],
+        "register": [MockFunction],
+      },
+      "basePath": BasePath {
+        "basePath": "/test",
+        "clientBasePath": "",
+        "get": [Function],
+        "getBasePath": [Function],
+        "prepend": [Function],
+        "remove": [Function],
+        "serverBasePath": "/test",
+      },
+      "delete": [MockFunction],
+      "fetch": [MockFunction],
+      "get": [MockFunction],
+      "getLoadingCount$": [MockFunction],
+      "head": [MockFunction],
+      "intercept": [MockFunction],
+      "options": [MockFunction],
+      "patch": [MockFunction],
+      "post": [MockFunction],
+      "put": [MockFunction],
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -16612,43 +16581,6 @@ exports[`Header renders page header with application title 1`] = `
           "syncErrorThrown": false,
           "syncErrorValue": null,
         },
-        Subscriber {
-          "_parentOrParents": null,
-          "_subscriptions": Array [
-            SubjectSubscription {
-              "_parentOrParents": [Circular],
-              "_subscriptions": null,
-              "closed": false,
-              "subject": [Circular],
-              "subscriber": [Circular],
-            },
-          ],
-          "closed": false,
-          "destination": SafeSubscriber {
-            "_complete": undefined,
-            "_context": [Circular],
-            "_error": undefined,
-            "_next": [Function],
-            "_parentOrParents": null,
-            "_parentSubscriber": [Circular],
-            "_subscriptions": null,
-            "closed": false,
-            "destination": Object {
-              "closed": true,
-              "complete": [Function],
-              "error": [Function],
-              "next": [Function],
-            },
-            "isStopped": false,
-            "syncErrorThrowable": false,
-            "syncErrorThrown": false,
-            "syncErrorValue": null,
-          },
-          "isStopped": false,
-          "syncErrorThrowable": true,
-          "syncErrorThrown": false,
-          "syncErrorValue": null,
-        },
       ],
       "thrownError": null,
     }
@@ -16982,102 +16914,33 @@ exports[`Header renders page header with application title 1`] = `
                     className="euiHeaderSectionItem"
                   >
                     <RecentItems
-                      basePath={
-                        BasePath {
-                          "basePath": "/test",
-                          "clientBasePath": "",
-                          "get": [Function],
-                          "getBasePath": [Function],
-                          "prepend": [Function],
-                          "remove": [Function],
-                          "serverBasePath": "/test",
-                        }
-                      }
                       buttonSize="xs"
-                      navLinks$={
-                        BehaviorSubject {
-                          "_isScalar": false,
-                          "_value": Array [],
-                          "closed": false,
-                          "hasError": false,
-                          "isStopped": false,
-                          "observers": Array [
-                            Subscriber {
-                              "_parentOrParents": null,
-                              "_subscriptions": Array [
-                                SubjectSubscription {
-                                  "_parentOrParents": [Circular],
-                                  "_subscriptions": null,
-                                  "closed": false,
-                                  "subject": [Circular],
-                                  "subscriber": [Circular],
-                                },
-                              ],
-                              "closed": false,
-                              "destination": SafeSubscriber {
-                                "_complete": undefined,
-                                "_context": [Circular],
-                                "_error": undefined,
-                                "_next": [Function],
-                                "_parentOrParents": null,
-                                "_parentSubscriber": [Circular],
-                                "_subscriptions": null,
-                                "closed": false,
-                                "destination": Object {
-                                  "closed": true,
-                                  "complete": [Function],
-                                  "error": [Function],
-                                  "next": [Function],
-                                },
-                                "isStopped": false,
-                                "syncErrorThrowable": false,
-                                "syncErrorThrown": false,
-                                "syncErrorValue": null,
-                              },
-                              "isStopped": false,
-                              "syncErrorThrowable": true,
-                              "syncErrorThrown": false,
-                              "syncErrorValue": null,
-                            },
-                            Subscriber {
-                              "_parentOrParents": null,
-                              "_subscriptions": Array [
-                                SubjectSubscription {
-                                  "_parentOrParents": [Circular],
-                                  "_subscriptions": null,
-                                  "closed": false,
-                                  "subject": [Circular],
-                                  "subscriber": [Circular],
-                                },
-                              ],
-                              "closed": false,
-                              "destination": SafeSubscriber {
-                                "_complete": undefined,
-                                "_context": [Circular],
-                                "_error": undefined,
-                                "_next": [Function],
-                                "_parentOrParents": null,
-                                "_parentSubscriber": [Circular],
-                                "_subscriptions": null,
-                                "closed": false,
-                                "destination": Object {
-                                  "closed": true,
-                                  "complete": [Function],
-                                  "error": [Function],
-                                  "next": [Function],
-                                },
-                                "isStopped": false,
-                                "syncErrorThrowable": false,
-                                "syncErrorThrown": false,
-                                "syncErrorValue": null,
-                              },
-                              "isStopped": false,
-                              "syncErrorThrowable": true,
-                              "syncErrorThrown": false,
-                              "syncErrorValue": null,
-                            },
-                          ],
-                          "thrownError": null,
+                      http={
+                        Object {
+                          "addLoadingCountSource": [MockFunction],
+                          "anonymousPaths": Object {
+                            "isAnonymous": [MockFunction],
+                            "register": [MockFunction],
+                          },
+                          "basePath": BasePath {
+                            "basePath": "/test",
+                            "clientBasePath": "",
+                            "get": [Function],
+                            "getBasePath": [Function],
+                            "prepend": [Function],
+                            "remove": [Function],
+                            "serverBasePath": "/test",
+                          },
+                          "delete": [MockFunction],
+                          "fetch": [MockFunction],
+                          "get": [MockFunction],
+                          "getLoadingCount$": [MockFunction],
+                          "head": [MockFunction],
+                          "intercept": [MockFunction],
+                          "options": [MockFunction],
+                          "patch": [MockFunction],
+                          "post": [MockFunction],
+                          "put": [MockFunction],
                         }
                       }
                       navigateToUrl={[MockFunction]}
@@ -17418,7 +17281,7 @@ exports[`Header renders page header with application title 1`] = `
                         anchorPosition="downCenter"
                         button={
                           <EuiToolTip
-                            content="Recents"
+                            content="Recent"
                             delay="long"
                             position="bottom"
                           >
@@ -17441,7 +17304,7 @@ exports[`Header renders page header with application title 1`] = `
                         initialFocus={false}
                         isOpen={false}
                         ownFocus={true}
-                        panelPaddingSize="s"
+                        panelPaddingSize="m"
                         repositionOnScroll={true}
                       >
                         <div
@@ -17451,7 +17314,7 @@ exports[`Header renders page header with application title 1`] = `
                             className="euiPopover__anchor"
                           >
                             <EuiToolTip
-                              content="Recents"
+                              content="Recent"
                               delay="long"
                               position="bottom"
                             >
@@ -18849,43 +18712,6 @@ exports[`Header renders page header with application title 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -20386,6 +20212,34 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
     }
   }
   homeHref="/"
+  http={
+    Object {
+      "addLoadingCountSource": [MockFunction],
+      "anonymousPaths": Object {
+        "isAnonymous": [MockFunction],
+        "register": [MockFunction],
+      },
+      "basePath": BasePath {
+        "basePath": "/test",
+        "clientBasePath": "",
+        "get": [Function],
+        "getBasePath": [Function],
+        "prepend": [Function],
+        "remove": [Function],
+        "serverBasePath": "/test",
+      },
+      "delete": [MockFunction],
+      "fetch": [MockFunction],
+      "get": [MockFunction],
+      "getLoadingCount$": [MockFunction],
+      "head": [MockFunction],
+      "intercept": [MockFunction],
+      "options": [MockFunction],
+      "patch": [MockFunction],
+      "post": [MockFunction],
+      "put": [MockFunction],
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -8290,6 +8290,43 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
           "syncErrorThrown": false,
           "syncErrorValue": null,
         },
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
       ],
       "thrownError": null,
     }
@@ -8624,6 +8661,17 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                     className="euiHeaderSectionItem"
                   >
                     <RecentItems
+                      basePath={
+                        BasePath {
+                          "basePath": "/test",
+                          "clientBasePath": "",
+                          "get": [Function],
+                          "getBasePath": [Function],
+                          "prepend": [Function],
+                          "remove": [Function],
+                          "serverBasePath": "/test",
+                        }
+                      }
                       buttonSize="s"
                       http={
                         Object {
@@ -8651,6 +8699,92 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                           "patch": [MockFunction],
                           "post": [MockFunction],
                           "put": [MockFunction],
+                        }
+                      }
+                      navLinks$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": Array [],
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
                         }
                       }
                       navigateToUrl={[MockFunction]}
@@ -9461,6 +9595,43 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -16581,6 +16752,43 @@ exports[`Header renders page header with application title 1`] = `
           "syncErrorThrown": false,
           "syncErrorValue": null,
         },
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
       ],
       "thrownError": null,
     }
@@ -16914,6 +17122,17 @@ exports[`Header renders page header with application title 1`] = `
                     className="euiHeaderSectionItem"
                   >
                     <RecentItems
+                      basePath={
+                        BasePath {
+                          "basePath": "/test",
+                          "clientBasePath": "",
+                          "get": [Function],
+                          "getBasePath": [Function],
+                          "prepend": [Function],
+                          "remove": [Function],
+                          "serverBasePath": "/test",
+                        }
+                      }
                       buttonSize="xs"
                       http={
                         Object {
@@ -16941,6 +17160,92 @@ exports[`Header renders page header with application title 1`] = `
                           "patch": [MockFunction],
                           "post": [MockFunction],
                           "put": [MockFunction],
+                        }
+                      }
+                      navLinks$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": Array [],
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": true,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                          ],
+                          "thrownError": null,
                         }
                       }
                       navigateToUrl={[MockFunction]}
@@ -18712,6 +19017,43 @@ exports[`Header renders page header with application title 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
+                  "_subscriptions": null,
+                  "closed": false,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
+                },
+                "isStopped": false,
+                "syncErrorThrowable": false,
+                "syncErrorThrown": false,
+                "syncErrorValue": null,
+              },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -50,6 +50,7 @@ function mockProps() {
   const application = applicationServiceMock.createInternalStartContract();
 
   return {
+    http,
     application,
     opensearchDashboardsVersion: '1.0.0',
     appTitle$: new BehaviorSubject('test'),

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -79,6 +79,7 @@ import { HomeLoader } from './home_loader';
 import { RecentItems } from './recent_items';
 
 export interface HeaderProps {
+  http: HttpStart;
   opensearchDashboardsVersion: string;
   application: InternalApplicationStart;
   appTitle$: Observable<string>;
@@ -120,6 +121,7 @@ export interface HeaderProps {
 }
 
 export function Header({
+  http,
   opensearchDashboardsVersion,
   opensearchDashboardsDocLink,
   application,
@@ -351,11 +353,12 @@ export function Header({
   const renderRecentItems = () => (
     <EuiHeaderSectionItem border={useUpdatedHeader ? 'none' : 'right'}>
       <RecentItems
+        http={http}
         recentlyAccessed$={observables.recentlyAccessed$}
         workspaceList$={observables.workspaceList$}
         navigateToUrl={application.navigateToUrl}
-        navLinks$={observables.navLinks$}
-        basePath={basePath}
+        // navLinks$={observables.navLinks$}
+        // basePath={basePath}
         renderBreadcrumbs={renderBreadcrumbs(true)}
         buttonSize={useApplicationHeader ? 's' : 'xs'}
       />

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -357,8 +357,6 @@ export function Header({
         recentlyAccessed$={observables.recentlyAccessed$}
         workspaceList$={observables.workspaceList$}
         navigateToUrl={application.navigateToUrl}
-        // navLinks$={observables.navLinks$}
-        // basePath={basePath}
         renderBreadcrumbs={renderBreadcrumbs(true)}
         buttonSize={useApplicationHeader ? 's' : 'xs'}
       />

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -354,6 +354,8 @@ export function Header({
     <EuiHeaderSectionItem border={useUpdatedHeader ? 'none' : 'right'}>
       <RecentItems
         http={http}
+        navLinks$={observables.navLinks$}
+        basePath={basePath}
         recentlyAccessed$={observables.recentlyAccessed$}
         workspaceList$={observables.workspaceList$}
         navigateToUrl={application.navigateToUrl}

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -10,14 +10,6 @@ import { applicationServiceMock, httpServiceMock } from '../../../mocks';
 import { SavedObjectWithMetadata } from './recent_items';
 import { RecentItems } from './recent_items';
 
-jest.mock('./nav_link', () => ({
-  createRecentNavLink: jest.fn().mockImplementation(() => {
-    return {
-      href: '/recent_nav_link',
-    };
-  }),
-}));
-
 const mockRecentlyAccessed = new BehaviorSubject([
   {
     id: '6ef856c0-5f86-11ef-b7df-1bb1cf26ce5b',

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -80,18 +80,13 @@ describe('Recent items', () => {
       recentlyAccessed$: mockRecentlyAccessed,
     };
 
-    let getByText: (text: string) => HTMLElement;
-    let getByTestId: (testId: string) => HTMLElement;
-
     await act(async () => {
-      const renderResult = render(<RecentItems {...mockProps} />);
-      getByText = renderResult.getByText;
-      getByTestId = renderResult.getByTestId;
+      render(<RecentItems {...mockProps} />);
     });
 
-    const mockRecentButton = getByTestId!('recentItemsSectionButton');
+    const mockRecentButton = screen.getByTestId('recentItemsSectionButton');
     fireEvent.click(mockRecentButton);
-    expect(getByText!('visualizeMock')).toBeInTheDocument();
+    expect(screen.getByText('visualizeMock')).toBeInTheDocument();
   });
 
   it('shoulde be able to display workspace name if the asset is attched to a workspace and render it with brackets wrapper ', async () => {
@@ -101,18 +96,13 @@ describe('Recent items', () => {
       workspaceList$: mockWorkspaceList,
     };
 
-    let getByText: (text: string) => HTMLElement;
-    let getByTestId: (testId: string) => HTMLElement;
-
     await act(async () => {
-      const renderResult = render(<RecentItems {...mockProps} />);
-      getByText = renderResult.getByText;
-      getByTestId = renderResult.getByTestId;
+      render(<RecentItems {...mockProps} />);
     });
 
-    const mockRecentButton = getByTestId!('recentItemsSectionButton');
+    const mockRecentButton = screen.getByTestId('recentItemsSectionButton');
     fireEvent.click(mockRecentButton);
-    expect(getByText!('(WorkspaceMock_1)')).toBeInTheDocument();
+    expect(screen.getByText('(WorkspaceMock_1)')).toBeInTheDocument();
   });
 
   it('should call navigateToUrl with link generated from createRecentNavLink when clicking a recent item', async () => {
@@ -122,14 +112,10 @@ describe('Recent items', () => {
       workspaceList$: mockWorkspaceList,
     };
 
-    let getByText: (text: string) => HTMLElement;
-    let getByTestId: (testId: string) => HTMLElement;
     const navigateToUrl = jest.fn();
 
     await act(async () => {
-      const renderResult = render(<RecentItems {...mockProps} navigateToUrl={navigateToUrl} />);
-      getByText = renderResult.getByText;
-      getByTestId = renderResult.getByTestId;
+      render(<RecentItems {...mockProps} navigateToUrl={navigateToUrl} />);
     });
 
     const button = screen.getByTestId('recentItemsSectionButton');
@@ -145,19 +131,16 @@ describe('Recent items', () => {
       ...defaultMockProps,
       recentlyAccessed$: mockRecentlyAccessed,
     };
-    let getByText: (text: string) => HTMLElement;
-    let getByTestId: (testId: string) => HTMLElement;
 
     await act(async () => {
-      const renderResult = render(<RecentItems {...mockProps} />);
-      getByText = renderResult.getByText;
-      getByTestId = renderResult.getByTestId;
+      render(<RecentItems {...mockProps} />);
     });
+
     const button = screen.getByTestId('recentItemsSectionButton');
     fireEvent.click(button);
 
     const preferencesButton = screen.getByTestId('preferencesSettingButton');
     fireEvent.click(preferencesButton);
-    expect(getByTestId!('preferencesSettingPopover')).toBeInTheDocument();
+    expect(screen.getByTestId('preferencesSettingPopover')).toBeInTheDocument();
   });
 });

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -67,6 +67,11 @@ jest.spyOn(defaultMockProps.http, 'get').mockImplementation(
 );
 
 describe('Recent items', () => {
+  it('should render base element normally', () => {
+    const { baseElement } = render(<RecentItems {...defaultMockProps} />);
+    expect(baseElement).toMatchSnapshot();
+  });
+
   it('render with empty recent work', () => {
     const { getByText, getByTestId } = render(<RecentItems {...defaultMockProps} />);
     const mockRecentButton = getByTestId('recentItemsSectionButton');

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
 import React from 'react';
 import { BehaviorSubject } from 'rxjs';
 import { applicationServiceMock, httpServiceMock } from '../../../mocks';
-import { Props, RecentItems } from './recent_items';
+import { SavedObjectWithMetadata } from './recent_items';
+import { RecentItems } from './recent_items';
 
 jest.mock('./nav_link', () => ({
   createRecentNavLink: jest.fn().mockImplementation(() => {
@@ -17,73 +18,146 @@ jest.mock('./nav_link', () => ({
   }),
 }));
 
+const mockRecentlyAccessed = new BehaviorSubject([
+  {
+    id: '6ef856c0-5f86-11ef-b7df-1bb1cf26ce5b',
+    label: 'visualizeMock',
+    link: '/app/visualize',
+    workspaceId: 'workspace_1',
+    meta: { type: 'visualization' },
+  },
+]);
+
+const mockWorkspaceList = new BehaviorSubject([
+  {
+    id: 'workspace_1',
+    name: 'WorkspaceMock_1',
+  },
+]);
+
+const savedObjectsFromServer: SavedObjectWithMetadata[] = [
+  {
+    type: 'visualization',
+    id: '6ef856c0-5f86-11ef-b7df-1bb1cf26ce5b',
+    attributes: {},
+    references: [],
+    updated_at: '2024-07-20T00:00:00.000Z',
+    meta: {},
+  },
+];
 const defaultMockProps = {
   navigateToUrl: applicationServiceMock.createStartContract().navigateToUrl,
   workspaceList$: new BehaviorSubject([]),
   recentlyAccessed$: new BehaviorSubject([]),
-  navLinks$: new BehaviorSubject([]),
-  basePath: httpServiceMock.createStartContract().basePath,
+  http: httpServiceMock.createSetupContract(),
   renderBreadcrumbs: <></>,
 };
-const setup = (props: Props) => {
-  return render(<RecentItems {...props} />);
-};
+
+jest.spyOn(defaultMockProps.http, 'get').mockImplementation(
+  (url): Promise<SavedObjectWithMetadata> => {
+    if (typeof url === 'string') {
+      if ((url as string).includes('6ef856c0-5f86-11ef-b7df-1bb1cf26ce5b')) {
+        return Promise.resolve(savedObjectsFromServer[0]);
+      } else {
+        return Promise.resolve(savedObjectsFromServer[1]);
+      }
+    }
+    return Promise.reject(new Error('Invalid URL'));
+  }
+);
+
 describe('Recent items', () => {
-  it('should render base element normally', () => {
-    const { baseElement } = setup(defaultMockProps);
-    expect(baseElement).toMatchSnapshot();
+  it('render with empty recent work', () => {
+    const { getByText, getByTestId } = render(<RecentItems {...defaultMockProps} />);
+    const mockRecentButton = getByTestId('recentItemsSectionButton');
+    fireEvent.click(mockRecentButton);
+    expect(getByText('No recently viewed items')).toBeInTheDocument();
   });
 
-  it('should get workspace name through workspace id and render it with brackets wrapper', () => {
-    const workspaceList$ = new BehaviorSubject([
-      {
-        id: 'workspace_id',
-        name: 'workspace_name',
-      },
-    ]);
-    const recentlyAccessed$ = new BehaviorSubject([
-      {
-        label: 'item_label',
-        link: 'item_link',
-        id: 'item_id',
-        workspaceId: 'workspace_id',
-      },
-    ]);
-
-    setup({
+  it('should be able to render recent works', async () => {
+    const mockProps = {
       ...defaultMockProps,
-      workspaceList$,
-      recentlyAccessed$,
-      navigateToUrl: defaultMockProps.navigateToUrl,
+      recentlyAccessed$: mockRecentlyAccessed,
+    };
+
+    let getByText: (text: string) => HTMLElement;
+    let getByTestId: (testId: string) => HTMLElement;
+
+    await act(async () => {
+      const renderResult = render(<RecentItems {...mockProps} />);
+      getByText = renderResult.getByText;
+      getByTestId = renderResult.getByTestId;
     });
-    const button = screen.getByTestId('recentItemsSectionButton');
-    fireEvent.click(button);
-    expect(screen.getByText('(workspace_name)')).toBeInTheDocument();
+
+    const mockRecentButton = getByTestId!('recentItemsSectionButton');
+    fireEvent.click(mockRecentButton);
+    expect(getByText!('visualizeMock')).toBeInTheDocument();
   });
 
-  it('should call navigateToUrl with link generated from createRecentNavLink when clicking item', () => {
-    const workspaceList$ = new BehaviorSubject([]);
-    const recentlyAccessed$ = new BehaviorSubject([
-      {
-        label: 'item_label',
-        link: 'item_link',
-        id: 'item_id',
-      },
-    ]);
+  it('shoulde be able to display workspace name if the asset is attched to a workspace and render it with brackets wrapper ', async () => {
+    const mockProps = {
+      ...defaultMockProps,
+      recentlyAccessed$: mockRecentlyAccessed,
+      workspaceList$: mockWorkspaceList,
+    };
+
+    let getByText: (text: string) => HTMLElement;
+    let getByTestId: (testId: string) => HTMLElement;
+
+    await act(async () => {
+      const renderResult = render(<RecentItems {...mockProps} />);
+      getByText = renderResult.getByText;
+      getByTestId = renderResult.getByTestId;
+    });
+
+    const mockRecentButton = getByTestId!('recentItemsSectionButton');
+    fireEvent.click(mockRecentButton);
+    expect(getByText!('(WorkspaceMock_1)')).toBeInTheDocument();
+  });
+
+  it('should call navigateToUrl with link generated from createRecentNavLink when clicking a recent item', async () => {
+    const mockProps = {
+      ...defaultMockProps,
+      recentlyAccessed$: mockRecentlyAccessed,
+      workspaceList$: mockWorkspaceList,
+    };
+
+    let getByText: (text: string) => HTMLElement;
+    let getByTestId: (testId: string) => HTMLElement;
     const navigateToUrl = jest.fn();
-    const renderBreadcrumbs = <></>;
-    setup({
-      ...defaultMockProps,
-      workspaceList$,
-      recentlyAccessed$,
-      navigateToUrl,
-      renderBreadcrumbs,
+
+    await act(async () => {
+      const renderResult = render(<RecentItems {...mockProps} navigateToUrl={navigateToUrl} />);
+      getByText = renderResult.getByText;
+      getByTestId = renderResult.getByTestId;
     });
+
     const button = screen.getByTestId('recentItemsSectionButton');
     fireEvent.click(button);
-    const item = screen.getByText('item_label');
+    const item = screen.getByText('visualizeMock');
     expect(navigateToUrl).not.toHaveBeenCalled();
     fireEvent.click(item);
-    expect(navigateToUrl).toHaveBeenCalledWith('/recent_nav_link');
+    expect(navigateToUrl).toHaveBeenCalledWith('/app/visualize');
+  });
+
+  it('should be able to display the preferences popover setting when clicking Preferences button', async () => {
+    const mockProps = {
+      ...defaultMockProps,
+      recentlyAccessed$: mockRecentlyAccessed,
+    };
+    let getByText: (text: string) => HTMLElement;
+    let getByTestId: (testId: string) => HTMLElement;
+
+    await act(async () => {
+      const renderResult = render(<RecentItems {...mockProps} />);
+      getByText = renderResult.getByText;
+      getByTestId = renderResult.getByTestId;
+    });
+    const button = screen.getByTestId('recentItemsSectionButton');
+    fireEvent.click(button);
+
+    const preferencesButton = screen.getByTestId('preferencesSettingButton');
+    fireEvent.click(preferencesButton);
+    expect(getByTestId!('preferencesSettingPopover')).toBeInTheDocument();
   });
 });

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -10,6 +10,14 @@ import { applicationServiceMock, httpServiceMock } from '../../../mocks';
 import { SavedObjectWithMetadata } from './recent_items';
 import { RecentItems } from './recent_items';
 
+jest.mock('./nav_link', () => ({
+  createRecentNavLink: jest.fn().mockImplementation(() => {
+    return {
+      href: '/recent_nav_link',
+    };
+  }),
+}));
+
 const mockRecentlyAccessed = new BehaviorSubject([
   {
     id: '6ef856c0-5f86-11ef-b7df-1bb1cf26ce5b',
@@ -41,6 +49,8 @@ const defaultMockProps = {
   navigateToUrl: applicationServiceMock.createStartContract().navigateToUrl,
   workspaceList$: new BehaviorSubject([]),
   recentlyAccessed$: new BehaviorSubject([]),
+  navLinks$: new BehaviorSubject([]),
+  basePath: httpServiceMock.createStartContract().basePath,
   http: httpServiceMock.createSetupContract(),
   renderBreadcrumbs: <></>,
 };
@@ -120,7 +130,7 @@ describe('Recent items', () => {
     const item = screen.getByText('visualizeMock');
     expect(navigateToUrl).not.toHaveBeenCalled();
     fireEvent.click(item);
-    expect(navigateToUrl).toHaveBeenCalledWith('/app/visualize');
+    expect(navigateToUrl).toHaveBeenCalledWith('/recent_nav_link');
   });
 
   it('should be able to display the preferences popover setting when clicking Preferences button', async () => {

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -122,7 +122,7 @@ export const RecentItems = ({
     <EuiPopover
       data-test-subj="preferencesSettingPopover"
       ownFocus={false}
-      panelPaddingSize="m"
+      panelPaddingSize="s"
       button={
         <EuiButtonEmpty
           data-test-subj="preferencesSettingButton"

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -2,76 +2,129 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import * as Rx from 'rxjs';
+import moment from 'moment';
 import {
-  EuiPopover,
-  EuiTextColor,
+  EuiPanel,
   EuiListGroup,
   EuiListGroupItem,
   EuiTitle,
+  EuiPopoverTitle,
+  EuiIcon,
   EuiText,
+  EuiButtonEmpty,
   EuiSpacer,
   EuiHeaderSectionItemButtonProps,
   EuiButtonIcon,
+  EuiRadioGroup,
+  EuiTextColor,
+  EuiPopover,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import useObservable from 'react-use/lib/useObservable';
-import { ChromeRecentlyAccessedHistoryItem } from '../..';
+import { SavedObjectsNamespaceType } from 'src/core/public';
+import { ChromeRecentlyAccessedHistoryItem, SavedObject } from 'opensearch-dashboards/public';
 import { WorkspaceObject } from '../../../workspace';
-import { createRecentNavLink } from './nav_link';
 import { HttpStart } from '../../../http';
-import { ChromeNavLink } from '../../../';
 import './recent_items.scss';
+
+const widthForRightMargin = 8;
 
 export interface Props {
   recentlyAccessed$: Rx.Observable<ChromeRecentlyAccessedHistoryItem[]>;
   workspaceList$: Rx.Observable<WorkspaceObject[]>;
   navigateToUrl: (url: string) => Promise<void>;
-  basePath: HttpStart['basePath'];
-  navLinks$: Rx.Observable<ChromeNavLink[]>;
   renderBreadcrumbs: React.JSX.Element;
   buttonSize?: EuiHeaderSectionItemButtonProps['size'];
+  http: HttpStart;
 }
+
+interface SavedObjectMetadata {
+  icon?: string;
+  title?: string;
+  editUrl?: string;
+  inAppUrl?: { path: string; uiCapabilitiesPath: string };
+  namespaceType?: SavedObjectsNamespaceType;
+}
+export type SavedObjectWithMetadata<T = unknown> = SavedObject<T> & {
+  meta: SavedObjectMetadata;
+};
+
+type DetailedRecentlyAccessedItem = ChromeRecentlyAccessedHistoryItem &
+  SavedObjectWithMetadata &
+  ChromeRecentlyAccessedHistoryItem['meta'] & {
+    updatedAt: number;
+    workspaceName?: string;
+  };
+
+export const bulkGetDetail = (
+  savedObjects: Array<Pick<SavedObject, 'type' | 'id'>>,
+  http: HttpStart
+) => {
+  return Promise.all(
+    savedObjects.map((obj) =>
+      http
+        .get<SavedObjectWithMetadata>(
+          `/api/opensearch-dashboards/management/saved_objects/${encodeURIComponent(
+            obj.type
+          )}/${encodeURIComponent(obj.id)}`
+        )
+        .catch((error) => ({
+          id: obj.id,
+          type: obj.type,
+          error,
+          attributes: {},
+          references: [],
+          meta: {},
+          updated_at: '',
+        }))
+    )
+  );
+};
+
+const recentsRadios = [
+  {
+    id: 'recent_5',
+    label: '5 pages',
+  },
+  {
+    id: 'recent_10',
+    label: '10 pages',
+  },
+  {
+    id: 'recent_15',
+    label: '15 pages',
+  },
+];
 
 export const RecentItems = ({
   recentlyAccessed$,
   workspaceList$,
   navigateToUrl,
-  navLinks$,
-  basePath,
   renderBreadcrumbs,
   buttonSize = 's',
+  http,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-
+  const [isPreferencesPopoverOpen, setIsPreferencesPopoverOpen] = useState(false);
   const recentlyAccessedItems = useObservable(recentlyAccessed$, []);
+  const [recentsRadioIdSelected, setRecentsRadioIdSelected] = useState('recent_5');
   const workspaceList = useObservable(workspaceList$, []);
-  const navLinks = useObservable(navLinks$, []).filter((link) => !link.hidden);
-
-  const items = useMemo(() => {
-    // Only display five most recent items
-    return recentlyAccessedItems.slice(0, 5).map((item) => {
-      return {
-        link: createRecentNavLink(item, navLinks, basePath, navigateToUrl).href,
-        label: item.label,
-        workspaceId: item.workspaceId,
-        workspaceName:
-          workspaceList.find((workspace) => workspace.id === item.workspaceId)?.name ?? '',
-      };
-    });
-  }, [recentlyAccessedItems, workspaceList, basePath, navLinks, navigateToUrl]);
+  const [detailedSavedObjects, setDetailedSavedObjects] = useState<DetailedRecentlyAccessedItem[]>(
+    []
+  );
 
   const handleItemClick = (link: string) => {
     navigateToUrl(link);
     setIsPopoverOpen(false);
   };
 
-  const button = (
+  const recentButton = (
     <EuiToolTip
       content={i18n.translate('core.ui.chrome.headerGlobalNav.viewRecentItemsTooltip', {
-        defaultMessage: 'Recents',
+        defaultMessage: 'Recent',
       })}
       delay="long"
       position="bottom"
@@ -94,9 +147,45 @@ export const RecentItems = ({
     </EuiToolTip>
   );
 
+  useEffect(() => {
+    const savedObjects = recentlyAccessedItems
+      .filter((item) => item.meta?.type)
+      .map((item) => ({
+        type: item.meta?.type || '',
+        id: item.id,
+      }));
+
+    if (savedObjects.length) {
+      bulkGetDetail(savedObjects, http).then((res) => {
+        const formatDetailedSavedObjects = res.map((obj) => {
+          const recentAccessItem = recentlyAccessedItems.find(
+            (item) => item.id === obj.id
+          ) as ChromeRecentlyAccessedHistoryItem;
+
+          const findWorkspace = workspaceList.find(
+            (workspace) => workspace.id === recentAccessItem.workspaceId
+          );
+
+          return {
+            ...recentAccessItem,
+            ...obj,
+            ...recentAccessItem.meta,
+            updatedAt: moment(obj?.updated_at).valueOf(),
+            workspaceName: findWorkspace?.name,
+          };
+        });
+        setDetailedSavedObjects(formatDetailedSavedObjects);
+      });
+    }
+  }, [recentlyAccessedItems, http, workspaceList]);
+
+  const selectedRecentsItems = useMemo(() => {
+    return detailedSavedObjects.slice(0, Number(recentsRadioIdSelected.split('recent_')[1]));
+  }, [detailedSavedObjects, recentsRadioIdSelected]);
+
   return (
     <EuiPopover
-      button={button}
+      button={recentButton}
       isOpen={isPopoverOpen}
       closePopover={() => {
         setIsPopoverOpen(false);
@@ -104,36 +193,86 @@ export const RecentItems = ({
       anchorPosition="downCenter"
       repositionOnScroll
       initialFocus={false}
-      panelPaddingSize="s"
+      panelPaddingSize="m"
     >
       {renderBreadcrumbs}
       <EuiSpacer size="s" />
+      <EuiPanel
+        hasShadow={false}
+        hasBorder={false}
+        paddingSize="none"
+        style={{ maxHeight: '35vh', overflow: 'auto' }}
+      >
+        <EuiTitle size="xxs">
+          <h4>Recent</h4>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        {selectedRecentsItems.length > 0 ? (
+          <EuiListGroup flush={true} gutterSize="s">
+            {selectedRecentsItems.map((item) => (
+              <EuiListGroupItem
+                onClick={() => handleItemClick(item.link)}
+                key={item.link}
+                style={{ padding: '1px' }}
+                label={
+                  <>
+                    <EuiIcon
+                      style={{ marginRight: widthForRightMargin }}
+                      type={item.meta.icon || 'apps'}
+                    />
+                    {item.label}
+                    {item.workspaceName ? (
+                      <EuiTextColor color="subdued">({item.workspaceName})</EuiTextColor>
+                    ) : null}
+                  </>
+                }
+                color="text"
+                size="s"
+              />
+            ))}
+          </EuiListGroup>
+        ) : (
+          <EuiText color="subdued">No recently viewed items</EuiText>
+        )}
+        <EuiSpacer size="s" />
 
-      <EuiTitle size="xxs">
-        <h4>Recents</h4>
-      </EuiTitle>
-      {items.length > 0 ? (
-        <EuiListGroup>
-          {items.map((item) => (
-            <EuiListGroupItem
-              onClick={() => handleItemClick(item.link)}
-              key={item.link}
-              label={
-                <>
-                  {item.label}
-                  {item.workspaceName ? (
-                    <EuiTextColor color="subdued">({item.workspaceName})</EuiTextColor>
-                  ) : null}
-                </>
-              }
-              color="text"
-              size="s"
-            />
-          ))}
-        </EuiListGroup>
-      ) : (
-        <EuiText color="subdued">No recently viewed items</EuiText>
-      )}
+        <EuiPopover
+          data-test-subj="preferencesSettingPopover"
+          ownFocus={false}
+          panelPaddingSize="m"
+          button={
+            <EuiButtonEmpty
+              data-test-subj="preferencesSettingButton"
+              flush="left"
+              color="primary"
+              onClick={() => {
+                setIsPreferencesPopoverOpen((IsPreferencesPopoverOpe) => !IsPreferencesPopoverOpe);
+              }}
+            >
+              Preferences
+            </EuiButtonEmpty>
+          }
+          isOpen={isPreferencesPopoverOpen}
+          anchorPosition="downLeft"
+          closePopover={() => {
+            setIsPreferencesPopoverOpen(false);
+          }}
+        >
+          <EuiPopoverTitle>Preferences</EuiPopoverTitle>
+          <EuiRadioGroup
+            options={recentsRadios}
+            idSelected={recentsRadioIdSelected}
+            onChange={(id) => {
+              setRecentsRadioIdSelected(id);
+              setIsPreferencesPopoverOpen(false);
+            }}
+            name="radio group"
+            legend={{
+              children: <span>Recents</span>,
+            }}
+          />
+        </EuiPopover>
+      </EuiPanel>
     </EuiPopover>
   );
 };

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -118,7 +118,7 @@ export const RecentItems = ({
     setIsPopoverOpen(false);
   };
 
-  const preferencesPopover = (
+  const preferencePopover = (
     <EuiPopover
       data-test-subj="preferencesSettingPopover"
       ownFocus={false}
@@ -273,7 +273,7 @@ export const RecentItems = ({
         )}
         <EuiSpacer size="s" />
       </EuiPanel>
-      {preferencesPopover}
+      {preferencePopover}
     </EuiPopover>
   );
 };

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -59,10 +59,7 @@ type DetailedRecentlyAccessedItem = ChromeRecentlyAccessedHistoryItem &
     workspaceName?: string;
   };
 
-export const bulkGetDetail = (
-  savedObjects: Array<Pick<SavedObject, 'type' | 'id'>>,
-  http: HttpStart
-) => {
+const bulkGetDetail = (savedObjects: Array<Pick<SavedObject, 'type' | 'id'>>, http: HttpStart) => {
   return Promise.all(
     savedObjects.map((obj) =>
       http
@@ -86,15 +83,15 @@ export const bulkGetDetail = (
 
 const recentsRadios = [
   {
-    id: 'recent_5',
+    id: '5',
     label: '5 pages',
   },
   {
-    id: 'recent_10',
+    id: '10',
     label: '10 pages',
   },
   {
-    id: 'recent_15',
+    id: '15',
     label: '15 pages',
   },
 ];
@@ -110,7 +107,7 @@ export const RecentItems = ({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isPreferencesPopoverOpen, setIsPreferencesPopoverOpen] = useState(false);
   const recentlyAccessedItems = useObservable(recentlyAccessed$, []);
-  const [recentsRadioIdSelected, setRecentsRadioIdSelected] = useState('recent_5');
+  const [recentsRadioIdSelected, setRecentsRadioIdSelected] = useState(recentsRadios[0].id);
   const workspaceList = useObservable(workspaceList$, []);
   const [detailedSavedObjects, setDetailedSavedObjects] = useState<DetailedRecentlyAccessedItem[]>(
     []
@@ -121,6 +118,44 @@ export const RecentItems = ({
     setIsPopoverOpen(false);
   };
 
+  const preferencesPopover = (
+    <EuiPopover
+      data-test-subj="preferencesSettingPopover"
+      ownFocus={false}
+      panelPaddingSize="m"
+      button={
+        <EuiButtonEmpty
+          data-test-subj="preferencesSettingButton"
+          flush="left"
+          color="primary"
+          onClick={() => {
+            setIsPreferencesPopoverOpen((IsPreferencesPopoverOpe) => !IsPreferencesPopoverOpe);
+          }}
+        >
+          Preferences
+        </EuiButtonEmpty>
+      }
+      isOpen={isPreferencesPopoverOpen}
+      anchorPosition="downLeft"
+      closePopover={() => {
+        setIsPreferencesPopoverOpen(false);
+      }}
+    >
+      <EuiPopoverTitle>Preferences</EuiPopoverTitle>
+      <EuiRadioGroup
+        options={recentsRadios}
+        idSelected={recentsRadioIdSelected}
+        onChange={(id) => {
+          setRecentsRadioIdSelected(id);
+          setIsPreferencesPopoverOpen(false);
+        }}
+        name="radio group"
+        legend={{
+          children: <span>Recents</span>,
+        }}
+      />
+    </EuiPopover>
+  );
   const recentButton = (
     <EuiToolTip
       content={i18n.translate('core.ui.chrome.headerGlobalNav.viewRecentItemsTooltip', {
@@ -180,7 +215,7 @@ export const RecentItems = ({
   }, [recentlyAccessedItems, http, workspaceList]);
 
   const selectedRecentsItems = useMemo(() => {
-    return detailedSavedObjects.slice(0, Number(recentsRadioIdSelected.split('recent_')[1]));
+    return detailedSavedObjects.slice(0, Number(recentsRadioIdSelected));
   }, [detailedSavedObjects, recentsRadioIdSelected]);
 
   return (
@@ -232,47 +267,13 @@ export const RecentItems = ({
             ))}
           </EuiListGroup>
         ) : (
-          <EuiText color="subdued">No recently viewed items</EuiText>
+          <EuiText color="subdued" size="s">
+            No recently viewed items
+          </EuiText>
         )}
         <EuiSpacer size="s" />
-
-        <EuiPopover
-          data-test-subj="preferencesSettingPopover"
-          ownFocus={false}
-          panelPaddingSize="m"
-          button={
-            <EuiButtonEmpty
-              data-test-subj="preferencesSettingButton"
-              flush="left"
-              color="primary"
-              onClick={() => {
-                setIsPreferencesPopoverOpen((IsPreferencesPopoverOpe) => !IsPreferencesPopoverOpe);
-              }}
-            >
-              Preferences
-            </EuiButtonEmpty>
-          }
-          isOpen={isPreferencesPopoverOpen}
-          anchorPosition="downLeft"
-          closePopover={() => {
-            setIsPreferencesPopoverOpen(false);
-          }}
-        >
-          <EuiPopoverTitle>Preferences</EuiPopoverTitle>
-          <EuiRadioGroup
-            options={recentsRadios}
-            idSelected={recentsRadioIdSelected}
-            onChange={(id) => {
-              setRecentsRadioIdSelected(id);
-              setIsPreferencesPopoverOpen(false);
-            }}
-            name="radio group"
-            legend={{
-              children: <span>Recents</span>,
-            }}
-          />
-        </EuiPopover>
       </EuiPanel>
+      {preferencesPopover}
     </EuiPopover>
   );
 };


### PR DESCRIPTION
### Description
In this pr, I refactor the style of recent items card in the header by
1. Enable maxHeight; if exceeded, the menu will become scrollable.
2. Display associated icons.
3. The workspace name will be attached to the asset.
4. Allow setting preferences for the number of recent items displayed.

## Screenshot
https://github.com/user-attachments/assets/dd8a364d-abd2-4274-a647-cd9bc6942e44

empty state
<img width="221" alt="Screenshot 2024-08-22 at 17 40 35" src="https://github.com/user-attachments/assets/2607086b-f391-4a1f-9b20-0e0a92485047">

## Changelog
- feat: refractor the style of recent items card

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
