### PR TITLE
[CVE-2017-16100] Use a patched version of `dns-sync`

### DIFF
--- a/changelogs/fragments/7811.yml
+++ b/changelogs/fragments/7811.yml
@@ -1,0 +1,2 @@
+security:
+- [CVE-2017-16100] Use a patched version for the `dns-sync` dependency ([#7811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7811))

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "core-js": "^3.6.5",
     "deep-freeze-strict": "^1.1.1",
     "del": "^6.1.1",
-    "dns-sync": "^0.2.1",
+    "dns-sync": "npm:@amoo-miki/dns-sync@^0.2.1",
     "elastic-apm-node": "^3.43.0",
     "elasticsearch": "^16.7.0",
     "execa": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7174,10 +7174,10 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
-dns-sync@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/dns-sync/-/dns-sync-0.2.1.tgz#c519da400b90fa2e4a30a70030a1573330c72fa9"
-  integrity sha512-VB1pDSVs82kFsZuoHQ5/Ysx62WiIfDGn9sx/x55EoVyk8pLwdqWGB2XCaDDOusBllb+1y3XRijscFPJJfpbFiw==
+"dns-sync@npm:@amoo-miki/dns-sync@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@amoo-miki/dns-sync/-/dns-sync-0.2.2.tgz#e713eb46c3ddf6fde37e9453a31a4440ca45a8e7"
+  integrity sha512-GoWRmng1RpnFXrfITbAgfndTjvBgf438jRq1Q5m1Db9HfN9qR/TlRRcl7LXsvq+oS3iUzXyNECzoU62jHPilKw==
   dependencies:
     debug "^4"
     shelljs "~0.8"


### PR DESCRIPTION
### Description
[CVE-2017-16100] Use a patched version of `dns-sync`

##### dns-sync
The library hasn't been updated in years. Even though an [upstream PR](https://github.com/skoranga/node-dns-sync/pull/10) was created, due to the criticality of the CVE, until upstream package is updated a patched version is employed.

## Changelog
- security: [CVE-2017-16100] Use a patched version for the `dns-sync` dependency

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
