### PR TITLE
fix: correct size of dashboard panel options icon button

### DIFF
--- a/changelogs/fragments/7812.yml
+++ b/changelogs/fragments/7812.yml
@@ -1,0 +1,2 @@
+fix:
+- Correct size of dashboard panel options icon button ([#7812](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7812))

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_options_menu.tsx
@@ -32,7 +32,7 @@ import { i18n } from '@osd/i18n';
 import React from 'react';
 
 import {
-  EuiSmallButtonIcon,
+  EuiButtonIcon,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiPopover,
@@ -101,7 +101,7 @@ export class PanelOptionsMenu extends React.Component<PanelOptionsMenuProps, Sta
     );
 
     const button = (
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         iconType={isViewMode ? 'boxesHorizontal' : 'gear'}
         color="text"
         className="embPanel__optionsMenuButton"


### PR DESCRIPTION
### Description

Reverts back to an xs icon button for dashboard panel options.

### Issues Resolved

N/A

## Screenshot

Before

<img width="621" alt="image" src="https://github.com/user-attachments/assets/3dd5e210-671c-4abe-b3a6-13e4d0835400">

After

<img width="691" alt="image" src="https://github.com/user-attachments/assets/60e014a2-1464-435e-8adb-106b7260e909">

## Testing the changes

tested locally

## Changelog
- fix: correct size of dashboard panel options icon button

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
