### PR TITLE
[Workspace]Fix maximum call stack error in use case service

### DIFF
--- a/changelogs/fragments/7817.yml
+++ b/changelogs/fragments/7817.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace] maximum call stack error in use case service ([#7817](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7817))

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -14,11 +14,16 @@ export type Services = CoreStart & {
   navigationUI?: NavigationPublicPluginStart['ui'];
 };
 
+export interface WorkspaceUseCaseFeature {
+  id: string;
+  title?: string;
+}
+
 export interface WorkspaceUseCase {
   id: string;
   title: string;
   description: string;
-  features: Array<{ id: string; title?: string }>;
+  features: WorkspaceUseCaseFeature[];
   systematic?: boolean;
   order?: number;
 }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -558,6 +558,23 @@ describe('workspace utils: isEqualWorkspaceUseCase', () => {
       })
     ).toEqual(false);
   });
+  it('should return false for duplicate features', () => {
+    expect(
+      isEqualWorkspaceUseCase(
+        { ...useCaseMock, features: [useCaseMock.features[0], useCaseMock.features[0]] },
+        {
+          ...useCaseMock,
+          features: [
+            useCaseMock.features[0],
+            {
+              id: 'another',
+              title: 'Another',
+            },
+          ],
+        }
+      )
+    ).toEqual(false);
+  });
   it('should return true when all properties equal', () => {
     expect(
       isEqualWorkspaceUseCase(useCaseMock, {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -575,6 +575,21 @@ describe('workspace utils: isEqualWorkspaceUseCase', () => {
       )
     ).toEqual(false);
   });
+  it('should return true for multi same features', () => {
+    const anotherFeature = {
+      id: 'another',
+      title: 'Another',
+    };
+    expect(
+      isEqualWorkspaceUseCase(
+        { ...useCaseMock, features: [useCaseMock.features[0], anotherFeature] },
+        {
+          ...useCaseMock,
+          features: [useCaseMock.features[0], anotherFeature],
+        }
+      )
+    ).toEqual(true);
+  });
   it('should return true when all properties equal', () => {
     expect(
       isEqualWorkspaceUseCase(useCaseMock, {

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -24,7 +24,7 @@ import {
   WorkspaceAvailability,
 } from '../../../core/public';
 import { DEFAULT_SELECTED_FEATURES_IDS, WORKSPACE_DETAIL_APP_ID } from '../common/constants';
-import { WorkspaceUseCase } from './types';
+import { WorkspaceUseCase, WorkspaceUseCaseFeature } from './types';
 import { formatUrlWithWorkspaceId } from '../../../core/public/utils';
 import { SigV4ServiceName } from '../../../plugins/data_source/common/data_sources';
 
@@ -260,6 +260,23 @@ export const convertNavGroupToWorkspaceUseCase = ({
   order,
 });
 
+const compareFeatures = (
+  features1: WorkspaceUseCaseFeature[],
+  features2: WorkspaceUseCaseFeature[]
+) => {
+  const features1Set = new Set(features1.map(({ id, title }) => `${id}-${title}`));
+  const features2Set = new Set(features2.map(({ id, title }) => `${id}-${title}`));
+  if (features1Set.size !== features2Set.size) {
+    return false;
+  }
+  for (const feature of features1Set) {
+    if (!features2Set.has(feature)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 export const isEqualWorkspaceUseCase = (a: WorkspaceUseCase, b: WorkspaceUseCase) => {
   if (a.id !== b.id) {
     return false;
@@ -276,14 +293,7 @@ export const isEqualWorkspaceUseCase = (a: WorkspaceUseCase, b: WorkspaceUseCase
   if (a.order !== b.order) {
     return false;
   }
-  if (
-    a.features.length !== b.features.length ||
-    a.features.some((aFeature) =>
-      b.features.some(
-        (bFeature) => aFeature.id !== bFeature.id || aFeature.title !== bFeature.title
-      )
-    )
-  ) {
+  if (a.features.length !== b.features.length || !compareFeatures(a.features, b.features)) {
     return false;
   }
   return true;

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -265,17 +265,9 @@ const compareFeatures = (
   features2: WorkspaceUseCaseFeature[]
 ) => {
   const featureSerialize = ({ id, title }: WorkspaceUseCaseFeature) => `${id}-${title}`;
-  const features1Set = new Set(features1.map(featureSerialize));
-  const features2Set = new Set(features2.map(featureSerialize));
-  if (features1Set.size !== features2Set.size) {
-    return false;
-  }
-  for (const feature of features1Set) {
-    if (!features2Set.has(feature)) {
-      return false;
-    }
-  }
-  return true;
+  return (
+    features1.map(featureSerialize).sort().join() === features2.map(featureSerialize).sort().join()
+  );
 };
 
 export const isEqualWorkspaceUseCase = (a: WorkspaceUseCase, b: WorkspaceUseCase) => {

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -264,10 +264,12 @@ const compareFeatures = (
   features1: WorkspaceUseCaseFeature[],
   features2: WorkspaceUseCaseFeature[]
 ) => {
-  const featureSerialize = ({ id, title }: WorkspaceUseCaseFeature) => `${id}-${title}`;
-  return (
-    features1.map(featureSerialize).sort().join() === features2.map(featureSerialize).sort().join()
-  );
+  const featuresSerializer = (features: WorkspaceUseCaseFeature[]) =>
+    features
+      .map(({ id, title }) => `${id}-${title}`)
+      .sort()
+      .join();
+  return featuresSerializer(features1) === featuresSerializer(features2);
 };
 
 export const isEqualWorkspaceUseCase = (a: WorkspaceUseCase, b: WorkspaceUseCase) => {

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -264,8 +264,9 @@ const compareFeatures = (
   features1: WorkspaceUseCaseFeature[],
   features2: WorkspaceUseCaseFeature[]
 ) => {
-  const features1Set = new Set(features1.map(({ id, title }) => `${id}-${title}`));
-  const features2Set = new Set(features2.map(({ id, title }) => `${id}-${title}`));
+  const featureSerialize = ({ id, title }: WorkspaceUseCaseFeature) => `${id}-${title}`;
+  const features1Set = new Set(features1.map(featureSerialize));
+  const features2Set = new Set(features2.map(featureSerialize));
   if (features1Set.size !== features2Set.size) {
     return false;
   }


### PR DESCRIPTION
### Description

This PR is for fixing maximum call stack error in use case service, separate a function to compare features using `sort` instead of using `Array.property.some`. 
The root cause of this bug should be error features compare result see below example:
```
// use case 1
{
    features:[{id:"1"},{id:"2"}]
}
// use case 2
{
    features:[{id:"1"},{id:"2"}]
}
```
The result should be `true` which means two use case should be equal. But the old compare logic will return `false`. We should change `b.features.some` to `b.features.every`, then the result would be correct. Using `some` and `every` to implement the compare logic would be a little bit complicated, it can't handle duplicate features. So we change to use `sort` to compare the use case.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#7820 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI changes

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Clone branch code and run `yarn osd bootstrap --single-version ignore`
- Add below configs in `config/opensearch_dashboards.yml`
```
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
```
- Run `yarn start --no-base-path`
- Login and visit workspace detail page
- Open devtools and should no `Maximum call stack error` in the console

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Workspace] maximum call stack error in use case service

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
