### PR TITLE
[Workspace] feat: add data source and owners column to workspace list page table

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -126,6 +126,7 @@ export {
   ChromeNavGroup,
   NavGroupType,
   NavGroupStatus,
+  WorkspaceAttributeWithPermission,
 } from '../types';
 
 export {

--- a/src/core/public/saved_objects/simple_saved_object.ts
+++ b/src/core/public/saved_objects/simple_saved_object.ts
@@ -52,6 +52,7 @@ export class SimpleSavedObject<T = unknown> {
   public error: SavedObjectType<T>['error'];
   public references: SavedObjectType<T>['references'];
   public updated_at: SavedObjectType<T>['updated_at'];
+  public workspaces: SavedObjectType<T>['workspaces'];
 
   constructor(
     private client: SavedObjectsClientContract,
@@ -64,6 +65,7 @@ export class SimpleSavedObject<T = unknown> {
       references,
       migrationVersion,
       updated_at: updateAt,
+      workspaces,
     }: SavedObjectType<T>
   ) {
     this.id = id;
@@ -73,6 +75,7 @@ export class SimpleSavedObject<T = unknown> {
     this._version = version;
     this.migrationVersion = migrationVersion;
     this.updated_at = updateAt;
+    this.workspaces = workspaces;
     if (error) {
       this.error = error;
     }

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                     data-test-subj="tableHeaderCell_name_0"
                     role="columnheader"
                     scope="col"
-                    style="width: 25%;"
+                    style="width: 15%;"
                   >
                     <button
                       class="euiTableHeaderButton euiTableHeaderButton-isSorted"
@@ -250,7 +250,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                     data-test-subj="tableHeaderCell_useCase_1"
                     role="columnheader"
                     scope="col"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <span
                       class="euiTableCellContent"
@@ -268,7 +268,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                     data-test-subj="tableHeaderCell_description_2"
                     role="columnheader"
                     scope="col"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <span
                       class="euiTableCellContent"
@@ -283,10 +283,28 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </th>
                   <th
                     class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_lastUpdatedTime_3"
+                    data-test-subj="tableHeaderCell_permissions_3"
                     role="columnheader"
                     scope="col"
-                    style="width: 25%;"
+                    style="width: 15%;"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Owners"
+                      >
+                        Owners
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_lastUpdatedTime_4"
+                    role="columnheader"
+                    scope="col"
+                    style="width: 15%;"
                   >
                     <span
                       class="euiTableCellContent"
@@ -296,6 +314,24 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                         title="Last updated"
                       >
                         Last updated
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_dataSources_5"
+                    role="columnheader"
+                    scope="col"
+                    style="width: 15%;"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Data sources"
+                      >
+                        Data sources
                       </span>
                     </span>
                   </th>
@@ -346,7 +382,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 25%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -375,7 +411,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -394,7 +430,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -418,7 +454,53 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 25%;"
+                    style="width: 15%;"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Owners
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    >
+                      admin
+                       
+                      <span
+                        class="euiBadge euiBadge--hollow euiBadge--iconRight"
+                      >
+                        <span
+                          class="euiBadge__content"
+                        >
+                          <button
+                            aria-label="Open workspace detail"
+                            class="euiBadge__childButton"
+                            data-test-subj="workspaceList-more-collaborators-badge"
+                            title="+ 1 more"
+                          >
+                            + 
+                            1
+                             more
+                          </button>
+                          <button
+                            aria-label="Open workspace detail"
+                            class="euiBadge__iconButton"
+                            title="Open workspace detail"
+                            type="button"
+                          >
+                            <span
+                              class="euiBadge__icon"
+                              color="inherit"
+                              data-euiicon-type="popout"
+                            />
+                          </button>
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -430,6 +512,19 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                     >
                       Aug 5, 1999 @ 22:00:00.000
                     </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                    style="width: 15%;"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Data sources
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    />
                   </td>
                   <td
                     class="euiTableRowCell euiTableRowCell--hasActions"
@@ -498,7 +593,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 25%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -527,7 +622,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -546,7 +641,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -570,7 +665,20 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 25%;"
+                    style="width: 15%;"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Owners
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    />
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -582,6 +690,19 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                     >
                       Aug 5, 1999 @ 20:00:00.000
                     </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                    style="width: 15%;"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Data sources
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    />
                   </td>
                   <td
                     class="euiTableRowCell euiTableRowCell--hasActions"
@@ -650,7 +771,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 25%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -679,7 +800,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -698,7 +819,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 20%;"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -720,7 +841,20 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   </td>
                   <td
                     class="euiTableRowCell"
-                    style="width: 25%;"
+                    style="width: 15%;"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Owners
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    />
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                    style="width: 15%;"
                   >
                     <div
                       class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -732,6 +866,19 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                     >
                       Aug 5, 1999 @ 21:00:00.000
                     </div>
+                  </td>
+                  <td
+                    class="euiTableRowCell"
+                    style="width: 15%;"
+                  >
+                    <div
+                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                    >
+                      Data sources
+                    </div>
+                    <div
+                      class="euiTableCellContent euiTableCellContent--overflowingContent"
+                    />
                   </td>
                   <td
                     class="euiTableRowCell euiTableRowCell--hasActions"

--- a/src/plugins/workspace/public/components/workspace_list/index.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import moment from 'moment';
 import { of } from 'rxjs';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@osd/i18n/react';
 import { coreMock } from '../../../../../core/public/mocks';
 import { navigateToWorkspaceDetail } from '../utils/workspace';
@@ -42,8 +42,18 @@ jest.mock('../../utils', () => {
     ...original,
     getDataSourcesList: jest.fn().mockResolvedValue(() => [
       {
-        id: 'id1',
-        title: 'title1',
+        id: 'ds_id1',
+        title: 'ds_title1',
+        workspaces: 'id1',
+      },
+      {
+        id: 'ds_id2',
+        title: 'ds_title2',
+        workspaces: 'id1',
+      },
+      {
+        id: 'ds_id3',
+        title: 'ds_title3',
         workspaces: 'id1',
       },
     ]),
@@ -59,6 +69,11 @@ function getWrapWorkspaceListInContext(
       description:
         'should be able to see the description tooltip when hovering over the description',
       lastUpdatedTime: '1999-08-06T02:00:00.00Z',
+      permissions: {
+        write: {
+          users: ['admin', 'nonadmin'],
+        },
+      },
     },
     {
       id: 'id2',
@@ -118,6 +133,10 @@ function getWrapWorkspaceListInContext(
 }
 
 describe('WorkspaceList', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render title and table normally', () => {
     const { getByText, getByRole, container } = render(getWrapWorkspaceListInContext());
     expect(
@@ -281,5 +300,27 @@ describe('WorkspaceList', () => {
   it('should hide create workspace button for non dashboard admin', async () => {
     const { queryByText } = render(getWrapWorkspaceListInContext([], false));
     expect(queryByText('Create workspace')).toBeNull();
+  });
+
+  it('should render data source badge when more than two data sources', async () => {
+    const { getByTestId } = render(getWrapWorkspaceListInContext());
+    expect(navigateToWorkspaceDetail).not.toHaveBeenCalled();
+    await waitFor(() => {
+      const badge = getByTestId('workspaceList-more-dataSources-badge');
+      expect(badge).toBeInTheDocument();
+      fireEvent.click(badge);
+    });
+    expect(navigateToWorkspaceDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render owners badge when more than one owners', async () => {
+    const { getByTestId } = render(getWrapWorkspaceListInContext());
+    expect(navigateToWorkspaceDetail).not.toHaveBeenCalled();
+    await waitFor(() => {
+      const badge = getByTestId('workspaceList-more-collaborators-badge');
+      expect(badge).toBeInTheDocument();
+      fireEvent.click(badge);
+    });
+    expect(navigateToWorkspaceDetail).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/workspace/public/components/workspace_list/index.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.test.tsx
@@ -36,6 +36,20 @@ jest.mock('../delete_workspace_modal', () => ({
   ),
 }));
 
+jest.mock('../../utils', () => {
+  const original = jest.requireActual('../../utils');
+  return {
+    ...original,
+    getDataSourcesList: jest.fn().mockResolvedValue(() => [
+      {
+        id: 'id1',
+        title: 'title1',
+        workspaces: 'id1',
+      },
+    ]),
+  };
+});
+
 function getWrapWorkspaceListInContext(
   workspaceList = [
     {

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -36,11 +36,10 @@ import { DetailTab } from '../workspace_form/constants';
 import { WORKSPACE_CREATE_APP_ID } from '../../../common/constants';
 
 import { DeleteWorkspaceModal } from '../delete_workspace_modal';
-import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
+import { getFirstUseCaseOfFeatureConfigs, getDataSourcesList } from '../../utils';
 import { WorkspaceUseCase } from '../../types';
 import { NavigationPublicPluginStart } from '../../../../../plugins/navigation/public';
 import { WorkspacePermissionMode } from '../../../common/constants';
-import { getDataSourcesList } from '../../utils';
 import { DataSourceAttributesWithWorkspaces } from '../../types';
 
 export interface WorkspaceListProps {
@@ -221,6 +220,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
           iconOnClick={() => handleSwitchWorkspace(workspaceId, tab)}
           iconOnClickAriaLabel="Open workspace detail"
           onClickAriaLabel="Open workspace detail"
+          data-test-subj={`workspaceList-more-${tab}-badge`}
         >
           + {amount - maxDisplayedAmount} more
         </EuiBadge>

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -7,6 +7,7 @@ import { CoreStart } from '../../../core/public';
 import { WorkspaceClient } from './workspace_client';
 import { DataSourceManagementPluginSetup } from '../../../plugins/data_source_management/public';
 import { NavigationPublicPluginStart } from '../../../plugins/navigation/public';
+import { DataSourceAttributes } from '../../../plugins/data_source/common/data_sources';
 
 export type Services = CoreStart & {
   workspaceClient: WorkspaceClient;
@@ -21,4 +22,8 @@ export interface WorkspaceUseCase {
   features: Array<{ id: string; title?: string }>;
   systematic?: boolean;
   order?: number;
+}
+
+export interface DataSourceAttributesWithWorkspaces extends Omit<DataSourceAttributes, 'endpoint'> {
+  workspaces?: string[];
 }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -398,6 +398,7 @@ describe('workspace utils: getDataSourcesList', () => {
         auth: 'mock_value',
         description: 'description1',
         dataSourceEngineType: 'dataSourceEngineType1',
+        workspaces: [],
       },
     ]);
   });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -202,13 +202,16 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
   return visibleApplications;
 };
 
-export const getDataSourcesList = (client: SavedObjectsStart['client'], workspaces: string[]) => {
+export const getDataSourcesList = (
+  client: SavedObjectsStart['client'],
+  targetWorkspaces: string[]
+) => {
   return client
     .find({
       type: 'data-source',
       fields: ['id', 'title', 'auth', 'description', 'dataSourceEngineType'],
       perPage: 10000,
-      workspaces,
+      workspaces: targetWorkspaces,
     })
     .then((response) => {
       const objects = response?.savedObjects;
@@ -216,6 +219,7 @@ export const getDataSourcesList = (client: SavedObjectsStart['client'], workspac
         return objects.map((source) => {
           const id = source.id;
           const title = source.get('title');
+          const workspaces = source.workspaces ?? [];
           const auth = source.get('auth');
           const description = source.get('description');
           const dataSourceEngineType = source.get('dataSourceEngineType');
@@ -225,6 +229,7 @@ export const getDataSourcesList = (client: SavedObjectsStart['client'], workspac
             auth,
             description,
             dataSourceEngineType,
+            workspaces,
           };
         });
       } else {


### PR DESCRIPTION
### Description

Add data source and owners column to workspace list page table

## Screenshot

![image](https://github.com/user-attachments/assets/22edb870-b806-49e3-bf9a-8fff1d9a1aa1)


## Testing the changes

Go to workspace name and then you would see new column.

## Changelog

- feat: add data source and owners column to workspace list page table

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
