### PR TITLE
Fix the adoption of the new header in the index pattern management pages

### DIFF
--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
@@ -35,6 +35,7 @@ import {
   EuiGlobalToastListToast,
   EuiPageContent,
   EuiHorizontalRule,
+  EuiCode,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
@@ -65,6 +66,7 @@ import { DataSourceRef, IndexPatternManagmentContextValue } from '../../types';
 import { MatchedItem } from './types';
 import { DuplicateIndexPatternError, IndexPattern } from '../../../../data/public';
 import { StepDataSource } from './components/step_data_source';
+import { TopNavControlDescriptionData } from '../../../../navigation/public';
 
 interface CreateIndexPatternWizardState {
   step: StepType;
@@ -298,6 +300,38 @@ export class CreateIndexPatternWizard extends Component<
 
     const header = this.renderHeader();
 
+    const descriptionHeaderControl = useUpdatedUX ? (
+      <HeaderControl
+        controls={[
+          {
+            description: ((
+              <FormattedMessage
+                id="indexPatternManagement.createIndexPattern.description"
+                defaultMessage="An index pattern can match a single source, for example, {single}, or {multiple} data sources, {star}."
+                values={{
+                  multiple: <strong>multiple</strong>,
+                  single: <EuiCode>filebeat-4-3-22</EuiCode>,
+                  star: <EuiCode>filebeat-*</EuiCode>,
+                }}
+              />
+            ) as unknown) as string,
+            links: [
+              {
+                href: docLinks.links.noDocumentation.indexPatterns.introduction,
+                controlType: 'link',
+                flush: 'both',
+                target: '_blank',
+                label: i18n.translate('indexPatternManagement.createIndexPattern.documentation', {
+                  defaultMessage: 'Read documentation',
+                }),
+              },
+            ],
+          } as TopNavControlDescriptionData,
+        ]}
+        setMountPoint={application.setAppDescriptionControls}
+      />
+    ) : null;
+
     if (step === DATA_SOURCE_STEP) {
       const component = (
         <StepDataSource
@@ -306,17 +340,11 @@ export class CreateIndexPatternWizard extends Component<
           hideLocalCluster={hideLocalCluster}
         />
       );
+
       return useUpdatedUX ? (
         <>
           {component}
-          <HeaderControl
-            controls={[
-              {
-                renderComponent: <Description docLinks={docLinks} />,
-              },
-            ]}
-            setMountPoint={application.setAppDescriptionControls}
-          />
+          {descriptionHeaderControl}
         </>
       ) : (
         <EuiPageContent>
@@ -346,18 +374,12 @@ export class CreateIndexPatternWizard extends Component<
           catchAndWarn={this.catchAndWarn}
         />
       );
+
       return useUpdatedUX ? (
         <>
           {/* Except StepDataSource, other components need to use PageContent to wrap when using new UX */}
           <EuiPageContent>{component}</EuiPageContent>
-          <HeaderControl
-            controls={[
-              {
-                renderComponent: <Description docLinks={docLinks} />,
-              },
-            ]}
-            setMountPoint={application.setAppDescriptionControls}
-          />
+          {descriptionHeaderControl}
         </>
       ) : (
         <EuiPageContent>
@@ -380,18 +402,12 @@ export class CreateIndexPatternWizard extends Component<
           stepInfo={stepInfo}
         />
       );
+
       return useUpdatedUX ? (
         <>
           {/* Except StepDataSource, other components need to use PageContent to wrap when using new UX */}
           <EuiPageContent>{component}</EuiPageContent>
-          <HeaderControl
-            controls={[
-              {
-                renderComponent: <Description docLinks={docLinks} />,
-              },
-            ]}
-            setMountPoint={application.setAppDescriptionControls}
-          />
+          {descriptionHeaderControl}
         </>
       ) : (
         <EuiPageContent>

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -50,6 +50,7 @@ import { Tabs } from './tabs';
 import { IndexHeader } from './index_header';
 import { IndexPatternTableItem } from '../types';
 import { getIndexPatterns } from '../utils';
+import { TopNavControlDescriptionData } from '../../../../navigation/public';
 
 export interface EditIndexPatternProps extends RouteComponentProps {
   indexPattern: IndexPattern;
@@ -201,32 +202,41 @@ export const EditIndexPattern = withRouter(
     const useUpdatedUX = uiSettings.get('home:useNewHomePage');
 
     const renderDescription = () => {
-      const component = (
-        <EuiText size="s">
-          <p>
-            <FormattedMessage
-              id="indexPatternManagement.editIndexPattern.timeFilterLabel.timeFilterDetail"
-              defaultMessage="This page lists every field in the {indexPatternTitle} index and the field's associated core type as recorded by OpenSearch. To change a field type, use the OpenSearch"
-              values={{ indexPatternTitle: <strong>{indexPattern.title}</strong> }}
-            />{' '}
-            <EuiLink href={docLinks.links.opensearch.indexTemplates.base} target="_blank" external>
-              {mappingAPILink}
-            </EuiLink>
-          </p>
-        </EuiText>
+      const descriptionText = (
+        <FormattedMessage
+          id="indexPatternManagement.editIndexPattern.timeFilterLabel.timeFilterDetail"
+          defaultMessage="This page lists every field in the {indexPatternTitle} index and the field's associated core type as recorded by OpenSearch. To change a field type, use the OpenSearch"
+          values={{ indexPatternTitle: <strong>{indexPattern.title}</strong> }}
+        />
       );
 
       return useUpdatedUX ? (
         <HeaderControl
           controls={[
             {
-              renderComponent: component,
-            },
+              description: (descriptionText as unknown) as string,
+              links: [
+                {
+                  href: docLinks.links.opensearch.indexTemplates.base,
+                  controlType: 'link',
+                  target: '_blank',
+                  flush: 'both',
+                  label: mappingAPILink,
+                },
+              ],
+            } as TopNavControlDescriptionData,
           ]}
           setMountPoint={application.setAppDescriptionControls}
         />
       ) : (
-        component
+        <EuiText size="s">
+          <p>
+            {descriptionText}{' '}
+            <EuiLink href={docLinks.links.opensearch.indexTemplates.base} target="_blank" external>
+              {mappingAPILink}
+            </EuiLink>
+          </p>
+        </EuiText>
       );
     };
 

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -30,18 +30,11 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import {
-  EuiFlexGroup,
-  EuiToolTip,
-  EuiFlexItem,
-  EuiSmallButtonIcon,
-  EuiText,
-  EuiButtonIcon,
-  EuiButton,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiToolTip, EuiFlexItem, EuiSmallButtonIcon, EuiText } from '@elastic/eui';
 import { IIndexPattern } from 'src/plugins/data/public';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { IndexPatternManagmentContext } from '../../../types';
+import { TopNavControlButtonData, TopNavControlIconData } from '../../../../../navigation/public';
 
 interface IndexHeaderProps {
   indexPattern: IIndexPattern;
@@ -102,65 +95,49 @@ export function IndexHeader({
         ...(deleteIndexPatternClick
           ? [
               {
-                renderComponent: (
-                  <EuiToolTip content={removeTooltip}>
-                    <EuiButtonIcon
-                      color="danger"
-                      onClick={deleteIndexPatternClick}
-                      iconType="trash"
-                      aria-label={removeAriaLabel}
-                      data-test-subj="deleteIndexPatternButton"
-                      display="base"
-                      type="base"
-                      size="s"
-                    />
-                  </EuiToolTip>
-                ),
-              },
+                color: 'danger',
+                run: deleteIndexPatternClick,
+                iconType: 'trash',
+                ariaLabel: removeAriaLabel,
+                testId: 'deleteIndexPatternButton',
+                display: 'base',
+                controlType: 'icon',
+                tooltip: removeTooltip,
+              } as TopNavControlIconData,
             ]
           : []),
         ...(defaultIndex !== indexPattern.id && setDefault
           ? [
               {
-                renderComponent: (
-                  <EuiButton
-                    onClick={setDefault}
-                    aria-label={setDefaultAriaLabel}
-                    data-test-subj="setDefaultIndexPatternButton"
-                    size="s"
-                  >
-                    {i18n.translate(
-                      'indexPatternManagement.editIndexPattern.setDefaultButton.text',
-                      {
-                        defaultMessage: 'Set as default index',
-                      }
-                    )}
-                  </EuiButton>
+                run: setDefault,
+                ariaLabel: setDefaultAriaLabel,
+                testId: 'setDefaultIndexPatternButton',
+                label: i18n.translate(
+                  'indexPatternManagement.editIndexPattern.setDefaultButton.text',
+                  {
+                    defaultMessage: 'Set as default index',
+                  }
                 ),
-              },
+                controlType: 'button',
+              } as TopNavControlButtonData,
             ]
           : []),
         ...(refreshFields
           ? [
               {
-                renderComponent: (
-                  <EuiButton
-                    size="s"
-                    onClick={refreshFields}
-                    iconType="refresh"
-                    aria-label={refreshAriaLabel}
-                    data-test-subj="refreshFieldsIndexPatternButton"
-                    fill={true}
-                  >
-                    {i18n.translate(
-                      'indexPatternManagement.editIndexPattern.refreshFieldsButton.text',
-                      {
-                        defaultMessage: 'Refresh field list',
-                      }
-                    )}
-                  </EuiButton>
+                run: refreshFields,
+                iconType: 'refresh',
+                ariaLabel: refreshAriaLabel,
+                testId: 'refreshFieldsIndexPatternButton',
+                fill: true,
+                label: i18n.translate(
+                  'indexPatternManagement.editIndexPattern.refreshFieldsButton.text',
+                  {
+                    defaultMessage: 'Refresh field list',
+                  }
                 ),
-              },
+                controlType: 'button',
+              } as TopNavControlButtonData,
             ]
           : []),
       ]}

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -243,12 +243,12 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
     );
   })();
 
-  const description = (
+  const description = ((
     <FormattedMessage
       id="indexPatternManagement.indexPatternTable.indexPatternExplanation"
       defaultMessage="Create and manage the index patterns that help you retrieve your data from OpenSearch."
     />
-  );
+  ) as unknown) as string;
   const pageTitleAndDescription = showActionsInHeader ? (
     <HeaderControl
       controls={[{ description }]}


### PR DESCRIPTION
### Description

Fix the adoption of the new header in the index pattern management pages

## Screenshot
<img width="381" alt="Screenshot 2024-08-23 at 11 41 54 AM" src="https://github.com/user-attachments/assets/5d4cdde3-07d9-45af-b244-11418b352060">

---

<img width="496" alt="Screenshot 2024-08-23 at 11 42 40 AM" src="https://github.com/user-attachments/assets/7c46db41-b895-46ea-982f-890202502be4">


## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
