### PR TITLE
[Workspace]Remove default appended features

### DIFF
--- a/changelogs/fragments/7841.yml
+++ b/changelogs/fragments/7841.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Remove default appended features ([#7841](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7841))

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -13,11 +13,6 @@ export const WORKSPACE_DETAIL_APP_ID = 'workspace_detail';
 export const WORKSPACE_INITIAL_APP_ID = 'workspace_initial';
 export const WORKSPACE_NAVIGATION_APP_ID = 'workspace_navigation';
 
-/**
- * Since every workspace always have overview and update page, these features will be selected by default
- * and can't be changed in the workspace form feature selector
- */
-export const DEFAULT_SELECTED_FEATURES_IDS = [WORKSPACE_DETAIL_APP_ID];
 export const WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID = 'workspace';
 export const WORKSPACE_CONFLICT_CONTROL_SAVED_OBJECTS_CLIENT_WRAPPER_ID =
   'workspace_conflict_control';

--- a/src/plugins/workspace/public/components/workspace_form/use_workspace_form.test.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_workspace_form.test.ts
@@ -123,7 +123,7 @@ describe('useWorkspaceForm', () => {
     expect(onSubmitMock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'test-workspace-name',
-        features: ['use-case-observability', 'workspace_detail'],
+        features: ['use-case-observability'],
       })
     );
   });

--- a/src/plugins/workspace/public/components/workspace_form/use_workspace_form.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_workspace_form.ts
@@ -15,7 +15,6 @@ import {
 import { DataSource } from '../../../common/types';
 import { WorkspaceFormProps, WorkspaceFormErrors, WorkspacePermissionSetting } from './types';
 import {
-  appendDefaultFeatureIds,
   generatePermissionSettingsState,
   getNumberOfChanges,
   getNumberOfErrors,
@@ -42,9 +41,7 @@ export const useWorkspaceForm = ({
     generatePermissionSettingsState(operationType, defaultValues?.permissionSettings)
   );
 
-  const [featureConfigs, setFeatureConfigs] = useState(
-    appendDefaultFeatureIds(defaultValues?.features ?? [])
-  );
+  const [featureConfigs, setFeatureConfigs] = useState<string[]>(defaultValues?.features ?? []);
   const selectedUseCase = useMemo(() => getFirstUseCaseOfFeatureConfigs(featureConfigs), [
     featureConfigs,
   ]);
@@ -138,7 +135,7 @@ export const useWorkspaceForm = ({
     setName(resetValues?.name ?? '');
     setDescription(resetValues?.description ?? '');
     setColor(resetValues?.color);
-    setFeatureConfigs(appendDefaultFeatureIds(resetValues?.features ?? []));
+    setFeatureConfigs(resetValues?.features ?? []);
     setPermissionSettings(initialPermissionSettingsRef.current);
     setFormErrors({});
     setIsEditing(false);

--- a/src/plugins/workspace/public/components/workspace_form/utils.ts
+++ b/src/plugins/workspace/public/components/workspace_form/utils.ts
@@ -6,11 +6,7 @@
 import { i18n } from '@osd/i18n';
 
 import type { SavedObjectPermissions } from '../../../../../core/types';
-import {
-  CURRENT_USER_PLACEHOLDER,
-  DEFAULT_SELECTED_FEATURES_IDS,
-  WorkspacePermissionMode,
-} from '../../../common/constants';
+import { CURRENT_USER_PLACEHOLDER, WorkspacePermissionMode } from '../../../common/constants';
 import { isUseCaseFeatureConfig } from '../../utils';
 import {
   optionIdToWorkspacePermissionModesMap,
@@ -31,11 +27,6 @@ import {
 } from './types';
 import { DataSource } from '../../../common/types';
 import { validateWorkspaceColor } from '../../../common/utils';
-
-export const appendDefaultFeatureIds = (ids: string[]) => {
-  // concat default checked ids and unique the result
-  return Array.from(new Set(ids.concat(DEFAULT_SELECTED_FEATURES_IDS)));
-};
 
 export const isValidFormTextInput = (input?: string) => {
   /**

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -23,7 +23,7 @@ import {
   WorkspaceObject,
   WorkspaceAvailability,
 } from '../../../core/public';
-import { DEFAULT_SELECTED_FEATURES_IDS, WORKSPACE_DETAIL_APP_ID } from '../common/constants';
+import { WORKSPACE_DETAIL_APP_ID } from '../common/constants';
 import { WorkspaceUseCase, WorkspaceUseCaseFeature } from './types';
 import { formatUrlWithWorkspaceId } from '../../../core/public/utils';
 import { SigV4ServiceName } from '../../../plugins/data_source/common/data_sources';
@@ -188,7 +188,6 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
       const filterCondition =
         navLinkStatus !== AppNavLinkStatus.hidden &&
         !chromeless &&
-        !DEFAULT_SELECTED_FEATURES_IDS.includes(id) &&
         workspaceAvailability !== WorkspaceAvailability.outsideWorkspace;
       // If the category is management, only retain Dashboards Management which contains saved objets and index patterns.
       // Saved objets can show all saved objects in the current workspace and index patterns is at workspace level.


### PR DESCRIPTION
### Description

This PR is for removing default appended features logic for workspace create and update page. For now only `workspace_detail` will be appended to the features array in the workspace form. But the `workspace_detail` feature already been added to workspace's use case in [this code](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/workspace/public/services/use_case_service.ts#L83-L88). Which means the `workspace_detail` feature will always be able to access inside workspace, then we don't need to append by default.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#7844

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI changes

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version ignore`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
```
- Run `yarn start --no-base-path`
- Login and visit workspace create page
- Fill out workspace form and open devtools
- Click create button and check `POST /api/workspaces` request in devtools, the features array should not includes `workspace_detail` like below image
![image](https://github.com/user-attachments/assets/012be732-7dd3-439f-b3ed-e42af6609e91)
- Page will redirect to workspace_detail after create successfully
- Click "Edit" button and add change description
- Click "Save changes" and check `PUT /api/workspaces/{:id}`, the features array should not includes `workspace_detail` like below image
![image](https://github.com/user-attachments/assets/5aa09126-6f0b-4a4b-a29e-e9d80c5024d8)


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace]Remove default appended features

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
