### PR TITLE
Fix Nav Bar layout in New Discover

### DIFF
--- a/changelogs/fragments/7853.yml
+++ b/changelogs/fragments/7853.yml
@@ -1,0 +1,2 @@
+fix:
+- Nav bar layout in Discover when Query Enhancement Flag is On ([#7853](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7853))

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -225,6 +225,7 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
         className="euiSuperUpdateButton"
         iconType="play"
         fill
+        size={'s'}
       >
         Run
       </EuiButton>
@@ -292,6 +293,7 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
           dateFormat={uiSettings!.get('dateFormat')}
           isAutoRefreshOnly={props.showAutoRefreshOnly}
           className="osdQueryEditor__datePicker"
+          compressed={true}
         />
       </EuiFlexItem>
     );

--- a/src/plugins/data_explorer/public/components/app_container.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.tsx
@@ -54,7 +54,7 @@ export const AppContainer = React.memo(
         {isEnhancementsEnabled && (
           <EuiFlexGroup
             direction="row"
-            className={`mainPage ${showActionsInGroup ? '' : 'navBar'}"`}
+            className={showActionsInGroup ? '' : 'mainPage navBar'}
             gutterSize="none"
             alignItems="center"
             justifyContent="spaceBetween"

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -121,11 +121,12 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     dispatch(setSavedQuery(newSavedQueryId));
   };
 
+  const displayToNavLinkInPortal =
+    isEnhancementsEnabled && !!opts?.optionalRef?.topLinkRef?.current && !showActionsInGroup;
+
   return (
     <>
-      {isEnhancementsEnabled &&
-        !!opts?.optionalRef?.topLinkRef?.current &&
-        !showActionsInGroup &&
+      {displayToNavLinkInPortal &&
         createPortal(
           <EuiFlexGroup gutterSize="m">
             {topNavLinks.map((topNavLink) => (
@@ -146,7 +147,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
         )}
       <TopNavMenu
         appName={PLUGIN_ID}
-        config={topNavLinks}
+        config={displayToNavLinkInPortal ? [] : topNavLinks}
         showSearchBar={TopNavMenuItemRenderType.IN_PLACE}
         showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
         showSaveQuery={showSaveQuery}


### PR DESCRIPTION
### Description

Fixed the Nav bar layout in Discover when Query Enhancement flag is on. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

Case 1: When Query Enhancement is ON and New Home Page is ON
![image](https://github.com/user-attachments/assets/72bd0aef-e4df-42e8-8849-d1e969a69d0e)

Case 2: When Query Enhancement is ON and New Home Page is OFF
![image](https://github.com/user-attachments/assets/a198ff48-0b18-412f-9f60-fcfbdcf9d05a)

Case 3: When Query Enhancement is OFF and New Home Page is ON
![image](https://github.com/user-attachments/assets/de910ead-ff78-4fc3-876b-f2f1cec94c3a)

Case 4: When Query Enhancement is OFF and New Home Page is OFF
![image](https://github.com/user-attachments/assets/df43025b-e864-476c-bccf-4480fd1c07c8)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Nav bar layout in Discover when Query Enhancement Flag is On

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
