### PR TITLE
[Bug][Workspace]fix: revert new home page ui setting for workspace default route

### DIFF
--- a/changelogs/fragments/7858.yml
+++ b/changelogs/fragments/7858.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace] Revert new home page ui setting for workspace default route ([#7858](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7858))

--- a/src/plugins/workspace/server/plugin.test.ts
+++ b/src/plugins/workspace/server/plugin.test.ts
@@ -183,23 +183,6 @@ describe('Workspace server plugin', () => {
   describe('#setUpRedirectPage', () => {
     const setupMock = coreMock.createSetup();
     const uiSettingsMock = uiSettingsServiceMock.createClient();
-    setupMock.getStartServices.mockResolvedValue([
-      {
-        ...coreMock.createStart(),
-        uiSettings: {
-          asScopedToClient: () => ({
-            ...uiSettingsMock,
-            get: jest.fn().mockImplementation((key) => {
-              if (key === 'home:useNewHomePage') {
-                return Promise.resolve(true);
-              }
-            }),
-          }),
-        },
-      },
-      {},
-      {},
-    ]);
     const initializerContextConfigMock = coreMock.createPluginInitializerContext({
       enabled: true,
       permission: {
@@ -304,8 +287,6 @@ describe('Workspace server plugin', () => {
               get: jest.fn().mockImplementation((key) => {
                 if (key === 'defaultWorkspace') {
                   return Promise.resolve('defaultWorkspace');
-                } else if (key === 'home:useNewHomePage') {
-                  return Promise.resolve('true');
                 }
               }),
             }),
@@ -336,29 +317,6 @@ describe('Workspace server plugin', () => {
           location: '/mock-server-basepath/w/defaultWorkspace/app/workspace_navigation',
         },
       });
-    });
-
-    it('with / request path and home:useNewHomePage is false', async () => {
-      const request = httpServerMock.createOpenSearchDashboardsRequest({
-        path: '/',
-      });
-      setupMock.getStartServices.mockResolvedValue([
-        {
-          ...coreMock.createStart(),
-          uiSettings: {
-            asScopedToClient: () => ({
-              ...uiSettingsMock,
-              get: jest.fn().mockResolvedValue(false),
-            }),
-          },
-        },
-        {},
-        {},
-      ]);
-      const toolKitMock = httpServerMock.createToolkit();
-
-      await registerOnPostAuthFn(request, response, toolKitMock);
-      expect(toolKitMock.next).toBeCalledTimes(1);
     });
   });
 

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -114,15 +114,6 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     core.http.registerOnPostAuth(async (request, response, toolkit) => {
       const path = request.url.pathname;
       if (path === '/') {
-        const [coreStart] = await core.getStartServices();
-        const uiSettings = coreStart.uiSettings.asScopedToClient(
-          coreStart.savedObjects.getScopedClient(request)
-        );
-        const useNewHomePage = await uiSettings.get('home:useNewHomePage');
-        if (!useNewHomePage) {
-          return toolkit.next();
-        }
-
         const workspaceListResponse = await this.client?.list(
           { request, logger: this.logger },
           { page: 1, perPage: 100 }
@@ -139,6 +130,10 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
               },
             });
           }
+          const [coreStart] = await core.getStartServices();
+          const uiSettings = coreStart.uiSettings.asScopedToClient(
+            coreStart.savedObjects.getScopedClient(request)
+          );
           // Temporarily use defaultWorkspace as a placeholder
           const defaultWorkspaceId = await uiSettings.get('defaultWorkspace');
           const defaultWorkspace = workspaceList.find(


### PR DESCRIPTION
### Description

Revert new home page ui setting for workspace default route.

```
uiSettings:
  overrides:
    "home:useNewHomePage": true
```
and
```
workspace.enabled: true
```
are enabled/disabled at the same time.

We do not handle the case where useNewHomePage and workspace are inconsistent.
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
 - fix: [Workspace] Revert new home page ui setting for workspace default route
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
