### PR TITLE
[Manual Backport][2.x][Workspace] Use small button, small padding and compressed.

### DIFF
--- a/changelogs/fragments/7842.yml
+++ b/changelogs/fragments/7842.yml
@@ -1,0 +1,2 @@
+refactor:
+- [Workspace] Use small button, small padding and compressed. ([#7842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7842))

--- a/src/plugins/workspace/public/components/home_get_start_card/use_case_footer.tsx
+++ b/src/plugins/workspace/public/components/home_get_start_card/use_case_footer.tsx
@@ -10,7 +10,6 @@ import {
   EuiPanel,
   EuiAvatar,
   EuiSpacer,
-  EuiButton,
   EuiPopover,
   EuiFlexItem,
   EuiModalBody,
@@ -20,6 +19,7 @@ import {
   EuiModalHeader,
   EuiContextMenu,
   EuiModalHeaderTitle,
+  EuiSmallButton,
 } from '@elastic/eui';
 import React, { useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
@@ -88,7 +88,7 @@ export const UseCaseFooter = ({
 
     return (
       <>
-        <EuiButton
+        <EuiSmallButton
           iconType="plus"
           onClick={showModal}
           data-test-subj="useCase.footer.createWorkspace.button"
@@ -96,7 +96,7 @@ export const UseCaseFooter = ({
           {i18n.translate('workspace.useCase.footer.createWorkspace', {
             defaultMessage: 'Create workspace',
           })}
-        </EuiButton>
+        </EuiSmallButton>
         {isModalVisible && (
           <EuiModal onClose={closeModal} style={{ width: '450px' }}>
             <EuiModalHeader>
@@ -108,13 +108,16 @@ export const UseCaseFooter = ({
             </EuiModalBody>
 
             <EuiModalFooter>
-              <EuiButton onClick={closeModal} data-test-subj="useCase.footer.modal.close.button">
+              <EuiSmallButton
+                onClick={closeModal}
+                data-test-subj="useCase.footer.modal.close.button"
+              >
                 {i18n.translate('workspace.useCase.footer.modal.close', {
                   defaultMessage: 'Close',
                 })}
-              </EuiButton>
+              </EuiSmallButton>
               {isDashboardAdmin && (
-                <EuiButton
+                <EuiSmallButton
                   href={core.application.getUrlForApp('workspace_create', { absolute: false })}
                   data-test-subj="useCase.footer.modal.create.button"
                   fill
@@ -122,7 +125,7 @@ export const UseCaseFooter = ({
                   {i18n.translate('workspace.useCase.footer.modal.create', {
                     defaultMessage: 'Create workspace',
                   })}
-                </EuiButton>
+                </EuiSmallButton>
               )}
             </EuiModalFooter>
           </EuiModal>
@@ -138,9 +141,9 @@ export const UseCaseFooter = ({
       basePath
     );
     return (
-      <EuiButton href={useCaseURL} data-test-subj="useCase.footer.openWorkspace.button">
+      <EuiSmallButton href={useCaseURL} data-test-subj="useCase.footer.openWorkspace.button">
         {i18n.translate('workspace.useCase.footer.openWorkspace', { defaultMessage: 'Open' })}
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
@@ -176,11 +179,11 @@ export const UseCaseFooter = ({
   };
 
   const button = (
-    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+    <EuiSmallButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
       {i18n.translate('workspace.useCase.footer.selectWorkspace', {
         defaultMessage: 'Select workspace',
       })}
-    </EuiButton>
+    </EuiSmallButton>
   );
   const panels = [
     {
@@ -195,7 +198,7 @@ export const UseCaseFooter = ({
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="none"
+      panelPaddingSize="s"
       anchorPosition="downCenter"
     >
       <EuiPanel hasBorder={false} color="transparent" paddingSize="s">

--- a/src/plugins/workspace/public/components/workspace_detail/__snapshots__/workspace_detail.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_detail/__snapshots__/workspace_detail.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`WorkspaceDetail render workspace detail page normally 1`] = `
                                 value="observability"
                               />
                               <div
-                                class="euiFormControlLayout"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
                                 <div
                                   class="euiFormControlLayout__childrenWrapper"
@@ -460,7 +460,7 @@ exports[`WorkspaceDetail render workspace detail page normally 1`] = `
                                     aria-describedby="generated-id-help-0"
                                     aria-haspopup="true"
                                     aria-labelledby="generated-id generated-id"
-                                    class="euiSuperSelectControl"
+                                    class="euiSuperSelectControl euiSuperSelectControl--compressed"
                                     disabled=""
                                     readonly=""
                                     type="button"
@@ -549,14 +549,14 @@ exports[`WorkspaceDetail render workspace detail page normally 1`] = `
                             class="euiPopover__anchor"
                           >
                             <div
-                              class="euiFormControlLayout euiFormControlLayout--readOnly"
+                              class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--readOnly"
                             >
                               <div
                                 class="euiFormControlLayout__childrenWrapper"
                               >
                                 <div>
                                   <div
-                                    class="euiFormControlLayout euiFormControlLayout--readOnly"
+                                    class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--readOnly"
                                   >
                                     <div
                                       class="euiFormControlLayout__childrenWrapper"
@@ -564,7 +564,7 @@ exports[`WorkspaceDetail render workspace detail page normally 1`] = `
                                       <input
                                         aria-label="Press the down key to open a popover containing color options"
                                         autocomplete="off"
-                                        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+                                        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFieldText--compressed"
                                         data-test-subj="euiColorPickerAnchor workspaceForm-workspaceDetails-colorPicker"
                                         id="generated-id"
                                         placeholder="Transparent"

--- a/src/plugins/workspace/public/components/workspace_detail/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/association_data_source_modal.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import {
   EuiText,
   EuiModal,
-  EuiButton,
+  EuiSmallButton,
   EuiModalBody,
   EuiSelectable,
   EuiModalFooter,
@@ -99,13 +99,13 @@ export const AssociationDataSourceModal = ({
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButton onClick={closeModal} fill>
+        <EuiSmallButton onClick={closeModal} fill>
           <FormattedMessage
             id="workspace.detail.dataSources.associateModal.close.button"
             defaultMessage="Close"
           />
-        </EuiButton>
-        <EuiButton
+        </EuiSmallButton>
+        <EuiSmallButton
           onClick={() => handleAssignDataSources(selectedDataSources)}
           isDisabled={!selectedDataSources || selectedDataSources.length === 0}
           fill
@@ -114,7 +114,7 @@ export const AssociationDataSourceModal = ({
             id="workspace.detail.dataSources.associateModal.save.button"
             defaultMessage="Save changes"
           />
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/src/plugins/workspace/public/components/workspace_detail/opensearch_connections_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/opensearch_connections_table.tsx
@@ -6,7 +6,7 @@
 import React, { useMemo, useState } from 'react';
 import {
   EuiSpacer,
-  EuiButton,
+  EuiSmallButton,
   EuiFlexItem,
   EuiFlexGroup,
   EuiFieldSearch,
@@ -160,7 +160,7 @@ export const OpenSearchConnectionTable = ({
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
         {selectedItems.length > 0 && !modalVisible && (
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               color="danger"
               onClick={() => setModalVisible(true)}
               data-test-subj="workspace-detail-dataSources-table-bulkRemove"
@@ -169,7 +169,7 @@ export const OpenSearchConnectionTable = ({
                 defaultMessage: 'Remove {numberOfSelect} association(s)',
                 values: { numberOfSelect: selectedItems.length },
               })}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         )}
         <EuiFlexItem>

--- a/src/plugins/workspace/public/components/workspace_form/workspace_detail_form_details.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_detail_form_details.tsx
@@ -4,8 +4,8 @@
  */
 
 import {
-  EuiSuperSelect,
-  EuiColorPicker,
+  EuiCompressedSuperSelect,
+  EuiCompressedColorPicker,
   EuiCompressedFormRow,
   EuiDescribedFormGroup,
 } from '@elastic/eui';
@@ -104,7 +104,7 @@ export const WorkspaceDetailFormDetails = ({
           error={formErrors.features?.message}
           helpText={detailsUseCaseHelpText}
         >
-          <EuiSuperSelect
+          <EuiCompressedSuperSelect
             options={options}
             valueOfSelected={value}
             onChange={(id) => {
@@ -125,7 +125,7 @@ export const WorkspaceDetailFormDetails = ({
           isInvalid={!!formErrors.color}
           error={formErrors.color?.message}
         >
-          <EuiColorPicker
+          <EuiCompressedColorPicker
             color={formData.color}
             onChange={handleColorChange}
             readOnly={!isEditing}

--- a/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`WorkspaceInitial render workspace initial page normally when theme is d
                 class="euiFlexItem euiFlexItem--flexGrowZero eui-displayInline"
               >
                 <a
-                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
                   data-test-subj="workspace-initial-button-openSearch"
                   href="https://www.opensearch.org/"
                   rel="noreferrer"
@@ -327,7 +327,7 @@ exports[`WorkspaceInitial render workspace initial page normally when theme is d
             </div>
           </div>
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
             data-test-subj="workspace-initial-button-settingsAndSetup"
             type="button"
           >
@@ -420,7 +420,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is da
                 class="euiFlexItem euiFlexItem--flexGrowZero eui-displayInline"
               >
                 <a
-                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
                   data-test-subj="workspace-initial-button-openSearch"
                   href="https://www.opensearch.org/"
                   rel="noreferrer"
@@ -684,7 +684,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is da
             </div>
           </div>
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
             data-test-subj="workspace-initial-button-settingsAndSetup"
             type="button"
           >
@@ -777,7 +777,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is no
                 class="euiFlexItem euiFlexItem--flexGrowZero eui-displayInline"
               >
                 <a
-                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
                   data-test-subj="workspace-initial-button-openSearch"
                   href="https://www.opensearch.org/"
                   rel="noreferrer"
@@ -1017,7 +1017,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is no
             </div>
           </div>
           <button
-            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushLeft"
             data-test-subj="workspace-initial-button-settingsAndSetup"
             type="button"
           >

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
@@ -18,10 +18,10 @@ import {
   EuiPageBody,
   EuiFlexItem,
   EuiFlexGroup,
-  EuiButtonEmpty,
   EuiPageContent,
   EuiSmallButton,
   EuiToolTip,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import BackgroundLightSVG from '../../assets/background_light.svg';
@@ -169,7 +169,7 @@ export const WorkspaceInitial = () => {
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false} className="eui-displayInline">
-        <EuiButtonEmpty
+        <EuiSmallButtonEmpty
           href="https://www.opensearch.org/"
           iconType="popout"
           iconSide="right"
@@ -181,7 +181,7 @@ export const WorkspaceInitial = () => {
               defaultMessage: 'Learn more from documentation and more.',
             })}
           </EuiText>
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
       </EuiFlexItem>
 
       <EuiFlexItem grow={false} style={{ maxWidth: '540px' }}>
@@ -216,7 +216,7 @@ export const WorkspaceInitial = () => {
             >
               {content}
             </EuiPageContent>
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               iconType="gear"
               iconSide="left"
               flush="left"
@@ -228,7 +228,7 @@ export const WorkspaceInitial = () => {
                   defaultMessage: 'Settings and setup',
                 })}
               </EuiText>
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageBody>

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -11,17 +11,15 @@ import {
   EuiPanel,
   EuiTitle,
   EuiAvatar,
-  EuiButton,
   EuiPopover,
   EuiToolTip,
   EuiFlexItem,
   EuiFlexGroup,
   EuiListGroup,
-  EuiButtonEmpty,
-  EuiSmallButton,
   EuiSmallButtonIcon,
   EuiSmallButtonEmpty,
   EuiListGroupItem,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -179,7 +177,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       button={currentWorkspaceButton}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="none"
+      panelPaddingSize="s"
       anchorPosition="downCenter"
     >
       <EuiPanel paddingSize="s" hasBorder={false} color="transparent">
@@ -257,8 +255,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       <EuiPanel paddingSize="s" hasBorder={false} color="transparent">
         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              size="xs"
+            <EuiSmallButtonEmpty
               flush="left"
               key={WORKSPACE_LIST_APP_ID}
               data-test-subj="workspace-menu-view-all-button"
@@ -268,14 +265,13 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
               }}
             >
               {viewAllButton}
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           {isDashboardAdmin && (
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 color="text"
                 iconType="plus"
-                size="s"
                 key={WORKSPACE_CREATE_APP_ID}
                 data-test-subj="workspace-menu-create-workspace-button"
                 onClick={() => {
@@ -284,7 +280,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
                 }}
               >
                 {createWorkspaceButton}
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>


### PR DESCRIPTION
### Description

Use small button, small padding and compressed.

### Issues Resolved

Manual backport https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7842

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
