### PR TITLE
Fix issue when bootstrapping on 2.x

### DIFF
--- a/changelogs/fragments/7901.yml
+++ b/changelogs/fragments/7901.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix bootstrap errors in 2.x ([#7901](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7901))

--- a/src/core/server/config/service/config_store_client/opensearch_config_store.test.ts
+++ b/src/core/server/config/service/config_store_client/opensearch_config_store.test.ts
@@ -71,6 +71,7 @@ describe('OpenSearchConfigStoreClient', () => {
               hits: mockHits.map((hit) => ({
                 _index: getDynamicConfigIndexName(1),
                 _id: JSON.stringify(hit),
+                _version: 1,
                 _source: hit,
               })),
             },
@@ -299,6 +300,11 @@ describe('OpenSearchConfigStoreClient', () => {
           {
             create: {
               _id: itemId,
+              _index: DYNAMIC_APP_CONFIG_ALIAS,
+              retry_on_conflict: 2,
+              routing: '',
+              version: 1,
+              version_type: 'external',
             },
           },
           {
@@ -314,6 +320,11 @@ describe('OpenSearchConfigStoreClient', () => {
           {
             update: {
               _id: JSON.stringify(configDocument),
+              _index: DYNAMIC_APP_CONFIG_ALIAS,
+              retry_on_conflict: 2,
+              routing: '',
+              version: 2,
+              version_type: 'external',
             },
           },
           {
@@ -483,6 +494,11 @@ describe('OpenSearchConfigStoreClient', () => {
             {
               update: {
                 _id: JSON.stringify(oldConfig),
+                _index: DYNAMIC_APP_CONFIG_ALIAS,
+                retry_on_conflict: 2,
+                routing: '',
+                version: 2,
+                version_type: 'external',
               },
             },
             {
@@ -503,6 +519,11 @@ describe('OpenSearchConfigStoreClient', () => {
             {
               create: {
                 _id: JSON.stringify(config),
+                _index: DYNAMIC_APP_CONFIG_ALIAS,
+                retry_on_conflict: 2,
+                routing: '',
+                version: 1,
+                version_type: 'external',
               },
             },
             {

--- a/src/core/server/config/service/config_store_client/opensearch_config_store_client.ts
+++ b/src/core/server/config/service/config_store_client/opensearch_config_store_client.ts
@@ -240,6 +240,11 @@ export class OpenSearchConfigStoreClient implements IDynamicConfigStoreClient {
         {
           update: {
             _id: config._id,
+            _index: DYNAMIC_APP_CONFIG_ALIAS,
+            retry_on_conflict: 2,
+            routing: '',
+            version: config._version! + 1,
+            version_type: 'external',
           },
         },
         {
@@ -267,6 +272,11 @@ export class OpenSearchConfigStoreClient implements IDynamicConfigStoreClient {
         {
           create: {
             _id: uniqueId(),
+            _index: DYNAMIC_APP_CONFIG_ALIAS,
+            retry_on_conflict: 2,
+            routing: '',
+            version: 1,
+            version_type: 'external',
           },
         },
         newConfigDocument


### PR DESCRIPTION
### Description

Fixes bootstrap within `2.x` branch caused by #7194 . This is due to `@opensearch-project/opensearch` major version difference between `main` and `2.x`, which has interface changes that break bootstrap (#3464).

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Fix bootstrap errors in 2.x

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
