### PR TITLE
[workspace] refine style of workspace list table

### DIFF
--- a/changelogs/fragments/7913.yml
+++ b/changelogs/fragments/7913.yml
@@ -1,2 +1,2 @@
 fix:
-- Refactor the style of workspace list table ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))
+- Refa the style ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))

--- a/changelogs/fragments/7913.yml
+++ b/changelogs/fragments/7913.yml
@@ -1,2 +1,2 @@
 fix:
-- Refa the style ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))
+- Refactor the style for the work list table ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))

--- a/changelogs/fragments/7913.yml
+++ b/changelogs/fragments/7913.yml
@@ -1,2 +1,2 @@
 fix:
-- Align the style ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))
+- Refactor the style of workspace list table ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))

--- a/changelogs/fragments/7913.yml
+++ b/changelogs/fragments/7913.yml
@@ -1,0 +1,2 @@
+fix:
+- Align the style ([#7913](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7913))

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -444,7 +444,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                         class="euiToolTipAnchor"
                       >
                         <div
-                          class="euiText euiText--small eui-textTruncate"
+                          class="euiText euiText--extraSmall eui-textTruncate"
                           style="max-width: 150px;"
                         >
                           should be able to see the description tooltip when hovering over the description
@@ -655,7 +655,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                         class="euiToolTipAnchor"
                       >
                         <div
-                          class="euiText euiText--small eui-textTruncate"
+                          class="euiText euiText--extraSmall eui-textTruncate"
                           style="max-width: 150px;"
                         >
                           should be able to see the description tooltip when hovering over the description
@@ -833,7 +833,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                         class="euiToolTipAnchor"
                       >
                         <div
-                          class="euiText euiText--small eui-textTruncate"
+                          class="euiText euiText--extraSmall eui-textTruncate"
                           style="max-width: 150px;"
                         />
                       </span>

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
               </div>
             </div>
             <table
-              class="euiTable euiTable--responsive"
+              class="euiTable euiTable--compressed euiTable--responsive"
               id="__table_generated-id"
               tabindex="-1"
             >

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -327,7 +327,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
           data-test-subj="workspaceList-hover-description"
         >
           {/* Here I need to set width mannuly as the tooltip will ineffect the property : truncateText ',  */}
-          <EuiText size="s" className="eui-textTruncate" style={{ maxWidth: 150 }}>
+          <EuiText className="eui-textTruncate" size="xs" style={{ maxWidth: 150 }}>
             {description}
           </EuiText>
         </EuiToolTip>
@@ -379,7 +379,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
                 iconType="copy"
                 color="text"
               >
-                <EuiText size="m">Copy ID</EuiText>
+                Copy ID
               </EuiButtonEmpty>
             );
           },
@@ -400,7 +400,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
                 size="xs"
                 color="text"
               >
-                <EuiText size="m">Edit</EuiText>
+                Edit
               </EuiButtonEmpty>
             );
           },
@@ -416,11 +416,12 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
                 onClick={() => {
                   setDeletedWorkspaces([item]);
                 }}
-                size="xs"
+                size="s"
                 iconType="trash"
                 color="danger"
+                style={{ padding: 0 }}
               >
-                <EuiText size="m">Delete</EuiText>
+                Delete
               </EuiButtonEmpty>
             );
           },
@@ -430,7 +431,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
   ];
 
   return (
-    <EuiPage>
+    <EuiPage paddingSize="m">
       <HeaderControl
         controls={[
           {
@@ -442,7 +443,13 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
         setMountPoint={application?.setAppDescriptionControls}
       />
       {isDashboardAdmin && renderCreateWorkspaceButton()}
-      <EuiPageContent verticalPosition="center" horizontalPosition="center" hasShadow={false}>
+      <EuiPageContent
+        verticalPosition="center"
+        horizontalPosition="center"
+        panelPaddingSize="l"
+        paddingSize="m"
+        hasShadow={false}
+      >
         <EuiInMemoryTable
           compressed={true}
           items={newWorkspaceList}

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -430,7 +430,7 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
   ];
 
   return (
-    <EuiPage paddingSize="m">
+    <EuiPage>
       <HeaderControl
         controls={[
           {
@@ -442,14 +442,9 @@ export const WorkspaceList = ({ registeredUseCases$ }: WorkspaceListProps) => {
         setMountPoint={application?.setAppDescriptionControls}
       />
       {isDashboardAdmin && renderCreateWorkspaceButton()}
-      <EuiPageContent
-        verticalPosition="center"
-        horizontalPosition="center"
-        paddingSize="m"
-        panelPaddingSize="l"
-        hasShadow={false}
-      >
+      <EuiPageContent verticalPosition="center" horizontalPosition="center" hasShadow={false}>
         <EuiInMemoryTable
+          compressed={true}
           items={newWorkspaceList}
           columns={columns}
           itemId="id"


### PR DESCRIPTION
### Description

In this pr, I make a small change for the work list table followed by Trineo: Fit and Finish Guidance :

1. compress input
2. change back text size to xs, according to "Please DO NOT increase the size of existing extra-small text that is associated with tables, form elements, or where we may have intentionally chosen an extra-small size"

## Screenshot
<img width="1663" alt="Screenshot 2024-08-29 at 15 13 29" src="https://github.com/user-attachments/assets/0639f91e-a5be-48e1-b445-3e0c6c87ee8a">

## Changelog
- fix: refactor the style for the work list table

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
