### PR TITLE
Fix dynamicConfigService mock import

### DIFF
--- a/src/core/server/config/index.ts
+++ b/src/core/server/config/index.ts
@@ -30,8 +30,6 @@
 
 export { coreDeprecationProvider } from './deprecation';
 
-export { dynamicConfigServiceMock } from './mocks';
-
 export { config } from './dynamic_config_service_config';
 
 export {

--- a/src/core/server/config/mocks.ts
+++ b/src/core/server/config/mocks.ts
@@ -36,3 +36,8 @@ export {
 } from '@osd/config/target/mocks';
 
 export { dynamicConfigServiceMock } from './dynamic_config_service.mock';
+
+export {
+  internalDynamicConfigurationClientMock,
+  dynamicConfigurationClientMock,
+} from './service/configuration_client.mock';

--- a/src/core/server/config/service/config_store_client/dummy_config_store_client.test.ts
+++ b/src/core/server/config/service/config_store_client/dummy_config_store_client.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DummyConfigStoreClient } from './dummy_config_store_client';
+
+describe('DummyConfigStoreClient', () => {
+  const expectedResponse = {
+    body: {},
+    statusCode: 200,
+    headers: {},
+    warnings: [],
+    meta: {},
+  };
+  const dummyStoreConfigClient = new DummyConfigStoreClient();
+
+  it('should return empty map for listConfigs', async () => {
+    const response = await dummyStoreConfigClient.listConfigs();
+    expect(response).toMatchObject(new Map());
+  });
+
+  it('should return expectedResponse for bulkCreateConfigs', async () => {
+    const response = await dummyStoreConfigClient.bulkCreateConfigs({
+      configs: [],
+    });
+    expect(response).toMatchObject(expectedResponse);
+  });
+
+  it('should return expectedResponse for createConfigs', async () => {
+    const response = await dummyStoreConfigClient.createConfig({
+      config: {
+        name: 'foo',
+        updatedConfig: {},
+      },
+    });
+    expect(response).toMatchObject(expectedResponse);
+  });
+
+  it('should return expectedResponse for bulkDeleteConfigs', async () => {
+    const response = await dummyStoreConfigClient.bulkDeleteConfigs({
+      paths: [],
+    });
+    expect(response).toMatchObject(expectedResponse);
+  });
+
+  it('should return expectedResponse for deleteConfig', async () => {
+    const response = await dummyStoreConfigClient.deleteConfig({
+      pluginConfigPath: 'foo',
+    });
+    expect(response).toMatchObject(expectedResponse);
+  });
+
+  it('should return undefined for getConfig', async () => {
+    const response = await dummyStoreConfigClient.getConfig('foo');
+    expect(response).toBeUndefined();
+  });
+
+  it('should return empty for bulkGetConfigs', async () => {
+    const response = await dummyStoreConfigClient.bulkGetConfigs([]);
+    expect(response).toMatchObject(new Map());
+  });
+});

--- a/src/core/server/config/service/config_store_client/dummy_config_store_client.ts
+++ b/src/core/server/config/service/config_store_client/dummy_config_store_client.ts
@@ -11,7 +11,7 @@ import {
   DynamicConfigurationClientOptions,
   IDynamicConfigStoreClient,
 } from '../../types';
-import { dynamicConfigurationClientMock } from '../configuration_client.mock';
+import { createApiResponse } from '../../utils/utils';
 
 /**
  * The DummyConfigStoreClient is the client DAO that will used when dynamic config service is "disabled".
@@ -27,28 +27,28 @@ export class DummyConfigStoreClient implements IDynamicConfigStoreClient {
     bulkCreateConfigProps: BulkCreateConfigProps,
     options?: DynamicConfigurationClientOptions | undefined
   ) {
-    return Promise.resolve(dynamicConfigurationClientMock.createApiResponse());
+    return Promise.resolve(createApiResponse());
   }
 
   public async createConfig(
     createConfigProps: CreateConfigProps,
     options?: DynamicConfigurationClientOptions | undefined
   ) {
-    return Promise.resolve(dynamicConfigurationClientMock.createApiResponse());
+    return Promise.resolve(createApiResponse());
   }
 
   public async bulkDeleteConfigs(
     bulkDeleteConfigs: BulkDeleteConfigProps,
     options?: DynamicConfigurationClientOptions | undefined
   ) {
-    return Promise.resolve(dynamicConfigurationClientMock.createApiResponse());
+    return Promise.resolve(createApiResponse());
   }
 
   public async deleteConfig(
     deleteConfigs: ConfigIdentifier,
     options?: DynamicConfigurationClientOptions | undefined
   ) {
-    return Promise.resolve(dynamicConfigurationClientMock.createApiResponse());
+    return Promise.resolve(createApiResponse());
   }
 
   public async getConfig(

--- a/src/core/server/config/service/configuration_client.mock.ts
+++ b/src/core/server/config/service/configuration_client.mock.ts
@@ -5,19 +5,7 @@
 
 import { ApiResponse } from '@opensearch-project/opensearch/.';
 import { IDynamicConfigurationClient, IInternalDynamicConfigurationClient } from '../types';
-
-const createApiResponse = <TResponse = Record<string, any>>(
-  opts: Partial<ApiResponse> = {}
-): ApiResponse<TResponse> => {
-  return {
-    body: {} as any,
-    statusCode: 200,
-    headers: {},
-    warnings: [],
-    meta: {} as any,
-    ...opts,
-  };
-};
+import { createApiResponse } from '../utils/utils';
 
 const createInternalDynamicConfigurationClientMock = (
   props: InternalDynamicConfigurationClientMockProps = {

--- a/src/core/server/config/utils/utils.ts
+++ b/src/core/server/config/utils/utils.ts
@@ -6,6 +6,7 @@
 import _ from 'lodash';
 import { Logger } from '@osd/logging';
 import { Request } from 'hapi__hapi';
+import { ApiResponse } from '@opensearch-project/opensearch/.';
 import { ConfigIdentifier } from '../types';
 import { DYNAMIC_APP_CONFIG_INDEX_PREFIX } from './constants';
 import { OpenSearchDashboardsRequest } from '../../http';
@@ -23,6 +24,19 @@ export const pathToString = (configIdentifier: ConfigIdentifier) => {
     return Array.isArray(pluginConfigPath) ? pluginConfigPath.join('.') : pluginConfigPath;
   }
   return _.snakeCase(name);
+};
+
+export const createApiResponse = <TResponse = Record<string, any>>(
+  opts: Partial<ApiResponse> = {}
+): ApiResponse<TResponse> => {
+  return {
+    body: {} as any,
+    statusCode: 200,
+    headers: {},
+    warnings: [],
+    meta: {} as any,
+    ...opts,
+  };
 };
 
 /**

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -55,6 +55,7 @@ import { crossCompatibilityServiceMock } from './cross_compatibility/cross_compa
 import { dynamicConfigServiceMock } from './config/dynamic_config_service.mock';
 
 export { configServiceMock } from './config/mocks';
+export { dynamicConfigServiceMock } from './config/mocks';
 export { httpServerMock } from './http/http_server.mocks';
 export { httpResourcesMock } from './http_resources/http_resources_service.mock';
 export { sessionStorageMock } from './http/cookie_session_storage.mocks';

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
@@ -16,8 +16,7 @@ import { registerFetchDataSourceMetaDataRoute } from './fetch_data_source_metada
 import { AuthType } from '../../common/data_sources';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
-// eslint-disable-next-line @osd/eslint/no-restricted-paths
-import { dynamicConfigServiceMock } from '../../../../../src/core/server/config';
+import { dynamicConfigServiceMock } from '../../../../../src/core/server/mocks';
 
 type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 

--- a/src/plugins/data_source/server/routes/test_connection.test.ts
+++ b/src/plugins/data_source/server/routes/test_connection.test.ts
@@ -16,8 +16,7 @@ import { registerTestConnectionRoute } from './test_connection';
 import { AuthType } from '../../common/data_sources';
 // eslint-disable-next-line @osd/eslint/no-restricted-paths
 import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
-// eslint-disable-next-line @osd/eslint/no-restricted-paths
-import { dynamicConfigServiceMock } from '../../../../../src/core/server/config';
+import { dynamicConfigServiceMock } from '../../../../../src/core/server/mocks';
 
 type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 

--- a/src/plugins/usage_collection/server/routes/integration_tests/stats.test.ts
+++ b/src/plugins/usage_collection/server/routes/integration_tests/stats.test.ts
@@ -45,8 +45,7 @@ import { createHttpServer } from '../../../../../core/server/test_utils';
 import { registerStatsRoute } from '../stats';
 import supertest from 'supertest';
 import { CollectorSet } from '../../collector';
-// eslint-disable-next-line @osd/eslint/no-restricted-paths
-import { dynamicConfigServiceMock } from '../../../../../core/server/config';
+import { dynamicConfigServiceMock } from '../../../../../core/server/mocks';
 
 type HttpService = ReturnType<typeof createHttpServer>;
 type HttpSetup = UnwrapPromise<ReturnType<HttpService['setup']>>;

--- a/src/plugins/workspace/server/integration_tests/duplicate.test.ts
+++ b/src/plugins/workspace/server/integration_tests/duplicate.test.ts
@@ -12,8 +12,7 @@ import { setupServer } from '../../../../core/server/test_utils';
 import { registerDuplicateRoute } from '../routes/duplicate';
 import { createListStream } from '../../../../core/server/utils/streams';
 import Boom from '@hapi/boom';
-// eslint-disable-next-line @osd/eslint/no-restricted-paths
-import { dynamicConfigServiceMock } from '../../../../core/server/config';
+import { dynamicConfigServiceMock } from '../../../../core/server/mocks';
 
 jest.mock('../../../../core/server/saved_objects/export', () => ({
   exportSavedObjectsToStream: jest.fn(),


### PR DESCRIPTION
### Description

This PR separates `mock` files from `index`, which fixes the build artifact not bootstrapping

### Issues Resolved

closes #7911

## Testing the changes

Built artifact and it starts (`opensearch` was not started hence the `ECONNREFUSED` error)
```bash
05:57:45 opensearch-dashboards-3.0.0-SNAPSHOT-linux-x64 ±|mock-fix ✗|→ ./bin/opensearch-dashboards
  log   [17:57:52.601] [info][plugins-service] Plugin "applicationConfig" is disabled.
  log   [17:57:52.604] [info][plugins-service] Plugin "cspHandler" is disabled.
  log   [17:57:52.605] [info][plugins-service] Plugin "dataSource" is disabled.
  log   [17:57:52.605] [info][plugins-service] Plugin "visTypeXy" is disabled.
  log   [17:57:52.606] [info][plugins-service] Plugin "workspace" is disabled.
  log   [17:57:52.651] [info][dynamic-config-service] registering middleware to inject context to AsyncLocalStorage
[agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTimeout instead
  log   [17:57:52.696] [info][plugins-system] Setting up [40] plugins: [usageCollection,opensearchDashboardsUsageCollection,opensearchDashboardsLegacy,mapsLegacy,share,opensearchUiShared,legacyExport,embeddable,expressions,data,savedObjects,queryEnhancements,home,apmOss,dashboard,visualizations,visTypeVega,visTypeTimeline,visTypeTable,visTypeMarkdown,visBuilder,visAugmenter,tileMap,regionMap,inputControlVis,visualize,management,indexPatternManagement,dataSourceManagement,console,advancedSettings,dataExplorer,charts,visTypeVislib,visTypeTimeseries,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,bfetch]
[agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTimeout instead
  log   [17:57:52.740] [info][plugins][queryEnhancements] queryEnhancements: Setup complete
[agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTimeout instead
  log   [17:57:52.901] [info][dynamic-config-service] initiating start()
  log   [17:57:52.902] [info][dynamic-config-service] finished start()
  log   [17:57:52.918] [info][savedobjects-service] Waiting until all OpenSearch nodes are compatible with OpenSearch Dashboards before starting saved objects migrations...
  log   [17:57:52.928] [error][data][opensearch] [ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200
  log   [17:57:52.938] [error][savedobjects-service] Unable to retrieve version information from OpenSearch nodes.
  log   [17:57:55.428] [error][data][opensearch] [ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200
  log   [17:57:57.929] [error][data][opensearch] [ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200
  log   [17:58:00.430] [error][data][opensearch] [ConnectionError]: connect ECONNREFUSED 127.0.0.1:9200
```

## Changelog
- fix: Fix dynamicConfigService so that build artifact bootstraps

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
