### PR TITLE
Add Data connection saved-object type for external connections

### DIFF
--- a/changelogs/fragments/7925.yml
+++ b/changelogs/fragments/7925.yml
@@ -1,0 +1,2 @@
+feat:
+- Introduce a data-connection saved-object type for external data connections ([#7925](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7925))

--- a/src/plugins/data_source/common/data_connections/data_connection_saved_object_attributes.ts
+++ b/src/plugins/data_source/common/data_connections/data_connection_saved_object_attributes.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectAttributes } from 'src/core/types';
+
+export const DATA_CONNECTION_SAVED_OBJECT_TYPE = 'data-connection';
+
+/**
+ * Represents the attributes of a data connection saved object.
+ * @property connectionId: The name of the data connection.
+ * @property type: The type of the data connection based on enum DataConnectionType
+ * @property meta: Additional metadata associated with the data connection.
+ */
+export interface DataConnectionSavedObjectAttributes extends SavedObjectAttributes {
+  connectionId: string;
+  type: DataConnectionType;
+  meta?: string;
+}
+
+export enum DataConnectionType {
+  CloudWatch = 'AWS CloudWatch',
+  SecurityLake = 'AWS Security Lake',
+  NA = 'None',
+}
+
+export const DATA_CONNECTION_ID_LENGTH_LIMIT = 32;

--- a/src/plugins/data_source/common/data_connections/index.ts
+++ b/src/plugins/data_source/common/data_connections/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './data_connection_saved_object_attributes';

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -22,7 +22,7 @@ import { DataSourcePluginConfigType } from '../config';
 import { LoggingAuditor } from './audit/logging_auditor';
 import { CryptographyService, CryptographyServiceSetup } from './cryptography_service';
 import { DataSourceService, DataSourceServiceSetup } from './data_source_service';
-import { DataSourceSavedObjectsClientWrapper, dataSource } from './saved_objects';
+import { dataConnection, dataSource, DataSourceSavedObjectsClientWrapper } from './saved_objects';
 import { AuthenticationMethod, DataSourcePluginSetup, DataSourcePluginStart } from './types';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
 
@@ -55,6 +55,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
 
     // Register data source saved object type
     core.savedObjects.registerType(dataSource);
+    core.savedObjects.registerType(dataConnection);
 
     const config: DataSourcePluginConfigType = await this.config$.pipe(first()).toPromise();
 

--- a/src/plugins/data_source/server/saved_objects/data_connection.ts
+++ b/src/plugins/data_source/server/saved_objects/data_connection.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsType } from 'opensearch-dashboards/server';
+
+export const dataConnection: SavedObjectsType = {
+  name: 'data-connection',
+  namespaceType: 'agnostic',
+  hidden: false,
+  management: {
+    icon: 'apps',
+    defaultSearchField: 'connectionId',
+    importableAndExportable: true,
+  },
+  mappings: {
+    dynamic: false,
+    properties: {
+      connectionId: {
+        type: 'text',
+      },
+      type: {
+        type: 'text',
+      },
+      meta: {
+        type: 'text',
+      },
+    },
+  },
+  migrations: {},
+};

--- a/src/plugins/data_source/server/saved_objects/index.ts
+++ b/src/plugins/data_source/server/saved_objects/index.ts
@@ -5,3 +5,5 @@
 
 export { dataSource } from './data_source';
 export { DataSourceSavedObjectsClientWrapper } from './data_source_saved_objects_client_wrapper';
+
+export { dataConnection } from './data_connection';


### PR DESCRIPTION
### Description

Today MDS plugin only supports OpenSearch datasources. With the new saved-object type data-connection, the intention is to allow the external data connections like CloudWatch and Security Lake.

### Issues Resolved
NA
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
NA
<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes
Saved objects API testing sample inputs (unit tests added as well):

```
1. Create:
Input: 
POST http://localhost:5601/api/saved_objects/data-connection/12345
{
  "attributes": {
    "connectionId": "security-lake",
    "type": "AWS CloudWatch"
  }
}
Output: 
{
"type":  "data-connection",
"id":  "1234567",
"attributes":  {
"connectionId":  "security-lake",
"type":  "AWS CloudWatch"
},
"references":  [],
"updated_at":  "2024-08-29T21:38:20.344Z"
}

2. Update
Input:
PUT http://localhost:5601/api/saved_objects/data-connection/12345
{
  "attributes": {
    "connectionId": "security-lake",
    "type": "AWS CloudWatch"
  }
}

3. Bulk create - failure
Input:
POST http://localhost:5601/api/saved_objects/_bulk_create
[
    {
      "type": "data-connection",
      "id": "12345",
      "attributes": {
        "connectionId": "security-lake",
        "type": "AWS Security "
      }
    },
    {
      "type": "data-connection",
      "id": "67890",
      "attributes": {
        "connectionId": "cloudwatch",
        "type": "AWS CloudWatch1"
      }
    }
  ]
Output:
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Invalid attribute type: 'AWS Security ' for connection id: 'security-lake': Bad Request"
}

4. Bulk update
PUT http://localhost:5601/api/saved_objects/_bulk_update
[
    {
      "type": "data-connection",
      "id": "12345",
      "attributes": {
        "connectionId": "security-lake",
        "type": "AWS Security "
      }
    },
    {
      "type": "data-connection",
      "id": "67890",
      "attributes": {
        "connectionId": "cloudwatch",
        "type": "AWS CloudWatch1"
      }
    }
  ]
Output: 
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Updating a data-connection saved-object type is not supported: Bad Request"
}

3. Bulk create - success
Input:
POST http://localhost:5601/api/saved_objects/_bulk_create
[
    {
      "type": "data-connection",
      "id": "12345",
      "attributes": {
        "connectionId": "security-lake1",
        "type": "AWS Security Lake"
      }
    },
    {
      "type": "data-connection",
      "id": "67890",
      "attributes": {
        "connectionId": "cloudwatch1",
        "type": "AWS CloudWatch"
      }
    }
  ]
Output:
{
    "saved_objects": [
        {
            "type": "data-connection",
            "id": "123456",
            "attributes": {
                "connectionId": "security-lake1",
                "type": "AWS Security Lake"
            },
            "references": [],
            "updated_at": "2024-08-29T21:37:52.262Z",
            "version": "1"
        },
        {
            "type": "data-connection",
            "id": "678901",
            "attributes": {
                "connectionId": "cloudwatch1",
                "type": "AWS CloudWatch"
            },
            "references": [],
            "updated_at": "2024-08-29T21:37:52.262Z",
            "version": "1"
        }
    ]
}
```



## Changelog
- feat: Introduce a data-connection saved-object type for external data connections

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
