### PR TITLE
[Workspace]Fix dynamicConfigServiceMock import path in workspace routes UT

### DIFF
--- a/changelogs/fragments/7954.yml
+++ b/changelogs/fragments/7954.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace]dynamicConfigServiceMock not found in workspace routes UT ([#7954](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7954))

--- a/src/plugins/workspace/server/routes/index.test.ts
+++ b/src/plugins/workspace/server/routes/index.test.ts
@@ -7,9 +7,7 @@ import supertest from 'supertest';
 import { UnwrapPromise } from '@osd/utility-types';
 
 import { setupServer } from '../../../../core/server/test_utils';
-import { loggingSystemMock } from '../../../../core/server/mocks';
-// eslint-disable-next-line @osd/eslint/no-restricted-paths
-import { dynamicConfigServiceMock } from '../../../../core/server/config';
+import { loggingSystemMock, dynamicConfigServiceMock } from '../../../../core/server/mocks';
 
 import { workspaceClientMock } from '../workspace_client.mock';
 


### PR DESCRIPTION
### Description

The `dynamicConfigServiceMock` has been changed in [this PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7922/files). Current PR is for fixing `dynamicConfigServiceMock` was missing error. This PR will import dynamicConfigServiceMock from `core/server/mocks` directly.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#7955

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI Changes

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Clone branch and Run `yarn osd bootstrap`
- Run `yarn test:jest src/plugins/workspace/server/routes/index.test.ts`
- All cases should be passed

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Workspace]dynamicConfigServiceMock not found in workspace routes UT

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
