### PR TITLE
[Workspace] add use case cards when workspace is disabled, refine the style of recent_work in the home page.

### DIFF
--- a/src/core/utils/default_nav_groups.ts
+++ b/src/core/utils/default_nav_groups.ts
@@ -52,8 +52,7 @@ const defaultNavGroups = {
       defaultMessage: 'Observability',
     }),
     description: i18n.translate('core.ui.group.observability.description', {
-      defaultMessage:
-        'Gain visibility into system health, performance, and reliability through monitoring and analysis of logs, metrics, and traces.',
+      defaultMessage: 'Gain visibility into your application and infrastructure',
     }),
     order: 4000,
     icon: 'wsObservability',
@@ -64,8 +63,7 @@ const defaultNavGroups = {
       defaultMessage: 'Security Analytics',
     }),
     description: i18n.translate('core.ui.group.security.analytics.description', {
-      defaultMessage:
-        'Detect and investigate potential security threats and vulnerabilities across your systems and data.',
+      defaultMessage: 'Enhance your security posture with advanced analytics',
     }),
     order: 5000,
     icon: 'wsSecurityAnalytics',
@@ -88,8 +86,7 @@ const defaultNavGroups = {
       defaultMessage: 'Search',
     }),
     description: i18n.translate('core.ui.group.search.description', {
-      defaultMessage:
-        "Quickly find and explore relevant information across your organization's data sources.",
+      defaultMessage: 'Discover and query your data with ease',
     }),
     order: 6000,
     icon: 'wsSearch',

--- a/src/plugins/home/public/application/components/use_case_card.test.ts
+++ b/src/plugins/home/public/application/components/use_case_card.test.ts
@@ -17,7 +17,7 @@ describe('registerUseCaseCard', () => {
 
   it('should register useCase card correctly', () => {
     registerUseCaseCard(contentManagementStartMock, {
-      id: 'test_id',
+      id: 'testId',
       order: 1,
       target: 'osd_homepage/get_started',
       icon: 'wsObservability',
@@ -32,7 +32,7 @@ describe('registerUseCaseCard', () => {
     expect(registerCall.getTargetArea()).toEqual('osd_homepage/get_started');
 
     expect(registerCall.getContent()).toEqual({
-      id: 'test_id',
+      id: 'testId',
       kind: 'card',
       order: 1,
       description: 'Gain visibility into your application and infrastructure',

--- a/src/plugins/home/public/application/components/use_case_card.test.ts
+++ b/src/plugins/home/public/application/components/use_case_card.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiIcon } from '@elastic/eui';
+
+import { registerUseCaseCard } from './use_case_card';
+import { contentManagementPluginMocks } from '../../../../content_management/public';
+
+describe('registerUseCaseCard', () => {
+  const registerContentProviderFn = jest.fn();
+  const contentManagementStartMock = {
+    ...contentManagementPluginMocks.createStartContract(),
+    registerContentProvider: registerContentProviderFn,
+  };
+
+  it('should register useCase card correctly', () => {
+    registerUseCaseCard(contentManagementStartMock, {
+      id: 'test_id',
+      order: 1,
+      target: 'osd_homepage/get_started',
+      icon: 'wsObservability',
+      title: 'observability',
+      description: 'Gain visibility into your application and infrastructure',
+    });
+
+    expect(contentManagementStartMock.registerContentProvider).toHaveBeenCalledTimes(1);
+
+    const registerCall = contentManagementStartMock.registerContentProvider.mock.calls[0][0];
+
+    expect(registerCall.getTargetArea()).toEqual('osd_homepage/get_started');
+
+    expect(registerCall.getContent()).toEqual({
+      id: 'test_id',
+      kind: 'card',
+      order: 1,
+      description: 'Gain visibility into your application and infrastructure',
+      title: 'observability',
+      cardProps: {
+        layout: 'horizontal',
+      },
+      getIcon: expect.any(Function),
+    });
+
+    const icon = registerCall.getContent().getIcon();
+    expect(icon.type).toBe(EuiIcon);
+    expect(icon.props).toEqual({
+      size: 'l',
+      color: 'subdued',
+      type: 'wsObservability',
+    });
+  });
+});

--- a/src/plugins/home/public/application/components/use_case_card.test.ts
+++ b/src/plugins/home/public/application/components/use_case_card.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { EuiIcon } from '@elastic/eui';
+import { coreMock } from '../../../../../core/public/mocks';
 import { registerUseCaseCard } from './use_case_card';
 import { contentManagementPluginMocks } from '../../../../content_management/public';
 
@@ -15,7 +16,8 @@ describe('registerUseCaseCard', () => {
   };
 
   it('should register useCase card correctly', () => {
-    registerUseCaseCard(contentManagementStartMock, {
+    const workspaceEnabled = false;
+    registerUseCaseCard(contentManagementStartMock, workspaceEnabled, {
       id: 'testId',
       order: 1,
       target: 'osd_homepage/get_started',

--- a/src/plugins/home/public/application/components/use_case_card.test.ts
+++ b/src/plugins/home/public/application/components/use_case_card.test.ts
@@ -4,7 +4,6 @@
  */
 
 import { EuiIcon } from '@elastic/eui';
-
 import { registerUseCaseCard } from './use_case_card';
 import { contentManagementPluginMocks } from '../../../../content_management/public';
 

--- a/src/plugins/home/public/application/components/use_case_card.test.ts
+++ b/src/plugins/home/public/application/components/use_case_card.test.ts
@@ -15,15 +15,17 @@ describe('registerUseCaseCard', () => {
     registerContentProvider: registerContentProviderFn,
   };
 
+  const core = coreMock.createStart();
+
   it('should register useCase card correctly', () => {
-    const workspaceEnabled = false;
-    registerUseCaseCard(contentManagementStartMock, workspaceEnabled, {
+    registerUseCaseCard(contentManagementStartMock, core, {
       id: 'testId',
       order: 1,
       target: 'osd_homepage/get_started',
       icon: 'wsObservability',
       title: 'observability',
       description: 'Gain visibility into your application and infrastructure',
+      navigateAppId: 'observability_overview',
     });
 
     expect(contentManagementStartMock.registerContentProvider).toHaveBeenCalledTimes(1);
@@ -41,6 +43,7 @@ describe('registerUseCaseCard', () => {
       cardProps: {
         layout: 'horizontal',
       },
+      onClick: expect.any(Function),
       getIcon: expect.any(Function),
     });
 
@@ -51,5 +54,25 @@ describe('registerUseCaseCard', () => {
       color: 'subdued',
       type: 'wsObservability',
     });
+  });
+
+  it('should be able to navigate to the expected overview page when click the card', () => {
+    const navigateToAppMock = jest.fn();
+    core.application.navigateToApp = navigateToAppMock;
+
+    registerUseCaseCard(contentManagementStartMock, core, {
+      id: 'testId',
+      order: 1,
+      target: 'osd_homepage/get_started',
+      icon: 'wsObservability',
+      title: 'observability',
+      description: 'Gain visibility into your application and infrastructure',
+      navigateAppId: 'observability_overview',
+    });
+
+    const registerCall = contentManagementStartMock.registerContentProvider.mock.calls[0][0];
+    const card = registerCall.getContent();
+    card.onClick();
+    expect(navigateToAppMock).toHaveBeenCalledWith('observability_overview');
   });
 });

--- a/src/plugins/home/public/application/components/use_case_card.ts
+++ b/src/plugins/home/public/application/components/use_case_card.ts
@@ -9,6 +9,7 @@ import { ContentManagementPluginStart } from '../../../../content_management/pub
 
 export const registerUseCaseCard = (
   contentManagement: ContentManagementPluginStart,
+  workspaceEnabled: boolean,
   {
     target,
     order,
@@ -25,6 +26,7 @@ export const registerUseCaseCard = (
     icon: string;
   }
 ) => {
+  if (workspaceEnabled) return;
   contentManagement.registerContentProvider({
     id: `home_get_started_${id}`,
     getTargetArea: () => target,

--- a/src/plugins/home/public/application/components/use_case_card.ts
+++ b/src/plugins/home/public/application/components/use_case_card.ts
@@ -4,12 +4,13 @@
  */
 
 import React from 'react';
+import { CoreStart } from 'opensearch-dashboards/public';
 import { EuiIcon } from '@elastic/eui';
 import { ContentManagementPluginStart } from '../../../../content_management/public';
 
 export const registerUseCaseCard = (
   contentManagement: ContentManagementPluginStart,
-  workspaceEnabled: boolean,
+  core: CoreStart,
   {
     target,
     order,
@@ -17,6 +18,7 @@ export const registerUseCaseCard = (
     title,
     description,
     icon,
+    navigateAppId,
   }: {
     target: string;
     order: number;
@@ -24,9 +26,9 @@ export const registerUseCaseCard = (
     title: string;
     description: string;
     icon: string;
+    navigateAppId: string;
   }
 ) => {
-  if (workspaceEnabled) return;
   contentManagement.registerContentProvider({
     id: `home_get_started_${id}`,
     getTargetArea: () => target,
@@ -38,6 +40,9 @@ export const registerUseCaseCard = (
       title,
       cardProps: {
         layout: 'horizontal',
+      },
+      onClick: () => {
+        core.application.navigateToApp(navigateAppId);
       },
       getIcon: () =>
         React.createElement(EuiIcon, {

--- a/src/plugins/home/public/application/components/use_case_card.ts
+++ b/src/plugins/home/public/application/components/use_case_card.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiIcon } from '@elastic/eui';
+import { ContentManagementPluginStart } from '../../../../content_management/public';
+
+export const registerUseCaseCard = (
+  contentManagement: ContentManagementPluginStart,
+  {
+    target,
+    order,
+    id,
+    title,
+    description,
+    icon,
+  }: {
+    target: string;
+    order: number;
+    id: string;
+    title: string;
+    description: string;
+    icon: string;
+  }
+) => {
+  contentManagement.registerContentProvider({
+    id: `home_get_started_${id}`,
+    getTargetArea: () => target,
+    getContent: () => ({
+      id,
+      kind: 'card',
+      order,
+      description,
+      title,
+      cardProps: {
+        layout: 'horizontal',
+      },
+      getIcon: () =>
+        React.createElement(EuiIcon, {
+          size: 'l',
+          color: 'subdued',
+          type: icon,
+        }),
+    }),
+  });
+};

--- a/src/plugins/home/public/application/home_render.test.tsx
+++ b/src/plugins/home/public/application/home_render.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_NAV_GROUPS } from '../../../../core/public';
+import {
+  HOME_CONTENT_AREAS,
+  SEARCH_OVERVIEW_PAGE_ID,
+  OBSERVABILITY_OVERVIEW_PAGE_ID,
+  SECURITY_ANALYTICS_OVERVIEW_PAGE_ID,
+} from '../../../../plugins/content_management/public';
+import { contentManagementPluginMocks } from '../../../../plugins/content_management/public/mocks';
+import { registerUseCaseCard } from './components/use_case_card';
+import { initHome } from './home_render';
+
+import {
+  WHATS_NEW_CONFIG,
+  LEARN_OPENSEARCH_CONFIG,
+  registerHomeListCard,
+} from './components/home_list_card';
+
+jest.mock('./components/use_case_card', () => ({
+  registerUseCaseCard: jest.fn(),
+}));
+
+jest.mock('./components/home_list_card', () => ({
+  registerHomeListCard: jest.fn(),
+}));
+
+describe('initHome', () => {
+  const registerContentProviderFn = jest.fn();
+  const contentManagementStartMock = {
+    ...contentManagementPluginMocks.createStartContract(),
+    registerContentProvider: registerContentProviderFn,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should register use case cards when workspace is enabled', () => {
+    const coreMock = {
+      createStart: jest.fn(() => ({
+        application: {
+          capabilities: {
+            workspaces: {
+              enabled: false,
+            },
+          },
+          navigateToApp: jest.fn(),
+        },
+      })),
+    };
+    const core = coreMock.createStart();
+
+    initHome(contentManagementStartMock, core);
+
+    expect(registerUseCaseCard).toHaveBeenCalledTimes(3);
+
+    expect(registerUseCaseCard).toHaveBeenCalledWith(contentManagementStartMock, core, {
+      id: DEFAULT_NAV_GROUPS.observability.id,
+      order: 1,
+      description: DEFAULT_NAV_GROUPS.observability.description,
+      title: DEFAULT_NAV_GROUPS.observability.title,
+      target: HOME_CONTENT_AREAS.GET_STARTED,
+      icon: DEFAULT_NAV_GROUPS.observability.icon ?? '',
+      navigateAppId: OBSERVABILITY_OVERVIEW_PAGE_ID,
+    });
+
+    expect(registerUseCaseCard).toHaveBeenCalledWith(contentManagementStartMock, core, {
+      id: DEFAULT_NAV_GROUPS.search.id,
+      order: 2,
+      description: DEFAULT_NAV_GROUPS.search.description,
+      title: DEFAULT_NAV_GROUPS.search.title,
+      target: HOME_CONTENT_AREAS.GET_STARTED,
+      icon: DEFAULT_NAV_GROUPS.search.icon ?? '',
+      navigateAppId: SEARCH_OVERVIEW_PAGE_ID,
+    });
+
+    expect(registerUseCaseCard).toHaveBeenCalledWith(contentManagementStartMock, core, {
+      id: DEFAULT_NAV_GROUPS['security-analytics'].id,
+      order: 3,
+      description: DEFAULT_NAV_GROUPS['security-analytics'].description,
+      title: DEFAULT_NAV_GROUPS['security-analytics'].title,
+      target: HOME_CONTENT_AREAS.GET_STARTED,
+      icon: DEFAULT_NAV_GROUPS['security-analytics'].icon ?? '',
+      navigateAppId: SECURITY_ANALYTICS_OVERVIEW_PAGE_ID,
+    });
+  });
+
+  it('should not register use case cards when workspace is disabled', () => {
+    const coreMock = {
+      createStart: jest.fn(() => ({
+        application: {
+          capabilities: {
+            workspaces: {
+              enabled: true,
+            },
+          },
+        },
+      })),
+    };
+    const core = coreMock.createStart();
+    initHome(contentManagementStartMock, core);
+    expect(registerUseCaseCard).not.toHaveBeenCalled();
+  });
+
+  it('should register home list cards correctly', () => {
+    const coreMock = {
+      createStart: jest.fn(() => ({
+        application: {
+          capabilities: {
+            workspaces: {
+              enabled: false,
+            },
+          },
+        },
+      })),
+    };
+    const core = coreMock.createStart();
+    initHome(contentManagementStartMock, core);
+
+    expect(registerHomeListCard).toHaveBeenCalledTimes(2);
+
+    expect(registerHomeListCard).toHaveBeenCalledWith(contentManagementStartMock, {
+      id: 'whats_new',
+      order: 10,
+      config: WHATS_NEW_CONFIG,
+      target: HOME_CONTENT_AREAS.SERVICE_CARDS,
+      width: 16,
+    });
+
+    expect(registerHomeListCard).toHaveBeenCalledWith(contentManagementStartMock, {
+      id: 'learn_opensearch_new',
+      order: 11,
+      config: LEARN_OPENSEARCH_CONFIG,
+      target: HOME_CONTENT_AREAS.SERVICE_CARDS,
+      width: 16,
+    });
+  });
+});

--- a/src/plugins/home/public/application/home_render.tsx
+++ b/src/plugins/home/public/application/home_render.tsx
@@ -12,6 +12,9 @@ import {
   HOME_PAGE_ID,
   SECTIONS,
   HOME_CONTENT_AREAS,
+  SEARCH_OVERVIEW_PAGE_ID,
+  OBSERVABILITY_OVERVIEW_PAGE_ID,
+  SECURITY_ANALYTICS_OVERVIEW_PAGE_ID,
 } from '../../../../plugins/content_management/public';
 import {
   WHATS_NEW_CONFIG,
@@ -63,22 +66,28 @@ export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
 export const initHome = (contentManagement: ContentManagementPluginStart, core: CoreStart) => {
   const workspaceEnabled = core.application.capabilities.workspaces.enabled;
 
-  const useCases = [
-    DEFAULT_NAV_GROUPS.observability,
-    DEFAULT_NAV_GROUPS.search,
-    DEFAULT_NAV_GROUPS['security-analytics'],
-  ];
+  if (!workspaceEnabled) {
+    const useCases = [
+      { ...DEFAULT_NAV_GROUPS.observability, navigateAppId: OBSERVABILITY_OVERVIEW_PAGE_ID },
+      { ...DEFAULT_NAV_GROUPS.search, navigateAppId: SEARCH_OVERVIEW_PAGE_ID },
+      {
+        ...DEFAULT_NAV_GROUPS['security-analytics'],
+        navigateAppId: SECURITY_ANALYTICS_OVERVIEW_PAGE_ID,
+      },
+    ];
 
-  useCases.forEach((useCase, index) => {
-    registerUseCaseCard(contentManagement, workspaceEnabled, {
-      id: useCase.id,
-      order: index + 1,
-      description: useCase.description,
-      title: useCase.title,
-      target: HOME_CONTENT_AREAS.GET_STARTED,
-      icon: useCase.icon ?? '',
+    useCases.forEach((useCase, index) => {
+      registerUseCaseCard(contentManagement, core, {
+        id: useCase.id,
+        order: index + 1,
+        description: useCase.description,
+        title: useCase.title,
+        target: HOME_CONTENT_AREAS.GET_STARTED,
+        icon: useCase.icon ?? '',
+        navigateAppId: useCase.navigateAppId,
+      });
     });
-  });
+  }
 
   registerHomeListCard(contentManagement, {
     id: 'whats_new',

--- a/src/plugins/home/public/application/home_render.tsx
+++ b/src/plugins/home/public/application/home_render.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
+import { DEFAULT_NAV_GROUPS } from '../../../../core/public';
 import {
   ContentManagementPluginSetup,
   ContentManagementPluginStart,
@@ -18,16 +19,13 @@ import {
   registerHomeListCard,
 } from './components/home_list_card';
 
+import { registerUseCaseCard } from './components/use_case_card';
+
 export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
   contentManagement.registerPage({
     id: HOME_PAGE_ID,
     title: 'Home',
     sections: [
-      {
-        id: SECTIONS.SERVICE_CARDS,
-        order: 3000,
-        kind: 'dashboard',
-      },
       {
         id: SECTIONS.RECENTLY_VIEWED,
         order: 2000,
@@ -48,9 +46,14 @@ export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
         },
       },
       {
+        id: SECTIONS.SERVICE_CARDS,
+        order: 3000,
+        kind: 'dashboard',
+      },
+      {
         id: SECTIONS.GET_STARTED,
         order: 1000,
-        title: 'Get started with OpenSearch’s powerful features',
+        title: "Get started with OpenSearch's powerful features",
         kind: 'card',
       },
     ],
@@ -58,9 +61,30 @@ export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
 };
 
 export const initHome = (contentManagement: ContentManagementPluginStart, core: CoreStart) => {
+  const workspaceEnabled = core.application.capabilities.workspaces.enabled;
+
+  if (!workspaceEnabled) {
+    const useCases = [
+      DEFAULT_NAV_GROUPS.observability,
+      DEFAULT_NAV_GROUPS.search,
+      DEFAULT_NAV_GROUPS['security-analytics'],
+    ];
+
+    useCases.forEach((useCase, index) => {
+      registerUseCaseCard(contentManagement, {
+        id: useCase.id,
+        order: index + 1,
+        description: useCase.description,
+        title: useCase.title,
+        target: HOME_CONTENT_AREAS.GET_STARTED,
+        icon: useCase.icon ?? '',
+      });
+    });
+  }
+
   registerHomeListCard(contentManagement, {
     id: 'whats_new',
-    order: 3,
+    order: 10,
     config: WHATS_NEW_CONFIG,
     target: HOME_CONTENT_AREAS.SERVICE_CARDS,
     width: 16,
@@ -68,7 +92,7 @@ export const initHome = (contentManagement: ContentManagementPluginStart, core: 
 
   registerHomeListCard(contentManagement, {
     id: 'learn_opensearch_new',
-    order: 4,
+    order: 11,
     config: LEARN_OPENSEARCH_CONFIG,
     target: HOME_CONTENT_AREAS.SERVICE_CARDS,
     width: 16,

--- a/src/plugins/home/public/application/home_render.tsx
+++ b/src/plugins/home/public/application/home_render.tsx
@@ -63,24 +63,22 @@ export const setupHome = (contentManagement: ContentManagementPluginSetup) => {
 export const initHome = (contentManagement: ContentManagementPluginStart, core: CoreStart) => {
   const workspaceEnabled = core.application.capabilities.workspaces.enabled;
 
-  if (!workspaceEnabled) {
-    const useCases = [
-      DEFAULT_NAV_GROUPS.observability,
-      DEFAULT_NAV_GROUPS.search,
-      DEFAULT_NAV_GROUPS['security-analytics'],
-    ];
+  const useCases = [
+    DEFAULT_NAV_GROUPS.observability,
+    DEFAULT_NAV_GROUPS.search,
+    DEFAULT_NAV_GROUPS['security-analytics'],
+  ];
 
-    useCases.forEach((useCase, index) => {
-      registerUseCaseCard(contentManagement, {
-        id: useCase.id,
-        order: index + 1,
-        description: useCase.description,
-        title: useCase.title,
-        target: HOME_CONTENT_AREAS.GET_STARTED,
-        icon: useCase.icon ?? '',
-      });
+  useCases.forEach((useCase, index) => {
+    registerUseCaseCard(contentManagement, workspaceEnabled, {
+      id: useCase.id,
+      order: index + 1,
+      description: useCase.description,
+      title: useCase.title,
+      target: HOME_CONTENT_AREAS.GET_STARTED,
+      icon: useCase.icon ?? '',
     });
-  }
+  });
 
   registerHomeListCard(contentManagement, {
     id: 'whats_new',

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
@@ -258,56 +258,65 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
                   href={recentNavLink.href}
                   footer={
                     <>
-                      <EuiFlexGrid columns={2} gutterSize="s">
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="xs" color="default">
-                            {selectedSort === recentlyViewed
-                              ? i18n.translate(
-                                  'savedObjectsManagement.recentWorkSection.viewedAt',
-                                  {
-                                    defaultMessage: 'Viewed',
-                                  }
-                                )
-                              : i18n.translate(
-                                  'savedObjectsManagement.recentWorkSection.updatedAt',
-                                  {
-                                    defaultMessage: 'Updated',
-                                  }
-                                )}
-                            :{' '}
-                          </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
-                          <EuiText size="xs" color="default">
-                            <b>
-                              {selectedSort === recentlyViewed
-                                ? moment(recentAccessItem?.lastAccessedTime).fromNow()
-                                : moment(recentAccessItem?.updatedAt).fromNow()}
-                            </b>
-                          </EuiText>
-                        </EuiFlexItem>
-
-                        {workspaceEnabled && (
-                          <>
+                      <EuiFlexGroup
+                        justifyContent="spaceBetween"
+                        direction="column"
+                        gutterSize="none"
+                      >
+                        <EuiFlexItem>
+                          <EuiFlexGrid columns={2} gutterSize="s">
                             <EuiFlexItem grow={false}>
                               <EuiText size="xs" color="default">
-                                {i18n.translate(
-                                  'savedObjectsManagement.recentWorkSection.workspace',
-                                  {
-                                    defaultMessage: 'Workspace',
-                                  }
-                                )}
-                                :
+                                {selectedSort === recentlyViewed
+                                  ? i18n.translate(
+                                      'savedObjectsManagement.recentWorkSection.viewedAt',
+                                      {
+                                        defaultMessage: 'Viewed',
+                                      }
+                                    )
+                                  : i18n.translate(
+                                      'savedObjectsManagement.recentWorkSection.updatedAt',
+                                      {
+                                        defaultMessage: 'Updated',
+                                      }
+                                    )}
+                                :{' '}
                               </EuiText>
                             </EuiFlexItem>
                             <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
                               <EuiText size="xs" color="default">
-                                <b>{recentAccessItem.workspaceName || 'N/A'} </b>
+                                <b>
+                                  {selectedSort === recentlyViewed
+                                    ? moment(recentAccessItem?.lastAccessedTime).fromNow()
+                                    : moment(recentAccessItem?.updatedAt).fromNow()}
+                                </b>
                               </EuiText>
                             </EuiFlexItem>
-                          </>
+                          </EuiFlexGrid>
+                        </EuiFlexItem>
+                        {workspaceEnabled && (
+                          <EuiFlexItem>
+                            <EuiFlexGrid columns={2} gutterSize="s">
+                              <EuiFlexItem grow={false}>
+                                <EuiText size="xs" color="default">
+                                  {i18n.translate(
+                                    'savedObjectsManagement.recentWorkSection.workspace',
+                                    {
+                                      defaultMessage: 'Workspace',
+                                    }
+                                  )}
+                                  :
+                                </EuiText>
+                              </EuiFlexItem>
+                              <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
+                                <EuiText size="xs" color="default">
+                                  <b>{recentAccessItem.workspaceName || 'N/A'} </b>
+                                </EuiText>
+                              </EuiFlexItem>
+                            </EuiFlexGrid>
+                          </EuiFlexItem>
                         )}
-                      </EuiFlexGrid>
+                      </EuiFlexGroup>
                     </>
                   }
                   onClick={recentNavLink.onClick}

--- a/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/recent_work.tsx
@@ -257,67 +257,65 @@ export const RecentWork = (props: { core: CoreStart; workspaceEnabled?: boolean 
                   textAlign="left"
                   href={recentNavLink.href}
                   footer={
-                    <>
-                      <EuiFlexGroup
-                        justifyContent="spaceBetween"
-                        direction="column"
-                        gutterSize="none"
-                      >
+                    <EuiFlexGroup
+                      justifyContent="spaceBetween"
+                      direction="column"
+                      gutterSize="none"
+                    >
+                      <EuiFlexItem>
+                        <EuiFlexGrid columns={2} gutterSize="s">
+                          <EuiFlexItem grow={false}>
+                            <EuiText size="xs" color="default">
+                              {selectedSort === recentlyViewed
+                                ? i18n.translate(
+                                    'savedObjectsManagement.recentWorkSection.viewedAt',
+                                    {
+                                      defaultMessage: 'Viewed',
+                                    }
+                                  )
+                                : i18n.translate(
+                                    'savedObjectsManagement.recentWorkSection.updatedAt',
+                                    {
+                                      defaultMessage: 'Updated',
+                                    }
+                                  )}
+                              :{' '}
+                            </EuiText>
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={1} className="eui-textRight">
+                            <EuiText size="xs" color="default">
+                              <b>
+                                {selectedSort === recentlyViewed
+                                  ? moment(recentAccessItem?.lastAccessedTime).fromNow()
+                                  : moment(recentAccessItem?.updatedAt).fromNow()}
+                              </b>
+                            </EuiText>
+                          </EuiFlexItem>
+                        </EuiFlexGrid>
+                      </EuiFlexItem>
+                      {workspaceEnabled && (
                         <EuiFlexItem>
                           <EuiFlexGrid columns={2} gutterSize="s">
                             <EuiFlexItem grow={false}>
                               <EuiText size="xs" color="default">
-                                {selectedSort === recentlyViewed
-                                  ? i18n.translate(
-                                      'savedObjectsManagement.recentWorkSection.viewedAt',
-                                      {
-                                        defaultMessage: 'Viewed',
-                                      }
-                                    )
-                                  : i18n.translate(
-                                      'savedObjectsManagement.recentWorkSection.updatedAt',
-                                      {
-                                        defaultMessage: 'Updated',
-                                      }
-                                    )}
-                                :{' '}
+                                {i18n.translate(
+                                  'savedObjectsManagement.recentWorkSection.workspace',
+                                  {
+                                    defaultMessage: 'Workspace',
+                                  }
+                                )}
+                                :
                               </EuiText>
                             </EuiFlexItem>
-                            <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
+                            <EuiFlexItem grow={1} className="eui-textRight">
                               <EuiText size="xs" color="default">
-                                <b>
-                                  {selectedSort === recentlyViewed
-                                    ? moment(recentAccessItem?.lastAccessedTime).fromNow()
-                                    : moment(recentAccessItem?.updatedAt).fromNow()}
-                                </b>
+                                <b>{recentAccessItem.workspaceName || 'N/A'} </b>
                               </EuiText>
                             </EuiFlexItem>
                           </EuiFlexGrid>
                         </EuiFlexItem>
-                        {workspaceEnabled && (
-                          <EuiFlexItem>
-                            <EuiFlexGrid columns={2} gutterSize="s">
-                              <EuiFlexItem grow={false}>
-                                <EuiText size="xs" color="default">
-                                  {i18n.translate(
-                                    'savedObjectsManagement.recentWorkSection.workspace',
-                                    {
-                                      defaultMessage: 'Workspace',
-                                    }
-                                  )}
-                                  :
-                                </EuiText>
-                              </EuiFlexItem>
-                              <EuiFlexItem grow={1} style={{ textAlign: 'right' }}>
-                                <EuiText size="xs" color="default">
-                                  <b>{recentAccessItem.workspaceName || 'N/A'} </b>
-                                </EuiText>
-                              </EuiFlexItem>
-                            </EuiFlexGrid>
-                          </EuiFlexItem>
-                        )}
-                      </EuiFlexGroup>
-                    </>
+                      )}
+                    </EuiFlexGroup>
                   }
                   onClick={recentNavLink.onClick}
                 />

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -53,9 +53,9 @@ export const WORKSPACE_USE_CASES = Object.freeze({
       defaultMessage: 'Observability',
     }),
     description: i18n.translate('workspace.usecase.observability.description', {
-      defaultMessage:
-        'Gain visibility into system health, performance, and reliability through monitoring and analysis of logs, metrics, and traces.',
+      defaultMessage: 'Gain visibility into your application and infrastructure',
     }),
+    icon: 'wsObservability',
     features: [
       'discover',
       'dashboards',
@@ -79,9 +79,9 @@ export const WORKSPACE_USE_CASES = Object.freeze({
       defaultMessage: 'Security Analytics',
     }),
     description: i18n.translate('workspace.usecase.analytics.description', {
-      defaultMessage:
-        'Detect and investigate potential security threats and vulnerabilities across your systems and data.',
+      defaultMessage: 'Enhance your security posture with advanced analytics',
     }),
+    icon: 'wsSecurityAnalytics',
     features: [
       'discover',
       'dashboards',
@@ -103,9 +103,9 @@ export const WORKSPACE_USE_CASES = Object.freeze({
       defaultMessage: 'Essentials',
     }),
     description: i18n.translate('workspace.usecase.essentials.description', {
-      defaultMessage:
-        'Analyze data to derive insights, identify patterns and trends, and make data-driven decisions.',
+      defaultMessage: 'Get start with just the basics',
     }),
+    icon: 'wsEssentials',
     features: [
       'discover',
       'dashboards',
@@ -126,9 +126,9 @@ export const WORKSPACE_USE_CASES = Object.freeze({
       defaultMessage: 'Search',
     }),
     description: i18n.translate('workspace.usecase.search.description', {
-      defaultMessage:
-        "Quickly find and explore relevant information across your organization's data sources.",
+      defaultMessage: 'Discover and query your data with ease',
     }),
+    icon: 'wsSearch',
     features: [
       'discover',
       'dashboards',

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -45,6 +45,7 @@ export const PRIORITY_FOR_PERMISSION_CONTROL_WRAPPER = 0;
  * store a static map in workspace.
  *
  */
+
 export const WORKSPACE_USE_CASES = Object.freeze({
   observability: {
     id: 'observability',

--- a/src/plugins/workspace/public/components/use_case_overview/setup_overview.test.tsx
+++ b/src/plugins/workspace/public/components/use_case_overview/setup_overview.test.tsx
@@ -137,7 +137,7 @@ describe('Setup use case overview', () => {
         "cardProps": Object {
           "layout": "horizontal",
         },
-        "description": "Gain visibility into system health, performance, and reliability through monitoring and analysis of logs, metrics, and traces.",
+        "description": "Gain visibility into your application and infrastructure",
         "getIcon": [Function],
         "id": "observability",
         "kind": "card",


### PR DESCRIPTION
### Description
This pr can be divided as 2 parts:
1. add use case cards when workspace is disabled
2. refine the style of recent_work in the home page, fix the line break issue that occurs when the screen becomes excessively large.

## Screenshot
1. add use case cards when workspace is disabled
<img width="1571" alt="Screenshot 2024-09-03 at 13 05 23" src="https://github.com/user-attachments/assets/b60b8a9b-70de-4811-bae8-64305b0b3760">

2. fix the line break issue that occurs when the screen becomes excessively large
before:
<img width="1600" alt="Screenshot 2024-09-03 at 13 08 39" src="https://github.com/user-attachments/assets/f54e8a4d-3e61-4240-8f1c-f642855045a3">

now:
<img width="1600" alt="Screenshot 2024-09-03 at 13 07 15" src="https://github.com/user-attachments/assets/b862c383-790c-42f2-826e-d64bf29fb4ef">

## Changelog
- feat: add use case cards when workspace is disabled, refine the style of recent_work in the home page.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
