### PR TITLE
[Workspace]Hide saved object import button when user is outside workspace

### DIFF
--- a/changelogs/fragments/7989.yml
+++ b/changelogs/fragments/7989.yml
@@ -1,0 +1,2 @@
+refactor:
+- Hide saved object import button when user is outside workspace ([#7989](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7989))

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -1042,6 +1042,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
     onExportAll={[Function]}
     onImport={[Function]}
     onRefresh={[Function]}
+    showImportButton={true}
   />
   <EuiSpacer
     size="xs"

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/header.test.tsx.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Header - workspace enabled should render \`Import\` button inside a workspace 1`] = `
+<Fragment>
+  <EuiFlexGroup
+    alignItems="baseline"
+    justifyContent="spaceBetween"
+  >
+    <HeaderControl
+      controls={
+        Array [
+          Object {
+            "controlType": "button",
+            "iconType": "exportAction",
+            "label": "Export all objects",
+            "run": [Function],
+            "testId": "exportAllObjects",
+          },
+          Object {
+            "controlType": "button",
+            "iconType": "importAction",
+            "label": "Import",
+            "run": [Function],
+            "testId": "importObjects",
+          },
+        ]
+      }
+      setMountPoint={[MockFunction]}
+    />
+  </EuiFlexGroup>
+  <EuiSpacer
+    size="l"
+  />
+  <HeaderControl
+    controls={
+      Array [
+        Object {
+          "description": "Manage and share your assets.",
+        },
+      ]
+    }
+    setMountPoint={[MockFunction]}
+  />
+</Fragment>
+`;
+
 exports[`Header should render normally 1`] = `
 <Fragment>
   <EuiFlexGroup

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.test.tsx
@@ -43,6 +43,7 @@ const defaultProps = {
   useUpdatedUX: false,
   navigationUI: { HeaderControl: () => null, TopNavMenu: () => null },
   applications: applicationServiceMock.createStartContract(),
+  showImportButton: true,
 };
 
 describe('Header', () => {
@@ -91,5 +92,49 @@ describe('Header - workspace enabled', () => {
     const component = shallow(<Header {...props} />);
 
     expect(component.find('EuiButtonEmpty[data-test-subj="duplicateObjects"]').exists()).toBe(true);
+  });
+
+  it('should render `Import` button inside a workspace', () => {
+    const props = {
+      ...defaultProps,
+      showImportButton: true,
+    };
+
+    const component = shallow(<Header {...props} />);
+
+    expect(component.find('EuiButtonEmpty[data-test-subj="importObjects"]').exists()).toBe(true);
+
+    const newUxProps = {
+      ...defaultProps,
+      showImportButton: true,
+      useUpdatedUX: true,
+    };
+
+    const newUxComponent = shallow(<Header {...newUxProps} />);
+
+    expect(newUxComponent).toMatchSnapshot();
+  });
+
+  it('should not render `Import` button outside a workspace', () => {
+    const props = {
+      ...defaultProps,
+      showImportButton: false,
+    };
+
+    const component = shallow(<Header {...props} />);
+
+    expect(component.find('EuiButtonEmpty[data-test-subj="importObjects"]').exists()).toBe(false);
+
+    const newUxProps = {
+      ...defaultProps,
+      showImportButton: true,
+      useUpdatedUX: false,
+    };
+
+    const newUxComponent = shallow(<Header {...newUxProps} />);
+
+    expect(newUxComponent.find('EuiButtonEmpty[data-test-subj="importObjects"]').exists()).toBe(
+      true
+    );
   });
 });

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/header.tsx
@@ -56,6 +56,7 @@ export const Header = ({
   navigationUI: { HeaderControl },
   applications,
   currentWorkspaceName,
+  showImportButton,
 }: {
   onExportAll: () => void;
   onImport: () => void;
@@ -67,6 +68,7 @@ export const Header = ({
   navigationUI: NavigationPublicPluginStart['ui'];
   applications: ApplicationStart;
   currentWorkspaceName: string;
+  showImportButton: boolean;
 }) => {
   const title = useUpdatedUX ? null : (
     <EuiFlexItem grow={false}>
@@ -143,15 +145,22 @@ export const Header = ({
             defaultMessage: 'Export all objects',
           }),
         } as TopNavControlButtonData,
-        {
-          testId: 'importObjects',
-          run: onImport,
-          controlType: 'button',
-          iconType: 'importAction',
-          label: i18n.translate('savedObjectsManagement.objectsTable.header.importButtonLabel', {
-            defaultMessage: 'Import',
-          }),
-        } as TopNavControlButtonData,
+        ...(showImportButton
+          ? [
+              {
+                testId: 'importObjects',
+                run: onImport,
+                controlType: 'button',
+                iconType: 'importAction',
+                label: i18n.translate(
+                  'savedObjectsManagement.objectsTable.header.importButtonLabel',
+                  {
+                    defaultMessage: 'Import',
+                  }
+                ),
+              } as TopNavControlButtonData,
+            ]
+          : []),
       ]}
       setMountPoint={applications.setAppRightControls}
     />
@@ -187,19 +196,21 @@ export const Header = ({
             />
           </EuiButtonEmpty>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            size="s"
-            iconType="importAction"
-            data-test-subj="importObjects"
-            onClick={onImport}
-          >
-            <FormattedMessage
-              id="savedObjectsManagement.objectsTable.header.importButtonLabel"
-              defaultMessage="Import"
-            />
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+        {showImportButton && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              iconType="importAction"
+              data-test-subj="importObjects"
+              onClick={onImport}
+            >
+              <FormattedMessage
+                id="savedObjectsManagement.objectsTable.header.importButtonLabel"
+                defaultMessage="Import"
+              />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        )}
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty size="s" iconType="refresh" onClick={onRefresh}>
             <FormattedMessage

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -1166,6 +1166,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
           navigationUI={navigationUI}
           applications={applications}
           currentWorkspaceName={currentWorkspace?.name}
+          showImportButton={!workspaceEnabled || !!currentWorkspace}
         />
         {!useUpdatedUX && <EuiSpacer size="xs" />}
         <RedirectAppLinks application={applications}>


### PR DESCRIPTION
### Description

Hide saved object import button in the save object management page(assets page)when user is outside workspace.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
Related issue https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4944
## Screenshot
outside workspace
<img width="1442" alt="image" src="https://github.com/user-attachments/assets/57fed56b-c4c3-4494-8ada-203903cf4a28">
inside a workspace
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/139b780b-9e3f-4f16-8b08-828108e9f9a7">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
 - refactor: Hide saved object import button when user is outside workspace

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
