### PR TITLE
[Workspace] Hide first home breadcrumbs within workspace

### DIFF
--- a/changelogs/fragments/7992.yml
+++ b/changelogs/fragments/7992.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Hide home breadcrumbs when in a workspace ([#7992](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7992))

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -8919,7 +8919,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                               "thrownError": null,
                             }
                           }
-                          hideFirstHome={false}
+                          dropHomeFromBreadcrumb={false}
                           renderFullLength={true}
                           useUpdatedHeader={true}
                         />
@@ -17425,7 +17425,7 @@ exports[`Header renders page header with application title 1`] = `
                               "thrownError": null,
                             }
                           }
-                          hideFirstHome={false}
+                          dropHomeFromBreadcrumb={false}
                           renderFullLength={true}
                           useUpdatedHeader={true}
                         />
@@ -17771,7 +17771,7 @@ exports[`Header renders page header with application title 1`] = `
                   "thrownError": null,
                 }
               }
-              hideFirstHome={false}
+              dropHomeFromBreadcrumb={false}
               renderFullLength={false}
               useUpdatedHeader={true}
             >

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -468,7 +468,45 @@ exports[`Header handles visibility and lock changes 1`] = `
       "closed": false,
       "hasError": false,
       "isStopped": false,
-      "observers": Array [],
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
       "thrownError": null,
     }
   }
@@ -7540,7 +7578,45 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
       "closed": false,
       "hasError": false,
       "isStopped": false,
-      "observers": Array [],
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
       "thrownError": null,
     }
   }
@@ -8843,6 +8919,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                               "thrownError": null,
                             }
                           }
+                          hideFirstHome={false}
                           renderFullLength={true}
                           useUpdatedHeader={true}
                         />
@@ -10100,7 +10177,45 @@ exports[`Header renders condensed header 1`] = `
       "closed": false,
       "hasError": false,
       "isStopped": false,
-      "observers": Array [],
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
       "thrownError": null,
     }
   }
@@ -15743,7 +15858,45 @@ exports[`Header renders page header with application title 1`] = `
       "closed": false,
       "hasError": false,
       "isStopped": false,
-      "observers": Array [],
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
       "thrownError": null,
     }
   }
@@ -17272,6 +17425,7 @@ exports[`Header renders page header with application title 1`] = `
                               "thrownError": null,
                             }
                           }
+                          hideFirstHome={false}
                           renderFullLength={true}
                           useUpdatedHeader={true}
                         />
@@ -17617,6 +17771,8 @@ exports[`Header renders page header with application title 1`] = `
                   "thrownError": null,
                 }
               }
+              hideFirstHome={false}
+              renderFullLength={false}
               useUpdatedHeader={true}
             >
               <EuiHeaderBreadcrumbs
@@ -19379,7 +19535,45 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
       "closed": false,
       "hasError": false,
       "isStopped": false,
-      "observers": Array [],
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
       "thrownError": null,
     }
   }

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -204,14 +204,14 @@ export function Header({
     />
   );
 
-  const renderBreadcrumbs = (renderFullLength?: boolean, hideFirstHome?: boolean) => (
+  const renderBreadcrumbs = (renderFullLength?: boolean, dropHomeFromBreadcrumb?: boolean) => (
     <HeaderBreadcrumbs
       appTitle$={observables.appTitle$}
       breadcrumbs$={observables.breadcrumbs$}
       breadcrumbsEnricher$={observables.breadcrumbsEnricher$}
       useUpdatedHeader={useUpdatedHeader}
       renderFullLength={renderFullLength}
-      hideFirstHome={hideFirstHome}
+      dropHomeFromBreadcrumb={dropHomeFromBreadcrumb}
     />
   );
 

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -143,6 +143,7 @@ export function Header({
   const [isNavOpen, setIsNavOpen] = useState(false);
   const sidecarConfig = useObservable(observables.sidecarConfig$, undefined);
   const breadcrumbs = useObservable(observables.breadcrumbs$, []);
+  const currentWorkspace = useObservable(observables.currentWorkspace$, undefined);
 
   const sidecarPaddingStyle = useMemo(() => {
     return getOsdSidecarPaddingStyle(sidecarConfig);
@@ -203,13 +204,14 @@ export function Header({
     />
   );
 
-  const renderBreadcrumbs = (renderFullLength?: boolean) => (
+  const renderBreadcrumbs = (renderFullLength?: boolean, hideFirstHome?: boolean) => (
     <HeaderBreadcrumbs
       appTitle$={observables.appTitle$}
       breadcrumbs$={observables.breadcrumbs$}
       breadcrumbsEnricher$={observables.breadcrumbsEnricher$}
       useUpdatedHeader={useUpdatedHeader}
       renderFullLength={renderFullLength}
+      hideFirstHome={hideFirstHome}
     />
   );
 
@@ -351,7 +353,7 @@ export function Header({
         recentlyAccessed$={observables.recentlyAccessed$}
         workspaceList$={observables.workspaceList$}
         navigateToUrl={application.navigateToUrl}
-        renderBreadcrumbs={renderBreadcrumbs(true)}
+        renderBreadcrumbs={renderBreadcrumbs(true, false)}
         buttonSize={useApplicationHeader ? 's' : 'xs'}
       />
     </EuiHeaderSectionItem>
@@ -399,7 +401,7 @@ export function Header({
 
         <EuiHeaderSection grow={false}>{renderRecentItems()}</EuiHeaderSection>
 
-        {renderBreadcrumbs()}
+        {renderBreadcrumbs(false, !!currentWorkspace)}
       </EuiHeader>
 
       {/* Secondary header */}

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
@@ -31,8 +31,8 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { ChromeBreadcrumb, ChromeBreadcrumbEnricher } from '../../chrome_service';
+import { BehaviorSubject } from 'rxjs';
+import { ChromeBreadcrumb } from '../../chrome_service';
 import { HeaderBreadcrumbs } from './header_breadcrumbs';
 
 describe('HeaderBreadcrumbs', () => {
@@ -123,7 +123,7 @@ describe('HeaderBreadcrumbs', () => {
         dropHomeFromBreadcrumb={true}
       />
     );
-    const breadcrumbs = wrapper.find('.euiBreadcrumbWrapper');
+    let breadcrumbs = wrapper.find('.euiBreadcrumbWrapper');
     expect(breadcrumbs).toHaveLength(2);
     expect(breadcrumbs.at(0).text()).toBe('Analytics');
     expect(breadcrumbs.at(1).text()).toBe('First');
@@ -134,8 +134,17 @@ describe('HeaderBreadcrumbs', () => {
       breadcrumbs$.next([{ text: 'Home' }, { text: 'Second' }]);
     });
     wrapper.update();
+    breadcrumbs = wrapper.find('.euiBreadcrumbWrapper');
     expect(breadcrumbs).toHaveLength(2);
     expect(breadcrumbs.at(0).text()).toBe('Home');
     expect(breadcrumbs.at(1).text()).toBe('Second');
+
+    act(() => {
+      breadcrumbsEnricher$.next((items) => []);
+      breadcrumbs$.next([{ text: 'Home' }, { text: 'Second' }]);
+    });
+    wrapper.update();
+    breadcrumbs = wrapper.find('.euiBreadcrumbWrapper');
+    expect(breadcrumbs).toHaveLength(0);
   });
 });

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
@@ -107,4 +107,25 @@ describe('HeaderBreadcrumbs', () => {
     wrapper.update();
     expect(wrapper.find('.euiBreadcrumbWrapper')).toHaveLength(2);
   });
+
+  it('remove heading home when workspace is enabled', () => {
+    const breadcrumbs$ = new BehaviorSubject([{ text: 'First' }]);
+    const breadcrumbsEnricher$ = new BehaviorSubject((crumbs: ChromeBreadcrumb[]) => [
+      { text: 'Home' },
+      { text: 'Analytics' },
+      ...crumbs,
+    ]);
+    const wrapper = mount(
+      <HeaderBreadcrumbs
+        appTitle$={new BehaviorSubject('')}
+        breadcrumbs$={breadcrumbs$}
+        breadcrumbsEnricher$={breadcrumbsEnricher$}
+        hideFirstHome={true}
+      />
+    );
+    const breadcrumbs = wrapper.find('.euiBreadcrumbWrapper');
+    expect(breadcrumbs).toHaveLength(2);
+    expect(breadcrumbs.at(0).text()).toBe('Analytics');
+    expect(breadcrumbs.at(1).text()).toBe('First');
+  });
 });

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.test.tsx
@@ -31,8 +31,8 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { BehaviorSubject } from 'rxjs';
-import { ChromeBreadcrumb } from '../../chrome_service';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { ChromeBreadcrumb, ChromeBreadcrumbEnricher } from '../../chrome_service';
 import { HeaderBreadcrumbs } from './header_breadcrumbs';
 
 describe('HeaderBreadcrumbs', () => {
@@ -111,7 +111,7 @@ describe('HeaderBreadcrumbs', () => {
   it('remove heading home when workspace is enabled', () => {
     const breadcrumbs$ = new BehaviorSubject([{ text: 'First' }]);
     const breadcrumbsEnricher$ = new BehaviorSubject((crumbs: ChromeBreadcrumb[]) => [
-      { text: 'Home' },
+      { text: 'Home', home: true },
       { text: 'Analytics' },
       ...crumbs,
     ]);
@@ -120,12 +120,22 @@ describe('HeaderBreadcrumbs', () => {
         appTitle$={new BehaviorSubject('')}
         breadcrumbs$={breadcrumbs$}
         breadcrumbsEnricher$={breadcrumbsEnricher$}
-        hideFirstHome={true}
+        dropHomeFromBreadcrumb={true}
       />
     );
     const breadcrumbs = wrapper.find('.euiBreadcrumbWrapper');
     expect(breadcrumbs).toHaveLength(2);
     expect(breadcrumbs.at(0).text()).toBe('Analytics');
     expect(breadcrumbs.at(1).text()).toBe('First');
+
+    // if no home property, we don't drop by text
+    act(() => {
+      breadcrumbsEnricher$.next((items) => items);
+      breadcrumbs$.next([{ text: 'Home' }, { text: 'Second' }]);
+    });
+    wrapper.update();
+    expect(breadcrumbs).toHaveLength(2);
+    expect(breadcrumbs.at(0).text()).toBe('Home');
+    expect(breadcrumbs.at(1).text()).toBe('Second');
   });
 });

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -75,7 +75,7 @@ export function HeaderBreadcrumbs({
     crumbs = breadcrumbEnricher(crumbs);
   }
 
-  if (dropHomeFromBreadcrumb && Object.hasOwn(crumbs[0], 'home')) {
+  if (dropHomeFromBreadcrumb && crumbs.length && Object.hasOwn(crumbs[0], 'home')) {
     crumbs = crumbs.slice(1);
   }
 

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -41,6 +41,7 @@ interface Props {
   breadcrumbsEnricher$: Observable<ChromeBreadcrumbEnricher | undefined>;
   useUpdatedHeader?: boolean;
   renderFullLength?: boolean;
+  hideFirstHome?: boolean;
 }
 
 export function HeaderBreadcrumbs({
@@ -49,6 +50,7 @@ export function HeaderBreadcrumbs({
   breadcrumbsEnricher$,
   useUpdatedHeader,
   renderFullLength,
+  hideFirstHome,
 }: Props) {
   const appTitle = useObservable(appTitle$, 'OpenSearch Dashboards');
   const breadcrumbs = useObservable(breadcrumbs$, []);
@@ -71,6 +73,10 @@ export function HeaderBreadcrumbs({
 
   if (breadcrumbEnricher) {
     crumbs = breadcrumbEnricher(crumbs);
+  }
+
+  if (hideFirstHome && crumbs[0].text === 'Home') {
+    crumbs = crumbs.slice(1);
   }
 
   crumbs = crumbs.map((breadcrumb, i) => ({

--- a/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
+++ b/src/core/public/chrome/ui/header/header_breadcrumbs.tsx
@@ -41,7 +41,7 @@ interface Props {
   breadcrumbsEnricher$: Observable<ChromeBreadcrumbEnricher | undefined>;
   useUpdatedHeader?: boolean;
   renderFullLength?: boolean;
-  hideFirstHome?: boolean;
+  dropHomeFromBreadcrumb?: boolean;
 }
 
 export function HeaderBreadcrumbs({
@@ -50,7 +50,7 @@ export function HeaderBreadcrumbs({
   breadcrumbsEnricher$,
   useUpdatedHeader,
   renderFullLength,
-  hideFirstHome,
+  dropHomeFromBreadcrumb,
 }: Props) {
   const appTitle = useObservable(appTitle$, 'OpenSearch Dashboards');
   const breadcrumbs = useObservable(breadcrumbs$, []);
@@ -75,7 +75,7 @@ export function HeaderBreadcrumbs({
     crumbs = breadcrumbEnricher(crumbs);
   }
 
-  if (hideFirstHome && crumbs[0].text === 'Home') {
+  if (dropHomeFromBreadcrumb && Object.hasOwn(crumbs[0], 'home')) {
     crumbs = crumbs.slice(1);
   }
 

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -385,8 +385,9 @@ export function prependWorkspaceToBreadcrumbs(
     return;
   }
 
-  const homeBreadcrumb: ChromeBreadcrumb = {
+  const homeBreadcrumb: ChromeBreadcrumb & { home: boolean } = {
     text: 'Home',
+    home: true,
     onClick: () => {
       core.application.navigateToApp('home');
     },


### PR DESCRIPTION
### Description

Hide the home breadcrumbs when we are in a workspace, but keep it in recent popover

![image](https://github.com/user-attachments/assets/1fba0175-be39-417d-ab94-e0073cc7e4da)


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: [Workspace] Hide home breadcrumbs when in a workspace

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
