### PR TITLE
[discover] pass connection title correctly and set session id

### DIFF
--- a/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
@@ -7,11 +7,23 @@
 
 import { s3TypeConfig } from './s3_type';
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
-import { DataStructure, Dataset } from '../../../data/common';
+import {
+  DATA_STRUCTURE_META_TYPES,
+  DataStructure,
+  DataStructureCustomMeta,
+  Dataset,
+} from '../../../data/common';
+import { DATASET } from '../../common';
+import { IDataPluginServices } from 'src/plugins/data/public';
 
 describe('s3TypeConfig', () => {
-  const mockHttp = {} as HttpSetup;
-  const mockSavedObjectsClient = {} as SavedObjectsClientContract;
+  const mockHttp = ({
+    fetch: jest.fn(),
+    post: jest.fn(),
+  } as unknown) as HttpSetup;
+  const mockSavedObjectsClient = ({
+    find: jest.fn(),
+  } as unknown) as SavedObjectsClientContract;
   const mockServices = {
     http: mockHttp,
     savedObjects: { client: mockSavedObjectsClient },
@@ -21,43 +33,115 @@ describe('s3TypeConfig', () => {
     jest.clearAllMocks();
   });
 
-  test('toDataset converts DataStructure path to Dataset', () => {
-    const mockPath: DataStructure[] = [
-      { id: 'ds1', title: 'DataSource 1', type: 'DATA_SOURCE' },
-      { id: 'conn1', title: 'Connection 1', type: 'CONNECTION' },
-      { id: 'db1', title: 'Database 1', type: 'DATABASE' },
-      { id: 'table1', title: 'Table 1', type: 'TABLE' },
-    ];
+  describe('toDataset', () => {
+    it('should convert DataStructure path to Dataset', () => {
+      const mockPath: DataStructure[] = [
+        { id: 'ds1', title: 'DataSource 1', type: 'DATA_SOURCE' },
+        { id: 'conn1', title: 'Connection 1', type: 'CONNECTION' },
+        {
+          id: 'db1',
+          title: 'Database 1',
+          type: 'DATABASE',
+          meta: {
+            name: 'conn1',
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          } as DataStructureCustomMeta,
+        },
+        {
+          id: 'table1',
+          title: 'Table 1',
+          type: 'TABLE',
+          meta: {
+            name: 'conn1',
+            sessionId: 'session123',
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          } as DataStructureCustomMeta,
+        },
+      ];
 
-    const result = s3TypeConfig.toDataset(mockPath);
+      const result = s3TypeConfig.toDataset(mockPath);
 
-    expect(result).toEqual({
-      id: 'table1',
-      title: 'Connection 1.Database 1.Table 1',
-      type: 'S3',
-      dataSource: {
-        id: 'ds1',
-        title: 'DataSource 1',
-        type: 'DATA_SOURCE',
-      },
+      expect(result).toEqual({
+        id: 'table1',
+        title: 'Connection 1.Database 1.Table 1',
+        type: DATASET.S3,
+        dataSource: {
+          id: 'ds1',
+          title: 'DataSource 1',
+          type: 'DATA_SOURCE',
+          meta: { name: 'conn1', sessionId: 'session123', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+        },
+      });
+    });
+
+    it('should handle missing connection or database in path', () => {
+      const mockPath: DataStructure[] = [
+        { id: 'ds1', title: 'DataSource 1', type: 'DATA_SOURCE' },
+        {
+          id: 'table1',
+          title: 'Table 1',
+          type: 'TABLE',
+          meta: {
+            sessionId: 'session123',
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          } as DataStructureCustomMeta,
+        },
+      ];
+
+      const result = s3TypeConfig.toDataset(mockPath);
+
+      expect(result).toEqual({
+        id: 'table1',
+        title: 'undefined.undefined.Table 1',
+        type: DATASET.S3,
+        dataSource: {
+          id: 'ds1',
+          title: 'DataSource 1',
+          type: 'DATA_SOURCE',
+          meta: { sessionId: 'session123', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+        },
+      });
     });
   });
 
-  test.skip('fetch returns correct structure based on input', async () => {
-    const mockFetch = jest.fn().mockResolvedValue({ datarows: [['db1'], ['db2']] });
-    mockHttp.fetch = mockFetch;
+  describe('fetch', () => {
+    it('should fetch connections for DATA_SOURCE type', async () => {
+      mockHttp.fetch = jest.fn().mockResolvedValue([
+        { name: 'conn1', connector: 'S3GLUE' },
+        { name: 'conn2', connector: 'S3GLUE' },
+      ]);
 
-    const mockFind = jest.fn().mockResolvedValue({
-      savedObjects: [{ id: 'ds1', attributes: { title: 'DataSource 1' } }],
+      const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
+        {
+          id: 'ds1',
+          title: 'DS 1',
+          type: 'DATA_SOURCE',
+          meta: {
+            query: { id: 'ds1' },
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          } as DataStructureCustomMeta,
+        },
+      ]);
+
+      expect(result.children).toHaveLength(2);
+      expect(result.children?.[0].title).toBe('conn1');
+      expect(result.children?.[1].title).toBe('conn2');
+      expect(result.hasNext).toBe(true);
     });
-    mockSavedObjectsClient.find = mockFind;
 
-    const result = await s3TypeConfig.fetch(mockServices as any, [
-      { id: 'ds1', title: 'DS 1', type: 'DATA_SOURCE' },
-    ]);
+    it('should fetch data sources for unknown type', async () => {
+      mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
+        savedObjects: [{ id: 'ds1', attributes: { title: 'DataSource 1' } }],
+      });
 
-    expect(result.children).toBeDefined();
-    expect(result.hasNext).toBe(true);
+      const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
+        { id: 'unknown', title: 'Unknown', type: 'UNKNOWN' },
+      ]);
+
+      expect(result.children).toHaveLength(2); // Including DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE
+      expect(result.children?.[1].title).toBe('DataSource 1');
+      expect(result.hasNext).toBe(true);
+    });
   });
 
   test('fetchFields returns empty array', async () => {

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -109,6 +109,7 @@ const fetch = async (
   type: 'DATABASE' | 'TABLE'
 ): Promise<DataStructure[]> => {
   const dataSource = path.find((ds) => ds.type === 'DATA_SOURCE');
+  const connection = path.find((ds) => ds.type === 'CONNECTION');
   const parent = path[path.length - 1];
   const meta = parent.meta as DataStructureCustomMeta;
 
@@ -129,8 +130,8 @@ const fetch = async (
       type,
       meta: {
         type: DATA_STRUCTURE_META_TYPES.CUSTOM,
-        query: meta.query,
-        session: meta.session,
+        sessionId: meta.sessionId,
+        name: connection?.title,
       } as DataStructureCustomMeta,
     }));
   } catch (error) {

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -39,13 +39,14 @@ export class Facet {
     try {
       const query: Query = request.body.query;
       const { dataSource } = query.dataset!;
+      const { meta } = dataSource!;
       const { format, lang } = request.body;
       const params = {
         body: {
           query: query.query,
-          ...(dataSource && { datasource: dataSource.title }),
-          ...(dataSource?.meta?.sessionId && {
-            sessionId: dataSource?.meta?.sessionId,
+          ...(meta?.name && { datasource: meta.name }),
+          ...(meta?.sessionId && {
+            sessionId: meta.sessionId,
           }),
           ...(lang && { lang }),
         },


### PR DESCRIPTION
### Description

Updated so the session ID gets correctly passed along to speed up subsequent queries. Also set the connection title to the datasource meta field to be used as originally interfaced.

### Issues Resolved

n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
