### PR TITLE
[WIP][discover] PPL and SQL use default internal search route

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -167,6 +167,7 @@
     - [Opensearch dashboards.release notes 2.14.0](../release-notes/opensearch-dashboards.release-notes-2.14.0.md)
     - [Opensearch dashboards.release notes 2.15.0](../release-notes/opensearch-dashboards.release-notes-2.15.0.md)
     - [Opensearch dashboards.release notes 2.16.0](../release-notes/opensearch-dashboards.release-notes-2.16.0.md)
+    - [Opensearch dashboards.release notes 2.17.0](../release-notes/opensearch-dashboards.release-notes-2.17.0.md)
     - [Opensearch dashboards.release notes 2.2.0](../release-notes/opensearch-dashboards.release-notes-2.2.0.md)
     - [Opensearch dashboards.release notes 2.2.1](../release-notes/opensearch-dashboards.release-notes-2.2.1.md)
     - [Opensearch dashboards.release notes 2.3.0](../release-notes/opensearch-dashboards.release-notes-2.3.0.md)

--- a/src/plugins/data/common/search/search_source/fetch/get_search_params.ts
+++ b/src/plugins/data/common/search/search_source/fetch/get_search_params.ts
@@ -53,19 +53,16 @@ export function getExternalSearchParamsFromRequest(
   searchRequest: SearchRequest,
   dependencies: {
     getConfig: GetConfigFn;
-    getDataFrame: GetDataFrameFn;
   }
 ): ISearchRequestParams {
-  const { getConfig, getDataFrame } = dependencies;
+  const { getConfig } = dependencies;
   const searchParams = getSearchParams(getConfig);
-  const dataFrame = getDataFrame();
   const indexTitle = searchRequest.index.title || searchRequest.index;
 
   return {
     index: indexTitle,
     body: {
       ...searchRequest.body,
-      ...(dataFrame && dataFrame?.name === indexTitle ? { df: dataFrame } : {}),
     },
     ...searchParams,
   };

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -424,30 +424,25 @@ export class SearchSource {
   private async fetchExternalSearch(searchRequest: SearchRequest, options: ISearchOptions) {
     const { search, getConfig, onResponse } = this.dependencies;
 
-    const currentDataframe = this.getDataFrame();
-    if (!currentDataframe || currentDataframe.name !== searchRequest.index?.id) {
-      await this.createDataFrame(searchRequest);
-    }
-
     const params = getExternalSearchParamsFromRequest(searchRequest, {
       getConfig,
-      getDataFrame: this.getDataFrame.bind(this),
     });
 
     return search({ params }, options).then(async (response: any) => {
-      if (response.hasOwnProperty('type')) {
-        if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.DEFAULT) {
-          const dataFrameResponse = response as IDataFrameResponse;
+      const rawResponse = response.rawResponse;
+      if (rawResponse.hasOwnProperty('type')) {
+        if ((rawResponse as IDataFrameResponse).type === DATA_FRAME_TYPES.DEFAULT) {
+          const dataFrameResponse = rawResponse as IDataFrameResponse;
           await this.setDataFrame(dataFrameResponse.body as IDataFrame);
-          return onResponse(searchRequest, convertResult(response as IDataFrameResponse));
+          return onResponse(searchRequest, convertResult(rawResponse as IDataFrameResponse));
         }
-        if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.POLLING) {
-          const dataFrameResponse = response as IDataFrameResponse;
+        if ((rawResponse as IDataFrameResponse).type === DATA_FRAME_TYPES.POLLING) {
+          const dataFrameResponse = rawResponse as IDataFrameResponse;
           await this.setDataFrame(dataFrameResponse.body as IDataFrame);
-          return onResponse(searchRequest, convertResult(response as IDataFrameResponse));
+          return onResponse(searchRequest, convertResult(rawResponse as IDataFrameResponse));
         }
-        if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.ERROR) {
-          const dataFrameError = response as IDataFrameError;
+        if ((rawResponse as IDataFrameResponse).type === DATA_FRAME_TYPES.ERROR) {
+          const dataFrameError = rawResponse as IDataFrameError;
           throw new RequestFailure(null, dataFrameError);
         }
       }

--- a/src/plugins/data/server/search/routes/shim_hits_total.ts
+++ b/src/plugins/data/server/search/routes/shim_hits_total.ts
@@ -38,7 +38,10 @@ import { SearchResponse } from 'elasticsearch';
  * @internal
  */
 export function shimHitsTotal(response: SearchResponse<any>) {
-  const total = (response.hits?.total as any)?.value ?? response.hits?.total;
+  if (!response.hits) {
+    return response;
+  }
+  const total = (response.hits.total as any)?.value ?? response.hits.total;
   const hits = { ...response.hits, total };
   return { ...response, hits };
 }

--- a/src/plugins/query_enhancements/common/constants.ts
+++ b/src/plugins/query_enhancements/common/constants.ts
@@ -20,10 +20,6 @@ export const SEARCH_STRATEGY = {
 };
 
 export const API = {
-  SEARCH: `${BASE_API}/search`,
-  PPL_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.PPL}`,
-  SQL_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.SQL}`,
-  SQL_ASYNC_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.SQL_ASYNC}`,
   QUERY_ASSIST: {
     LANGUAGES: `${BASE_API}/assist/languages`,
     GENERATE: `${BASE_API}/assist/generate`,

--- a/src/plugins/query_enhancements/common/types.ts
+++ b/src/plugins/query_enhancements/common/types.ts
@@ -23,7 +23,7 @@ export interface QueryStatusConfig {
 
 export interface EnhancedFetchContext {
   http: CoreSetup['http'];
-  path: string;
+  strategy?: string;
   signal?: AbortSignal;
 }
 

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -4,6 +4,7 @@
  */
 
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import { trimEnd } from 'lodash';
 import {
   DATA_STRUCTURE_META_TYPES,
   DEFAULT_DATA,
@@ -14,7 +15,7 @@ import {
   DatasetField,
 } from '../../../data/common';
 import { DatasetTypeConfig, IDataPluginServices } from '../../../data/public';
-import { DATASET, handleQueryStatus } from '../../common';
+import { API, DATASET, handleQueryStatus } from '../../common';
 import S3_ICON from '../assets/s3_mark.svg';
 
 export const s3TypeConfig: DatasetTypeConfig = {
@@ -115,7 +116,7 @@ const fetch = async (
   try {
     const response = await handleQueryStatus({
       fetchStatus: () =>
-        http.fetch('../../api/enhancements/datasource/jobs', {
+        http.fetch(trimEnd(API.DATA_SOURCE.ASYNC_JOBS), {
           query: {
             id: dataSource?.id,
             queryId: meta.queryId,
@@ -172,7 +173,7 @@ const fetchConnections = async (
   dataSource: DataStructure
 ): Promise<DataStructure[]> => {
   const query = (dataSource.meta as DataStructureCustomMeta).query;
-  const response = await http.fetch(`../../api/enhancements/datasource/external`, {
+  const response = await http.fetch(trimEnd(API.DATA_SOURCE.EXTERNAL), {
     query,
   });
 
@@ -193,7 +194,7 @@ const fetchDatabases = async (http: HttpSetup, path: DataStructure[]): Promise<D
   const dataSource = path.find((ds) => ds.type === 'DATA_SOURCE');
   const connection = path[path.length - 1];
   const meta = connection.meta as DataStructureCustomMeta;
-  const response = await http.post(`../../api/enhancements/datasource/jobs`, {
+  const response = await http.post(trimEnd(API.DATA_SOURCE.ASYNC_JOBS), {
     body: JSON.stringify({
       lang: 'sql',
       query: `SHOW DATABASES in ${connection.title}`,
@@ -215,7 +216,7 @@ const fetchTables = async (http: HttpSetup, path: DataStructure[]): Promise<Data
   const connection = path.find((ds) => ds.type === 'CONNECTION');
   const sessionId = (connection?.meta as DataStructureCustomMeta).sessionId;
   const database = path[path.length - 1];
-  const response = await http.post(`../../api/enhancements/datasource/jobs`, {
+  const response = await http.post(trimEnd(API.DATA_SOURCE.ASYNC_JOBS), {
     body: JSON.stringify({
       lang: 'sql',
       query: `SHOW TABLES in ${database.title}`,

--- a/src/plugins/query_enhancements/server/plugin.ts
+++ b/src/plugins/query_enhancements/server/plugin.ts
@@ -82,11 +82,7 @@ export class QueryEnhancementsPlugin
       dataSourceEnabled: !!dataSource,
     }));
 
-    defineRoutes(this.logger, router, client, {
-      ppl: pplSearchStrategy,
-      sql: sqlSearchStrategy,
-      sqlasync: sqlAsyncSearchStrategy,
-    });
+    defineRoutes(router, client);
 
     this.logger.info('queryEnhancements: Setup complete');
     return {};

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -3,184 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { schema } from '@osd/config-schema';
-import {
-  IOpenSearchDashboardsResponse,
-  IRouter,
-  Logger,
-  ResponseError,
-} from '../../../../core/server';
-import { IDataFrameResponse, IOpenSearchDashboardsSearchRequest } from '../../../data/common';
-import { ISearchStrategy } from '../../../data/server';
-import { API, SEARCH_STRATEGY } from '../../common';
+import { IRouter } from '../../../../core/server';
 import { registerQueryAssistRoutes } from './query_assist';
 import { registerDataSourceConnectionsRoutes } from './data_source_connection';
-
-/**
- * Defines a route for a specific search strategy.
- *
- * @experimental This function is experimental and might change in future releases.
- *
- * @param logger - The logger instance.
- * @param router - The router instance.
- * @param searchStrategies - The available search strategies.
- * @param searchStrategyId - The ID of the search strategy to use.
- *
- * @example
- * API Request Body:
- * ```json
- * {
- *   "query": {
- *     "query": "SELECT * FROM my_index",
- *     "language": "sql",
- *     "dataset": {
- *       "id": "my_dataset_id",
- *       "title": "My Dataset"
- *     },
- *     "format": "json"
- *   },
- *   @experimental
- *   "aggConfig": {
- *     // Optional aggregation configuration
- *   },
- *   @deprecated
- *   "df": {
- *     // Optional data frame configuration
- *   }
- * }
- * ```
- */
-function defineRoute(
-  logger: Logger,
-  router: IRouter,
-  searchStrategies: Record<
-    string,
-    ISearchStrategy<IOpenSearchDashboardsSearchRequest, IDataFrameResponse>
-  >,
-  searchStrategyId: string
-) {
-  const path = `${API.SEARCH}/${searchStrategyId}`;
-  router.post(
-    {
-      path,
-      validate: {
-        body: schema.object({
-          query: schema.object({
-            query: schema.string(),
-            language: schema.string(),
-            dataset: schema.nullable(schema.object({}, { unknowns: 'allow' })),
-            format: schema.string(),
-          }),
-          aggConfig: schema.nullable(schema.object({}, { unknowns: 'allow' })),
-          df: schema.nullable(schema.object({}, { unknowns: 'allow' })),
-        }),
-      },
-    },
-    async (context, req, res): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      try {
-        const queryRes: IDataFrameResponse = await searchStrategies[searchStrategyId].search(
-          context,
-          req as any,
-          {}
-        );
-        return res.ok({ body: { ...queryRes } });
-      } catch (err) {
-        return res.custom({
-          statusCode: err.name,
-          body: err.message,
-        });
-      }
-    }
-  );
-
-  router.get(
-    {
-      path: `${path}/{queryId}`,
-      validate: {
-        params: schema.object({
-          queryId: schema.string(),
-        }),
-      },
-    },
-    async (context, req, res): Promise<any> => {
-      try {
-        const queryRes: IDataFrameResponse = await searchStrategies[searchStrategyId].search(
-          context,
-          req as any,
-          {}
-        );
-        const result: any = {
-          body: {
-            ...queryRes,
-          },
-        };
-        return res.ok(result);
-      } catch (err) {
-        logger.error(err);
-        return res.custom({
-          statusCode: 500,
-          body: err,
-        });
-      }
-    }
-  );
-
-  router.get(
-    {
-      path: `${path}/{queryId}/{dataSourceId}`,
-      validate: {
-        params: schema.object({
-          queryId: schema.string(),
-          dataSourceId: schema.string(),
-        }),
-      },
-    },
-    async (context, req, res): Promise<any> => {
-      try {
-        const queryRes: IDataFrameResponse = await searchStrategies[searchStrategyId].search(
-          context,
-          req as any,
-          {}
-        );
-        const result: any = {
-          body: {
-            ...queryRes,
-          },
-        };
-        return res.ok(result);
-      } catch (err) {
-        logger.error(err);
-        return res.custom({
-          statusCode: 500,
-          body: err,
-        });
-      }
-    }
-  );
-}
 
 /**
  * Defines routes for various search strategies and registers additional routes.
  *
  * @experimental This function is experimental and might change in future releases.
  *
- * @param logger - The logger instance.
  * @param router - The router instance.
  * @param client - The client instance.
- * @param searchStrategies - The available search strategies.
  */
-export function defineRoutes(
-  logger: Logger,
-  router: IRouter,
-  client: any,
-  searchStrategies: Record<
-    string,
-    ISearchStrategy<IOpenSearchDashboardsSearchRequest, IDataFrameResponse>
-  >
-) {
-  defineRoute(logger, router, searchStrategies, SEARCH_STRATEGY.PPL);
-  defineRoute(logger, router, searchStrategies, SEARCH_STRATEGY.SQL);
-  defineRoute(logger, router, searchStrategies, SEARCH_STRATEGY.SQL_ASYNC);
+export function defineRoutes(router: IRouter, client: any) {
   registerDataSourceConnectionsRoutes(router, client);
   registerQueryAssistRoutes(router);
 }


### PR DESCRIPTION
### Description

commit currently doesn't work.

likely because we need to parse the bare minimum required request for PPL endpoints as it seems to be sending too much an error.

After all the refactoring for 2.17. The default /internal/search with search strategy is now usable. Effectly ensuring we are using no new API routes.

also i think this should fix the issue where index patterns dont work with ppl and sql (could be a new issue)

### Issues Resolved
n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
