### PR TITLE
add Huy as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi @mengweieric @LDrago27 @virajsanghvi @sejli @joshuali925
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi @mengweieric @LDrago27 @virajsanghvi @sejli @joshuali925 @huyaboo

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,6 +29,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Viraj Sanghvi             | [virajsanghvi](https://github.com/virajsanghvi)     | Amazon      |
 | Sean Li                   | [sejli](https://github.com/sejli)                   | Amazon      |
 | Joshua Li                 | [joshuali925](https://github.com/joshuali925)       | Amazon      |
+| Huy Nguyen                | [huyaboo](https://github.com/huyaboo)               | Amazon      |
 
 ## Emeritus
 

--- a/changelogs/fragments/8025.yml
+++ b/changelogs/fragments/8025.yml
@@ -1,0 +1,2 @@
+doc:
+- Add Huy as maintainer ([#8025](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8025))


### PR DESCRIPTION
### Description

Add Huy(huyaboo) as maintainer

### Issues Resolved

NA

## Screenshot

N/A

## Testing the changes

NA

## Changelog
- doc: add Huy as maintainer


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
