### PR TITLE
Bump `micromatch` from 4.0.7 to 4.0.8

### DIFF
--- a/changelogs/fragments/8026.yml
+++ b/changelogs/fragments/8026.yml
@@ -1,0 +1,2 @@
+security:
+- Bump `micromatch` from 4.0.7 to 4.0.8 ([#8026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8026))

--- a/yarn.lock
+++ b/yarn.lock
@@ -12290,9 +12290,9 @@ methods@^1.1.1, methods@^1.1.2:
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
 micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.7.tgz#33e8190d9fe474a9895525f5618eee136d46c2e5"
-  integrity sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"


### PR DESCRIPTION
### Description

Bump `micromatch` from 4.0.7 to 4.0.8

## Changelog
- security: Bump `micromatch` from 4.0.7 to 4.0.8

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
