### PR TITLE
[discover] undefined datasource fix for index patterns for PPL and SQL

### DIFF
--- a/src/plugins/query_enhancements/server/utils/facet.test.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from 'opensearch-dashboards/server';
+import { Facet, FacetProps } from './facet';
+
+describe('Facet', () => {
+  let facet: Facet;
+  let mockClient: jest.Mock;
+  let mockLogger: jest.Mocked<Logger>;
+  let mockContext: any;
+  let mockRequest: any;
+
+  beforeEach(() => {
+    mockClient = jest.fn();
+    mockLogger = ({
+      error: jest.fn(),
+    } as unknown) as jest.Mocked<Logger>;
+
+    const props: FacetProps = {
+      client: { asScoped: jest.fn().mockReturnValue({ callAsCurrentUser: mockClient }) },
+      logger: mockLogger,
+      endpoint: 'test-endpoint',
+    };
+
+    facet = new Facet(props);
+
+    mockContext = {
+      dataSource: {
+        opensearch: {
+          legacy: {
+            getClient: jest.fn().mockReturnValue({ callAPI: mockClient }),
+          },
+        },
+      },
+    };
+
+    mockRequest = {
+      body: {
+        query: {
+          query: 'test query',
+          dataset: {
+            dataSource: {
+              id: 'test-id',
+              meta: {
+                name: 'test-name',
+                sessionId: 'test-session',
+              },
+            },
+          },
+        },
+        format: 'jdbc',
+        lang: 'sql',
+      },
+    };
+  });
+
+  describe('describeQuery', () => {
+    it('should handle request with complete dataset information', async () => {
+      mockClient.mockResolvedValue({ result: 'success' });
+
+      const result = await facet.describeQuery(mockContext, mockRequest);
+
+      expect(result).toEqual({ success: true, data: { result: 'success' } });
+      expect(mockClient).toHaveBeenCalledWith('test-endpoint', {
+        body: {
+          query: 'test query',
+          datasource: 'test-name',
+          sessionId: 'test-session',
+          lang: 'sql',
+        },
+      });
+    });
+
+    it('should handle request with missing dataSource', async () => {
+      mockRequest.body.query.dataset.dataSource = undefined;
+      mockClient.mockResolvedValue({ result: 'success' });
+
+      const result = await facet.describeQuery(mockContext, mockRequest);
+
+      expect(result).toEqual({ success: true, data: { result: 'success' } });
+      expect(mockClient).toHaveBeenCalledWith('test-endpoint', {
+        body: {
+          query: 'test query',
+          lang: 'sql',
+        },
+      });
+    });
+
+    it('should handle request with missing dataset', async () => {
+      mockRequest.body.query.dataset = undefined;
+      mockClient.mockResolvedValue({ result: 'success' });
+
+      const result = await facet.describeQuery(mockContext, mockRequest);
+
+      expect(result).toEqual({ success: true, data: { result: 'success' } });
+      expect(mockClient).toHaveBeenCalledWith('test-endpoint', {
+        body: {
+          query: 'test query',
+          lang: 'sql',
+        },
+      });
+    });
+
+    it('should handle errors', async () => {
+      const error = new Error('Test error');
+      mockClient.mockRejectedValue(error);
+
+      const result = await facet.describeQuery(mockContext, mockRequest);
+
+      expect(result).toEqual({ success: false, data: error });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Facet fetch: test-endpoint: Error: Test error'
+      );
+    });
+  });
+});

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -38,8 +38,8 @@ export class Facet {
   ): Promise<FacetResponse> => {
     try {
       const query: Query = request.body.query;
-      const { dataSource } = query.dataset!;
-      const { meta } = dataSource!;
+      const dataSource = query.dataset?.dataSource;
+      const meta = dataSource?.meta;
       const { format, lang } = request.body;
       const params = {
         body: {


### PR DESCRIPTION
### Description

Deconstructing the dataSource caused an exception when no dataSource was set with the query. This can be the case with index patterns that are created and pointed to the `default`. Most times the default is the local cluster so there is no data source object in the query the case of the local.

Accessing by dot notation with null operator fixes this issue. Adding tests to prevent this happening again.

With query enhancements enabled we should considered ensuring index patterns always have a datasource object in the query.

### Issues Resolved

Index patterns failed on SQL and PPL

## Screenshot

URL:

`query:(dataset:(id:d3d7af60-4c81-11e8-b3d7-01146121b73d,timeFieldName:timestamp,title:opensearch_dashboards_sample_data_flights,type:INDEX_PATTERN),` 

<img width="1505" alt="Screenshot 2024-09-05 at 12 44 55 PM" src="https://github.com/user-attachments/assets/5dca8129-3302-4894-8b7c-2403a92613f0">

## Testing the changes

- local
- unit tests

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
