### PR TITLE
Readjust space between the search bar and the actions

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/_global_filter_group.scss
+++ b/src/plugins/data/public/ui/filter_bar/_global_filter_group.scss
@@ -18,8 +18,7 @@
 
 .headerAppActionMenu .globalQueryBar,
 .headerAppActionMenu .globalDatePicker {
-  // The left-padding is a magic number just to add some space to the left that reduces with screen width
-  padding: 0 0 0 calc(100vw - 1600px);
+  padding: 0;
 }
 
 .globalFilterGroup__filterBar {

--- a/src/plugins/navigation/public/top_nav_menu/_index.scss
+++ b/src/plugins/navigation/public/top_nav_menu/_index.scss
@@ -70,9 +70,12 @@
   .euiText {
     line-height: $euiFormControlCompressedHeight;
     white-space: nowrap;
-    max-width: 18ch;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    @media only screen and (max-width: map-get($euiBreakpoints, "xxl")) {
+      max-width: 18ch;
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Drop the arbitrary space to the left of the search bar and only apply a max-width to the title when the screen is not wide (xxl).




## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
