### PR TITLE
[Workspace]Deny get or bulkGet for global data source

### DIFF
--- a/changelogs/fragments/8043.yml
+++ b/changelogs/fragments/8043.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Deny get or bulkGet for global data source ([#8043](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8043))

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
@@ -55,6 +55,12 @@ const generateWorkspaceSavedObjectsClientWrapper = (role = NO_DASHBOARD_ADMIN) =
     },
     {
       type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+      id: 'global-data-source-empty-workspaces',
+      attributes: { title: 'Global data source empty workspaces' },
+      workspaces: [],
+    },
+    {
+      type: DATA_SOURCE_SAVED_OBJECT_TYPE,
       id: 'workspace-1-data-source',
       attributes: { title: 'Workspace 1 data source' },
       workspaces: ['workspace-1'],
@@ -620,6 +626,33 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           workspaces: ['workspace-1'],
         });
       });
+
+      it('should throw permission error when tried to access a global data source', async () => {
+        const { wrapper } = generateWorkspaceSavedObjectsClientWrapper();
+        let errorCatched;
+        try {
+          await wrapper.get('data-source', 'global-data-source');
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
+      });
+
+      it('should throw permission error when tried to access a empty workspaces global data source', async () => {
+        const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
+        updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
+        let errorCatched;
+        try {
+          await wrapper.get('data-source', 'global-data-source-empty-workspaces');
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
+      });
     });
     describe('bulk get', () => {
       it("should call permission validate with object's workspace and throw permission error", async () => {
@@ -743,6 +776,36 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
             },
           ],
         });
+      });
+
+      it('should throw permission error when tried to bulk get global data source', async () => {
+        const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
+        updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
+        let errorCatched;
+        try {
+          await wrapper.bulkGet([{ type: 'data-source', id: 'global-data-source' }]);
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
+      });
+
+      it('should throw permission error when tried to bulk get a empty workspace global data source', async () => {
+        const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
+        updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
+        let errorCatched;
+        try {
+          await wrapper.bulkGet([
+            { type: 'data-source', id: 'global-data-source-empty-workspaces' },
+          ]);
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
       });
     });
     describe('find', () => {

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -204,7 +204,24 @@ export class WorkspaceSavedObjectsClientWrapper {
     request: OpenSearchDashboardsRequest
   ) => {
     const requestWorkspaceId = getWorkspaceState(request).requestWorkspaceId;
-    return !requestWorkspaceId || !!object.workspaces?.includes(requestWorkspaceId);
+    // Deny access if the object is a global data source (no workspaces assigned)
+    if (!object.workspaces || object.workspaces.length === 0) {
+      return false;
+    }
+    /**
+     * Allow access if no specific workspace is requested.
+     * This typically occurs when retrieving data sources or performing operations
+     * that don't require a specific workspace, such as pages within the
+     * Data Administration navigation group that include a data source picker.
+     */
+    if (!requestWorkspaceId) {
+      return true;
+    }
+    /*
+     * Allow access if the requested workspace matches one of the object's assigned workspaces
+     * This ensures that the user can only access data sources within their current workspace
+     */
+    return object.workspaces.includes(requestWorkspaceId);
   };
 
   private getWorkspaceTypeEnabledClient(request: OpenSearchDashboardsRequest) {


### PR DESCRIPTION
### Description

This PR is for adding permission validation in saved objects client's `get` or `bulkGet` methods. Currently, a user can call `get` / `bulkGet` with data source id for global data source (not assigned to any workspace). These two methods will throw error when operating on these global data sources. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#8044

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI changes

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version ignore`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
opensearchDashboards.dashboardAdmin.users: ['admin']
```
- Run `yarn start --no-base-path`
- Login with admin user
- Create a data source and record the data source id
- Create a `test-user` with `kibanauser` backend roles
- Call curl with created data source use below commands, it should response error
- Test bulkGet
```
# Test with get
curl 'http://localhost:5601/api/saved_objects/data-source/<created_data_source_id>"' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:5601' \
  -H 'Pragma: no-cache' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'osd-version: 3.0.0' \
  -H 'osd-xsrf: osd-fetch' \
  -H 'authorization: Basic <TOKEN_TO_TEST_USER>'

# Test with bulk get
curl 'http://localhost:5601/api/saved_objects/_bulk_get' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:5601' \
  -H 'Pragma: no-cache' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'osd-version: 3.0.0' \
  -H 'osd-xsrf: osd-fetch' \
  -H 'authorization: Basic <TOKEN_TO_TEST_USER>' \
  --data-raw '[{"id":"<created_data_source_id>","type":"data-source"}]'
```
These two commands should response `{"statusCode":403,"error":"Forbidden","message":"Invalid data source permission, please associate it to current workspace"}`

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace]Deny get or bulkGet for global data source

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
