### PR TITLE
fix: order of query editor extensions not working

### DIFF
--- a/changelogs/fragments/8045.yml
+++ b/changelogs/fragments/8045.yml
@@ -1,0 +1,2 @@
+fix:
+- Order of query editor extensions not working ([#8045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045))

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -150,6 +150,15 @@
   }
 }
 
+.osdQueryEditor__header {
+  display: flex;
+  align-items: center;
+
+  .osdQueryEditorExtensionComponent {
+    padding: 0 $euiSizeXS $euiSizeXS;
+  }
+}
+
 .osdQueryEditor__topBar {
   display: flex;
   align-items: center;

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
@@ -26,15 +26,21 @@ const QueryEditorExtensions: React.FC<QueryEditorExtensionsProps> = React.memo((
 
   return (
     <>
-      {sortedConfigs.map((config) => (
-        <QueryEditorExtension
-          key={config.id}
-          config={config}
-          dependencies={dependencies}
-          componentContainer={componentContainer}
-          bannerContainer={bannerContainer}
-        />
-      ))}
+      {sortedConfigs.map((config) => {
+        const extensionComponentContainer = document.createElement('div');
+        extensionComponentContainer.className = `osdQueryEditorExtensionComponent osdQueryEditorExtensionComponent__${config.id}`;
+        componentContainer.appendChild(extensionComponentContainer);
+
+        return (
+          <QueryEditorExtension
+            key={config.id}
+            config={config}
+            dependencies={dependencies}
+            componentContainer={extensionComponentContainer}
+            bannerContainer={bannerContainer}
+          />
+        );
+      })}
     </>
   );
 });

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -4,8 +4,6 @@
  */
 
 .queryAssist {
-  &.queryAssist__form {}
-
   &.queryAssist__callout {
     margin-top: $euiSizeXS;
   }

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -4,11 +4,13 @@
  */
 
 .queryAssist {
-  &.queryAssist__form {
-    padding: 0 $euiSizeXS $euiSizeXS;
-  }
+  &.queryAssist__form {}
 
   &.queryAssist__callout {
     margin-top: $euiSizeXS;
   }
+}
+
+.osdQueryEditorExtensionComponent__query-assist {
+  flex-grow: 1;
 }


### PR DESCRIPTION
### Description
When the react portal was created asynchronously within the same container, the order of query editor extensions cannot not be guaranteed. As react portal append the rendered component to the same container at the time when it's mounted. To fix the issue, now rendering the extension to different pre-ordered container.

This PR also introduced a few style changes so that multiple extensions can be render horizontally: 
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/86f13dd2-17a4-4f3a-8310-94305aa67838">


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: order of query editor extensions not working

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
