### PR TITLE
[workspace]feat: bypass permission control when construct ui settings client

### DIFF
--- a/changelogs/fragments/8053.yml
+++ b/changelogs/fragments/8053.yml
@@ -1,0 +1,2 @@
+fix:
+- Bypass permission control when construct ui settings client ([#8053](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8053))

--- a/src/core/server/core_route_handler_context.ts
+++ b/src/core/server/core_route_handler_context.ts
@@ -113,6 +113,9 @@ class CoreUiSettingsRouteHandlerContext {
         WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID
       )
         ? this.savedObjectsStart.getScopedClient(this.request, {
+            // If workspace permission control is turned on,
+            // need to bypass permission control wrapper in ui settings client
+            // so that it can find all the config in global.
             excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
           })
         : this.savedObjectsRouterHandlerContext.client;

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -372,7 +372,12 @@ export {
 } from './metrics';
 
 export { AppCategory, WorkspaceAttribute, PermissionModeId } from '../types';
-export { DEFAULT_APP_CATEGORIES, WORKSPACE_TYPE, DEFAULT_NAV_GROUPS } from '../utils';
+export {
+  DEFAULT_APP_CATEGORIES,
+  WORKSPACE_TYPE,
+  DEFAULT_NAV_GROUPS,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
+} from '../utils';
 
 export {
   SavedObject,

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -221,6 +221,7 @@ export class LegacyService implements CoreService {
         createInternalRepository: startDeps.core.savedObjects.createInternalRepository,
         createSerializer: startDeps.core.savedObjects.createSerializer,
         getTypeRegistry: startDeps.core.savedObjects.getTypeRegistry,
+        isWrapperRegistered: startDeps.core.savedObjects.isWrapperRegistered,
       },
       metrics: {
         collectionInterval: startDeps.core.metrics.collectionInterval,

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -266,6 +266,7 @@ export function createPluginStartContext<TPlugin, TPluginDependencies>(
       createScopedRepository: deps.savedObjects.createScopedRepository,
       createSerializer: deps.savedObjects.createSerializer,
       getTypeRegistry: deps.savedObjects.getTypeRegistry,
+      isWrapperRegistered: deps.savedObjects.isWrapperRegistered,
     },
     metrics: {
       collectionInterval: deps.metrics.collectionInterval,

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -55,6 +55,7 @@ const createStartContractMock = (typeRegistry?: jest.Mocked<ISavedObjectTypeRegi
     createScopedRepository: jest.fn(),
     createSerializer: jest.fn(),
     getTypeRegistry: jest.fn(),
+    isWrapperRegistered: jest.fn(),
   };
 
   startContrat.getScopedClient.mockReturnValue(savedObjectsClientMock.create());

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -507,5 +507,17 @@ describe('SavedObjectsService', () => {
         });
       });
     });
+
+    describe('#isWrapperRegistered', () => {
+      it('should return true if the wrapper has been registered', async () => {
+        const coreContext = createCoreContext();
+        const soService = new SavedObjectsService(coreContext);
+        const setup = await soService.setup(createSetupDeps());
+        setup.addClientWrapper(0, 'foo', (wrapperOptions) => wrapperOptions.client);
+        const coreStart = createStartDeps();
+        const start = await soService.start(coreStart);
+        expect(start.isWrapperRegistered('foo')).toEqual(true);
+      });
+    });
   });
 });

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -247,6 +247,12 @@ export interface SavedObjectsServiceStart {
    * {@link SavedObjectsType | saved object types}
    */
   getTypeRegistry: () => ISavedObjectTypeRegistry;
+  /**
+   * Returns a boolean to indicate if a specific wrapper is registered
+   * @param id
+   * @returns boolean
+   */
+  isWrapperRegistered: (id: string) => boolean;
 }
 
 export type InternalSavedObjectsServiceStart = SavedObjectsServiceStart;
@@ -540,6 +546,8 @@ export class SavedObjectsService
       createInternalRepository: repositoryFactory.createInternalRepository,
       createSerializer: () => new SavedObjectsSerializer(this.typeRegistry),
       getTypeRegistry: () => this.typeRegistry,
+      isWrapperRegistered: (id: string) =>
+        this.clientFactoryWrappers.some((wrapper) => wrapper.id === id),
     };
   }
 

--- a/src/core/utils/constants.ts
+++ b/src/core/utils/constants.ts
@@ -6,3 +6,5 @@
 export const WORKSPACE_TYPE = 'workspace';
 
 export const WORKSPACE_PATH_PREFIX = '/w';
+
+export const WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID = 'workspace';

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -37,7 +37,11 @@ export {
   IContextProvider,
 } from './context';
 export { DEFAULT_APP_CATEGORIES } from './default_app_categories';
-export { WORKSPACE_PATH_PREFIX, WORKSPACE_TYPE } from './constants';
+export {
+  WORKSPACE_PATH_PREFIX,
+  WORKSPACE_TYPE,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
+} from './constants';
 export { getWorkspaceIdFromUrl, formatUrlWithWorkspaceId, cleanWorkspaceId } from './workspace';
 export {
   DEFAULT_NAV_GROUPS,

--- a/src/legacy/ui/ui_render/ui_render_mixin.js
+++ b/src/legacy/ui/ui_render/ui_render_mixin.js
@@ -38,7 +38,10 @@ import * as v8dark from '@elastic/eui/dist/eui_theme_next_dark.json';
 import * as v9light from '@elastic/eui/dist/eui_theme_v9_light.json';
 import * as v9dark from '@elastic/eui/dist/eui_theme_v9_dark.json';
 import * as UiSharedDeps from '@osd/ui-shared-deps';
-import { OpenSearchDashboardsRequest } from '../../../core/server';
+import {
+  OpenSearchDashboardsRequest,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
+} from '../../../core/server';
 import { AppBootstrap } from './bootstrap';
 import { getApmConfig } from '../apm';
 
@@ -201,7 +204,10 @@ export function uiRenderMixin(osdServer, server, config) {
     },
     async handler(request, h) {
       const soClient = osdServer.newPlatform.start.core.savedObjects.getScopedClient(
-        OpenSearchDashboardsRequest.from(request)
+        OpenSearchDashboardsRequest.from(request),
+        {
+          excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
+        }
       );
       const uiSettings = osdServer.newPlatform.start.core.uiSettings.asScopedToClient(soClient);
 
@@ -310,7 +316,9 @@ export function uiRenderMixin(osdServer, server, config) {
     const { rendering } = osdServer.newPlatform.__internals;
     const req = OpenSearchDashboardsRequest.from(h.request);
     const uiSettings = osdServer.newPlatform.start.core.uiSettings.asScopedToClient(
-      savedObjects.getScopedClient(req)
+      savedObjects.getScopedClient(req, {
+        excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
+      })
     );
     const vars = {
       apmConfig: getApmConfig(h.request.path),

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -12,7 +12,6 @@ export const WORKSPACE_DETAIL_APP_ID = 'workspace_detail';
 export const WORKSPACE_INITIAL_APP_ID = 'workspace_initial';
 export const WORKSPACE_NAVIGATION_APP_ID = 'workspace_navigation';
 
-export const WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID = 'workspace';
 export const WORKSPACE_CONFLICT_CONTROL_SAVED_OBJECTS_CLIENT_WRAPPER_ID =
   'workspace_conflict_control';
 export const WORKSPACE_UI_SETTINGS_CLIENT_WRAPPER_ID = 'workspace_ui_settings';

--- a/src/plugins/workspace/server/permission_control/client.ts
+++ b/src/plugins/workspace/server/permission_control/client.ts
@@ -14,8 +14,8 @@ import {
   SavedObject,
   WORKSPACE_TYPE,
   HttpAuth,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
 } from '../../../../core/server';
-import { WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID } from '../../common/constants';
 import { getPrincipalsFromRequest } from '../../../../core/server/utils';
 
 export type SavedObjectsPermissionControlContract = Pick<

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -12,9 +12,9 @@ import {
   Logger,
   CoreStart,
   SharedGlobalConfig,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
 } from '../../../core/server';
 import {
-  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
   WORKSPACE_CONFLICT_CONTROL_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
   WORKSPACE_ID_CONSUMER_WRAPPER_ID,
   PRIORITY_FOR_WORKSPACE_CONFLICT_CONTROL_WRAPPER,
@@ -134,7 +134,9 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
           }
           const [coreStart] = await core.getStartServices();
           const uiSettingsClient = coreStart.uiSettings.asScopedToClient(
-            coreStart.savedObjects.getScopedClient(request)
+            coreStart.savedObjects.getScopedClient(request, {
+              excludedWrappers: [WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID],
+            })
           );
           const defaultWorkspaceId = await uiSettingsClient.get(DEFAULT_WORKSPACE);
           const defaultWorkspace = workspaceList.find(

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -27,12 +27,10 @@ import {
   SavedObjectsServiceStart,
   SavedObjectsClientContract,
   SavedObjectsDeleteByWorkspaceOptions,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
 } from '../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
-import {
-  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
-  WorkspacePermissionMode,
-} from '../../common/constants';
+import { WorkspacePermissionMode } from '../../common/constants';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../data_source/common';
 
 // Can't throw unauthorized for now, the page will be refreshed if unauthorized

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -13,6 +13,7 @@ import {
   UiSettingsServiceStart,
   WORKSPACE_TYPE,
   Logger,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
 } from '../../../core/server';
 import { updateWorkspaceState, getWorkspaceState } from '../../../core/server/utils';
 import {
@@ -24,10 +25,7 @@ import {
 } from './types';
 import { workspace } from './saved_objects';
 import { generateRandomId, getDataSourcesList, checkAndSetDefaultDataSource } from './utils';
-import {
-  WORKSPACE_ID_CONSUMER_WRAPPER_ID,
-  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
-} from '../common/constants';
+import { WORKSPACE_ID_CONSUMER_WRAPPER_ID } from '../common/constants';
 import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../data_source/common';
 
 const WORKSPACE_ID_SIZE = 6;


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
In 2.16 we refactored the way how we construct the find query based on workspace and permission control, which makes normal user unable to `find` global objects. And this behavior breaks the upgrade flow of advanced settings as it is using find to list all of the global configs

This PR is to fix this issue by constructing a saved objects client that will bypass workspace permission control wrapper so that the upgrade flow can work as it was.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Turn on workspace permission control by turning on `savedObjects.permission.enabled: true` and config a user as the dashboard admin.
- Login with a non-dashboard-admin user
- Create a config whose doc id is `config:2.9.0` with some customized attributes and delete the existing config whose doc id is `config:3.0.0`
- Refresh the page and you should see a new doc with id `config:3.0.0` should be created, with the customized attributes upgraded from `config:2.9.0`

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: bypass permission control when construct ui settings client

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
