### PR TITLE
Fix row rendering in infinite scroll

### DIFF
--- a/changelogs/fragments/8060.yml
+++ b/changelogs/fragments/8060.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix row rendering in Discover infinite scroll ([#8060](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8060))

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.test.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { act, render, waitFor, screen } from '@testing-library/react';
+import { DefaultDiscoverTable } from './default_discover_table';
+import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
+import { coreMock } from '../../../../../../core/public/mocks';
+import { getStubIndexPattern } from '../../../../../data/public/test_utils';
+
+jest.mock('../../../opensearch_dashboards_services', () => ({
+  getServices: jest.fn().mockReturnValue({
+    uiSettings: {
+      get: jest.fn().mockImplementation((key) => {
+        switch (key) {
+          case 'discover:sampleSize':
+            return 50;
+          case 'shortDots:enable':
+            return true;
+          case 'doc_table:hideTimeColumn':
+            return false;
+          case 'discover:sort:defaultOrder':
+            return 'desc';
+          default:
+            return null;
+        }
+      }),
+    },
+  }),
+}));
+
+describe('DefaultDiscoverTable', () => {
+  const indexPattern = getStubIndexPattern(
+    'test-index-pattern',
+    (cfg) => cfg,
+    '@timestamp',
+    [
+      { name: 'textField', type: 'text' },
+      { name: 'longField', type: 'long' },
+      { name: '@timestamp', type: 'date' },
+    ],
+    coreMock.createSetup()
+  );
+
+  // Generate 50 hits with sample fields
+  const hits = [...Array(50).keys()].map((key) => {
+    return {
+      _id: key.toString(),
+      fields: {
+        textField: `value${key}`,
+        longField: key,
+        '@timestamp': new Date((1720000000 + key) * 1000),
+      },
+    };
+  });
+
+  const getDefaultDiscoverTable = () => (
+    <IntlProvider locale="en">
+      <DefaultDiscoverTable
+        columns={['textField', 'longField', '@timestamp']}
+        rows={hits as OpenSearchSearchHit[]}
+        indexPattern={indexPattern}
+        sort={[]}
+        onSort={jest.fn()}
+        onRemoveColumn={jest.fn()}
+        onMoveColumn={jest.fn()}
+        onAddColumn={jest.fn()}
+        onFilter={jest.fn()}
+      />
+    </IntlProvider>
+  );
+
+  let intersectionObserverCallback: (entries: IntersectionObserverEntry[]) => void = (_) => {};
+  const mockIntersectionObserver = jest.fn();
+
+  beforeEach(() => {
+    mockIntersectionObserver.mockImplementation((...args) => {
+      intersectionObserverCallback = args[0];
+      return {
+        observe: () => null,
+        unobserve: () => null,
+        disconnect: () => null,
+      };
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
+  });
+
+  it('should render the correct number of rows initially', () => {
+    const { container } = render(getDefaultDiscoverTable());
+
+    const tableRows = container.querySelectorAll('tbody tr');
+    expect(tableRows.length).toBe(10);
+  });
+
+  it('should load more rows when scrolling to the bottom', async () => {
+    const { container } = render(getDefaultDiscoverTable());
+
+    const sentinel = container.querySelector('div[data-test-subj="discoverRenderedRowsProgress"]');
+    const mockScrollEntry = { isIntersecting: true, target: sentinel };
+    act(() => {
+      intersectionObserverCallback([mockScrollEntry] as IntersectionObserverEntry[]);
+    });
+
+    await waitFor(() => {
+      const tableRows = container.querySelectorAll('tbody tr');
+      expect(tableRows.length).toBe(20);
+    });
+  });
+
+  it('should not load more rows than the total number of rows', async () => {
+    const { container } = render(getDefaultDiscoverTable());
+
+    const sentinel = container.querySelector('div[data-test-subj="discoverRenderedRowsProgress"]');
+
+    // Simulate scrolling to the bottom multiple times
+    for (let i = 0; i < 3; i++) {
+      const mockScrollEntry = { isIntersecting: true, target: sentinel };
+      act(() => {
+        intersectionObserverCallback([mockScrollEntry] as IntersectionObserverEntry[]);
+      });
+    }
+
+    await waitFor(() => {
+      const tableRows = container.querySelectorAll('tbody tr');
+      expect(tableRows.length).toBe(40);
+    });
+  });
+
+  it('should display the sample size callout when all rows are rendered', async () => {
+    const { container } = render(getDefaultDiscoverTable());
+
+    let sentinel = container.querySelector('div[data-test-subj="discoverRenderedRowsProgress"]');
+
+    // Simulate scrolling to the bottom until all rows are rendered
+    while (sentinel) {
+      const mockScrollEntry = { isIntersecting: true, target: sentinel };
+      act(() => {
+        intersectionObserverCallback([mockScrollEntry] as IntersectionObserverEntry[]);
+      });
+      sentinel = container.querySelector('div[data-test-subj="discoverRenderedRowsProgress"]');
+    }
+
+    await waitFor(() => {
+      const callout = screen.getByTestId('discoverDocTableFooter');
+      expect(callout).toBeInTheDocument();
+    });
+  });
+});

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.test.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.test.tsx
@@ -17,7 +17,7 @@ jest.mock('../../../opensearch_dashboards_services', () => ({
       get: jest.fn().mockImplementation((key) => {
         switch (key) {
           case 'discover:sampleSize':
-            return 50;
+            return 100;
           case 'shortDots:enable':
             return true;
           case 'doc_table:hideTimeColumn':
@@ -46,7 +46,7 @@ describe('DefaultDiscoverTable', () => {
   );
 
   // Generate 50 hits with sample fields
-  const hits = [...Array(50).keys()].map((key) => {
+  const hits = [...Array(100).keys()].map((key) => {
     return {
       _id: key.toString(),
       fields: {

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -264,7 +264,16 @@ const DefaultDiscoverTableUI = ({
         </table>
         {!showPagination && renderedRowCount < rows.length && (
           <div ref={sentinelRef}>
-            <EuiProgress size="xs" color="accent" data-test-subj="discoverRenderedRowsProgress" />
+            <EuiProgress
+              size="xs"
+              color="accent"
+              data-test-subj="discoverRenderedRowsProgress"
+              style={{
+                // Add a little margin if we aren't rendering the truncation callout below, to make
+                // the progress bar render better when it's not present
+                marginBottom: rows.length !== sampleSize ? '5px' : '0',
+              }}
+            />
           </div>
         )}
         {!showPagination && rows.length === sampleSize && (

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -5,7 +5,7 @@
 
 import './_doc_table.scss';
 
-import React, { useEffect, useMemo, useRef, useState, useCallback, SetStateAction } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { EuiSmallButtonEmpty, EuiCallOut, EuiProgress } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { TableHeader } from './table_header';

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -123,7 +123,11 @@ const DefaultDiscoverTableUI = ({
             setDesiredRowCount((prevRowCount) => prevRowCount + DESIRED_ROWS_LOOKAHEAD);
           }
         },
-        { threshold: 1.0 }
+        {
+          // Important that 0 < threshold < 1, since there OSD application div has a transparent
+          // fade at the bottom which causes the sentinel element to sometimes not be 100% visible
+          threshold: 0.5,
+        }
       );
 
       observerRef.current.observe(sentinelElement);
@@ -171,11 +175,6 @@ const DefaultDiscoverTableUI = ({
           }
           lazyLoadLastTimeRef.current = time;
           lazyLoadRequestFrameRef.current = requestAnimationFrame(loadMoreRows);
-        }
-        // Ensure we have more desired rows in the queue to prevent stalling when we render the
-        // current desired row count
-        if (renderedRowCount + DESIRED_ROWS_LOOKAHEAD > desiredRowCount) {
-          setDesiredRowCount(Math.min(renderedRowCount + DESIRED_ROWS_LOOKAHEAD, rows.length));
         }
       };
       lazyLoadRequestFrameRef.current = requestAnimationFrame(loadMoreRows);

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -181,7 +181,7 @@ const DefaultDiscoverTableUI = ({
     }
 
     return () => cancelAnimationFrame(lazyLoadRequestFrameRef.current);
-  }, [showPagination, renderedRowCount, desiredRowCount, rows.length]);
+  }, [showPagination, renderedRowCount, desiredRowCount]);
 
   // Allow auto column-sizing using the initially rendered rows and then convert to fixed
   const tableLayoutRequestFrameRef = useRef<number>(0);

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -126,7 +126,7 @@ const DefaultDiscoverTableUI = ({
         {
           // Important that 0 < threshold < 1, since there OSD application div has a transparent
           // fade at the bottom which causes the sentinel element to sometimes not be 100% visible
-          threshold: 0.5,
+          threshold: 0.1,
         }
       );
 

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -5,7 +5,7 @@
 
 import './_doc_table.scss';
 
-import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback, SetStateAction } from 'react';
 import { EuiSmallButtonEmpty, EuiCallOut, EuiProgress } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { TableHeader } from './table_header';
@@ -155,6 +155,10 @@ const DefaultDiscoverTableUI = ({
   const lazyLoadRequestFrameRef = useRef<number>(0);
   const lazyLoadLastTimeRef = useRef<number>(0);
 
+  // When doing infinite scrolling, the `rows` prop gets regularly updated from the outside: we only
+  // render the additional rows when we know the load isn't too high. To prevent overloading the
+  // renderer, we throttle by current framerate and only render if the frames are fast enough, then
+  // we increase the rendered row count and trigger a re-render.
   React.useEffect(() => {
     if (!showPagination) {
       const loadMoreRows = (time: number) => {

--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -254,7 +254,7 @@ const DefaultDiscoverTableUI = ({
         </table>
         {!showPagination && renderedRowCount < rows.length && (
           <div ref={sentinelRef}>
-            <EuiProgress size="xs" color="accent" />
+            <EuiProgress size="xs" color="accent" data-test-subj="discoverRenderedRowsProgress" />
           </div>
         )}
         {!showPagination && rows.length === sampleSize && (


### PR DESCRIPTION
### Description

When rendering infinite scrolling PPL/SQL in the new Discover UI, the rendering was stalling and entering an infinite loading loop. The root cause turns out to be that there's a small amount of fade-out at the bottom of the OSD application:

![image](https://github.com/user-attachments/assets/7729f617-b60d-4848-8f6d-5081f575919e)

This was causing an issue with the progress bar observer responsible for loading the next batch of rows: it had `threshold: 1.0` set which meant that it would only trigger if the progress bar is 100% visible. This isn't a problem for DQL where large amounts of data records have a limit disclaimer at the bottom:

![image](https://github.com/user-attachments/assets/89688222-8509-416b-963a-7dfd68c4654e)

But when that disclaimer isn't present (for PPL and SQL), this fade effect would cover the progress bar, causing it not to meet the `1.0` threshold:

![image](https://github.com/user-attachments/assets/08d41583-a356-41ec-971d-48846bb7eceb)

In addition to fixing the bug, this PR adds a batch of unit tests for the discover table.

### Issues Resolved

N/A

## Screenshot

After reaching the end of the available records:

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/d5b0d865-7f63-4a2f-9311-9236b18e8cc5">

## Testing the changes

The PR features a new set of unit tests for the involved functionality, but given the nature of the bug it's hard to test the fault directly (we would need to mock the entire OSD application and assert that the intersection threshold is > 0.5 when we scroll to the end). Theoretically possible, but probably too much effort for a one-line fix.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Fix row rendering in Discover infinite scroll 

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
