### PR TITLE
Fix header look and feel changes

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
@@ -7,6 +7,7 @@ import React, { memo, useState, useEffect } from 'react';
 import { IndexPattern } from 'src/plugins/data/public';
 import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
+import { i18n } from '@osd/i18n';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { getTopNavConfig, getTopNavRightConfig, getTopNavLegacyConfig } from './top_nav';
 import { DashboardAppStateContainer, DashboardAppState, DashboardServices } from '../../../types';
@@ -144,7 +145,12 @@ const TopNav = ({
         appName={'dashboard'}
         config={showTopNavMenu ? topNavMenu : undefined}
         className={isFullScreenMode ? 'osdTopNavMenu-isFullScreen' : undefined}
-        screenTitle={currentAppState.title}
+        screenTitle={
+          currentAppState.title ||
+          i18n.translate('discover.savedSearch.newTitle', {
+            defaultMessage: 'New dashboard',
+          })
+        }
         showSearchBar={showSearchBar && TopNavMenuItemRenderType.IN_PORTAL}
         showQueryBar={showQueryBar}
         showQueryInput={showQueryInput}

--- a/src/plugins/dashboard/public/application/embeddable/empty/dashboard_empty_screen.scss
+++ b/src/plugins/dashboard/public/application/embeddable/empty/dashboard_empty_screen.scss
@@ -18,5 +18,6 @@
   padding: $euiSizeXXL * 2;
   max-width: 400px;
   margin-left: $euiSizeS;
+  margin-top: $euiSizeS;
   text-align: center;
 }

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -124,7 +124,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     setScreenTitle(
       savedSearch?.title ||
         i18n.translate('discover.savedSearch.newTitle', {
-          defaultMessage: 'Untitled',
+          defaultMessage: 'New search',
         })
     );
   }, [savedSearch?.title]);

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -542,7 +542,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
           </EuiFlexGroup>
         )}
 
-        <EuiSpacer size="m" />
+        {!this.props.showUpdatedUx && <EuiSpacer size="m" />}
 
         {this.renderListingLimitWarning()}
         {this.renderFetchError()}

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { isEqual } from 'lodash';
 import { useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
+import { i18n } from '@osd/i18n';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { getLegacyTopNavConfig, getNavActions, getTopNavConfig } from '../utils/get_top_nav_config';
 import { VisBuilderServices } from '../../types';
@@ -151,7 +152,10 @@ export const TopNav = () => {
         onSavedQueryIdChange={updateSavedQueryId}
         groupActions={showActionsInGroup}
         screenTitle={
-          savedVisBuilderVis?.title.length ? savedVisBuilderVis?.title : 'New visualization'
+          savedVisBuilderVis?.title ||
+          i18n.translate('discover.savedSearch.newTitle', {
+            defaultMessage: 'New visualization',
+          })
         }
       />
     </div>

--- a/src/plugins/visualize/public/application/components/visualize_listing.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_listing.tsx
@@ -234,6 +234,7 @@ export const VisualizeListing = () => {
         })}
         toastNotifications={toastNotifications}
         showUpdatedUx={showUpdatedUx}
+        paddingSize={showUpdatedUx ? 'm' : 'l'}
       />
     </>
   );

--- a/src/plugins/visualize/public/application/components/visualize_top_nav.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_top_nav.tsx
@@ -259,7 +259,12 @@ const TopNav = ({
       savedQueryId={currentAppState.savedQuery}
       onSavedQueryIdChange={stateContainer.transitions.updateSavedQuery}
       indexPatterns={indexPatterns}
-      screenTitle={vis.title.length ?? '' ? vis.title : 'New visualization'}
+      screenTitle={
+        vis.title ||
+        i18n.translate('discover.savedSearch.newTitle', {
+          defaultMessage: 'New visualization',
+        })
+      }
       showAutoRefreshOnly={!showDatePicker()}
       showDatePicker={showDatePicker()}
       showFilterBar={showFilterBar}


### PR DESCRIPTION
### Description

The changes in the PR aims at improving the look and feel of the Application header.
- Change the titles of new Dashboard - New dashboard, Visualization - New visualization, Discover - New search
- Fix padding & spacing issues in visualization landing page
- Fix margin for the Add an existing object to the dashboard wizard

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/1d52827f-75af-433b-b1af-24664b8b8418)

![image](https://github.com/user-attachments/assets/7f1bcfad-c78f-4f09-b800-636188611f2e)

![image](https://github.com/user-attachments/assets/fca4da3c-d2b0-48a4-95a0-6beacb62153d)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- Fix header look and feel changes for Discover, Dashboards and Visualization Pages 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
