### PR TITLE
[Manual backport 2.17]display direct query connections of local cluster in data sources page (#8059)

### DIFF
--- a/src/plugins/data_source_management/public/components/create_button/create_button.test.tsx
+++ b/src/plugins/data_source_management/public/components/create_button/create_button.test.tsx
@@ -17,7 +17,9 @@ describe('CreateButton', () => {
   let component: ShallowWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
 
   beforeEach(() => {
-    component = shallow(<CreateButton history={history} dataTestSubj={dataTestSubj} />);
+    component = shallow(
+      <CreateButton history={history} dataTestSubj={dataTestSubj} featureFlagStatus={true} />
+    );
   });
 
   it('should render normally', () => {

--- a/src/plugins/data_source_management/public/components/create_button/create_button.tsx
+++ b/src/plugins/data_source_management/public/components/create_button/create_button.tsx
@@ -13,9 +13,10 @@ interface Props {
   history: History;
   isEmptyState?: boolean;
   dataTestSubj: string;
+  featureFlagStatus: boolean;
 }
 
-export const CreateButton = ({ history, isEmptyState, dataTestSubj }: Props) => {
+export const CreateButton = ({ history, isEmptyState, dataTestSubj, featureFlagStatus }: Props) => {
   return (
     <EuiSmallButton
       data-test-subj={dataTestSubj}
@@ -24,7 +25,9 @@ export const CreateButton = ({ history, isEmptyState, dataTestSubj }: Props) => 
     >
       <FormattedMessage
         id="dataSourcesManagement.dataSourceListing.createButton"
-        defaultMessage="Create data source connection"
+        defaultMessage={
+          featureFlagStatus ? 'Create data source connection' : 'Create direct query connection'
+        }
       />
     </EuiSmallButton>
   );

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_home_panel.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_home_panel.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`DataSourceHomePanel renders correctly 1`] = `
             grow={false}
           >
             <DataSourceHeader
+              featureFlagStatus={true}
               history={
                 Object {
                   "push": [MockFunction],
@@ -27,6 +28,7 @@ exports[`DataSourceHomePanel renders correctly 1`] = `
           >
             <CreateButton
               dataTestSubj="createDataSourceButton"
+              featureFlagStatus={true}
               history={
                 Object {
                   "push": [MockFunction],

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_page_header.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_page_header.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`DataSourceHeader renders correctly 1`] = `
       <p>
         <FormattedMessage
           defaultMessage="Create and manage data source connections."
-          id="dataSourcesManagement.dataSourcesTable.description"
+          id="dataSourcesManagement.dataSourcesTable.mdsEnabled.description"
           values={Object {}}
         />
       </p>

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.test.tsx
@@ -100,9 +100,9 @@ describe('DataSourceHomePanel', () => {
     expect(wrapper.find(ManageDirectQueryDataConnectionsTableWithRouter)).toHaveLength(1);
   });
 
-  test('does not render OpenSearch connections tab when featureFlagStatus is false', () => {
+  test('does not render any tab when featureFlagStatus is false', () => {
     const wrapper = shallowComponent({ ...defaultProps, featureFlagStatus: false });
-    expect(wrapper.find(EuiTab)).toHaveLength(1);
+    expect(wrapper.find(EuiTab)).toHaveLength(0);
   });
 
   test('calls history.push when CreateButton is clicked', () => {

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
@@ -38,17 +38,9 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
   useNewUX,
   ...props
 }) => {
-  const {
-    setBreadcrumbs,
-    notifications,
-    http,
-    savedObjects,
-    uiSettings,
-    application,
-    workspaces,
-    docLinks,
-    navigation,
-  } = useOpenSearchDashboards<DataSourceManagementContext>().services;
+  const { setBreadcrumbs, application, workspaces, docLinks, navigation } = useOpenSearchDashboards<
+    DataSourceManagementContext
+  >().services;
 
   const defaultTabId = featureFlagStatus
     ? 'manageOpensearchDataSources'
@@ -69,7 +61,7 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
   const createDataSourceButton = [
     {
       id: 'Create data source',
-      label: 'Create data source connection',
+      label: featureFlagStatus ? 'Create data source connection' : 'Create direct query connection',
       testId: 'createDataSourceButton',
       run: () => props.history.push('/create'),
       fill: true,
@@ -110,6 +102,25 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
     },
   ];
 
+  const description = {
+    description: i18n.translate('dataSourcesManagement.dataSourcesTable.description', {
+      defaultMessage: featureFlagStatus
+        ? 'Create and manage data source connections.'
+        : 'Manage direct query data source connections.',
+    }),
+    links: [
+      {
+        href: docLinks.links.opensearchDashboards.dataSource.guide,
+        controlType: 'link',
+        target: '_blank',
+        className: 'external-link-inline-block',
+        label: i18n.translate('dataSourcesManagement.dataSourcesTable.documentation', {
+          defaultMessage: 'Learn more',
+        }),
+      },
+    ],
+  } as TopNavControlDescriptionData;
+
   const renderTabs = () => {
     return tabs.map((tab) => (
       <EuiTab
@@ -126,10 +137,12 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
     <EuiPanel>
       {useNewUX && (
         <>
-          <HeaderControl
-            setMountPoint={application.setAppCenterControls}
-            controls={connectionTypeButton}
-          />
+          {featureFlagStatus && (
+            <HeaderControl
+              setMountPoint={application.setAppCenterControls}
+              controls={connectionTypeButton}
+            />
+          )}
           {canManageDataSource && (
             <HeaderControl
               setMountPoint={application.setAppRightControls}
@@ -151,28 +164,7 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
                       }
                     ),
                   }
-                : ({
-                    description: i18n.translate(
-                      'dataSourcesManagement.dataSourcesTable.description',
-                      {
-                        defaultMessage: 'Create and manage data source connections.',
-                      }
-                    ),
-                    links: [
-                      {
-                        href: docLinks.links.opensearchDashboards.dataSource.guide,
-                        controlType: 'link',
-                        target: '_blank',
-                        className: 'external-link-inline-block',
-                        label: i18n.translate(
-                          'dataSourcesManagement.dataSourcesTable.documentation',
-                          {
-                            defaultMessage: 'Learn more',
-                          }
-                        ),
-                      },
-                    ],
-                  } as TopNavControlDescriptionData),
+                : description,
             ]}
           />
         </>
@@ -184,28 +176,40 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
               <EuiPageHeader>
                 <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <DataSourceHeader history={props.history} />
+                    <DataSourceHeader
+                      history={props.history}
+                      featureFlagStatus={featureFlagStatus}
+                    />
                   </EuiFlexItem>
                   {canManageDataSource ? (
                     <EuiFlexItem grow={false}>
-                      <CreateButton history={props.history} dataTestSubj="createDataSourceButton" />
+                      <CreateButton
+                        history={props.history}
+                        featureFlagStatus={featureFlagStatus}
+                        dataTestSubj="createDataSourceButton"
+                      />
                     </EuiFlexItem>
                   ) : null}
                 </EuiFlexGroup>
               </EuiPageHeader>
             </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiSpacer size="s" />
-              <EuiTabs size="s">{renderTabs()}</EuiTabs>
-            </EuiFlexItem>
+            {featureFlagStatus && (
+              <EuiFlexItem>
+                <EuiSpacer size="s" />
+                <EuiTabs size="s">{renderTabs()}</EuiTabs>
+              </EuiFlexItem>
+            )}
           </>
         )}
         <EuiFlexItem>
           {selectedTabId === 'manageOpensearchDataSources' && featureFlagStatus && (
             <DataSourceTableWithRouter {...props} />
           )}
-          {selectedTabId === 'manageDirectQueryDataSources' && featureFlagStatus && (
-            <ManageDirectQueryDataConnectionsTableWithRouter {...props} />
+          {(!featureFlagStatus || selectedTabId === 'manageDirectQueryDataSources') && (
+            <ManageDirectQueryDataConnectionsTableWithRouter
+              featureFlagStatus={featureFlagStatus}
+              {...props}
+            />
           )}
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.test.tsx
@@ -16,7 +16,8 @@ describe('DataSourceHeader', () => {
     match: {} as any,
   };
 
-  const shallowComponent = (props = defaultProps) => shallow(<DataSourceHeader {...props} />);
+  const shallowComponent = (props = defaultProps) =>
+    shallow(<DataSourceHeader {...props} featureFlagStatus={true} />);
 
   test('renders correctly', () => {
     const wrapper = shallowComponent();
@@ -31,7 +32,7 @@ describe('DataSourceHeader', () => {
 
     const descriptionMessage = wrapper.find(EuiText).at(1).find(FormattedMessage);
     expect(descriptionMessage.prop('id')).toEqual(
-      'dataSourcesManagement.dataSourcesTable.description'
+      'dataSourcesManagement.dataSourcesTable.mdsEnabled.description'
     );
     expect(descriptionMessage.prop('defaultMessage')).toEqual(
       'Create and manage data source connections.'

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_page_header.tsx
@@ -8,9 +8,11 @@ import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 import { RouteComponentProps } from 'react-router-dom';
 
-type DataSourceHeaderProps = RouteComponentProps;
+interface DataSourceHeaderProps extends RouteComponentProps {
+  featureFlagStatus: boolean;
+}
 
-export const DataSourceHeader: React.FC<DataSourceHeaderProps> = () => {
+export const DataSourceHeader: React.FC<DataSourceHeaderProps> = ({ featureFlagStatus }) => {
   return (
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem grow={false}>
@@ -25,10 +27,17 @@ export const DataSourceHeader: React.FC<DataSourceHeaderProps> = () => {
         <EuiSpacer size="s" />
         <EuiText size="s">
           <p>
-            <FormattedMessage
-              id="dataSourcesManagement.dataSourcesTable.description"
-              defaultMessage="Create and manage data source connections."
-            />
+            {featureFlagStatus ? (
+              <FormattedMessage
+                id="dataSourcesManagement.dataSourcesTable.mdsEnabled.description"
+                defaultMessage="Create and manage data source connections."
+              />
+            ) : (
+              <FormattedMessage
+                id="dataSourcesManagement.dataSourcesTable.mdsDisabled.description"
+                defaultMessage="Manage direct query data source connections."
+              />
+            )}
           </p>
         </EuiText>
       </EuiFlexItem>

--- a/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
@@ -155,12 +155,12 @@ exports[`DataSourceTable should get datasources failed should render empty table
                         className="euiButton__text"
                       >
                         <FormattedMessage
-                          defaultMessage="Create data source connection"
+                          defaultMessage="Create direct query connection"
                           id="dataSourcesManagement.dataSourceListing.createButton"
                           values={Object {}}
                         >
                           <span>
-                            Create data source connection
+                            Create direct query connection
                           </span>
                         </FormattedMessage>
                       </span>
@@ -1452,11 +1452,12 @@ exports[`DataSourceTable should get datasources successful should render normall
                                 className="euiTableCellContent euiTableCellContent--overflowingContent"
                               >
                                 <EuiButtonEmpty
+                                  flush="left"
                                   onClick={[Function]}
                                   size="xs"
                                 >
                                   <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                     disabled={false}
                                     onClick={[Function]}
                                     type="button"
@@ -1676,11 +1677,12 @@ exports[`DataSourceTable should get datasources successful should render normall
                                 className="euiTableCellContent euiTableCellContent--overflowingContent"
                               >
                                 <EuiButtonEmpty
+                                  flush="left"
                                   onClick={[Function]}
                                   size="xs"
                                 >
                                   <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                     disabled={false}
                                     onClick={[Function]}
                                     type="button"
@@ -1900,11 +1902,12 @@ exports[`DataSourceTable should get datasources successful should render normall
                                 className="euiTableCellContent euiTableCellContent--overflowingContent"
                               >
                                 <EuiButtonEmpty
+                                  flush="left"
                                   onClick={[Function]}
                                   size="xs"
                                 >
                                   <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                     disabled={false}
                                     onClick={[Function]}
                                     type="button"
@@ -2124,11 +2127,12 @@ exports[`DataSourceTable should get datasources successful should render normall
                                 className="euiTableCellContent euiTableCellContent--overflowingContent"
                               >
                                 <EuiButtonEmpty
+                                  flush="left"
                                   onClick={[Function]}
                                   size="xs"
                                 >
                                   <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                     disabled={false}
                                     onClick={[Function]}
                                     type="button"

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
@@ -82,7 +82,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
     setIsLoading(true);
     getDataSources(savedObjects.client)
       .then((response: DataSourceTableItem[]) => {
-        return fetchDataSourceConnections(response, http, notifications);
+        return fetchDataSourceConnections(response, http, notifications, false);
       })
       .then((finalData) => {
         setDataSources(finalData);
@@ -166,7 +166,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
         }
       ) => (
         <>
-          <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `${index.id}`)}>
+          <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `${index.id}`)} flush="left">
             {name}
           </EuiButtonEmpty>
           {index.id === getDefaultDataSourceId(uiSettings) ? (

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/__snapshots__/manage_direct_query_data_connections_table.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/__snapshots__/manage_direct_query_data_connections_table.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
   locale="en"
 >
   <ManageDirectQueryDataConnectionsTable
+    featureFlagStatus={true}
     history={
       Object {
         "action": "PUSH",
@@ -75,13 +76,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                         "render": [Function],
                         "sortable": true,
                         "truncateText": true,
-                        "width": "25%",
+                        "width": "32%",
                       },
                       Object {
                         "field": "type",
                         "name": "Type",
                         "truncateText": true,
-                        "width": "15%",
+                        "width": "22%",
                       },
                       Object {
                         "field": "description",
@@ -90,7 +91,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                         },
                         "name": "Description",
                         "truncateText": true,
-                        "width": "35%",
+                        "width": "45%",
                       },
                       Object {
                         "align": "right",
@@ -138,6 +139,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                   selection={
                     Object {
                       "onSelectionChange": [Function],
+                      "selectable": [Function],
                     }
                   }
                   sorting={
@@ -486,13 +488,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                             "render": [Function],
                             "sortable": true,
                             "truncateText": true,
-                            "width": "25%",
+                            "width": "32%",
                           },
                           Object {
                             "field": "type",
                             "name": "Type",
                             "truncateText": true,
-                            "width": "15%",
+                            "width": "22%",
                           },
                           Object {
                             "field": "description",
@@ -501,7 +503,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                             },
                             "name": "Description",
                             "truncateText": true,
-                            "width": "35%",
+                            "width": "45%",
                           },
                           Object {
                             "align": "right",
@@ -536,6 +538,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                       selection={
                         Object {
                           "onSelectionChange": [Function],
+                          "selectable": [Function],
                         }
                       }
                       sorting={
@@ -854,7 +857,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                       isSorted={true}
                                       key="_data_h_title_1"
                                       onSort={[Function]}
-                                      width="25%"
+                                      width="32%"
                                     >
                                       <th
                                         aria-live="polite"
@@ -865,7 +868,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         scope="col"
                                         style={
                                           Object {
-                                            "width": "25%",
+                                            "width": "32%",
                                           }
                                         }
                                       >
@@ -923,7 +926,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                       align="left"
                                       data-test-subj="tableHeaderCell_type_2"
                                       key="_data_h_type_2"
-                                      width="15%"
+                                      width="22%"
                                     >
                                       <th
                                         className="euiTableHeaderCell"
@@ -932,7 +935,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         scope="col"
                                         style={
                                           Object {
-                                            "width": "15%",
+                                            "width": "22%",
                                           }
                                         }
                                       >
@@ -975,7 +978,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                           "show": false,
                                         }
                                       }
-                                      width="35%"
+                                      width="45%"
                                     >
                                       <th
                                         className="euiTableHeaderCell euiTableHeaderCell--hideForMobile"
@@ -984,7 +987,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         scope="col"
                                         style={
                                           Object {
-                                            "width": "35%",
+                                            "width": "45%",
                                           }
                                         }
                                       >
@@ -1124,6 +1127,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
   locale="en"
 >
   <ManageDirectQueryDataConnectionsTable
+    featureFlagStatus={true}
     history={
       Object {
         "action": "PUSH",
@@ -1194,13 +1198,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                         "render": [Function],
                         "sortable": true,
                         "truncateText": true,
-                        "width": "25%",
+                        "width": "32%",
                       },
                       Object {
                         "field": "type",
                         "name": "Type",
                         "truncateText": true,
-                        "width": "15%",
+                        "width": "22%",
                       },
                       Object {
                         "field": "description",
@@ -1209,7 +1213,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                         },
                         "name": "Description",
                         "truncateText": true,
-                        "width": "35%",
+                        "width": "45%",
                       },
                       Object {
                         "align": "right",
@@ -1291,6 +1295,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                   selection={
                     Object {
                       "onSelectionChange": [Function],
+                      "selectable": [Function],
                     }
                   }
                   sorting={
@@ -1663,13 +1668,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                             "render": [Function],
                             "sortable": true,
                             "truncateText": true,
-                            "width": "25%",
+                            "width": "32%",
                           },
                           Object {
                             "field": "type",
                             "name": "Type",
                             "truncateText": true,
-                            "width": "15%",
+                            "width": "22%",
                           },
                           Object {
                             "field": "description",
@@ -1678,7 +1683,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                             },
                             "name": "Description",
                             "truncateText": true,
-                            "width": "35%",
+                            "width": "45%",
                           },
                           Object {
                             "align": "right",
@@ -1739,6 +1744,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                       selection={
                         Object {
                           "onSelectionChange": [Function],
+                          "selectable": [Function],
                         }
                       }
                       sorting={
@@ -2057,7 +2063,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                       isSorted={true}
                                       key="_data_h_title_1"
                                       onSort={[Function]}
-                                      width="25%"
+                                      width="32%"
                                     >
                                       <th
                                         aria-live="polite"
@@ -2068,7 +2074,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         scope="col"
                                         style={
                                           Object {
-                                            "width": "25%",
+                                            "width": "32%",
                                           }
                                         }
                                       >
@@ -2126,7 +2132,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                       align="left"
                                       data-test-subj="tableHeaderCell_type_2"
                                       key="_data_h_type_2"
-                                      width="15%"
+                                      width="22%"
                                     >
                                       <th
                                         className="euiTableHeaderCell"
@@ -2135,7 +2141,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         scope="col"
                                         style={
                                           Object {
-                                            "width": "15%",
+                                            "width": "22%",
                                           }
                                         }
                                       >
@@ -2178,7 +2184,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                           "show": false,
                                         }
                                       }
-                                      width="35%"
+                                      width="45%"
                                     >
                                       <th
                                         className="euiTableHeaderCell euiTableHeaderCell--hideForMobile"
@@ -2187,7 +2193,7 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         scope="col"
                                         style={
                                           Object {
-                                            "width": "35%",
+                                            "width": "45%",
                                           }
                                         }
                                       >
@@ -2401,13 +2407,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         setScopeRow={false}
                                         textOnly={false}
                                         truncateText={true}
-                                        width="25%"
+                                        width="32%"
                                       >
                                         <td
                                           className="euiTableRowCell"
                                           style={
                                             Object {
-                                              "width": "25%",
+                                              "width": "32%",
                                             }
                                           }
                                         >
@@ -2421,7 +2427,9 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                           >
                                             <EuiButtonEmpty
                                               className=""
-                                              href="http://localhost//manage/test1?dataSourceMDSId=undefined"
+                                              disabled={false}
+                                              flush="left"
+                                              href="http://localhost/manage/test1"
                                               key=".0"
                                               size="xs"
                                               style={
@@ -2431,8 +2439,8 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                               }
                                             >
                                               <a
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                                                href="http://localhost//manage/test1?dataSourceMDSId=undefined"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                                href="http://localhost/manage/test1"
                                                 rel="noreferrer"
                                                 style={
                                                   Object {
@@ -2478,13 +2486,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         setScopeRow={false}
                                         textOnly={true}
                                         truncateText={true}
-                                        width="15%"
+                                        width="22%"
                                       >
                                         <td
                                           className="euiTableRowCell"
                                           style={
                                             Object {
-                                              "width": "15%",
+                                              "width": "22%",
                                             }
                                           }
                                         >
@@ -2517,13 +2525,13 @@ exports[`ManageDirectQueryDataConnectionsTable should get direct query connectio
                                         setScopeRow={false}
                                         textOnly={true}
                                         truncateText={true}
-                                        width="35%"
+                                        width="45%"
                                       >
                                         <td
                                           className="euiTableRowCell euiTableRowCell--hideForMobile"
                                           style={
                                             Object {
-                                              "width": "35%",
+                                              "width": "45%",
                                             }
                                           }
                                         >

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.test.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.test.tsx
@@ -34,6 +34,7 @@ describe('ManageDirectQueryDataConnectionsTable', () => {
         component = await mount(
           wrapWithIntl(
             <ManageDirectQueryDataConnectionsTable
+              featureFlagStatus={true}
               history={history}
               location={({} as unknown) as RouteComponentProps['location']}
               match={({} as unknown) as RouteComponentProps['match']}
@@ -60,11 +61,13 @@ describe('ManageDirectQueryDataConnectionsTable', () => {
       spyOn(utils, 'fetchDataSourceConnections').and.returnValue(
         Promise.resolve(getMappedDataSources)
       );
+      spyOn(utils, 'getHideLocalCluster').and.returnValue(false);
       spyOn(uiSettings, 'get').and.returnValue('test1');
       await act(async () => {
         component = await mount(
           wrapWithIntl(
             <ManageDirectQueryDataConnectionsTable
+              featureFlagStatus={true}
               history={history}
               location={({} as unknown) as RouteComponentProps['location']}
               match={({} as unknown) as RouteComponentProps['match']}

--- a/src/plugins/data_source_management/public/constants.ts
+++ b/src/plugins/data_source_management/public/constants.ts
@@ -7,6 +7,7 @@ import { DirectQueryDatasourceType } from './types';
 
 export const QUERY_RESTRICTED = 'query-restricted';
 export const QUERY_ALL = 'query-all';
+export const LOCAL_CLUSTER = 'local_cluster';
 
 export const DatasourceTypeToDisplayName: { [key in DirectQueryDatasourceType]: string } = {
   PROMETHEUS: 'Prometheus',


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Backport https://github.com/opensearch-project/OpenSearch-Dashboards/commit/e62142256484ca56382ca46b6394ed874b5a10e9 from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8059.
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
