### PR TITLE
[Workspace]Fix workspace description error when name invalid

### DIFF
--- a/changelogs/fragments/8079.yml
+++ b/changelogs/fragments/8079.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace]Fix workspace description error when name invalid ([#8079](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8079))

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
@@ -123,11 +123,7 @@ export const WorkspaceCreatorForm = (props: WorkspaceCreatorFormProps) => {
           />
           <EuiSpacer size="m" />
           <div {...generateRightSidebarScrollProps(RightSidebarScrollField.Description)} />
-          <WorkspaceDescriptionField
-            value={formData.description}
-            onChange={setDescription}
-            error={formErrors.name?.message}
-          />
+          <WorkspaceDescriptionField value={formData.description} onChange={setDescription} />
           <EuiSpacer size="m" />
           <EuiCompressedFormRow
             label={i18n.translate('workspace.form.workspaceDetails.color.label', {

--- a/src/plugins/workspace/public/components/workspace_form/workspace_detail_form_details.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_detail_form_details.tsx
@@ -98,7 +98,6 @@ export const WorkspaceDetailFormDetails = ({
           value={formData.description}
           onChange={setDescription}
           readOnly={!isEditing}
-          error={formErrors.name?.message}
         />
       </EuiDescribedFormGroup>
       <EuiDescribedFormGroup title={<h3>{detailsUseCaseLabel}</h3>}>


### PR DESCRIPTION
### Description

This PR is for fixing workspace description field error when name invalid in the workspace create and detail page. 


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#8081 
## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/100749ee-db51-450a-950a-41ea7eb61978)
![image](https://github.com/user-attachments/assets/20512f9c-45cc-4ea7-8617-186da120a2fc)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version ignore`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
```
- Run `yarn start --no-base-path`
- Login and visit workspace create page
- Input a invalid workspace name, such as "Observability~!@"
- Click "Create workspace" button
- Workspace name should show error and workspace description should not show error
- Input a valid workspace name, and click "Create workspace" button
- Go to the created workspace page and click "Edit" button
- Input a in valid workspace name and click "Save changes" button
- Workspace name should show error and workspace description should not show error

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Workspace]Fix workspace description error when name invalid

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
