### PR TITLE
fix: it should not create multiple query editor extension container

### DIFF
--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -153,10 +153,7 @@
 .osdQueryEditor__header {
   display: flex;
   align-items: center;
-
-  .osdQueryEditorExtensionComponent {
-    padding: 0 $euiSizeXS $euiSizeXS;
-  }
+  padding: 0 $euiSizeXS $euiSizeXS;
 }
 
 .osdQueryEditor__topBar {

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
@@ -27,16 +27,22 @@ const QueryEditorExtensions: React.FC<QueryEditorExtensionsProps> = React.memo((
   return (
     <>
       {sortedConfigs.map((config) => {
-        const extensionComponentContainer = document.createElement('div');
-        extensionComponentContainer.className = `osdQueryEditorExtensionComponent osdQueryEditorExtensionComponent__${config.id}`;
-        componentContainer.appendChild(extensionComponentContainer);
+        const id = `osdQueryEditorExtensionComponent-${config.id}`;
+
+        let container = document.getElementById(id);
+        if (!container) {
+          container = document.createElement('div');
+          container.className = `osdQueryEditorExtensionComponent osdQueryEditorExtensionComponent__${config.id}`;
+          container.id = id;
+          componentContainer.appendChild(container);
+        }
 
         return (
           <QueryEditorExtension
             key={config.id}
             config={config}
             dependencies={dependencies}
-            componentContainer={extensionComponentContainer}
+            componentContainer={container}
             bannerContainer={bannerContainer}
           />
         );


### PR DESCRIPTION
### Description
This is a follow up of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045. With this PR, it only creates the query extension container when the container not exists, this will avoid creating duplicate containers.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
