### PR TITLE
[Workspace] fix:Prevent user from visiting dashboards / visualizations when out of a workspace

### DIFF
--- a/changelogs/fragments/8107.yml
+++ b/changelogs/fragments/8107.yml
@@ -1,0 +1,2 @@
+fix:
+- Prevent user from visiting dashboards / visualizations when out of a workspace ([#8107](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8107))

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -122,7 +122,7 @@ export class WorkspacePlugin
    */
   private filterNavLinks = (core: CoreStart) => {
     const currentWorkspace$ = core.workspaces.currentWorkspace$;
-
+    const isDashboardAdmin = core.application.capabilities.dashboards?.isDashboardAdmin;
     this.workspaceAndUseCasesCombineSubscription?.unsubscribe();
     this.workspaceAndUseCasesCombineSubscription = combineLatest([
       currentWorkspace$,
@@ -145,6 +145,7 @@ export class WorkspacePlugin
           if (app.status === AppStatus.inaccessible) {
             return;
           }
+
           if (
             registeredUseCases.some(
               (useCase) =>
@@ -159,6 +160,19 @@ export class WorkspacePlugin
            */
           return { status: AppStatus.inaccessible };
         });
+      } else {
+        /**
+         * If out of the workspace, dashboards and visualize are not accessible
+         * If trying to access such app, an "Application Not Found" page will be displayed
+         * However, the admin could be able to access dashboards and visualize
+         */
+        if (!isDashboardAdmin) {
+          this.appUpdater$.next((app) => {
+            if (app.id === 'dashboards' || app.id === 'visualize') {
+              return { status: AppStatus.inaccessible };
+            }
+          });
+        }
       }
     });
 


### PR DESCRIPTION
### Description
This pr adresses:
1. Prevent user from visiting dashboards / visualizations when out of a workspace
2. However, the admin could be able to access dashboards and visualize

## Screenshot
If the user is not an admin and tries to access dashboards or visualizations, a message saying "Application not found" will be shown.
<img width="1070" alt="截屏2024-09-10 17 50 51" src="https://github.com/user-attachments/assets/02b86179-4a76-4824-9ce2-b2bf8f86d717">

## Changelog
- fix:  Prevent user from visiting dashboards / visualizations when out of a workspace


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
