### PR TITLE
Correct the size of disabled ValidatedDualRange components in InputControl visualizations

### DIFF
--- a/changelogs/fragments/8108.yml
+++ b/changelogs/fragments/8108.yml
@@ -1,0 +1,2 @@
+fix:
+- Correct the size of disabled ValidatedDualRange components in InputControl visualizations ([#8108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8108))

--- a/src/plugins/input_control_vis/public/components/vis/__snapshots__/range_control.test.tsx.snap
+++ b/src/plugins/input_control_vis/public/components/vis/__snapshots__/range_control.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`disabled 1`] = `
   <ValidatedDualRange
     allowEmptyRange={true}
     disabled={true}
+    formRowDisplay="rowCompressed"
     fullWidth={false}
     showInput={true}
   />

--- a/src/plugins/input_control_vis/public/components/vis/range_control.tsx
+++ b/src/plugins/input_control_vis/public/components/vis/range_control.tsx
@@ -104,7 +104,7 @@ export class RangeControl extends PureComponent<RangeControlProps, RangeControlS
 
   renderControl() {
     if (!this.props.control.isEnabled()) {
-      return <ValidatedDualRange disabled showInput />;
+      return <ValidatedDualRange disabled showInput formRowDisplay="rowCompressed" />;
     }
 
     const decimalPlaces = _.get(this.props, 'control.options.decimalPlaces', 0);
@@ -121,7 +121,7 @@ export class RangeControl extends PureComponent<RangeControlProps, RangeControlS
         id={this.props.control.id}
         min={min}
         max={max}
-        formRowDisplay={'rowCompressed'}
+        formRowDisplay="rowCompressed"
         value={this.state.value}
         onChange={this.onChangeComplete}
         showInput


### PR DESCRIPTION
### Description

Correctly size of disabled ValidatedDualRange components in InputControl visualizations


## Screenshot
Before:
<img src="https://github.com/user-attachments/assets/46e4408e-90b2-4fa6-a672-0541d4b75842" height="62" />

After:
<img src="https://github.com/user-attachments/assets/6a60b98f-e20f-48e4-aad4-745e369bd4f5" height="54" />



## Changelog
- fix: Correct the size of disabled ValidatedDualRange components in InputControl visualizations

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
