### PR TITLE
[Manual backport 1.3][CVE-2017-16100] Use a patched version of `dns-sync` (#7811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased](https://github.com/opensearch-project/OpenSearch-Dashboards/compare/1.3.18...1.3)
+
+### 💥 Breaking Changes
+
+### Deprecations
+
+### 🛡 Security
+
+- [CVE-2017-16100] Use a patched version for the `dns-sync` dependency ([#7811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7811))
+
+### 📈 Features/Enhancements
+
+### 🐛 Bug Fixes
+
+### 🚞 Infrastructure
+
+### 📝 Documentation
+
+### 🛠 Maintenance
+
+### 🪛 Refactoring
+
+### 🔩 Tests
+
 ## [1.3.19 - 2024-08-26](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/1.3.19)
 
 ### 💥 Breaking Changes

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "core-js": "^3.6.5",
     "deep-freeze-strict": "^1.1.1",
     "del": "^6.1.1",
-    "dns-sync": "^0.2.1",
+    "dns-sync": "npm:@amoo-miki/dns-sync@^0.2.1",
     "elastic-apm-node": "^3.7.0",
     "elasticsearch": "^16.7.0",
     "execa": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7979,10 +7979,10 @@ dns-packet@^1.3.1:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
 
-dns-sync@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/dns-sync/-/dns-sync-0.2.1.tgz#c519da400b90fa2e4a30a70030a1573330c72fa9"
-  integrity sha512-VB1pDSVs82kFsZuoHQ5/Ysx62WiIfDGn9sx/x55EoVyk8pLwdqWGB2XCaDDOusBllb+1y3XRijscFPJJfpbFiw==
+"dns-sync@npm:@amoo-miki/dns-sync@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@amoo-miki/dns-sync/-/dns-sync-0.2.2.tgz#e713eb46c3ddf6fde37e9453a31a4440ca45a8e7"
+  integrity sha512-GoWRmng1RpnFXrfITbAgfndTjvBgf438jRq1Q5m1Db9HfN9qR/TlRRcl7LXsvq+oS3iUzXyNECzoU62jHPilKw==
   dependencies:
     debug "^4"
     shelljs "~0.8"


### PR DESCRIPTION
Cherry-picked dcd170aa7d6ee0d09bbd0f8d397a93e5a73d8f67 from #7811