### PR TITLE
Extended Dataset type config to provide search options like strategy

### DIFF
--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -251,3 +251,7 @@ export interface DatasetField {
   displayName?: string;
   // TODO:  osdFieldType?
 }
+
+export interface DatasetSearchOptions {
+  strategy?: string;
+}

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { EuiIconProps } from '@elastic/eui';
-import { Dataset, DatasetField, DataStructure } from '../../../../common';
+import { Dataset, DatasetField, DatasetSearchOptions, DataStructure } from '../../../../common';
 import { IDataPluginServices } from '../../../types';
 
 /**
@@ -44,4 +44,9 @@ export interface DatasetTypeConfig {
    * @returns {Promise<string[]>} A promise that resolves to an array of supported language ids.
    */
   supportedLanguages: (dataset: Dataset) => string[];
+  /**
+   * Retrieves the search options to be used for running the query on the data connection associated
+   * with this Dataset
+   */
+  getSearchOptions?: () => DatasetSearchOptions;
 }

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -57,13 +57,15 @@ export class PPLSearchInterceptor extends SearchInterceptor {
   public search(request: IOpenSearchDashboardsSearchRequest, options: ISearchOptions) {
     const dataset = this.queryService.queryString.getQuery().dataset;
     const datasetType = dataset?.type;
-    let datasetTypeConfig;
+    let strategy = SEARCH_STRATEGY.PPL;
 
     if (datasetType) {
-      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(datasetType);
+      const datasetTypeConfig = this.queryService.queryString
+        .getDatasetService()
+        .getType(datasetType);
+      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
     }
 
-    const strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? SEARCH_STRATEGY.PPL;
     return this.runSearch(request, options.abortSignal, strategy);
   }
 

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -45,7 +45,7 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     const { id, ...searchRequest } = request;
     const context: EnhancedFetchContext = {
       http: this.deps.http,
-      path: trimEnd(API.PPL_SEARCH),
+      path: trimEnd(`${API.SEARCH}/${strategy}`),
       signal,
     };
 
@@ -55,7 +55,16 @@ export class PPLSearchInterceptor extends SearchInterceptor {
   }
 
   public search(request: IOpenSearchDashboardsSearchRequest, options: ISearchOptions) {
-    return this.runSearch(request, options.abortSignal, SEARCH_STRATEGY.PPL);
+    const dataset = this.queryService.queryString.getQuery().dataset;
+    const datasetType = dataset?.type;
+    let datasetTypeConfig;
+
+    if (datasetType) {
+      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(dataset?.type);
+    }
+
+    const strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? SEARCH_STRATEGY.PPL;
+    return this.runSearch(request, options.abortSignal, strategy);
   }
 
   private buildQuery() {

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -60,7 +60,7 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     let datasetTypeConfig;
 
     if (datasetType) {
-      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(dataset?.type);
+      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(datasetType);
     }
 
     const strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? SEARCH_STRATEGY.PPL;

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -58,7 +58,7 @@ export class SQLSearchInterceptor extends SearchInterceptor {
     let datasetTypeConfig;
 
     if (datasetType) {
-      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(dataset?.type);
+      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(datasetType);
     }
 
     const strategy =

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -55,16 +55,14 @@ export class SQLSearchInterceptor extends SearchInterceptor {
   public search(request: IOpenSearchDashboardsSearchRequest, options: ISearchOptions) {
     const dataset = this.queryService.queryString.getQuery().dataset;
     const datasetType = dataset?.type;
-    let datasetTypeConfig;
+    let strategy = datasetType === DATASET.S3 ? SEARCH_STRATEGY.SQL_ASYNC : SEARCH_STRATEGY.SQL;
 
     if (datasetType) {
-      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(datasetType);
+      const datasetTypeConfig = this.queryService.queryString
+        .getDatasetService()
+        .getType(datasetType);
+      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
     }
-
-    const strategy =
-      datasetTypeConfig?.getSearchOptions?.().strategy ?? datasetType === DATASET.S3
-        ? SEARCH_STRATEGY.SQL_ASYNC
-        : SEARCH_STRATEGY.SQL;
 
     return this.runSearch(request, options.abortSignal, strategy);
   }

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -39,7 +39,7 @@ export class SQLSearchInterceptor extends SearchInterceptor {
     const isAsync = strategy === SEARCH_STRATEGY.SQL_ASYNC;
     const context: EnhancedFetchContext = {
       http: this.deps.http,
-      path: trimEnd(isAsync ? API.SQL_ASYNC_SEARCH : API.SQL_SEARCH),
+      path: trimEnd(`${API.SEARCH}/${strategy}`),
       signal,
     };
 
@@ -54,7 +54,18 @@ export class SQLSearchInterceptor extends SearchInterceptor {
 
   public search(request: IOpenSearchDashboardsSearchRequest, options: ISearchOptions) {
     const dataset = this.queryService.queryString.getQuery().dataset;
-    const strategy = dataset?.type === DATASET.S3 ? SEARCH_STRATEGY.SQL_ASYNC : SEARCH_STRATEGY.SQL;
+    const datasetType = dataset?.type;
+    let datasetTypeConfig;
+
+    if (datasetType) {
+      datasetTypeConfig = this.queryService.queryString.getDatasetService().getType(dataset?.type);
+    }
+
+    const strategy =
+      datasetTypeConfig?.getSearchOptions?.().strategy ?? datasetType === DATASET.S3
+        ? SEARCH_STRATEGY.SQL_ASYNC
+        : SEARCH_STRATEGY.SQL;
+
     return this.runSearch(request, options.abortSignal, strategy);
   }
 }


### PR DESCRIPTION
### Description
Extended Dataset type config to provide search options like strategy to shift the strategy provided by language to the dataset itself.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
