### PR TITLE
[discover] wait for dataset to created before emitted update

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -167,6 +167,7 @@
     - [Opensearch dashboards.release notes 2.14.0](../release-notes/opensearch-dashboards.release-notes-2.14.0.md)
     - [Opensearch dashboards.release notes 2.15.0](../release-notes/opensearch-dashboards.release-notes-2.15.0.md)
     - [Opensearch dashboards.release notes 2.16.0](../release-notes/opensearch-dashboards.release-notes-2.16.0.md)
+    - [Opensearch dashboards.release notes 2.17.0](../release-notes/opensearch-dashboards.release-notes-2.17.0.md)
     - [Opensearch dashboards.release notes 2.2.0](../release-notes/opensearch-dashboards.release-notes-2.2.0.md)
     - [Opensearch dashboards.release notes 2.2.1](../release-notes/opensearch-dashboards.release-notes-2.2.1.md)
     - [Opensearch dashboards.release notes 2.3.0](../release-notes/opensearch-dashboards.release-notes-2.3.0.md)

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -160,8 +160,8 @@ export const Configurator = ({
           />
         </EuiButton>
         <EuiButton
-          onClick={() => {
-            queryString.getDatasetService().cacheDataset(dataset);
+          onClick={async () => {
+            await queryString.getDatasetService().cacheDataset(dataset);
             onConfirm(dataset);
           }}
           fill

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -12,7 +12,7 @@ import { cloneDeep } from 'lodash';
 import { useLocation } from 'react-router-dom';
 import { RequestAdapter } from '../../../../../inspector/public';
 import { DiscoverViewServices } from '../../../build_services';
-import { QueryStatus, search } from '../../../../../data/public';
+import { search } from '../../../../../data/public';
 import { validateTimeRange } from '../../helpers/validate_time_range';
 import { updateSearchSource } from './update_search_source';
 import { useIndexPattern } from './use_index_pattern';


### PR DESCRIPTION
### Description

Cache dataset is an async function that ends up creating the temporary index pattern. The temporary index pattern was not created and was causing an exception so the index pattern was never updated.

The index pattern not being updated didn't trigger the hooks to update the other parts of the app.

### Issues Resolved

Available fields from previous selection are persisted when only index is changed, not index pattern

## Screenshot

<img width="864" alt="Screenshot 2024-09-10 at 3 55 21 PM" src="https://github.com/user-attachments/assets/44f898a2-5a53-4556-a105-93b19cd9c225">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
