### PR TITLE
fix: data source permission client wrapper error of not returning explicitly the saved object client functions

### DIFF
--- a/changelogs/fragments/8118.yml
+++ b/changelogs/fragments/8118.yml
@@ -1,0 +1,2 @@
+fix:
+- Necessary functions are missing from data source permission saved object wrapper ([#8118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8118))

--- a/src/plugins/data_source_management/server/saved_objects/data_source_premission_client_wrapper.ts
+++ b/src/plugins/data_source_management/server/saved_objects/data_source_premission_client_wrapper.ts
@@ -148,6 +148,14 @@ export class DataSourcePermissionClientWrapper {
       delete: deleteWithManageableBy,
       update: updateWithManageableBy,
       bulkUpdate: bulkUpdateWithManageableBy,
+      get: wrapperOptions.client.get,
+      checkConflicts: wrapperOptions.client.checkConflicts,
+      errors: wrapperOptions.client.errors,
+      addToNamespaces: wrapperOptions.client.addToNamespaces,
+      deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
+      find: wrapperOptions.client.find,
+      bulkGet: wrapperOptions.client.bulkGet,
+      deleteByWorkspace: wrapperOptions.client.deleteByWorkspace,
     };
   };
 


### PR DESCRIPTION
### Description
This PR fixed the issue:
```
log   [18:03:38.100] [error][http] TypeError: this.savedObjectsClient.get is not a function
    at UiSettingsClient.read (/usr/share/opensearch-dashboards/src/core/server/ui_settings/ui_settings_client.js:202:50)
    at UiSettingsClient.getUserProvided (/usr/share/opensearch-dashboards/src/core/server/ui_settings/ui_settings_client.js:94:53)
    at UiSettingsClient.getRaw (/usr/share/opensearch-dashboards/src/core/server/ui_settings/ui_settings_client.js:138:37)
    at UiSettingsClient.getAll (/usr/share/opensearch-dashboards/src/core/server/ui_settings/ui_settings_client.js:86:28)
    at UiSettingsClient.get (/usr/share/opensearch-dashboards/src/core/server/ui_settings/ui_settings_client.js:82:28)
    at /usr/share/opensearch-dashboards/src/core/server/core_app/core_app.js:57:63
    at /usr/share/opensearch-dashboards/src/core/utils/context.js:184:16
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Router.handle (/usr/share/opensearch-dashboards/src/core/server/http/router/router.js:174:44)
    at handler (/usr/share/opensearch-dashboards/src/core/server/http/router/router.js:140:50)
    at exports.Manager.execute (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at Object.internals.handler (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at exports.execute (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at Request._lifecycle (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/request.js:371:32)
    at Request._execute (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/request.js:281:9)
 error  [18:03:38.097]  Error: Internal Server Error
    at HapiResponseAdapter.toInternalError (/usr/share/opensearch-dashboards/src/core/server/http/router/response_adapter.js:69:19)
    at Router.handle (/usr/share/opensearch-dashboards/src/core/server/http/router/router.js:186:34)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at handler (/usr/share/opensearch-dashboards/src/core/server/http/router/router.js:140:50)
    at exports.Manager.execute (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at Object.internals.handler (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at exports.execute (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at Request._lifecycle (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/request.js:371:32)
    at Request._execute (/usr/share/opensearch-dashboards/node_modules/@hapi/hapi/lib/request.js:281:9)
```

Before the fix, open OSD shows error:
<img width="916" alt="image" src="https://github.com/user-attachments/assets/38291134-1eda-4781-8f7a-8fae558cdb6f">

After the fix, OSD is opened properly:
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/5f046238-513e-4379-a179-22f6ea431bdd">


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: necessary functions are missing from data source permission saved object wrapper

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
