### PR TITLE
[Manual backport] [Backport 2.x] data source permission client wrapper error of not returning explicitly the saved object client functions

### DIFF
--- a/changelogs/fragments/8118.yml
+++ b/changelogs/fragments/8118.yml
@@ -1,0 +1,2 @@
+fix:
+- Necessary functions are missing from data source permission saved object wrapper ([#8118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8118))

--- a/src/plugins/data_source_management/server/saved_objects/data_source_premission_client_wrapper.ts
+++ b/src/plugins/data_source_management/server/saved_objects/data_source_premission_client_wrapper.ts
@@ -148,6 +148,14 @@ export class DataSourcePermissionClientWrapper {
       delete: deleteWithManageableBy,
       update: updateWithManageableBy,
       bulkUpdate: bulkUpdateWithManageableBy,
+      get: wrapperOptions.client.get,
+      checkConflicts: wrapperOptions.client.checkConflicts,
+      errors: wrapperOptions.client.errors,
+      addToNamespaces: wrapperOptions.client.addToNamespaces,
+      deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
+      find: wrapperOptions.client.find,
+      bulkGet: wrapperOptions.client.bulkGet,
+      deleteByWorkspace: wrapperOptions.client.deleteByWorkspace,
     };
   };
 


### PR DESCRIPTION
### Description
Manual backport #8118 
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
