### PR TITLE
[Workspace] Integrate dashboard admin with dynamic config

### DIFF
--- a/changelogs/fragments/8137.yml
+++ b/changelogs/fragments/8137.yml
@@ -1,0 +1,2 @@
+refactor:
+- [Workspace] Integrate dashboard admin with dynamic config ([#8137](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8137))

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -168,6 +168,7 @@ export enum AssociationDataSourceModalMode {
   DirectQueryConnections = 'direction-query-connections',
 }
 export const USE_CASE_PREFIX = 'use-case-';
+export const OPENSEARCHDASHBOARDS_CONFIG_PATH = 'opensearchDashboards';
 
 // Workspace will handle both data source and data connection type saved object.
 export const WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES = [

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -5,6 +5,7 @@
 
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
+import { cloneDeep } from 'lodash';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -26,6 +27,7 @@ import {
   WORKSPACE_NAVIGATION_APP_ID,
   DEFAULT_WORKSPACE,
   PRIORITY_FOR_REPOSITORY_WRAPPER,
+  OPENSEARCHDASHBOARDS_CONFIG_PATH,
 } from '../common/constants';
 import { IWorkspaceClientImpl, WorkspacePluginSetup, WorkspacePluginStart } from './types';
 import { WorkspaceClient } from './workspace_client';
@@ -47,7 +49,7 @@ import {
   SavedObjectsPermissionControl,
   SavedObjectsPermissionControlContract,
 } from './permission_control/client';
-import { getOSDAdminConfigFromYMLConfig, updateDashboardAdminStateForRequest } from './utils';
+import { updateDashboardAdminStateForRequest } from './utils';
 import { WorkspaceIdConsumerWrapper } from './saved_objects/workspace_id_consumer_wrapper';
 import { WorkspaceUiSettingsClientWrapper } from './saved_objects/workspace_ui_settings_client_wrapper';
 import { uiSettings } from './ui_settings';
@@ -97,8 +99,17 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
       } catch (e) {
         return toolkit.next();
       }
+      // Get config from dynamic service client.
+      const dynamicConfigServiceStart = await core.dynamicConfigService.getStartService();
+      const store = dynamicConfigServiceStart.getAsyncLocalStore();
+      const client = dynamicConfigServiceStart.getClient();
+      const config = await client.getConfig(
+        { pluginConfigPath: OPENSEARCHDASHBOARDS_CONFIG_PATH },
+        { asyncLocalStorageContext: store! }
+      );
+      const configUsers: string[] = cloneDeep(config.dashboardAdmin.users);
+      const configGroups: string[] = cloneDeep(config.dashboardAdmin.groups);
 
-      const [configGroups, configUsers] = await getOSDAdminConfigFromYMLConfig(this.globalConfig$);
       updateDashboardAdminStateForRequest(request, groups, users, configGroups, configUsers);
       return toolkit.next();
     });

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -3,23 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthStatus } from '../../../core/server';
 import {
   httpServerMock,
-  httpServiceMock,
   savedObjectsClientMock,
   uiSettingsServiceMock,
 } from '../../../core/server/mocks';
 import {
   generateRandomId,
-  getOSDAdminConfigFromYMLConfig,
   updateDashboardAdminStateForRequest,
   transferCurrentUserInPermissions,
   getDataSourcesList,
   checkAndSetDefaultDataSource,
 } from './utils';
 import { getWorkspaceState } from '../../../core/server/utils';
-import { Observable, of } from 'rxjs';
 import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../data_source_management/common';
 import { OSD_ADMIN_WILDCARD_MATCH_ALL } from '../common/constants';
 
@@ -95,27 +91,6 @@ describe('workspace utils', () => {
     const configUsers: string[] = [OSD_ADMIN_WILDCARD_MATCH_ALL];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
-  });
-
-  it('should get correct admin config when admin config is enabled ', async () => {
-    const globalConfig$: Observable<any> = of({
-      opensearchDashboards: {
-        dashboardAdmin: {
-          groups: ['group1', 'group2'],
-          users: ['user1', 'user2'],
-        },
-      },
-    });
-    const [groups, users] = await getOSDAdminConfigFromYMLConfig(globalConfig$);
-    expect(groups).toEqual(['group1', 'group2']);
-    expect(users).toEqual(['user1', 'user2']);
-  });
-
-  it('should get [] when admin config is not enabled', async () => {
-    const globalConfig$: Observable<any> = of({});
-    const [groups, users] = await getOSDAdminConfigFromYMLConfig(globalConfig$);
-    expect(groups).toEqual([]);
-    expect(users).toEqual([]);
   });
 
   it('should transfer current user placeholder in permissions', () => {

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -4,11 +4,8 @@
  */
 
 import crypto from 'crypto';
-import { Observable } from 'rxjs';
-import { first } from 'rxjs/operators';
 import {
   OpenSearchDashboardsRequest,
-  SharedGlobalConfig,
   Permissions,
   SavedObjectsClientContract,
   IUiSettingsClient,
@@ -51,17 +48,6 @@ export const updateDashboardAdminStateForRequest = (
   return updateWorkspaceState(request, {
     isDashboardAdmin: groupMatchAny || userMatchAny,
   });
-};
-
-export const getOSDAdminConfigFromYMLConfig = async (
-  globalConfig$: Observable<SharedGlobalConfig>
-) => {
-  const globalConfig = await globalConfig$.pipe(first()).toPromise();
-  const groupsResult = (globalConfig.opensearchDashboards?.dashboardAdmin?.groups ||
-    []) as string[];
-  const usersResult = (globalConfig.opensearchDashboards?.dashboardAdmin?.users || []) as string[];
-
-  return [groupsResult, usersResult];
 };
 
 export const transferCurrentUserInPermissions = (


### PR DESCRIPTION
### Description

 Integrate dashboard admin with dynamic config(https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7194)

If you do not config users/groups, anyone will not be dashboard admin.
```
opensearchDashboards.dashboardAdmin.groups: []
opensearchDashboards.dashboardAdmin.users: []
```

If your backend role is admin, you will be dashboard admin.
```
opensearchDashboards.dashboardAdmin.groups: ["admin"]
opensearchDashboards.dashboardAdmin.users: []
```

If your login is admin, you will be dashboard admin.
```
opensearchDashboards.dashboardAdmin.groups: []
opensearchDashboards.dashboardAdmin.users: ["admin"]
```

If you do not config users as *, anyone will be dashboard admin.
```
opensearchDashboards.dashboardAdmin.groups: []
opensearchDashboards.dashboardAdmin.users: ["*"]
```


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
 - refactor: [Workspace] Integrate dashboard admin with dynamic config
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
