### PR TITLE
[Workspace]fix the UI of menu content picker

### DIFF
--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -161,7 +161,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
         {isDashboardAdmin ? (
           <>
             <EuiHorizontalRule margin="none" size="full" />
-            <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false} color="transparent">
+            <EuiPanel paddingSize="m" hasBorder={false} hasShadow={false} color="transparent">
               <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="none">
                 <EuiFlexItem grow={false}>
                   <EuiButtonEmpty

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -14,6 +14,7 @@ import {
   EuiButtonIcon,
   EuiFlexItem,
   EuiIcon,
+  EuiSpacer,
   EuiFlexGroup,
   EuiHorizontalRule,
   EuiButtonEmpty,
@@ -86,106 +87,111 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       button={currentWorkspaceButton}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="s"
+      panelPaddingSize="none"
       anchorPosition="downCenter"
       repositionOnScroll={true}
     >
-      <EuiPanel hasBorder={false} color="transparent">
-        <EuiFlexGroup
-          justifyContent="spaceAround"
-          alignItems="center"
-          direction="column"
-          gutterSize="s"
-        >
-          {currentWorkspace ? (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiIcon
-                  size="xl"
-                  data-test-subj={`current-workspace-icon-${getUseCase(currentWorkspace)?.icon}`}
-                  type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
-                  color={getValidWorkspaceColor(currentWorkspace.color)}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-                data-test-subj="workspace-menu-current-workspace-name"
-                style={{ maxWidth: '200px' }}
-              >
-                <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
-                <EuiText
-                  size="xs"
-                  data-test-subj="workspace-menu-current-use-case"
-                  textAlign="center"
-                  color="subdued"
-                >
-                  {getUseCase(currentWorkspace)?.title ?? ''}
-                </EuiText>
-              </EuiFlexItem>
-            </>
-          ) : (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiIcon size="xl" color="subdued" type="wsSelector" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
-                <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
-              </EuiFlexItem>
-            </>
-          )}
-        </EuiFlexGroup>
-      </EuiPanel>
-
-      <EuiPanel
-        paddingSize="s"
-        hasBorder={false}
-        color="transparent"
-        style={{ height: '30vh' }}
-        className="eui-fullHeight"
-      >
-        <WorkspacePickerContent
-          coreStart={coreStart}
-          registeredUseCases$={registeredUseCases$}
-          onClickWorkspace={() => setPopover(false)}
-        />
-      </EuiPanel>
-
-      {isDashboardAdmin && (
-        <EuiPanel paddingSize="s" hasBorder={false} color="transparent">
-          <EuiHorizontalRule />
-          <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s">
-            <EuiFlexItem>
-              <EuiButtonEmpty
-                color="primary"
-                size="xs"
-                data-test-subj="workspace-menu-manage-button"
-                onClick={() => {
-                  closePopover();
-                  coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
-                }}
-              >
-                <EuiText size="s">{manageWorkspacesButton}</EuiText>
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color="primary"
-                iconType="plus"
-                size="s"
-                key={WORKSPACE_CREATE_APP_ID}
-                data-test-subj="workspace-menu-create-workspace-button"
-                onClick={() => {
-                  closePopover();
-                  coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
-                }}
-              >
-                <EuiText size="s">{createWorkspaceButton}</EuiText>
-              </EuiButton>
-            </EuiFlexItem>
+      <EuiPanel hasBorder={false} color="transparent" paddingSize="none" style={{ width: '280px' }}>
+        <EuiPanel paddingSize="m" hasBorder={false} color="transparent">
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
+            alignItems="center"
+            direction="column"
+            gutterSize="s"
+          >
+            {currentWorkspace ? (
+              <>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon
+                    size="xl"
+                    data-test-subj={`current-workspace-icon-${getUseCase(currentWorkspace)?.icon}`}
+                    type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
+                    color={getValidWorkspaceColor(currentWorkspace.color)}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
+                  <EuiText textAlign="center" size="m">
+                    {currentWorkspaceName}
+                  </EuiText>
+                  <EuiText
+                    size="s"
+                    data-test-subj="workspace-menu-current-use-case"
+                    textAlign="center"
+                    color="subdued"
+                  >
+                    {getUseCase(currentWorkspace)?.title ?? ''}
+                  </EuiText>
+                </EuiFlexItem>
+              </>
+            ) : (
+              <>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon size="xl" color="subdued" type="wsSelector" />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
+                  <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
+                </EuiFlexItem>
+              </>
+            )}
           </EuiFlexGroup>
         </EuiPanel>
-      )}
+
+        <EuiHorizontalRule margin="none" size="full" />
+        <EuiPanel
+          paddingSize="s"
+          hasBorder={false}
+          color="transparent"
+          style={{ height: '25vh' }}
+          className="eui-fullHeight"
+        >
+          <WorkspacePickerContent
+            coreStart={coreStart}
+            registeredUseCases$={registeredUseCases$}
+            onClickWorkspace={() => setPopover(false)}
+          />
+        </EuiPanel>
+
+        {isDashboardAdmin ? (
+          <>
+            <EuiHorizontalRule margin="none" size="full" />
+            <EuiPanel paddingSize="m" hasBorder={false} color="transparent">
+              <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="none">
+                <EuiFlexItem>
+                  <EuiButtonEmpty
+                    color="primary"
+                    size="xs"
+                    data-test-subj="workspace-menu-manage-button"
+                    onClick={() => {
+                      closePopover();
+                      coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
+                    }}
+                  >
+                    <EuiText size="s">{manageWorkspacesButton}</EuiText>
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    color="primary"
+                    iconType="plus"
+                    size="s"
+                    key={WORKSPACE_CREATE_APP_ID}
+                    data-test-subj="workspace-menu-create-workspace-button"
+                    onClick={() => {
+                      closePopover();
+                      coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
+                    }}
+                  >
+                    <EuiText size="s">{createWorkspaceButton}</EuiText>
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+          </>
+        ) : (
+          <EuiSpacer />
+        )}
+      </EuiPanel>
     </EuiPopover>
   );
 };

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -91,13 +91,19 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       anchorPosition="downCenter"
       repositionOnScroll={true}
     >
-      <EuiPanel hasBorder={false} color="transparent" paddingSize="none" style={{ width: '280px' }}>
+      <EuiPanel
+        hasBorder={false}
+        color="transparent"
+        hasShadow={false}
+        paddingSize="none"
+        style={{ width: '280px' }}
+      >
         <EuiPanel paddingSize="m" hasBorder={false} color="transparent">
           <EuiFlexGroup
             justifyContent="spaceBetween"
             alignItems="center"
             direction="column"
-            gutterSize="s"
+            gutterSize="xs"
           >
             {currentWorkspace ? (
               <>
@@ -140,8 +146,9 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
         <EuiPanel
           paddingSize="s"
           hasBorder={false}
+          hasShadow={false}
           color="transparent"
-          style={{ height: '25vh' }}
+          style={{ height: '30vh' }}
           className="eui-fullHeight"
         >
           <WorkspacePickerContent
@@ -154,19 +161,20 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
         {isDashboardAdmin ? (
           <>
             <EuiHorizontalRule margin="none" size="full" />
-            <EuiPanel paddingSize="m" hasBorder={false} color="transparent">
+            <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false} color="transparent">
               <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="none">
-                <EuiFlexItem>
+                <EuiFlexItem grow={false}>
                   <EuiButtonEmpty
                     color="primary"
                     size="xs"
+                    flush="left"
                     data-test-subj="workspace-menu-manage-button"
                     onClick={() => {
                       closePopover();
                       coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
                     }}
                   >
-                    <EuiText size="s">{manageWorkspacesButton}</EuiText>
+                    <EuiText size="s"> {manageWorkspacesButton}</EuiText>
                   </EuiButtonEmpty>
                 </EuiFlexItem>
 
@@ -174,6 +182,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
                   <EuiButton
                     color="primary"
                     iconType="plus"
+                    className="eui-textRight"
                     size="s"
                     key={WORKSPACE_CREATE_APP_ID}
                     data-test-subj="workspace-menu-create-workspace-button"

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -99,7 +99,7 @@ export const WorkspacePickerContent = ({
         iconType="wsSelector"
         data-test-subj="empty-workspace-prompt"
         title={
-          <EuiText size="m">
+          <EuiText size="s">
             <p>
               {i18n.translate('workspace.picker.empty.state.title', {
                 defaultMessage: 'No workspace available',
@@ -138,7 +138,7 @@ export const WorkspacePickerContent = ({
           data-test-subj={`workspace-menu-item-${itemType}-${workspace.id}`}
           icon={
             <EuiIcon
-              size="s"
+              size="m"
               type={useCase?.icon || 'wsSelector'}
               color={getValidWorkspaceColor(workspace.color)}
             />
@@ -156,17 +156,18 @@ export const WorkspacePickerContent = ({
         <EuiTitle size="xxs">
           <h4>{itemType === 'all' ? allWorkspacesTitle : recentWorkspacesTitle}</h4>
         </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiListGroup showToolTips flush gutterSize="none" wrapText maxWidth={240}>
+        <EuiSpacer size="xs" />
+        <EuiListGroup flush gutterSize="none" maxWidth={240}>
           {listItems}
         </EuiListGroup>
-        <EuiSpacer size="s" />
+        <EuiSpacer size="xs" />
       </>
     );
   };
 
   return (
     <>
+      <EuiSpacer size="s" />
       <EuiFieldSearch
         compressed={true}
         fullWidth={true}
@@ -174,13 +175,13 @@ export const WorkspacePickerContent = ({
         onChange={(e) => setSearch(e.target.value)}
         placeholder={searchFieldPlaceholder}
       />
-      <EuiSpacer />
+      <EuiSpacer size="s" />
 
       <EuiPanel
         paddingSize="none"
         color="transparent"
         hasBorder={false}
-        className="eui-yScrollWithShadows"
+        className="euiYScrollWithShadows"
       >
         {queriedRecentWorkspace.length > 0 &&
           getWorkspaceListGroup(queriedRecentWorkspace, 'recent')}


### PR DESCRIPTION
### Description
This pr fixes the UI of menu content picker according to feedback

## Screenshot
1. fix: Tooltip is misaligned and causes a jump
<img width="508" alt="截屏2024-09-12 14 37 53" src="https://github.com/user-attachments/assets/fddeec2d-6ef1-4206-9569-4b20ba2da446">

2. fix: the width will be consistent in non-admin mode
![截屏2024-09-11 17 49 32](https://github.com/user-attachments/assets/0c3a0c51-29d0-48ba-9ce5-580002926b5a)
![截屏2024-09-11 17 49 37](https://github.com/user-attachments/assets/bbff2e3e-4539-4fba-8f59-914a822f81d0)

3. overall appearance
<img width="315" alt="截屏2024-09-12 14 37 30" src="https://github.com/user-attachments/assets/4ebec516-6999-488e-8dfb-9ab605eb0fc2">
<img width="315" alt="截屏2024-09-12 14 36 22" src="https://github.com/user-attachments/assets/3a6c67fb-581b-4c94-83a9-6f1208135922">


## Changelog
- fix: fix the UI of menu content picker

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

