### PR TITLE
[discover ]Adjust icon size to fix spacing in action table

### DIFF
--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_add.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_add.tsx
@@ -30,7 +30,7 @@
 
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { EuiToolTip, EuiSmallButtonIcon } from '@elastic/eui';
+import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
 export interface Props {
@@ -53,7 +53,7 @@ export function DocViewTableRowBtnFilterAdd({ onClick, disabled = false }: Props
 
   return (
     <EuiToolTip content={tooltipContent}>
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         aria-label={i18n.translate('discover.docViews.table.filterForValueButtonAriaLabel', {
           defaultMessage: 'Filter for value',
         })}
@@ -63,6 +63,7 @@ export function DocViewTableRowBtnFilterAdd({ onClick, disabled = false }: Props
         onClick={onClick}
         iconType={'magnifyWithPlus'}
         iconSize={'s'}
+        size={'xs'}
       />
     </EuiToolTip>
   );

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_exists.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_exists.tsx
@@ -30,7 +30,7 @@
 
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { EuiToolTip, EuiSmallButtonIcon } from '@elastic/eui';
+import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
 export interface Props {
@@ -65,7 +65,7 @@ export function DocViewTableRowBtnFilterExists({
 
   return (
     <EuiToolTip content={tooltipContent}>
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         aria-label={i18n.translate('discover.docViews.table.filterForFieldPresentButtonAriaLabel', {
           defaultMessage: 'Filter for field present',
         })}
@@ -75,6 +75,7 @@ export function DocViewTableRowBtnFilterExists({
         disabled={disabled}
         iconType={'indexOpen'}
         iconSize={'s'}
+        size={'xs'}
       />
     </EuiToolTip>
   );

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_remove.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_remove.tsx
@@ -30,7 +30,7 @@
 
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { EuiToolTip, EuiSmallButtonIcon } from '@elastic/eui';
+import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
 export interface Props {
@@ -53,7 +53,7 @@ export function DocViewTableRowBtnFilterRemove({ onClick, disabled = false }: Pr
 
   return (
     <EuiToolTip content={tooltipContent}>
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         aria-label={i18n.translate('discover.docViews.table.filterOutValueButtonAriaLabel', {
           defaultMessage: 'Filter out value',
         })}
@@ -63,6 +63,7 @@ export function DocViewTableRowBtnFilterRemove({ onClick, disabled = false }: Pr
         onClick={onClick}
         iconType={'magnifyWithMinus'}
         iconSize={'s'}
+        size={'xs'}
       />
     </EuiToolTip>
   );

--- a/src/plugins/discover/public/application/components/table/table_row_btn_toggle_column.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_toggle_column.tsx
@@ -30,7 +30,7 @@
 
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { EuiToolTip, EuiSmallButtonIcon } from '@elastic/eui';
+import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
 export interface Props {
@@ -42,7 +42,7 @@ export interface Props {
 export function DocViewTableRowBtnToggleColumn({ onClick, active, disabled = false }: Props) {
   if (disabled) {
     return (
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         aria-label={i18n.translate('discover.docViews.table.toggleColumnInTableButtonAriaLabel', {
           defaultMessage: 'Toggle column in table',
         })}
@@ -51,6 +51,7 @@ export function DocViewTableRowBtnToggleColumn({ onClick, active, disabled = fal
         disabled
         iconType={'tableOfContents'}
         iconSize={'s'}
+        size={'xs'}
       />
     );
   }
@@ -63,7 +64,7 @@ export function DocViewTableRowBtnToggleColumn({ onClick, active, disabled = fal
         />
       }
     >
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         aria-label={i18n.translate('discover.docViews.table.toggleColumnInTableButtonAriaLabel', {
           defaultMessage: 'Toggle column in table',
         })}
@@ -73,6 +74,7 @@ export function DocViewTableRowBtnToggleColumn({ onClick, active, disabled = fal
         data-test-subj="toggleColumnButton"
         iconType={'tableOfContents'}
         iconSize={'s'}
+        size={'xs'}
       />
     </EuiToolTip>
   );


### PR DESCRIPTION
### Description
Adjust the sizing of the icons in the actions table of discover. They are currently not matching the other elements and causing spacing/allignment issues in each row.

## Screenshot
Before:
<img width="556" alt="Before" src="https://github.com/user-attachments/assets/8f579c1e-39c6-48c1-8df9-a02e0c07ec80">
After:
<img width="598" alt="After" src="https://github.com/user-attachments/assets/230c7fc7-d09c-4a0e-bab6-f0297ffd57c8">

## Testing the changes
- local

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
