### PR TITLE
Allow unknown query parameter for ui settings route

### DIFF
--- a/src/core/server/ui_settings/routes/delete.ts
+++ b/src/core/server/ui_settings/routes/delete.ts
@@ -39,11 +39,14 @@ const validate = {
   params: schema.object({
     key: schema.string(),
   }),
-  query: schema.object({
-    scope: schema.maybe(
-      schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
-    ),
-  }),
+  query: schema.object(
+    {
+      scope: schema.maybe(
+        schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
+      ),
+    },
+    { unknowns: 'allow' }
+  ),
 };
 
 export function registerDeleteRoute(router: IRouter) {

--- a/src/core/server/ui_settings/routes/get.ts
+++ b/src/core/server/ui_settings/routes/get.ts
@@ -35,11 +35,14 @@ import { SavedObjectsErrorHelpers } from '../../saved_objects';
 import { UiSettingScope } from '../types';
 
 const validate = {
-  query: schema.object({
-    scope: schema.maybe(
-      schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
-    ),
-  }),
+  query: schema.object(
+    {
+      scope: schema.maybe(
+        schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
+      ),
+    },
+    { unknowns: 'allow' }
+  ),
 };
 
 export function registerGetRoute(router: IRouter) {

--- a/src/core/server/ui_settings/routes/set.ts
+++ b/src/core/server/ui_settings/routes/set.ts
@@ -42,11 +42,14 @@ const validate = {
   body: schema.object({
     value: schema.any(),
   }),
-  query: schema.object({
-    scope: schema.maybe(
-      schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
-    ),
-  }),
+  query: schema.object(
+    {
+      scope: schema.maybe(
+        schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
+      ),
+    },
+    { unknowns: 'allow' }
+  ),
 };
 
 export function registerSetRoute(router: IRouter) {

--- a/src/core/server/ui_settings/routes/set_many.ts
+++ b/src/core/server/ui_settings/routes/set_many.ts
@@ -39,11 +39,14 @@ const validate = {
   body: schema.object({
     changes: schema.object({}, { unknowns: 'allow' }),
   }),
-  query: schema.object({
-    scope: schema.maybe(
-      schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
-    ),
-  }),
+  query: schema.object(
+    {
+      scope: schema.maybe(
+        schema.oneOf([schema.literal(UiSettingScope.GLOBAL), schema.literal(UiSettingScope.USER)])
+      ),
+    },
+    { unknowns: 'allow' }
+  ),
 };
 
 export function registerSetManyRoute(router: IRouter) {


### PR DESCRIPTION
### Description

1. Allow unknown query parameter for ui settings route

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

functional test set ui settings with tenant specified

https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/c9884bf615b9ab50c013abda4f878f7899a9d1d8/cypress/utils/commands.js#L483-L506

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->


calling `api/opensearch-dashboards/settings` with query parameter 
```
curl --request POST \
  --url 'http://localhost:5601/api/opensearch-dashboards/settings?security_tenant=global&scope=global' \
  --header 'Authorization: Basic YWRtaW46YWRtaW4=' \
  --header 'Content-Type: application/json' \
  --header 'osd-xsrf: osd-fetch' \
  --data '{
 "changes": {
  "defaultIndex": "logstash-*"
 }
}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:5601 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:5601...
* Connected to localhost (::1) port 5601
> POST /api/opensearch-dashboards/settings?security_tenant=global&scope=global HTTP/1.1
> Host: localhost:5601
> User-Agent: curl/8.7.1
> Accept: */*
> Authorization: Basic YWRtaW46YWRtaW4=
> Content-Type: application/json
> osd-xsrf: osd-fetch
> Content-Length: 51
>
* upload completely sent off: 51 bytes
< HTTP/1.1 200 OK
< osd-name: bcd07463160c
< content-type: application/json; charset=utf-8
< cache-control: private, no-cache, no-store, must-revalidate
< set-cookie: security_authentication=Fe26.2**a26b8853b4084cc1bb2e7cc413d6fbf0ef0ad2b48d44fac8d237f2e5bd43e8d0*bBmO5QGqIstYOVS5uRbL2g*uh4Sb1t2xprEzZ5SM1PKR2-VPUmyU6Kox8OpnyyYPFf1NHEXQDsBKtBNl1xkpytYkKaJ2c1FstobPeLJ1e5cypXpWGCkgNmezW27V4IRB16Bozs1IWdwY78ZNnqRVp1RM5MAOyWYH7b7b5UAjQYphkLbpLRy3kOT0ZJgsrOmE7Sv6xil3bsL0-5s8ZyCtd_u**94958446b535f884e268e463e5c17595b639322327c26b1c0e43882f5b5f3e33*cpNv4dIlj9ohII5JN6HALMYWU5Sb3rqVzNizsRnt7rk; HttpOnly; Path=/
< content-length: 306
< Date: Thu, 12 Sep 2024 03:34:25 GMT
< Connection: keep-alive
< Keep-Alive: timeout=120
<
* Connection #0 to host localhost left intact
{"settings":{"buildNum":{"userValue":9007199254740991},"theme:version":{"userValue":"v7"},"defaultIndex":{"userValue":"logstash-*"},"defaultDataSource":{"userValue":"5827a650-709b-11ef-bee4-cb96037aeecd"},"defaultWorkspace":{"userValue":"123"},"home:useNewHomePage":{"isOverridden":true,"userValue":true}}}%

```

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
