### PR TITLE
fix: do not automatically append workspaces params when creating config

### DIFF
--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -12,7 +12,10 @@ import {
   SavedObjectsCheckConflictsObject,
   OpenSearchDashboardsRequest,
   SavedObjectsFindOptions,
+  SavedObject,
 } from '../../../../core/server';
+
+const UI_SETTINGS_SAVED_OBJECTS_TYPE = 'config';
 
 type WorkspaceOptions = Pick<SavedObjectsBaseOptions, 'workspaces'> | undefined;
 
@@ -39,6 +42,10 @@ export class WorkspaceIdConsumerWrapper {
     };
   }
 
+  private isConfigType(type: SavedObject['type']): boolean {
+    return type === UI_SETTINGS_SAVED_OBJECTS_TYPE;
+  }
+
   public wrapperFactory: SavedObjectsClientWrapperFactory = (wrapperOptions) => {
     return {
       ...wrapperOptions.client,
@@ -46,7 +53,9 @@ export class WorkspaceIdConsumerWrapper {
         wrapperOptions.client.create(
           type,
           attributes,
-          this.formatWorkspaceIdParams(wrapperOptions.request, options)
+          this.isConfigType(type)
+            ? options
+            : this.formatWorkspaceIdParams(wrapperOptions.request, options)
         ),
       bulkCreate: <T = unknown>(
         objects: Array<SavedObjectsBulkCreateObject<T>>,


### PR DESCRIPTION
### Description

fix: do not automatically append workspaces params when creating config

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
