### PR TITLE
[Discover] UI Updates to Dataset Configurator

### DIFF
--- a/changelogs/fragments/8166.yml
+++ b/changelogs/fragments/8166.yml
@@ -1,0 +1,2 @@
+fix:
+- Fixes UI issues in Discover and data configurator ([#8166](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8166))

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -315,6 +315,7 @@ exports[`Dashboard top nav render in embed mode 1`] = `
               },
               "indexPatterns": Object {
                 "clearCache": [MockFunction],
+                "create": [MockFunction],
                 "createField": [MockFunction],
                 "createFieldList": [MockFunction],
                 "ensureDefaultIndexPattern": [MockFunction],
@@ -322,6 +323,7 @@ exports[`Dashboard top nav render in embed mode 1`] = `
                 "get": [MockFunction],
                 "getDefault": [MockFunction],
                 "make": [Function],
+                "saveToCache": [MockFunction],
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
@@ -1380,6 +1382,7 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
               },
               "indexPatterns": Object {
                 "clearCache": [MockFunction],
+                "create": [MockFunction],
                 "createField": [MockFunction],
                 "createFieldList": [MockFunction],
                 "ensureDefaultIndexPattern": [MockFunction],
@@ -1387,6 +1390,7 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
                 "get": [MockFunction],
                 "getDefault": [MockFunction],
                 "make": [Function],
+                "saveToCache": [MockFunction],
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
@@ -2445,6 +2449,7 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
               },
               "indexPatterns": Object {
                 "clearCache": [MockFunction],
+                "create": [MockFunction],
                 "createField": [MockFunction],
                 "createFieldList": [MockFunction],
                 "ensureDefaultIndexPattern": [MockFunction],
@@ -2452,6 +2457,7 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
                 "get": [MockFunction],
                 "getDefault": [MockFunction],
                 "make": [Function],
+                "saveToCache": [MockFunction],
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
@@ -3510,6 +3516,7 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
               },
               "indexPatterns": Object {
                 "clearCache": [MockFunction],
+                "create": [MockFunction],
                 "createField": [MockFunction],
                 "createFieldList": [MockFunction],
                 "ensureDefaultIndexPattern": [MockFunction],
@@ -3517,6 +3524,7 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
                 "get": [MockFunction],
                 "getDefault": [MockFunction],
                 "make": [Function],
+                "saveToCache": [MockFunction],
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
@@ -4575,6 +4583,7 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
               },
               "indexPatterns": Object {
                 "clearCache": [MockFunction],
+                "create": [MockFunction],
                 "createField": [MockFunction],
                 "createFieldList": [MockFunction],
                 "ensureDefaultIndexPattern": [MockFunction],
@@ -4582,6 +4591,7 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
                 "get": [MockFunction],
                 "getDefault": [MockFunction],
                 "make": [Function],
+                "saveToCache": [MockFunction],
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],
@@ -5640,6 +5650,7 @@ exports[`Dashboard top nav render with all components 1`] = `
               },
               "indexPatterns": Object {
                 "clearCache": [MockFunction],
+                "create": [MockFunction],
                 "createField": [MockFunction],
                 "createFieldList": [MockFunction],
                 "ensureDefaultIndexPattern": [MockFunction],
@@ -5647,6 +5658,7 @@ exports[`Dashboard top nav render with all components 1`] = `
                 "get": [MockFunction],
                 "getDefault": [MockFunction],
                 "make": [Function],
+                "saveToCache": [MockFunction],
               },
               "query": Object {
                 "addToQueryLog": [MockFunction],

--- a/src/plugins/data/public/mocks.ts
+++ b/src/plugins/data/public/mocks.ts
@@ -91,6 +91,12 @@ const createStartContract = (isEnhancementsEnabled: boolean = false): Start => {
         })
       ),
       clearCache: jest.fn(),
+      create: jest.fn().mockResolvedValue({
+        id: 'test-index-pattern',
+        title: 'Test Index Pattern',
+        type: 'INDEX_PATTERN',
+      }),
+      saveToCache: jest.fn(),
     } as unknown) as IndexPatternsContract,
     dataSources: dataSourceServiceMock.createStartContract(),
   };

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -9,7 +9,6 @@ import {
   DataStructure,
   IndexPatternSpec,
   DEFAULT_DATA,
-  IFieldType,
   UI_SETTINGS,
   DataStorage,
   CachedDataStructure,
@@ -64,14 +63,11 @@ export class DatasetService {
 
   public async cacheDataset(dataset: Dataset): Promise<void> {
     const type = this.getType(dataset.type);
-    if (dataset) {
+    if (dataset && dataset.type !== DEFAULT_DATA.SET_TYPES.INDEX_PATTERN) {
       const spec = {
         id: dataset.id,
         title: dataset.title,
-        timeFieldName: {
-          name: dataset.timeFieldName,
-          type: 'date',
-        } as Partial<IFieldType>,
+        timeFieldName: dataset.timeFieldName,
         fields: await type?.fetchFields(dataset),
         dataSourceRef: dataset.dataSource
           ? {

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -80,6 +80,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
     return fields.map((field: any) => ({
       name: field.name,
       type: field.type,
+      aggregatable: field?.aggregatable,
     }));
   },
 

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -52,5 +52,5 @@ export interface LanguageConfig {
   showDocLinks?: boolean;
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
-  noTimeField?: boolean;
+  disableDatePicker?: boolean;
 }

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -52,4 +52,5 @@ export interface LanguageConfig {
   showDocLinks?: boolean;
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
+  noTimeField?: boolean;
 }

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -52,5 +52,5 @@ export interface LanguageConfig {
   showDocLinks?: boolean;
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
-  disableDatePicker?: boolean;
+  hideDatePicker?: boolean;
 }

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -19,7 +19,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import React, { useEffect, useState } from 'react';
-import { BaseDataset, Dataset, DatasetField } from '../../../common';
+import { BaseDataset, DEFAULT_DATA, Dataset, DatasetField } from '../../../common';
 import { getIndexPatterns, getQueryService } from '../../services';
 
 export const Configurator = ({
@@ -112,16 +112,17 @@ export const Configurator = ({
                     text: field.displayName || field.name,
                     value: field.name,
                   })),
-                  { text: '-----', value: '', disabled: true },
-                  { text: 'No time field', value: undefined },
+                  { text: '-----', value: '-----', disabled: true },
+                  { text: 'I dont want to use time filter', value: '' },
                 ]}
                 value={timeFieldName}
                 onChange={(e) => {
-                  const value = e.target.value === 'undefined' ? undefined : e.target.value;
-                  setTimeFieldName(value);
+                  setTimeFieldName(e.target.value);
+                  const value = e.target.value === '' ? undefined : e.target.value;
                   setDataset({ ...dataset, timeFieldName: value });
                 }}
-                disabled={dataset?.timeFieldName !== undefined}
+                hasNoInitialSelection={dataset.type === DEFAULT_DATA.SET_TYPES.INDEX}
+                disabled={dataset.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN}
               />
             </EuiFormRow>
           )}
@@ -166,7 +167,7 @@ export const Configurator = ({
             onConfirm(dataset);
           }}
           fill
-          disabled={timeFields && timeFields.length > 0 && timeFieldName === undefined}
+          disabled={timeFieldName === undefined && dataset.type === DEFAULT_DATA.SET_TYPES.INDEX}
         >
           <FormattedMessage
             id="data.explorer.datasetSelector.advancedSelector.confirm"

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -52,7 +52,7 @@ export const Configurator = ({
     return languages[0];
   });
 
-  const displayTimeFieldSelector = (ds: Dataset, lang: string, fields: DatasetField[]) => {
+  const shouldDisplayTimeFieldSelector = (ds: Dataset, lang: string, fields: DatasetField[]) => {
     return (
       !(
         languageService.getLanguage(lang)?.disableDatePicker ||
@@ -113,7 +113,7 @@ export const Configurator = ({
             !languageService.getLanguage(language)?.disableDatePicker && (
               <EuiFormRow
                 label={i18n.translate(
-                  'data.explorer.datasetSelector.advancedSelector.configurator.datasetLabel',
+                  'data.explorer.datasetSelector.advancedSelector.configurator.indexPatternTimeFieldLabel',
                   {
                     defaultMessage: 'Time field',
                   }
@@ -122,7 +122,7 @@ export const Configurator = ({
                 <EuiFieldText disabled value={dataset.timeFieldName ?? 'No time field'} />
               </EuiFormRow>
             )}
-          {displayTimeFieldSelector(dataset, language, timeFields) && (
+          {shouldDisplayTimeFieldSelector(dataset, language, timeFields) && (
             <EuiFormRow
               label={i18n.translate(
                 'data.explorer.datasetSelector.advancedSelector.configurator.timeFieldLabel',
@@ -192,7 +192,8 @@ export const Configurator = ({
           }}
           fill
           disabled={
-            timeFieldName === undefined && displayTimeFieldSelector(dataset, language, timeFields)
+            timeFieldName === undefined &&
+            shouldDisplayTimeFieldSelector(dataset, language, timeFields)
           }
         >
           <FormattedMessage

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -52,9 +52,9 @@ export const Configurator = ({
     return languages[0];
   });
 
-  const requiresTimeField = (ds: Dataset, lang: string, fields: DatasetField[]) => {
+  const displayTimeFieldSelector = (ds: Dataset, lang: string, fields: DatasetField[]) => {
     if (
-      languageService.getLanguage(lang)?.noTimeField ||
+      languageService.getLanguage(lang)?.disableDatePicker ||
       ds.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN
     ) {
       return false;
@@ -62,6 +62,7 @@ export const Configurator = ({
     if (fields && fields.length > 0) {
       return true;
     }
+    return false;
   };
 
   useEffect(() => {
@@ -111,7 +112,7 @@ export const Configurator = ({
             <EuiFieldText disabled value={dataset.title} />
           </EuiFormRow>
           {dataset.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN &&
-            !languageService.getLanguage(language)?.noTimeField && (
+            !languageService.getLanguage(language)?.disableDatePicker && (
               <EuiFormRow
                 label={i18n.translate(
                   'data.explorer.datasetSelector.advancedSelector.configurator.datasetLabel',
@@ -123,7 +124,7 @@ export const Configurator = ({
                 <EuiFieldText disabled value={dataset.timeFieldName ?? 'No time field'} />
               </EuiFormRow>
             )}
-          {requiresTimeField(dataset, language, timeFields) && (
+          {displayTimeFieldSelector(dataset, language, timeFields) && (
             <EuiFormRow
               label={i18n.translate(
                 'data.explorer.datasetSelector.advancedSelector.configurator.timeFieldLabel',
@@ -147,7 +148,7 @@ export const Configurator = ({
                   setTimeFieldName(e.target.value);
                   setDataset({ ...dataset, timeFieldName: value });
                 }}
-                hasNoInitialSelection={dataset.type === DEFAULT_DATA.SET_TYPES.INDEX}
+                hasNoInitialSelection={dataset.type !== DEFAULT_DATA.SET_TYPES.INDEX_PATTERN}
               />
             </EuiFormRow>
           )}
@@ -192,7 +193,9 @@ export const Configurator = ({
             onConfirm(dataset);
           }}
           fill
-          disabled={timeFieldName === undefined && requiresTimeField(dataset, language, timeFields)}
+          disabled={
+            timeFieldName === undefined && displayTimeFieldSelector(dataset, language, timeFields)
+          }
         >
           <FormattedMessage
             id="data.explorer.datasetSelector.advancedSelector.confirm"

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -43,7 +43,12 @@ export const Configurator = ({
   const [dataset, setDataset] = useState<Dataset>(baseDataset);
   const [timeFields, setTimeFields] = useState<DatasetField[]>([]);
   const [timeFieldName, setTimeFieldName] = useState<string | undefined>(dataset.timeFieldName);
-  const noTimeFilter = "I don't want to use the time filter";
+  const noTimeFilter = i18n.translate(
+    'data.explorer.datasetSelector.advancedSelector.configurator.timeField.noTimeFieldOptionLabel',
+    {
+      defaultMessage: "I don't want to use the time filter",
+    }
+  );
   const [language, setLanguage] = useState<string>(() => {
     const currentLanguage = queryString.getQuery().language;
     if (languages.includes(currentLanguage)) {

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -121,6 +121,7 @@ export const Configurator = ({
                   setTimeFieldName(value);
                   setDataset({ ...dataset, timeFieldName: value });
                 }}
+                disabled={dataset?.timeFieldName !== undefined}
               />
             </EuiFormRow>
           )}
@@ -165,6 +166,7 @@ export const Configurator = ({
             onConfirm(dataset);
           }}
           fill
+          disabled={timeFields && timeFields.length > 0 && timeFieldName === undefined}
         >
           <FormattedMessage
             id="data.explorer.datasetSelector.advancedSelector.confirm"

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -43,7 +43,7 @@ export const Configurator = ({
   const [dataset, setDataset] = useState<Dataset>(baseDataset);
   const [timeFields, setTimeFields] = useState<DatasetField[]>([]);
   const [timeFieldName, setTimeFieldName] = useState<string | undefined>(dataset.timeFieldName);
-  const noTimeFilter = 'I dont want to use the time filter';
+  const noTimeFilter = "I don't want to use the time filter";
   const [language, setLanguage] = useState<string>(() => {
     const currentLanguage = queryString.getQuery().language;
     if (languages.includes(currentLanguage)) {
@@ -53,16 +53,14 @@ export const Configurator = ({
   });
 
   const displayTimeFieldSelector = (ds: Dataset, lang: string, fields: DatasetField[]) => {
-    if (
-      languageService.getLanguage(lang)?.disableDatePicker ||
-      ds.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN
-    ) {
-      return false;
-    }
-    if (fields && fields.length > 0) {
-      return true;
-    }
-    return false;
+    return (
+      !(
+        languageService.getLanguage(lang)?.disableDatePicker ||
+        ds.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN
+      ) &&
+      fields &&
+      fields.length > 0
+    );
   };
 
   useEffect(() => {

--- a/src/plugins/data_explorer/public/components/app_container.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.tsx
@@ -84,7 +84,10 @@ export const AppContainer = React.memo(
         )}
 
         <EuiPage
-          className={classNames('deLayout', isEnhancementsEnabled && 'dsc--next')}
+          className={classNames(
+            'deLayout',
+            isEnhancementsEnabled && !showActionsInGroup ? 'dsc--next' : undefined
+          )}
           paddingSize="none"
           grow={false}
         >

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -100,7 +100,7 @@ export class QueryEnhancementsPlugin
       editor: enhancedSQLQueryEditor,
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],
-      disableDatePicker: true,
+      hideDatePicker: true,
     };
     queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
 

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -100,7 +100,7 @@ export class QueryEnhancementsPlugin
       editor: enhancedSQLQueryEditor,
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],
-      noTimeField: true,
+      disableDatePicker: true,
     };
     queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
 

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -100,6 +100,7 @@ export class QueryEnhancementsPlugin
       editor: enhancedSQLQueryEditor,
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],
+      noTimeField: true,
     };
     queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
* Fixes blank row at bottom of Discover, thanks @ashwin-pc @AMoo-Miki for the change
* Fixes an issue where indexes were able to be selected with a placeholder time field, which would cause issues
* Disables time field selector in index pattern configurator if the index pattern already has a time field.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
<img width="689" alt="image" src="https://github.com/user-attachments/assets/1c07a777-e356-45c6-a57d-24e4d406bed1">

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/3f5c6c40-852d-42cd-8e7a-93ec115db042">

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/159fbad0-47bf-4950-9258-a785f2527e9b">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Fixes UI issues in Discover and data configurator

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
