### PR TITLE
Fix Discover Embeddable not showing _source when all other column are removed

### DIFF
--- a/changelogs/fragments/8167.yml
+++ b/changelogs/fragments/8167.yml
@@ -1,0 +1,2 @@
+fix:
+- Discover Embeddable not showing _source when all other column are removed ([#8167](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8167))

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -85,7 +85,7 @@ export const DataGridTable = ({
     />
   ) : (
     <DefaultDiscoverTable
-      columns={columns}
+      columns={adjustedColumns}
       indexPattern={indexPattern}
       sort={sort}
       onSort={onSort}


### PR DESCRIPTION
### Description

Fix Discover Embeddable not showing _source when all other column are removed.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
Issue Before the fix 

https://github.com/user-attachments/assets/41ddde2e-c05d-4928-beda-f08eb651e20c

After Fix

https://github.com/user-attachments/assets/9967192c-628f-471d-b655-ea2ce5bdba01




## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
- Navigate to Dashboards page
- Add a discover Save Search which contains multiple columns
- Remove all the columns 
- Check if _source column is displayed

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Discover Embeddable not showing _source when all other column are removed

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
