### PR TITLE
Sync query and filter when refreshing discover page

### DIFF
--- a/changelogs/fragments/8168.yml
+++ b/changelogs/fragments/8168.yml
@@ -1,0 +1,2 @@
+fix:
+- Sync query and filter when refreshing discover page ([#8168](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8168))

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -324,6 +324,11 @@ export const useSearch = (services: DiscoverViewServices) => {
       const savedSearchInstance = await getSavedSearchById(savedSearchId);
       setSavedSearch(savedSearchInstance);
 
+      // if saved search does not exist, do not atempt to sync filters and query from savedObject
+      if (!savedSearch) {
+        return;
+      }
+
       // sync initial app filters from savedObject to filterManager
       const filters = cloneDeep(savedSearchInstance.searchSource.getOwnField('filter'));
       const query =

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -321,13 +321,13 @@ export const useSearch = (services: DiscoverViewServices) => {
   // Get savedSearch if it exists
   useEffect(() => {
     (async () => {
-      // if saved search does not exist, do not atempt to sync filters and query from savedObject
-      if (!savedSearchId) {
-        return;
-      }
-
       const savedSearchInstance = await getSavedSearchById(savedSearchId);
       setSavedSearch(savedSearchInstance);
+
+      // if saved search does not exist, do not atempt to sync filters and query from savedObject
+      if (!savedSearch) {
+        return;
+      }
 
       // sync initial app filters from savedObject to filterManager
       const filters = cloneDeep(savedSearchInstance.searchSource.getOwnField('filter'));

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -321,13 +321,13 @@ export const useSearch = (services: DiscoverViewServices) => {
   // Get savedSearch if it exists
   useEffect(() => {
     (async () => {
-      const savedSearchInstance = await getSavedSearchById(savedSearchId);
-      setSavedSearch(savedSearchInstance);
-
       // if saved search does not exist, do not atempt to sync filters and query from savedObject
-      if (!savedSearch) {
+      if (!savedSearchId) {
         return;
       }
+
+      const savedSearchInstance = await getSavedSearchById(savedSearchId);
+      setSavedSearch(savedSearchInstance);
 
       // sync initial app filters from savedObject to filterManager
       const filters = cloneDeep(savedSearchInstance.searchSource.getOwnField('filter'));


### PR DESCRIPTION
### Description

This PR resolves previously identified three similar bugs when using legacy discover:

Query and filter failed to persist when: 
* refresh the page
* switching between default discover table and datagrid
* using the share link

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/2b8e5b54-756a-4435-ba52-284e7c875616



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Sync query and filter when refreshing discover page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
