### PR TITLE
[Dynamic Config] Fix bug when attempting dynamic config index creation

### DIFF
--- a/changelogs/fragments/8184.yml
+++ b/changelogs/fragments/8184.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix bug when dynamic config index and alias are checked ([#8184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8184))

--- a/src/core/server/config/utils/utils.test.ts
+++ b/src/core/server/config/utils/utils.test.ts
@@ -3,9 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createLocalStore, mergeConfigs, pathToString } from './utils';
+import {
+  createLocalStore,
+  extractVersionFromDynamicConfigIndex,
+  isDynamicConfigIndex,
+  mergeConfigs,
+  pathToString,
+} from './utils';
 import { Request } from 'hapi__hapi';
 import { loggerMock } from '../../logging/logger.mock';
+import { DYNAMIC_APP_CONFIG_INDEX_PREFIX } from './constants';
 
 describe('Utils', () => {
   test.each([
@@ -176,6 +183,79 @@ describe('Utils', () => {
       expectedMap.forEach((value, key) => {
         expect(actualMap.get(key)).toEqual(value);
       });
+    }
+  );
+
+  test.each([
+    {
+      index: `.sanity_check_2`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_144b`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_354.4`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_-4`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_asdfasdfasdf`,
+      result: false,
+    },
+    {
+      index: `opensearch_dashboards_dynamic_config_2`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}3`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}`,
+      result: false,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_0`,
+      result: true,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_1`,
+      result: true,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_141515`,
+      result: true,
+    },
+  ])('isDynamicConfigIndex() should return $result when index is $index', ({ index, result }) => {
+    expect(isDynamicConfigIndex(index)).toBe(result);
+  });
+
+  test.each([
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_-10`,
+      result: 0,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_0`,
+      result: 0,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_1`,
+      result: 1,
+    },
+    {
+      index: `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_5732`,
+      result: 5732,
+    },
+  ])(
+    'extractVersionFromDynamicConfigIndex() should extract number $result from index $index',
+    ({ index, result }) => {
+      expect(extractVersionFromDynamicConfigIndex(index)).toBe(result);
     }
   );
 });

--- a/src/core/server/config/utils/utils.ts
+++ b/src/core/server/config/utils/utils.ts
@@ -75,6 +75,25 @@ export const getDynamicConfigIndexName = (n: number) => {
   return `${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_${n}`;
 };
 
+/**
+ * Basic check to ensure the index matches the pattern (will pass for ${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_0)
+ *
+ * @param index
+ * @returns
+ */
+export const isDynamicConfigIndex = (index: string) => {
+  const regex = new RegExp(`^${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_\\d+$`);
+  return regex.test(index);
+};
+
+export const extractVersionFromDynamicConfigIndex = (index: string) => {
+  if (!isDynamicConfigIndex(index)) {
+    return 0;
+  }
+  const indexSuffix = index.replace(`${DYNAMIC_APP_CONFIG_INDEX_PREFIX}_`, '');
+  return Number(indexSuffix);
+};
+
 export const createLocalStoreFromOsdRequest = (
   logger: Logger,
   request: OpenSearchDashboardsRequest,


### PR DESCRIPTION
### Description

This PR fixes a bug that can occur if the alias `.opensearch_dashboards_dynamic_config` exists but not the index `opensearch_dashboards_dynamic_config_N`. In particular the following test cases are as follows:

| **Alias present?** | **Alias points to what index(es)?**                       | **Expected behavior**           |
|----------------|-------------------------------------------------------|-----------------------------|
| No             | No index                                              | Create new index with alias |
| No             | `.opensearch_dashboards_dynamic_config_N`               | Update index with alias     |
| No             | `.opensearch_dashboards_dynamic_config_1`               | Update index with alias     |
| Yes            | Multiple indexes                                      | Throw error                 |
| Yes            | A non `.opensearch_dashboards_dynamic_config_*` index   | Throw error                 |
| Yes            | A valid `.opensearch_dashboards_dynamic_config_*` index | Do nothing                  |

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Testing the changes

Attached are the following cases when calling dev tools or by looking in application logs:
- No alias, no `.opensearch_dashboards_dynamic_config_1` index
```
GET _cat/indices

yellow open .opensearch_dashboards_dynamic_config_1 sXe3MP8hS7ibdy0KMQwIIQ 1 1 0 0  208b  208b
green  open .kibana_1                               SAzyiuKvSCKNn4zrIVUY9Q 1 0 1 0 5.1kb 5.1kb

GET _cat/aliases
.opensearch_dashboards_dynamic_config .opensearch_dashboards_dynamic_config_1 - - - -
.kibana                               .kibana_1                               - - - -
```

- No alias, `.opensearch_dashboards_dynamic_config_N` present (used below curl command)
```bash
curl -X PUT "http://localhost:9200/.opensearch_dashboards_dynamic_config_4"
```

```
GET _cat/indices

yellow open .opensearch_dashboards_dynamic_config_4 OcHhtiswT7Op03sr260hxg 1 1 0 0  208b  208b
green  open .kibana_1                               VZGJVZFURPiE3Xx3AyTgsg 1 0 1 0 5.1kb 5.1kb

GET _cat/aliases
.opensearch_dashboards_dynamic_config .opensearch_dashboards_dynamic_config_4 - - - -
.kibana                               .kibana_1                               - - - -
```

- No alias, `.opensearch_dashboards_dynamic_config_1` present (used below curl command)
```bash
curl -X PUT "http://localhost:9200/.opensearch_dashboards_dynamic_config_1"
```

```
GET _cat/indices

yellow open ..opensearch_dashboards_dynamic_config i5GcQi6OTEGwvGxI4kKnow 1 1 0 0  208b  208b
green  open .kibana_1                               ytbTll4tQ6mWGGMtiiuEXQ 1 0 1 0 5.1kb 5.1kb

GET _cat/aliases
.opensearch_dashboards_dynamic_config .opensearch_dashboards_dynamic_config_1 - - - -
.kibana                               .kibana_1                               - - - -
```

- Alias, multiple indices pointed to alias
```bash
 FATAL  Error: Alias .opensearch_dashboards_dynamic_config is pointing to 0 or multiple indices. Please remove the alias(es) and restart the server
```

- Alias, `.random_index_3` pointed to alias (used below curl command)
```bash
curl -X PUT "http://localhost:9200/.random_index_3" -H 'Content-Type: application/json' -d '
{
  "aliases": {
    ".opensearch_dashboards_dynamic_config": {}
  }
}
'
```

```
 FATAL  Error: Alias .opensearch_dashboards_dynamic_config is pointing to a non dynamic config index. Please remove the alias and restart the server
```

- Alias, valid `.opensearch_dashboards_dynamic_config_1` pointed to alias
```
GET _cat/indices

yellow open .opensearch_dashboards_dynamic_config_1 i5GcQi6OTEGwvGxI4kKnow 1 1 0 0  208b  208b
green  open .kibana_1                               ytbTll4tQ6mWGGMtiiuEXQ 1 0 1 0 5.1kb 5.1kb

GET _cat/aliases
.opensearch_dashboards_dynamic_config .opensearch_dashboards_dynamic_config_1 - - - -
.kibana                               .kibana_1                               - - - -
```


## Changelog

- fix: Fix bug when dynamic config index and alias are checked

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
