### PR TITLE
[navigation]fix: optimize the logic to detect current nav group

### DIFF
--- a/changelogs/fragments/8189.yml
+++ b/changelogs/fragments/8189.yml
@@ -1,0 +1,3 @@
+fix:
+- Current nav group will be mapped to global system nav group even if user is in a workspace. ([#8189](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8189))
+- Current nav group will be mapped to a nav group even when user is out of a workspace. ([#8189](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8189))

--- a/src/core/public/chrome/nav_group/nav_group_service.test.ts
+++ b/src/core/public/chrome/nav_group/nav_group_service.test.ts
@@ -502,7 +502,7 @@ describe('ChromeNavGroupService#start()', () => {
     expect(currentNavGroup).toBeFalsy();
   });
 
-  it('should erase current nav group if application can only be found in use case but there are more than 1 visible nav groups', async () => {
+  it('should erase current nav group if application can only be found in use case but outside workspace', async () => {
     const uiSettings = uiSettingsServiceMock.createSetupContract();
     const navGroupEnabled$ = new Rx.BehaviorSubject(true);
     uiSettings.get$.mockImplementation(() => navGroupEnabled$);


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR is to fix the bug that:
1. current nav group will be mapped to global system nav group even if user is in a workspace.

https://github.com/user-attachments/assets/08052f01-98ae-4f90-8cf3-337be011ef47

2. current nav group will be mapped to a nav group even when user is out of a workspace.
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/a8795787-6c45-4f3a-921b-72c2e6c6971f">  

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### 1. current nav group will be mapped to global system nav group even if user is in a workspace.

https://github.com/user-attachments/assets/d0f06152-24ee-4599-9bf4-ff82854467dd

### 2. current nav group will be mapped to a nav group even when user is out of a workspace.
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/b577274b-cd74-4b42-8886-2a376ce32c0c">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: current nav group will be mapped to global system nav group even if user is in a workspace.
- fix: current nav group will be mapped to a nav group even when user is out of a workspace.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
