### PR TITLE
Add the version bump per major based on CVE website for path-to-regexp

### DIFF
--- a/changelogs/fragments/8196.yml
+++ b/changelogs/fragments/8196.yml
@@ -1,0 +1,2 @@
+fix:
+- CVE version bumping per major version ([#8196](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8196))

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     "**/yaml": "^2.2.2",
     "path-to-regexp": "1.9.0",
     "**/path-to-regexp@^2.2.1": "6.3.0",
-    "**/path-to-regexp@^6.2.0": "6.3.0"
+    "**/path-to-regexp@^6.2.0": "6.3.0",
+    "**/path-to-regexp@^7.0.0": "8.0.0"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13565,12 +13565,7 @@ path-to-regexp@1.9.0, path-to-regexp@^1.7.0, path-to-regexp@^2.2.1, path-to-rege
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^2.2.1@6.3.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-7.2.0.tgz#3d9cc9d46527e2ce2ef7b2cf696aad3cd1ae4f2b"
-  integrity sha512-0W4AcUxPpFlcS8ql8ZEmFwaI0X5WshUVAFdXe3PBurrt18DK8bvSS+UKHvJUAfGILco/nTtc/E4LcPNfVysfwQ==
-
-path-to-regexp@^6.2.0@6.3.0:
+path-to-regexp@^2.2.1@6.3.0, path-to-regexp@^6.2.0@6.3.0, path-to-regexp@^7.0.0@8.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

### Issues Resolved

https://build.ci.opensearch.org/job/docker-scan/3826/artifact/scan_docker_image.txt/*view*/

## Screenshot

https://build.ci.opensearch.org/job/docker-scan/3826/artifact/scan_docker_image.txt/*view*/

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: CVE version bumping per major version

<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
