### PR TITLE
[Workspace] feat: update workspace server to support data connection type

### DIFF
--- a/changelogs/fragments/8200.yml
+++ b/changelogs/fragments/8200.yml
@@ -1,0 +1,2 @@
+feat:
+- Update workspace server to support data connection type ([#8200](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8200))

--- a/src/plugins/data_source/common/index.ts
+++ b/src/plugins/data_source/common/index.ts
@@ -6,3 +6,4 @@
 export const PLUGIN_ID = 'dataSource';
 export const PLUGIN_NAME = 'data_source';
 export const DATA_SOURCE_SAVED_OBJECT_TYPE = 'data-source';
+export { DATA_CONNECTION_SAVED_OBJECT_TYPE } from './data_connections';

--- a/src/plugins/data_source/opensearch_dashboards.json
+++ b/src/plugins/data_source/opensearch_dashboards.json
@@ -6,5 +6,5 @@
   "ui": true,
   "requiredPlugins": ["opensearchDashboardsUtils"],
   "optionalPlugins": [],
-  "extraPublicDirs": ["common/data_sources", "common/util"]
+  "extraPublicDirs": ["common","common/data_sources", "common/util"]
 }

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -4,7 +4,10 @@
  */
 
 import { i18n } from '@osd/i18n';
-
+import {
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+} from '../../data_source/common';
 export const WORKSPACE_FATAL_ERROR_APP_ID = 'workspace_fatal_error';
 export const WORKSPACE_CREATE_APP_ID = 'workspace_create';
 export const WORKSPACE_LIST_APP_ID = 'workspace_list';
@@ -158,3 +161,9 @@ export enum AssociationDataSourceModalMode {
   DirectQueryConnections = 'direction-query-connections',
 }
 export const USE_CASE_PREFIX = 'use-case-';
+
+// Workspace will handle both data source and data connection type saved object.
+export const WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES = [
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+];

--- a/src/plugins/workspace/common/types.ts
+++ b/src/plugins/workspace/common/types.ts
@@ -7,7 +7,7 @@ import { DataSourceAttributes } from 'src/plugins/data_source/common/data_source
 
 export type DataSource = Pick<
   DataSourceAttributes,
-  'title' | 'description' | 'dataSourceEngineType'
+  'title' | 'description' | 'dataSourceEngineType' | 'type'
 > & {
   // Id defined in SavedObjectAttribute could be single or array, here only should be single string.
   id: string;
@@ -16,6 +16,7 @@ export type DataSource = Pick<
 export enum DataSourceConnectionType {
   OpenSearchConnection,
   DirectQueryConnection,
+  DataConnection,
 }
 
 export interface DataSourceConnection {

--- a/src/plugins/workspace/common/utils.ts
+++ b/src/plugins/workspace/common/utils.ts
@@ -2,10 +2,13 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { USE_CASE_PREFIX } from './constants';
+import { USE_CASE_PREFIX, WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES } from './constants';
 
 // Reference https://github.com/opensearch-project/oui/blob/main/src/services/color/is_valid_hex.ts
 export const validateWorkspaceColor = (color?: string) =>
   !!color && /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(color);
 
 export const getUseCaseFeatureConfig = (useCaseId: string) => `${USE_CASE_PREFIX}${useCaseId}`;
+
+export const validateIsWorkspaceDataSourceAndConnectionObjectType = (type: string) =>
+  WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES.includes(type);

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -204,6 +204,7 @@ export class WorkspaceClient implements IWorkspaceClient {
     settings: {
       dataSources?: string[];
       permissions?: SavedObjectPermissions;
+      dataConnections?: string[];
     }
   ): Promise<IResponse<Pick<WorkspaceAttributeWithPermission, 'id'>>> {
     const path = this.getPath();
@@ -298,6 +299,7 @@ export class WorkspaceClient implements IWorkspaceClient {
     settings: {
       dataSources?: string[];
       permissions?: SavedObjectPermissions;
+      dataConnections?: string[];
     }
   ): Promise<IResponse<boolean>> {
     const path = this.getPath(id);

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -37,10 +37,12 @@ const workspacePermissions = schema.recordOf(
 );
 
 const dataSourceIds = schema.arrayOf(schema.string());
+const dataConnectionIds = schema.arrayOf(schema.string());
 
 const settingsSchema = schema.object({
   permissions: schema.maybe(workspacePermissions),
   dataSources: schema.maybe(dataSourceIds),
+  dataConnections: schema.maybe(dataConnectionIds),
 });
 
 const featuresSchema = schema.arrayOf(schema.string(), {
@@ -203,6 +205,7 @@ export function registerRoutes({
       const principals = permissionControlClient?.getPrincipalsFromRequest(req);
       const createPayload: Omit<WorkspaceAttributeWithPermission, 'id'> & {
         dataSources?: string[];
+        dataConnections?: string[];
       } = attributes;
 
       if (isPermissionControlEnabled) {
@@ -217,6 +220,7 @@ export function registerRoutes({
       }
 
       createPayload.dataSources = settings.dataSources;
+      createPayload.dataConnections = settings.dataConnections;
 
       const result = await client.create(
         {
@@ -255,6 +259,7 @@ export function registerRoutes({
           ...attributes,
           ...(isPermissionControlEnabled ? { permissions: settings.permissions } : {}),
           ...{ dataSources: settings.dataSources },
+          ...{ dataConnections: settings.dataConnections },
         }
       );
       return res.ok({ body: result });

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.test.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.test.ts
@@ -7,7 +7,10 @@ import { SavedObject } from '../../../../core/public';
 import { httpServerMock, savedObjectsClientMock, coreMock } from '../../../../core/server/mocks';
 import { WorkspaceConflictSavedObjectsClientWrapper } from './saved_objects_wrapper_for_check_workspace_conflict';
 import { SavedObjectsSerializer } from '../../../../core/server';
-import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../../plugins/data_source/common';
+import {
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+} from '../../../../plugins/data_source/common';
 
 describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
   const requestHandlerContext = coreMock.createRequestHandlerContext();
@@ -131,6 +134,19 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
         )
       ).rejects.toMatchInlineSnapshot(
         `[Error: Unsupported type in workspace: 'data-source' is not allowed to be created in workspace.]`
+      );
+
+      await expect(
+        wrapperClient.create(
+          DATA_CONNECTION_SAVED_OBJECT_TYPE,
+          {},
+
+          {
+            workspaces: ['foo'],
+          }
+        )
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Unsupported type in workspace: 'data-connection' is not allowed to be created in workspace.]`
       );
 
       await expect(
@@ -336,6 +352,10 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
             type: DATA_SOURCE_SAVED_OBJECT_TYPE,
             id: 'foo',
           }),
+          getSavedObject({
+            type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+            id: 'foo',
+          }),
         ],
         {
           workspaces: ['foo'],
@@ -356,6 +376,13 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
         expect.objectContaining({
           message:
             "Unsupported type in workspace: 'data-source' is not allowed to be imported in workspace.",
+          statusCode: 400,
+        })
+      );
+      expect(result.saved_objects[2].error).toEqual(
+        expect.objectContaining({
+          message:
+            "Unsupported type in workspace: 'data-connection' is not allowed to be imported in workspace.",
           statusCode: 400,
         })
       );
@@ -474,6 +501,10 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
             type: DATA_SOURCE_SAVED_OBJECT_TYPE,
             id: 'foo',
           }),
+          getSavedObject({
+            type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+            id: 'foo',
+          }),
         ],
         {
           workspaces: ['foo'],
@@ -494,6 +525,13 @@ describe('WorkspaceConflictSavedObjectsClientWrapper', () => {
         expect.objectContaining({
           message:
             "Unsupported type in workspace: 'data-source' is not allowed to be imported in workspace.",
+          statusCode: 400,
+        })
+      );
+      expect(result.errors[2].error).toEqual(
+        expect.objectContaining({
+          message:
+            "Unsupported type in workspace: 'data-connection' is not allowed to be imported in workspace.",
           statusCode: 400,
         })
       );

--- a/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
+++ b/src/plugins/workspace/server/saved_objects/saved_objects_wrapper_for_check_workspace_conflict.ts
@@ -17,7 +17,7 @@ import {
   SavedObjectsCheckConflictsResponse,
   SavedObjectsFindOptions,
 } from '../../../../core/server';
-import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../data_source/common';
+import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
 
 const UI_SETTINGS_SAVED_OBJECTS_TYPE = 'config';
 
@@ -42,10 +42,10 @@ export class WorkspaceConflictSavedObjectsClientWrapper {
 
   private isDataSourceType(type: SavedObjectsFindOptions['type']): boolean {
     if (Array.isArray(type)) {
-      return type.every((item) => item === DATA_SOURCE_SAVED_OBJECT_TYPE);
+      return type.every((item) => validateIsWorkspaceDataSourceAndConnectionObjectType(item));
     }
 
-    return type === DATA_SOURCE_SAVED_OBJECT_TYPE;
+    return validateIsWorkspaceDataSourceAndConnectionObjectType(type);
   }
   private isConfigType(type: SavedObject['type']): boolean {
     return type === UI_SETTINGS_SAVED_OBJECTS_TYPE;

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
@@ -7,7 +7,10 @@ import { getWorkspaceState, updateWorkspaceState } from '../../../../core/server
 import { SavedObjectsErrorHelpers } from '../../../../core/server';
 import { WorkspaceSavedObjectsClientWrapper } from './workspace_saved_objects_client_wrapper';
 import { httpServerMock } from '../../../../core/server/mocks';
-import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../data_source/common';
+import {
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+} from '../../../data_source/common';
 
 const DASHBOARD_ADMIN = 'dashboard_admin';
 const NO_DASHBOARD_ADMIN = 'no_dashboard_admin';
@@ -54,9 +57,20 @@ const generateWorkspaceSavedObjectsClientWrapper = (role = NO_DASHBOARD_ADMIN) =
       attributes: { title: 'Global data source' },
     },
     {
+      type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+      id: 'global-data-connection',
+      attributes: { title: 'Global data connection' },
+    },
+    {
       type: DATA_SOURCE_SAVED_OBJECT_TYPE,
       id: 'global-data-source-empty-workspaces',
       attributes: { title: 'Global data source empty workspaces' },
+      workspaces: [],
+    },
+    {
+      type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+      id: 'global-data-connection-empty-workspaces',
+      attributes: { title: 'Global data connection empty workspaces' },
       workspaces: [],
     },
     {
@@ -66,9 +80,21 @@ const generateWorkspaceSavedObjectsClientWrapper = (role = NO_DASHBOARD_ADMIN) =
       workspaces: ['workspace-1'],
     },
     {
+      type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+      id: 'workspace-1-data-connection',
+      attributes: { title: 'Workspace 1 data connection' },
+      workspaces: ['workspace-1'],
+    },
+    {
       type: DATA_SOURCE_SAVED_OBJECT_TYPE,
       id: 'workspace-2-data-source',
       attributes: { title: 'Workspace 2 data source' },
+      workspaces: ['mock-request-workspace-id'],
+    },
+    {
+      type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+      id: 'workspace-2-data-connection',
+      attributes: { title: 'Workspace 2 data connection' },
       workspaces: ['mock-request-workspace-id'],
     },
   ];
@@ -581,7 +607,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
         expect(result).toMatchInlineSnapshot(`[Error: Not Found]`);
       });
 
-      it('should validate data source workspace field', async () => {
+      it('should validate data source or data connection workspace field', async () => {
         const { wrapper } = generateWorkspaceSavedObjectsClientWrapper();
         let errorCatched;
         try {
@@ -593,7 +619,16 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           'Invalid data source permission, please associate it to current workspace'
         );
 
-        const result = await wrapper.get('data-source', 'workspace-2-data-source');
+        try {
+          await wrapper.get('data-connection', 'workspace-1-data-connection');
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
+
+        let result = await wrapper.get('data-source', 'workspace-2-data-source');
         expect(result).toEqual({
           attributes: {
             title: 'Workspace 2 data source',
@@ -602,16 +637,32 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           type: 'data-source',
           workspaces: ['mock-request-workspace-id'],
         });
+        result = await wrapper.get('data-connection', 'workspace-2-data-connection');
+        expect(result).toEqual({
+          attributes: {
+            title: 'Workspace 2 data connection',
+          },
+          id: 'workspace-2-data-connection',
+          type: 'data-connection',
+          workspaces: ['mock-request-workspace-id'],
+        });
       });
 
-      it('should not validate data source when not in workspace', async () => {
+      it('should not validate data source or data connection when not in workspace', async () => {
         const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
         updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
-        const result = await wrapper.get('data-source', 'workspace-1-data-source');
+        let result = await wrapper.get('data-source', 'workspace-1-data-source');
         expect(result).toEqual({
           type: DATA_SOURCE_SAVED_OBJECT_TYPE,
           id: 'workspace-1-data-source',
           attributes: { title: 'Workspace 1 data source' },
+          workspaces: ['workspace-1'],
+        });
+        result = await wrapper.get('data-connection', 'workspace-1-data-connection');
+        expect(result).toEqual({
+          type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+          id: 'workspace-1-data-connection',
+          attributes: { title: 'Workspace 1 data connection' },
           workspaces: ['workspace-1'],
         });
       });
@@ -627,7 +678,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
         });
       });
 
-      it('should throw permission error when tried to access a global data source', async () => {
+      it('should throw permission error when tried to access a global data source or data connection', async () => {
         const { wrapper } = generateWorkspaceSavedObjectsClientWrapper();
         let errorCatched;
         try {
@@ -638,14 +689,30 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
         expect(errorCatched?.message).toEqual(
           'Invalid data source permission, please associate it to current workspace'
         );
+        try {
+          await wrapper.get('data-connection', 'global-data-connection');
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
       });
 
-      it('should throw permission error when tried to access a empty workspaces global data source', async () => {
+      it('should throw permission error when tried to access a empty workspaces global data source or data connection', async () => {
         const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
         updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
         let errorCatched;
         try {
           await wrapper.get('data-source', 'global-data-source-empty-workspaces');
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
+        try {
+          await wrapper.get('data-connection', 'global-data-connection-empty-workspaces');
         } catch (e) {
           errorCatched = e;
         }
@@ -718,7 +785,7 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           {}
         );
       });
-      it('should validate data source workspace field', async () => {
+      it('should validate data source or data connection workspace field', async () => {
         const { wrapper } = generateWorkspaceSavedObjectsClientWrapper();
         let errorCatched;
         try {
@@ -735,7 +802,21 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           'Invalid data source permission, please associate it to current workspace'
         );
 
-        const result = await await wrapper.bulkGet([
+        try {
+          await wrapper.bulkGet([
+            {
+              type: 'data-connection',
+              id: 'workspace-1-data-connection',
+            },
+          ]);
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
+
+        let result = await await wrapper.bulkGet([
           {
             type: 'data-source',
             id: 'workspace-2-data-source',
@@ -753,12 +834,31 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
             },
           ],
         });
+
+        result = await await wrapper.bulkGet([
+          {
+            type: 'data-connection',
+            id: 'workspace-2-data-connection',
+          },
+        ]);
+        expect(result).toEqual({
+          saved_objects: [
+            {
+              attributes: {
+                title: 'Workspace 2 data connection',
+              },
+              id: 'workspace-2-data-connection',
+              type: 'data-connection',
+              workspaces: ['mock-request-workspace-id'],
+            },
+          ],
+        });
       });
 
-      it('should not validate data source when not in workspace', async () => {
+      it('should not validate data source or data connection when not in workspace', async () => {
         const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
         updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
-        const result = await wrapper.bulkGet([
+        let result = await wrapper.bulkGet([
           {
             type: 'data-source',
             id: 'workspace-1-data-source',
@@ -776,9 +876,28 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
             },
           ],
         });
+
+        result = await wrapper.bulkGet([
+          {
+            type: 'data-connection',
+            id: 'workspace-1-data-connection',
+          },
+        ]);
+        expect(result).toEqual({
+          saved_objects: [
+            {
+              attributes: {
+                title: 'Workspace 1 data connection',
+              },
+              id: 'workspace-1-data-connection',
+              type: 'data-connection',
+              workspaces: ['workspace-1'],
+            },
+          ],
+        });
       });
 
-      it('should throw permission error when tried to bulk get global data source', async () => {
+      it('should throw permission error when tried to bulk get global data source or data connection', async () => {
         const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
         updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
         let errorCatched;
@@ -790,9 +909,17 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
         expect(errorCatched?.message).toEqual(
           'Invalid data source permission, please associate it to current workspace'
         );
+        try {
+          await wrapper.bulkGet([{ type: 'data-connection', id: 'global-data-connection' }]);
+        } catch (e) {
+          errorCatched = e;
+        }
+        expect(errorCatched?.message).toEqual(
+          'Invalid data source permission, please associate it to current workspace'
+        );
       });
 
-      it('should throw permission error when tried to bulk get a empty workspace global data source', async () => {
+      it('should throw permission error when tried to bulk get a empty workspace global data source or data connection', async () => {
         const { wrapper, requestMock } = generateWorkspaceSavedObjectsClientWrapper();
         updateWorkspaceState(requestMock, { requestWorkspaceId: undefined });
         let errorCatched;
@@ -806,6 +933,13 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
         expect(errorCatched?.message).toEqual(
           'Invalid data source permission, please associate it to current workspace'
         );
+        try {
+          await wrapper.bulkGet([
+            { type: 'data-connection', id: 'global-data-connection-empty-workspaces' },
+          ]);
+        } catch (e) {
+          errorCatched = e;
+        }
       });
     });
     describe('find', () => {
@@ -1055,6 +1189,20 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           {}
         );
         expect(permissionControlMock.validate).not.toHaveBeenCalled();
+
+        await wrapper.addToWorkspaces(
+          DATA_CONNECTION_SAVED_OBJECT_TYPE,
+          'data-connection-id',
+          ['workspace-1'],
+          {}
+        );
+        expect(clientMock.addToWorkspaces).toHaveBeenCalledWith(
+          DATA_CONNECTION_SAVED_OBJECT_TYPE,
+          'data-connection-id',
+          ['workspace-1'],
+          {}
+        );
+        expect(permissionControlMock.validate).not.toHaveBeenCalled();
       });
       it('should bypass permission check for call client.deleteFromWorkspaces', async () => {
         await wrapper.deleteFromWorkspaces(
@@ -1070,11 +1218,25 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           {}
         );
         expect(permissionControlMock.validate).not.toHaveBeenCalled();
+
+        await wrapper.deleteFromWorkspaces(
+          DATA_CONNECTION_SAVED_OBJECT_TYPE,
+          'data-connection-id',
+          ['workspace-1'],
+          {}
+        );
+        expect(clientMock.deleteFromWorkspaces).toHaveBeenCalledWith(
+          DATA_CONNECTION_SAVED_OBJECT_TYPE,
+          'data-connection-id',
+          ['workspace-1'],
+          {}
+        );
+        expect(permissionControlMock.validate).not.toHaveBeenCalled();
       });
     });
 
     describe('addToWorkspaces', () => {
-      it('should throw error when non dashboard admin add data source to workspaces', async () => {
+      it('should throw error when non dashboard admin add data source or data connection to workspaces', async () => {
         const { wrapper } = generateWorkspaceSavedObjectsClientWrapper();
 
         let errorCatch;
@@ -1086,11 +1248,19 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           errorCatch = e;
         }
         expect(errorCatch.message).toEqual('Invalid permission, please contact OSD admin');
+        try {
+          await wrapper.addToWorkspaces(DATA_CONNECTION_SAVED_OBJECT_TYPE, 'data-connection-id', [
+            'workspace-id',
+          ]);
+        } catch (e) {
+          errorCatch = e;
+        }
+        expect(errorCatch.message).toEqual('Invalid permission, please contact OSD admin');
       });
     });
 
     describe('deleteFromWorkspaces', () => {
-      it('should throw error when non dashboard admin delete data source from workspaces', async () => {
+      it('should throw error when non dashboard admin delete data source or data connection from workspaces', async () => {
         const { wrapper } = generateWorkspaceSavedObjectsClientWrapper();
 
         let errorCatch;
@@ -1098,6 +1268,17 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           await wrapper.deleteFromWorkspaces(DATA_SOURCE_SAVED_OBJECT_TYPE, 'data-source-id', [
             'workspace-id',
           ]);
+        } catch (e) {
+          errorCatch = e;
+        }
+        expect(errorCatch.message).toEqual('Invalid permission, please contact OSD admin');
+
+        try {
+          await wrapper.deleteFromWorkspaces(
+            DATA_CONNECTION_SAVED_OBJECT_TYPE,
+            'data-connection-id',
+            ['workspace-id']
+          );
         } catch (e) {
           errorCatch = e;
         }

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -33,7 +33,7 @@ import {
   WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
   WorkspacePermissionMode,
 } from '../../common/constants';
-import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../../../data_source/common';
+import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
 
 // Can't throw unauthorized for now, the page will be refreshed if unauthorized
 const generateWorkspacePermissionError = () =>
@@ -431,7 +431,7 @@ export class WorkspaceSavedObjectsClientWrapper {
     ): Promise<SavedObject<T>> => {
       const objectToGet = await wrapperOptions.client.get<T>(type, id, options);
 
-      if (objectToGet.type === DATA_SOURCE_SAVED_OBJECT_TYPE) {
+      if (validateIsWorkspaceDataSourceAndConnectionObjectType(objectToGet.type)) {
         if (isDataSourceAdmin) {
           return objectToGet;
         }
@@ -469,7 +469,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       );
 
       for (const object of objectToBulkGet.saved_objects) {
-        if (object.type === DATA_SOURCE_SAVED_OBJECT_TYPE) {
+        if (validateIsWorkspaceDataSourceAndConnectionObjectType(object.type)) {
           const hasPermission = this.validateDataSourcePermissions(object, wrapperOptions.request);
           if (!hasPermission) {
             throw generateDataSourcePermissionError();
@@ -498,10 +498,11 @@ export class WorkspaceSavedObjectsClientWrapper {
       if (
         isDataSourceAdmin &&
         options?.type &&
-        (options.type === DATA_SOURCE_SAVED_OBJECT_TYPE ||
+        ((!Array.isArray(options.type) &&
+          validateIsWorkspaceDataSourceAndConnectionObjectType(options.type)) ||
           (Array.isArray(options.type) &&
             options.type.length === 1 &&
-            options.type[0] === DATA_SOURCE_SAVED_OBJECT_TYPE))
+            validateIsWorkspaceDataSourceAndConnectionObjectType(options.type[0])))
       ) {
         return await wrapperOptions.client.find<T>(options);
       }
@@ -589,7 +590,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       options: SavedObjectsBaseOptions = {}
     ) => {
       // Only dashboard admin can assign data source to workspace
-      if (type === DATA_SOURCE_SAVED_OBJECT_TYPE) {
+      if (validateIsWorkspaceDataSourceAndConnectionObjectType(type)) {
         throw generateOSDAdminPermissionError();
       }
       // In current version, only the type is data-source that will call addToWorkspaces
@@ -603,7 +604,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       options: SavedObjectsBaseOptions = {}
     ) => {
       // Only dashboard admin can unassign data source to workspace
-      if (type === DATA_SOURCE_SAVED_OBJECT_TYPE) {
+      if (validateIsWorkspaceDataSourceAndConnectionObjectType(type)) {
         throw generateOSDAdminPermissionError();
       }
       // In current version, only the type is data-source will that call deleteFromWorkspaces

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -593,7 +593,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       if (validateIsWorkspaceDataSourceAndConnectionObjectType(type)) {
         throw generateOSDAdminPermissionError();
       }
-      // In current version, only the type is data-source that will call addToWorkspaces
+      // In current version, only the type is data-source and data-connection that will call addToWorkspaces
       return await wrapperOptions.client.addToWorkspaces(type, id, targetWorkspaces, options);
     };
 
@@ -603,11 +603,11 @@ export class WorkspaceSavedObjectsClientWrapper {
       targetWorkspaces: string[],
       options: SavedObjectsBaseOptions = {}
     ) => {
-      // Only dashboard admin can unassign data source to workspace
+      // Only dashboard admin can unassign data source and data-connection to workspace
       if (validateIsWorkspaceDataSourceAndConnectionObjectType(type)) {
         throw generateOSDAdminPermissionError();
       }
-      // In current version, only the type is data-source will that call deleteFromWorkspaces
+      // In current version, only the type is data-source and data-connection will that call deleteFromWorkspaces
       return await wrapperOptions.client.deleteFromWorkspaces(type, id, targetWorkspaces, options);
     };
 

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -16,7 +16,11 @@ import {
 } from '../../../core/server';
 import { updateWorkspaceState } from '../../../core/server/utils';
 import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../data_source_management/common';
-import { CURRENT_USER_PLACEHOLDER, WorkspacePermissionMode } from '../common/constants';
+import {
+  CURRENT_USER_PLACEHOLDER,
+  WorkspacePermissionMode,
+  WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
+} from '../common/constants';
 import { PermissionModeId } from '../../../core/server';
 
 /**
@@ -85,8 +89,8 @@ export const transferCurrentUserInPermissions = (
 export const getDataSourcesList = (client: SavedObjectsClientContract, workspaces: string[]) => {
   return client
     .find({
-      type: 'data-source',
-      fields: ['id', 'title'],
+      type: WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
+      fields: ['id', 'title', 'type'],
       perPage: 10000,
       workspaces,
     })
@@ -95,8 +99,10 @@ export const getDataSourcesList = (client: SavedObjectsClientContract, workspace
       if (objects) {
         return objects.map((source) => {
           const id = source.id;
+          const type = source.type;
           return {
             id,
+            type,
           };
         });
       } else {


### PR DESCRIPTION
### Description

Update workspace server to support data connection type

This is a PR picked from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8013, as we want to separate frontend and server changes and merge server changes first for testing, so we extract server changes from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8013 and create this PR.


## Testing the changes

### Create workspace
post http://localhost:6601/api/workspaces
```
{
    "attributes": {
        "name": "workspace-name1",
        "color": "#54B399",
        "features": [
            "use-case-observability"
        ]
    },
    "settings": {
        "dataSources": [],
        "dataConnections": [
            "12345" // data connection object id
        ],
        "permissions": {
            "library_write": {
                "users": [
                    "%me%"
                ]
            },
            "write": {
                "users": [
                    "%me%"
                ]
            }
        }
    }
}
```
Result
```
{
    "success": true,
    "result": {
        "id": "_IlxNR"
    }
}
```


### Update workspace
put http://localhost:6601/api/_IlxNR
```
{
    "attributes": {
        "name": "workspace-name1",
        "color": "#54B399",
        "features": [
            "use-case-observability"
        ]
    },
    "settings": {
        "dataSources": [],
        "dataConnections": [
            "12346" // new data connection object ids that you want to associate
        ],
        "permissions": {
            "library_write": {
                "users": [
                    "%me%"
                ]
            },
            "write": {
                "users": [
                    "%me%"
                ]
            }
        }
    }
}
```
Result
```
{
    "success": true,
    "result": true
}
```

### Verify
get data-connection objects with workspace field 
http://localhost:6601/api/saved_objects/_find?fields=id&fields=title&fields=workspaces&per_page=10000&type=data-connection&workspaces=*

Result
![image](https://github.com/user-attachments/assets/76a952f5-d11b-48c0-a078-1cb7cffbdbcf)


## Changelog

- feat: update workspace server to support data connection type

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
