### PR TITLE
[Discover] Fix the overlap issue of datapicker and query editor input bar for DQL

### DIFF
--- a/changelogs/fragments/8204.yml
+++ b/changelogs/fragments/8204.yml
@@ -1,0 +1,2 @@
+fix:
+- Update the graph ([#8204](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8204))

--- a/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
+++ b/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
@@ -30,20 +30,20 @@
     flex: 1;
     align-self: center;
   }
-}
 
-.datasetSelector__button--truncate {
-  display: flex;
-  align-items: center;
-  max-width: 400px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-
-  .datasetSelector__title {
+  &__button--truncate {
+    display: flex;
+    align-items: center;
+    max-width: 400px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    flex-grow: 1;
+
+    .datasetSelector__title {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      flex-grow: 1;
+    }
   }
 }

--- a/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
+++ b/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
@@ -34,7 +34,7 @@
   &__button--truncate {
     display: flex;
     align-items: center;
-    max-width: 300px;
+    max-width: euiSizeXXL;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
+++ b/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
@@ -34,7 +34,7 @@
   &__button--truncate {
     display: flex;
     align-items: center;
-    max-width: 400px;
+    max-width: 300px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
+++ b/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
@@ -34,7 +34,7 @@
   &__button--truncate {
     display: flex;
     align-items: center;
-    max-width: euiSizeXXL;
+    max-width: 300px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
+++ b/src/plugins/data/public/ui/dataset_selector/_dataset_selector.scss
@@ -31,3 +31,19 @@
     align-self: center;
   }
 }
+
+.datasetSelector__button--truncate {
+  display: flex;
+  align-items: center;
+  max-width: 400px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  .datasetSelector__title {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    flex-grow: 1;
+  }
+}

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -13,6 +13,7 @@ import {
   EuiSelectable,
   EuiSelectableOption,
   EuiToolTip,
+  EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { toMountPoint } from '../../../../opensearch_dashboards_react/public';
@@ -140,7 +141,7 @@ export const DatasetSelector = ({
             onClick={togglePopover}
           >
             <EuiIcon type={datasetIcon} className="datasetSelector__icon" />
-            <span className="datasetSelector__title">{datasetTitle}</span>
+            <EuiText className="datasetSelector__title">{datasetTitle} </EuiText>
           </EuiButtonEmpty>
         </EuiToolTip>
       }

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -134,13 +134,13 @@ export const DatasetSelector = ({
       button={
         <EuiToolTip content={`${selectedDataset?.title ?? 'Select data'}`}>
           <EuiButtonEmpty
-            className="datasetSelector__button"
+            className="datasetSelector__button datasetSelector__button--truncate"
             iconType="arrowDown"
             iconSide="right"
             onClick={togglePopover}
           >
             <EuiIcon type={datasetIcon} className="datasetSelector__icon" />
-            {datasetTitle}
+            <span className="datasetSelector__title">{datasetTitle}</span>
           </EuiButtonEmpty>
         </EuiToolTip>
       }

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -141,7 +141,9 @@ export const DatasetSelector = ({
             onClick={togglePopover}
           >
             <EuiIcon type={datasetIcon} className="datasetSelector__icon" />
-            <EuiText className="datasetSelector__title">{datasetTitle} </EuiText>
+            <EuiText size="s" className="datasetSelector__title">
+              {datasetTitle}
+            </EuiText>
           </EuiButtonEmpty>
         </EuiToolTip>
       }

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -179,7 +179,7 @@
   .osdQueryEditor__input {
     flex: 1 1 auto; // Allow growing and shrinking
     min-width: 0; // Allow shrinking below content size
-    overflow: hidden; // Prevent overflow
+    overflow: visible; // Prevent overflow
   }
 
   .osdQueryEditor__querycontrols {

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -194,6 +194,11 @@
   }
 }
 
+// TODO: improve how this is styled. Styling just for the DQL editor.
+.osdQueryEditor__body .globalFilterGroup__wrapper {
+  margin-top: -$euiSizeS;
+}
+
 .osdQuerEditor__singleLine {
   padding: $euiSizeS;
   background-color: $euiColorEmptyShade;

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -212,7 +212,7 @@
 
 .suggest-widget {
   position: absolute;
-  z-index: 1000;
+  z-index: 1;
 
   &.visible::after {
     position: absolute;

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -162,7 +162,7 @@
   padding: $euiSizeXS;
 
   > * {
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     min-width: 0;
   }
 
@@ -199,7 +199,9 @@
 .osdQuerEditor__singleLine {
   padding: $euiSizeS;
   background-color: $euiColorEmptyShade;
-  overflow: initial !important; // needed for suggestion window, otherwise will be hidden in child
+  overflow: visible !important; // needed for suggestion window
+  position: relative;
+  z-index: 2;  // Same as the input
 
   .monaco-editor .view-overlays .current-line {
     border: none;
@@ -207,7 +209,8 @@
 }
 
 .suggest-widget {
-  position: relative;
+  position: absolute;
+  z-index: 1000;  // Ensure it's above everything else
 
   &.visible::after {
     position: absolute;

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -162,13 +162,8 @@
   padding: $euiSizeXS;
 
   > * {
-    flex: 0 0 auto;
+    flex: 0 0 auto; // Changed from 0 1 auto to prevent shrinking
     min-width: 0;
-  }
-
-  .osdQueryEditor__querycontrols {
-    float: right;
-    margin: $euiSizeS $euiSizeS;
   }
 
   .osdQueryEditor__dataSetPicker {
@@ -182,7 +177,15 @@
   }
 
   .osdQueryEditor__input {
-    flex-grow: 1;
+    flex: 1 1 auto; // Allow growing and shrinking
+    min-width: 0; // Allow shrinking below content size
+    overflow: hidden; // Prevent overflow
+  }
+
+  .osdQueryEditor__querycontrols {
+    display: flex;
+    align-items: center;
+    margin-left: $euiSizeS;
   }
 
   #savedQueryPopover {
@@ -191,17 +194,11 @@
   }
 }
 
-// TODO: improve how this is styled. Styling just for the DQL editor.
-.osdQueryEditor__body .globalFilterGroup__wrapper {
-  margin-top: -$euiSizeS;
-}
-
 .osdQuerEditor__singleLine {
   padding: $euiSizeS;
   background-color: $euiColorEmptyShade;
   overflow: visible !important; // needed for suggestion window
-  position: relative;
-  z-index: 2;  // Same as the input
+  width: 100%; // Ensure it takes full width of its container
 
   .monaco-editor .view-overlays .current-line {
     border: none;
@@ -210,7 +207,7 @@
 
 .suggest-widget {
   position: absolute;
-  z-index: 1000;  // Ensure it's above everything else
+  z-index: 1000;
 
   &.visible::after {
     position: absolute;


### PR DESCRIPTION
### Description

Fix the overlap issue of datapicker and query editor input bar

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

before:

https://github.com/user-attachments/assets/4abfd6cb-870f-4366-9d2f-66c4b3eb5d60


after:

https://github.com/user-attachments/assets/311cfacf-9437-4d59-a13e-2ce6fd76dd5b


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Update the graph
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: [Discover] Fix the overlap issue of datapicker and query editor input bar

- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
