### PR TITLE
Add loading indicator and counter to query result

### DIFF
--- a/changelogs/fragments/8212.yml
+++ b/changelogs/fragments/8212.yml
@@ -1,0 +1,2 @@
+feat:
+- Add loading indicator and counter to query result ([#8212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8212))

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Query Result show error status with error message 2`] = `
+<EuiPopover
+  anchorPosition="downRight"
+  button={
+    <EuiButtonEmpty
+      data-test-subj="queryResultErrorBtn"
+      iconSide="left"
+      iconType="alert"
+      onClick={[Function]}
+      size="xs"
+    >
+      <EuiText
+        color="subdued"
+        size="xs"
+      >
+        Error
+      </EuiText>
+    </EuiButtonEmpty>
+  }
+  closePopover={[Function]}
+  data-test-subj="queryResultError"
+  display="inlineBlock"
+  hasArrow={true}
+  isOpen={false}
+  ownFocus={true}
+  panelPaddingSize="s"
+>
+  <EuiPopoverTitle>
+    ERRORS
+  </EuiPopoverTitle>
+  <div
+    style={
+      Object {
+        "width": "250px",
+      }
+    }
+  >
+    <EuiText
+      size="s"
+    >
+      <strong>
+        Reasons:
+      </strong>
+      error reason
+    </EuiText>
+    <EuiText
+      size="s"
+    >
+      <p>
+        <strong>
+          Details:
+        </strong>
+         
+        error details
+      </p>
+    </EuiText>
+  </div>
+</EuiPopover>
+`;
+
+exports[`Query Result shows loading status 1`] = `""`;

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`Query Result show error status with error message 2`] = `
         <strong>
           Details:
         </strong>
-         
         error details
       </p>
     </EuiText>

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -61,10 +61,10 @@ describe('Query Result', () => {
       },
     };
     const component = mountWithIntl(<QueryResult {...props} />);
-    expect(component.find('EuiText').text()).toEqual('Completed in 2 s');
+    expect(component.find('EuiText').text()).toEqual('Completed in 2.0 s');
   });
 
-  it('shows ready status with round down seconds', () => {
+  it('shows ready status with split seconds', () => {
     const props = {
       queryStatus: {
         status: ResultStatus.READY,
@@ -73,7 +73,7 @@ describe('Query Result', () => {
       },
     };
     const component = mountWithIntl(<QueryResult {...props} />);
-    expect(component.find('EuiText').text()).toEqual('Completed in 2 s');
+    expect(component.find('EuiText').text()).toEqual('Completed in 2.7 s');
   });
 
   it('show error status with error message', () => {

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mountWithIntl, shallowWithIntl } from 'test_utils/enzyme_helpers';
+import { QueryResult } from './query_result';
+
+enum ResultStatus {
+  UNINITIALIZED = 'uninitialized',
+  LOADING = 'loading', // initial data load
+  READY = 'ready', // results came back
+  NO_RESULTS = 'none', // no results came back
+  ERROR = 'error', // error occurred
+}
+
+describe('Query Result', () => {
+  it('shows loading status', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.LOADING,
+        startTime: Number.NEGATIVE_INFINITY,
+      },
+    };
+    const component = shallowWithIntl(<QueryResult {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('shows ready status with complete message', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.READY,
+        startTime: new Date().getTime(),
+      },
+    };
+    const component = mountWithIntl(<QueryResult {...props} />);
+    const loadingIndicator = component.find(`[data-test-subj="queryResultLoading"]`);
+    expect(loadingIndicator.exists()).toBeFalsy();
+    expect(component.find('EuiText').text()).toEqual('Completed');
+  });
+
+  it('shows ready status with complete in miliseconds message', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.READY,
+        startTime: new Date().getTime(),
+        elapsedMs: 500,
+      },
+    };
+    const component = mountWithIntl(<QueryResult {...props} />);
+    expect(component.find('EuiText').text()).toEqual('Completed in 500 ms');
+  });
+
+  it('shows ready status with complete in seconds message', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.READY,
+        startTime: new Date().getTime(),
+        elapsedMs: 2000,
+      },
+    };
+    const component = mountWithIntl(<QueryResult {...props} />);
+    expect(component.find('EuiText').text()).toEqual('Completed in 2 s');
+  });
+
+  it('shows ready status with round down seconds', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.READY,
+        startTime: new Date().getTime(),
+        elapsedMs: 2700,
+      },
+    };
+    const component = mountWithIntl(<QueryResult {...props} />);
+    expect(component.find('EuiText').text()).toEqual('Completed in 2 s');
+  });
+
+  it('show error status with error message', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.ERROR,
+        body: {
+          error: {
+            reason: 'error reason',
+            details: 'error details',
+          },
+          statusCode: 400,
+        },
+      },
+    };
+    const component = shallowWithIntl(<QueryResult {...props} />);
+    expect(component.find(`[data-test-subj="queryResultError"]`).text()).toMatchInlineSnapshot(
+      `"<EuiPopover />"`
+    );
+    component.find(`[data-test-subj="queryResultError"]`).simulate('click');
+    expect(component).toMatchSnapshot();
+  });
+
+  it('returns null when error body is empty', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.ERROR,
+      },
+    };
+    const component = shallowWithIntl(<QueryResult {...props} />);
+    expect(component).toEqual({});
+  });
+});

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -41,8 +41,8 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     setPopover(!isPopoverOpen);
   };
 
-  const getTime = () => {
-    const time = new Date().getTime() - props.queryStatus.startTime!;
+  const updateElapsedTime = () => {
+    const time = Date.now() - (props.queryStatus.startTime || 0);
     if (time > BUFFER_TIME) {
       setElapsedTime(time);
     } else {
@@ -51,7 +51,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
   };
 
   useEffect(() => {
-    const interval = setInterval(getTime, 1000);
+    const interval = setInterval(updateElapsedTime, 1000);
 
     return () => clearInterval(interval);
   });
@@ -69,7 +69,9 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
         isLoading
         data-test-subj="queryResultLoading"
       >
-        {`Loading ${time} s`}
+        {i18n.translate('data.query.languageService.queryResults.completeTime', {
+          defaultMessage: `Loading ${time} s`,
+        })}
       </EuiButtonEmpty>
     );
   }
@@ -77,11 +79,20 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
   if (props.queryStatus.status === ResultStatus.READY) {
     let message;
     if (!props.queryStatus.elapsedMs) {
-      message = 'Completed';
+      message = i18n.translate('data.query.languageService.queryResults.completeTime', {
+        defaultMessage: `Completed`,
+      });
     } else if (props.queryStatus.elapsedMs < 1000) {
-      message = `Completed in ${props.queryStatus.elapsedMs} ms`;
+      message = i18n.translate(
+        'data.query.languageService.queryResults.completeTimeInMiliseconds',
+        {
+          defaultMessage: `Completed in ${props.queryStatus.elapsedMs} ms`,
+        }
+      );
     } else {
-      message = `Completed in ${Math.floor(props.queryStatus.elapsedMs / 1000)} s`;
+      message = i18n.translate('data.query.languageService.queryResults.completeTimeInSeconds', {
+        defaultMessage: `Completed in ${(props.queryStatus.elapsedMs / 1000).toFixed(1)} s`,
+      });
     }
 
     return (
@@ -108,7 +119,9 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
           data-test-subj="queryResultErrorBtn"
         >
           <EuiText size="xs" color="subdued">
-            {'Error'}
+            {i18n.translate('data.query.languageService.queryResults.error', {
+              defaultMessage: `Error`,
+            })}
           </EuiText>
         </EuiButtonEmpty>
       }
@@ -134,7 +147,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
               {i18n.translate('data.query.languageService.queryResults.details', {
                 defaultMessage: `Details:`,
               })}
-            </strong>{' '}
+            </strong>
             {props.queryStatus.body.error.details}
           </p>
         </EuiText>

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -62,7 +62,13 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     }
     const time = Math.floor(elapsedTime / 1000);
     return (
-      <EuiButtonEmpty color="text" size="xs" onClick={() => {}} isLoading>
+      <EuiButtonEmpty
+        color="text"
+        size="xs"
+        onClick={() => {}}
+        isLoading
+        data-test-subj="queryResultLoading"
+      >
         {`Loading ${time} s`}
       </EuiButtonEmpty>
     );
@@ -80,7 +86,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
 
     return (
       <EuiButtonEmpty iconSide="left" iconType={'checkInCircleEmpty'} size="xs" onClick={() => {}}>
-        <EuiText size="xs" color="subdued">
+        <EuiText size="xs" color="subdued" data-test-subj="queryResultCompleteMsg">
           {message}
         </EuiText>
       </EuiButtonEmpty>
@@ -94,7 +100,13 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
   return (
     <EuiPopover
       button={
-        <EuiButtonEmpty iconSide="left" iconType={'alert'} size="xs" onClick={onButtonClick}>
+        <EuiButtonEmpty
+          iconSide="left"
+          iconType={'alert'}
+          size="xs"
+          onClick={onButtonClick}
+          data-test-subj="queryResultErrorBtn"
+        >
           <EuiText size="xs" color="subdued">
             {'Error'}
           </EuiText>
@@ -104,6 +116,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       closePopover={() => setPopover(false)}
       panelPaddingSize="s"
       anchorPosition={'downRight'}
+      data-test-subj="queryResultError"
     >
       <EuiPopoverTitle>ERRORS</EuiPopoverTitle>
       <div style={{ width: '250px' }}>

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -8,7 +8,7 @@ import { i18n } from '@osd/i18n';
 import './_recent_query.scss';
 import { EuiButtonEmpty, EuiPopover, EuiText, EuiPopoverTitle } from '@elastic/eui';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export enum ResultStatus {
   UNINITIALIZED = 'uninitialized',
@@ -28,21 +28,60 @@ export interface QueryStatus {
     statusCode?: number;
   };
   elapsedMs?: number;
+  startTime?: number;
 }
+
+// This is the time in milliseconds that the query will wait before showing the loading spinner
+const BUFFER_TIME = 3000;
 
 export function QueryResult(props: { queryStatus: QueryStatus }) {
   const [isPopoverOpen, setPopover] = useState(false);
+  const [elapsedTime, setElapsedTime] = useState(0);
   const onButtonClick = () => {
     setPopover(!isPopoverOpen);
   };
 
+  const getTime = () => {
+    const time = new Date().getTime() - props.queryStatus.startTime!;
+    if (time > BUFFER_TIME) {
+      setElapsedTime(time);
+    } else {
+      setElapsedTime(0);
+    }
+  };
+
+  useEffect(() => {
+    const interval = setInterval(getTime, 1000);
+
+    return () => clearInterval(interval);
+  });
+
+  if (props.queryStatus.status === ResultStatus.LOADING) {
+    if (elapsedTime < BUFFER_TIME) {
+      return null;
+    }
+    const time = Math.floor(elapsedTime / 1000);
+    return (
+      <EuiButtonEmpty color="text" size="xs" onClick={() => {}} isLoading>
+        {`Loading ${time} s`}
+      </EuiButtonEmpty>
+    );
+  }
+
   if (props.queryStatus.status === ResultStatus.READY) {
+    let message;
+    if (!props.queryStatus.elapsedMs) {
+      message = 'Completed';
+    } else if (props.queryStatus.elapsedMs < 1000) {
+      message = `Completed in ${props.queryStatus.elapsedMs} ms`;
+    } else {
+      message = `Completed in ${Math.floor(props.queryStatus.elapsedMs / 1000)} s`;
+    }
+
     return (
       <EuiButtonEmpty iconSide="left" iconType={'checkInCircleEmpty'} size="xs" onClick={() => {}}>
         <EuiText size="xs" color="subdued">
-          {props.queryStatus.elapsedMs
-            ? `Completed in ${props.queryStatus.elapsedMs} ms`
-            : 'Completed'}
+          {message}
         </EuiText>
       </EuiButtonEmpty>
     );

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -14,7 +14,6 @@ import {
   EuiText,
   PopoverAnchorPosition,
 } from '@elastic/eui';
-import { BehaviorSubject } from 'rxjs';
 import classNames from 'classnames';
 import { isEqual } from 'lodash';
 import React, { Component, createRef, RefObject } from 'react';

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -120,7 +120,7 @@ export const useSearch = (services: DiscoverViewServices) => {
     );
   }, [savedSearch, services.uiSettings, timefilter]);
 
-  const startTime = new Date().getTime();
+  const startTime = Date.now();
   const data$ = useMemo(
     () =>
       new BehaviorSubject<SearchData>({

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -60,6 +60,7 @@ export interface SearchData {
       statusCode?: number;
     };
     elapsedMs?: number;
+    startTime?: number;
   };
 }
 
@@ -119,12 +120,14 @@ export const useSearch = (services: DiscoverViewServices) => {
     );
   }, [savedSearch, services.uiSettings, timefilter]);
 
+  const startTime = new Date().getTime();
   const data$ = useMemo(
     () =>
       new BehaviorSubject<SearchData>({
         status: shouldSearchOnPageLoad() ? ResultStatus.LOADING : ResultStatus.UNINITIALIZED,
+        queryStatus: { startTime },
       }),
-    [shouldSearchOnPageLoad]
+    [shouldSearchOnPageLoad, startTime]
   );
   const refetch$ = useMemo(() => new Subject<SearchRefetch>(), []);
 
@@ -161,7 +164,6 @@ export const useSearch = (services: DiscoverViewServices) => {
     dataset = searchSource.getField('index');
 
     let elapsedMs;
-
     try {
       // Only show loading indicator if we are fetching when the rows are empty
       if (fetchStateRef.current.rows?.length === 0) {
@@ -267,14 +269,14 @@ export const useSearch = (services: DiscoverViewServices) => {
     }
   }, [
     indexPattern,
-    interval,
     timefilter,
     toastNotifications,
+    interval,
     data,
     services,
+    sort,
     savedSearch?.searchSource,
     data$,
-    sort,
     shouldSearchOnPageLoad,
     inspectorAdapters.requests,
   ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15981,7 +15981,7 @@ string-similarity@^4.0.1:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16015,15 +16015,6 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -16103,7 +16094,7 @@ stringify-entities@^3.0.1:
     character-entities-legacy "^1.0.0"
     xtend "^4.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16144,13 +16135,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -18295,7 +18279,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18316,15 +18300,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15981,7 +15981,7 @@ string-similarity@^4.0.1:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16015,6 +16015,15 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -16094,7 +16103,7 @@ stringify-entities@^3.0.1:
     character-entities-legacy "^1.0.0"
     xtend "^4.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16135,6 +16144,13 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -18279,7 +18295,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18300,6 +18316,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Description

* when a query takes longer than 3s to complete, a loading indicator will appear after 3s and will also show a time counter; the completion time will show in seconds.
* when a query takes less than 1s to complete, the completion time will be shown in miliseconds. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/60e9d207-7cd4-4e14-b0f6-42a5a6e6c993




## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: Add loading indicator and counter to query result

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
