### PR TITLE
fix: fix overlay offsets on pages with feature header

### DIFF
--- a/changelogs/fragments/8223.yml
+++ b/changelogs/fragments/8223.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix overlay offsets on pages with feature header ([#8223](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8223))

--- a/src/core/public/chrome/ui/header/header.scss
+++ b/src/core/public/chrome/ui/header/header.scss
@@ -13,7 +13,7 @@
   gap: $euiSizeS;
 
   &.primaryHeader {
-    margin-top: $euiSizeM;
+    padding-top: $euiSizeM;
   }
 
   &.primaryApplicationHeader {


### PR DESCRIPTION
### Description

When overlays are positioned, the body becomes positioned relative. The margin on the feature page header vertically offset the body, which caused absolutely positioned overlays (like tooltips) to be 12px lower than expected. Using padding avoids this offset.

### Issues Resolved
N/A

## Screenshot

Before:
![image](https://github.com/user-attachments/assets/48ed82c7-2d39-4282-8567-035f0abc2049)

After:
![image](https://github.com/user-attachments/assets/5a33f33d-3660-48e6-b9b9-d94f78c62a3d)
![image](https://github.com/user-attachments/assets/6aa72fe3-b31f-43ee-8f34-90794f0ab359)

This should resolve the dropdown issue we were seeing as well.

## Testing the changes

Tested locally

## Changelog
- fix: fix overlay offsets on pages with feature header

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
