### PR TITLE
Change page title of application headers to h1 and xs

### DIFF
--- a/changelogs/fragments/8227.yml
+++ b/changelogs/fragments/8227.yml
@@ -1,0 +1,2 @@
+feat:
+- Adjust semantics and sizing of page titles in application headers ([#8227](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8227))

--- a/src/plugins/navigation/public/top_nav_menu/_index.scss
+++ b/src/plugins/navigation/public/top_nav_menu/_index.scss
@@ -67,7 +67,7 @@
 
 .osdTopNavMenuScreenTitle {
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-  .euiText {
+  .euiTitle {
     line-height: $euiFormControlCompressedHeight;
     white-space: nowrap;
     overflow: hidden;

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiHeaderLinks, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiHeaderLinks, EuiText, EuiTitle } from '@elastic/eui';
 import classNames from 'classnames';
 import React, { ReactElement, useRef } from 'react';
 
@@ -177,7 +177,9 @@ export function TopNavMenu(props: TopNavMenuProps): ReactElement | null {
                 <MountPointPortal setMountPoint={setMenuMountPoint}>
                   <EuiFlexGroup alignItems="stretch" gutterSize="none">
                     <EuiFlexItem grow={false} className="osdTopNavMenuScreenTitle">
-                      <EuiText size="s">{screenTitle}</EuiText>
+                      <EuiTitle size="xs">
+                        <h1>{screenTitle}</h1>
+                      </EuiTitle>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>{renderMenu(menuClassName)}</EuiFlexItem>
                     <EuiFlexItem>{renderSearchBar({ isFilterBarPortable: true })}</EuiFlexItem>
@@ -192,7 +194,9 @@ export function TopNavMenu(props: TopNavMenuProps): ReactElement | null {
               <MountPointPortal setMountPoint={setMenuMountPoint}>
                 <EuiFlexGroup alignItems="stretch" gutterSize="none">
                   <EuiFlexItem grow={false} className="osdTopNavMenuScreenTitle">
-                    <EuiText size="s">{screenTitle}</EuiText>
+                    <EuiTitle size="xs">
+                      <h1>{screenTitle}</h1>
+                    </EuiTitle>
                   </EuiFlexItem>
                   <EuiFlexItem>{renderMenu(menuClassName, true)}</EuiFlexItem>
                 </EuiFlexGroup>
@@ -210,7 +214,9 @@ export function TopNavMenu(props: TopNavMenuProps): ReactElement | null {
                 <MountPointPortal setMountPoint={setMenuMountPoint}>
                   <EuiFlexGroup alignItems="stretch" gutterSize="none">
                     <EuiFlexItem grow={false} className="osdTopNavMenuScreenTitle">
-                      <EuiText size="s">{screenTitle}</EuiText>
+                      <EuiTitle size="xs">
+                        <h1>{screenTitle}</h1>
+                      </EuiTitle>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>{renderMenu(menuClassName)}</EuiFlexItem>
                     <EuiFlexItem className="globalDatePicker">


### PR DESCRIPTION
### Description

Change page title of application headers to h1 and xs

## Screenshot

#### Before

##### v7
![ov7](https://github.com/user-attachments/assets/115321bd-f82b-4e5a-9c6c-69439439ec76)


##### vNext
![ov8](https://github.com/user-attachments/assets/48d403cc-f485-4921-8a28-193871e58bab)


##### v9
![ov9](https://github.com/user-attachments/assets/38c47fcd-1851-4c63-8e33-b1505b7bf32a)

#### After
##### v7
![hv7](https://github.com/user-attachments/assets/934e027c-ce94-459d-9a69-d2095941f47b)

##### vNext
![hv8](https://github.com/user-attachments/assets/365efc8f-7b0a-4158-8f4c-4e78b030b130)


##### v9
![hv9](https://github.com/user-attachments/assets/5f5a4552-098e-4288-8ed6-2decf71e0275)


## Changelog
- feat: Adjust semantics and sizing of page titles in application headers

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
