### PR TITLE
Use @osd/std to prettify objects for display

### DIFF
--- a/changelogs/fragments/8232.yml
+++ b/changelogs/fragments/8232.yml
@@ -1,0 +1,2 @@
+fix:
+- Use @osd/std to prettify objects for display ([#8232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8232))

--- a/src/plugins/data/common/field_formats/utils/as_pretty_string.test.ts
+++ b/src/plugins/data/common/field_formats/utils/as_pretty_string.test.ts
@@ -42,7 +42,11 @@ describe('asPrettyString', () => {
   });
 
   test('Converts objects values into presentable strings', () => {
-    expect(asPrettyString({ key: 'value' })).toBe('{\n  "key": "value"\n}');
+    const longPositive = BigInt(Number.MAX_SAFE_INTEGER) * 2n;
+    const longNegative = BigInt(Number.MIN_SAFE_INTEGER) * 2n;
+    expect(asPrettyString({ key: 'value', longPositive, longNegative })).toBe(
+      `{\n  "key": "value",\n  "longPositive": ${longPositive.toString()},\n  "longNegative": ${longNegative.toString()}\n}`
+    );
   });
 
   test('Converts other non-string values into strings', () => {

--- a/src/plugins/data/common/field_formats/utils/as_pretty_string.ts
+++ b/src/plugins/data/common/field_formats/utils/as_pretty_string.ts
@@ -28,6 +28,8 @@
  * under the License.
  */
 
+import { stringify } from '@osd/std';
+
 /**
  * Convert a value to a presentable string
  */
@@ -37,7 +39,7 @@ export function asPrettyString(val: any): string {
     case 'string':
       return val;
     case 'object':
-      return JSON.stringify(val, null, '  ');
+      return stringify(val, null, '  ');
     default:
       return '' + val;
   }


### PR DESCRIPTION
### Description

Use @osd/std to prettify objects for display

### Issues Resolved

Fixes #8211

## Testing the changes

Follow steps in #8211

## Changelog
- fix: Use @osd/std to prettify objects for display

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
