### PR TITLE
Temporary fix for a bug with Chrome 129 when handling mask-image

### DIFF
--- a/changelogs/fragments/8274.yml
+++ b/changelogs/fragments/8274.yml
@@ -1,0 +1,2 @@
+fix:
+- Add a temporary fix for a bug with Chrome 129 when handling mask-image ([#8274](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8274))

--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -63,3 +63,31 @@ $euiCollapsibleNavWidth: $euiSize * 20;
   height: auto;
   width: auto;
 }
+
+// Temporary fix for a bug with Chrome 129 when handling mask-image
+// OUI provides the mask-image used in these which Chrome 129 fails to render correctly.
+// It is not known if or when Chrome will fix this. Since almost all of these classes
+// are applied to elements with scrollbars where their content contained, containing the
+// paint is a safe solution.
+// This can be achieved with various tricks like transform: translate?(0) or
+// transform-style: preserve-3d but they add to the browsers workload; contain doesn't.
+// ToDo: Remove these when most used versions of Chrome no longer suffer from the bug.
+// From OUI: any ruleset containing mask-image
+.eui-yScrollWithShadows,
+.eui-xScrollWithShadows,
+.euiYScrollWithShadows,
+.euiDataGrid__controlScroll,
+.euiDataGridColumnSelector__columnList,
+.euiDataGridColumnSorting__fieldList,
+.euiFlyoutBody .euiFlyoutBody__overflow,
+.euiFlyoutBody .euiFlyoutBody__overflow.euiFlyoutBody__overflow--hasBanner,
+.euiModalBody .euiModalBody__overflow,
+.euiSelectableList__list,
+// For OSD: consumers of eui?ScrollWithShadows
+.osdQueryBar__textarea:not(:focus):not(:invalid),
+.osdSavedQueryManagement__list,
+.dscCanvas,
+.vbConfig,
+.vbSidenav__style {
+  contain: paint;
+}


### PR DESCRIPTION
### Description

Temporary fix for Chrome's problem with rendering mask images.

OUI provides the mask-image which Chrome 129 fails to render correctly.
It is not known if or when Chrome will fix this. Since almost all of these classes
are applied to elements with scrollbars where their content contained, containing the
paint is a safe solution.

Pulled from https://github.com/opensearch-project/oui/pull/1414

### Issues Resolved

Fixes #8250

## Testing the changes

Follow steps on #8250

## Changelog
- fix: Add a temporary fix for a bug with Chrome 129 when handling mask-image

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
