### PR TITLE
[navigation]feat: remember state when expand / collapse left nav

### DIFF
--- a/changelogs/fragments/8286.yml
+++ b/changelogs/fragments/8286.yml
@@ -1,0 +1,2 @@
+feat:
+- [navigation] remember state when expand / collapse left nav ([#8286](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8286))

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.test.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.test.tsx
@@ -69,7 +69,6 @@ describe('<CollapsibleNavGroupEnabled />', () => {
       appId$: new BehaviorSubject('test'),
       basePath: mockBasePath,
       id: 'collapsibe-nav',
-      isLocked: false,
       isNavOpen: false,
       currentWorkspace$: new BehaviorSubject<WorkspaceObject | null>({ id: 'test', name: 'test' }),
       navLinks$: new BehaviorSubject([
@@ -94,7 +93,6 @@ describe('<CollapsibleNavGroupEnabled />', () => {
         ...(props?.navLinks || []),
       ]),
       storage: new StubBrowserStorage(),
-      onIsLockedUpdate: () => {},
       closeNav: () => {},
       navigateToApp: () => Promise.resolve(),
       navigateToUrl: () => Promise.resolve(),

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -23,7 +23,6 @@ import { ChromeNavControl, ChromeNavLink } from '../..';
 import { AppCategory, NavGroupType } from '../../../../types';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
-import { OnIsLockedUpdate } from './';
 import { createEuiListItem } from './nav_link';
 import type { Logos } from '../../../../common/types';
 import {
@@ -42,11 +41,9 @@ export interface CollapsibleNavGroupEnabledProps {
   collapsibleNavHeaderRender?: () => JSX.Element | null;
   basePath: HttpStart['basePath'];
   id: string;
-  isLocked: boolean;
   isNavOpen: boolean;
   navLinks$: Rx.Observable<ChromeNavLink[]>;
   storage?: Storage;
-  onIsLockedUpdate: OnIsLockedUpdate;
   closeNav: () => void;
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
@@ -80,10 +77,8 @@ enum NavWidth {
 export function CollapsibleNavGroupEnabled({
   basePath,
   id,
-  isLocked,
   isNavOpen,
   storage = window.localStorage,
-  onIsLockedUpdate,
   closeNav,
   navigateToApp,
   navigateToUrl,

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -257,4 +257,19 @@ describe('Header', () => {
     expect(component.find('[data-test-subj="headerRightControl"]').exists()).toBeFalsy();
     expect(component).toMatchSnapshot();
   });
+
+  it('should remember the collapse state when new nav is enabled', () => {
+    const branding = {
+      useExpandedHeader: false,
+    };
+    const props = {
+      ...mockProps(),
+      branding,
+      navGroupEnabled: true,
+      storage: new StubBrowserStorage(),
+    };
+    const component = mountWithIntl(<Header {...props} />);
+    component.find(EuiHeaderSectionItemButton).first().simulate('click');
+    expect(props.storage.getItem('core.leftNav.navGroupEnabled-true.isNavOpen')).toEqual('true');
+  });
 });

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -265,11 +265,11 @@ describe('Header', () => {
     const props = {
       ...mockProps(),
       branding,
-      navGroupEnabled: true,
-      storage: new StubBrowserStorage(),
+      useUpdatedHeader: true,
+      onIsLockedUpdate: jest.fn(),
     };
     const component = mountWithIntl(<Header {...props} />);
     component.find(EuiHeaderSectionItemButton).first().simulate('click');
-    expect(props.storage.getItem('core.leftNav.navGroupEnabled-true.isNavOpen')).toEqual('true');
+    expect(props.onIsLockedUpdate).toBeCalledWith(true);
   });
 });

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -152,7 +152,7 @@ export function Header({
   const isVisible = useObservable(observables.isVisible$, false);
   const headerVariant = useObservable(observables.headerVariant$, HeaderVariant.PAGE);
   const isLocked = useObservable(observables.isLocked$, false);
-  const [isNavOpenState, setIsNavOpenState] = useState(isLocked);
+  const [isNavOpenState, setIsNavOpenState] = useState(false);
   const sidecarConfig = useObservable(observables.sidecarConfig$, undefined);
   const breadcrumbs = useObservable(observables.breadcrumbs$, []);
   const currentWorkspace = useObservable(observables.currentWorkspace$, undefined);


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
When new left nav is enabled, we should remember the state of the left nav.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/e87479c9-ed15-427b-8a5a-f39d7236d150

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [navigation] remember state when expand / collapse left nav

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
