### PR TITLE
[navigation]fix: add xxl and xxxl for left nav responsiveness

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -10442,7 +10442,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
               aria-expanded={false}
               aria-label="Toggle primary navigation"
               aria-pressed={false}
-              className="newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+              className="newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
               data-test-subj="toggleNavButton"
               flush="both"
               isSmallScreen={true}
@@ -10460,7 +10460,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                       aria-expanded="false"
                       aria-label="Toggle primary navigation"
                       aria-pressed="false"
-                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
                       data-test-subj="toggleNavButton"
                       type="button"
                     >
@@ -10491,7 +10491,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                     </button>,
                   }
                 }
-                className="euiHeaderSectionItemButton newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+                className="euiHeaderSectionItemButton newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
                 color="text"
                 data-test-subj="toggleNavButton"
                 flush="both"
@@ -10503,7 +10503,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                   aria-expanded={false}
                   aria-label="Toggle primary navigation"
                   aria-pressed={false}
-                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newAppTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
                   data-test-subj="toggleNavButton"
                   disabled={false}
                   isSmallScreen={true}
@@ -19316,7 +19316,7 @@ exports[`Header renders page header with application title 1`] = `
               aria-expanded={false}
               aria-label="Toggle primary navigation"
               aria-pressed={false}
-              className="newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+              className="newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
               data-test-subj="toggleNavButton"
               flush="both"
               isSmallScreen={true}
@@ -19334,7 +19334,7 @@ exports[`Header renders page header with application title 1`] = `
                       aria-expanded="false"
                       aria-label="Toggle primary navigation"
                       aria-pressed="false"
-                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
                       data-test-subj="toggleNavButton"
                       type="button"
                     >
@@ -19365,7 +19365,7 @@ exports[`Header renders page header with application title 1`] = `
                     </button>,
                   }
                 }
-                className="euiHeaderSectionItemButton newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+                className="euiHeaderSectionItemButton newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
                 color="text"
                 data-test-subj="toggleNavButton"
                 flush="both"
@@ -19377,7 +19377,7 @@ exports[`Header renders page header with application title 1`] = `
                   aria-expanded={false}
                   aria-label="Toggle primary navigation"
                   aria-pressed={false}
-                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l"
+                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushBoth euiHeaderSectionItemButton newPageTopNavExpander navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl"
                   data-test-subj="toggleNavButton"
                   disabled={false}
                   isSmallScreen={true}

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -368,7 +368,7 @@ export function CollapsibleNavGroupEnabled({
   return (
     <>
       <EuiHideFor sizes={['xs', 's', 'm']}>{rendeLeftNav()}</EuiHideFor>
-      <EuiHideFor sizes={['xl', 'l']}>
+      <EuiHideFor sizes={['xl', 'l', 'xxl', 'xxxl']}>
         {isNavOpen
           ? rendeLeftNav({
               type: 'overlay',

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -11,6 +11,7 @@ import {
   EuiSpacer,
   EuiHideFor,
   EuiFlyoutProps,
+  EuiShowFor,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React, { useMemo } from 'react';
@@ -368,7 +369,7 @@ export function CollapsibleNavGroupEnabled({
   return (
     <>
       <EuiHideFor sizes={['xs', 's', 'm']}>{rendeLeftNav()}</EuiHideFor>
-      <EuiHideFor sizes={['xl', 'l', 'xxl', 'xxxl']}>
+      <EuiShowFor sizes={['xs', 's', 'm']}>
         {isNavOpen
           ? rendeLeftNav({
               type: 'overlay',
@@ -378,7 +379,7 @@ export function CollapsibleNavGroupEnabled({
               ownFocus: true,
             })
           : null}
-      </EuiHideFor>
+      </EuiShowFor>
     </>
   );
 }

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -282,7 +282,8 @@ export function Header({
             })}
         {renderNavToggleWithExtraProps({
           flush: 'both',
-          className: 'navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l',
+          className:
+            'navToggleInSmallScreen eui-hideFor--xl eui-hideFor--l eui-hideFor--xxl eui-hideFor--xxxl',
           isSmallScreen: true,
         })}
       </>


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
OUI v13.0 introduces xxl and xxxl, and it breaks the behavior of responsiveness break points when the screen is larger than 1679px. Comply 2 components with the new introduced `hideFor` classes to fix the issue.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Before the fix

https://github.com/user-attachments/assets/1197ca3d-22a5-47da-bd0d-af38e93532d7

### After the fix
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/2f22366d-e342-40ec-9061-9bdfcb027d5e">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
