### PR TITLE
Expose datasets and data_frames directories for specific imports

### DIFF
--- a/changelogs/fragments/8299.yml
+++ b/changelogs/fragments/8299.yml
@@ -1,0 +1,2 @@
+fix:
+- Expose datasets and data_frames directories for specific imports ([#8299](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8299))

--- a/src/plugins/data/opensearch_dashboards.json
+++ b/src/plugins/data/opensearch_dashboards.json
@@ -5,7 +5,13 @@
   "ui": true,
   "requiredPlugins": ["expressions", "uiActions"],
   "optionalPlugins": ["usageCollection", "dataSource"],
-  "extraPublicDirs": ["common", "common/utils/abort_utils", "common/index_patterns/utils.ts"],
+  "extraPublicDirs": [
+    "common", 
+    "common/utils/abort_utils", 
+    "common/index_patterns/utils.ts", 
+    "common/data_frames", 
+    "common/datasets"
+  ],
   "requiredBundles": [
     "usageCollection",
     "opensearchDashboardsUtils",


### PR DESCRIPTION
### Description
Expose datasets and data_frames directories for specific imports. This will ensure that external plugins consuming the data plugins can import from these sub directories to avoid importing complete common code 

## Changelog

- fix: Expose datasets and data_frames directories for specific imports

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
