### PR TITLE
  [WIP][discover][s3] fetch options with fields and caches it

### DIFF
--- a/src/plugins/data/common/constants.ts
+++ b/src/plugins/data/common/constants.ts
@@ -104,6 +104,7 @@ export const UI_SETTINGS = {
   FILTERS_PINNED_BY_DEFAULT: 'filters:pinnedByDefault',
   FILTERS_EDITOR_SUGGEST_VALUES: 'filterEditor:suggestValues',
   QUERY_ENHANCEMENTS_ENABLED: 'query:enhancements:enabled',
+  QUERY_CACHED_DATA_STRUCTURES_TTL: 'query:cachedDataStructures:ttl',
   QUERY_DATAFRAME_HYDRATION_STRATEGY: 'query:dataframe:hydrationStrategy',
   SEARCH_QUERY_LANGUAGE_BLOCKLIST: 'search:queryLanguageBlocklist',
   NEW_HOME_PAGE: 'home:useNewHomePage',

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -160,6 +160,7 @@ export interface DataStructureCustomMeta {
   icon?: EuiIconProps;
   tooltip?: string;
   updatedAt?: number;
+  isCacheable?: boolean;
   [key: string]: any;
 }
 

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -159,6 +159,7 @@ export interface DataStructureCustomMeta {
   type: DATA_STRUCTURE_META_TYPES.CUSTOM;
   icon?: EuiIconProps;
   tooltip?: string;
+  updatedAt?: number;
   [key: string]: any;
 }
 

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -102,7 +102,12 @@ export class DatasetService {
     const cacheKey = `${dataType}.${lastPathItem.id}`;
 
     const cachedDataStructure = this.sessionStorage.get<CachedDataStructure>(cacheKey);
-    if (cachedDataStructure?.children?.length > 0) {
+    if (
+      cachedDataStructure?.children?.length > 0 &&
+      (!cachedDataStructure?.meta?.updatedAt ||
+        Date.now() - cachedDataStructure?.meta?.updatedAt <
+          this.uiSettings.get(UI_SETTINGS.QUERY_CACHED_DATA_STRUCTURES_TTL))
+    ) {
       return this.cacheToDataStructure(dataType, cachedDataStructure);
     }
 

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -13,6 +13,7 @@ import {
   UI_SETTINGS,
   DataStorage,
   CachedDataStructure,
+  DataStructureCustomMeta,
 } from '../../../../common';
 import { DatasetTypeConfig } from './types';
 import { indexPatternTypeConfig, indexTypeConfig } from './lib';
@@ -62,7 +63,7 @@ export class DatasetService {
     return this.defaultDataset;
   }
 
-  public async cacheDataset(dataset: Dataset): Promise<void> {
+  public async cacheDataset(services: IDataPluginServices, dataset: Dataset): Promise<void> {
     const type = this.getType(dataset.type);
     if (dataset) {
       const spec = {
@@ -72,7 +73,7 @@ export class DatasetService {
           name: dataset.timeFieldName,
           type: 'date',
         } as Partial<IFieldType>,
-        fields: await type?.fetchFields(dataset),
+        fields: await type?.fetchFields(services, dataset),
         dataSourceRef: dataset.dataSource
           ? {
               id: dataset.dataSource.id!,
@@ -143,6 +144,9 @@ export class DatasetService {
   }
 
   private cacheDataStructure(dataType: string, dataStructure: DataStructure) {
+    const isCacheable = (dataStructure.meta as DataStructureCustomMeta)?.isCacheable ?? true;
+    if (!isCacheable) return;
+
     const cachedDataStructure: CachedDataStructure = {
       id: dataStructure.id,
       title: dataStructure.title,

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
@@ -9,6 +9,7 @@ import { indexPatternTypeConfig } from './index_pattern_type';
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { DATA_STRUCTURE_META_TYPES, DataStructure, Dataset } from '../../../../../common';
 import * as services from '../../../../services';
+import { IDataPluginServices } from '../../../../types';
 
 jest.mock('../../../../services', () => ({
   getIndexPatterns: jest.fn(),
@@ -60,7 +61,10 @@ describe('indexPatternTypeConfig', () => {
     (services.getIndexPatterns as jest.Mock).mockReturnValue({ get: mockGet });
 
     const mockDataset: Dataset = { id: 'test-pattern', title: 'Test', type: 'INDEX_PATTERN' };
-    const result = await indexPatternTypeConfig.fetchFields(mockDataset);
+    const result = await indexPatternTypeConfig.fetchFields(
+      mockServices as IDataPluginServices,
+      mockDataset
+    );
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({ name: 'field1', type: 'string' });

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -55,7 +55,7 @@ export const indexPatternTypeConfig: DatasetTypeConfig = {
     };
   },
 
-  fetchFields: async (dataset: Dataset): Promise<DatasetField[]> => {
+  fetchFields: async (_, dataset: Dataset): Promise<DatasetField[]> => {
     const indexPattern = await getIndexPatterns().get(dataset.id);
     return indexPattern.fields.map((field: any) => ({
       name: field.name,

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
@@ -9,6 +9,7 @@ import { indexTypeConfig } from './index_type';
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { DATA_STRUCTURE_META_TYPES, DataStructure, Dataset } from '../../../../../common';
 import * as services from '../../../../services';
+import { IDataPluginServices } from '../../../../types';
 
 jest.mock('../../../../services', () => ({
   getSearchService: jest.fn(),
@@ -66,7 +67,10 @@ describe('indexTypeConfig', () => {
     });
 
     const mockDataset: Dataset = { id: 'index1', title: 'Index 1', type: 'INDEX' };
-    const result = await indexTypeConfig.fetchFields(mockDataset);
+    const result = await indexTypeConfig.fetchFields(
+      mockServices as IDataPluginServices,
+      mockDataset
+    );
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({ name: 'field1', type: 'string' });

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -72,7 +72,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
     }
   },
 
-  fetchFields: async (dataset) => {
+  fetchFields: async (_, dataset) => {
     const fields = await getIndexPatterns().getFieldsForWildcard({
       pattern: dataset.title,
       dataSourceId: dataset.dataSource?.id,

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -36,9 +36,11 @@ export interface DatasetTypeConfig {
   fetch: (services: IDataPluginServices, path: DataStructure[]) => Promise<DataStructure>;
   /**
    * Fetches fields for the dataset.
+   * @param {IDataPluginServices} services - The data plugin services.
+   * @param {Dataset} dataset - The current dataset.
    * @returns {Promise<DatasetField[]>} A promise that resolves to an array of DatasetFields.
    */
-  fetchFields: (dataset: Dataset) => Promise<DatasetField[]>;
+  fetchFields: (services: IDataPluginServices, dataset: Dataset) => Promise<DatasetField[]>;
   /**
    * Retrieves the supported query languages for this dataset type.
    * @returns {Promise<string[]>} A promise that resolves to an array of supported language ids.

--- a/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
@@ -52,6 +52,7 @@ export const AdvancedSelector = ({
 
   return selectedDataset ? (
     <Configurator
+      services={services}
       baseDataset={selectedDataset}
       onConfirm={onSelect}
       onCancel={onCancel}

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -21,13 +21,16 @@ import { FormattedMessage } from '@osd/i18n/react';
 import React, { useEffect, useState } from 'react';
 import { BaseDataset, Dataset, DatasetField } from '../../../common';
 import { getIndexPatterns, getQueryService } from '../../services';
+import { IDataPluginServices } from '../../types';
 
 export const Configurator = ({
+  services,
   baseDataset,
   onConfirm,
   onCancel,
   onPrevious,
 }: {
+  services: IDataPluginServices;
   baseDataset: BaseDataset;
   onConfirm: (dataset: Dataset) => void;
   onCancel: () => void;
@@ -56,14 +59,14 @@ export const Configurator = ({
       const datasetFields = await queryString
         .getDatasetService()
         .getType(baseDataset.type)
-        ?.fetchFields(baseDataset);
+        ?.fetchFields(services, baseDataset);
 
       const dateFields = datasetFields?.filter((field) => field.type === 'date');
       setTimeFields(dateFields || []);
     };
 
     fetchFields();
-  }, [baseDataset, indexPatternsService, queryString]);
+  }, [baseDataset, indexPatternsService, queryString, services]);
 
   return (
     <>
@@ -161,7 +164,7 @@ export const Configurator = ({
         </EuiButton>
         <EuiButton
           onClick={async () => {
-            await queryString.getDatasetService().cacheDataset(dataset);
+            await queryString.getDatasetService().cacheDataset(services, dataset);
             onConfirm(dataset);
           }}
           fill

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -720,6 +720,20 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
       requiresPageReload: true,
       schema: schema.boolean(),
     },
+    [UI_SETTINGS.QUERY_CACHED_DATA_STRUCTURES_TTL]: {
+      name: i18n.translate('data.advancedSettings.query.cachedDataStructures.ttl', {
+        defaultMessage: 'Cached data structures TTL',
+      }),
+      value: 600000,
+      description: i18n.translate('data.advancedSettings.query.cachedDataStructures.ttl', {
+        defaultMessage: `
+          <strong>Experimental</strong>:
+          Cached data structures TTL before refetching if the data type has it configured.`,
+      }),
+      category: ['search'],
+      requiresPageReload: true,
+      schema: schema.oneOf([schema.number({ min: 0 }), schema.literal('Infinity')]),
+    },
     [UI_SETTINGS.QUERY_DATAFRAME_HYDRATION_STRATEGY]: {
       name: i18n.translate('data.advancedSettings.query.dataFrameHydrationStrategyTitle', {
         defaultMessage: 'Data frame hydration strategy',

--- a/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
@@ -146,7 +146,7 @@ describe('s3TypeConfig', () => {
 
   test('fetchFields returns empty array', async () => {
     const mockDataset: Dataset = { id: 'table1', title: 'Table 1', type: 'S3' };
-    const result = await s3TypeConfig.fetchFields(mockDataset);
+    const result = await s3TypeConfig.fetchFields(mockServices as IDataPluginServices, mockDataset);
 
     expect(result).toEqual([]);
   });

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -146,6 +146,7 @@ const setMeta = (dataStructure: DataStructure, response: any) => {
     ...dataStructure.meta,
     queryId: response.queryId,
     sessionId: response.sessionId,
+    updatedAt: Date.now(),
   } as DataStructureCustomMeta;
 };
 


### PR DESCRIPTION
### Description

NOTE: Contains commit from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8271. For this PR just look at: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8304/commits/a9fa1dfad809cd7522ebd150137dda983bd1d1f6

NOTE: Currently does not work. Could it be the wrong query being sent?

Follow-up item should be what happens in the case where fetch fields fails? Or takes too long? Should we put a spinner on the configurator to not display until fetch fields has return a result (regardless of success or fail). Should we disable the `Select data` if fields have not returned a result?

With sample it did send
    `DESCRIBE default.http_logs_partitioned`
    
But failed with: Total size of serialized results of 6 task is bigger than maxResult size.

Otherwise it should be calling the same helper functions that cache the data structure.

### Issues Resolved

n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
