### PR TITLE
fix: update osd to respect new oui breakpoints

### DIFF
--- a/changelogs/fragments/8320.yml
+++ b/changelogs/fragments/8320.yml
@@ -1,0 +1,2 @@
+fix:
+- Update osd to respect new oui breakpoints ([#8320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8320))

--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -1860,6 +1860,8 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
                 Array [
                   "l",
                   "xl",
+                  "xxl",
+                  "xxxl",
                 ]
               }
             >
@@ -3065,6 +3067,8 @@ exports[`CollapsibleNav renders the default nav 3`] = `
                 Array [
                   "l",
                   "xl",
+                  "xxl",
+                  "xxxl",
                 ]
               }
             >
@@ -4182,6 +4186,8 @@ exports[`CollapsibleNav with custom branding renders the nav bar in dark mode 1`
                 Array [
                   "l",
                   "xl",
+                  "xxl",
+                  "xxxl",
                 ]
               }
             >
@@ -5298,6 +5304,8 @@ exports[`CollapsibleNav with custom branding renders the nav bar in default mode
                 Array [
                   "l",
                   "xl",
+                  "xxl",
+                  "xxxl",
                 ]
               }
             >
@@ -6407,6 +6415,8 @@ exports[`CollapsibleNav without custom branding renders the nav bar in dark mode
                 Array [
                   "l",
                   "xl",
+                  "xxl",
+                  "xxxl",
                 ]
               }
             >
@@ -7512,6 +7522,8 @@ exports[`CollapsibleNav without custom branding renders the nav bar in default m
                 Array [
                   "l",
                   "xl",
+                  "xxl",
+                  "xxxl",
                 ]
               }
             >

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3431,6 +3431,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                       "m",
                       "l",
                       "xl",
+                      "xxl",
+                      "xxxl",
                     ]
                   }
                 >
@@ -3571,6 +3573,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                       "m",
                       "l",
                       "xl",
+                      "xxl",
+                      "xxxl",
                     ]
                   }
                 >
@@ -4184,6 +4188,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                         "m",
                         "l",
                         "xl",
+                        "xxl",
+                        "xxxl",
                       ]
                     }
                   >
@@ -4336,6 +4342,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                         "m",
                         "l",
                         "xl",
+                        "xxl",
+                        "xxxl",
                       ]
                     }
                   />
@@ -8680,6 +8688,8 @@ exports[`Header handles visibility and lock changes 1`] = `
                     Array [
                       "l",
                       "xl",
+                      "xxl",
+                      "xxxl",
                     ]
                   }
                 >
@@ -27695,6 +27705,8 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
                     Array [
                       "l",
                       "xl",
+                      "xxl",
+                      "xxxl",
                     ]
                   }
                 >

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -282,7 +282,7 @@ export function CollapsibleNav({
         ))}
 
         {/* Docking button only for larger screens that can support it*/}
-        <EuiShowFor sizes={['l', 'xl']}>
+        <EuiShowFor sizes={['l', 'xl', 'xxl', 'xxxl']}>
           <EuiCollapsibleNavGroup>
             <EuiListGroup flush>
               <EuiListGroupItem

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -197,7 +197,7 @@ export function Header({
         },
         {
           items: [
-            <EuiShowFor sizes={['m', 'l', 'xl']}>
+            <EuiShowFor sizes={['m', 'l', 'xl', 'xxl', 'xxxl']}>
               <HeaderNavControls navControls$={observables.navControlsExpandedCenter$} />
             </EuiShowFor>,
           ],
@@ -205,7 +205,7 @@ export function Header({
         },
         {
           items: [
-            <EuiHideFor sizes={['m', 'l', 'xl']}>
+            <EuiHideFor sizes={['m', 'l', 'xl', 'xxl', 'xxxl']}>
               <HeaderNavControls navControls$={observables.navControlsExpandedCenter$} />
             </EuiHideFor>,
             <HeaderNavControls navControls$={observables.navControlsExpandedRight$} />,

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -122,7 +122,7 @@
 }
 
 // IE specific fix for the datepicker to not collapse
-@include euiBreakpoint("m", "l", "xl") {
+@include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
   .osdQueryEditor__datePickerWrapper {
     max-width: 40vw;
     flex-grow: 0 !important;

--- a/src/plugins/data/public/ui/query_string_input/_query_bar.scss
+++ b/src/plugins/data/public/ui/query_string_input/_query_bar.scss
@@ -72,7 +72,7 @@
 }
 
 // IE specific fix for the datepicker to not collapse
-@include euiBreakpoint("m", "l", "xl") {
+@include euiBreakpoint("m", "l", "xl", "xxl", "xxl") {
   .osdQueryBar__datePickerWrapper {
     max-width: 40vw;
     flex-grow: 0 !important;

--- a/src/plugins/home/public/application/components/_solutions_section.scss
+++ b/src/plugins/home/public/application/components/_solutions_section.scss
@@ -45,7 +45,7 @@
     max-width: calc(75% - #{$euiSizeM * 2});
   }
 
-  @include euiBreakpoint("xl") {
+  @include euiBreakpoint("xl", "xxl", "xxxl") {
     max-width: calc(50% - #{$euiSizeM * 2});
   }
 }

--- a/src/plugins/opensearch_dashboards_overview/public/components/_overview.scss
+++ b/src/plugins/opensearch_dashboards_overview/public/components/_overview.scss
@@ -56,13 +56,13 @@
 
 .osdOverviewApps__item {
   .osdOverviewApps__group--primary & {
-    @include euiBreakpoint("m", "l", "xl") {
+    @include euiBreakpoint("m", "l", "xl", "xxl", "xxl") {
       max-width: calc(50% - #{$euiSizeM * 2});
     }
   }
 
   .osdOverviewApps__group--secondary & {
-    @include euiBreakpoint("m", "l", "xl") {
+    @include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
       max-width: calc(25% - #{$euiSizeM * 2});
     }
   }
@@ -86,7 +86,7 @@
 }
 
 .osdOverviewMore__item {
-  @include euiBreakpoint("m", "l", "xl") {
+  @include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
     max-width: calc(33.3333% - #{$euiSizeM * 2});
   }
 }
@@ -101,13 +101,13 @@
 
 .osdOverviewSupplements--noNews .osdOverviewMore {
   h2 {
-    @include euiBreakpoint("m", "l", "xl") {
+    @include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
       text-align: center;
     }
   }
 
   .osdOverviewMore__content {
-    @include euiBreakpoint("m", "l", "xl") {
+    @include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
       justify-content: center;
     }
   }
@@ -129,7 +129,7 @@
 }
 
 .osdOverviewDataManage__item:not(:only-child) {
-  @include euiBreakpoint("m", "l", "xl") {
+  @include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
     flex: 0 0 calc(50% - #{$euiSizeM * 2});
   }
 }

--- a/src/plugins/vis_default_editor/public/_default.scss
+++ b/src/plugins/vis_default_editor/public/_default.scss
@@ -22,7 +22,7 @@
     width: 100% !important;
   }
 
-  @include euiBreakpoint("l", "xl") {
+  @include euiBreakpoint("l", "xl", "xxl", "xxxl") {
     max-width: 75%;
   }
 }

--- a/src/plugins/vis_default_editor/public/_sidebar.scss
+++ b/src/plugins/vis_default_editor/public/_sidebar.scss
@@ -33,7 +33,7 @@
     flex-grow: 0;
   }
 
-  @include euiBreakpoint("l", "xl") {
+  @include euiBreakpoint("l", "xl", "xxl", "xxxl") {
     @include flex-parent(1, 1, 1px);
     @include euiScrollBar;
 


### PR DESCRIPTION
### Description

[New breakpoints were added to OUI](https://github.com/opensearch-project/oui/commit/b8a9daa3edc9e6af0b4b07ef5b6a19a5b4410cd3) but OSD did not respect them, causing some bugs. This tries to address that by looking for consumption of breakpoints and just treating largest sizes like xl.

This incorporates https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8289.

### Issues Resolved

N/A

## Screenshot

N/A

## Testing the changes

Tested some of these cases locally.

## Changelog
- fix: update osd to respect new oui breakpoints

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
