### PR TITLE
fix discover input background not shrink

### DIFF
--- a/changelogs/fragments/8331.yml
+++ b/changelogs/fragments/8331.yml
@@ -1,0 +1,2 @@
+fix:
+- Discover query input background not shrink when window resize ([#8331](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8331))

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -200,6 +200,7 @@
   padding: $euiSizeS;
   background-color: $euiColorEmptyShade;
   overflow: initial !important; // needed for suggestion window, otherwise will be hidden in child
+  min-width: 0;
 
   .monaco-editor .view-overlays .current-line {
     border: none;


### PR DESCRIPTION
### Description
This one line change fixed an issue of the query input on discover page that the input background container didn't not shrink when resizing, see the screen records:

Before:

https://github.com/user-attachments/assets/4acee382-adeb-4b1b-91f3-7b6f846772e1

After:

https://github.com/user-attachments/assets/ca2cffc9-846d-4a34-a390-924e7a37e00e



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: discover query input background not shrink when window resize

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
