### PR TITLE
refactor: move the render of query extension control buttons to extension component

### DIFF
--- a/changelogs/fragments/8334.yml
+++ b/changelogs/fragments/8334.yml
@@ -1,0 +1,2 @@
+refactor:
+- Move the render of query extension control buttons to extension component ([#8334](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8334))

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -169,6 +169,12 @@
   .osdQueryEditor__querycontrols {
     float: right;
     margin: $euiSizeS $euiSizeS;
+
+    .osdQueryEditor__extensionQueryControls {
+      display: flex;
+      padding: 0 $euiSizeS 0 $euiSizeXS;
+      border-right: $euiBorderThin;
+    }
   }
 
   .osdQueryEditor__dataSetPicker {

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -106,6 +106,7 @@ export default class QueryEditorUI extends Component<Props, State> {
   private services = this.props.opensearchDashboards.services;
   private headerRef: RefObject<HTMLDivElement> = createRef();
   private bannerRef: RefObject<HTMLDivElement> = createRef();
+  private queryControlsContainer: RefObject<HTMLDivElement> = createRef();
   private extensionMap = this.languageManager.getQueryEditorExtensionMap();
 
   private getQueryString = () => {
@@ -121,6 +122,7 @@ export default class QueryEditorUI extends Component<Props, State> {
       !(
         this.headerRef.current &&
         this.bannerRef.current &&
+        this.queryControlsContainer.current &&
         this.props.query.language &&
         this.extensionMap &&
         Object.keys(this.extensionMap).length > 0
@@ -137,6 +139,7 @@ export default class QueryEditorUI extends Component<Props, State> {
         configMap={this.extensionMap}
         componentContainer={this.headerRef.current}
         bannerContainer={this.bannerRef.current}
+        queryControlsContainer={this.queryControlsContainer.current}
       />
     );
   }
@@ -336,25 +339,6 @@ export default class QueryEditorUI extends Component<Props, State> {
     return <QueryControls queryControls={queryControls} />;
   };
 
-  private renderExtensionSearchBarButton = () => {
-    if (!this.extensionMap || Object.keys(this.extensionMap).length === 0) return null;
-    const sortedConfigs = Object.values(this.extensionMap).sort((a, b) => a.order - b.order);
-    return (
-      <>
-        {sortedConfigs.map((config) => {
-          return config.getSearchBarButton
-            ? config.getSearchBarButton({
-                language: this.props.query.language,
-                onSelectLanguage: this.onSelectLanguage,
-                isCollapsed: this.state.isCollapsed,
-                setIsCollapsed: this.setIsCollapsed,
-              })
-            : null;
-        })}
-      </>
-    );
-  };
-
   public render() {
     const className = classNames(this.props.className);
 
@@ -471,9 +455,12 @@ export default class QueryEditorUI extends Component<Props, State> {
           {languageSelector}
           <div className="osdQueryEditor__querycontrols">
             <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+              <div
+                ref={this.queryControlsContainer}
+                className="osdQueryEditor__extensionQueryControls"
+              />
               {this.renderQueryControls(languageEditor.TopBar.Controls)}
               {!languageEditor.TopBar.Expanded && this.renderToggleIcon()}
-              {!languageEditor.TopBar.Expanded && this.renderExtensionSearchBarButton()}
               {this.props.savedQueryManagement}
             </EuiFlexGroup>
           </div>

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extension.tsx
@@ -14,6 +14,7 @@ interface QueryEditorExtensionProps {
   dependencies: QueryEditorExtensionDependencies;
   componentContainer: Element;
   bannerContainer: Element;
+  queryControlsContainer: Element;
 }
 
 export interface QueryEditorExtensionDependencies {
@@ -97,6 +98,11 @@ export const QueryEditorExtension: React.FC<QueryEditorExtensionProps> = (props)
     props.dependencies,
   ]);
 
+  const queryControlButtons = useMemo(() => props.config.getSearchBarButton?.(props.dependencies), [
+    props.config,
+    props.dependencies,
+  ]);
+
   useEffect(() => {
     isMounted.current = true;
     return () => {
@@ -120,6 +126,9 @@ export const QueryEditorExtension: React.FC<QueryEditorExtensionProps> = (props)
       </QueryEditorExtensionPortal>
       <QueryEditorExtensionPortal container={props.componentContainer}>
         {component}
+      </QueryEditorExtensionPortal>
+      <QueryEditorExtensionPortal container={props.queryControlsContainer}>
+        {queryControlButtons}
       </QueryEditorExtensionPortal>
     </>
   );

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.test.tsx
@@ -23,6 +23,7 @@ describe('QueryEditorExtensions', () => {
   const defaultProps: QueryEditorExtensionsProps = {
     componentContainer: document.createElement('div'),
     bannerContainer: document.createElement('div'),
+    queryControlsContainer: document.createElement('div'),
     language: 'Test-lang',
     onSelectLanguage: jest.fn(),
     isCollapsed: false,

--- a/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_extensions/query_editor_extensions.tsx
@@ -14,10 +14,17 @@ interface QueryEditorExtensionsProps extends QueryEditorExtensionDependencies {
   configMap?: Record<string, QueryEditorExtensionConfig>;
   componentContainer: Element;
   bannerContainer: Element;
+  queryControlsContainer: Element;
 }
 
 const QueryEditorExtensions: React.FC<QueryEditorExtensionsProps> = React.memo((props) => {
-  const { configMap, componentContainer, bannerContainer, ...dependencies } = props;
+  const {
+    configMap,
+    componentContainer,
+    bannerContainer,
+    queryControlsContainer,
+    ...dependencies
+  } = props;
 
   const sortedConfigs = useMemo(() => {
     if (!configMap || Object.keys(configMap).length === 0) return [];
@@ -27,14 +34,25 @@ const QueryEditorExtensions: React.FC<QueryEditorExtensionsProps> = React.memo((
   return (
     <>
       {sortedConfigs.map((config) => {
-        const id = `osdQueryEditorExtensionComponent-${config.id}`;
+        const extensionComponentId = `osdQueryEditorExtensionComponent-${config.id}`;
+        const extensionQueryControlsId = `osdQueryEditorExtensionQueryControls-${config.id}`;
 
-        let container = document.getElementById(id);
-        if (!container) {
-          container = document.createElement('div');
-          container.className = `osdQueryEditorExtensionComponent osdQueryEditorExtensionComponent__${config.id}`;
-          container.id = id;
-          componentContainer.appendChild(container);
+        // Make sure extension components are rendered in order
+        let extensionComponentContainer = document.getElementById(extensionComponentId);
+        if (!extensionComponentContainer) {
+          extensionComponentContainer = document.createElement('div');
+          extensionComponentContainer.className = `osdQueryEditorExtensionComponent osdQueryEditorExtensionComponent__${config.id}`;
+          extensionComponentContainer.id = extensionComponentId;
+          componentContainer.appendChild(extensionComponentContainer);
+        }
+
+        // Make sure extension query controls are rendered in order
+        let extensionQueryControlsContainer = document.getElementById(extensionQueryControlsId);
+        if (!extensionQueryControlsContainer) {
+          extensionQueryControlsContainer = document.createElement('div');
+          extensionQueryControlsContainer.className = `osdQueryEditorExtensionQueryControls osdQueryEditorExtensionQueryControls__${config.id}`;
+          extensionQueryControlsContainer.id = extensionQueryControlsId;
+          queryControlsContainer.appendChild(extensionQueryControlsContainer);
         }
 
         return (
@@ -42,8 +60,9 @@ const QueryEditorExtensions: React.FC<QueryEditorExtensionsProps> = React.memo((
             key={config.id}
             config={config}
             dependencies={dependencies}
-            componentContainer={container}
+            componentContainer={extensionComponentContainer}
             bannerContainer={bannerContainer}
+            queryControlsContainer={extensionQueryControlsContainer}
           />
         );
       })}

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_button.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_button.tsx
@@ -32,7 +32,7 @@ export const QueryAssistButton: React.FC<QueryAssistButtonProps> = (props) => {
         iconType={
           !props.dependencies.isCollapsed && !isQueryAssistCollapsed ? expandIcon : collapsedIcon
         }
-        aria-label={i18n.translate('queryEnhancements.queryAssist.button.ariaLable', {
+        aria-label={i18n.translate('queryEnhancements.queryAssist.button.ariaLabel', {
           defaultMessage: `Query Assist Toggle`,
         })}
         onClick={onClick}


### PR DESCRIPTION
### Description
Move the rendering of query extension control buttons to extension component to align with the existing pattern.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- refactor: move the render of query extension control buttons to extension component

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
