### PR TITLE
Temporary fix for a bug with Chrome 129 when handling mask-image

### DIFF
--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -83,6 +83,8 @@ $euiCollapsibleNavWidth: $euiSize * 20;
 .euiFlyoutBody .euiFlyoutBody__overflow.euiFlyoutBody__overflow--hasBanner,
 .euiModalBody .euiModalBody__overflow,
 .euiSelectableList__list,
+// From @elastic/charts: any ruleset containing mask-image
+.echLegend .echLegendListContainer,
 // For OSD: consumers of eui?ScrollWithShadows
 .osdQueryBar__textarea:not(:focus):not(:invalid),
 .osdSavedQueryManagement__list,


### PR DESCRIPTION
Temporary fix for a bug with Chrome 129 when handling mask-image
* Mitigate @elastic/charts' use of `mask-image`



## Changelog
-skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
