### PR TITLE
Add UI Metric for Discover 2.0

### DIFF
--- a/src/plugins/data/public/ui/index_pattern_select/index_pattern_select.test.tsx
+++ b/src/plugins/data/public/ui/index_pattern_select/index_pattern_select.test.tsx
@@ -49,7 +49,7 @@ describe('IndexPatternSelect', () => {
 
     bulkGetMock.mockResolvedValue({ savedObjects: [{ attributes: { title: 'test1' } }] });
     compInstance.debouncedFetch('');
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await new Promise((resolve) => setTimeout(resolve, 600));
     await nextTick();
     expect(bulkGetMock).toBeCalledWith([{ id: 'testDataSourceId', type: 'data-source' }]);
   });

--- a/src/plugins/data_explorer/opensearch_dashboards.json
+++ b/src/plugins/data_explorer/opensearch_dashboards.json
@@ -8,7 +8,8 @@
     "data",
     "navigation",
     "embeddable",
-    "expressions"
+    "expressions",
+    "usageCollection"
   ],
   "optionalPlugins": [],
   "requiredBundles": [

--- a/src/plugins/data_explorer/public/components/app_container.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { memo, useRef } from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -23,6 +23,13 @@ import './app_container.scss';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { IDataPluginServices } from '../../../data/public';
 import { QUERY_ENHANCEMENT_ENABLED_SETTING } from './constants';
+import {
+  DISCOVER_LOAD_EVENT,
+  NEW_DISCOVER_LOAD_EVENT,
+  NEW_DISCOVER_OPT_IN,
+  NEW_DISCOVER_OPT_OUT,
+  trackUiMetric,
+} from '../ui_metric';
 
 export const AppContainer = React.memo(
   ({ view, params }: { view?: View; params: AppMountParameters }) => {
@@ -35,8 +42,14 @@ export const AppContainer = React.memo(
 
     const topLinkRef = useRef<HTMLDivElement>(null);
     const datePickerRef = useRef<HTMLDivElement>(null);
+
     if (!view) {
       return <NoView />;
+    }
+
+    trackUiMetric(DISCOVER_LOAD_EVENT);
+    if (isEnhancementsEnabled) {
+      trackUiMetric(NEW_DISCOVER_LOAD_EVENT);
     }
 
     const { Canvas, Panel, Context } = view;

--- a/src/plugins/data_explorer/public/plugin.ts
+++ b/src/plugins/data_explorer/public/plugin.ts
@@ -31,6 +31,7 @@ import {
 } from '../../opensearch_dashboards_utils/public';
 import { getPreloadedStore } from './utils/state_management';
 import { opensearchFilters } from '../../data/public';
+import { setUsageCollector } from './services';
 
 export class DataExplorerPlugin
   implements
@@ -47,10 +48,11 @@ export class DataExplorerPlugin
 
   public setup(
     core: CoreSetup<DataExplorerPluginStartDependencies, DataExplorerPluginStart>,
-    { data }: DataExplorerPluginSetupDependencies
+    { data, usageCollection }: DataExplorerPluginSetupDependencies
   ): DataExplorerPluginSetup {
     const viewService = this.viewService;
 
+    setUsageCollector(usageCollection);
     const { appMounted, appUnMounted, stop: stopUrlTracker } = createOsdUrlTracker({
       baseUrl: core.http.basePath.prepend(`/app/${PLUGIN_ID}`),
       defaultSubUrl: '#/',

--- a/src/plugins/data_explorer/public/services.ts
+++ b/src/plugins/data_explorer/public/services.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createGetterSetter } from '../../opensearch_dashboards_utils/public';
+import { UsageCollectionSetup } from '../../usage_collection/public';
+
+export const [getUsageCollector, setUsageCollector] = createGetterSetter<UsageCollectionSetup>(
+  'UsageCollector'
+);

--- a/src/plugins/data_explorer/public/types.ts
+++ b/src/plugins/data_explorer/public/types.ts
@@ -10,6 +10,7 @@ import { ViewServiceStart, ViewServiceSetup } from './services/view_service';
 import { IOsdUrlStateStorage } from '../../opensearch_dashboards_utils/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public';
 import { Store } from './utils/state_management';
+import { UsageCollectionSetup } from '../../usage_collection/public';
 
 export type DataExplorerPluginSetup = ViewServiceSetup;
 
@@ -18,6 +19,7 @@ export interface DataExplorerPluginStart {}
 
 export interface DataExplorerPluginSetupDependencies {
   data: DataPublicPluginSetup;
+  usageCollection: UsageCollectionSetup;
 }
 
 export interface DataExplorerPluginStartDependencies {

--- a/src/plugins/data_explorer/public/ui_metric/constants.ts
+++ b/src/plugins/data_explorer/public/ui_metric/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const NEW_DISCOVER_LOAD_EVENT = 'new_discover_load_count';
+export const DISCOVER_LOAD_EVENT = 'discover_load_count';
+export const NEW_DISCOVER_APP_NAME = 'New_Discover';

--- a/src/plugins/data_explorer/public/ui_metric/index.ts
+++ b/src/plugins/data_explorer/public/ui_metric/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './constants';
+export * from './report_ui_metric';

--- a/src/plugins/data_explorer/public/ui_metric/report_ui_metric.ts
+++ b/src/plugins/data_explorer/public/ui_metric/report_ui_metric.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { UiStatsMetricType } from 'packages/osd-analytics/target/types';
+import { METRIC_TYPE } from '../../../usage_collection/public';
+import { NEW_DISCOVER_APP_NAME } from './constants';
+import { getUsageCollector } from '../services';
+
+export const trackUiMetric = (
+  eventName: string,
+  appName: string = NEW_DISCOVER_APP_NAME,
+  metricType: UiStatsMetricType = METRIC_TYPE.COUNT
+) => {
+  try {
+    const usageCollector = getUsageCollector();
+    usageCollector.reportUiStats(appName, metricType, eventName);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+};

--- a/src/plugins/discover/opensearch_dashboards.json
+++ b/src/plugins/discover/opensearch_dashboards.json
@@ -13,7 +13,8 @@
     "urlForwarding",
     "navigation",
     "uiActions",
-    "visualizations"
+    "visualizations",
+    "usageCollection"
   ],
   "optionalPlugins": ["home", "share"],
   "requiredBundles": [

--- a/src/plugins/discover/public/opensearch_dashboards_services.ts
+++ b/src/plugins/discover/public/opensearch_dashboards_services.ts
@@ -37,6 +37,7 @@ import { createGetterSetter } from '../../opensearch_dashboards_utils/public';
 import { search } from '../../data/public';
 import { DocViewsRegistry } from './application/doc_views/doc_views_registry';
 import { DocViewsLinksRegistry } from './application/doc_views_links/doc_views_links_registry';
+import { UsageCollectionSetup } from '../../usage_collection/public';
 
 let services: DiscoverServices | null = null;
 let uiActions: UiActionsStart;
@@ -66,6 +67,10 @@ export const [getDocViewsRegistry, setDocViewsRegistry] = createGetterSetter<Doc
 export const [getDocViewsLinksRegistry, setDocViewsLinksRegistry] = createGetterSetter<
   DocViewsLinksRegistry
 >('DocViewsLinksRegistry');
+
+export const [getUsageCollector, setUsageCollector] = createGetterSetter<UsageCollectionSetup>(
+  'UsageCollector'
+);
 
 /**
  * Makes sure discover and context are using one instance of history.

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -51,6 +51,7 @@ import {
   setScopedHistory,
   syncHistoryLocations,
   getServices,
+  setUsageCollector,
 } from './opensearch_dashboards_services';
 import { createSavedSearchesLoader } from './saved_searches';
 import { buildServices } from './build_services';
@@ -75,6 +76,7 @@ declare module '../../share/public' {
     [DISCOVER_APP_URL_GENERATOR]: UrlGeneratorState<DiscoverUrlGeneratorState>;
   }
 }
+import { UsageCollectionSetup } from '../../usage_collection/public';
 
 /**
  * @public
@@ -128,6 +130,7 @@ export interface DiscoverSetupPlugins {
   visualizations: VisualizationsSetup;
   data: DataPublicPluginSetup;
   dataExplorer: DataExplorerPluginSetup;
+  usageCollection: UsageCollectionSetup;
 }
 
 /**
@@ -174,6 +177,7 @@ export class DiscoverPlugin
       );
     }
 
+    setUsageCollector(plugins.usageCollection);
     this.docViewsRegistry = new DocViewsRegistry();
     setDocViewsRegistry(this.docViewsRegistry);
     this.docViewsRegistry.addDocView({

--- a/src/plugins/discover/public/ui_metric/constants.ts
+++ b/src/plugins/discover/public/ui_metric/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DATASET_METRIC_SUFFIX = 'dataset_queries_count';
+export const LANGUAGE_METRIC_SUFFIX = 'language_queries_count';
+export const NEW_DISCOVER_APP_NAME = 'New_Discover';

--- a/src/plugins/discover/public/ui_metric/index.ts
+++ b/src/plugins/discover/public/ui_metric/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './constants';
+export * from './report_ui_metric';

--- a/src/plugins/discover/public/ui_metric/report_ui_metric.ts
+++ b/src/plugins/discover/public/ui_metric/report_ui_metric.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { UiStatsMetricType } from 'packages/osd-analytics/target/types';
+import { METRIC_TYPE } from '../../../usage_collection/public';
+import { DATASET_METRIC_SUFFIX, LANGUAGE_METRIC_SUFFIX, NEW_DISCOVER_APP_NAME } from './constants';
+import { getUsageCollector } from '../opensearch_dashboards_services';
+import { Query } from '../../../data/public';
+
+export const getDatasetTypeMetricEventName = (datasource: string) => {
+  return `${datasource}_${DATASET_METRIC_SUFFIX}`;
+};
+
+export const getLanguageMetricEventName = (language: string) => {
+  return `${language}_${LANGUAGE_METRIC_SUFFIX}`;
+};
+
+export const trackUiMetric = (
+  eventName: string,
+  appName: string = NEW_DISCOVER_APP_NAME,
+  metricType: UiStatsMetricType = METRIC_TYPE.COUNT
+) => {
+  try {
+    const usageCollector = getUsageCollector();
+    usageCollector.reportUiStats(appName, metricType, eventName);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+};
+
+export const trackQueryMetric = (query: Query) => {
+  trackUiMetric(getDatasetTypeMetricEventName(query.dataset?.type!));
+  trackUiMetric(getLanguageMetricEventName(query.language));
+};


### PR DESCRIPTION
### Description

The PR aims at capturing following UI Metrics. 

1.  No of times discover has been loaded
2. No of times new discover has been loaded
3. No of times each datasource type queries have been executed
4. No of times each language queries have been executed

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/6189d9e3-da7b-47d1-89b0-7d80d7843977)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

1. Set usageCollection.uiMetric.enabled to true
5. Call the API /api/stats?extended=true&legacy=true&exclude_usage=false
6. Verify the ui_metric doesn't contain an entry corresponding to Discover
7. Navigate to Discover
8. Interact with Discover change the datasources, language
9. Wait for 90s
10. Call the API /api/stats?extended=true&legacy=true&exclude_usage=false and verify ui_metric contains an entry corresponding to Discover with the metrics corresponding to above interaction

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
