### PR TITLE
[CVE-2024-45801] Bump `dompurify` from 3.0.11 to 3.1.6

### DIFF
--- a/changelogs/fragments/8346.yml
+++ b/changelogs/fragments/8346.yml
@@ -1,0 +1,2 @@
+security:
+- [CVE-2024-45801] Bump `dompurify` from 3.0.11 to 3.1.6 ([#8346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8346))

--- a/yarn.lock
+++ b/yarn.lock
@@ -7263,9 +7263,9 @@ domhandler@^4.0, domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.2.2, domhan
     domelementtype "^2.2.0"
 
 dompurify@^3.0.11:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.11.tgz#c163f5816eaac6aeef35dae2b77fca0504564efe"
-  integrity sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.6.tgz#43c714a94c6a7b8801850f82e756685300a027e2"
+  integrity sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==
 
 domutils@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
### Description

[CVE-2024-45801] Bump `dompurify` from 3.0.11 to 3.1.6


## Changelog
-security: [CVE-2024-45801] Bump `dompurify` from 3.0.11 to 3.1.6

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
