### PR TITLE
Replace JSON11-produced hex escape codes with unicode escape codes

### DIFF
--- a/packages/osd-std/src/json.test.ts
+++ b/packages/osd-std/src/json.test.ts
@@ -173,4 +173,10 @@ describe('json', () => {
 
     expect(stringify(input, replacer, 4)).toMatchSnapshot();
   });
+
+  it('can handle BigInt values and ANSI escape sequences', () => {
+    const input = {message: "hello \u001b[38;7;2mworld\u001b[0m", value: BigInt(Number.MAX_SAFE_INTEGER) * 2n};
+    const result = parse(stringify(input));
+    expect(result).toEqual(input);
+  })
 });

--- a/packages/osd-std/src/json.ts
+++ b/packages/osd-std/src/json.ts
@@ -4,6 +4,7 @@
  */
 
 import JSON11 from 'json11';
+const hexEscapeRegex = /\\x([0-9A-Fa-f]{2})/g;
 
 export const stringify = (
   obj: any,
@@ -52,7 +53,7 @@ export const stringify = (
       quote: '"',
       quoteNames: true,
     });
-    if (temp) text = temp;
+    if (temp) text = temp.replace(hexEscapeRegex, (_, c) => `\\u00${c}`);
   }
 
   return text;


### PR DESCRIPTION
### Description

JSON11.stringify produces JSON5 documents with hex escape codes (`\x1b`), which aren't standard JSON and cause `JSON.parse` to error. When using JSON11, replace all `\xXX` escape codes with the JSON-compatible equivalent Unicode escape codes (`\u00XX`).

### Issues Resolved

~Fixes~ Partially addresses #7367.

## Screenshot

## Testing the changes

Included a unit test. Without the fix in this PR, the test fails:

```
    ✕ can handle BigInt values and ANSI escape sequences (2 ms)

  ● json › can handle BigInt values and ANSI escape sequences

    SyntaxError: Unexpected token x in JSON at position 19
        at JSON.parse (<anonymous>)

       96 |    * still need it in its string form to find a suitable marker.
       97 |    */
    >  98 |   obj = JSON.parse(text, checkForLargeNumerals);

```

With this fix, the test passes.

## Changelog

- fix: Replace JSON11 hex escape codes with unicode escape codes

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
