### PR TITLE
[workspace]feat/add workspace selector to left nav bar.

### DIFF
--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -14,7 +14,7 @@ import {
   EuiShowFor,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import * as Rx from 'rxjs';
 import classNames from 'classnames';
@@ -79,6 +79,10 @@ export function CollapsibleNavGroupEnabled({
   id,
   isNavOpen,
   storage = window.localStorage,
+<<<<<<< HEAD
+=======
+  currentWorkspace$,
+>>>>>>> 3dce1748aa (fix/the_UI_of_recent_assets, resolve comments)
   closeNav,
   navigateToApp,
   navigateToUrl,
@@ -88,6 +92,7 @@ export function CollapsibleNavGroupEnabled({
   collapsibleNavHeaderRender,
   ...observables
 }: CollapsibleNavGroupEnabledProps) {
+  const currentWorkspace = useObservable(currentWorkspace$);
   const allNavLinks = useObservable(observables.navLinks$, []);
   const navLinks = allNavLinks.filter((link) => !link.hidden);
   const homeLink = useMemo(() => allNavLinks.find((item) => item.id === 'home'), [allNavLinks]);
@@ -308,7 +313,7 @@ export function CollapsibleNavGroupEnabled({
               shouldShrinkNavigation={!isNavOpen}
               onClickShrink={closeNav}
               visibleUseCases={visibleUseCases}
-              currentWorkspace$={observables.currentWorkspace$}
+              currentWorkspace={currentWorkspace}
             />
           </EuiPanel>
         )}
@@ -320,13 +325,16 @@ export function CollapsibleNavGroupEnabled({
             hasShadow={false}
             className="eui-yScroll flex-1-container"
           >
-            {shouldShowCollapsedNavHeaderContent && collapsibleNavHeaderRender ? (
+            {shouldShowCollapsedNavHeaderContent &&
+            collapsibleNavHeaderRender &&
+            !currentWorkspace ? (
               <>
                 <EuiPanel
                   paddingSize="none"
                   color="transparent"
                   hasBorder={false}
                   hasShadow={false}
+                  style={{ height: '40vh' }}
                 >
                   {collapsibleNavHeaderRender()}
                 </EuiPanel>

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -70,7 +70,7 @@ const customCategory: AppCategory = {
 };
 
 enum NavWidth {
-  Expanded = 270,
+  Expanded = 350,
   Collapsed = 48, // The Collasped width is supposed to be aligned with the hamburger icon on the top left navigation.
 }
 
@@ -322,7 +322,14 @@ export function CollapsibleNavGroupEnabled({
           >
             {shouldShowCollapsedNavHeaderContent && collapsibleNavHeaderRender ? (
               <>
-                {collapsibleNavHeaderRender()}
+                <EuiPanel
+                  paddingSize="none"
+                  color="transparent"
+                  hasBorder={false}
+                  hasShadow={false}
+                >
+                  {collapsibleNavHeaderRender()}
+                </EuiPanel>
                 <EuiSpacer />
               </>
             ) : null}

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -70,7 +70,7 @@ const customCategory: AppCategory = {
 };
 
 enum NavWidth {
-  Expanded = 350,
+  Expanded = 270,
   Collapsed = 48, // The Collasped width is supposed to be aligned with the hamburger icon on the top left navigation.
 }
 

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -94,7 +94,6 @@ export function CollapsibleNavGroupEnabled({
   const appId = useObservable(observables.appId$, '');
   const navGroupsMap = useObservable(observables.navGroupsMap$, {});
   const currentNavGroup = useObservable(observables.currentNavGroup$, undefined);
-
   const visibleUseCases = useMemo(() => getVisibleUseCases(navGroupsMap), [navGroupsMap]);
 
   const currentNavGroupId = useMemo(() => {
@@ -300,6 +299,7 @@ export function CollapsibleNavGroupEnabled({
             <CollapsibleNavTop
               homeLink={homeLink}
               navGroupsMap={navGroupsMap}
+              collapsibleNavHeaderRender={collapsibleNavHeaderRender}
               navLinks={navLinks}
               navigateToApp={navigateToApp}
               logos={logos}

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -8,13 +8,12 @@ import {
   EuiFlyout,
   EuiPanel,
   EuiHorizontalRule,
-  EuiSpacer,
   EuiHideFor,
   EuiFlyoutProps,
   EuiShowFor,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import * as Rx from 'rxjs';
 import classNames from 'classnames';
@@ -23,7 +22,6 @@ import { ChromeNavControl, ChromeNavLink } from '../..';
 import { AppCategory, NavGroupType } from '../../../../types';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
-import { OnIsLockedUpdate } from './';
 import { createEuiListItem } from './nav_link';
 import type { Logos } from '../../../../common/types';
 import {
@@ -42,11 +40,9 @@ export interface CollapsibleNavGroupEnabledProps {
   collapsibleNavHeaderRender?: () => JSX.Element | null;
   basePath: HttpStart['basePath'];
   id: string;
-  isLocked: boolean;
   isNavOpen: boolean;
   navLinks$: Rx.Observable<ChromeNavLink[]>;
   storage?: Storage;
-  onIsLockedUpdate: OnIsLockedUpdate;
   closeNav: () => void;
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
@@ -80,10 +76,8 @@ enum NavWidth {
 export function CollapsibleNavGroupEnabled({
   basePath,
   id,
-  isLocked,
   isNavOpen,
   storage = window.localStorage,
-  onIsLockedUpdate,
   currentWorkspace$,
   closeNav,
   navigateToApp,
@@ -94,7 +88,6 @@ export function CollapsibleNavGroupEnabled({
   collapsibleNavHeaderRender,
   ...observables
 }: CollapsibleNavGroupEnabledProps) {
-  const currentWorkspace = useObservable(currentWorkspace$);
   const allNavLinks = useObservable(observables.navLinks$, []);
   const navLinks = allNavLinks.filter((link) => !link.hidden);
   const homeLink = useMemo(() => allNavLinks.find((item) => item.id === 'home'), [allNavLinks]);
@@ -120,9 +113,6 @@ export function CollapsibleNavGroupEnabled({
   const shouldAppendManageCategory = capabilities.workspaces.enabled
     ? !currentNavGroupId
     : currentNavGroupId === ALL_USE_CASE_ID;
-
-  const shouldShowCollapsedNavHeaderContent =
-    isNavOpen && !!collapsibleNavHeaderRender && !currentNavGroupId;
 
   const navLinksForRender: ChromeNavLink[] = useMemo(() => {
     const getSystemNavGroups = () => {
@@ -315,7 +305,7 @@ export function CollapsibleNavGroupEnabled({
               shouldShrinkNavigation={!isNavOpen}
               onClickShrink={closeNav}
               visibleUseCases={visibleUseCases}
-              currentWorkspace={currentWorkspace}
+              currentWorkspace$={currentWorkspace$}
             />
           </EuiPanel>
         )}
@@ -327,22 +317,6 @@ export function CollapsibleNavGroupEnabled({
             hasShadow={false}
             className="eui-yScroll flex-1-container"
           >
-            {shouldShowCollapsedNavHeaderContent &&
-            collapsibleNavHeaderRender &&
-            !currentWorkspace ? (
-              <>
-                <EuiPanel
-                  paddingSize="none"
-                  color="transparent"
-                  hasBorder={false}
-                  hasShadow={false}
-                  style={{ height: '40vh' }}
-                >
-                  {collapsibleNavHeaderRender()}
-                </EuiPanel>
-                <EuiSpacer />
-              </>
-            ) : null}
             <NavGroups
               navLinks={navLinksForRender}
               navigateToApp={navigateToApp}

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.tsx
@@ -23,6 +23,7 @@ import { ChromeNavControl, ChromeNavLink } from '../..';
 import { AppCategory, NavGroupType } from '../../../../types';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
+import { OnIsLockedUpdate } from './';
 import { createEuiListItem } from './nav_link';
 import type { Logos } from '../../../../common/types';
 import {
@@ -41,9 +42,11 @@ export interface CollapsibleNavGroupEnabledProps {
   collapsibleNavHeaderRender?: () => JSX.Element | null;
   basePath: HttpStart['basePath'];
   id: string;
+  isLocked: boolean;
   isNavOpen: boolean;
   navLinks$: Rx.Observable<ChromeNavLink[]>;
   storage?: Storage;
+  onIsLockedUpdate: OnIsLockedUpdate;
   closeNav: () => void;
   navigateToApp: InternalApplicationStart['navigateToApp'];
   navigateToUrl: InternalApplicationStart['navigateToUrl'];
@@ -77,12 +80,11 @@ enum NavWidth {
 export function CollapsibleNavGroupEnabled({
   basePath,
   id,
+  isLocked,
   isNavOpen,
   storage = window.localStorage,
-<<<<<<< HEAD
-=======
+  onIsLockedUpdate,
   currentWorkspace$,
->>>>>>> 3dce1748aa (fix/the_UI_of_recent_assets, resolve comments)
   closeNav,
   navigateToApp,
   navigateToUrl,

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
@@ -14,7 +14,6 @@ import {
   EuiIcon,
   EuiPanel,
   EuiSpacer,
-  EuiText,
 } from '@elastic/eui';
 import { InternalApplicationStart } from 'src/core/public/application';
 import { createEuiListItem } from './nav_link';
@@ -25,6 +24,7 @@ import { fulfillRegistrationLinksToChromeNavLinks } from '../../utils';
 import './collapsible_nav_group_enabled_top.scss';
 
 export interface CollapsibleNavTopProps {
+  collapsibleNavHeaderRender?: () => JSX.Element | null;
   homeLink?: ChromeNavLink;
   navGroupsMap: Record<string, NavGroupItemInMap>;
   currentNavGroup?: NavGroupItemInMap;
@@ -39,6 +39,7 @@ export interface CollapsibleNavTopProps {
 }
 
 export const CollapsibleNavTop = ({
+  collapsibleNavHeaderRender,
   currentNavGroup,
   navigateToApp,
   logos,
@@ -148,10 +149,10 @@ export const CollapsibleNavTop = ({
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {currentNavGroup?.title && (
+      {currentNavGroup?.title && collapsibleNavHeaderRender && (
         <>
           <EuiSpacer />
-          <EuiText>{currentNavGroup?.title}</EuiText>
+          {collapsibleNavHeaderRender()}
         </>
       )}
     </EuiPanel>

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
@@ -5,14 +5,14 @@
 
 import React, { useCallback, useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
-import { Logos, WorkspaceObject, WorkspacesStart } from 'opensearch-dashboards/public';
+import { Logos, WorkspacesStart } from 'opensearch-dashboards/public';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiText,
+  EuiIcon,
   EuiPanel,
   EuiSpacer,
 } from '@elastic/eui';
@@ -34,7 +34,7 @@ export interface CollapsibleNavTopProps {
   onClickShrink?: () => void;
   shouldShrinkNavigation: boolean;
   visibleUseCases: NavGroupItemInMap[];
-  currentWorkspace: WorkspaceObject | null | undefined;
+  currentWorkspace$: WorkspacesStart['currentWorkspace$'];
   setCurrentNavGroup: ChromeNavGroupServiceStartContract['setCurrentNavGroup'];
   navLinks: ChromeNavLink[];
 }
@@ -47,12 +47,13 @@ export const CollapsibleNavTop = ({
   onClickShrink,
   shouldShrinkNavigation,
   visibleUseCases,
-  currentWorkspace,
+  currentWorkspace$,
   setCurrentNavGroup,
   homeLink,
   navGroupsMap,
   navLinks,
 }: CollapsibleNavTopProps) => {
+  const currentWorkspace = useObservable(currentWorkspace$);
   const firstVisibleNavLinkInFirstVisibleUseCase = useMemo(
     () =>
       fulfillRegistrationLinksToChromeNavLinks(
@@ -148,10 +149,14 @@ export const CollapsibleNavTop = ({
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {collapsibleNavHeaderRender && currentWorkspace && (
+      {(currentNavGroup?.title || collapsibleNavHeaderRender) && (
         <>
           <EuiSpacer />
-          {collapsibleNavHeaderRender()}
+          {collapsibleNavHeaderRender ? (
+            collapsibleNavHeaderRender()
+          ) : (
+            <EuiText>{currentNavGroup?.title}</EuiText>
+          )}
         </>
       )}
     </EuiPanel>

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
@@ -149,7 +149,7 @@ export const CollapsibleNavTop = ({
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {(currentNavGroup?.title || collapsibleNavHeaderRender) && (
+      {(currentNavGroup?.type || collapsibleNavHeaderRender) && (
         <>
           <EuiSpacer />
           {collapsibleNavHeaderRender ? (

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
@@ -149,16 +149,19 @@ export const CollapsibleNavTop = ({
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {(currentNavGroup?.type || collapsibleNavHeaderRender) && (
-        <>
-          <EuiSpacer />
-          {collapsibleNavHeaderRender ? (
-            collapsibleNavHeaderRender()
-          ) : (
-            <EuiText>{currentNavGroup?.title}</EuiText>
-          )}
-        </>
-      )}
+      {
+        // Nav groups with type are system(global) nav group and we should show title for those nav groups
+        (currentNavGroup?.type || collapsibleNavHeaderRender) && (
+          <>
+            <EuiSpacer />
+            {currentNavGroup?.type ? (
+              <EuiText>{currentNavGroup?.title}</EuiText>
+            ) : (
+              collapsibleNavHeaderRender?.()
+            )}
+          </>
+        )
+      }
     </EuiPanel>
   );
 };

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled_top.tsx
@@ -5,13 +5,14 @@
 
 import React, { useCallback, useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
-import { Logos, WorkspacesStart } from 'opensearch-dashboards/public';
+import { Logos, WorkspaceObject, WorkspacesStart } from 'opensearch-dashboards/public';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiText,
   EuiPanel,
   EuiSpacer,
 } from '@elastic/eui';
@@ -33,7 +34,7 @@ export interface CollapsibleNavTopProps {
   onClickShrink?: () => void;
   shouldShrinkNavigation: boolean;
   visibleUseCases: NavGroupItemInMap[];
-  currentWorkspace$: WorkspacesStart['currentWorkspace$'];
+  currentWorkspace: WorkspaceObject | null | undefined;
   setCurrentNavGroup: ChromeNavGroupServiceStartContract['setCurrentNavGroup'];
   navLinks: ChromeNavLink[];
 }
@@ -46,14 +47,12 @@ export const CollapsibleNavTop = ({
   onClickShrink,
   shouldShrinkNavigation,
   visibleUseCases,
-  currentWorkspace$,
+  currentWorkspace,
   setCurrentNavGroup,
   homeLink,
   navGroupsMap,
   navLinks,
 }: CollapsibleNavTopProps) => {
-  const currentWorkspace = useObservable(currentWorkspace$);
-
   const firstVisibleNavLinkInFirstVisibleUseCase = useMemo(
     () =>
       fulfillRegistrationLinksToChromeNavLinks(
@@ -149,7 +148,7 @@ export const CollapsibleNavTop = ({
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {currentNavGroup?.title && collapsibleNavHeaderRender && (
+      {collapsibleNavHeaderRender && currentWorkspace && (
         <>
           <EuiSpacer />
           {collapsibleNavHeaderRender()}

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.scss
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.scss
@@ -1,0 +1,3 @@
+.workspaceMenuHeader {
+    padding: $ouiSizeL;
+}

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.scss
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.scss
@@ -1,3 +1,3 @@
 .workspaceMenuHeader {
-    padding: $ouiSizeL;
+  padding: $ouiSizeL;
 }

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-
+import moment from 'moment';
 import { WorkspaceMenu } from './workspace_menu';
 import { coreMock } from '../../../../../core/public/mocks';
 import { CoreStart, DEFAULT_NAV_GROUPS } from '../../../../../core/public';
@@ -64,16 +64,14 @@ describe('<WorkspaceMenu />', () => {
     const selectButton = screen.getByTestId('workspace-select-button');
     fireEvent.click(selectButton);
 
-    expect(screen.getByText(/all workspaces/i)).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-item-all-workspace-1')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-item-all-workspace-2')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-menu-item-workspace-1')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-menu-item-workspace-2')).toBeInTheDocument();
   });
 
   it('should display a list of recent workspaces in the dropdown', () => {
-    jest.spyOn(recentWorkspaceManager, 'getRecentWorkspaces').mockReturnValue([
-      { id: 'workspace-1', timestamp: 1234567890 },
-      { id: 'workspace-2', timestamp: 1234567899 },
-    ]);
+    jest
+      .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')
+      .mockReturnValue([{ id: 'workspace-1', timestamp: 1234567890 }]);
 
     coreStartMock.workspaces.workspaceList$.next([
       { id: 'workspace-1', name: 'workspace 1', features: [] },
@@ -85,9 +83,7 @@ describe('<WorkspaceMenu />', () => {
     const selectButton = screen.getByTestId('workspace-select-button');
     fireEvent.click(selectButton);
 
-    expect(screen.getByText(/recent workspaces/i)).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-item-recent-workspace-1')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-item-recent-workspace-2')).toBeInTheDocument();
+    expect(screen.getByText(`viewed ${moment(1234567890).fromNow()}`)).toBeInTheDocument();
   });
 
   it('should be able to display empty state when the workspace list is empty', () => {
@@ -113,8 +109,8 @@ describe('<WorkspaceMenu />', () => {
 
     const searchInput = screen.getByRole('searchbox');
     fireEvent.change(searchInput, { target: { value: 'works' } });
-    expect(screen.getByTestId('workspace-menu-item-recent-workspace-1')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-item-recent-workspace-1')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-menu-item-workspace-1')).toBeInTheDocument();
+    expect(screen.queryByText('workspace-menu-item-workspace-1')).not.toBeInTheDocument();
   });
 
   it('should be able to display empty state when seach is not found', () => {

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -141,7 +141,7 @@ describe('<WorkspaceMenu />', () => {
 
     fireEvent.click(screen.getByTestId('workspace-select-button'));
     expect(screen.getByTestId('workspace-menu-current-workspace-name')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-current-use-case')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-menu-current-workspace-use-case')).toBeInTheDocument();
     expect(screen.getByTestId('current-workspace-icon-wsObservability')).toBeInTheDocument();
     expect(screen.getByText('Observability')).toBeInTheDocument();
   });

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -2,7 +2,6 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { i18n } from '@osd/i18n';
 import React, { useState } from 'react';
 import { useObservable } from 'react-use';

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -101,7 +101,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
         direction="column"
         alignItems="center"
         gutterSize="none"
-        style={{ width: '300px' }}
+        style={{ width: '310px' }}
       >
         <EuiFlexItem style={{ padding: '24px' }}>
           <EuiFlexGroup

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -25,7 +25,7 @@ import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
 import { WorkspaceUseCase } from '../../types';
 import { validateWorkspaceColor } from '../../../common/utils';
 import { WorkspacePickerContent } from '../workspace_picker_content/workspace_picker_content';
-
+import './workspace_menu.scss';
 const defaultHeaderName = i18n.translate('workspace.menu.defaultHeaderName', {
   defaultMessage: 'Workspaces',
 });
@@ -102,7 +102,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
         gutterSize="none"
         style={{ width: '310px' }}
       >
-        <EuiFlexItem style={{ padding: '24px' }}>
+        <EuiFlexItem className="workspaceMenuHeader">
           <EuiFlexGroup
             justifyContent="spaceAround"
             alignItems="center"

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -93,18 +93,12 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       button={currentWorkspaceButton}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="none"
       anchorPosition="downCenter"
+      panelPaddingSize="s"
       repositionOnScroll={true}
     >
-      <EuiFlexGroup
-        direction="column"
-        alignItems="center"
-        gutterSize="none"
-        // padding equals to size s
-        style={{ padding: '4px' }}
-      >
-        <EuiFlexItem style={{ padding: '12px' }}>
+      <EuiFlexGroup direction="column" alignItems="center" gutterSize="none">
+        <EuiFlexItem style={{ padding: '24px' }}>
           <EuiFlexGroup
             justifyContent="spaceAround"
             alignItems="center"
@@ -168,7 +162,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
               <EuiFlexItem grow={false} className="eui-textLeft">
                 <EuiButtonEmpty
                   color="primary"
-                  size="xs"
+                  size="s"
                   data-test-subj="workspace-menu-manage-button"
                   onClick={() => {
                     closePopover();
@@ -182,7 +176,7 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
               <EuiFlexItem grow={false} className="eui-textRight">
                 <EuiButtonEmpty
                   color="primary"
-                  size="xs"
+                  size="s"
                   iconType="plus"
                   key={WORKSPACE_CREATE_APP_ID}
                   data-test-subj="workspace-menu-create-workspace-button"

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -26,6 +26,7 @@ import { WorkspaceUseCase } from '../../types';
 import { validateWorkspaceColor } from '../../../common/utils';
 import { WorkspacePickerContent } from '../workspace_picker_content/workspace_picker_content';
 import './workspace_menu.scss';
+
 const defaultHeaderName = i18n.translate('workspace.menu.defaultHeaderName', {
   defaultMessage: 'Workspaces',
 });

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -97,13 +97,18 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       panelPaddingSize="s"
       repositionOnScroll={true}
     >
-      <EuiFlexGroup direction="column" alignItems="center" gutterSize="none">
+      <EuiFlexGroup
+        direction="column"
+        alignItems="center"
+        gutterSize="none"
+        style={{ width: '300px' }}
+      >
         <EuiFlexItem style={{ padding: '24px' }}>
           <EuiFlexGroup
             justifyContent="spaceAround"
             alignItems="center"
             direction="column"
-            gutterSize="s"
+            gutterSize="none"
           >
             {currentWorkspace ? (
               <>
@@ -115,15 +120,19 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
                     color={getValidWorkspaceColor(currentWorkspace.color)}
                   />
                 </EuiFlexItem>
-                <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
-                  <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
+                <EuiFlexItem data-test-subj="workspace-menu-current-workspace-name">
+                  <EuiText textAlign="center" size="s">
+                    <h3>{currentWorkspaceName}</h3>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
                   <EuiText
                     size="xs"
-                    data-test-subj="workspace-menu-current-use-case"
+                    data-test-subj="workspace-menu-current-workspace-use-case"
                     textAlign="center"
                     color="subdued"
                   >
-                    {getUseCase(currentWorkspace)?.title ?? ''}
+                    <p>{getUseCase(currentWorkspace)?.title ?? ''}</p>
                   </EuiText>
                 </EuiFlexItem>
               </>
@@ -139,18 +148,19 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
             )}
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem className="eui-fullWidth">
           <EuiPanel
             paddingSize="none"
             hasBorder={false}
             hasShadow={false}
             color="transparent"
-            style={{ height: '42vh', width: '300px' }}
+            style={{ height: '40vh' }}
           >
             <WorkspacePickerContent
               coreStart={coreStart}
               registeredUseCases$={registeredUseCases$}
               onClickWorkspace={() => setPopover(false)}
+              isInTwoLines={false}
             />
           </EuiPanel>
         </EuiFlexItem>

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -9,11 +9,11 @@ import { useObservable } from 'react-use';
 import {
   EuiText,
   EuiPanel,
-  EuiButton,
   EuiPopover,
   EuiButtonIcon,
   EuiFlexItem,
   EuiIcon,
+  EuiSpacer,
   EuiFlexGroup,
   EuiHorizontalRule,
   EuiButtonEmpty,
@@ -93,106 +93,111 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
       button={currentWorkspaceButton}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="s"
+      panelPaddingSize="none"
       anchorPosition="downCenter"
       repositionOnScroll={true}
     >
-      <EuiPanel hasBorder={false} color="transparent">
-        <EuiFlexGroup
-          justifyContent="spaceAround"
-          alignItems="center"
-          direction="column"
-          gutterSize="s"
-        >
-          {currentWorkspace ? (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiIcon
-                  size="xl"
-                  data-test-subj={`current-workspace-icon-${getUseCase(currentWorkspace)?.icon}`}
-                  type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
-                  color={getValidWorkspaceColor(currentWorkspace.color)}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-                data-test-subj="workspace-menu-current-workspace-name"
-                style={{ maxWidth: '200px' }}
-              >
-                <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
-                <EuiText
-                  size="xs"
-                  data-test-subj="workspace-menu-current-use-case"
-                  textAlign="center"
-                  color="subdued"
-                >
-                  {getUseCase(currentWorkspace)?.title ?? ''}
-                </EuiText>
-              </EuiFlexItem>
-            </>
-          ) : (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiIcon size="xl" color="subdued" type="wsSelector" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
-                <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
-              </EuiFlexItem>
-            </>
-          )}
-        </EuiFlexGroup>
-      </EuiPanel>
-
-      <EuiPanel
-        paddingSize="s"
-        hasBorder={false}
-        color="transparent"
-        style={{ height: '30vh' }}
-        className="eui-fullHeight"
+      <EuiFlexGroup
+        direction="column"
+        alignItems="center"
+        gutterSize="none"
+        // padding equals to size s
+        style={{ padding: '4px' }}
       >
-        <WorkspacePickerContent
-          coreStart={coreStart}
-          registeredUseCases$={registeredUseCases$}
-          onClickWorkspace={() => setPopover(false)}
-        />
-      </EuiPanel>
-
-      {isDashboardAdmin && (
-        <EuiPanel paddingSize="s" hasBorder={false} color="transparent">
-          <EuiHorizontalRule />
-          <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s">
-            <EuiFlexItem>
-              <EuiButtonEmpty
-                color="primary"
-                size="xs"
-                data-test-subj="workspace-menu-manage-button"
-                onClick={() => {
-                  closePopover();
-                  coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
-                }}
-              >
-                <EuiText size="s">{manageWorkspacesButton}</EuiText>
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color="primary"
-                iconType="plus"
-                size="s"
-                key={WORKSPACE_CREATE_APP_ID}
-                data-test-subj="workspace-menu-create-workspace-button"
-                onClick={() => {
-                  closePopover();
-                  coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
-                }}
-              >
-                <EuiText size="s">{createWorkspaceButton}</EuiText>
-              </EuiButton>
-            </EuiFlexItem>
+        <EuiFlexItem style={{ padding: '12px' }}>
+          <EuiFlexGroup
+            justifyContent="spaceAround"
+            alignItems="center"
+            direction="column"
+            gutterSize="s"
+          >
+            {currentWorkspace ? (
+              <>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon
+                    size="xl"
+                    data-test-subj={`current-workspace-icon-${getUseCase(currentWorkspace)?.icon}`}
+                    type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
+                    color={getValidWorkspaceColor(currentWorkspace.color)}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
+                  <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
+                  <EuiText
+                    size="xs"
+                    data-test-subj="workspace-menu-current-use-case"
+                    textAlign="center"
+                    color="subdued"
+                  >
+                    {getUseCase(currentWorkspace)?.title ?? ''}
+                  </EuiText>
+                </EuiFlexItem>
+              </>
+            ) : (
+              <>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon size="xl" color="subdued" type="wsSelector" />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false} data-test-subj="workspace-menu-current-workspace-name">
+                  <EuiText textAlign="center">{currentWorkspaceName}</EuiText>
+                </EuiFlexItem>
+              </>
+            )}
           </EuiFlexGroup>
-        </EuiPanel>
-      )}
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel
+            paddingSize="none"
+            hasBorder={false}
+            hasShadow={false}
+            color="transparent"
+            style={{ height: '42vh', width: '300px' }}
+          >
+            <WorkspacePickerContent
+              coreStart={coreStart}
+              registeredUseCases$={registeredUseCases$}
+              onClickWorkspace={() => setPopover(false)}
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+        {isDashboardAdmin && (
+          <EuiFlexItem className="eui-fullWidth">
+            <EuiHorizontalRule size="full" margin="none" />
+            <EuiSpacer size="s" />
+            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+              <EuiFlexItem grow={false} className="eui-textLeft">
+                <EuiButtonEmpty
+                  color="primary"
+                  size="xs"
+                  data-test-subj="workspace-menu-manage-button"
+                  onClick={() => {
+                    closePopover();
+                    coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
+                  }}
+                >
+                  <EuiText size="s">{manageWorkspacesButton}</EuiText>
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+
+              <EuiFlexItem grow={false} className="eui-textRight">
+                <EuiButtonEmpty
+                  color="primary"
+                  size="xs"
+                  iconType="plus"
+                  key={WORKSPACE_CREATE_APP_ID}
+                  data-test-subj="workspace-menu-create-workspace-button"
+                  onClick={() => {
+                    closePopover();
+                    coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
+                  }}
+                >
+                  <EuiText size="s">{createWorkspaceButton}</EuiText>
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
     </EuiPopover>
   );
 };

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.tsx
@@ -126,12 +126,12 @@ export const WorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText
-                    size="xs"
+                    size="s"
                     data-test-subj="workspace-menu-current-workspace-use-case"
                     textAlign="center"
                     color="subdued"
                   >
-                    <p>{getUseCase(currentWorkspace)?.title ?? ''}</p>
+                    <small>{getUseCase(currentWorkspace)?.title ?? ''}</small>
                   </EuiText>
                 </EuiFlexItem>
               </>

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -158,7 +158,7 @@ export const WorkspacePickerContent = ({
             data-test-subj={`workspace-menu-item-${workspace.id}`}
             icon={
               <EuiIcon
-                size="m"
+                size="l"
                 type={useCase?.icon || 'wsSelector'}
                 color={getValidWorkspaceColor(workspace.color)}
               />
@@ -224,7 +224,7 @@ export const WorkspacePickerContent = ({
         hasBorder={false}
         hasShadow={false}
         color="transparent"
-        // adding this inline style to make sure that part of list won't be hidden, and enable scrolling in side bar as well
+        // adding this inline style to make sure that part of list won't be hidden
         style={{ maxHeight: 'calc(100% - 50px)' }}
         className="euiYScrollWithShadows"
       >

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -54,13 +54,14 @@ interface Props {
   coreStart: CoreStart;
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
   onClickWorkspace?: () => void;
-  isReturnLists?: boolean;
+  isInTwoLines?: boolean;
 }
 
 export const WorkspacePickerContent = ({
   coreStart,
   registeredUseCases$,
   onClickWorkspace,
+  isInTwoLines,
 }: Props) => {
   const isDashboardAdmin = coreStart.application.capabilities?.dashboards?.isDashboardAdmin;
   const availableUseCases = useObservable(registeredUseCases$, []);
@@ -164,26 +165,52 @@ export const WorkspacePickerContent = ({
               />
             }
             label={
-              <EuiFlexGroup direction="column" gutterSize="none" className="eui-fullWidth">
-                <EuiFlexItem>
-                  <EuiText className="eui-textTruncate">{workspace.name}</EuiText>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiFlexGroup justifyContent="spaceBetween">
-                    <EuiFlexItem className="eui-textLeft" grow={false}>
-                      <EuiText size="xs" color="subdued">
-                        {useCase?.title}
-                      </EuiText>
-                    </EuiFlexItem>
-                    {/* text-alignRight is ineffective here*/}
-                    <EuiFlexItem grow={1} style={{ position: 'absolute', right: '0px' }}>
-                      <EuiText size="xs" color="subdued">
-                        {workspace.accessTime}
-                      </EuiText>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+              !isInTwoLines ? (
+                <EuiFlexGroup direction="column" gutterSize="none" className="eui-fullWidth">
+                  <EuiFlexItem>
+                    <EuiText className="eui-textTruncate" size="s">
+                      {workspace.name}
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiFlexGroup justifyContent="spaceBetween">
+                      <EuiFlexItem className="eui-textLeft" grow={false}>
+                        <EuiText size="xs" color="subdued">
+                          {useCase?.title}
+                        </EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={1} style={{ position: 'absolute', right: '0px' }}>
+                        <EuiText size="xs" color="subdued">
+                          <p> {workspace.accessTime}</p>
+                        </EuiText>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              ) : (
+                <EuiFlexGroup
+                  direction="column"
+                  gutterSize="none"
+                  className="eui-fullWidth"
+                  alignItems="flexStart"
+                >
+                  <EuiFlexItem>
+                    <EuiText className="eui-textTruncate" size="s">
+                      {workspace.name}
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiText size="xs" color="subdued">
+                      {useCase?.title}
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiText size="xs" color="subdued">
+                      {workspace.accessTime}
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              )
             }
             onClick={() => {
               onClickWorkspace?.();
@@ -200,9 +227,7 @@ export const WorkspacePickerContent = ({
     const listItems = getWorkspaceLists(filterWorkspaceList);
     return (
       <>
-        <EuiListGroup gutterSize="none" maxWidth="300px">
-          {listItems}
-        </EuiListGroup>
+        <EuiListGroup gutterSize="none">{listItems}</EuiListGroup>
       </>
     );
   };
@@ -223,10 +248,9 @@ export const WorkspacePickerContent = ({
         paddingSize="none"
         hasBorder={false}
         hasShadow={false}
-        color="transparent"
         // adding this inline style to make sure that part of list won't be hidden
         style={{ maxHeight: 'calc(100% - 50px)' }}
-        className="euiYScrollWithShadows"
+        className="euiYScrollWithShadows eui-fullWidth"
       >
         {queriedWorkspace.length > 0 && getWorkspaceListGroup(queriedWorkspace)}
 

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -176,12 +176,12 @@ export const WorkspacePickerContent = ({
                     <EuiFlexGroup justifyContent="spaceBetween">
                       <EuiFlexItem className="eui-textLeft" grow={false}>
                         <EuiText size="xs" color="subdued">
-                          {useCase?.title}
+                          <small>{useCase?.title}</small>
                         </EuiText>
                       </EuiFlexItem>
                       <EuiFlexItem grow={1} style={{ position: 'absolute', right: '0px' }}>
                         <EuiText size="xs" color="subdued">
-                          <p> {workspace.accessTime}</p>
+                          <small> {workspace.accessTime}</small>
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -175,12 +175,12 @@ export const WorkspacePickerContent = ({
                   <EuiFlexItem>
                     <EuiFlexGroup justifyContent="spaceBetween">
                       <EuiFlexItem className="eui-textLeft" grow={false}>
-                        <EuiText size="xs" color="subdued">
+                        <EuiText size="s" color="subdued">
                           <small>{useCase?.title}</small>
                         </EuiText>
                       </EuiFlexItem>
                       <EuiFlexItem grow={1} style={{ position: 'absolute', right: '0px' }}>
-                        <EuiText size="xs" color="subdued">
+                        <EuiText size="s" color="subdued">
                           <small> {workspace.accessTime}</small>
                         </EuiText>
                       </EuiFlexItem>
@@ -200,13 +200,13 @@ export const WorkspacePickerContent = ({
                     </EuiText>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiText size="xs" color="subdued">
-                      {useCase?.title}
+                    <EuiText size="s" color="subdued">
+                      <small>{useCase?.title}</small>
                     </EuiText>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiText size="xs" color="subdued">
-                      {workspace.accessTime}
+                    <EuiText size="s" color="subdued">
+                      <small> {workspace.accessTime}</small>
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
@@ -6,14 +6,18 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import moment from 'moment';
-import { WorkspaceMenu } from './workspace_menu';
+import { WorkspaceSelector } from './workspace_selector';
 import { coreMock } from '../../../../../core/public/mocks';
-import { CoreStart, DEFAULT_NAV_GROUPS } from '../../../../../core/public';
+import { CoreStart, DEFAULT_NAV_GROUPS, WorkspaceObject } from '../../../../../core/public';
 import { BehaviorSubject } from 'rxjs';
 import { IntlProvider } from 'react-intl';
 import { recentWorkspaceManager } from '../../recent_workspace_manager';
-
-describe('<WorkspaceMenu />', () => {
+jest.mock('@osd/i18n', () => ({
+  i18n: {
+    translate: (id: string, { defaultMessage }: { defaultMessage: string }) => defaultMessage,
+  },
+}));
+describe('<WorkspaceSelector />', () => {
   let coreStartMock: CoreStart;
   const navigateToApp = jest.fn();
   const registeredUseCases$ = new BehaviorSubject([
@@ -30,21 +34,28 @@ describe('<WorkspaceMenu />', () => {
       workspaces: { permissionEnabled: true },
       dashboards: { isDashboardAdmin: true },
     };
+
     coreStartMock.application = {
       ...coreStartMock.application,
       navigateToApp,
     };
 
-    coreStartMock.workspaces.initialized$.next(true);
+    const mockCurrentWorkspace = [
+      { id: 'workspace-1', name: 'workspace 1', timestamp: 1234567890 },
+    ];
+    coreStartMock.workspaces.currentWorkspace$ = new BehaviorSubject<WorkspaceObject | null>(
+      mockCurrentWorkspace
+    );
+
     jest.spyOn(coreStartMock.application, 'getUrlForApp').mockImplementation((appId: string) => {
       return `https://test.com/app/${appId}`;
     });
   });
 
-  const WorkspaceMenuCreatorComponent = () => {
+  const WorkspaceSelectorCreatorComponent = () => {
     return (
       <IntlProvider locale="en">
-        <WorkspaceMenu coreStart={coreStartMock} registeredUseCases$={registeredUseCases$} />
+        <WorkspaceSelector coreStart={coreStartMock} registeredUseCases$={registeredUseCases$} />
       </IntlProvider>
     );
   };
@@ -55,13 +66,17 @@ describe('<WorkspaceMenu />', () => {
   });
 
   it('should display a list of workspaces in the dropdown', () => {
+    jest
+      .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')
+      .mockReturnValue([{ id: 'workspace-1', timestamp: 1234567890 }]);
+
     coreStartMock.workspaces.workspaceList$.next([
       { id: 'workspace-1', name: 'workspace 1', features: [] },
-      { id: 'workspace-2', name: 'workspace 2' },
+      { id: 'workspace-2', name: 'workspace 2', features: [] },
     ]);
 
-    render(<WorkspaceMenuCreatorComponent />);
-    const selectButton = screen.getByTestId('workspace-select-button');
+    render(<WorkspaceSelectorCreatorComponent />);
+    const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
 
     expect(screen.getByTestId('workspace-menu-item-workspace-1')).toBeInTheDocument();
@@ -78,9 +93,9 @@ describe('<WorkspaceMenu />', () => {
       { id: 'workspace-2', name: 'workspace 2', features: [] },
     ]);
 
-    render(<WorkspaceMenuCreatorComponent />);
+    render(<WorkspaceSelectorCreatorComponent />);
 
-    const selectButton = screen.getByTestId('workspace-select-button');
+    const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
 
     expect(screen.getByText(`viewed ${moment(1234567890).fromNow()}`)).toBeInTheDocument();
@@ -88,8 +103,8 @@ describe('<WorkspaceMenu />', () => {
 
   it('should be able to display empty state when the workspace list is empty', () => {
     coreStartMock.workspaces.workspaceList$.next([]);
-    render(<WorkspaceMenuCreatorComponent />);
-    const selectButton = screen.getByTestId('workspace-select-button');
+    render(<WorkspaceSelectorCreatorComponent />);
+    const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
     expect(screen.getByText(/no workspace available/i)).toBeInTheDocument();
   });
@@ -102,9 +117,9 @@ describe('<WorkspaceMenu />', () => {
     jest
       .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')
       .mockReturnValue([{ id: 'workspace-1', timestamp: 1234567890 }]);
-    render(<WorkspaceMenuCreatorComponent />);
+    render(<WorkspaceSelectorCreatorComponent />);
 
-    const selectButton = screen.getByTestId('workspace-select-button');
+    const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
 
     const searchInput = screen.getByRole('searchbox');
@@ -121,29 +136,14 @@ describe('<WorkspaceMenu />', () => {
     jest
       .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')
       .mockReturnValue([{ id: 'workspace-1', timestamp: 1234567890 }]);
-    render(<WorkspaceMenuCreatorComponent />);
+    render(<WorkspaceSelectorCreatorComponent />);
 
-    const selectButton = screen.getByTestId('workspace-select-button');
+    const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
 
     const searchInput = screen.getByRole('searchbox');
     fireEvent.change(searchInput, { target: { value: 'noitems' } });
     expect(screen.getByText(/no workspace available/i)).toBeInTheDocument();
-  });
-
-  it('should display current workspace name, use case name and associated icon', () => {
-    coreStartMock.workspaces.currentWorkspace$.next({
-      id: 'workspace-1',
-      name: 'workspace 1',
-      features: ['use-case-observability'],
-    });
-    render(<WorkspaceMenuCreatorComponent />);
-
-    fireEvent.click(screen.getByTestId('workspace-select-button'));
-    expect(screen.getByTestId('workspace-menu-current-workspace-name')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-current-workspace-use-case')).toBeInTheDocument();
-    expect(screen.getByTestId('current-workspace-icon-wsObservability')).toBeInTheDocument();
-    expect(screen.getByText('Observability')).toBeInTheDocument();
   });
 
   it('should navigate to the first feature of workspace use case', () => {
@@ -158,8 +158,8 @@ describe('<WorkspaceMenu />', () => {
       },
     });
 
-    render(<WorkspaceMenuCreatorComponent />);
-    fireEvent.click(screen.getByTestId('workspace-select-button'));
+    render(<WorkspaceSelectorCreatorComponent />);
+    fireEvent.click(screen.getByTestId('workspace-selector-button'));
     fireEvent.click(screen.getByText(/workspace 1/i));
 
     expect(window.location.assign).toHaveBeenCalledWith(
@@ -183,8 +183,8 @@ describe('<WorkspaceMenu />', () => {
       },
     });
 
-    render(<WorkspaceMenuCreatorComponent />);
-    fireEvent.click(screen.getByTestId('workspace-select-button'));
+    render(<WorkspaceSelectorCreatorComponent />);
+    fireEvent.click(screen.getByTestId('workspace-selector-button'));
     fireEvent.click(screen.getByText(/workspace 1/i));
 
     expect(window.location.assign).toHaveBeenCalledWith(
@@ -197,16 +197,16 @@ describe('<WorkspaceMenu />', () => {
   });
 
   it('should navigate to create workspace page', () => {
-    render(<WorkspaceMenuCreatorComponent />);
-    fireEvent.click(screen.getByTestId('workspace-select-button'));
+    render(<WorkspaceSelectorCreatorComponent />);
+    fireEvent.click(screen.getByTestId('workspace-selector-button'));
     fireEvent.click(screen.getByText(/create workspace/i));
     expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_create');
   });
 
   it('should navigate to workspace list page', () => {
-    render(<WorkspaceMenuCreatorComponent />);
+    render(<WorkspaceSelectorCreatorComponent />);
 
-    fireEvent.click(screen.getByTestId('workspace-select-button'));
+    fireEvent.click(screen.getByTestId('workspace-selector-button'));
     fireEvent.click(screen.getByText(/manage/i));
     expect(coreStartMock.application.navigateToApp).toHaveBeenCalledWith('workspace_list');
   });
@@ -219,9 +219,9 @@ describe('<WorkspaceMenu />', () => {
         isDashboardAdmin: false,
       },
     };
-    render(<WorkspaceMenuCreatorComponent />);
+    render(<WorkspaceSelectorCreatorComponent />);
 
-    fireEvent.click(screen.getByTestId('workspace-select-button'));
+    fireEvent.click(screen.getByTestId('workspace-selector-button'));
     expect(screen.queryByText(/manage/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/create workspaces/i)).toBeNull();
   });

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
@@ -40,9 +40,7 @@ describe('<WorkspaceSelector />', () => {
       navigateToApp,
     };
 
-    const mockCurrentWorkspace = [
-      { id: 'workspace-1', name: 'workspace 1', timestamp: 1234567890 },
-    ];
+    const mockCurrentWorkspace = [{ id: 'workspace-1', name: 'workspace 1' }];
     coreStartMock.workspaces.currentWorkspace$ = new BehaviorSubject<WorkspaceObject | null>(
       mockCurrentWorkspace
     );
@@ -65,6 +63,11 @@ describe('<WorkspaceSelector />', () => {
     jest.restoreAllMocks();
   });
 
+  it('should display the current workspace name', () => {
+    render(<WorkspaceSelectorCreatorComponent />);
+    expect(screen.getByTestId('workspace-selector-current-title')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-selector-current-name')).toBeInTheDocument();
+  });
   it('should display a list of workspaces in the dropdown', () => {
     jest
       .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -90,9 +90,9 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup direction="column" gutterSize="none">
-                  <EuiFlexItem grow={false} style={{ maxWidth: '150px' }}>
+                  <EuiFlexItem grow={false} style={{ maxWidth: '130px' }}>
                     <EuiText size="s">
-                      <h3 className="eui-textTruncate">{currentWorkspace.name}</h3>
+                      <h4 className="eui-textTruncate">{currentWorkspace.name}</h4>
                     </EuiText>
                   </EuiFlexItem>
                   <EuiFlexItem>
@@ -121,11 +121,10 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   return (
     <EuiPopover
       button={button}
-      hasArrow={false}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="s"
-      anchorPosition="downCenter"
+      anchorPosition="downLeft"
       repositionOnScroll={true}
       display="block"
       className="eui-fullWidth"
@@ -138,12 +137,13 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
             hasShadow={false}
             color="transparent"
             // set the width fixed to achieve a similar appearance to Superselect
-            style={{ height: '42vh', width: '282px' }}
+            style={{ height: '40vh', width: '300px' }}
           >
             <WorkspacePickerContent
               coreStart={coreStart}
               registeredUseCases$={registeredUseCases$}
               onClickWorkspace={() => setPopover(false)}
+              isInTwoLines={false}
             />
           </EuiPanel>
         </EuiFlexItem>

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -11,16 +11,28 @@ import {
   EuiIcon,
   EuiPopover,
   EuiPanel,
+  EuiHorizontalRule,
   EuiText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiSpacer,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import { BehaviorSubject } from 'rxjs';
+import { WORKSPACE_CREATE_APP_ID, WORKSPACE_LIST_APP_ID } from '../../../common/constants';
 import { CoreStart, WorkspaceObject } from '../../../../../core/public';
 import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
 import { WorkspaceUseCase } from '../../types';
 import { validateWorkspaceColor } from '../../../common/utils';
 import { WorkspacePickerContent } from '../workspace_picker_content/workspace_picker_content';
+
+const createWorkspaceButton = i18n.translate('workspace.menu.button.createWorkspace', {
+  defaultMessage: 'Create workspace',
+});
+
+const manageWorkspacesButton = i18n.translate('workspace.menu.button.manageWorkspaces', {
+  defaultMessage: 'Manage',
+});
 
 const getValidWorkspaceColor = (color?: string) =>
   validateWorkspaceColor(color) ? color : undefined;
@@ -34,6 +46,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   const [isPopoverOpen, setPopover] = useState(false);
   const currentWorkspace = useObservable(coreStart.workspaces.currentWorkspace$, null);
   const availableUseCases = useObservable(registeredUseCases$, []);
+  const isDashboardAdmin = coreStart.application.capabilities?.dashboards?.isDashboardAdmin;
 
   const getUseCase = (workspace: WorkspaceObject) => {
     if (!workspace.features) {
@@ -50,9 +63,8 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   const closePopover = () => {
     setPopover(false);
   };
-
   const button = currentWorkspace ? (
-    <>
+    <EuiPanel paddingSize="none" color="transparent" hasBorder={false} hasShadow={false}>
       <EuiText
         size="xs"
         // here I try inline style to achive the label looks
@@ -66,29 +78,33 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
         <p>worksapce</p>
       </EuiText>
       <EuiPanel paddingSize="s" borderRadius="m">
-        <EuiFlexGroup gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiIcon
-              size="l"
-              type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
-              color={getValidWorkspaceColor(currentWorkspace.color)}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup direction="column" gutterSize="none">
-              <EuiFlexItem grow={false} style={{ maxWidth: '150px' }}>
-                <EuiText size="s">
-                  <h3 className="eui-textTruncate">{currentWorkspace.name}</h3>
-                </EuiText>
+        <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize="s" justifyContent="flexStart">
+              <EuiFlexItem grow={false}>
+                <EuiIcon
+                  size="l"
+                  type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
+                  color={getValidWorkspaceColor(currentWorkspace.color)}
+                />
               </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiText size="xs" color="subdued">
-                  <p>
-                    {i18n.translate('workspace.left.nav.selector.description', {
-                      defaultMessage: getUseCase(currentWorkspace)?.title || '',
-                    })}
-                  </p>
-                </EuiText>
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup direction="column" gutterSize="none">
+                  <EuiFlexItem grow={false} style={{ maxWidth: '150px' }}>
+                    <EuiText size="s">
+                      <h3 className="eui-textTruncate">{currentWorkspace.name}</h3>
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiText size="xs" color="subdued">
+                      <p>
+                        {i18n.translate('workspace.left.nav.selector.description', {
+                          defaultMessage: getUseCase(currentWorkspace)?.title || '',
+                        })}
+                      </p>
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
@@ -97,7 +113,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>
-    </>
+    </EuiPanel>
   ) : (
     <EuiButton onClick={onButtonClick}>Select a Workspace</EuiButton>
   );
@@ -105,16 +121,76 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   return (
     <EuiPopover
       button={button}
+      hasArrow={false}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="s"
-      anchorPosition="downRight"
+      panelPaddingSize="none"
+      anchorPosition="downCenter"
+      repositionOnScroll={true}
+      display="block"
+      className="eui-fullWidth"
     >
-      <WorkspacePickerContent
-        coreStart={coreStart}
-        registeredUseCases$={registeredUseCases$}
-        onClickWorkspace={() => setPopover(false)}
-      />
+      <EuiFlexGroup
+        direction="column"
+        alignItems="center"
+        gutterSize="none"
+        // padding equals to size s
+        style={{ padding: '4px' }}
+      >
+        <EuiFlexItem>
+          <EuiPanel
+            paddingSize="none"
+            hasBorder={false}
+            hasShadow={false}
+            color="transparent"
+            style={{ height: '42vh', width: '285px' }}
+          >
+            <WorkspacePickerContent
+              coreStart={coreStart}
+              registeredUseCases$={registeredUseCases$}
+              onClickWorkspace={() => setPopover(false)}
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+
+        {isDashboardAdmin && (
+          <EuiFlexItem className="eui-fullWidth" style={{ padding: '4px' }}>
+            <EuiHorizontalRule size="full" margin="none" />
+            <EuiSpacer size="s" />
+            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+              <EuiFlexItem grow={false} className="eui-textLeft">
+                <EuiButtonEmpty
+                  color="primary"
+                  size="xs"
+                  data-test-subj="workspace-menu-manage-button"
+                  onClick={() => {
+                    closePopover();
+                    coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
+                  }}
+                >
+                  <EuiText size="s">{manageWorkspacesButton}</EuiText>
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+
+              <EuiFlexItem grow={false} className="eui-textRight">
+                <EuiButtonEmpty
+                  color="primary"
+                  size="xs"
+                  iconType="plus"
+                  key={WORKSPACE_CREATE_APP_ID}
+                  data-test-subj="workspace-menu-create-workspace-button"
+                  onClick={() => {
+                    closePopover();
+                    coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
+                  }}
+                >
+                  <EuiText size="s">{createWorkspaceButton}</EuiText>
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
     </EuiPopover>
   );
 };

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -124,26 +124,21 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
       hasArrow={false}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      panelPaddingSize="none"
+      panelPaddingSize="s"
       anchorPosition="downCenter"
       repositionOnScroll={true}
       display="block"
       className="eui-fullWidth"
     >
-      <EuiFlexGroup
-        direction="column"
-        alignItems="center"
-        gutterSize="none"
-        // padding equals to size s
-        style={{ padding: '4px' }}
-      >
+      <EuiFlexGroup direction="column" alignItems="center" gutterSize="none">
         <EuiFlexItem>
           <EuiPanel
             paddingSize="none"
             hasBorder={false}
             hasShadow={false}
             color="transparent"
-            style={{ height: '42vh', width: '285px' }}
+            // set the width fixed to achieve a similar appearance to Superselect
+            style={{ height: '42vh', width: '282px' }}
           >
             <WorkspacePickerContent
               coreStart={coreStart}

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { useObservable } from 'react-use';
+import { i18n } from '@osd/i18n';
+import {
+  EuiButton,
+  EuiIcon,
+  EuiPopover,
+  EuiPanel,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+import { BehaviorSubject } from 'rxjs';
+import { CoreStart, WorkspaceObject } from '../../../../../core/public';
+import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
+import { WorkspaceUseCase } from '../../types';
+import { validateWorkspaceColor } from '../../../common/utils';
+import { WorkspacePickerContent } from '../workspace_picker_content/workspace_picker_content';
+
+const getValidWorkspaceColor = (color?: string) =>
+  validateWorkspaceColor(color) ? color : undefined;
+
+interface Props {
+  coreStart: CoreStart;
+  registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
+}
+
+export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const currentWorkspace = useObservable(coreStart.workspaces.currentWorkspace$, null);
+  const availableUseCases = useObservable(registeredUseCases$, []);
+
+  const getUseCase = (workspace: WorkspaceObject) => {
+    if (!workspace.features) {
+      return;
+    }
+    const useCaseId = getFirstUseCaseOfFeatureConfigs(workspace.features);
+    return availableUseCases.find((useCase) => useCase.id === useCaseId);
+  };
+
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
+  };
+
+  const closePopover = () => {
+    setPopover(false);
+  };
+
+  const button = currentWorkspace ? (
+    <>
+      <EuiText
+        size="xs"
+        // here I try inline style to achive the label looks
+        style={{
+          position: 'relative',
+          bottom: '-10px',
+          zIndex: 1,
+          padding: '0 5px',
+        }}
+      >
+        <p>worksapce</p>
+      </EuiText>
+      <EuiPanel paddingSize="s" borderRadius="m">
+        <EuiFlexGroup gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiIcon
+              size="l"
+              type={getUseCase(currentWorkspace)?.icon || 'wsSelector'}
+              color={getValidWorkspaceColor(currentWorkspace.color)}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem grow={false} style={{ maxWidth: '150px' }}>
+                <EuiText size="s">
+                  <h3 className="eui-textTruncate">{currentWorkspace.name}</h3>
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="xs" color="subdued">
+                  <p>
+                    {i18n.translate('workspace.left.nav.selector.description', {
+                      defaultMessage: getUseCase(currentWorkspace)?.title || '',
+                    })}
+                  </p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false} style={{ alignSelf: 'center' }} onClick={onButtonClick}>
+            <EuiIcon type="arrowDown" size="m" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </>
+  ) : (
+    <EuiButton onClick={onButtonClick}>Select a Workspace</EuiButton>
+  );
+
+  return (
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="s"
+      anchorPosition="downRight"
+    >
+      <WorkspacePickerContent
+        coreStart={coreStart}
+        registeredUseCases$={registeredUseCases$}
+        onClickWorkspace={() => setPopover(false)}
+      />
+    </EuiPopover>
+  );
+};

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -137,7 +137,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
             hasShadow={false}
             color="transparent"
             // set the width fixed to achieve a similar appearance to Superselect
-            style={{ height: '40vh', width: '300px' }}
+            style={{ height: '40vh', width: '310px' }}
           >
             <WorkspacePickerContent
               coreStart={coreStart}

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -169,6 +169,10 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
                   color="primary"
                   size="xs"
                   data-test-subj="workspace-menu-manage-button"
+                  onClick={() => {
+                    closePopover();
+                    coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
+                  }}
                 >
                   <EuiText size="s">{manageWorkspacesButton}</EuiText>
                 </EuiButtonEmpty>

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -64,10 +64,17 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
     setPopover(false);
   };
   const button = currentWorkspace ? (
-    <EuiPanel paddingSize="none" color="transparent" hasBorder={false} hasShadow={false}>
+    <EuiPanel
+      paddingSize="none"
+      color="transparent"
+      hasBorder={false}
+      hasShadow={false}
+      data-test-subj="workspace-selector-button"
+      onClick={onButtonClick}
+    >
       <EuiText
         size="xs"
-        // here I try inline style to achive the label looks
+        // TODO: Use standard OuiComponent to achieve the label looks
         style={{
           position: 'relative',
           bottom: '-10px',
@@ -75,7 +82,11 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
           padding: '0 5px',
         }}
       >
-        <p>worksapce</p>
+        <small>
+          {i18n.translate('workspace.left.nav.selector.label', {
+            defaultMessage: 'WORKSPACE',
+          })}
+        </small>
       </EuiText>
       <EuiPanel paddingSize="s" borderRadius="m">
         <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">
@@ -97,18 +108,18 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiText size="xs" color="subdued">
-                      <p>
+                      <small>
                         {i18n.translate('workspace.left.nav.selector.description', {
                           defaultMessage: getUseCase(currentWorkspace)?.title || '',
                         })}
-                      </p>
+                      </small>
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ alignSelf: 'center' }} onClick={onButtonClick}>
+          <EuiFlexItem grow={false} style={{ alignSelf: 'center' }}>
             <EuiIcon type="arrowDown" size="m" />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -136,7 +147,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
             hasBorder={false}
             hasShadow={false}
             color="transparent"
-            // set the width fixed to achieve a similar appearance to Superselect
+            // set the width fixed to achieve text truncation
             style={{ height: '40vh', width: '310px' }}
           >
             <WorkspacePickerContent
@@ -158,10 +169,6 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
                   color="primary"
                   size="xs"
                   data-test-subj="workspace-menu-manage-button"
-                  onClick={() => {
-                    closePopover();
-                    coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
-                  }}
                 >
                   <EuiText size="s">{manageWorkspacesButton}</EuiText>
                 </EuiButtonEmpty>

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -102,14 +102,18 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup direction="column" gutterSize="none">
                   <EuiFlexItem grow={false} style={{ maxWidth: '130px' }}>
-                    <EuiText size="s">
+                    <EuiText size="s" data-test-subj="workspace-selector-current-name">
                       <h4 className="eui-textTruncate">{currentWorkspace.name}</h4>
                     </EuiText>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiText size="xs" color="subdued">
+                    <EuiText
+                      size="xs"
+                      color="subdued"
+                      data-test-subj="workspace-selector-current-title"
+                    >
                       <small>
-                        {i18n.translate('workspace.left.nav.selector.description', {
+                        {i18n.translate('workspace.left.nav.selector.title', {
                           defaultMessage: getUseCase(currentWorkspace)?.title || '',
                         })}
                       </small>
@@ -160,7 +164,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
         </EuiFlexItem>
 
         {isDashboardAdmin && (
-          <EuiFlexItem className="eui-fullWidth" style={{ padding: '4px' }}>
+          <EuiFlexItem className="eui-fullWidth">
             <EuiHorizontalRule size="full" margin="none" />
             <EuiSpacer size="s" />
             <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">

--- a/src/plugins/workspace/public/index.ts
+++ b/src/plugins/workspace/public/index.ts
@@ -4,7 +4,6 @@
  */
 
 import { WorkspacePlugin } from './plugin';
-
 export function plugin() {
   return new WorkspacePlugin();
 }

--- a/src/plugins/workspace/public/index.ts
+++ b/src/plugins/workspace/public/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { WorkspacePlugin } from './plugin';
+
 export function plugin() {
   return new WorkspacePlugin();
 }

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -221,7 +221,20 @@ describe('Workspace plugin', () => {
     );
   });
 
-  it('#setup should register registerCollapsibleNavHeader when new left nav is turned on', async () => {
+  it('#setup should register registerCollapsibleNavHeader when enter a workspace', async () => {
+    const windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(
+      () =>
+        ({
+          location: {
+            href: 'http://localhost/w/workspaceId/app',
+          },
+        } as any)
+    );
+    workspaceClientMock.enterWorkspace.mockResolvedValueOnce({
+      success: true,
+      error: 'error',
+    });
     const setupMock = coreMock.createSetup();
     let collapsibleNavHeaderImplementation = () => null;
     setupMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
@@ -234,6 +247,7 @@ describe('Workspace plugin', () => {
     const startMock = coreMock.createStart();
     await workspacePlugin.start(startMock, getMockDependencies());
     expect(collapsibleNavHeaderImplementation()).not.toEqual(null);
+    windowSpy.mockRestore();
   });
 
   it('#setup should register workspace essential use case when new home is disabled', async () => {

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -554,6 +554,7 @@ export class WorkspacePlugin
               key: 'workspacePickerContent',
               coreStart: this.coreStart,
               registeredUseCases$: this.registeredUseCases$,
+              isInTwoLines: true,
             }),
           ],
         });

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -567,10 +567,17 @@ export class WorkspacePlugin
         if (!this.coreStart) {
           return null;
         }
-        return React.createElement(WorkspaceSelector, {
-          key: 'workspaceSelector',
-          coreStart: this.coreStart,
-          registeredUseCases$: this.registeredUseCases$,
+        return React.createElement(EuiPanel, {
+          hasShadow: false,
+          hasBorder: false,
+          paddingSize: 'none',
+          children: [
+            React.createElement(WorkspaceSelector, {
+              key: 'workspaceSelector',
+              coreStart: this.coreStart,
+              registeredUseCases$: this.registeredUseCases$,
+            }),
+          ],
         });
       });
     }

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -60,6 +60,7 @@ import { UseCaseService } from './services/use_case_service';
 import { WorkspaceListCard } from './components/service_card';
 import { NavigationPublicPluginStart } from '../../../plugins/navigation/public';
 import { WorkspacePickerContent } from './components/workspace_picker_content/workspace_picker_content';
+import { WorkspaceSelector } from './components/workspace_selector/workspace_selector';
 import { HOME_CONTENT_AREAS } from '../../../plugins/content_management/public';
 import {
   registerEssentialOverviewContent,
@@ -122,7 +123,6 @@ export class WorkspacePlugin
    */
   private filterNavLinks = (core: CoreStart) => {
     const currentWorkspace$ = core.workspaces.currentWorkspace$;
-
     this.workspaceAndUseCasesCombineSubscription?.unsubscribe();
     this.workspaceAndUseCasesCombineSubscription = combineLatest([
       currentWorkspace$,
@@ -555,6 +555,22 @@ export class WorkspacePlugin
               registeredUseCases$: this.registeredUseCases$,
             }),
           ],
+        });
+      });
+    }
+
+    if (workspaceId) {
+      /**
+       * Show workspace selector when inside of workspace
+       */
+      core.chrome.registerCollapsibleNavHeader(() => {
+        if (!this.coreStart) {
+          return null;
+        }
+        return React.createElement(WorkspaceSelector, {
+          key: 'workspaceSelector',
+          coreStart: this.coreStart,
+          registeredUseCases$: this.registeredUseCases$,
         });
       });
     }

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -537,50 +537,24 @@ export class WorkspacePlugin
     ]);
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
-      /**
-       * Show workspace picker content when outside of workspace and not in any nav group
-       */
       core.chrome.registerCollapsibleNavHeader(() => {
         if (!this.coreStart) {
           return null;
         }
-        return React.createElement(EuiPanel, {
-          hasShadow: false,
-          hasBorder: false,
-          paddingSize: 's',
-          style: { height: '65vh' },
-          children: [
-            React.createElement(WorkspacePickerContent, {
-              key: 'workspacePickerContent',
-              coreStart: this.coreStart,
-              registeredUseCases$: this.registeredUseCases$,
-              isInTwoLines: true,
-            }),
-          ],
-        });
-      });
-    }
-
-    if (workspaceId) {
-      /**
-       * Show workspace selector when inside of workspace
-       */
-      core.chrome.registerCollapsibleNavHeader(() => {
-        if (!this.coreStart) {
-          return null;
+        if (workspaceId) {
+          return React.createElement(WorkspaceSelector, {
+            key: 'workspaceSelector',
+            coreStart: this.coreStart,
+            registeredUseCases$: this.registeredUseCases$,
+          });
+        } else {
+          return React.createElement(WorkspacePickerContent, {
+            key: 'workspacePickerContent',
+            coreStart: this.coreStart,
+            registeredUseCases$: this.registeredUseCases$,
+            isInTwoLines: true,
+          });
         }
-        return React.createElement(EuiPanel, {
-          hasShadow: false,
-          hasBorder: false,
-          paddingSize: 'none',
-          children: [
-            React.createElement(WorkspaceSelector, {
-              key: 'workspaceSelector',
-              coreStart: this.coreStart,
-              registeredUseCases$: this.registeredUseCases$,
-            }),
-          ],
-        });
       });
     }
 

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -536,25 +536,16 @@ export class WorkspacePlugin
       },
     ]);
 
-    if (core.chrome.navGroup.getNavGroupEnabled()) {
+    if (workspaceId) {
       core.chrome.registerCollapsibleNavHeader(() => {
         if (!this.coreStart) {
           return null;
         }
-        if (workspaceId) {
-          return React.createElement(WorkspaceSelector, {
-            key: 'workspaceSelector',
-            coreStart: this.coreStart,
-            registeredUseCases$: this.registeredUseCases$,
-          });
-        } else {
-          return React.createElement(WorkspacePickerContent, {
-            key: 'workspacePickerContent',
-            coreStart: this.coreStart,
-            registeredUseCases$: this.registeredUseCases$,
-            isInTwoLines: true,
-          });
-        }
+        return React.createElement(WorkspaceSelector, {
+          key: 'workspaceSelector',
+          coreStart: this.coreStart,
+          registeredUseCases$: this.registeredUseCases$,
+        });
       });
     }
 

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -548,6 +548,7 @@ export class WorkspacePlugin
           hasShadow: false,
           hasBorder: false,
           paddingSize: 's',
+          style: { height: '65vh' },
           children: [
             React.createElement(WorkspacePickerContent, {
               key: 'workspacePickerContent',


### PR DESCRIPTION
### Description
This pr:
1. adds workspace selectors to left nav bar when inside of a workspace
2. updates the UI of workspace picker content to the newest design

## Screenshot
1. the workspace list only appears in homepage
https://github.com/user-attachments/assets/a5cca6b0-710b-41de-ac98-f2296c188402

2. workspace selector
https://github.com/user-attachments/assets/d61b067d-4f2c-40e4-9595-985ff43c19ce

3. left bottom popover
https://github.com/user-attachments/assets/9150379f-fcce-4ab1-a7e6-10c74d8099b1


## Changelog
- feat: add workspace selector to left nav bar

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
