### PR TITLE
fix(queryEnhancements): data.search() should not ignore the `strategy` passed as parameter

### DIFF
--- a/changelogs/fragments/8368.yml
+++ b/changelogs/fragments/8368.yml
@@ -1,0 +1,2 @@
+fix:
+- Data.search() should not ignore the strategy passed as parameter ([#8368](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8368))

--- a/src/plugins/data/public/search/search_service.ts
+++ b/src/plugins/data/public/search/search_service.ts
@@ -155,7 +155,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
   ): ISearchStart {
     const search = ((request, options) => {
       const isEnhancedEnabled = uiSettings.get(UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED);
-      if (isEnhancedEnabled) {
+      if (isEnhancedEnabled && !options?.strategy) {
         const queryStringManager = getQueryService().queryString;
         const language = queryStringManager.getQuery().language;
         const languageConfig = queryStringManager.getLanguageService().getLanguage(language);


### PR DESCRIPTION
This is quick fix for the issue that the search strategy passed to data.search() API been completely ignored when query enhancement is enabled and the localStorage has a language preserved.

For example, selecting a language from discover language selector will make data.search() called with a specific strategy to use the language config stored in localStorage which is unexpected.

With this fix, language config is only used when search strategy is not passed explicitly.

Sharing my two cents:
1. I think it's better the `language` is passed as a parameter to `data.search()` instead of reading directly from query string manager(which has default value from local storage that different feature could share the same value). I think `data.search()` needs to be UI/feature-agnostic
2. I'm fine with having different search intercepters for different languages, but it seems the current intercepters(ppl & sql) does way too much than than an "intercepter" should. IMHO, a search intercepter will just intercepts the search params(input) and search response(output), and does things like error handling, validation, etc. But now it seems we're building the search query in the intercepter by reading from some global state: time fitter, aggregation, etc. Shouldn't this be done upfront and passed to `data.search()` as search params?

I may not have a full picture of the entire idea of query enhancement, and I'm open to any other ideas :)

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix:  data.search() should not ignore the strategy passed as parameter

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
