### PR TITLE
Fix dynamic uses of i18n and correct duplicate i18n identifiers in console plugin

### DIFF
--- a/changelogs/fragments/8393.yml
+++ b/changelogs/fragments/8393.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix dynamic uses of i18n and correct duplicate i18n identifiers in console plugin ([#8393](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8393))

--- a/src/plugins/console/public/application/components/import_flyout.tsx
+++ b/src/plugins/console/public/application/components/import_flyout.tsx
@@ -215,7 +215,7 @@ export const ImportFlyout = ({ close, refresh }: ImportFlyoutProps) => {
       } else {
         setStatus('error');
         setError(
-          i18n.translate('console.ImportFlyout.importFileErrorMessage', {
+          i18n.translate('console.ImportFlyout.importFileErrorMessage.notJSON', {
             defaultMessage: 'The selected file is not valid. Please select a valid JSON file.',
           })
         );

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -228,10 +228,14 @@ function EditorUI({ initialTextValue, dataSourceId }: EditorProps) {
     });
   }, [sendCurrentRequestToOpenSearch, openDocumentation]);
 
-  const tooltipDefaultMessage =
-    dataSourceId === undefined ? `Select a data source` : `Click to send request`;
-
-  const toolTipButtonDiasbled = dataSourceId === undefined;
+  const toolTipButtonDisabled = dataSourceId === undefined;
+  const sendLabel = toolTipButtonDisabled
+    ? i18n.translate('console.sendRequestButtonTooltip.withoutDataSourceId', {
+        defaultMessage: 'Select a data source',
+      })
+    : i18n.translate('console.sendRequestButtonTooltip', {
+        defaultMessage: 'Send request',
+      });
 
   return (
     <div style={abs} className="conApp">
@@ -243,19 +247,13 @@ function EditorUI({ initialTextValue, dataSourceId }: EditorProps) {
           responsive={false}
         >
           <EuiFlexItem>
-            <EuiToolTip
-              content={i18n.translate('console.sendRequestButtonTooltip', {
-                defaultMessage: tooltipDefaultMessage,
-              })}
-            >
+            <EuiToolTip content={sendLabel}>
               <button
                 onClick={sendCurrentRequestToOpenSearch}
                 data-test-subj="sendRequestButton"
-                aria-label={i18n.translate('console.sendRequestButtonTooltip', {
-                  defaultMessage: tooltipDefaultMessage,
-                })}
+                aria-label={sendLabel}
                 className="conApp__editorActionButton conApp__editorActionButton--success"
-                disabled={toolTipButtonDiasbled}
+                disabled={toolTipButtonDisabled}
               >
                 <EuiIcon type="play" />
               </button>


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n and correct duplicate i18n identifiers in console plugin


## Changelog
- fix: Fix dynamic uses of i18n and correct duplicate i18n identifiers in console plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
