### PR TITLE
Fix dynamic uses of i18n and correct unprefixed and duplicate i18n identifiers in dataSourceManagement plugin

### DIFF
--- a/changelogs/fragments/8394.yml
+++ b/changelogs/fragments/8394.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix dynamic and correct unprefixed and duplicate i18n identifiers in dataSourceManagement plugin ([#8394](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8394))

--- a/src/plugins/data_source_management/public/components/breadcrumbs.ts
+++ b/src/plugins/data_source_management/public/components/breadcrumbs.ts
@@ -28,16 +28,24 @@ export function getCreateBreadcrumbs() {
     },
   ];
 }
+
 export function getCreateOpenSearchDataSourceBreadcrumbs(useNewUX: boolean) {
   return [
     ...getCreateBreadcrumbs(),
     {
-      text: i18n.translate(
-        'dataSourcesManagement.dataSources.createOpenSearchDataSourceBreadcrumbs',
-        {
-          defaultMessage: useNewUX ? 'Connect OpenSearch Cluster' : 'Open Search',
-        }
-      ),
+      text: useNewUX
+        ? i18n.translate(
+            'dataSourcesManagement.dataSources.createOpenSearchDataSourceBreadcrumbs',
+            {
+              defaultMessage: 'Connect OpenSearch Cluster',
+            }
+          )
+        : i18n.translate(
+            'dataSourcesManagement.legacyUX.dataSources.createOpenSearchDataSourceBreadcrumbs',
+            {
+              defaultMessage: 'Open Search',
+            }
+          ),
       href: `/configure/OpenSearch`,
     },
   ];
@@ -47,12 +55,16 @@ export function getCreateAmazonS3DataSourceBreadcrumbs(useNewUX: boolean) {
   return [
     ...getCreateBreadcrumbs(),
     {
-      text: i18n.translate(
-        'dataSourcesManagement.dataSources.createAmazonS3DataSourceBreadcrumbs',
-        {
-          defaultMessage: useNewUX ? 'Connect Amazon S3' : 'Amazon S3',
-        }
-      ),
+      text: useNewUX
+        ? i18n.translate('dataSourcesManagement.dataSources.createAmazonS3DataSourceBreadcrumbs', {
+            defaultMessage: 'Connect Amazon S3',
+          })
+        : i18n.translate(
+            'dataSourcesManagement.legacyUX.dataSources.createAmazonS3DataSourceBreadcrumbs',
+            {
+              defaultMessage: 'Amazon S3',
+            }
+          ),
       href: `/configure/AmazonS3AWSGlue`,
     },
   ];
@@ -62,12 +74,19 @@ export function getCreatePrometheusDataSourceBreadcrumbs(useNewUX: boolean) {
   return [
     ...getCreateBreadcrumbs(),
     {
-      text: i18n.translate(
-        'dataSourcesManagement.dataSources.createPrometheusDataSourceBreadcrumbs',
-        {
-          defaultMessage: useNewUX ? 'Connect Prometheus' : 'Prometheus',
-        }
-      ),
+      text: useNewUX
+        ? i18n.translate(
+            'dataSourcesManagement.dataSources.createPrometheusDataSourceBreadcrumbs',
+            {
+              defaultMessage: 'Connect Prometheus',
+            }
+          )
+        : i18n.translate(
+            'dataSourcesManagement.legacyUX.dataSources.createPrometheusDataSourceBreadcrumbs',
+            {
+              defaultMessage: 'Prometheus',
+            }
+          ),
       href: `/configure/Prometheus`,
     },
   ];
@@ -77,12 +96,7 @@ export function getManageDirectQueryDataSourceBreadcrumbs(directQueryDatasourceN
   return [
     ...getListBreadcrumbs(),
     {
-      text: i18n.translate(
-        'dataSourcesManagement.dataSources.manageDirectQueryDataSourceBreadcrumbs',
-        {
-          defaultMessage: directQueryDatasourceName,
-        }
-      ),
+      text: directQueryDatasourceName,
       href: `/manage/${directQueryDatasourceName}`,
     },
   ];

--- a/src/plugins/data_source_management/public/components/constants.tsx
+++ b/src/plugins/data_source_management/public/components/constants.tsx
@@ -5,19 +5,14 @@
 
 import { i18n } from '@osd/i18n';
 import { DataSourceOption } from './data_source_menu/types';
-import { DatasourceType } from '../types';
+import { DatasourceType } from '../../framework/types';
 
 export const LocalCluster: DataSourceOption = {
-  label: i18n.translate('dataSource.localCluster', {
+  label: i18n.translate('dataSourcesManagement.localCluster', {
     defaultMessage: 'Local cluster',
   }),
   id: '',
 };
-
-export const NO_DATASOURCES_CONNECTED_MESSAGE = 'No data sources connected yet.';
-export const CONNECT_DATASOURCES_MESSAGE = 'Connect your data sources to get started.';
-export const NO_COMPATIBLE_DATASOURCES_MESSAGE = 'No compatible data sources are available.';
-export const ADD_COMPATIBLE_DATASOURCES_MESSAGE = 'Add a compatible data source.';
 
 export const OPENSEARCH_DOCUMENTATION_URL =
   'https://opensearch.org/docs/latest/dashboards/management/data-sources/';

--- a/src/plugins/data_source_management/public/components/create_button/__snapshots__/create_button.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/create_button/__snapshots__/create_button.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CreateButton should render normally 1`] = `
 >
   <FormattedMessage
     defaultMessage="Create data source connection"
-    id="dataSourcesManagement.dataSourceListing.createButton"
+    id="dataSourcesManagement.dataSourceListing.createDataSourceButton"
     values={Object {}}
   />
 </EuiSmallButton>

--- a/src/plugins/data_source_management/public/components/create_button/create_button.tsx
+++ b/src/plugins/data_source_management/public/components/create_button/create_button.tsx
@@ -23,12 +23,17 @@ export const CreateButton = ({ history, isEmptyState, dataTestSubj, featureFlagS
       fill={isEmptyState ? false : true}
       onClick={() => history.push('/create')}
     >
-      <FormattedMessage
-        id="dataSourcesManagement.dataSourceListing.createButton"
-        defaultMessage={
-          featureFlagStatus ? 'Create data source connection' : 'Create direct query connection'
-        }
-      />
+      {featureFlagStatus ? (
+        <FormattedMessage
+          id="dataSourcesManagement.dataSourceListing.createDataSourceButton"
+          defaultMessage="Create data source connection"
+        />
+      ) : (
+        <FormattedMessage
+          id="dataSourcesManagement.dataSourceListing.createDirectQueryButton"
+          defaultMessage="Create direct query connection"
+        />
+      )}
     </EuiSmallButton>
   );
 };

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/components/create_form/create_data_source_form.tsx
@@ -47,6 +47,7 @@ import {
   getDefaultAuthMethod,
   isValidUrl,
 } from '../../../utils';
+import { DataSourceOptionalLabelSuffix } from '../../../data_source_optional_label_suffix';
 
 export interface CreateDataSourceProps {
   useNewUX: boolean;
@@ -399,36 +400,6 @@ export class CreateDataSourceForm extends React.Component<
     );
   };
 
-  /* Render Section header*/
-  renderSectionHeader = (i18nId: string, defaultMessage: string) => {
-    return (
-      <>
-        <EuiText grow={false} size="s">
-          <h2>
-            <FormattedMessage id={i18nId} defaultMessage={defaultMessage} />
-          </h2>
-        </EuiText>
-      </>
-    );
-  };
-  /* Render field label with Optional text*/
-  renderFieldLabelAsOptional = (i18nId: string, defaultMessage: string) => {
-    return (
-      <>
-        {<FormattedMessage id={i18nId} defaultMessage={defaultMessage} />}{' '}
-        <i style={{ fontWeight: 'normal' }}>
-          -{' '}
-          {
-            <FormattedMessage
-              id="dataSourcesManagement.createDataSource.optionalText"
-              defaultMessage="optional"
-            />
-          }
-        </i>
-      </>
-    );
-  };
-
   /* Render create new credentials*/
   renderCreateNewCredentialsForm = (type: AuthType) => {
     switch (type) {
@@ -581,10 +552,14 @@ export class CreateDataSourceForm extends React.Component<
           {this.renderHeader()}
           <EuiForm data-test-subj="data-source-creation">
             {/* Endpoint section */}
-            {this.renderSectionHeader(
-              'dataSourceManagement.connectToDataSource.connectionDetails',
-              'Connection Details'
-            )}
+            <EuiText grow={false} size="s">
+              <h2>
+                <FormattedMessage
+                  id="dataSourcesManagement.connectToDataSource.connectionDetails"
+                  defaultMessage="Connection Details"
+                />
+              </h2>
+            </EuiText>
             <EuiSpacer size="s" />
 
             {/* Title */}
@@ -613,10 +588,13 @@ export class CreateDataSourceForm extends React.Component<
 
             {/* Description */}
             <EuiCompressedFormRow
-              label={this.renderFieldLabelAsOptional(
-                'dataSourceManagement.createDataSource.description',
-                'Description'
-              )}
+              label={
+                <FormattedMessage
+                  id="dataSourcesManagement.createDataSource.descriptionOptional"
+                  defaultMessage="Description {optionalLabel}"
+                  values={{ optionalLabel: <DataSourceOptionalLabelSuffix /> }}
+                />
+              }
             >
               <EuiCompressedFieldText
                 name="dataSourceDescription"
@@ -660,31 +638,30 @@ export class CreateDataSourceForm extends React.Component<
 
             <EuiSpacer size="xl" />
 
-            {this.renderSectionHeader(
-              'dataSourceManagement.connectToDataSource.authenticationHeader',
-              'Authentication Method'
-            )}
+            <EuiText grow={false} size="s">
+              <h2>
+                <FormattedMessage
+                  id="dataSourcesManagement.connectToDataSource.authenticationHeader"
+                  defaultMessage="Authentication Method"
+                />
+              </h2>
+            </EuiText>
+
             <EuiSpacer size="m" />
 
             <EuiCompressedFormRow>
               <EuiText size="s">
-                <FormattedMessage
-                  id="dataSourcesManagement.createDataSource.authenticationMethodDescription"
-                  defaultMessage="Enter the authentication details to access the endpoint."
-                />
-                {this.isNoAuthOptionEnabled && (
+                {this.isNoAuthOptionEnabled ? (
+                  <FormattedMessage
+                    id="dataSourcesManagement.createDataSource.authenticationMethodDescriptionWithNoAuth"
+                    defaultMessage="Enter the authentication details to access the endpoint. If no authentication is required, select {buttonLabel}."
+                    values={{ buttonLabel: <b>No authentication</b> }}
+                  />
+                ) : (
                   <FormattedMessage
                     id="dataSourcesManagement.createDataSource.authenticationMethodDescription"
-                    defaultMessage=" If no authentication is required, select "
+                    defaultMessage="Enter the authentication details to access the endpoint."
                   />
-                )}
-                {this.isNoAuthOptionEnabled && (
-                  <b>
-                    <FormattedMessage
-                      id="dataSourcesManagement.createDataSource.noAuthentication"
-                      defaultMessage="No authentication"
-                    />
-                  </b>
                 )}
               </EuiText>
             </EuiCompressedFormRow>

--- a/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
+++ b/src/plugins/data_source_management/public/components/create_data_source_wizard/create_data_source_wizard.tsx
@@ -11,8 +11,8 @@ import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react
 import {
   DataSourceAttributes,
   DataSourceManagementContext,
+  DataSourceManagementToastMessageItem,
   DataSourceTableItem,
-  ToastMessageItem,
 } from '../../types';
 import { getCreateOpenSearchDataSourceBreadcrumbs } from '../breadcrumbs';
 import { CreateDataSourceForm } from './components/create_form';
@@ -65,8 +65,9 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
       }
     } catch (e) {
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.createDataSource.existingDatasourceNames',
-        defaultMessage: 'Unable to fetch some resources.',
+        message: i18n.translate('dataSourcesManagement.createDataSource.existingDatasourceNames', {
+          defaultMessage: 'Unable to fetch some resources.',
+        }),
       });
       props.history.push('');
     } finally {
@@ -90,8 +91,9 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
     } catch (e) {
       setIsLoading(false);
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.createDataSource.createDataSourceFailMsg',
-        defaultMessage: 'Creation of the Data Source failed with some errors.',
+        message: i18n.translate('dataSourcesManagement.createDataSource.createDataSourceFailMsg', {
+          defaultMessage: 'Creation of the Data Source failed with some errors.',
+        }),
       });
     }
   };
@@ -102,27 +104,32 @@ export const CreateDataSourceWizard: React.FunctionComponent<CreateDataSourceWiz
     try {
       await testConnection(http, attributes);
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.createDataSource.testConnectionSuccessMsg',
-        defaultMessage:
-          'Connecting to the endpoint using the provided authentication method was successful.',
+        message: i18n.translate('dataSourcesManagement.createDataSource.testConnectionSuccessMsg', {
+          defaultMessage:
+            'Connecting to the endpoint using the provided authentication method was successful.',
+        }),
         success: true,
       });
     } catch (e) {
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.createDataSource.testConnectionFailMsg',
-        defaultMessage:
-          'Failed Connecting to the endpoint using the provided authentication method.',
+        message: i18n.translate('dataSourcesManagement.createDataSource.testConnectionFailMsg', {
+          defaultMessage:
+            'Failed Connecting to the endpoint using the provided authentication method.',
+        }),
       });
     } finally {
       setIsLoading(false);
     }
   };
 
-  const handleDisplayToastMessage = ({ id, defaultMessage, success }: ToastMessageItem) => {
+  const handleDisplayToastMessage = ({
+    message,
+    success,
+  }: DataSourceManagementToastMessageItem) => {
     if (success) {
-      toasts.addSuccess(i18n.translate(id, { defaultMessage }));
+      toasts.addSuccess(message);
     } else {
-      toasts.addDanger(i18n.translate(id, { defaultMessage }));
+      toasts.addDanger(message);
     }
   };
 

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.test.tsx
@@ -425,7 +425,8 @@ describe('DataSourceAggregatedView empty state test due to filter out with local
           dataSourceFilter={filter}
         />
       );
-      const noCompatibleDataSourcesMessage = `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`;
+      const noCompatibleDataSourcesMessage =
+        'No compatible data sources are available. Add a compatible data source.';
 
       expect(component).toMatchSnapshot();
       await nextTick();
@@ -528,8 +529,10 @@ describe('DataSourceAggregatedView warning messages', () => {
   const dataSourceSelection = new DataSourceSelectionService();
   const nextTick = () => new Promise((res) => process.nextTick(res));
   let toasts: IToasts;
-  const noDataSourcesConnectedMessage = `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
-  const noCompatibleDataSourcesMessage = `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`;
+  const noDataSourcesConnectedMessage =
+    'No data sources connected yet. Connect your data sources to get started.';
+  const noCompatibleDataSourcesMessage =
+    'No compatible data sources are available. Add a compatible data source.';
 
   beforeEach(() => {
     toasts = notificationServiceMock.createStartContract().toasts;
@@ -576,11 +579,7 @@ describe('DataSourceAggregatedView warning messages', () => {
       );
       await nextTick();
 
-      expect(toasts.add).toBeCalledWith(
-        expect.objectContaining({
-          title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
-        })
-      );
+      expect(toasts.add).toBeCalledWith(expect.objectContaining({ title: defaultMessage }));
     }
   );
 });

--- a/src/plugins/data_source_management/public/components/data_source_column/data_source_column.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_column/data_source_column.tsx
@@ -20,7 +20,7 @@ export class DataSourceColumn implements IndexPatternTableColumn<DataSourceMap> 
 
   public euiColumn = {
     field: 'referenceId',
-    name: i18n.translate('dataSource.management.dataSourceColumn', {
+    name: i18n.translate('dataSourcesManagement.dataSourceColumn', {
       defaultMessage: 'Data Source Connection',
     }),
     render: (referenceId: string) => {

--- a/src/plugins/data_source_management/public/components/data_source_error_menu/data_source_error_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_error_menu/data_source_error_menu.tsx
@@ -44,9 +44,12 @@ export const DataSourceErrorMenu = ({ application }: DataSourceErrorMenuProps) =
     <EuiButtonIcon
       className="euiHeaderLink"
       data-test-subj="dataSourceErrorMenuHeaderLink"
-      aria-label={i18n.translate('dataSourceError.dataSourceErrorMenuHeaderLink', {
-        defaultMessage: 'dataSourceErrorMenuHeaderLink',
-      })}
+      aria-label={i18n.translate(
+        'dataSourcesManagement.dataSourceError.dataSourceErrorMenuHeaderLink',
+        {
+          defaultMessage: 'dataSourceErrorMenuHeaderLink',
+        }
+      )}
       iconType={() => <ErrorIcon />}
       size="s"
       onClick={() => setShowPopover(!showPopover)}

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
@@ -103,11 +103,13 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
   ];
 
   const description = {
-    description: i18n.translate('dataSourcesManagement.dataSourcesTable.description', {
-      defaultMessage: featureFlagStatus
-        ? 'Create and manage data source connections.'
-        : 'Manage direct query data source connections.',
-    }),
+    description: featureFlagStatus
+      ? i18n.translate('dataSourcesManagement.dataSourcesTable.descriptionWithDataSource', {
+          defaultMessage: 'Create and manage data source connections.',
+        })
+      : i18n.translate('dataSourcesManagement.dataSourcesTable.description', {
+          defaultMessage: 'Manage direct query data source connections.',
+        }),
     links: [
       {
         href: docLinks.links.opensearchDashboards.dataSource.guide,

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/create_data_source_menu.test.tsx.snap
@@ -127,7 +127,7 @@ Object {
             data-label="Data source"
           >
             <button
-              aria-label="dataSourceSelectableButton"
+              aria-label="Data source selector"
               class="euiButton euiButton--text euiButton--small dataSourceMenuPopoverButtonLabel"
               data-test-subj="dataSourceSelectableButton"
               type="button"
@@ -168,7 +168,7 @@ Object {
           data-label="Data source"
         >
           <button
-            aria-label="dataSourceSelectableButton"
+            aria-label="Data source selector"
             class="euiButton euiButton--text euiButton--small dataSourceMenuPopoverButtonLabel"
             data-test-subj="dataSourceSelectableButton"
             type="button"
@@ -274,7 +274,7 @@ Object {
                 data-label="Data source"
               >
                 <button
-                  aria-label="dataSourceSelectableButton"
+                  aria-label="Data source selector"
                   class="euiButton euiButton--text euiButton--small dataSourceMenuPopoverButtonLabel"
                   data-test-subj="dataSourceSelectableButton"
                   type="button"

--- a/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_menu/__snapshots__/data_source_menu.test.tsx.snap
@@ -80,7 +80,7 @@ Object {
             data-label="Data source"
           >
             <button
-              aria-label="dataSourceAggregatedViewButton"
+              aria-label="Data source selector"
               class="euiButton euiButton--text euiButton--small euiButton-isDisabled dataSourceMenuPopoverButtonLabel"
               data-test-subj="dataSourceAggregatedViewButton"
               disabled=""
@@ -117,7 +117,7 @@ Object {
           data-label="Data source"
         >
           <button
-            aria-label="dataSourceAggregatedViewButton"
+            aria-label="Data source selector"
             class="euiButton euiButton--text euiButton--small euiButton-isDisabled dataSourceMenuPopoverButtonLabel"
             data-test-subj="dataSourceAggregatedViewButton"
             disabled=""

--- a/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/__snapshots__/data_source_optional_label_suffix.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/__snapshots__/data_source_optional_label_suffix.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Datasource Management: Optional Label Suffix should render normally 1`] = `
+<span
+  className="dataSourceManagement-optionalSuffix"
+>
+  – 
+  <FormattedMessage
+    defaultMessage="optional"
+    id="dataSourcesManagement.createDataSource.optionalText"
+    values={Object {}}
+  />
+</span>
+`;

--- a/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/data_source_optional_label_suffix.scss
+++ b/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/data_source_optional_label_suffix.scss
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.dataSourceManagement-optionalSuffix {
+  font-weight: 300;
+  font-style: italic;
+}

--- a/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/data_source_optional_label_suffix.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/data_source_optional_label_suffix.test.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { DataSourceOptionalLabelSuffix } from '.';
+
+describe('Datasource Management: Optional Label Suffix', () => {
+  test('should render normally', () => {
+    const component = shallow(<DataSourceOptionalLabelSuffix />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/data_source_optional_label_suffix.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/data_source_optional_label_suffix.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
+
+import './data_source_optional_label_suffix.scss';
+
+export const DataSourceOptionalLabelSuffix = () => (
+  <span className="dataSourceManagement-optionalSuffix">
+    &ndash;&nbsp;
+    <FormattedMessage
+      id="dataSourcesManagement.createDataSource.optionalText"
+      defaultMessage="optional"
+    />
+  </span>
+);

--- a/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/index.ts
+++ b/src/plugins/data_source_management/public/components/data_source_optional_label_suffix/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './data_source_optional_label_suffix';

--- a/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/__snapshots__/data_source_selectable.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`DataSourceSelectable should filter options if configured 1`] = `
 </EuiPopover>
 `;
 
-exports[`DataSourceSelectable should render normally with local cluster is hidden 1`] = `
+exports[`DataSourceSelectable should render normally when local cluster is hidden 1`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={
@@ -136,7 +136,7 @@ exports[`DataSourceSelectable should render normally with local cluster is hidde
 </EuiPopover>
 `;
 
-exports[`DataSourceSelectable should render normally with local cluster not hidden 1`] = `
+exports[`DataSourceSelectable should render normally when local cluster is not hidden 1`] = `
 <EuiPopover
   anchorPosition="downLeft"
   button={
@@ -196,7 +196,7 @@ exports[`DataSourceSelectable should render normally with local cluster not hidd
 </EuiPopover>
 `;
 
-exports[`DataSourceSelectable should show popover when click on button 1`] = `
+exports[`DataSourceSelectable should show popover with button click 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -214,7 +214,7 @@ Object {
             data-label="Data source"
           >
             <button
-              aria-label="dataSourceSelectableButton"
+              aria-label="Data source selector"
               class="euiButton euiButton--text euiButton--small dataSourceMenuPopoverButtonLabel"
               data-test-subj="dataSourceSelectableButton"
               type="button"
@@ -394,7 +394,7 @@ Object {
           data-label="Data source"
         >
           <button
-            aria-label="dataSourceSelectableButton"
+            aria-label="Data source selector"
             class="euiButton euiButton--text euiButton--small dataSourceMenuPopoverButtonLabel"
             data-test-subj="dataSourceSelectableButton"
             type="button"

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.test.tsx
@@ -31,8 +31,10 @@ describe('DataSourceSelectable', () => {
 
   const { toasts } = notificationServiceMock.createStartContract();
   const nextTick = () => new Promise((res) => process.nextTick(res));
-  const noDataSourcesConnectedMessage = `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
-  const noCompatibleDataSourcesMessage = `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`;
+  const noDataSourcesConnectedMessage =
+    'No data sources connected yet. Connect your data sources to get started.';
+  const noCompatibleDataSourcesMessage =
+    'No compatible data sources are available. Add a compatible data source.';
   const dataSourceSelection = new DataSourceSelectionService();
 
   beforeEach(() => {
@@ -43,7 +45,7 @@ describe('DataSourceSelectable', () => {
     spyOn(utils, 'getDataSourceSelection').and.returnValue(dataSourceSelection);
   });
 
-  it('should render normally with local cluster not hidden', () => {
+  it('should render normally when local cluster is not hidden', () => {
     component = shallow(
       <DataSourceSelectable
         savedObjectsClient={client}
@@ -63,7 +65,7 @@ describe('DataSourceSelectable', () => {
     expect(toasts.addWarning).toBeCalledTimes(0);
   });
 
-  it('should render normally with local cluster is hidden', () => {
+  it('should render normally when local cluster is hidden', () => {
     component = shallow(
       <DataSourceSelectable
         savedObjectsClient={client}
@@ -101,7 +103,7 @@ describe('DataSourceSelectable', () => {
     expect(toasts.addWarning).toBeCalledTimes(0);
   });
 
-  it('should show popover when click on button', async () => {
+  it('should show popover with button click', async () => {
     const onSelectedDataSource = jest.fn();
     const container = render(
       <DataSourceSelectable
@@ -124,7 +126,7 @@ describe('DataSourceSelectable', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should callback if changed state', async () => {
+  it('should invoke the onSelectedDataSource callback when state changes', async () => {
     const onSelectedDataSource = jest.fn();
     spyOn(utils, 'getDefaultDataSource').and.returnValue([{ id: 'test2', label: 'test2' }]);
     const container = mount(
@@ -194,7 +196,7 @@ describe('DataSourceSelectable', () => {
     expect(utils.getDefaultDataSource).toHaveBeenCalled();
   });
 
-  it('should display selected option label normally', async () => {
+  it(`should display selectedOption[0]'s label when available`, async () => {
     const onSelectedDataSource = jest.fn();
     const container = render(
       <DataSourceSelectable
@@ -214,7 +216,7 @@ describe('DataSourceSelectable', () => {
     expect(button).toHaveTextContent('test2');
   });
 
-  it('should render normally even only provide dataSourceId', async () => {
+  it(`should display selectedOption[0]'s id when label is not available`, async () => {
     const onSelectedDataSource = jest.fn();
     const container = render(
       <DataSourceSelectable
@@ -233,7 +235,7 @@ describe('DataSourceSelectable', () => {
     expect(button).toHaveTextContent('test2');
   });
 
-  it('should render warning if provide undefined dataSourceId', async () => {
+  it(`should display a warning when selectedOption[0]'s id is undefined`, async () => {
     const onSelectedDataSource = jest.fn();
     const container = render(
       <DataSourceSelectable
@@ -250,10 +252,10 @@ describe('DataSourceSelectable', () => {
     await nextTick();
     const button = await container.findByTestId('dataSourceSelectableButton');
     expect(button).toHaveTextContent('');
-    expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
+    expect(toasts.addWarning).toBeCalledWith('Data source with ID "" is not available');
   });
 
-  it('should render warning if provide empty object', async () => {
+  it(`should display a warning when selectedOption[0] is an empty object`, async () => {
     const onSelectedDataSource = jest.fn();
     const container = render(
       <DataSourceSelectable
@@ -270,9 +272,9 @@ describe('DataSourceSelectable', () => {
     await nextTick();
     const button = await container.findByTestId('dataSourceSelectableButton');
     expect(button).toHaveTextContent('');
-    expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
+    expect(toasts.addWarning).toBeCalledWith('Data source with ID "" is not available');
   });
-  it('should warning if only provide label', async () => {
+  it(`should display a warning when selectedOption[0] is missing id but has a label`, async () => {
     const onSelectedDataSource = jest.fn();
     const container = render(
       <DataSourceSelectable
@@ -287,11 +289,11 @@ describe('DataSourceSelectable', () => {
       />
     );
     await nextTick();
-    expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
+    expect(toasts.addWarning).toBeCalledWith('Data source with ID "" is not available');
   });
-  it('should warning if only provide empty label', async () => {
+  it(`should display a warning when selectedOption[0] is missing id but has a blank label`, async () => {
     const onSelectedDataSource = jest.fn();
-    const container = render(
+    render(
       <DataSourceSelectable
         savedObjectsClient={client}
         notifications={toasts}
@@ -304,12 +306,12 @@ describe('DataSourceSelectable', () => {
       />
     );
     await nextTick();
-    expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
+    expect(toasts.addWarning).toBeCalledWith('Data source with ID "" is not available');
   });
 
-  it('should warning if only provide empty array', async () => {
+  it(`should display a warning when selectedOption is an empty array`, async () => {
     const onSelectedDataSource = jest.fn();
-    const container = render(
+    render(
       <DataSourceSelectable
         savedObjectsClient={client}
         notifications={toasts}
@@ -321,10 +323,10 @@ describe('DataSourceSelectable', () => {
       />
     );
     await nextTick();
-    expect(toasts.addWarning).toBeCalledWith('Data source with id: undefined is not available');
+    expect(toasts.addWarning).toBeCalledWith('Data source with ID "" is not available');
   });
 
-  it('should render the selected option when pass in the valid dataSourceId', async () => {
+  it(`should render the selected option when selectedOption[0]'s id is found`, async () => {
     const onSelectedDataSource = jest.fn();
     const container = mount(
       <DataSourceSelectable
@@ -470,7 +472,7 @@ describe('DataSourceSelectable', () => {
 
       expect(toasts.add).toBeCalledWith(
         expect.objectContaining({
-          title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
+          title: defaultMessage,
         })
       );
       expect(onSelectedDataSource).toBeCalledWith([]);

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -120,8 +120,9 @@ export class DataSourceSelectable extends React.Component<
     const dsOption = dataSourceOptions.find((ds) => ds.id === id);
     if (!dsOption) {
       this.props.notifications.addWarning(
-        i18n.translate('dataSource.fetchDataSourceError', {
-          defaultMessage: `Data source with id: ${id} is not available`,
+        i18n.translate('dataSourcesManagement.error.fetchDataSourceById', {
+          defaultMessage: 'Data source with ID "{id}" is not available',
+          values: { id },
         })
       );
       this.setState({

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/data_source_selector.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`DataSourceSelector: check dataSource options should return empty option
 
 exports[`DataSourceSelector: check dataSource options should show custom placeholder text if configured 1`] = `
 <EuiComboBox
-  aria-label="Make a selection"
+  aria-label="Select a data source"
   async={false}
   compressed={false}
   data-test-subj="dataSourceSelectorComboBox"

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiComboBox } from '@elastic/eui';
+import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 import { SavedObjectsClientContract, ToastsStart, SavedObject } from 'opensearch-dashboards/public';
 import { IUiSettingsClient } from 'src/core/public';
 import {
@@ -22,7 +22,7 @@ import './data_source_selector.scss';
 import { DataSourceOption } from '../data_source_menu/types';
 
 export const LocalCluster: DataSourceOption = {
-  label: i18n.translate('dataSource.localCluster', {
+  label: i18n.translate('dataSourcesManagement.localCluster', {
     defaultMessage: 'Local cluster',
   }),
   id: '',
@@ -92,8 +92,9 @@ export class DataSourceSelector extends React.Component<
     // Invalid/filtered out datasource
     if (!dataSource) {
       this.props.notifications.addWarning(
-        i18n.translate('dataSource.fetchDataSourceError', {
-          defaultMessage: 'Data source with id is not available',
+        i18n.translate('dataSourcesManagement.error.fetchDataSourceById', {
+          defaultMessage: 'Data source with ID "{id}" is not available',
+          values: { id },
         })
       );
     }
@@ -190,7 +191,7 @@ export class DataSourceSelector extends React.Component<
       this.handleDefaultDataSource(dataSourceOptions, fetchedDataSources, defaultDataSource);
     } catch (err) {
       this.props.notifications.addWarning(
-        i18n.translate('dataSource.fetchDataSourceError', {
+        i18n.translate('dataSourcesManagement.error.fetchExisting', {
           defaultMessage: 'Unable to fetch existing data sources',
         })
       );
@@ -206,9 +207,15 @@ export class DataSourceSelector extends React.Component<
   }
 
   render() {
+    const defaultPlaceholderText = i18n.translate(
+      'dataSourcesManagement.dataSourceSelector.placeholder',
+      {
+        defaultMessage: 'Select a data source',
+      }
+    );
     const placeholderText =
       this.props.placeholderText === undefined
-        ? 'Select a data source'
+        ? defaultPlaceholderText
         : this.props.placeholderText;
 
     // The filter condition can be changed, thus we filter again here to make sure each time we will get the filtered data sources before rendering
@@ -221,28 +228,16 @@ export class DataSourceSelector extends React.Component<
     return (
       <EuiComboBox
         isClearable={this.props.isClearable}
-        aria-label={
-          placeholderText
-            ? i18n.translate('dataSourceSelectorComboBoxAriaLabel', {
-                defaultMessage: placeholderText,
-              })
-            : 'dataSourceSelectorCombobox'
-        }
-        placeholder={
-          placeholderText
-            ? i18n.translate('dataSourceSelectorComboBoxPlaceholder', {
-                defaultMessage: placeholderText,
-              })
-            : ''
-        }
+        aria-label={defaultPlaceholderText}
+        placeholder={placeholderText}
         singleSelection={{ asPlainText: true }}
-        options={options}
-        selectedOptions={this.state.selectedOption}
+        options={options as EuiComboBoxOptionOption[]}
+        selectedOptions={this.state.selectedOption as EuiComboBoxOptionOption[]}
         onChange={(e) => this.onChange(e)}
         prepend={
           this.props.removePrepend
             ? undefined
-            : i18n.translate('dataSourceSelectorComboBoxPrepend', {
+            : i18n.translate('dataSourcesManagement.dataSourceSelectorComboBoxPrepend', {
                 defaultMessage: 'Data source',
               })
         }

--- a/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_table/__snapshots__/data_source_table.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`DataSourceTable should get datasources failed should render empty table
                       >
                         <FormattedMessage
                           defaultMessage="Create direct query connection"
-                          id="dataSourcesManagement.dataSourceListing.createButton"
+                          id="dataSourcesManagement.dataSourceListing.createDirectQueryButton"
                           values={Object {}}
                         >
                           <span>

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
@@ -23,7 +23,11 @@ import {
   reactRouterNavigate,
   useOpenSearchDashboards,
 } from '../../../../opensearch_dashboards_react/public';
-import { DataSourceManagementContext, DataSourceTableItem, ToastMessageItem } from '../../types';
+import {
+  DataSourceManagementContext,
+  DataSourceManagementToastMessageItem,
+  DataSourceTableItem,
+} from '../../types';
 import { CreateButton } from '../create_button';
 import {
   deleteMultipleDataSources,
@@ -90,8 +94,12 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
       .catch(() => {
         setDataSources([]);
         handleDisplayToastMessage({
-          id: 'dataSourcesManagement.dataSourceListing.fetchDataSourceFailMsg',
-          defaultMessage: 'Error occurred while fetching the records for Data sources.',
+          message: i18n.translate(
+            'dataSourcesManagement.dataSourceListing.fetchDataSourceFailMsg',
+            {
+              defaultMessage: 'Error occurred while fetching the records for Data sources.',
+            }
+          ),
         });
       })
       .finally(() => {
@@ -270,9 +278,13 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
       })
       .catch(() => {
         handleDisplayToastMessage({
-          id: 'dataSourcesManagement.dataSourceListing.deleteDataSourceFailMsg',
-          defaultMessage:
-            'Error occurred while deleting selected records for Data sources. Please try it again',
+          message: i18n.translate(
+            'dataSourcesManagement.dataSourceListing.deleteDataSourceFailMsg',
+            {
+              defaultMessage:
+                'Error occurred while deleting selected records for Data sources. Please try it again',
+            }
+          ),
         });
       })
       .finally(() => {
@@ -290,8 +302,13 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
       }
     } catch (e) {
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.setDefaultDataSourceFailMsg',
-        defaultMessage: 'Unable to find a default datasource. Please set a new default datasource.',
+        message: i18n.translate(
+          'dataSourcesManagement.editDataSource.setDefaultDataSourceFailMsg',
+          {
+            defaultMessage:
+              'Unable to find a default datasource. Please set a new default datasource.',
+          }
+        ),
       });
     } finally {
       setIsDeleting(false);
@@ -309,12 +326,8 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
 
   /* Toast Handlers */
 
-  const handleDisplayToastMessage = ({ id, defaultMessage }: ToastMessageItem) => {
-    notifications.toasts.addDanger(
-      i18n.translate(id, {
-        defaultMessage,
-      })
-    );
+  const handleDisplayToastMessage = ({ message }: DataSourceManagementToastMessageItem) => {
+    notifications.toasts.addDanger(message);
   };
 
   /* Render Ui elements*/

--- a/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_view/__snapshots__/data_source_view.test.tsx.snap
@@ -288,7 +288,7 @@ Object {
             data-label="Data source"
           >
             <button
-              aria-label="dataSourceViewButton"
+              aria-label="Data source selector"
               class="euiButton euiButton--text euiButton--small euiButton-isDisabled dataSourceMenuPopoverButtonLabel"
               data-test-subj="dataSourceViewButton"
               disabled=""
@@ -325,7 +325,7 @@ Object {
           data-label="Data source"
         >
           <button
-            aria-label="dataSourceViewButton"
+            aria-label="Data source selector"
             class="euiButton euiButton--text euiButton--small euiButton-isDisabled dataSourceMenuPopoverButtonLabel"
             data-test-subj="dataSourceViewButton"
             disabled=""

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/associated_objects_details_flyout.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/associated_objects_details_flyout.tsx
@@ -44,11 +44,6 @@ import {
   getAccelerationName,
 } from '../acceleration_management/acceleration_utils';
 import {
-  ACCE_NO_DATA_DESCRIPTION,
-  ACCE_NO_DATA_TITLE,
-  CREATE_ACCELERATION_DESCRIPTION,
-} from './utils/associated_objects_tab_utils';
-import {
   isCatalogCacheFetching,
   redirectToExplorerWithDataSrc,
 } from './utils/associated_objects_tab_utils';
@@ -193,16 +188,19 @@ export const AssociatedObjectsDetailsFlyout = ({
     <EuiEmptyPrompt
       title={
         <h2>
-          {i18n.translate('datasources.associatedObjectsFlyout.noAccelerationTitle', {
-            defaultMessage: ACCE_NO_DATA_TITLE,
+          {i18n.translate('dataSourcesManagement.associatedObjectsFlyout.noAccelerationTitle', {
+            defaultMessage: 'You have no accelerations',
           })}
         </h2>
       }
       body={
         <p>
-          {i18n.translate('datasources.associatedObjectsFlyout.noAccelerationDescription', {
-            defaultMessage: ACCE_NO_DATA_DESCRIPTION,
-          })}
+          {i18n.translate(
+            'dataSourcesManagement.associatedObjectsFlyout.noAccelerationDescription',
+            {
+              defaultMessage: 'Accelerate query performing through OpenSearch Indexing',
+            }
+          )}
         </p>
       }
       actions={
@@ -221,9 +219,12 @@ export const AssociatedObjectsDetailsFlyout = ({
           iconType="popout"
           iconSide="left"
         >
-          {i18n.translate('datasources.associatedObjectsFlyout.createAccelerationButton', {
-            defaultMessage: CREATE_ACCELERATION_DESCRIPTION,
-          })}
+          {i18n.translate(
+            'dataSourcesManagement.associatedObjectsFlyout.createAccelerationButton',
+            {
+              defaultMessage: 'Create Acceleration',
+            }
+          )}
         </EuiButton>
       }
     />

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/associated_objects_tab.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/associated_objects_tab.tsx
@@ -39,12 +39,7 @@ import { AssociatedObjectsRefreshButton } from './utils/associated_objects_refre
 import { AssociatedObjectsTabEmpty } from './utils/associated_objects_tab_empty';
 import { AssociatedObjectsTabFailure } from './utils/associated_objects_tab_failure';
 import { AssociatedObjectsTabLoading } from './utils/associated_objects_tab_loading';
-import {
-  ASSC_OBJ_FRESH_MSG,
-  ASSC_OBJ_PANEL_DESCRIPTION,
-  ASSC_OBJ_PANEL_TITLE,
-  isCatalogCacheFetching,
-} from './utils/associated_objects_tab_utils';
+import { ASSC_OBJ_FRESH_MSG, isCatalogCacheFetching } from './utils/associated_objects_tab_utils';
 
 export interface AssociatedObjectsTabProps {
   datasource: DatasourceDetails;
@@ -117,13 +112,16 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
   };
 
   const AssociatedObjectsHeader = () => {
-    const panelTitle = i18n.translate('datasources.associatedObjectsTab.panelTitle', {
-      defaultMessage: ASSC_OBJ_PANEL_TITLE,
+    const panelTitle = i18n.translate('dataSourcesManagement.associatedObjectsTab.panelTitle', {
+      defaultMessage: 'Associated objects',
     });
 
-    const panelDescription = i18n.translate('datasources.associatedObjectsTab.panelDescription', {
-      defaultMessage: ASSC_OBJ_PANEL_DESCRIPTION,
-    });
+    const panelDescription = i18n.translate(
+      'dataSourcesManagement.associatedObjectsTab.panelDescription',
+      {
+        defaultMessage: 'Manage objects associated with this data sources.',
+      }
+    );
 
     const LastUpdatedText = () => {
       return (

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/associated_objects_table.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/associated_objects_table.tsx
@@ -64,7 +64,7 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
   const columns = [
     {
       field: 'name',
-      name: i18n.translate('datasources.associatedObjectsTab.column.name', {
+      name: i18n.translate('dataSourcesManagement.associatedObjectsTab.column.name', {
         defaultMessage: 'Name',
       }),
       sortable: true,
@@ -97,7 +97,7 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
     },
     {
       field: 'type',
-      name: i18n.translate('datasources.associatedObjectsTab.column.type', {
+      name: i18n.translate('dataSourcesManagement.associatedObjectsTab.column.type', {
         defaultMessage: 'Type',
       }),
       sortable: true,
@@ -108,7 +108,7 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
     },
     {
       field: 'accelerations',
-      name: i18n.translate('datasources.associatedObjectsTab.column.accelerations', {
+      name: i18n.translate('dataSourcesManagement.associatedObjectsTab.column.accelerations', {
         defaultMessage: 'Associations',
       }),
       sortable: true,
@@ -166,16 +166,16 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
       },
     },
     {
-      name: i18n.translate('datasources.associatedObjectsTab.column.actions', {
+      name: i18n.translate('dataSourcesManagement.associatedObjectsTab.column.actions', {
         defaultMessage: 'Actions',
       }),
       actions: [
         {
-          name: i18n.translate('datasources.associatedObjectsTab.action.discover.name', {
+          name: i18n.translate('dataSourcesManagement.associatedObjectsTab.action.discover.name', {
             defaultMessage: 'Discover',
           }),
           description: i18n.translate(
-            'datasources.associatedObjectsTab.action.discover.description',
+            'dataSourcesManagement.associatedObjectsTab.action.discover.description',
             {
               defaultMessage: 'Query in Observability Logs',
             }
@@ -201,11 +201,14 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
           },
         },
         {
-          name: i18n.translate('datasources.associatedObjectsTab.action.accelerate.name', {
-            defaultMessage: 'Accelerate',
-          }),
+          name: i18n.translate(
+            'dataSourcesManagement.associatedObjectsTab.action.accelerate.name',
+            {
+              defaultMessage: 'Accelerate',
+            }
+          ),
           description: i18n.translate(
-            'datasources.associatedObjectsTab.action.accelerate.description',
+            'dataSourcesManagement.associatedObjectsTab.action.accelerate.description',
             {
               defaultMessage: 'Accelerate this object',
             }

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/utils/associated_objects_tab_utils.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/associated_object_management/utils/associated_objects_tab_utils.tsx
@@ -31,12 +31,6 @@ export const ASSC_OBJ_REFRESH_BTN = 'Refresh';
 
 export const ASSC_OBJ_FRESH_MSG = 'Last updated at:';
 
-export const ACCE_NO_DATA_TITLE = 'You have no accelerations';
-
-export const ACCE_NO_DATA_DESCRIPTION = 'Accelerate query performing through OpenSearch Indexing';
-
-export const CREATE_ACCELERATION_DESCRIPTION = 'Create Acceleration';
-
 const catalogCacheFetchingStatus = [
   DirectQueryLoadingStatus.RUNNING,
   DirectQueryLoadingStatus.WAITING,

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -35,8 +35,8 @@ import {
   AuthType,
   DataSourceAttributes,
   DataSourceManagementContextValue,
+  DataSourceManagementToastMessageItem,
   sigV4ServiceOptions,
-  ToastMessageItem,
   UsernamePasswordTypedContent,
 } from '../../../../types';
 import { context as contextType } from '../../../../../../opensearch_dashboards_react/public';
@@ -49,6 +49,7 @@ import {
 import { UpdatePasswordModal } from '../update_password_modal';
 import { UpdateAwsCredentialModal } from '../update_aws_credential_modal';
 import { extractRegisteredAuthTypeCredentials, getDefaultAuthMethod } from '../../../utils';
+import { DataSourceOptionalLabelSuffix } from '../../../data_source_optional_label_suffix';
 
 export interface EditDataSourceProps {
   navigation: NavigationPublicPluginStart;
@@ -61,7 +62,7 @@ export interface EditDataSourceProps {
   handleTestConnection: (formValues: DataSourceAttributes) => Promise<void>;
   onDeleteDataSource?: () => Promise<void>;
   onSetDefaultDataSource: () => Promise<void>;
-  displayToastMessage: (info: ToastMessageItem) => void;
+  displayToastMessage: (info: DataSourceManagementToastMessageItem) => void;
   canManageDataSource: boolean;
 }
 export interface EditDataSourceState {
@@ -394,8 +395,9 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
         this.setFormValuesForEditMode();
       } catch (e) {
         this.props.displayToastMessage({
-          id: 'dataSourcesManagement.editDataSource.editDataSourceFailMsg',
-          defaultMessage: 'Updating the Data Source failed with some errors.',
+          message: i18n.translate('dataSourcesManagement.editDataSource.editDataSourceFailMsg', {
+            defaultMessage: 'Updating the Data Source failed with some errors.',
+          }),
         });
       } finally {
         this.setState({ isLoading: false });
@@ -463,16 +465,18 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
       await this.props.handleTestConnection(formValues);
 
       this.props.displayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.testConnectionSuccessMsg',
-        defaultMessage:
-          'Connecting to the endpoint using the provided authentication method was successful.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.testConnectionSuccessMsg', {
+          defaultMessage:
+            'Connecting to the endpoint using the provided authentication method was successful.',
+        }),
         success: true,
       });
     } catch (e) {
       this.props.displayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.testConnectionFailMsg',
-        defaultMessage:
-          'Failed Connecting to the endpoint using the provided authentication method.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.testConnectionFailMsg', {
+          defaultMessage:
+            'Failed Connecting to the endpoint using the provided authentication method.',
+        }),
       });
     } finally {
       this.setState({ isLoading: false });
@@ -514,14 +518,16 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     try {
       await this.props.handleSubmit(updateAttributes);
       this.props.displayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.updatePasswordSuccessMsg',
-        defaultMessage: 'Password updated successfully.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.updatePasswordSuccessMsg', {
+          defaultMessage: 'Password updated successfully.',
+        }),
         success: true,
       });
     } catch (e) {
       this.props.displayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.updatePasswordFailMsg',
-        defaultMessage: 'Updating the stored password failed with some errors.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.updatePasswordFailMsg', {
+          defaultMessage: 'Updating the stored password failed with some errors.',
+        }),
       });
     }
   };
@@ -547,14 +553,16 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     try {
       await this.props.handleSubmit(updateAttributes);
       this.props.displayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.updatePasswordSuccessMsg',
-        defaultMessage: 'Password updated successfully.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.updatePasswordSuccessMsg', {
+          defaultMessage: 'Password updated successfully.',
+        }),
         success: true,
       });
     } catch (e) {
       this.props.displayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.updatePasswordFailMsg',
-        defaultMessage: 'Updating the stored password failed with some errors.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.updatePasswordFailMsg', {
+          defaultMessage: 'Updating the stored password failed with some errors.',
+        }),
       });
     }
   };
@@ -663,24 +671,6 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
     );
   };
 
-  /* Render field label with Optional text*/
-  renderFieldLabelAsOptional = (i18nId: string, defaultMessage: string) => {
-    return (
-      <>
-        {<FormattedMessage id={i18nId} defaultMessage={defaultMessage} />}{' '}
-        <i style={{ fontWeight: 'normal' }}>
-          -{' '}
-          {
-            <FormattedMessage
-              id="dataSourcesManagement.editDataSource.optionalText"
-              defaultMessage="optional"
-            />
-          }
-        </i>
-      </>
-    );
-  };
-
   /* Render Connection Details Panel */
   renderConnectionDetailsSection = () => {
     return (
@@ -745,10 +735,13 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
           </EuiCompressedFormRow>
           {/* Description */}
           <EuiCompressedFormRow
-            label={this.renderFieldLabelAsOptional(
-              'dataSourceManagement.editDataSource.description',
-              'Description'
-            )}
+            label={
+              <FormattedMessage
+                id="dataSourcesManagement.editDataSource.descriptionOptional"
+                defaultMessage="Description {optionalLabel}"
+                values={{ optionalLabel: <DataSourceOptionalLabelSuffix /> }}
+              />
+            }
             data-test-subj="editDataSourceDescriptionFormRow"
           >
             <EuiCompressedFieldText

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/update_aws_credential_modal/update_aws_credential_modal.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/update_aws_credential_modal/update_aws_credential_modal.tsx
@@ -188,7 +188,7 @@ export const UpdateAwsCredentialModal = ({
             disabled={!isFormValid()}
           >
             {i18n.translate('dataSourcesManagement.editDataSource.updateStoredAwsCredential', {
-              defaultMessage: 'Update stored aws credential',
+              defaultMessage: 'Update stored AWS credential',
             })}
           </EuiSmallButton>
         </EuiModalFooter>

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
@@ -10,7 +10,11 @@ import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { DataSourceManagementContext, DataSourceTableItem, ToastMessageItem } from '../../types';
+import {
+  DataSourceManagementContext,
+  DataSourceManagementToastMessageItem,
+  DataSourceTableItem,
+} from '../../types';
 import {
   deleteDataSourceById,
   getDataSourceById,
@@ -81,8 +85,9 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
     } catch (e) {
       setDataSource(defaultDataSource);
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.fetchDataSourceFailMsg',
-        defaultMessage: 'Unable to find the Data Source.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.fetchDataSourceFailMsg', {
+          defaultMessage: 'Unable to find the Data Source.',
+        }),
       });
       props.history.push('');
     } finally {
@@ -102,11 +107,14 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
     await fetchDataSourceDetailsByID();
   };
 
-  const handleDisplayToastMessage = ({ id, defaultMessage, success }: ToastMessageItem) => {
+  const handleDisplayToastMessage = ({
+    message,
+    success,
+  }: DataSourceManagementToastMessageItem) => {
     if (success) {
-      toasts.addSuccess(i18n.translate(id, { defaultMessage }));
+      toasts.addSuccess(message);
     } else {
-      toasts.addWarning(i18n.translate(id, { defaultMessage }));
+      toasts.addWarning(message);
     }
   };
 
@@ -123,8 +131,10 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
     } catch (e) {
       setIsLoading(false);
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.deleteDataSourceFailMsg',
-        defaultMessage: 'Unable to delete the Data Source due to some errors. Please try it again.',
+        message: i18n.translate('dataSourcesManagement.editDataSource.deleteDataSourceFailMsg', {
+          defaultMessage:
+            'Unable to delete the Data Source due to some errors. Please try it again.',
+        }),
       });
     }
   };
@@ -137,8 +147,13 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
     } catch (e) {
       setIsLoading(false);
       handleDisplayToastMessage({
-        id: 'dataSourcesManagement.editDataSource.setDefaultDataSourceFailMsg',
-        defaultMessage: 'Unable to find a default datasource. Please set a new default datasource.',
+        message: i18n.translate(
+          'dataSourcesManagement.editDataSource.setDefaultDataSourceFailMsg',
+          {
+            defaultMessage:
+              'Unable to find a default datasource. Please set a new default datasource.',
+          }
+        ),
       });
     }
   };

--- a/src/plugins/data_source_management/public/components/no_data_source/__snapshots__/no_data_source.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/no_data_source/__snapshots__/no_data_source.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`NoDataSource should render correctly with the provided totalDataSourceC
         >
           <FormattedMessage
             defaultMessage="No data sources connected yet."
-            id="dataSourcesManagement.dataSourceEmptyMenu.noData"
+            id="dataSourcesManagement.dataSourceEmptyMenu.noConnectedDataSource"
             values={Object {}}
           />
         </EuiText>
@@ -126,7 +126,7 @@ exports[`NoDataSource should render normally when incompatibleDataSourcesExist i
         >
           <FormattedMessage
             defaultMessage="No data sources connected yet."
-            id="dataSourcesManagement.dataSourceEmptyMenu.noData"
+            id="dataSourcesManagement.dataSourceEmptyMenu.noConnectedDataSource"
             values={Object {}}
           />
         </EuiText>
@@ -209,7 +209,7 @@ exports[`NoDataSource should render normally when incompatibleDataSourcesExist i
         >
           <FormattedMessage
             defaultMessage="No data sources connected yet."
-            id="dataSourcesManagement.dataSourceEmptyMenu.noData"
+            id="dataSourcesManagement.dataSourceEmptyMenu.noConnectedDataSource"
             values={Object {}}
           />
         </EuiText>

--- a/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/no_data_source/no_data_source.tsx
@@ -20,12 +20,6 @@ import { FormattedMessage } from 'react-intl';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import { DSM_APP_ID } from '../../plugin';
 import { EmptyIcon } from '../custom_database_icon';
-import {
-  ADD_COMPATIBLE_DATASOURCES_MESSAGE,
-  CONNECT_DATASOURCES_MESSAGE,
-  NO_COMPATIBLE_DATASOURCES_MESSAGE,
-  NO_DATASOURCES_CONNECTED_MESSAGE,
-} from '../constants';
 
 interface DataSourceDropDownHeaderProps {
   incompatibleDataSourcesExist: boolean;
@@ -41,7 +35,7 @@ export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({
     <EuiButtonIcon
       className="euiHeaderLink"
       data-test-subj="dataSourceEmptyMenuHeaderLink"
-      aria-label={i18n.translate('dataSourceEmpty.dataSourceEmptyMenuHeaderLink', {
+      aria-label={i18n.translate('dataSourcesManagement.dataSourceEmptyMenuHeaderLink', {
         defaultMessage: 'dataSourceEmptyMenuHeaderLink',
       })}
       iconType={() => <EmptyIcon />}
@@ -70,29 +64,31 @@ export const NoDataSource: React.FC<DataSourceDropDownHeaderProps> = ({
   const text = (
     <>
       <EuiText size="s" textAlign="center">
-        {
+        {incompatibleDataSourcesExist ? (
           <FormattedMessage
-            id="dataSourcesManagement.dataSourceEmptyMenu.noData"
-            defaultMessage={
-              incompatibleDataSourcesExist
-                ? NO_COMPATIBLE_DATASOURCES_MESSAGE
-                : NO_DATASOURCES_CONNECTED_MESSAGE
-            }
+            id="dataSourcesManagement.dataSourceEmptyMenu.noCompatibleDataSource"
+            defaultMessage="No compatible data sources are available."
           />
-        }
+        ) : (
+          <FormattedMessage
+            id="dataSourcesManagement.dataSourceEmptyMenu.noConnectedDataSource"
+            defaultMessage="No data sources connected yet."
+          />
+        )}
       </EuiText>
 
       <EuiText size="s" textAlign="center">
-        {
+        {incompatibleDataSourcesExist ? (
+          <FormattedMessage
+            id="dataSourcesManagement.dataSourceEmptyMenu.addCompatible"
+            defaultMessage="Add a compatible data source."
+          />
+        ) : (
           <FormattedMessage
             id="dataSourcesManagement.dataSourceEmptyMenu.connect"
-            defaultMessage={
-              incompatibleDataSourcesExist
-                ? ADD_COMPATIBLE_DATASOURCES_MESSAGE
-                : CONNECT_DATASOURCES_MESSAGE
-            }
+            defaultMessage="Connect your data sources to get started."
           />
-        }
+        )}
       </EuiText>
     </>
   );

--- a/src/plugins/data_source_management/public/components/popover_button/popover_button.tsx
+++ b/src/plugins/data_source_management/public/components/popover_button/popover_button.tsx
@@ -31,8 +31,8 @@ export const DataSourceMenuPopoverButton: React.FC<DataSourceMenuPopoverButtonPr
         className="dataSourceMenuPopoverButtonLabel"
         data-test-subj={`${className}Button`}
         onClick={onClick}
-        aria-label={i18n.translate(`${className}.dataSourceOptionsViewAriaLabel`, {
-          defaultMessage: `${className}Button`,
+        aria-label={i18n.translate('dataSourcesManagement.popoverButton.ariaLabel', {
+          defaultMessage: 'Data source selector',
         })}
         iconType="database"
         iconSide="left"

--- a/src/plugins/data_source_management/public/components/toast_button/manage_data_source_button.tsx
+++ b/src/plugins/data_source_management/public/components/toast_button/manage_data_source_button.tsx
@@ -26,7 +26,7 @@ export const getManageDataSourceButton = (application?: ApplicationStart) => {
               })
             }
           >
-            {i18n.translate('dataSourceMenu.manageDataSourceToastButtonLabel', {
+            {i18n.translate('dataSourcesManagement.manageDataSourceToastButtonLabel', {
               defaultMessage: 'Manage data sources',
             })}
           </EuiButton>

--- a/src/plugins/data_source_management/public/components/toast_button/reload_button.tsx
+++ b/src/plugins/data_source_management/public/components/toast_button/reload_button.tsx
@@ -12,7 +12,7 @@ export const getReloadButton = () => {
       <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiButton size="s" onClick={() => window.location.reload()}>
-            {i18n.translate('dataSourceMenu.requiresPageReloadToastButtonLabel', {
+            {i18n.translate('dataSourcesManagement.requiresPageReloadToastButtonLabel', {
               defaultMessage: 'Refresh the page',
             })}
           </EuiButton>

--- a/src/plugins/data_source_management/public/components/utils.test.ts
+++ b/src/plugins/data_source_management/public/components/utils.test.ts
@@ -102,8 +102,10 @@ describe('DataSourceManagement: Utils.ts', () => {
 
   describe('Handle no available data source error', () => {
     let toasts: IToasts;
-    const noDataSourcesConnectedMessage = `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
-    const noCompatibleDataSourcesMessage = `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`;
+    const noDataSourcesConnectedMessage =
+      'No data sources connected yet. Connect your data sources to get started.';
+    const noCompatibleDataSourcesMessage =
+      'No compatible data sources are available. Add a compatible data source.';
 
     beforeEach(() => {
       toasts = notificationServiceMock.createStartContract().toasts;
@@ -128,11 +130,7 @@ describe('DataSourceManagement: Utils.ts', () => {
           incompatibleDataSourcesExist,
         });
         expect(toasts.add).toBeCalledTimes(1);
-        expect(toasts.add).toBeCalledWith(
-          expect.objectContaining({
-            title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
-          })
-        );
+        expect(toasts.add).toBeCalledWith(expect.objectContaining({ title: defaultMessage }));
       }
     );
   });

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -30,13 +30,7 @@ import { DataSourceGroupLabelOption } from './data_source_menu/types';
 import { createGetterSetter } from '../../../opensearch_dashboards_utils/public';
 import { toMountPoint } from '../../../opensearch_dashboards_react/public';
 import { getManageDataSourceButton, getReloadButton } from './toast_button';
-import {
-  ADD_COMPATIBLE_DATASOURCES_MESSAGE,
-  CONNECT_DATASOURCES_MESSAGE,
-  NO_COMPATIBLE_DATASOURCES_MESSAGE,
-  NO_DATASOURCES_CONNECTED_MESSAGE,
-  DEFAULT_DATA_SOURCE_UI_SETTINGS_ID,
-} from './constants';
+import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from './constants';
 import {
   DataSourceSelectionService,
   defaultDataSourceSelection,
@@ -142,7 +136,7 @@ export const fetchDataSourceConnections = async (
     );
   } catch (error) {
     notifications?.toasts.addDanger(
-      i18n.translate('dataSource.fetchDataSourceConnections', {
+      i18n.translate('dataSourcesManagement.fetchDataSourceConnections', {
         defaultMessage: 'Cannot fetch data sources',
       })
     );
@@ -235,14 +229,18 @@ export interface HandleNoAvailableDataSourceErrorProps {
 export function handleNoAvailableDataSourceError(props: HandleNoAvailableDataSourceErrorProps) {
   const { changeState, notifications, application, callback, incompatibleDataSourcesExist } = props;
 
-  const defaultMessage = incompatibleDataSourcesExist
-    ? `${NO_COMPATIBLE_DATASOURCES_MESSAGE} ${ADD_COMPATIBLE_DATASOURCES_MESSAGE}`
-    : `${NO_DATASOURCES_CONNECTED_MESSAGE} ${CONNECT_DATASOURCES_MESSAGE}`;
+  const notificationTitle = incompatibleDataSourcesExist
+    ? i18n.translate('dataSourcesManagement.noCompatibleDataSourceError', {
+        defaultMessage: 'No compatible data sources are available. Add a compatible data source.',
+      })
+    : i18n.translate('dataSourcesManagement.noAvailableDataSourceError', {
+        defaultMessage: 'No data sources connected yet. Connect your data sources to get started.',
+      });
 
   changeState();
   if (callback) callback([]);
   notifications.add({
-    title: i18n.translate('dataSource.noAvailableDataSourceError', { defaultMessage }),
+    title: notificationTitle,
     text: toMountPoint(getManageDataSourceButton(application)),
     color: 'warning',
   });
@@ -455,7 +453,7 @@ export const handleDataSourceFetchError = (
   changeState({ showError: true });
   if (callback) callback([]);
   notifications.add({
-    title: i18n.translate('dataSource.fetchDataSourceError', {
+    title: i18n.translate('dataSourcesManagement.error.fetchDataSources', {
       defaultMessage: 'Failed to fetch data sources',
     }),
     text: toMountPoint(getReloadButton()),

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -151,7 +151,7 @@ export class DataSourceManagementPlugin
         id: DSM_APP_ID,
         title: PLUGIN_NAME,
         order: 100,
-        description: i18n.translate('data_source_management.description', {
+        description: i18n.translate('dataSourcesManagement.description', {
           defaultMessage: 'Create and manage data source connections.',
         }),
         mount: async (params: AppMountParameters) => {

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -57,9 +57,17 @@ export interface DataSourceTableItem {
   relatedConnections?: DataSourceTableItem[];
 }
 
+/**
+ * @deprecated Use `DataSourceManagementToastMessageItem` instead.
+ */
 export interface ToastMessageItem {
   id: string;
   defaultMessage: string;
+  success?: boolean;
+}
+
+export interface DataSourceManagementToastMessageItem {
+  message: string;
   success?: boolean;
 }
 
@@ -71,7 +79,7 @@ export const defaultAuthType = AuthType.UsernamePasswordType;
 
 export const noAuthCredentialOption = {
   value: AuthType.NoAuth,
-  inputDisplay: i18n.translate('dataSourceManagement.credentialSourceOptions.NoAuthentication', {
+  inputDisplay: i18n.translate('dataSourcesManagement.credentialSourceOptions.NoAuthentication', {
     defaultMessage: 'No authentication',
   }),
 };
@@ -86,7 +94,7 @@ export const noAuthCredentialAuthMethod = {
 
 export const usernamePasswordCredentialOption = {
   value: AuthType.UsernamePasswordType,
-  inputDisplay: i18n.translate('dataSourceManagement.credentialSourceOptions.UsernamePassword', {
+  inputDisplay: i18n.translate('dataSourcesManagement.credentialSourceOptions.UsernamePassword', {
     defaultMessage: 'Username & Password',
   }),
 };
@@ -104,7 +112,7 @@ export const usernamePasswordAuthMethod = {
 
 export const sigV4CredentialOption = {
   value: AuthType.SigV4,
-  inputDisplay: i18n.translate('dataSourceManagement.credentialSourceOptions.AwsSigV4', {
+  inputDisplay: i18n.translate('dataSourcesManagement.credentialSourceOptions.AwsSigV4', {
     defaultMessage: 'AWS SigV4',
   }),
 };
@@ -112,13 +120,13 @@ export const sigV4CredentialOption = {
 export const sigV4ServiceOptions = [
   {
     value: SigV4ServiceName.OpenSearch,
-    inputDisplay: i18n.translate('dataSourceManagement.SigV4ServiceOptions.OpenSearch', {
+    inputDisplay: i18n.translate('dataSourcesManagement.SigV4ServiceOptions.OpenSearch', {
       defaultMessage: 'Amazon OpenSearch Service',
     }),
   },
   {
     value: SigV4ServiceName.OpenSearchServerless,
-    inputDisplay: i18n.translate('dataSourceManagement.SigV4ServiceOptions.OpenSearchServerless', {
+    inputDisplay: i18n.translate('dataSourcesManagement.SigV4ServiceOptions.OpenSearchServerless', {
       defaultMessage: 'Amazon OpenSearch Serverless',
     }),
   },

--- a/src/plugins/data_source_management/server/saved_objects/data_source_premission_client_wrapper.ts
+++ b/src/plugins/data_source_management/server/saved_objects/data_source_premission_client_wrapper.ts
@@ -162,7 +162,7 @@ export class DataSourcePermissionClientWrapper {
   private generatePermissionError = () =>
     SavedObjectsErrorHelpers.decorateForbiddenError(
       new Error(
-        i18n.translate('dashboard.admin.permission.invalidate', {
+        i18n.translate('dataSourcesManagement.admin.permission.invalid', {
           defaultMessage: 'You have no permission to perform this operation',
         })
       )


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n and correct unprefixed and duplicate i18n identifiers in dataSourceManagement plugin



## Changelog
- fix: Fix dynamic and correct unprefixed and duplicate i18n identifiers in dataSourceManagement plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
