### PR TITLE
Fix dynamic uses of i18n in discover plugin

### DIFF
--- a/changelogs/fragments/8396.yml
+++ b/changelogs/fragments/8396.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix dynamic uses of i18n in discover plugin ([#8396](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8396))

--- a/src/plugins/discover/public/application/components/chart/chart.tsx
+++ b/src/plugins/discover/public/application/components/chart/chart.tsx
@@ -94,7 +94,7 @@ export const DiscoverChart = ({
     </div>
   );
 
-  const toggleLabel = i18n.translate('histogram.collapse', {
+  const toggleLabel = i18n.translate('discover.histogram.collapse', {
     defaultMessage: 'Toggle histogram',
   });
 

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -49,7 +49,7 @@ const TableCellUI = ({
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '+')}
             iconType="plusInCircle"
-            aria-label={i18n.translate('discover.filterForValueLabel', {
+            aria-label={i18n.translate('discover.filterForValue', {
               defaultMessage: 'Filter for value',
             })}
             data-test-subj="filterForValue"
@@ -65,7 +65,7 @@ const TableCellUI = ({
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '-')}
             iconType="minusInCircle"
-            aria-label={i18n.translate('discover.filterOutValueLabel', {
+            aria-label={i18n.translate('discover.filterOutValue', {
               defaultMessage: 'Filter out value',
             })}
             data-test-subj="filterOutValue"

--- a/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_header_column.tsx
@@ -173,7 +173,8 @@ export function TableHeaderColumn({
       className="docTableHeaderField"
       role="columnheader"
       aria-label={i18n.translate('discover.defaultTable.docTableHeaderLabel', {
-        defaultMessage: `Discover table column: ${name}`,
+        defaultMessage: 'Discover table column: {name}',
+        values: { name },
       })}
     >
       <span data-test-subj={`docTableHeader-${name}`}>

--- a/src/plugins/discover/public/application/components/sidebar/discover_sidebar.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_sidebar.tsx
@@ -312,9 +312,7 @@ const FieldList = ({
         onClick={() => setExpanded(!expanded)}
         size="xs"
         className="dscSideBar_fieldGroup"
-        aria-label={i18n.translate('discover.fieldChooser.fieldGroupLabel', {
-          defaultMessage: title,
-        })}
+        aria-label={title}
       >
         {title}
       </EuiButtonEmpty>


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n in discover plugin



## Changelog
- fix: Fix dynamic uses of i18n in discover plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
