### PR TITLE
Fix dynamic uses of i18n and correct unprefixed i18n identifiers in queryEnhancements plugin

### DIFF
--- a/changelogs/fragments/8397.yml
+++ b/changelogs/fragments/8397.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix dynamic uses of i18n and correct unprefixed i18n identifiers in queryEnhancements plugin ([#8397](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8397))

--- a/src/plugins/query_enhancements/public/query_assist/components/call_outs.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/call_outs.tsx
@@ -26,7 +26,7 @@ const EmptyIndexCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
     data-test-subj="query-assist-empty-index-callout"
     title={
       <FormattedMessage
-        id="queryAssist.callOut.emptyIndex.title"
+        id="queryEnhancements.callOut.emptyIndex.title"
         defaultMessage="Select a data source or index to ask a question."
       />
     }
@@ -44,7 +44,7 @@ const ProhibitedQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
     data-test-subj="query-assist-guard-callout"
     title={
       <FormattedMessage
-        id="queryAssist.callOut.prohibitedQuery.title"
+        id="queryEnhancements.callOut.prohibitedQuery.title"
         defaultMessage="I am unable to respond to this query. Try another question."
       />
     }
@@ -62,7 +62,7 @@ const EmptyQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
     data-test-subj="query-assist-empty-query-callout"
     title={
       <FormattedMessage
-        id="queryAssist.callOut.emptyQuery.title"
+        id="queryEnhancements.callOut.emptyQuery.title"
         defaultMessage="Enter a natural language question to automatically generate a query to view results."
       />
     }
@@ -80,7 +80,7 @@ const QueryGeneratedCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
     data-test-subj="query-assist-query-generated-callout"
     title={
       <FormattedMessage
-        id="queryAssist.callOut.queryGenerated.title"
+        id="queryEnhancements.callOut.queryGenerated.title"
         defaultMessage="{language} query generated. If there are any issues with the response, try adding more context to the question or a new question to submit."
         values={{ language: props.language }}
       />

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
@@ -49,13 +49,13 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiBadge>
-              <FormattedMessage id="queryAssist.banner.badge" defaultMessage="New!" />
+              <FormattedMessage id="queryEnhancements.banner.badge" defaultMessage="New!" />
             </EuiBadge>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTextColor color="default">
               <FormattedMessage
-                id="queryAssist.banner.title.prefix"
+                id="queryEnhancements.banner.title.prefix"
                 defaultMessage="Use natural language to explore your data with "
               />
               <EuiLink
@@ -66,7 +66,7 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
                 }}
               >
                 <FormattedMessage
-                  id="queryAssist.banner.title.suffix"
+                  id="queryEnhancements.banner.title.suffix"
                   defaultMessage="Natural Language Query Generation for {languages}"
                   values={{ languages: props.languages.join(', ') }}
                 />

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
@@ -242,7 +242,8 @@ export const QueryAssistSummary: React.FC<QueryAssistSummaryProps> = (props) => 
                     type={'iInCircle'}
                     content={`Summary based on first ${sampleSize} records`}
                     aria-label={i18n.translate('queryEnhancements.queryAssist.summary.sampletip', {
-                      defaultMessage: `Summary based on first ${sampleSize} records`,
+                      defaultMessage: 'Summary based on first {sampleSize} records',
+                      values: { sampleSize },
                     })}
                   />
                 </EuiFlexItem>

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -105,7 +105,7 @@ export const createQueryAssistExtension = (
         return {
           type: DATA_STRUCTURE_META_TYPES.FEATURE,
           icon: { type: assistantMark },
-          tooltip: i18n.translate('queryAssist.meta.icon.tooltip', {
+          tooltip: i18n.translate('queryEnhancements.meta.icon.tooltip', {
             defaultMessage: 'Query assist is available',
           }),
         };

--- a/src/plugins/query_enhancements/public/query_editor/query_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor/query_language_reference.tsx
@@ -28,7 +28,7 @@ export class QueryLanguageReference {
     const button = (
       <EuiButtonIcon
         iconType={'iInCircle'}
-        aria-label={i18n.translate('discover.queryControls.languageReference', {
+        aria-label={i18n.translate('queryEnhancements.queryControls.languageReference', {
           defaultMessage: `PPL language Reference`,
         })}
         onClick={() => {


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n and correct unprefixed i18n identifiers in queryEnhancements plugin



## Changelog
- fix: Fix dynamic uses of i18n and correct unprefixed i18n identifiers in queryEnhancements plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
