### PR TITLE
Fix dynamic uses of i18n and correct unprefixed and duplicate i18n identifiers in visBuilder plugin

### DIFF
--- a/changelogs/fragments/8399.yml
+++ b/changelogs/fragments/8399.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix dynamic uses of i18n and correct unprefixed and duplicate i18n identifiers in visBuilder plugin ([#8399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8399))

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -153,7 +153,7 @@ export const TopNav = () => {
         groupActions={showActionsInGroup}
         screenTitle={
           savedVisBuilderVis?.title ||
-          i18n.translate('discover.savedSearch.newTitle', {
+          i18n.translate('visBuilder.savedSearch.newTitle', {
             defaultMessage: 'New visualization',
           })
         }

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -74,11 +74,11 @@ export const getLegacyTopNavConfig = (
       className: savedVisBuilderVis?.id && originatingApp ? 'saveAsButton' : '',
       label:
         savedVisBuilderVis?.id && originatingApp
-          ? i18n.translate('visBuilder.topNavMenu.saveVisualizationAsButtonLabel', {
-              defaultMessage: 'save as',
+          ? i18n.translate('visBuilder.topNavMenu.saveAsVisualizationAsButtonLabel', {
+              defaultMessage: 'Save as',
             })
           : i18n.translate('visBuilder.topNavMenu.saveVisualizationButtonLabel', {
-              defaultMessage: 'save',
+              defaultMessage: 'Save',
             }),
       testId: 'visBuilderSaveButton',
       disableButton: !!saveDisabledReason,
@@ -89,7 +89,7 @@ export const getLegacyTopNavConfig = (
       ? [
           {
             id: 'saveAndReturn',
-            label: i18n.translate('visualize.topNavMenu.saveAndReturnVisualizationButtonLabel', {
+            label: i18n.translate('visBuilder.topNavMenu.saveAndReturnVisualizationButtonLabel', {
               defaultMessage: 'Save and return',
             }),
             emphasize: true,
@@ -128,14 +128,14 @@ export const getTopNavConfig = (
       tooltip: !!saveDisabledReason
         ? saveDisabledReason
         : savedVisBuilderVis?.id && originatingApp
-        ? i18n.translate('visBuilder.topNavMenu.saveVisualizationAsButtonLabel', {
-            defaultMessage: 'save as',
+        ? i18n.translate('visBuilder.topNavMenu.saveAsVisualizationAsButtonLabel', {
+            defaultMessage: 'Save as',
           })
         : i18n.translate('visBuilder.topNavMenu.saveVisualizationButtonLabel', {
-            defaultMessage: 'save',
+            defaultMessage: 'Save',
           }),
       ariaLabel: i18n.translate('visBuilder.topNavMenu.saveVisualizationAsButtonLabel', {
-        defaultMessage: 'save',
+        defaultMessage: 'Save',
       }),
       testId: 'visBuilderSaveButton',
       run: navActions.save,
@@ -146,7 +146,7 @@ export const getTopNavConfig = (
     ...(originatingApp && savedVisBuilderVis && savedVisBuilderVis.id
       ? [
           {
-            tooltip: i18n.translate('visualize.topNavMenu.openInspectorTooltip', {
+            tooltip: i18n.translate('visBuilder.topNavMenu.openInspectorTooltip', {
               defaultMessage: 'Save and return',
             }),
             ariaLabel: i18n.translate(

--- a/src/plugins/vis_builder/public/application/utils/use/use_can_save.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_can_save.ts
@@ -23,20 +23,18 @@ export const useCanSave = () => {
 
 // TODO: Need to finalize the error messages
 const getErrorMsg = (isEmpty, hasNoChange, hasDraftAgg) => {
-  const i18nTranslate = (key: string, defaultMessage: string) =>
-    i18n.translate(`visBuilder.saveVisualizationTooltip.${key}`, {
-      defaultMessage,
-    });
-
   if (isEmpty) {
-    return i18nTranslate('empty', 'The canvas is empty. Add some aggregations before saving.');
+    return i18n.translate('visBuilder.saveVisualizationTooltip.empty', {
+      defaultMessage: 'The canvas is empty. Add some aggregations before saving.',
+    });
   } else if (hasNoChange) {
-    return i18nTranslate('noChange', 'Add some changes before saving.');
+    return i18n.translate('visBuilder.saveVisualizationTooltip.noChange', {
+      defaultMessage: 'Add some changes before saving.',
+    });
   } else if (hasDraftAgg) {
-    return i18nTranslate(
-      'hasDraftAgg',
-      'Has unapplied aggregations changes, update them before saving.'
-    );
+    return i18n.translate('visBuilder.saveVisualizationTooltip.hasDraftAgg', {
+      defaultMessage: 'Update unapplied aggregation changes before saving.',
+    });
   } else {
     return undefined;
   }

--- a/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
@@ -45,7 +45,7 @@ export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined
     } = services;
     const toastNotification = (message: string) => {
       toastNotifications.addDanger({
-        title: i18n.translate('visualize.createVisualization.failedToLoadErrorMessage', {
+        title: i18n.translate('visBuilder.createVisualization.failedToLoadErrorMessage', {
           defaultMessage: 'Failed to load the visualization',
         }),
         text: message,

--- a/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx
+++ b/src/plugins/vis_builder/public/embeddable/vis_builder_embeddable_factory.tsx
@@ -109,8 +109,6 @@ export class VisBuilderEmbeddableFactory
   }
 
   public getDisplayName() {
-    return i18n.translate('visBuilder.displayName', {
-      defaultMessage: PLUGIN_ID,
-    });
+    return PLUGIN_ID;
   }
 }

--- a/src/plugins/vis_builder/public/visualizations/metric/components/metric_viz_options.tsx
+++ b/src/plugins/vis_builder/public/visualizations/metric/components/metric_viz_options.tsx
@@ -28,19 +28,19 @@ import { Option } from '../../../application/app';
 const METRIC_COLOR_MODES = [
   {
     id: ColorModes.NONE,
-    label: i18n.translate('visTypeMetric.colorModes.noneOptionLabel', {
+    label: i18n.translate('visBuilder.colorModes.noneOptionLabel', {
       defaultMessage: 'None',
     }),
   },
   {
     id: ColorModes.LABELS,
-    label: i18n.translate('visTypeMetric.colorModes.labelsOptionLabel', {
+    label: i18n.translate('visBuilder.colorModes.labelsOptionLabel', {
       defaultMessage: 'Labels',
     }),
   },
   {
     id: ColorModes.BACKGROUND,
-    label: i18n.translate('visTypeMetric.colorModes.backgroundOptionLabel', {
+    label: i18n.translate('visBuilder.colorModes.backgroundOptionLabel', {
       defaultMessage: 'Background',
     }),
   },
@@ -59,18 +59,18 @@ function MetricVizOptions() {
     [dispatch, styleState]
   );
 
-  const metricColorModeLabel = i18n.translate('visTypeMetric.params.color.useForLabel', {
+  const metricColorModeLabel = i18n.translate('visBuilder.params.color.useForLabel', {
     defaultMessage: 'Use color for',
   });
 
   return (
     <>
       <Option
-        title={i18n.translate('visTypeMetric.params.settingsTitle', { defaultMessage: 'Settings' })}
+        title={i18n.translate('visBuilder.params.settingsTitle', { defaultMessage: 'Settings' })}
         initialIsOpen
       >
         <SwitchOption
-          label={i18n.translate('visTypeMetric.params.percentageModeLabel', {
+          label={i18n.translate('visBuilder.params.percentageModeLabel', {
             defaultMessage: 'Percentage mode',
           })}
           paramName="percentageMode"
@@ -83,7 +83,7 @@ function MetricVizOptions() {
         />
 
         <SwitchOption
-          label={i18n.translate('visTypeMetric.params.showTitleLabel', {
+          label={i18n.translate('visBuilder.params.showTitleLabel', {
             defaultMessage: 'Show title',
           })}
           paramName="show"
@@ -95,9 +95,7 @@ function MetricVizOptions() {
           }
         />
       </Option>
-      <Option
-        title={i18n.translate('visTypeMetric.params.rangesTitle', { defaultMessage: 'Ranges' })}
-      >
+      <Option title={i18n.translate('visBuilder.params.rangesTitle', { defaultMessage: 'Ranges' })}>
         <ColorRanges
           data-test-subj="metricColorRange"
           colorsRange={metric.colorsRange}
@@ -143,10 +141,10 @@ function MetricVizOptions() {
         />
       </Option>
       <Option
-        title={i18n.translate('visTypeMetric.params.style.styleTitle', { defaultMessage: 'Style' })}
+        title={i18n.translate('visBuilder.params.style.styleTitle', { defaultMessage: 'Style' })}
       >
         <RangeOption
-          label={i18n.translate('visTypeMetric.params.style.fontSizeLabel', {
+          label={i18n.translate('visBuilder.params.style.fontSizeLabel', {
             defaultMessage: 'Metric font size in points',
           })}
           min={12}

--- a/src/plugins/vis_builder/public/visualizations/metric/metric_viz_type.ts
+++ b/src/plugins/vis_builder/public/visualizations/metric/metric_viz_type.ts
@@ -48,7 +48,7 @@ export const createMetricConfig = (): VisualizationTypeOptions<MetricOptionsDefa
           {
             group: AggGroupNames.Metrics,
             name: 'metric',
-            title: i18n.translate('visTypeMetric.schemas.metricTitle', {
+            title: i18n.translate('visBuilder.schemas.metricTitle', {
               defaultMessage: 'Metric',
             }),
             min: 1,
@@ -73,7 +73,7 @@ export const createMetricConfig = (): VisualizationTypeOptions<MetricOptionsDefa
           {
             group: AggGroupNames.Buckets,
             name: 'group',
-            title: i18n.translate('visTypeMetric.schemas.splitGroupTitle', {
+            title: i18n.translate('visBuilder.schemas.splitGroupTitle', {
               defaultMessage: 'Split group',
             }),
             min: 0,

--- a/src/plugins/vis_builder/public/visualizations/table/components/table_viz_options.tsx
+++ b/src/plugins/vis_builder/public/visualizations/table/components/table_viz_options.tsx
@@ -35,7 +35,7 @@ function TableVizOptions() {
   return (
     <>
       <Option
-        title={i18n.translate('visTypeTableNewNew.params.settingsTitle', {
+        title={i18n.translate('visBuilder.params.settingsTitle', {
           defaultMessage: 'Settings',
         })}
         initialIsOpen
@@ -43,13 +43,13 @@ function TableVizOptions() {
         <NumberInputOption
           label={
             <>
-              {i18n.translate('visTypeTableNewNew.params.perPageLabel', {
+              {i18n.translate('visBuilder.params.perPageLabel', {
                 defaultMessage: 'Max rows per page',
               })}
               <EuiIconTip
                 content={
                   <FormattedMessage
-                    id="visTypeTableNewNews.field.emptyTooltip"
+                    id="visBuilder.field.emptyTooltip"
                     defaultMessage="Leaving this field empty means it will use number of buckets from the response."
                   />
                 }
@@ -69,7 +69,7 @@ function TableVizOptions() {
         />
 
         <SwitchOption
-          label={i18n.translate('visTypeTableNewNew.params.showMetricsLabel', {
+          label={i18n.translate('visBuilder.params.showMetricsLabel', {
             defaultMessage: 'Show metrics for every bucket/level',
           })}
           paramName="showMetricsAtAllLevels"
@@ -83,10 +83,10 @@ function TableVizOptions() {
         />
 
         <SwitchOption
-          label={i18n.translate('visTypeTableNewNew.params.showPartialRowsLabel', {
+          label={i18n.translate('visBuilder.params.showPartialRowsLabel', {
             defaultMessage: 'Show partial rows',
           })}
-          tooltip={i18n.translate('visTypeTableNewNew.params.showPartialRowsTip', {
+          tooltip={i18n.translate('visBuilder.params.showPartialRowsTip', {
             defaultMessage:
               'Show rows that have partial data. This will still calculate metrics for every bucket/level, even if they are not displayed.',
           })}

--- a/src/plugins/vis_builder/public/visualizations/table/table_viz_type.ts
+++ b/src/plugins/vis_builder/public/visualizations/table/table_viz_type.ts
@@ -29,7 +29,7 @@ export const createTableConfig = (): VisualizationTypeOptions<TableOptionsDefaul
           {
             group: AggGroupNames.Metrics,
             name: 'metric',
-            title: i18n.translate('visTypeTableNewNew.tableVisEditorConfig.schemas.metricTitle', {
+            title: i18n.translate('visBuilder.tableVisEditorConfig.schemas.metricTitle', {
               defaultMessage: 'Metric',
             }),
             min: 1,
@@ -46,7 +46,7 @@ export const createTableConfig = (): VisualizationTypeOptions<TableOptionsDefaul
           {
             group: AggGroupNames.Buckets,
             name: 'bucket',
-            title: i18n.translate('visTypeTableNewNew.tableVisEditorConfig.schemas.bucketTitle', {
+            title: i18n.translate('visBuilder.tableVisEditorConfig.schemas.bucketTitle', {
               defaultMessage: 'Split rows',
             }),
             aggFilter: ['!filter'],
@@ -57,7 +57,7 @@ export const createTableConfig = (): VisualizationTypeOptions<TableOptionsDefaul
           {
             group: AggGroupNames.Buckets,
             name: 'split_row',
-            title: i18n.translate('visTypeTableNewNew.tableVisEditorConfig.schemas.splitTitle', {
+            title: i18n.translate('visBuilder.tableVisEditorConfig.schemas.splitTitleInRows', {
               defaultMessage: 'Split table in rows',
             }),
             min: 0,
@@ -70,7 +70,7 @@ export const createTableConfig = (): VisualizationTypeOptions<TableOptionsDefaul
           {
             group: AggGroupNames.Buckets,
             name: 'split_column',
-            title: i18n.translate('visTypeTableNewNew.tableVisEditorConfig.schemas.splitTitle', {
+            title: i18n.translate('visBuilder.tableVisEditorConfig.schemas.splitTitleInColumns', {
               defaultMessage: 'Split table in columns',
             }),
             min: 0,

--- a/src/plugins/vis_builder/public/visualizations/vislib/area/area_vis_type.ts
+++ b/src/plugins/vis_builder/public/visualizations/vislib/area/area_vis_type.ts
@@ -29,7 +29,7 @@ export const createAreaConfig = (): VisualizationTypeOptions<AreaOptionsDefaults
           {
             group: AggGroupNames.Metrics,
             name: 'metric',
-            title: i18n.translate('visTypeVislib.area.metricTitle', {
+            title: i18n.translate('visBuilder.area.metricTitle', {
               defaultMessage: 'Y-axis',
             }),
             min: 1,
@@ -40,7 +40,7 @@ export const createAreaConfig = (): VisualizationTypeOptions<AreaOptionsDefaults
           {
             group: AggGroupNames.Buckets,
             name: 'segment',
-            title: i18n.translate('visTypeVislib.area.segmentTitle', {
+            title: i18n.translate('visBuilder.area.segmentTitle', {
               defaultMessage: 'X-axis',
             }),
             min: 0,
@@ -51,7 +51,7 @@ export const createAreaConfig = (): VisualizationTypeOptions<AreaOptionsDefaults
           {
             group: AggGroupNames.Buckets,
             name: 'group',
-            title: i18n.translate('visTypeVislib.area.groupTitle', {
+            title: i18n.translate('visBuilder.area.groupTitle', {
               defaultMessage: 'Split series',
             }),
             min: 0,
@@ -62,7 +62,7 @@ export const createAreaConfig = (): VisualizationTypeOptions<AreaOptionsDefaults
           {
             group: AggGroupNames.Buckets,
             name: 'split',
-            title: i18n.translate('visTypeVislib.area.splitTitle', {
+            title: i18n.translate('visBuilder.area.splitTitle', {
               defaultMessage: 'Split chart',
             }),
             min: 0,

--- a/src/plugins/vis_builder/public/visualizations/vislib/area/components/area_vis_options.tsx
+++ b/src/plugins/vis_builder/public/visualizations/vislib/area/components/area_vis_options.tsx
@@ -27,7 +27,7 @@ function AreaVisOptions() {
   return (
     <>
       <Option
-        title={i18n.translate('visTypeVislib.area.params.settingsTitle', {
+        title={i18n.translate('visBuilder.area.params.settingsTitle', {
           defaultMessage: 'Settings',
         })}
         initialIsOpen

--- a/src/plugins/vis_builder/public/visualizations/vislib/common/basic_vis_options.tsx
+++ b/src/plugins/vis_builder/public/visualizations/vislib/common/basic_vis_options.tsx
@@ -20,7 +20,7 @@ export const BasicVisOptions = ({ styleState, setOption }: Props) => {
   return (
     <>
       <SelectOption
-        label={i18n.translate('charts.controls.vislibBasicOptions.legendPositionLabel', {
+        label={i18n.translate('visBuilder.controls.vislibBasicOptions.legendPositionLabel', {
           defaultMessage: 'Legend position',
         })}
         options={legendPositions}
@@ -33,7 +33,7 @@ export const BasicVisOptions = ({ styleState, setOption }: Props) => {
         }
       />
       <SwitchOption
-        label={i18n.translate('charts.controls.vislibBasicOptions.showTooltipLabel', {
+        label={i18n.translate('visBuilder.controls.vislibBasicOptions.showTooltipLabel', {
           defaultMessage: 'Show tooltip',
         })}
         paramName="addTooltip"

--- a/src/plugins/vis_builder/public/visualizations/vislib/histogram/components/histogram_vis_options.tsx
+++ b/src/plugins/vis_builder/public/visualizations/vislib/histogram/components/histogram_vis_options.tsx
@@ -27,7 +27,7 @@ function HistogramVisOptions() {
   return (
     <>
       <Option
-        title={i18n.translate('visTypeVislib.histogram.params.settingsTitle', {
+        title={i18n.translate('visBuilder.histogram.params.settingsTitle', {
           defaultMessage: 'Settings',
         })}
         initialIsOpen

--- a/src/plugins/vis_builder/public/visualizations/vislib/histogram/histogram_vis_type.ts
+++ b/src/plugins/vis_builder/public/visualizations/vislib/histogram/histogram_vis_type.ts
@@ -29,7 +29,7 @@ export const createHistogramConfig = (): VisualizationTypeOptions<HistogramOptio
           {
             group: AggGroupNames.Metrics,
             name: 'metric',
-            title: i18n.translate('visTypeVislib.histogram.metricTitle', {
+            title: i18n.translate('visBuilder.histogram.metricTitle', {
               defaultMessage: 'Y-axis',
             }),
             min: 1,
@@ -40,7 +40,7 @@ export const createHistogramConfig = (): VisualizationTypeOptions<HistogramOptio
           {
             group: AggGroupNames.Buckets,
             name: 'segment',
-            title: i18n.translate('visTypeVislib.histogram.segmentTitle', {
+            title: i18n.translate('visBuilder.histogram.segmentTitle', {
               defaultMessage: 'X-axis',
             }),
             min: 0,
@@ -51,7 +51,7 @@ export const createHistogramConfig = (): VisualizationTypeOptions<HistogramOptio
           {
             group: AggGroupNames.Buckets,
             name: 'group',
-            title: i18n.translate('visTypeVislib.histogram.groupTitle', {
+            title: i18n.translate('visBuilder.histogram.groupTitle', {
               defaultMessage: 'Split series',
             }),
             min: 0,
@@ -62,7 +62,7 @@ export const createHistogramConfig = (): VisualizationTypeOptions<HistogramOptio
           {
             group: AggGroupNames.Buckets,
             name: 'split',
-            title: i18n.translate('visTypeVislib.histogram.splitTitle', {
+            title: i18n.translate('visBuilder.histogram.splitTitle', {
               defaultMessage: 'Split chart',
             }),
             min: 0,

--- a/src/plugins/vis_builder/public/visualizations/vislib/line/components/line_vis_options.tsx
+++ b/src/plugins/vis_builder/public/visualizations/vislib/line/components/line_vis_options.tsx
@@ -27,7 +27,7 @@ function LineVisOptions() {
   return (
     <>
       <Option
-        title={i18n.translate('visTypeVislib.line.params.settingsTitle', {
+        title={i18n.translate('visBuilder.line.params.settingsTitle', {
           defaultMessage: 'Settings',
         })}
         initialIsOpen

--- a/src/plugins/vis_builder/public/visualizations/vislib/line/line_vis_type.ts
+++ b/src/plugins/vis_builder/public/visualizations/vislib/line/line_vis_type.ts
@@ -29,7 +29,7 @@ export const createLineConfig = (): VisualizationTypeOptions<LineOptionsDefaults
           {
             group: AggGroupNames.Metrics,
             name: 'metric',
-            title: i18n.translate('visTypeVislib.line.metricTitle', {
+            title: i18n.translate('visBuilder.line.metricTitle', {
               defaultMessage: 'Y-axis',
             }),
             min: 1,
@@ -40,7 +40,7 @@ export const createLineConfig = (): VisualizationTypeOptions<LineOptionsDefaults
           {
             group: AggGroupNames.Buckets,
             name: 'segment',
-            title: i18n.translate('visTypeVislib.line.segmentTitle', {
+            title: i18n.translate('visBuilder.line.segmentTitle', {
               defaultMessage: 'X-axis',
             }),
             min: 0,
@@ -51,7 +51,7 @@ export const createLineConfig = (): VisualizationTypeOptions<LineOptionsDefaults
           {
             group: AggGroupNames.Buckets,
             name: 'group',
-            title: i18n.translate('visTypeVislib.line.groupTitle', {
+            title: i18n.translate('visBuilder.line.groupTitle', {
               defaultMessage: 'Split series',
             }),
             min: 0,
@@ -62,7 +62,7 @@ export const createLineConfig = (): VisualizationTypeOptions<LineOptionsDefaults
           {
             group: AggGroupNames.Buckets,
             name: 'split',
-            title: i18n.translate('visTypeVislib.line.splitTitle', {
+            title: i18n.translate('visBuilder.line.splitTitle', {
               defaultMessage: 'Split chart',
             }),
             min: 0,
@@ -73,7 +73,7 @@ export const createLineConfig = (): VisualizationTypeOptions<LineOptionsDefaults
           {
             group: AggGroupNames.Metrics,
             name: 'radius',
-            title: i18n.translate('visTypeVislib.line.radiusTitle', {
+            title: i18n.translate('visBuilder.line.radiusTitle', {
               defaultMessage: 'Dot size',
             }),
             min: 0,

--- a/src/plugins/vis_builder/server/plugin.ts
+++ b/src/plugins/vis_builder/server/plugin.ts
@@ -37,11 +37,11 @@ export class VisBuilderPlugin implements Plugin<VisBuilderPluginSetup, VisBuilde
     // Register settings
     uiSettings.register({
       [VISBUILDER_ENABLE_VEGA_SETTING]: {
-        name: i18n.translate('visbuilder.advancedSettings.visbuilderEnableVegaTitle', {
+        name: i18n.translate('visBuilder.advancedSettings.visbuilderEnableVegaTitle', {
           defaultMessage: 'Enable vega transformation in visbuilder',
         }),
         value: false,
-        description: i18n.translate('visbuilder.advancedSettings.visbuilderEnableVegaText', {
+        description: i18n.translate('visBuilder.advancedSettings.visbuilderEnableVegaText', {
           defaultMessage: `Allow visbuilder to render visualizations via vega.`,
         }),
         category: ['visbuilder'],


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n and correct unprefixed and duplicate i18n identifiers in visBuilder plugin


## Changelog
- fix: Fix dynamic uses of i18n and correct unprefixed and duplicate i18n identifiers in visBuilder plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
