### PR TITLE
Fix dynamic uses of i18n in visTypeTimeline plugin

### DIFF
--- a/src/plugins/vis_type_timeline/server/series_functions/graphite.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/graphite.js
@@ -35,12 +35,6 @@ import moment from 'moment';
 import Datasource from '../lib/classes/datasource';
 import { isValidConfig } from './helpers/graphite_helper';
 
-const MISS_CHECKLIST_MESSAGE = `Please configure on the opensearch_dashboards.yml file.
-You can always enable the default allowlist configuration.`;
-
-const INVALID_URL_MESSAGE = `The Graphite URL provided by you is invalid.
-Please update your config from OpenSearch Dashboards's Advanced Setting.`;
-
 export default new Datasource('graphite', {
   args: [
     {
@@ -72,7 +66,8 @@ export default new Datasource('graphite', {
     if (allowedUrls.length === 0 && blockedIPs.length === 0) {
       throw new Error(
         i18n.translate('timeline.help.functions.missCheckGraphiteConfig', {
-          defaultMessage: MISS_CHECKLIST_MESSAGE,
+          defaultMessage:
+            'Please configure on the opensearch_dashboards.yml file. You can always enable the default allowlist configuration.',
         })
       );
     }
@@ -80,7 +75,7 @@ export default new Datasource('graphite', {
     if (!isValidConfig(blockedIPs, allowedUrls, configuredUrl)) {
       throw new Error(
         i18n.translate('timeline.help.functions.invalidGraphiteConfig', {
-          defaultMessage: INVALID_URL_MESSAGE,
+          defaultMessage: `The Graphite URL provided by you is invalid. Please update your config from OpenSearch Dashboards' Advanced Settings.`,
         })
       );
     }

--- a/src/plugins/vis_type_timeline/server/series_functions/graphite.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/graphite.test.js
@@ -32,11 +32,9 @@ const expect = require('chai').expect;
 
 import fn from './graphite';
 
-const MISS_CHECKLIST_MESSAGE = `Please configure on the opensearch_dashboards.yml file.
-You can always enable the default allowlist configuration.`;
+const MISS_CHECKLIST_MESSAGE = `Please configure on the opensearch_dashboards.yml file. You can always enable the default allowlist configuration.`;
 
-const INVALID_URL_MESSAGE = `The Graphite URL provided by you is invalid.
-Please update your config from OpenSearch Dashboards's Advanced Setting.`;
+const INVALID_URL_MESSAGE = `The Graphite URL provided by you is invalid. Please update your config from OpenSearch Dashboards' Advanced Settings.`;
 
 jest.mock('node-fetch', () => (url) => {
   if (url.includes('redirect')) {


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n in visTypeTimeline plugin



## Changelog
- fix: Fix dynamic uses of i18n in visTypeTimeline plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
