### PR TITLE
Fix unprefixed i18n identifiers in dashboard plugin

### DIFF
--- a/changelogs/fragments/8401.yml
+++ b/changelogs/fragments/8401.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix unprefixed i18n identifiers in dashboard plugin ([#8401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8401))

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
@@ -147,7 +147,7 @@ const TopNav = ({
         className={isFullScreenMode ? 'osdTopNavMenu-isFullScreen' : undefined}
         screenTitle={
           currentAppState.title ||
-          i18n.translate('discover.savedSearch.newTitle', {
+          i18n.translate('dashboard.savedSearch.newTitle', {
             defaultMessage: 'New dashboard',
           })
         }


### PR DESCRIPTION
### Description

Fix unprefixed i18n identifiers in dashboard plugin



## Changelog
- fix: Fix unprefixed i18n identifiers in dashboard plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
