### PR TITLE
Fix incorrect use of TopNavControlDescriptionData in dataSourceManagement plugin

### DIFF
--- a/changelogs/fragments/8402.yml
+++ b/changelogs/fragments/8402.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix incorrect use of TopNavControlDescriptionData in dataSourceManagement plugin ([#8402](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8402))

--- a/src/plugins/data_source_management/public/components/data_source_creation_panel/create_data_source_panel.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_creation_panel/create_data_source_panel.tsx
@@ -3,15 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiPageHeader, EuiPanel, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPageHeader, EuiPanel } from '@elastic/eui';
 import React, { useEffect } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { FormattedMessage } from '@osd/i18n/react';
+import { i18n } from '@osd/i18n';
 import { CreateDataSourcePanelHeader } from './create_data_source_panel_header';
 import { CreateDataSourceCardView } from './create_data_source_card_view';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { getCreateBreadcrumbs } from '../breadcrumbs';
 import { DataSourceManagementContext } from '../../types';
+import { TopNavControlDescriptionData } from '../../../../navigation/public';
 
 interface CreateDataSourcePanelProps extends RouteComponentProps {
   featureFlagStatus: boolean;
@@ -39,15 +40,10 @@ export const CreateDataSourcePanel: React.FC<CreateDataSourcePanelProps> = ({
   const { HeaderControl } = navigation.ui;
   const description = [
     {
-      renderComponent: (
-        <EuiText size="s" color="subdued">
-          <FormattedMessage
-            id="dataSourcesManagement.createDataSourcePanel.description"
-            defaultMessage="Select a data source type to get started. "
-          />
-        </EuiText>
-      ),
-    },
+      description: i18n.translate('dataSourcesManagement.createDataSourcePanel.description', {
+        defaultMessage: 'Select a data source type to get started.',
+      }),
+    } as TopNavControlDescriptionData,
   ];
 
   return useNewUX ? (


### PR DESCRIPTION
### Description

Fix incorrect use of TopNavControlDescriptionData in dataSourceManagement plugin


## Changelog
- fix: Fix incorrect use of TopNavControlDescriptionData in dataSourceManagement plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
