### PR TITLE
Fix dynamic uses of i18n in opensearchDashboardsReact plugin

### DIFF
--- a/changelogs/fragments/8404.yml
+++ b/changelogs/fragments/8404.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix dynamic uses of i18n in opensearchDashboardsReact plugin ([#8404](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8404))

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.tsx
@@ -90,7 +90,9 @@ export const EditActionDropdown: React.FC<EditActionDropdownProps> = ({
       }}
       data-test-subj="dashboardEditDashboard"
     >
-      {i18n.translate('editActionDropdown.edit', { defaultMessage: 'Edit' })}
+      {i18n.translate('opensearch-dashboards-react..editActionDropdown.edit', {
+        defaultMessage: 'Edit',
+      })}
     </EuiContextMenuItem>,
   ];
   if (isVisBuilderCompatible) {
@@ -101,7 +103,7 @@ export const EditActionDropdown: React.FC<EditActionDropdownProps> = ({
         onClick={handleImportToVisBuilder}
         data-test-subj="dashboardImportToVisBuilder"
       >
-        {i18n.translate('editActionDropdown.importToVisBuilder', {
+        {i18n.translate('opensearch-dashboards-react.editActionDropdown.importToVisBuilder', {
           defaultMessage: 'Import to VisBuilder',
         })}
       </EuiContextMenuItem>

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/edit_action_dropdown.tsx
@@ -90,7 +90,7 @@ export const EditActionDropdown: React.FC<EditActionDropdownProps> = ({
       }}
       data-test-subj="dashboardEditDashboard"
     >
-      {i18n.translate('opensearch-dashboards-react..editActionDropdown.edit', {
+      {i18n.translate('opensearch-dashboards-react.editActionDropdown.edit', {
         defaultMessage: 'Edit',
       })}
     </EuiContextMenuItem>,


### PR DESCRIPTION
### Description

Fix dynamic uses of i18n in opensearchDashboardsReact plugin



## Changelog
- fix: Fix dynamic uses of i18n in opensearchDashboardsReact plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
