### PR TITLE
Fix duplicate i18n identifier in savedObjectsManagement plugin

### DIFF
--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Table prevents saved objects from being deleted 1`] = `
               checked={true}
               label={
                 <FormattedMessage
-                  defaultMessage="Include related related {useUpdatedUX, select, true {assets} other {objects}}"
+                  defaultMessage="Include related {useUpdatedUX, select, true {assets} other {objects}}"
                   id="savedObjectsManagement.objectsTable.exportObjectsConfirmModal.includeReferencesDeepLabel"
                   values={
                     Object {
@@ -328,7 +328,7 @@ exports[`Table should call onDuplicateSingle when show duplicate 1`] = `
               checked={true}
               label={
                 <FormattedMessage
-                  defaultMessage="Include related related {useUpdatedUX, select, true {assets} other {objects}}"
+                  defaultMessage="Include related {useUpdatedUX, select, true {assets} other {objects}}"
                   id="savedObjectsManagement.objectsTable.exportObjectsConfirmModal.includeReferencesDeepLabel"
                   values={
                     Object {
@@ -568,7 +568,7 @@ exports[`Table should render normally 1`] = `
               checked={true}
               label={
                 <FormattedMessage
-                  defaultMessage="Include related related {useUpdatedUX, select, true {assets} other {objects}}"
+                  defaultMessage="Include related {useUpdatedUX, select, true {assets} other {objects}}"
                   id="savedObjectsManagement.objectsTable.exportObjectsConfirmModal.includeReferencesDeepLabel"
                   values={
                     Object {
@@ -812,7 +812,7 @@ exports[`Table should render normally when use updated UX 1`] = `
               checked={true}
               label={
                 <FormattedMessage
-                  defaultMessage="Include related related {useUpdatedUX, select, true {assets} other {objects}}"
+                  defaultMessage="Include related {useUpdatedUX, select, true {assets} other {objects}}"
                   id="savedObjectsManagement.objectsTable.exportObjectsConfirmModal.includeReferencesDeepLabel"
                   values={
                     Object {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/flyout.tsx
@@ -885,7 +885,7 @@ export class Flyout extends Component<FlyoutProps, FlyoutState> {
             isLegacyFile={isLegacyFile}
             updateSelection={(newValues: ImportMode) => this.changeImportMode(newValues)}
             optionLabel={i18n.translate(
-              'savedObjectsManagement.objectsTable.importModeControl.importOptionsTitle',
+              'savedObjectsManagement.objectsTable.importModeControl.conflictManagementTitle',
               { defaultMessage: 'Conflict management' }
             )}
             useUpdatedUX={this.props.useUpdatedUX}

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -487,7 +487,7 @@ export class Table extends PureComponent<TableProps, TableState> {
                   label={
                     <FormattedMessage
                       id="savedObjectsManagement.objectsTable.exportObjectsConfirmModal.includeReferencesDeepLabel"
-                      defaultMessage="Include related related {useUpdatedUX, select, true {assets} other {objects}}"
+                      defaultMessage="Include related {useUpdatedUX, select, true {assets} other {objects}}"
                       values={{
                         useUpdatedUX: this.props.useUpdatedUX,
                       }}


### PR DESCRIPTION
### Description

Fix duplicate i18n identifier in savedObjectsManagement plugin



## Changelog
- fix: Fix duplicate i18n identifier in savedObjectsManagement plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
