### PR TITLE
Fix unprefixed i18n identifiers in visTypeVega plugin

### DIFF
--- a/changelogs/fragments/8406.yml
+++ b/changelogs/fragments/8406.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix unprefixed i18n identifiers in visTypeVega plugin ([#8406](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8406))

--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -156,21 +156,21 @@ export class SearchAPI {
   private getPPLRawResponseInspectorStats(response: RawPPLStrategySearchResponse['rawResponse']) {
     const stats: RequestStatistics = {};
     stats.hitsTotal = {
-      label: i18n.translate('data.search.searchSource.hitsTotalLabel', {
+      label: i18n.translate('visTypeVega.search.searchSource.hitsTotalLabel', {
         defaultMessage: 'Hits (total)',
       }),
       value: `${response.total}`,
-      description: i18n.translate('data.search.searchSource.hitsTotalDescription', {
+      description: i18n.translate('visTypeVega.search.searchSource.hitsTotalDescription', {
         defaultMessage: 'The number of documents that match the query.',
       }),
     };
 
     stats.hits = {
-      label: i18n.translate('data.search.searchSource.hitsLabel', {
+      label: i18n.translate('visTypeVega.search.searchSource.hitsLabel', {
         defaultMessage: 'Hits',
       }),
       value: `${response.size}`,
-      description: i18n.translate('data.search.searchSource.hitsDescription', {
+      description: i18n.translate('visTypeVega.search.searchSource.hitsDescription', {
         defaultMessage: 'The number of documents returned by the query.',
       }),
     };


### PR DESCRIPTION
### Description

Fix unprefixed i18n identifiers in visTypeVega plugin



## Changelog
- fix: Fix unprefixed i18n identifiers in visTypeVega plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
