### PR TITLE
Fix duplicate i18n identifiers in visualize plugin

### DIFF
--- a/changelogs/fragments/8407.yml
+++ b/changelogs/fragments/8407.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix duplicate i18n identifiers in visualize plugin ([#8407](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8407))

--- a/src/plugins/visualize/public/application/components/visualize_listing.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_listing.tsx
@@ -89,7 +89,7 @@ export const VisualizeListing = () => {
     if (showUpdatedUx) {
       chrome.setBreadcrumbs([
         {
-          text: i18n.translate('visualize.visualizeListingBreadcrumbsTitle', {
+          text: i18n.translate('visualize.listingBreadcrumbsTitle', {
             defaultMessage: 'Visualizations',
           }),
         },
@@ -97,7 +97,7 @@ export const VisualizeListing = () => {
     } else {
       chrome.setBreadcrumbs([
         {
-          text: i18n.translate('visualize.visualizeListingBreadcrumbsTitle', {
+          text: i18n.translate('visualize.legacy.listingBreadcrumbsTitle', {
             defaultMessage: 'Visualize',
           }),
         },

--- a/src/plugins/visualize/public/application/components/visualize_top_nav.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_top_nav.tsx
@@ -261,7 +261,7 @@ const TopNav = ({
       indexPatterns={indexPatterns}
       screenTitle={
         vis.title ||
-        i18n.translate('discover.savedSearch.newTitle', {
+        i18n.translate('visualize.savedSearch.newTitle', {
           defaultMessage: 'New visualization',
         })
       }

--- a/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
@@ -106,7 +106,7 @@ export const getLegacyTopNavConfig = (
     {
       id: 'inspector',
       label: i18n.translate('visualize.topNavMenu.openInspectorButtonLabel', {
-        defaultMessage: 'inspect',
+        defaultMessage: 'Inspect',
       }),
       description: i18n.translate('visualize.topNavMenu.openInspectorButtonAriaLabel', {
         defaultMessage: 'Open Inspector for visualization',
@@ -127,7 +127,7 @@ export const getLegacyTopNavConfig = (
     {
       id: 'share',
       label: i18n.translate('visualize.topNavMenu.shareVisualizationButtonLabel', {
-        defaultMessage: 'share',
+        defaultMessage: 'Share',
       }),
       description: i18n.translate('visualize.topNavMenu.shareVisualizationButtonAriaLabel', {
         defaultMessage: 'Share Visualization',
@@ -168,10 +168,10 @@ export const getLegacyTopNavConfig = (
             label:
               savedVis?.id && originatingApp
                 ? i18n.translate('visualize.topNavMenu.saveVisualizationAsButtonLabel', {
-                    defaultMessage: 'save as',
+                    defaultMessage: 'Save as',
                   })
                 : i18n.translate('visualize.topNavMenu.saveVisualizationButtonLabel', {
-                    defaultMessage: 'save',
+                    defaultMessage: 'Save',
                   }),
             emphasize: (savedVis && !savedVis.id) || !originatingApp,
             description: i18n.translate('visualize.topNavMenu.saveVisualizationButtonAriaLabel', {


### PR DESCRIPTION
### Description

Fix duplicate i18n identifiers in visualize plugin



## Changelog
- fix: Fix duplicate i18n identifiers in visualize plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
