### PR TITLE
Fix unprefixed i18n identifiers in management plugin

### DIFF
--- a/changelogs/fragments/8408.yml
+++ b/changelogs/fragments/8408.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix unprefixed i18n identifiers in management plugin ([#8408](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8408))

--- a/src/plugins/management/public/components/settings_icon.tsx
+++ b/src/plugins/management/public/components/settings_icon.tsx
@@ -53,7 +53,7 @@ export function SettingsIcon({ core }: { core: CoreStart }) {
       id="popoverForSettingsIcon"
       button={
         <EuiToolTip
-          content={i18n.translate('settings.icon.nav.title', {
+          content={i18n.translate('management.settings.icon.nav.title', {
             defaultMessage: 'Settings',
           })}
         >


### PR DESCRIPTION
### Description

Fix unprefixed i18n identifiers in management plugin



## Changelog
- fix: Fix unprefixed i18n identifiers in management plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
