### PR TITLE
Fix unprefixed and duplicate i18n identifiers in visAugmenter plugin

### DIFF
--- a/changelogs/fragments/8409.yml
+++ b/changelogs/fragments/8409.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix unprefixed and duplicate i18n identifiers in visAugmenter plugin ([#8409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8409))

--- a/src/plugins/vis_augmenter/public/actions/plugin_resource_delete_action.ts
+++ b/src/plugins/vis_augmenter/public/actions/plugin_resource_delete_action.ts
@@ -23,7 +23,7 @@ export class PluginResourceDeleteAction implements Action<PluginResourceDeleteCo
   }
 
   public getDisplayName() {
-    return i18n.translate('dashboard.actions.deleteSavedObject.name', {
+    return i18n.translate('visAugmenter.actions.deleteSavedObject.name', {
       defaultMessage:
         'Clean up all augment-vis saved objects associated to the deleted visualization',
     });

--- a/src/plugins/vis_augmenter/public/actions/saved_object_delete_action.ts
+++ b/src/plugins/vis_augmenter/public/actions/saved_object_delete_action.ts
@@ -23,8 +23,9 @@ export class SavedObjectDeleteAction implements Action<SavedObjectDeleteContext>
   }
 
   public getDisplayName() {
-    return i18n.translate('dashboard.actions.deleteSavedObject.name', {
-      defaultMessage: 'Clean up augment-vis saved objects associated to a deleted vis',
+    return i18n.translate('visAugmenter.actions.deleteSavedObject.name', {
+      defaultMessage:
+        'Clean up all augment-vis saved objects associated to the deleted visualization',
     });
   }
 

--- a/src/plugins/vis_augmenter/public/view_events_flyout/actions/open_events_flyout_action.ts
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/actions/open_events_flyout_action.ts
@@ -32,7 +32,7 @@ export class OpenEventsFlyoutAction implements Action<AugmentVisContext> {
   }
 
   public getDisplayName() {
-    return i18n.translate('dashboard.actions.viewEvents.displayName', {
+    return i18n.translate('visAugmenter.actions.viewEvents.displayName', {
       defaultMessage: 'View Events',
     });
   }

--- a/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
@@ -37,7 +37,7 @@ export class ViewEventsOptionAction implements Action<EmbeddableContext> {
   }
 
   public getDisplayName() {
-    return i18n.translate('dashboard.actions.viewEvents.displayName', {
+    return i18n.translate('visAugmenter.actions.viewEvents.displayName', {
       defaultMessage: 'View Events',
     });
   }

--- a/src/plugins/vis_augmenter/server/plugin.ts
+++ b/src/plugins/vis_augmenter/server/plugin.ts
@@ -53,23 +53,23 @@ export class VisAugmenterPlugin
     if (isAugmentationEnabled) {
       core.uiSettings.register({
         [PLUGIN_AUGMENTATION_ENABLE_SETTING]: {
-          name: i18n.translate('visualization.enablePluginAugmentationTitle', {
+          name: i18n.translate('visAugmenter.enablePluginAugmentationTitle', {
             defaultMessage: 'Enable plugin augmentation',
           }),
           value: true,
-          description: i18n.translate('visualization.enablePluginAugmentationText', {
+          description: i18n.translate('visAugmenter.enablePluginAugmentationText', {
             defaultMessage: 'Plugin functionality can be accessed from line chart visualizations',
           }),
           category: ['visualization'],
           schema: schema.boolean(),
         },
         [PLUGIN_AUGMENTATION_MAX_OBJECTS_SETTING]: {
-          name: i18n.translate('visualization.enablePluginAugmentation.maxPluginObjectsTitle', {
+          name: i18n.translate('visAugmenter.enablePluginAugmentation.maxPluginObjectsTitle', {
             defaultMessage: 'Max number of associated augmentations',
           }),
           value: 10,
           description: i18n.translate(
-            'visualization.enablePluginAugmentation.maxPluginObjectsText',
+            'visAugmenter.enablePluginAugmentation.maxPluginObjectsText',
             {
               defaultMessage:
                 'Associating more than 10 plugin resources per visualization can lead to performance ' +


### PR DESCRIPTION
### Description

Fix unprefixed and duplicate i18n identifiers in visAugmenter plugin



## Changelog
- fix: Fix unprefixed and duplicate i18n identifiers in visAugmenter plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
