### PR TITLE
Compress the OuiSearchBar instances used on Advanced Settings and Saved Object Management pages

### DIFF
--- a/src/plugins/advanced_settings/public/management_app/__snapshots__/advanced_settings.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/management_app/__snapshots__/advanced_settings.test.tsx.snap
@@ -523,10 +523,10 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
       search
     </Search>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <AdvancedSettingsVoiceAnnouncement

--- a/src/plugins/advanced_settings/public/management_app/advanced_settings.tsx
+++ b/src/plugins/advanced_settings/public/management_app/advanced_settings.tsx
@@ -241,7 +241,6 @@ export class AdvancedSettingsComponent extends Component<
       if (!this.props.useUpdatedUX) {
         return (
           <>
-            <EuiSpacer size="m" />
             <EuiFlexGroup gutterSize="none">
               <EuiFlexItem>
                 <PageTitle />
@@ -257,6 +256,7 @@ export class AdvancedSettingsComponent extends Component<
             <PageSubtitle />
             <EuiSpacer size="m" />
             <CallOuts />
+            <EuiSpacer size="m" />
           </>
         );
       } else {
@@ -272,7 +272,7 @@ export class AdvancedSettingsComponent extends Component<
               ]}
             />
             <Search query={query} categories={this.categories} onQueryChange={this.onQueryChange} />
-            <EuiSpacer size="m" />
+            <EuiSpacer size="s" />
           </>
         );
       }

--- a/src/plugins/advanced_settings/public/management_app/components/search/__snapshots__/search.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/management_app/components/search/__snapshots__/search.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Search should render normally 1`] = `
         "incremental": true,
       }
     }
+    compressed={true}
     filters={
       Array [
         Object {

--- a/src/plugins/advanced_settings/public/management_app/components/search/search.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/search/search.tsx
@@ -108,10 +108,22 @@ export class Search extends PureComponent<SearchProps> {
       );
     }
 
+    /* The `onChange` and `query` attributes below throw type errors for `_AST` and `Query` because
+     * OSD imports the types from the `eui` aliases which makes typescript believe that they are
+     * different.
+     */
+
     return (
       <Fragment>
-        {/* @ts-ignore The Query types that typescript complains about here are identical and is a false flag. Once OUI migration is complete, this ignore can be removed */}
-        <EuiSearchBar box={box} filters={filters} onChange={this.onChange} query={query} />
+        <EuiSearchBar
+          compressed
+          box={box}
+          filters={filters}
+          // @ts-expect-error
+          onChange={this.onChange}
+          // @ts-expect-error
+          query={query}
+        />
         {queryParseError}
       </Fragment>
     );

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/__snapshots__/table.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Table prevents saved objects from being deleted 1`] = `
         "data-test-subj": "savedObjectSearchBar",
       }
     }
+    compressed={true}
     filters={
       Array [
         Object {
@@ -240,6 +241,7 @@ exports[`Table should call onDuplicateSingle when show duplicate 1`] = `
         "data-test-subj": "savedObjectSearchBar",
       }
     }
+    compressed={true}
     filters={
       Array [
         Object {
@@ -493,6 +495,7 @@ exports[`Table should render normally 1`] = `
         "data-test-subj": "savedObjectSearchBar",
       }
     }
+    compressed={true}
     filters={
       Array [
         Object {
@@ -724,6 +727,7 @@ exports[`Table should render normally when use updated UX 1`] = `
         "data-test-subj": "savedObjectSearchBar",
       }
     }
+    compressed={true}
     filters={
       Array [
         Object {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -423,6 +423,7 @@ export class Table extends PureComponent<TableProps, TableState> {
         {activeActionContents}
         <EuiSearchBar
           box={{ 'data-test-subj': 'savedObjectSearchBar' }}
+          compressed
           filters={filters}
           onChange={this.onChange}
           toolsRight={[


### PR DESCRIPTION
### Description

Compress the OuiSearchBar instances used on Advanced Settings and Saved Object Management pages

Also:
* Fix spacing of the search bar on Advanced Settings page

Note: An OUI update will be required before these kick in.

## Screenshot

### Saved Object Management 

| Before | After |
|--------|------|
| ![Assets before](https://github.com/user-attachments/assets/bbeea2ca-0179-48af-a517-98339974a3d7) | ![Assets after](https://github.com/user-attachments/assets/363f2dfe-df22-48e5-ab19-139ebe2f0e17) |


### Advanced Settings
| Before | After |
|--------|------|
| ![New Settings before](https://github.com/user-attachments/assets/3825a109-4b79-408f-8a71-ddde41b3f65f) | ![New Settings after](https://github.com/user-attachments/assets/6b472a68-b147-4141-9a12-1628a298c384) |
| ![old settings before](https://github.com/user-attachments/assets/2ad25e2c-232e-40b6-bf9e-082f6125ecf4) | ![old settings after](https://github.com/user-attachments/assets/933616e5-4035-4519-b779-090284d148c8) |


## Changelog
- feat: Compress the OuiSearchBar used on Advanced Settings and Saved Object Management
- fix: Fix spacing of the search bar on Advanced Settings page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
