### PR TITLE
[Workspace]Add flag for workspace collaborator editor enabled

### DIFF
--- a/changelogs/fragments/8446.yml
+++ b/changelogs/fragments/8446.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Add flag for workspace collaborator editor enabled ([#8446](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8446))

--- a/changelogs/fragments/8446.yml
+++ b/changelogs/fragments/8446.yml
@@ -1,2 +1,0 @@
-feat:
-- [Workspace]Add flag for workspace collaborator editor enabled ([#8446](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8446))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -352,6 +352,8 @@
 # uiSettings:
 #   overrides:
 #     "home:useNewHomePage": true
+# Set the value to true to enable the collaborator editor in the workspace creation and settings pages.
+# workspace.collaboratorEditorEnabled: false
 
 # Optional settings to specify saved object types to be deleted during migration.
 # This feature can help address compatibility issues that may arise during the migration of saved objects, such as types defined by legacy applications.

--- a/src/plugins/workspace/config.ts
+++ b/src/plugins/workspace/config.ts
@@ -7,6 +7,7 @@ import { schema, TypeOf } from '@osd/config-schema';
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
+  collaboratorEditorEnabled: schema.boolean({ defaultValue: false }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -482,6 +482,10 @@ describe('WorkspaceCreator', () => {
     await waitFor(() => {
       expect(getByTestId('workspaceForm-bottomBar-createButton')).toBeInTheDocument();
     });
+    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
+    fireEvent.input(nameInput, {
+      target: { value: 'test workspace name' },
+    });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
     expect(workspaceClientCreate).toHaveBeenCalledTimes(1);
 
@@ -501,6 +505,10 @@ describe('WorkspaceCreator', () => {
     // Ensure workspace create form rendered
     await waitFor(() => {
       expect(getByTestId('workspaceForm-bottomBar-createButton')).toBeInTheDocument();
+    });
+    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
+    fireEvent.input(nameInput, {
+      target: { value: 'test workspace name' },
     });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
     jest.useFakeTimers();

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -18,6 +18,7 @@ import {
 import { DataSourceEngineType } from '../../../../data_source/common/data_sources';
 import { DataSourceConnectionType } from '../../../common/types';
 import * as utils from '../../utils';
+import { WorkspaceCreationPostProcessorService } from '../../services';
 
 const workspaceClientCreate = jest
   .fn()
@@ -532,8 +533,12 @@ describe('WorkspaceCreator', () => {
     });
   });
 
-  it('should redirect to workspace use case landing page after created successfully', async () => {
+  it('should call workspace creation post processor after created successfully', async () => {
+    const processorMock = jest.fn();
     const { getByTestId } = render(<WorkspaceCreator />);
+    const unregister = WorkspaceCreationPostProcessorService.getInstance().registerProcessor(
+      processorMock
+    );
 
     // Ensure workspace create form rendered
     await waitFor(() => {
@@ -544,11 +549,11 @@ describe('WorkspaceCreator', () => {
       target: { value: 'test workspace name' },
     });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
-    jest.useFakeTimers();
-    jest.runAllTimers();
+
     await waitFor(() => {
-      expect(setHrefSpy).toHaveBeenCalledWith(expect.stringContaining('/app/discover'));
+      processorMock();
     });
-    jest.useRealTimers();
+
+    unregister();
   });
 });

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -516,10 +516,6 @@ describe('WorkspaceCreator', () => {
     await waitFor(() => {
       expect(getByTestId('workspaceForm-bottomBar-createButton')).toBeInTheDocument();
     });
-    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
-    fireEvent.input(nameInput, {
-      target: { value: 'test workspace name' },
-    });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
     expect(workspaceClientCreate).toHaveBeenCalledTimes(1);
 
@@ -543,10 +539,6 @@ describe('WorkspaceCreator', () => {
     // Ensure workspace create form rendered
     await waitFor(() => {
       expect(getByTestId('workspaceForm-bottomBar-createButton')).toBeInTheDocument();
-    });
-    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
-    fireEvent.input(nameInput, {
-      target: { value: 'test workspace name' },
     });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
 

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -58,7 +58,6 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
     color: euiPaletteColorBlind()[0],
     ...(defaultSelectedUseCase
       ? {
-          name: defaultSelectedUseCase.title,
           features: [getUseCaseFeatureConfig(defaultSelectedUseCase.id)],
         }
       : {}),

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -13,13 +13,10 @@ import { WorkspaceFormSubmitData, WorkspaceOperationType } from '../workspace_fo
 import { WORKSPACE_DETAIL_APP_ID } from '../../../common/constants';
 import { getUseCaseFeatureConfig } from '../../../common/utils';
 import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
-import { WorkspaceClient } from '../../workspace_client';
 import { convertPermissionSettingsToPermissions } from '../workspace_form';
-import { DataSourceManagementPluginSetup } from '../../../../../plugins/data_source_management/public';
-import { WorkspaceUseCase } from '../../types';
+import { WorkspaceDependServices, WorkspaceUseCase } from '../../types';
 import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
 import { useFormAvailableUseCases } from '../workspace_form/use_form_available_use_cases';
-import { NavigationPublicPluginStart } from '../../../../../plugins/navigation/public';
 import { DataSourceConnectionType } from '../../../common/types';
 import { WorkspaceCreatorForm } from './workspace_creator_form';
 
@@ -38,12 +35,9 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
       savedObjects,
       dataSourceManagement,
       navigationUI: { HeaderControl },
+      collaboratorEditorEnabled,
     },
-  } = useOpenSearchDashboards<{
-    workspaceClient: WorkspaceClient;
-    dataSourceManagement?: DataSourceManagementPluginSetup;
-    navigationUI: NavigationPublicPluginStart['ui'];
-  }>();
+  } = useOpenSearchDashboards<WorkspaceDependServices>();
   const [isFormSubmitting, setIsFormSubmitting] = useState(false);
 
   const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
@@ -164,7 +158,7 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
               savedObjects={savedObjects}
               onSubmit={handleWorkspaceFormSubmit}
               operationType={WorkspaceOperationType.Create}
-              permissionEnabled={isPermissionEnabled}
+              permissionEnabled={isPermissionEnabled && collaboratorEditorEnabled}
               dataSourceManagement={dataSourceManagement}
               availableUseCases={availableUseCases}
               defaultValues={defaultWorkspaceFormValues}

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -52,6 +52,7 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
     color: euiPaletteColorBlind()[0],
     ...(defaultSelectedUseCase
       ? {
+          name: defaultSelectedUseCase.title,
           features: [getUseCaseFeatureConfig(defaultSelectedUseCase.id)],
         }
       : {}),

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
@@ -32,6 +32,7 @@ import './workspace_creator_form.scss';
 
 interface WorkspaceCreatorFormProps extends WorkspaceFormProps {
   isSubmitting: boolean;
+  collaboratorEditorEnabled: boolean;
 }
 
 export const WorkspaceCreatorForm = (props: WorkspaceCreatorFormProps) => {

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx
@@ -88,6 +88,7 @@ const WorkspaceDetailPage = (props: any) => {
   const workspacesService = props.workspacesService || createWorkspacesSetupContractMockWithValue();
   const values = props.defaultValues || defaultValues;
   const permissionEnabled = props.permissionEnabled ?? true;
+  const collaboratorEditorEnabled = props.collaboratorEditorEnabled ?? true;
   const dataSourceManagement =
     props.dataSourceEnabled !== false
       ? {
@@ -131,6 +132,7 @@ const WorkspaceDetailPage = (props: any) => {
           return null;
         },
       },
+      collaboratorEditorEnabled,
     },
   });
 
@@ -240,6 +242,16 @@ describe('WorkspaceDetail', () => {
     );
     expect(queryByText('Collaborators')).toBeNull();
     expect(queryByText('Data Sources')).toBeNull();
+  });
+
+  it('should not render "Collaborators" tab if collaborator editor not enabled', async () => {
+    const { queryByText } = render(
+      WorkspaceDetailPage({
+        permissionEnabled: true,
+        collaboratorEditorEnabled: false,
+      })
+    );
+    expect(queryByText('Collaborators')).toBeNull();
   });
 
   it('click on tab button will show navigate modal when number of changes > 1', async () => {

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx
@@ -16,6 +16,7 @@ import { WorkspaceFormProvider, WorkspaceOperationType } from '../workspace_form
 import { DataSourceConnectionType } from '../../../common/types';
 import * as utilsExports from '../../utils';
 import { IntlProvider } from 'react-intl';
+import { WorkspaceDetailCustomizedTabsService } from '../../services';
 
 // all applications
 const PublicAPPInfoMap = new Map([
@@ -252,6 +253,24 @@ describe('WorkspaceDetail', () => {
       })
     );
     expect(queryByText('Collaborators')).toBeNull();
+  });
+
+  it('should render customized tab', () => {
+    WorkspaceDetailCustomizedTabsService.getInstance().registerCustomizedTab({
+      id: 'customized-tab',
+      title: 'Customized Tab',
+      render: () => 'This is content of customized tab.',
+      order: 1000,
+    });
+    const { getByText } = render(
+      WorkspaceDetailPage({
+        permissionEnabled: true,
+        collaboratorEditorEnabled: false,
+      })
+    );
+    expect(getByText('Customized Tab')).toBeInTheDocument();
+    fireEvent.click(getByText('Customized Tab'));
+    expect(getByText('This is content of customized tab.')).toBeInTheDocument();
   });
 
   it('click on tab button will show navigate modal when number of changes > 1', async () => {

--- a/src/plugins/workspace/public/components/workspace_detail/workspace_detail.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/workspace_detail.tsx
@@ -16,7 +16,7 @@ import { i18n } from '@osd/i18n';
 import { useObservable } from 'react-use';
 import { BehaviorSubject, of } from 'rxjs';
 import { useHistory, useLocation } from 'react-router-dom';
-import { WorkspaceUseCase } from '../../types';
+import { WorkspaceDependServices, WorkspaceUseCase } from '../../types';
 import { WorkspaceDetailForm, useWorkspaceFormContext } from '../workspace_form';
 import { WorkspaceDetailPanel } from './workspace_detail_panel';
 import { DeleteWorkspaceModal } from '../delete_workspace_modal';
@@ -61,12 +61,9 @@ export const WorkspaceDetail = (props: WorkspaceDetailPropsWithFormSubmitting) =
       navigationUI: { HeaderControl },
       chrome,
       notifications,
+      collaboratorEditorEnabled,
     },
-  } = useOpenSearchDashboards<{
-    CoreStart: CoreStart;
-    dataSourceManagement?: DataSourceManagementPluginSetup;
-    navigationUI: NavigationPublicPluginStart['ui'];
-  }>();
+  } = useOpenSearchDashboards<WorkspaceDependServices>();
 
   const {
     isEditing,
@@ -89,7 +86,8 @@ export const WorkspaceDetail = (props: WorkspaceDetailPropsWithFormSubmitting) =
   const availableUseCases = useObservable(props.registeredUseCases$, []);
   const isDashboardAdmin = !!application?.capabilities?.dashboards?.isDashboardAdmin;
   const currentWorkspace = useObservable(workspaces ? workspaces.currentWorkspace$ : of(null));
-  const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
+  const isPermissionEnabled =
+    application?.capabilities.workspaces.permissionEnabled && collaboratorEditorEnabled;
   const currentUseCase = availableUseCases.find(
     (useCase) => useCase.id === getFirstUseCaseOfFeatureConfigs(currentWorkspace?.features ?? [])
   );

--- a/src/plugins/workspace/public/components/workspace_form/index.ts
+++ b/src/plugins/workspace/public/components/workspace_form/index.ts
@@ -13,6 +13,7 @@ export { WorkspaceNameField, WorkspaceDescriptionField } from './fields';
 export { ConnectionTypeIcon } from './connection_type_icon';
 export { DataSourceConnectionTable } from './data_source_connection_table';
 export { WorkspaceUseCaseFlyout } from './workspace_use_case_flyout';
+export { WorkspaceDetailTabPanel } from './workspace_detail_tab_panel';
 
 export { WorkspaceFormSubmitData, WorkspaceFormProps, WorkspaceFormDataState } from './types';
 export {

--- a/src/plugins/workspace/public/components/workspace_form/use_workspace_form.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_workspace_form.ts
@@ -41,7 +41,9 @@ export const useWorkspaceForm = ({
   const defaultValuesRef = useRef(defaultValues);
   const [isEditing, setIsEditing] = useState(false);
   const initialPermissionSettingsRef = useRef(
-    generatePermissionSettingsState(operationType, defaultValues?.permissionSettings)
+    permissionEnabled
+      ? generatePermissionSettingsState(operationType, defaultValues?.permissionSettings)
+      : []
   );
 
   const [featureConfigs, setFeatureConfigs] = useState<string[]>(defaultValues?.features ?? []);

--- a/src/plugins/workspace/public/components/workspace_form/workspace_detail_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_detail_form.tsx
@@ -11,9 +11,7 @@ import {
   EuiFlexItem,
   EuiTitle,
   EuiText,
-  EuiPanel,
   EuiSmallButton,
-  EuiHorizontalRule,
 } from '@elastic/eui';
 
 import { i18n } from '@osd/i18n';
@@ -23,6 +21,7 @@ import { DetailTab, usersAndPermissionsTitle } from './constants';
 import { WorkspaceFormErrorCallout } from './workspace_form_error_callout';
 import { useWorkspaceFormContext } from './workspace_form_context';
 import { WorkspaceDetailFormDetails } from './workspace_detail_form_details';
+import { WorkspaceDetailTabPanel } from './workspace_detail_tab_panel';
 
 interface FormGroupProps {
   title: React.ReactNode;
@@ -80,63 +79,62 @@ export const WorkspaceDetailForm = (props: WorkspaceDetailedFormProps) => {
       }}
       component="form"
     >
-      <EuiPanel>
-        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h2>{detailTitle}</h2>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            {isEditing ? (
-              <EuiSmallButton
-                onClick={handleResetForm}
-                data-test-subj="workspaceForm-workspaceDetails-discardChanges"
-              >
-                {i18n.translate('workspace.detail.button.discardChanges', {
-                  defaultMessage: 'Discard changes',
-                })}
-              </EuiSmallButton>
-            ) : (
-              <EuiSmallButton
-                onClick={() => setIsEditing((prevIsEditing) => !prevIsEditing)}
-                data-test-subj="workspaceForm-workspaceDetails-edit"
-              >
-                {i18n.translate('workspace.detail.button.edit', {
-                  defaultMessage: 'Edit',
-                })}
-              </EuiSmallButton>
-            )}
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiHorizontalRule margin="m" />
-        {numberOfErrors > 0 && (
-          <>
-            <WorkspaceFormErrorCallout errors={formErrors} />
-            <EuiSpacer />
-          </>
-        )}
-        {detailTab === DetailTab.Details && (
-          <WorkspaceDetailFormDetails availableUseCases={availableUseCases} />
-        )}
-        {detailTab === DetailTab.Collaborators && (
-          <FormGroup
-            title={usersAndPermissionsTitle}
-            describe={i18n.translate('workspace.detail.collaborators.permissionSetting.describe', {
-              defaultMessage: 'Manage access and permissions.',
-            })}
-          >
-            <WorkspacePermissionSettingPanel
-              errors={formErrors.permissionSettings?.fields}
-              onChange={setPermissionSettings}
-              permissionSettings={formData.permissionSettings}
-              disabledUserOrGroupInputIds={disabledUserOrGroupInputIdsRef.current}
-              data-test-subj={`workspaceForm-permissionSettingPanel`}
-              readOnly={!isEditing}
-            />
-          </FormGroup>
-        )}
-      </EuiPanel>
+      <WorkspaceDetailTabPanel
+        title={detailTitle}
+        actions={
+          isEditing ? (
+            <EuiSmallButton
+              onClick={handleResetForm}
+              data-test-subj="workspaceForm-workspaceDetails-discardChanges"
+            >
+              {i18n.translate('workspace.detail.button.discardChanges', {
+                defaultMessage: 'Discard changes',
+              })}
+            </EuiSmallButton>
+          ) : (
+            <EuiSmallButton
+              onClick={() => setIsEditing((prevIsEditing) => !prevIsEditing)}
+              data-test-subj="workspaceForm-workspaceDetails-edit"
+            >
+              {i18n.translate('workspace.detail.button.edit', {
+                defaultMessage: 'Edit',
+              })}
+            </EuiSmallButton>
+          )
+        }
+      >
+        <>
+          {numberOfErrors > 0 && (
+            <>
+              <WorkspaceFormErrorCallout errors={formErrors} />
+              <EuiSpacer />
+            </>
+          )}
+          {detailTab === DetailTab.Details && (
+            <WorkspaceDetailFormDetails availableUseCases={availableUseCases} />
+          )}
+          {detailTab === DetailTab.Collaborators && (
+            <FormGroup
+              title={usersAndPermissionsTitle}
+              describe={i18n.translate(
+                'workspace.detail.collaborators.permissionSetting.describe',
+                {
+                  defaultMessage: 'Manage access and permissions.',
+                }
+              )}
+            >
+              <WorkspacePermissionSettingPanel
+                errors={formErrors.permissionSettings?.fields}
+                onChange={setPermissionSettings}
+                permissionSettings={formData.permissionSettings}
+                disabledUserOrGroupInputIds={disabledUserOrGroupInputIdsRef.current}
+                data-test-subj={`workspaceForm-permissionSettingPanel`}
+                readOnly={!isEditing}
+              />
+            </FormGroup>
+          )}
+        </>
+      </WorkspaceDetailTabPanel>
       <EuiSpacer />
     </EuiForm>
   );

--- a/src/plugins/workspace/public/components/workspace_form/workspace_detail_tab_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_detail_tab_panel.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiPanel, EuiHorizontalRule } from '@elastic/eui';
+
+export const WorkspaceDetailTabPanel = ({
+  title,
+  actions,
+  children,
+}: React.PropsWithChildren<{
+  title?: string;
+  actions?: React.ReactNode;
+}>) => {
+  return (
+    <EuiPanel>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h2>{title}</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        {actions && <EuiFlexItem grow={false}>{actions}</EuiFlexItem>}
+      </EuiFlexGroup>
+      <EuiHorizontalRule margin="m" />
+      {children}
+    </EuiPanel>
+  );
+};

--- a/src/plugins/workspace/public/index.ts
+++ b/src/plugins/workspace/public/index.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PluginInitializerContext } from '../../../core/public';
 import { WorkspacePlugin } from './plugin';
 
-export function plugin() {
-  return new WorkspacePlugin();
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new WorkspacePlugin(initializerContext);
 }

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -23,7 +23,10 @@ import { WorkspacePlugin } from './plugin';
 import { contentManagementPluginMocks } from '../../content_management/public';
 import { navigationPluginMock } from '../../navigation/public/mocks';
 import * as applicationExports from './application';
-import { WorkspaceCreationPostProcessorService } from './services';
+import {
+  WorkspaceCreationPostProcessorService,
+  WorkspaceDetailCustomizedTabsService,
+} from './services';
 
 // Expect 6 app registrations: create, fatal error, detail, initial, navigation, and list apps.
 const registrationAppNumber = 6;
@@ -400,6 +403,20 @@ describe('Workspace plugin', () => {
     workspacePluginSetup.registerWorkspaceCreationPostProcessor(mockProcessor);
 
     expect(WorkspaceCreationPostProcessorService.getInstance().getProcessor()).toBe(mockProcessor);
+  });
+
+  it('#setup able to registerWorkspaceDetailCustomizedTab', async () => {
+    const setupMock = coreMock.createSetup();
+    const initializerContext = coreMock.createPluginInitializerContext();
+    const workspacePlugin = new WorkspacePlugin(initializerContext);
+    const workspacePluginSetup = await workspacePlugin.setup(setupMock, {});
+
+    const mockTab = { id: 'tab-1', title: 'Tab 1', order: 123, render: () => null };
+    workspacePluginSetup.registerWorkspaceDetailCustomizedTab(mockTab);
+
+    expect(
+      WorkspaceDetailCustomizedTabsService.getInstance().getCustomizedTabs$().getValue()[0]
+    ).toBe(mockTab);
   });
 
   it('#start add workspace detail page to breadcrumbs when start', async () => {

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -23,6 +23,7 @@ import { WorkspacePlugin } from './plugin';
 import { contentManagementPluginMocks } from '../../content_management/public';
 import { navigationPluginMock } from '../../navigation/public/mocks';
 import * as applicationExports from './application';
+import { WorkspaceCreationPostProcessorService } from './services';
 
 // Expect 6 app registrations: create, fatal error, detail, initial, navigation, and list apps.
 const registrationAppNumber = 6;
@@ -387,6 +388,18 @@ describe('Workspace plugin', () => {
         navLinkStatus: AppNavLinkStatus.hidden,
       })
     );
+  });
+
+  it('#setup able to registerWorkspaceCreationPostProcessor', async () => {
+    const setupMock = coreMock.createSetup();
+    const initializerContext = coreMock.createPluginInitializerContext();
+    const workspacePlugin = new WorkspacePlugin(initializerContext);
+    const workspacePluginSetup = await workspacePlugin.setup(setupMock, {});
+
+    const mockProcessor = () => {};
+    workspacePluginSetup.registerWorkspaceCreationPostProcessor(mockProcessor);
+
+    expect(WorkspaceCreationPostProcessorService.getInstance().getProcessor()).toBe(mockProcessor);
   });
 
   it('#start add workspace detail page to breadcrumbs when start', async () => {

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -57,7 +57,11 @@ import {
 } from './utils';
 import { recentWorkspaceManager } from './recent_workspace_manager';
 import { toMountPoint } from '../../opensearch_dashboards_react/public';
-import { UseCaseService } from './services/use_case_service';
+import {
+  UseCaseService,
+  WorkspaceCreationPostProcessor,
+  WorkspaceCreationPostProcessorService,
+} from './services';
 import { WorkspaceListCard } from './components/service_card';
 import { NavigationPublicPluginStart } from '../../../plugins/navigation/public';
 import { WorkspacePickerContent } from './components/workspace_picker_content/workspace_picker_content';
@@ -561,7 +565,10 @@ export class WorkspacePlugin
       });
     }
 
-    return {};
+    return {
+      registerWorkspaceCreationPostProcessor: (fn: WorkspaceCreationPostProcessor) =>
+        WorkspaceCreationPostProcessorService.getInstance().registerProcessor(fn),
+    };
   }
 
   public start(core: CoreStart, { contentManagement, navigation }: WorkspacePluginStartDeps) {

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -61,6 +61,8 @@ import {
   UseCaseService,
   WorkspaceCreationPostProcessor,
   WorkspaceCreationPostProcessorService,
+  WorkspaceDetailCustomizedTab,
+  WorkspaceDetailCustomizedTabsService,
 } from './services';
 import { WorkspaceListCard } from './components/service_card';
 import { NavigationPublicPluginStart } from '../../../plugins/navigation/public';
@@ -568,6 +570,8 @@ export class WorkspacePlugin
     return {
       registerWorkspaceCreationPostProcessor: (fn: WorkspaceCreationPostProcessor) =>
         WorkspaceCreationPostProcessorService.getInstance().registerProcessor(fn),
+      registerWorkspaceDetailCustomizedTab: (tab: WorkspaceDetailCustomizedTab) =>
+        WorkspaceDetailCustomizedTabsService.getInstance().registerCustomizedTab(tab),
     };
   }
 

--- a/src/plugins/workspace/public/services/index.ts
+++ b/src/plugins/workspace/public/services/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { UseCaseService } from './use_case_service';
+export {
+  WorkspaceCreationPostProcessor,
+  WorkspaceCreationPostProcessorService,
+} from './workspace_creation_post_processor_service';

--- a/src/plugins/workspace/public/services/index.ts
+++ b/src/plugins/workspace/public/services/index.ts
@@ -8,3 +8,7 @@ export {
   WorkspaceCreationPostProcessor,
   WorkspaceCreationPostProcessorService,
 } from './workspace_creation_post_processor_service';
+export {
+  WorkspaceDetailCustomizedTabsService,
+  WorkspaceDetailCustomizedTab,
+} from './workspace_detail_customized_tabs_service';

--- a/src/plugins/workspace/public/services/workspace_creation_post_processor_service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_creation_post_processor_service.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ApplicationStart, HttpStart } from '../../../../core/public';
+import { coreMock } from '../../../../core/public/mocks';
+import {
+  WorkspaceCreationPostProcessorService,
+  WorkspaceCreationPostProcessor,
+} from './workspace_creation_post_processor_service';
+
+describe('WorkspaceCreationPostProcessorService', () => {
+  let service: WorkspaceCreationPostProcessorService;
+  let mockHttp: HttpStart;
+  let mockApplication: ApplicationStart;
+
+  beforeEach(() => {
+    const coreStartMock = coreMock.createStart();
+    mockHttp = coreStartMock.http;
+    mockApplication = coreStartMock.application;
+
+    service = WorkspaceCreationPostProcessorService.getInstance();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the default processor initially', () => {
+    const defaultProcessor = service.getProcessor();
+    expect(defaultProcessor).toBeDefined();
+  });
+
+  it('should register a new processor', () => {
+    const mockProcessor: WorkspaceCreationPostProcessor = jest.fn();
+    const unregister = service.registerProcessor(mockProcessor);
+
+    const registeredProcessor = service.getProcessor();
+    expect(registeredProcessor).toBe(mockProcessor);
+
+    unregister();
+    const defaultProcessor = service.getProcessor();
+    expect(defaultProcessor).not.toBe(mockProcessor);
+  });
+
+  it('should call the default processor with correct arguments', () => {
+    const workspaceId = 'workspace-id';
+    const mockUseCaseLandingAppId = 'use-case-landing-app';
+    const defaultProcessor = service.getProcessor();
+    const { location: originalLocation } = window;
+    const setHrefSpy = jest.fn((href) => href);
+    if (window.location) {
+      // @ts-ignore
+      delete window.location;
+    }
+    window.location = {} as Location;
+    Object.defineProperty(window.location, 'href', {
+      get: () => 'http://localhost/w/workspace/app/workspace_create',
+      set: setHrefSpy,
+    });
+    jest.spyOn(mockApplication, 'getUrlForApp').mockImplementation((appId) => `/app/${appId}`);
+
+    jest.useFakeTimers();
+    defaultProcessor({
+      http: mockHttp,
+      workspaceId,
+      application: mockApplication,
+      useCaseLandingAppId: mockUseCaseLandingAppId,
+    });
+    jest.runAllTimers();
+
+    expect(setHrefSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/w/${workspaceId}/app/${mockUseCaseLandingAppId}`)
+    );
+
+    jest.useRealTimers();
+    window.location = originalLocation;
+  });
+});

--- a/src/plugins/workspace/public/services/workspace_creation_post_processor_service.ts
+++ b/src/plugins/workspace/public/services/workspace_creation_post_processor_service.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BehaviorSubject } from 'rxjs';
+
+import { ApplicationStart, HttpStart } from '../../../../core/public';
+import { formatUrlWithWorkspaceId } from '../../../../core/public/utils';
+
+const defaultProcessor = ({
+  http,
+  workspaceId,
+  application,
+  useCaseLandingAppId,
+}: {
+  http: HttpStart;
+  workspaceId: string;
+  application: ApplicationStart;
+  useCaseLandingAppId: string;
+}) => {
+  // Redirect page after one second, leave one second time to show create successful toast.
+  window.setTimeout(() => {
+    window.location.href = formatUrlWithWorkspaceId(
+      application.getUrlForApp(useCaseLandingAppId, {
+        absolute: true,
+      }),
+      workspaceId,
+      http.basePath
+    );
+  }, 1000);
+};
+
+export type WorkspaceCreationPostProcessor = typeof defaultProcessor;
+
+export class WorkspaceCreationPostProcessorService {
+  private static _instance: WorkspaceCreationPostProcessorService;
+  private _processor$ = new BehaviorSubject(defaultProcessor);
+
+  public getProcessor() {
+    return this._processor$.getValue();
+  }
+
+  public registerProcessor(processor: WorkspaceCreationPostProcessor) {
+    this._processor$.next(processor);
+    return () => {
+      if (this._processor$.getValue() === processor) {
+        this._processor$.next(defaultProcessor);
+      }
+    };
+  }
+
+  static getInstance() {
+    if (!WorkspaceCreationPostProcessorService._instance) {
+      WorkspaceCreationPostProcessorService._instance = new WorkspaceCreationPostProcessorService();
+    }
+    return WorkspaceCreationPostProcessorService._instance;
+  }
+}

--- a/src/plugins/workspace/public/services/workspace_detail_customized_tabs_service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_detail_customized_tabs_service.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WorkspaceDetailCustomizedTabsService } from './workspace_detail_customized_tabs_service';
+
+describe('WorkspaceDetailCustomizedTabsService', () => {
+  let service: WorkspaceDetailCustomizedTabsService;
+
+  beforeEach(() => {
+    service = new WorkspaceDetailCustomizedTabsService();
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    service = null;
+  });
+
+  it('should return an empty array of tabs initially', () => {
+    const tabs$ = service.getCustomizedTabs$();
+    tabs$.subscribe((tabs) => {
+      expect(tabs).toEqual([]);
+    });
+  });
+
+  it('should register a new tab', () => {
+    const mockTab = {
+      id: 'tab-1',
+      title: 'Tab 1',
+      render: jest.fn(),
+      order: 1,
+    };
+
+    const unregister = service.registerCustomizedTab(mockTab);
+
+    const tabs$ = service.getCustomizedTabs$();
+    tabs$.subscribe((tabs) => {
+      expect(tabs).toEqual([mockTab]);
+    });
+
+    unregister();
+
+    tabs$.subscribe((tabs) => {
+      expect(tabs).toEqual([]);
+    });
+  });
+
+  it('should sort tabs by order', () => {
+    const tab1 = {
+      id: 'tab-1',
+      title: 'Tab 1',
+      render: jest.fn(),
+      order: 2,
+    };
+
+    const tab2 = {
+      id: 'tab-2',
+      title: 'Tab 2',
+      render: jest.fn(),
+      order: 1,
+    };
+
+    service.registerCustomizedTab(tab1);
+    service.registerCustomizedTab(tab2);
+
+    const tabs$ = service.getCustomizedTabs$();
+    tabs$.subscribe((tabs) => {
+      expect(tabs).toEqual([tab2, tab1]);
+    });
+  });
+
+  it('should throw an error for duplicate tab id', () => {
+    const tab1 = {
+      id: 'tab-1',
+      title: 'Tab 1',
+      render: jest.fn(),
+      order: 1,
+    };
+
+    service.registerCustomizedTab(tab1);
+
+    expect(() => {
+      service.registerCustomizedTab(tab1);
+    }).toThrow('Duplicate tab id: tab-1');
+  });
+
+  it('should throw an error for duplicate with predefined tabs', () => {
+    const detailsTab = {
+      id: 'details',
+      title: 'Details',
+      render: jest.fn(),
+      order: 1,
+    };
+
+    expect(() => {
+      service.registerCustomizedTab(detailsTab);
+    }).toThrow('Duplicate tab id with predefined tabs');
+  });
+
+  it('static method getInstance should return same instance', () => {
+    expect(WorkspaceDetailCustomizedTabsService.getInstance()).toBe(
+      WorkspaceDetailCustomizedTabsService.getInstance()
+    );
+  });
+});

--- a/src/plugins/workspace/public/services/workspace_detail_customized_tabs_service.ts
+++ b/src/plugins/workspace/public/services/workspace_detail_customized_tabs_service.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { DetailTab } from '../components/workspace_form';
+
+export interface WorkspaceDetailCustomizedTab {
+  id: string;
+  title: string;
+  render: () => React.ReactNode;
+  order: number;
+}
+
+export class WorkspaceDetailCustomizedTabsService {
+  private static _instance: WorkspaceDetailCustomizedTabsService;
+  private _tabs$ = new BehaviorSubject<WorkspaceDetailCustomizedTab[]>([]);
+
+  public getCustomizedTabs$() {
+    return this._tabs$;
+  }
+
+  public registerCustomizedTab(tab: WorkspaceDetailCustomizedTab) {
+    if ((Object.values(DetailTab) as string[]).includes(tab.id)) {
+      throw new Error('Duplicate tab id with predefined tabs');
+    }
+    const tabs = this._tabs$.getValue();
+    if (tabs.some((existTab) => existTab.id === tab.id)) {
+      throw new Error(`Duplicate tab id: ${tab.id}`);
+    }
+    this._tabs$.next([...tabs, tab].sort((a, b) => a.order - b.order));
+    return () => {
+      this._tabs$.next(this._tabs$.getValue().filter((existTab) => existTab.id !== tab.id));
+    };
+  }
+
+  static getInstance() {
+    if (!WorkspaceDetailCustomizedTabsService._instance) {
+      WorkspaceDetailCustomizedTabsService._instance = new WorkspaceDetailCustomizedTabsService();
+    }
+    return WorkspaceDetailCustomizedTabsService._instance;
+  }
+}

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -10,12 +10,15 @@ import { NavigationPublicPluginStart } from '../../../plugins/navigation/public'
 import { ContentManagementPluginStart } from '../../../plugins/content_management/public';
 import { DataSourceAttributes } from '../../../plugins/data_source/common/data_sources';
 
-export type Services = CoreStart & {
+export interface WorkspaceDependServices {
   workspaceClient: WorkspaceClient;
   dataSourceManagement?: DataSourceManagementPluginSetup;
-  navigationUI?: NavigationPublicPluginStart['ui'];
+  navigationUI: NavigationPublicPluginStart['ui'];
   contentManagement?: ContentManagementPluginStart;
-};
+  collaboratorEditorEnabled?: boolean;
+}
+
+export type Services = CoreStart & WorkspaceDependServices;
 
 export interface WorkspaceUseCaseFeature {
   id: string;

--- a/src/plugins/workspace/server/index.ts
+++ b/src/plugins/workspace/server/index.ts
@@ -15,6 +15,9 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export const config: PluginConfigDescriptor = {
+  exposeToBrowser: {
+    collaboratorEditorEnabled: true,
+  },
   schema: configSchema,
 };
 


### PR DESCRIPTION
### Description

This PR add a feature flag to determine whether collaborator editor showed in workspace creation and workspace detail page. Beside this, this PR add two methods to register workspace creation post processor and register customized tab in workspace details page.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Without collaborator editor enabled
![image](https://github.com/user-attachments/assets/1a40e62b-84ed-498c-9377-1b183ff038f5)
![image](https://github.com/user-attachments/assets/5bddd5b1-f60a-41fd-9aeb-38feb249cebf)

### With collaborator editor enabled
![image](https://github.com/user-attachments/assets/dfd9537d-cd4a-41e6-b393-be29b9bba02a)
![image](https://github.com/user-attachments/assets/d8697041-f973-4bdb-9704-cfe7bb18642c)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version loose`
- Add configs below in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
opensearchDashboards.dashboardAdmin.users: ['admin']
workspace.collaboratorEditorEnabled: true
```
- Run `yarn start --no-base-path`
- Login with admin user and go to workspace creation page by bottom left menu
- The collaborator editor should be exists
- Click create button, it will redirect to workspace use case landing page
- Set `workspace.collaboratorEditorEnabled` to `false` in `config/opensearch_dashboards.yml`
- The collaborator editor should be hidden

For workspace details customized tabs tests, can refer "should render customized tab" in `src/plugins/workspace/public/components/workspace_detail/workspace_detail.test.tsx`.
For register workspace create post processor tests, can refer "#setup able to registerWorkspaceCreationPostProcessor" in `src/plugins/workspace/public/plugin.test.ts`
 

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace]Add flag for workspace collaborator editor enabled

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
