### PR TITLE
[i18n] Fix i18n String in New Discover Cache Time

### DIFF
--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
@@ -117,13 +117,13 @@ export const DatasetExplorer = ({
                   <EuiText size="s">
                     <FormattedMessage
                       id="data.explorer.datasetSelector.advancedSelector.lastUpdatedTime"
-                      defaultMessage={'Last updated at: {timestamp}. '}
+                      defaultMessage="Last updated at: {timestamp}."
                       values={{
                         timestamp: moment(queryString.getDatasetService().getLastCacheTime())
                           .format(uiSettings.get('dateFormat'))
                           .toString(),
                       }}
-                    />
+                    />{' '}
                   </EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Makes `defaultMessage` a string literal and removes space at the end.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
