### PR TITLE
[Fix] Replace segmented button with tabs for OpenSearch connections and Direct query connections

### DIFF
--- a/changelogs/fragments/8460.yml
+++ b/changelogs/fragments/8460.yml
@@ -1,0 +1,2 @@
+fix:
+- Replace segmented button with tabs for OpenSearch connections and Direct query connections ([#8460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8460))

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_home_panel.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/__snapshots__/data_source_home_panel.test.tsx.snap
@@ -1,78 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataSourceHomePanel renders correctly 1`] = `
-<EuiPanel>
-  <EuiFlexGroup
-    direction="column"
-  >
-    <EuiFlexItem>
-      <EuiPageHeader>
-        <EuiFlexGroup
-          alignItems="center"
-          justifyContent="spaceBetween"
-        >
-          <EuiFlexItem
-            grow={false}
+<Fragment>
+  <EuiPanel>
+    <EuiFlexGroup
+      direction="column"
+    >
+      <EuiFlexItem>
+        <EuiPageHeader>
+          <EuiFlexGroup
+            alignItems="center"
+            justifyContent="spaceBetween"
           >
-            <DataSourceHeader
-              featureFlagStatus={true}
-              history={
-                Object {
-                  "push": [MockFunction],
+            <EuiFlexItem
+              grow={false}
+            >
+              <DataSourceHeader
+                featureFlagStatus={true}
+                history={
+                  Object {
+                    "push": [MockFunction],
+                  }
                 }
-              }
-            />
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <CreateButton
+                dataTestSubj="createDataSourceButton"
+                featureFlagStatus={true}
+                history={
+                  Object {
+                    "push": [MockFunction],
+                  }
+                }
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPageHeader>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiSpacer
+          size="s"
+        />
+        <EuiTabs
+          size="s"
+        >
+          <EuiTab
+            isSelected={true}
+            key="manageOpensearchDataSources"
+            onClick={[Function]}
           >
-            <CreateButton
-              dataTestSubj="createDataSourceButton"
-              featureFlagStatus={true}
-              history={
-                Object {
-                  "push": [MockFunction],
-                }
-              }
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPageHeader>
-    </EuiFlexItem>
-    <EuiFlexItem>
-      <EuiSpacer
-        size="s"
-      />
-      <EuiTabs
-        size="s"
-      >
-        <EuiTab
-          isSelected={true}
-          key="manageOpensearchDataSources"
-          onClick={[Function]}
-        >
-          OpenSearch connections
-        </EuiTab>
-        <EuiTab
-          isSelected={false}
-          key="manageDirectQueryDataSources"
-          onClick={[Function]}
-        >
-          Direct query connections
-        </EuiTab>
-      </EuiTabs>
-    </EuiFlexItem>
-    <EuiFlexItem>
-      <DataSourceTableWithRouter
-        history={
-          Object {
-            "push": [MockFunction],
+            OpenSearch connections
+          </EuiTab>
+          <EuiTab
+            isSelected={false}
+            key="manageDirectQueryDataSources"
+            onClick={[Function]}
+          >
+            Direct query connections
+          </EuiTab>
+        </EuiTabs>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <DataSourceTableWithRouter
+          history={
+            Object {
+              "push": [MockFunction],
+            }
           }
-        }
-        location={Object {}}
-        match={Object {}}
-      />
-    </EuiFlexItem>
-  </EuiFlexGroup>
-</EuiPanel>
+          location={Object {}}
+          match={Object {}}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+</Fragment>
 `;

--- a/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_home_panel/data_source_home_panel.tsx
@@ -134,15 +134,9 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
   };
 
   return (
-    <EuiPanel>
+    <>
       {useNewUX && (
         <>
-          {featureFlagStatus && (
-            <HeaderControl
-              setMountPoint={application.setAppCenterControls}
-              controls={connectionTypeButton}
-            />
-          )}
           {canManageDataSource && (
             <HeaderControl
               setMountPoint={application.setAppRightControls}
@@ -167,52 +161,56 @@ export const DataSourceHomePanel: React.FC<DataSourceHomePanelProps> = ({
                 : description,
             ]}
           />
+          <EuiTabs size="s">{renderTabs()}</EuiTabs>
+          <EuiSpacer size="m" />
         </>
       )}
-      <EuiFlexGroup direction="column">
-        {!useNewUX && (
-          <>
-            <EuiFlexItem>
-              <EuiPageHeader>
-                <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-                  <EuiFlexItem grow={false}>
-                    <DataSourceHeader
-                      history={props.history}
-                      featureFlagStatus={featureFlagStatus}
-                    />
-                  </EuiFlexItem>
-                  {canManageDataSource ? (
+      <EuiPanel>
+        <EuiFlexGroup direction="column">
+          {!useNewUX && (
+            <>
+              <EuiFlexItem>
+                <EuiPageHeader>
+                  <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
                     <EuiFlexItem grow={false}>
-                      <CreateButton
+                      <DataSourceHeader
                         history={props.history}
                         featureFlagStatus={featureFlagStatus}
-                        dataTestSubj="createDataSourceButton"
                       />
                     </EuiFlexItem>
-                  ) : null}
-                </EuiFlexGroup>
-              </EuiPageHeader>
-            </EuiFlexItem>
-            {featureFlagStatus && (
-              <EuiFlexItem>
-                <EuiSpacer size="s" />
-                <EuiTabs size="s">{renderTabs()}</EuiTabs>
+                    {canManageDataSource ? (
+                      <EuiFlexItem grow={false}>
+                        <CreateButton
+                          history={props.history}
+                          featureFlagStatus={featureFlagStatus}
+                          dataTestSubj="createDataSourceButton"
+                        />
+                      </EuiFlexItem>
+                    ) : null}
+                  </EuiFlexGroup>
+                </EuiPageHeader>
               </EuiFlexItem>
+              {featureFlagStatus && (
+                <EuiFlexItem>
+                  <EuiSpacer size="s" />
+                  <EuiTabs size="s">{renderTabs()}</EuiTabs>
+                </EuiFlexItem>
+              )}
+            </>
+          )}
+          <EuiFlexItem>
+            {selectedTabId === 'manageOpensearchDataSources' && featureFlagStatus && (
+              <DataSourceTableWithRouter {...props} />
             )}
-          </>
-        )}
-        <EuiFlexItem>
-          {selectedTabId === 'manageOpensearchDataSources' && featureFlagStatus && (
-            <DataSourceTableWithRouter {...props} />
-          )}
-          {(!featureFlagStatus || selectedTabId === 'manageDirectQueryDataSources') && (
-            <ManageDirectQueryDataConnectionsTableWithRouter
-              featureFlagStatus={featureFlagStatus}
-              {...props}
-            />
-          )}
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
+            {(!featureFlagStatus || selectedTabId === 'manageDirectQueryDataSources') && (
+              <ManageDirectQueryDataConnectionsTableWithRouter
+                featureFlagStatus={featureFlagStatus}
+                {...props}
+              />
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </>
   );
 };


### PR DESCRIPTION
### Description

Replace segmented button with tabs for OpenSearch connections and Direct query connections

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

before:
![image](https://github.com/user-attachments/assets/8e66b771-a819-4fbb-839e-003b71c93a1a)
After:
<img width="1518" alt="image" src="https://github.com/user-attachments/assets/bb2a9f86-ad55-4d2a-8b51-23c38531f368">


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Replace segmented button with tabs for OpenSearch connections and Direct query connections
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
