### PR TITLE
[Workspace]Restrict at least one data source in workspace creation page

### DIFF
--- a/changelogs/fragments/8461.yml
+++ b/changelogs/fragments/8461.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Restrict at least one data source in workspace creation page ([#8461](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8461))

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_create_action_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_create_action_panel.test.tsx
@@ -9,6 +9,7 @@ import {
   MAX_WORKSPACE_DESCRIPTION_LENGTH,
   MAX_WORKSPACE_NAME_LENGTH,
 } from '../../../common/constants';
+import { DataSourceConnectionType } from '../../../common/types';
 import { WorkspaceCreateActionPanel } from './workspace_create_action_panel';
 
 const mockApplication = applicationServiceMock.createStartContract();
@@ -18,6 +19,14 @@ describe('WorkspaceCreateActionPanel', () => {
   const formData = {
     name: 'Test Workspace',
     description: 'This is a test workspace',
+    selectedDataSourceConnections: [
+      {
+        id: 'data-source-1',
+        name: 'Data Source 1',
+        type: '',
+        connectionType: DataSourceConnectionType.OpenSearchConnection,
+      },
+    ],
   };
 
   it('should disable the "Create Workspace" button when name exceeds the maximum length', () => {
@@ -25,9 +34,13 @@ describe('WorkspaceCreateActionPanel', () => {
     render(
       <WorkspaceCreateActionPanel
         formId={formId}
-        formData={{ name: longName, description: formData.description }}
+        formData={{
+          ...formData,
+          name: longName,
+        }}
         application={mockApplication}
         isSubmitting={false}
+        dataSourceEnabled
       />
     );
     const createButton = screen.getByText('Create workspace');
@@ -39,13 +52,51 @@ describe('WorkspaceCreateActionPanel', () => {
     render(
       <WorkspaceCreateActionPanel
         formId={formId}
-        formData={{ name: formData.name, description: longDescription }}
+        formData={{
+          ...formData,
+          description: longDescription,
+        }}
         application={mockApplication}
         isSubmitting={false}
+        dataSourceEnabled
       />
     );
     const createButton = screen.getByText('Create workspace');
     expect(createButton.closest('button')).toBeDisabled();
+  });
+
+  it('should disable the "Create Workspace" button when data source enabled and no data sources selected', () => {
+    render(
+      <WorkspaceCreateActionPanel
+        formId={formId}
+        formData={{
+          ...formData,
+          selectedDataSourceConnections: [],
+        }}
+        application={mockApplication}
+        isSubmitting={false}
+        dataSourceEnabled
+      />
+    );
+    const createButton = screen.getByText('Create workspace');
+    expect(createButton.closest('button')).toBeDisabled();
+  });
+
+  it('should enable the "Create Workspace" button when no data sources selected but no data source enabled', () => {
+    render(
+      <WorkspaceCreateActionPanel
+        formId={formId}
+        formData={{
+          ...formData,
+          selectedDataSourceConnections: [],
+        }}
+        application={mockApplication}
+        isSubmitting={false}
+        dataSourceEnabled={false}
+      />
+    );
+    const createButton = screen.getByText('Create workspace');
+    expect(createButton.closest('button')).not.toBeDisabled();
   });
 
   it('should enable the "Create Workspace" button when name and description are within the maximum length', () => {
@@ -55,6 +106,7 @@ describe('WorkspaceCreateActionPanel', () => {
         formData={formData}
         application={mockApplication}
         isSubmitting={false}
+        dataSourceEnabled
       />
     );
     const createButton = screen.getByText('Create workspace');
@@ -65,9 +117,10 @@ describe('WorkspaceCreateActionPanel', () => {
     render(
       <WorkspaceCreateActionPanel
         formId={formId}
-        formData={{ name: 'test' }}
+        formData={formData}
         application={mockApplication}
         isSubmitting
+        dataSourceEnabled
       />
     );
     expect(screen.getByText('Create workspace').closest('button')).toBeDisabled();

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_create_action_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_create_action_panel.tsx
@@ -21,9 +21,10 @@ import {
 
 interface WorkspaceCreateActionPanelProps {
   formId: string;
-  formData: Pick<WorkspaceFormDataState, 'name' | 'description'>;
+  formData: Pick<WorkspaceFormDataState, 'name' | 'description' | 'selectedDataSourceConnections'>;
   application: ApplicationStart;
   isSubmitting: boolean;
+  dataSourceEnabled: boolean;
 }
 
 export const WorkspaceCreateActionPanel = ({
@@ -31,13 +32,15 @@ export const WorkspaceCreateActionPanel = ({
   formData,
   application,
   isSubmitting,
+  dataSourceEnabled,
 }: WorkspaceCreateActionPanelProps) => {
   const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
   const closeCancelModal = useCallback(() => setIsCancelModalVisible(false), []);
   const showCancelModal = useCallback(() => setIsCancelModalVisible(true), []);
   const createButtonDisabled =
     (formData.name?.length ?? 0) > MAX_WORKSPACE_NAME_LENGTH ||
-    (formData.description?.length ?? 0) > MAX_WORKSPACE_DESCRIPTION_LENGTH;
+    (formData.description?.length ?? 0) > MAX_WORKSPACE_DESCRIPTION_LENGTH ||
+    (dataSourceEnabled && formData.selectedDataSourceConnections.length === 0);
 
   return (
     <>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -102,8 +102,9 @@ jest.spyOn(utils, 'fetchDataSourceConnections').mockImplementation(async (passed
 
 const WorkspaceCreator = ({
   isDashboardAdmin = false,
+  dataSourceEnabled = false,
   ...props
-}: Partial<WorkspaceCreatorProps & { isDashboardAdmin: boolean }>) => {
+}: Partial<WorkspaceCreatorProps & { isDashboardAdmin: boolean; dataSourceEnabled?: boolean }>) => {
   const { Provider } = createOpenSearchDashboardsReactContext({
     ...mockCoreStart,
     ...{
@@ -143,7 +144,7 @@ const WorkspaceCreator = ({
           }),
         },
       },
-      dataSourceManagement: {},
+      dataSourceManagement: dataSourceEnabled ? {} : undefined,
       navigationUI: {
         HeaderControl: () => null,
       },
@@ -364,7 +365,7 @@ describe('WorkspaceCreator', () => {
       value: 600,
     });
     const { getByTestId, getAllByText, getByText } = render(
-      <WorkspaceCreator isDashboardAdmin={true} />
+      <WorkspaceCreator isDashboardAdmin={true} dataSourceEnabled />
     );
 
     // Ensure workspace create form rendered
@@ -422,7 +423,7 @@ describe('WorkspaceCreator', () => {
       value: 600,
     });
     const { getByTestId, getAllByText, getByText } = render(
-      <WorkspaceCreator isDashboardAdmin={true} />
+      <WorkspaceCreator isDashboardAdmin={true} dataSourceEnabled />
     );
 
     // Ensure workspace create form rendered

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -483,6 +483,10 @@ describe('WorkspaceCreator', () => {
     await waitFor(() => {
       expect(getByTestId('workspaceForm-bottomBar-createButton')).toBeInTheDocument();
     });
+    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
+    fireEvent.input(nameInput, {
+      target: { value: 'test workspace name' },
+    });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
     expect(workspaceClientCreate).toHaveBeenCalledTimes(1);
 
@@ -502,6 +506,10 @@ describe('WorkspaceCreator', () => {
     // Ensure workspace create form rendered
     await waitFor(() => {
       expect(getByTestId('workspaceForm-bottomBar-createButton')).toBeInTheDocument();
+    });
+    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
+    fireEvent.input(nameInput, {
+      target: { value: 'test workspace name' },
     });
     fireEvent.click(getByTestId('workspaceForm-bottomBar-createButton'));
     jest.useFakeTimers();

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -58,7 +58,6 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
     color: euiPaletteColorBlind()[0],
     ...(defaultSelectedUseCase
       ? {
-          name: defaultSelectedUseCase.title,
           features: [getUseCaseFeatureConfig(defaultSelectedUseCase.id)],
         }
       : {}),

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
@@ -197,6 +197,7 @@ export const WorkspaceCreatorForm = (props: WorkspaceCreatorFormProps) => {
               formId={formId}
               application={application}
               isSubmitting={props.isSubmitting}
+              dataSourceEnabled={!!isDataSourceEnabled}
             />
           </div>
         </div>

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_form_summary_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_form_summary_panel.test.tsx
@@ -9,6 +9,8 @@ import { WorkspaceFormSummaryPanel, FieldSummaryItem } from './workspace_form_su
 import { RightSidebarScrollField } from './utils';
 import { WorkspacePermissionItemType } from '../workspace_form';
 import { applicationServiceMock } from '../../../../../../src/core/public/mocks';
+import { DataSourceConnectionType } from '../../../common/types';
+import { WorkspacePermissionMode } from '../../../common/constants';
 
 describe('WorkspaceFormSummaryPanel', () => {
   const formData = {
@@ -18,28 +20,43 @@ describe('WorkspaceFormSummaryPanel', () => {
     description: 'This is a test workspace',
     color: '#000000',
     selectedDataSourceConnections: [
-      { id: 'data-source-1', name: 'Data Source 1' },
-      { id: 'data-source-2', name: 'Data Source 2' },
-      { id: 'data-source-3', name: 'Data Source 3' },
+      {
+        id: 'data-source-1',
+        name: 'Data Source 1',
+        type: '',
+        connectionType: DataSourceConnectionType.OpenSearchConnection,
+      },
+      {
+        id: 'data-source-2',
+        name: 'Data Source 2',
+        type: '',
+        connectionType: DataSourceConnectionType.OpenSearchConnection,
+      },
+      {
+        id: 'data-source-3',
+        name: 'Data Source 3',
+        type: '',
+        connectionType: DataSourceConnectionType.OpenSearchConnection,
+      },
     ],
     permissionSettings: [
       {
         id: 1,
         type: WorkspacePermissionItemType.User,
         userId: 'user1',
-        modes: ['library_write', 'write'],
+        modes: [WorkspacePermissionMode.LibraryWrite, WorkspacePermissionMode.Write],
       },
       {
         id: 2,
         type: WorkspacePermissionItemType.Group,
         group: 'group1',
-        modes: ['library_read', 'read'],
+        modes: [WorkspacePermissionMode.LibraryRead, WorkspacePermissionMode.Read],
       },
       {
         id: 3,
         type: WorkspacePermissionItemType.User,
         userId: 'user2',
-        modes: ['library_write', 'read'],
+        modes: [WorkspacePermissionMode.LibraryWrite, WorkspacePermissionMode.Read],
       },
     ],
   };
@@ -71,6 +88,7 @@ describe('WorkspaceFormSummaryPanel', () => {
         formId="id"
         application={applicationMock}
         isSubmitting={false}
+        dataSourceEnabled
       />
     );
 
@@ -107,6 +125,7 @@ describe('WorkspaceFormSummaryPanel', () => {
         formId="id"
         application={applicationMock}
         isSubmitting={false}
+        dataSourceEnabled
       />
     );
 
@@ -148,6 +167,7 @@ describe('WorkspaceFormSummaryPanel', () => {
         formId="id"
         application={applicationMock}
         isSubmitting={false}
+        dataSourceEnabled
       />
     );
     expect(screen.getByText('user1')).toBeInTheDocument();
@@ -160,6 +180,21 @@ describe('WorkspaceFormSummaryPanel', () => {
 
     fireEvent.click(screen.getByText('Show less'));
     expect(screen.queryByText('user2')).toBeNull();
+  });
+
+  it('should hide "Data sources" if data source not enabled', () => {
+    render(
+      <WorkspaceFormSummaryPanel
+        formData={formData}
+        availableUseCases={availableUseCases}
+        permissionEnabled
+        formId="id"
+        application={applicationMock}
+        isSubmitting={false}
+        dataSourceEnabled={false}
+      />
+    );
+    expect(screen.queryByText('Data sources')).toBeNull();
   });
 });
 

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_form_summary_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_form_summary_panel.tsx
@@ -165,6 +165,7 @@ interface WorkspaceFormSummaryPanelProps {
   formId: string;
   application: ApplicationStart;
   isSubmitting: boolean;
+  dataSourceEnabled: boolean;
 }
 
 export const WorkspaceFormSummaryPanel = ({
@@ -174,6 +175,7 @@ export const WorkspaceFormSummaryPanel = ({
   formId,
   application,
   isSubmitting,
+  dataSourceEnabled,
 }: WorkspaceFormSummaryPanelProps) => {
   const useCase = availableUseCases.find((item) => item.id === formData.useCase);
   const userAndGroups: UserAndGroups[] = formData.permissionSettings.flatMap((setting) => {
@@ -213,18 +215,20 @@ export const WorkspaceFormSummaryPanel = ({
       <FieldSummaryItem field={RightSidebarScrollField.UseCase}>
         {useCase && <EuiText size="xs">{useCase.title}</EuiText>}
       </FieldSummaryItem>
-      <FieldSummaryItem field={RightSidebarScrollField.DataSource}>
-        {formData.selectedDataSourceConnections.length > 0 && (
-          <ExpandableTextList
-            items={formData.selectedDataSourceConnections.map((connection) => (
-              <ul key={connection.id} style={{ marginBottom: 0 }}>
-                <li>{connection.name}</li>
-              </ul>
-            ))}
-            collapseDisplayCount={3}
-          />
-        )}
-      </FieldSummaryItem>
+      {dataSourceEnabled && (
+        <FieldSummaryItem field={RightSidebarScrollField.DataSource}>
+          {formData.selectedDataSourceConnections.length > 0 && (
+            <ExpandableTextList
+              items={formData.selectedDataSourceConnections.map((connection) => (
+                <ul key={connection.id} style={{ marginBottom: 0 }}>
+                  <li>{connection.name}</li>
+                </ul>
+              ))}
+              collapseDisplayCount={3}
+            />
+          )}
+        </FieldSummaryItem>
+      )}
       {permissionEnabled && (
         <FieldSummaryItem bottomGap={false} field={RightSidebarScrollField.Collaborators}>
           {userAndGroups.length > 0 && (
@@ -240,6 +244,7 @@ export const WorkspaceFormSummaryPanel = ({
         formId={formId}
         application={application}
         isSubmitting={isSubmitting}
+        dataSourceEnabled={dataSourceEnabled}
       />
     </EuiCard>
   );

--- a/src/plugins/workspace/public/components/workspace_form/data_source_connection_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/data_source_connection_table.tsx
@@ -34,7 +34,10 @@ interface DataSourceConnectionTableProps {
   onUnlinkDataSource: (dataSources: DataSourceConnection) => void;
   onSelectionChange: (selections: DataSourceConnection[]) => void;
   dataSourceConnections: DataSourceConnection[];
-  tableProps?: Pick<EuiInMemoryTableProps<DataSourceConnection>, 'pagination' | 'search'>;
+  tableProps?: Pick<
+    EuiInMemoryTableProps<DataSourceConnection>,
+    'pagination' | 'search' | 'message'
+  >;
 }
 
 export const DataSourceConnectionTable = forwardRef<

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
@@ -229,4 +229,16 @@ describe('SelectDataSourcePanel', () => {
       )
     ).toBeNull();
   });
+
+  it('should render empty message and action buttons', () => {
+    const { getByText, getByTestId } = setup({
+      assignedDataSourceConnections: [],
+    });
+
+    expect(getByText('Associated data sources will appear here')).toBeInTheDocument();
+    expect(
+      getByTestId('workspace-creator-emptyPrompt-dataSources-assign-button')
+    ).toBeInTheDocument();
+    expect(getByTestId('workspace-creator-dqc-assign-button')).toBeInTheDocument();
+  });
 });

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
@@ -239,6 +239,6 @@ describe('SelectDataSourcePanel', () => {
     expect(
       getByTestId('workspace-creator-emptyPrompt-dataSources-assign-button')
     ).toBeInTheDocument();
-    expect(getByTestId('workspace-creator-dqc-assign-button')).toBeInTheDocument();
+    expect(getByTestId('workspace-creator-emptyPrompt-dqc-assign-button')).toBeInTheDocument();
   });
 });

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
@@ -4,7 +4,15 @@
  */
 
 import React, { useState } from 'react';
-import { EuiSpacer, EuiFlexItem, EuiSmallButton, EuiFlexGroup, EuiPanel } from '@elastic/eui';
+import {
+  EuiSpacer,
+  EuiFlexItem,
+  EuiSmallButton,
+  EuiFlexGroup,
+  EuiPanel,
+  EuiEmptyPrompt,
+  EuiText,
+} from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { SavedObjectsStart, CoreStart } from '../../../../../core/public';
 import { DataSourceConnection } from '../../../common/types';
@@ -55,28 +63,16 @@ export const SelectDataSourcePanel = ({
     handleUnassignDataSources([connection]);
   };
 
-  const renderTableContent = () => {
-    return (
-      <EuiPanel paddingSize="none" hasBorder={false}>
-        <DataSourceConnectionTable
-          isDashboardAdmin={showDataSourceManagement}
-          dataSourceConnections={assignedDataSourceConnections}
-          onUnlinkDataSource={handleSingleDataSourceUnAssign}
-          connectionType={AssociationDataSourceModalMode.OpenSearchConnections}
-          onSelectionChange={setSelectedItems}
-        />
-      </EuiPanel>
-    );
-  };
-
-  const addOpenSearchConnectionsButton = (
+  const renderAddOpenSearchConnectionsButton = (
+    testingId = 'workspace-creator-dataSources-assign-button'
+  ) => (
     <EuiSmallButton
       iconType="plusInCircle"
       onClick={() => {
         setToggleIdSelected(AssociationDataSourceModalMode.OpenSearchConnections);
         setModalVisible(true);
       }}
-      data-test-subj="workspace-creator-dataSources-assign-button"
+      data-test-subj={testingId}
     >
       {i18n.translate('workspace.form.selectDataSourcePanel.addNew', {
         defaultMessage: 'Associate OpenSearch connections',
@@ -84,14 +80,16 @@ export const SelectDataSourcePanel = ({
     </EuiSmallButton>
   );
 
-  const addDirectQueryConnectionsButton = (
+  const renderAddDirectQueryConnectionsButton = (
+    testingId = 'workspace-creator-dqc-assign-button'
+  ) => (
     <EuiSmallButton
       iconType="plusInCircle"
       onClick={() => {
         setToggleIdSelected(AssociationDataSourceModalMode.DirectQueryConnections);
         setModalVisible(true);
       }}
-      data-test-subj="workspace-creator-dqc-assign-button"
+      data-test-subj={testingId}
     >
       {i18n.translate('workspace.form.selectDataSourcePanel.addNewDQCs', {
         defaultMessage: 'Associate direct query connections',
@@ -114,6 +112,60 @@ export const SelectDataSourcePanel = ({
     </EuiSmallButton>
   );
 
+  const renderTableContent = () => {
+    const message =
+      assignedDataSourceConnections.length === 0 ? (
+        <EuiEmptyPrompt
+          iconType="database"
+          iconColor="default"
+          title={
+            <EuiText size="s">
+              <h3>
+                {i18n.translate('workspaces.forms.selectDataSourcePanel.emptyTableTitle', {
+                  defaultMessage: 'Associated data sources will appear here',
+                })}
+              </h3>
+            </EuiText>
+          }
+          body={
+            <EuiText size="s">
+              {i18n.translate('workspaces.forms.selectDataSourcePanel.emptyTableDescription', {
+                defaultMessage: 'At least one data source is required to create a workspace.',
+              })}
+            </EuiText>
+          }
+          actions={
+            showDataSourceManagement && (
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem>
+                  {renderAddOpenSearchConnectionsButton(
+                    'workspace-creator-emptyPrompt-dataSources-assign-button'
+                  )}
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  {renderAddDirectQueryConnectionsButton(
+                    'workspace-creator-emptyPrompt-dqc-assign-button'
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            )
+          }
+        />
+      ) : undefined;
+    return (
+      <EuiPanel paddingSize="none" hasBorder={false}>
+        <DataSourceConnectionTable
+          isDashboardAdmin={showDataSourceManagement}
+          dataSourceConnections={assignedDataSourceConnections}
+          onUnlinkDataSource={handleSingleDataSourceUnAssign}
+          connectionType={AssociationDataSourceModalMode.OpenSearchConnections}
+          onSelectionChange={setSelectedItems}
+          tableProps={{ message }}
+        />
+      </EuiPanel>
+    );
+  };
+
   return (
     <div>
       <EuiSpacer size="m" />
@@ -124,14 +176,14 @@ export const SelectDataSourcePanel = ({
             <EuiFlexItem grow={false}>{removeButton}</EuiFlexItem>
           )}
         {showDataSourceManagement && (
-          <EuiFlexItem grow={false}>{addOpenSearchConnectionsButton}</EuiFlexItem>
+          <EuiFlexItem grow={false}>{renderAddOpenSearchConnectionsButton()}</EuiFlexItem>
         )}
         {showDataSourceManagement && (
-          <EuiFlexItem grow={false}>{addDirectQueryConnectionsButton}</EuiFlexItem>
+          <EuiFlexItem grow={false}>{renderAddDirectQueryConnectionsButton()}</EuiFlexItem>
         )}
       </EuiFlexGroup>
-      {assignedDataSourceConnections.length > 0 && <EuiSpacer size="m" />}
-      {assignedDataSourceConnections.length > 0 && renderTableContent()}
+      <EuiSpacer size="m" />
+      {renderTableContent()}
       {modalVisible && chrome && (
         <AssociationDataSourceModal
           savedObjects={savedObjects}


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR is for adding required restriction for data source selector in workspace creation page. The create workspace button will be disabled if no data sources assigned. It added a empty prompt message for indicate this behavior when no data source assigned. This PR also removed the populated workspace name.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/c737ae66-daca-4ada-bfe5-9bb075944074)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version loose`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
opensearchDashboards.dashboardAdmin.users: ['admin']
```
- Run `yarn start --no-base-path`
- Login with admin user and go to workspace create page by bottom left menu
- No workspace name will be populated
- The create workspace button should be disabled until data source assigned
- The empty message in data source selector should like screenshot above

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace]Restrict at least one data source in workspace creation page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
