### PR TITLE
fix(deprecated): removed deprecated `yarn` attributes

### DIFF
--- a/packages/osd-pm/dist/index.js
+++ b/packages/osd-pm/dist/index.js
@@ -26160,7 +26160,7 @@ const YARN_EXEC = process.env.npm_execpath || 'yarn';
  * Install all dependencies in the given directory
  */
 async function installInDir(directory, extraArgs = [], useAdd = false) {
-  const options = [useAdd ? 'add' : 'install', '--non-interactive', ...extraArgs];
+  const options = [useAdd ? 'add' : 'install', ...extraArgs];
 
   // We pass the mutex flag to ensure only one instance of yarn runs at any
   // given time (e.g. to avoid conflicts).

--- a/packages/osd-pm/src/utils/scripts.ts
+++ b/packages/osd-pm/src/utils/scripts.ts
@@ -48,7 +48,7 @@ interface WorkspacesInfo {
  * Install all dependencies in the given directory
  */
 export async function installInDir(directory: string, extraArgs: string[] = [], useAdd = false) {
-  const options = [useAdd ? 'add' : 'install', '--non-interactive', ...extraArgs];
+  const options = [useAdd ? 'add' : 'install', ...extraArgs];
 
   // We pass the mutex flag to ensure only one instance of yarn runs at any
   // given time (e.g. to avoid conflicts).


### PR DESCRIPTION
### Description

Removed deprecated flags that avoid using newer yarn versions, like `corepack` and any yarn >= 1.xx.

### Issues Resolved

## Screenshot
### Before
![Before](https://github.com/user-attachments/assets/aa31bf4d-98df-4ab2-996f-4d8a74133270)
### After
![After](https://github.com/user-attachments/assets/d896e8d2-2774-4fcb-b69d-a01cbf91226e)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
