### PR TITLE
Fix inconsistent i18n key names in workspace and examples

### DIFF
--- a/changelogs/fragments/8483.yml
+++ b/changelogs/fragments/8483.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix inconsistent i18n key names in workspace and examples ([#8483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8483))

--- a/examples/ui_actions_explorer/public/app.tsx
+++ b/examples/ui_actions_explorer/public/app.tsx
@@ -85,7 +85,7 @@ const ActionsExplorer = () => {
             <EuiTitle size="l">
               <h1>
                 <FormattedMessage
-                  id="uiAsctionsExample.appTitle"
+                  id="uiActionsExplorer.appTitle"
                   defaultMessage="{name}"
                   values={{ name: 'UI Actions' }}
                 />

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
@@ -121,7 +121,7 @@ export const SelectDataSourcePanel = ({
           title={
             <EuiText size="s">
               <h3>
-                {i18n.translate('workspaces.forms.selectDataSourcePanel.emptyTableTitle', {
+                {i18n.translate('workspace.forms.selectDataSourcePanel.emptyTableTitle', {
                   defaultMessage: 'Associated data sources will appear here',
                 })}
               </h3>
@@ -129,7 +129,7 @@ export const SelectDataSourcePanel = ({
           }
           body={
             <EuiText size="s">
-              {i18n.translate('workspaces.forms.selectDataSourcePanel.emptyTableDescription', {
+              {i18n.translate('workspace.forms.selectDataSourcePanel.emptyTableDescription', {
                 defaultMessage: 'At least one data source is required to create a workspace.',
               })}
             </EuiText>


### PR DESCRIPTION
### Description

This PR is for updating inconsistent i18n key names in workspace plugin and examples. These keys should start with "workspace" instead of "workspaces" according #8423 


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Fix inconsistent i18n key names in workspace and examples

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
