### PR TITLE
[Workspace]Remove workspace name populate after use case selected

### DIFF
--- a/changelogs/fragments/8484.yml
+++ b/changelogs/fragments/8484.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Remove workspace name populate after use case selected ([#8484](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8484))

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { coreMock } from '../../../../../core/public/mocks';
 import { DataSourceManagementPluginSetup } from '../../../../../plugins/data_source_management/public';
 import { createMockedRegisteredUseCases } from '../../mocks';
@@ -67,25 +67,5 @@ describe('WorkspaceForm', () => {
     const { queryByText } = setup(true, undefined);
 
     expect(queryByText('Associate data source')).not.toBeInTheDocument();
-  });
-
-  it('should automatic update workspace name after use case changed', () => {
-    const { getByTestId } = setup(false, mockDataSourceManagementSetup);
-
-    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
-    expect(nameInput).toHaveValue('');
-    fireEvent.click(getByTestId('workspaceUseCase-observability'));
-    expect(nameInput).toHaveValue('Observability');
-  });
-
-  it('should not automatic update workspace name after manual input', () => {
-    const { getByTestId } = setup(false, mockDataSourceManagementSetup);
-
-    const nameInput = getByTestId('workspaceForm-workspaceDetails-nameInputText');
-    fireEvent.input(nameInput, {
-      target: { value: 'test workspace name' },
-    });
-    fireEvent.click(getByTestId('workspaceUseCase-observability'));
-    expect(nameInput).toHaveValue('test workspace name');
   });
 });

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator_form.tsx
@@ -52,33 +52,15 @@ export const WorkspaceCreatorForm = (props: WorkspaceCreatorFormProps) => {
     setDescription,
     handleFormSubmit,
     handleColorChange,
-    handleUseCaseChange: handleUseCaseChangeInHook,
+    handleUseCaseChange,
     setPermissionSettings,
     setSelectedDataSourceConnections,
   } = useWorkspaceForm(props);
-  const nameManualChangedRef = useRef(false);
 
   const disabledUserOrGroupInputIdsRef = useRef(
     defaultValues?.permissionSettings?.map((item) => item.id) ?? []
   );
   const isDashboardAdmin = application?.capabilities?.dashboards?.isDashboardAdmin ?? false;
-  const handleNameInputChange = useCallback(
-    (newName) => {
-      setName(newName);
-      nameManualChangedRef.current = true;
-    },
-    [setName]
-  );
-  const handleUseCaseChange = useCallback(
-    (newUseCase) => {
-      handleUseCaseChangeInHook(newUseCase);
-      const useCase = availableUseCases.find((item) => newUseCase === item.id);
-      if (!nameManualChangedRef.current && useCase) {
-        setName(useCase.title);
-      }
-    },
-    [handleUseCaseChangeInHook, availableUseCases, setName]
-  );
 
   return (
     <EuiFlexGroup className="workspaceCreateFormContainer">
@@ -99,7 +81,7 @@ export const WorkspaceCreatorForm = (props: WorkspaceCreatorFormProps) => {
             name={formData.name}
             color={formData.color}
             description={formData.description}
-            onNameChange={handleNameInputChange}
+            onNameChange={setName}
             onColorChange={handleColorChange}
             onDescriptionChange={setDescription}
           />

--- a/src/plugins/workspace/public/components/workspace_form/workspace_use_case.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_use_case.tsx
@@ -148,7 +148,7 @@ export const WorkspaceUseCase = ({
         error={formErrors.features?.message}
         fullWidth
       >
-        <EuiFlexGroup direction="column">
+        <EuiFlexGroup direction="column" gutterSize="s">
           {availableUseCases.map(({ id, icon, title, description, features, disabled }) => (
             <EuiFlexItem key={id}>
               <WorkspaceUseCaseCard


### PR DESCRIPTION
### Description

This PR include two changes in workspace use case selector.
1. Remove the workspace name populated logic after use case selected
2. Reduce gaps between use case cards


## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

![image](https://github.com/user-attachments/assets/abc0ab2a-b856-419d-bfb5-90082ce0ba06)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version loose`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
opensearchDashboards.dashboardAdmin.users: ['admin']
```
- Run `yarn start --no-base-path`
- Login with admin user and go to workspace create page by bottom left menu
- The use case selector should displayed like screenshot above
- The workspace name should be be populated after use case changed

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace]Remove workspace name populate after use case selected

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
