### PR TITLE
[Discover] support custom callback to combine multiple dataset selections

### DIFF
--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -64,4 +64,9 @@ export interface DatasetTypeConfig {
    * with this Dataset
    */
   getSearchOptions?: () => DatasetSearchOptions;
+  /**
+   * Combines a list of user selected data structures into a single one to use in discover.
+   * @see https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8362.
+   */
+  combineDataStructures?: (dataStructures: DataStructure[]) => DataStructure | undefined;
 }

--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
@@ -173,6 +173,7 @@ export const DatasetExplorer = ({
                 </EuiTitle>
                 {current.multiSelect ? (
                   <DatasetTable
+                    services={services}
                     path={path}
                     setPath={setPath}
                     index={index}

--- a/src/plugins/data/public/ui/dataset_selector/dataset_table.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_table.test.tsx
@@ -100,17 +100,12 @@ describe('DataSetTable', () => {
   });
 
   it('calls selectDataStructure with undefined when all items are deselected', async () => {
-    const propsWithSelection = {
-      ...mockProps,
-      explorerDataset: { id: 'child1,child2', title: 'Child 1,Child 2', type: 'index' },
-    };
-    renderWithIntl(<DatasetTable {...propsWithSelection} />);
+    renderWithIntl(<DatasetTable {...mockProps} />);
 
     const checkbox1 = screen.getByTestId('checkboxSelectRow-child1');
-    const checkbox2 = screen.getByTestId('checkboxSelectRow-child2');
 
     fireEvent.click(checkbox1);
-    fireEvent.click(checkbox2);
+    fireEvent.click(checkbox1);
 
     await waitFor(() => {
       expect(mockProps.selectDataStructure).toHaveBeenCalledWith(undefined, mockPath.slice(0, 3));

--- a/src/plugins/data/public/ui/dataset_selector/dataset_table.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_table.test.tsx
@@ -6,7 +6,9 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 import { IntlProvider } from 'react-intl';
-import { DataStructure } from '../../../common';
+import { CoreStart } from 'src/core/public';
+import { DataPublicPluginStart, IDataPluginServices } from '../..';
+import { DataStorage, DataStructure } from '../../../common';
 import { queryServiceMock } from '../../query/mocks';
 import { getQueryService } from '../../services';
 import { DatasetTable } from './dataset_table';
@@ -35,7 +37,26 @@ describe('DataSetTable', () => {
     },
   ];
 
+  const mockServices: IDataPluginServices = {
+    appName: 'testApp',
+    uiSettings: {} as CoreStart['uiSettings'],
+    savedObjects: {} as CoreStart['savedObjects'],
+    notifications: ({
+      toasts: {
+        addSuccess: jest.fn(),
+        addError: jest.fn(),
+      },
+    } as unknown) as CoreStart['notifications'],
+    http: {} as CoreStart['http'],
+    storage: {} as DataStorage,
+    data: {} as DataPublicPluginStart,
+    overlays: ({
+      openModal: jest.fn(),
+    } as unknown) as CoreStart['overlays'],
+  };
+
   const mockProps: ComponentProps<typeof DatasetTable> = {
+    services: mockServices,
     path: mockPath,
     setPath: jest.fn(),
     index: 2,


### PR DESCRIPTION
### Description

#8255 added a `DatasetTable` component to allow a `DatasetTypeConfig` to define if user can select and query multiple datasets. Discover currently only references one dataset (see #8362), so `DatasetTable` combines multiple selected datasets into a single one for Discover.

The `title` of the combined datasets will be used as part of the SQL/PPL query
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/cf7cb5bb5f6be4a7e83fa0ab71d98f843cfc67f0/src/plugins/query_enhancements/public/plugin.tsx#L73-L75
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/cf7cb5bb5f6be4a7e83fa0ab71d98f843cfc67f0/src/plugins/query_enhancements/public/plugin.tsx#L92-L94

and this syntax can be different for each dataset type. This PR allows the `DatasetTypeConfig` to define how should the user selected datasets be combined together, with a fallback combine function that keeps the previous behavior.

@ashwin-pc @amsiglan could you help to take a look? thanks

### Issues Resolved

Part of #8362

## Screenshot

No behavior change

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
