### PR TITLE
Allow overriding the themeTag temporarily via the query-string

### DIFF
--- a/packages/osd-ui-shared-deps/theme_config.d.ts
+++ b/packages/osd-ui-shared-deps/theme_config.d.ts
@@ -4,6 +4,16 @@
  */
 
 /**
+ * Types for valid theme versions
+ */
+type ThemeVersion = 'v7' | 'v8' | 'v9';
+
+/**
+ * Types for valid theme color-scheme modes
+ */
+type ThemeMode = 'light' | 'dark';
+
+/**
  * Types for valid theme tags (themeVersion + themeMode)
  * Note: used by @osd/optimizer
  */
@@ -15,6 +25,12 @@ export type ThemeTags = readonly ThemeTag[];
  * Note: used by @osd/optimizer
  */
 export const themeTags: ThemeTags;
+
+/**
+ * Map of themeTag values to their version and mode
+ * Note: this is used for ui display
+ */
+export const themeTagDetailMap: Map<ThemeTag, { version: ThemeVersion; mode: ThemeMode }>;
 
 /**
  * Map of themeVersion values to labels

--- a/packages/osd-ui-shared-deps/theme_config.js
+++ b/packages/osd-ui-shared-deps/theme_config.js
@@ -4,10 +4,11 @@
  */
 
 /**
- * The purpose of this file is to centalize theme configuration so it can be used across server,
+ * The purpose of this file is to centralize theme configuration so it can be used across server,
  * client, and dev tooling. DO NOT add dependencies that wouldn't operate in all of these contexts.
  *
  * Default theme is specified in the uiSettings schema.
+ * A version (key) and color-scheme mode cannot contain a backtick character.
  */
 
 const THEME_MODES = ['light', 'dark'];
@@ -23,13 +24,25 @@ const THEME_VERSION_VALUE_MAP = {
   ...Object.fromEntries(Object.keys(THEME_VERSION_LABEL_MAP).map((v) => [v, v])),
 };
 const THEME_VERSIONS = Object.keys(THEME_VERSION_LABEL_MAP);
-const THEME_TAGS = THEME_VERSIONS.flatMap((v) => THEME_MODES.map((m) => `${v}${m}`));
+const THEME_TAGS = [];
+
+const themeTagDetailMap = new Map();
+THEME_VERSIONS.forEach((version) => {
+  THEME_MODES.forEach((mode) => {
+    const key = `${version}${mode}`;
+
+    themeTagDetailMap.set(key, { version, mode });
+    THEME_TAGS.push(key);
+  });
+});
 
 exports.themeVersionLabelMap = THEME_VERSION_LABEL_MAP;
 
 exports.themeVersionValueMap = THEME_VERSION_VALUE_MAP;
 
 exports.themeTags = THEME_TAGS;
+
+exports.themeTagDetailMap = themeTagDetailMap;
 
 exports.themeCssDistFilenames = THEME_VERSIONS.reduce((map, v) => {
   map[v] = THEME_MODES.reduce((acc, m) => {

--- a/src/core/server/http/http_server.mocks.ts
+++ b/src/core/server/http/http_server.mocks.ts
@@ -153,6 +153,7 @@ function createRawRequestMock(customization: DeepPartial<Request> = {}) {
         isAuthenticated: true,
       },
       headers: {},
+      query: {},
       path,
       route: { settings: {} },
       url,

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -144,8 +144,8 @@ Object {
   "legacyMetadata": Object {
     "uiSettings": Object {
       "defaults": Object {
-        "registered": Object {
-          "name": "title",
+        "theme:darkMode": Object {
+          "value": true,
         },
       },
       "user": Object {},
@@ -306,11 +306,7 @@ Object {
   },
   "legacyMetadata": Object {
     "uiSettings": Object {
-      "defaults": Object {
-        "registered": Object {
-          "name": "title",
-        },
-      },
+      "defaults": Object {},
       "user": Object {},
     },
   },

--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -48,6 +48,8 @@ export const Styles: FunctionComponent<Props> = ({ theme, darkMode }) => {
 
   return (
     <style
+      data-theme={theme}
+      data-color-scheme={darkMode ? 'dark' : 'light'}
       dangerouslySetInnerHTML={{
         __html: `
           :root {

--- a/src/core/server/ui_settings/ui_settings_client.test.ts
+++ b/src/core/server/ui_settings/ui_settings_client.test.ts
@@ -367,7 +367,7 @@ describe('ui settings', () => {
       const value = chance.word();
       const override = chance.word();
       const defaults = { key: { value } };
-      const overrides = { key: { value: override } };
+      const overrides = { key: override };
       const { uiSettings } = setup({ defaults, overrides });
       expect(uiSettings.getOverrideOrDefault('key')).toEqual(override);
     });

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -120,7 +120,7 @@ export class UiSettingsClient implements IUiSettingsClient {
   }
 
   getOverrideOrDefault(key: string): unknown {
-    return this.isOverridden(key) ? this.overrides[key].value : this.defaults[key]?.value;
+    return this.isOverridden(key) ? this.overrides[key] : this.defaults[key]?.value;
   }
 
   getDefault(key: string): unknown {
@@ -155,7 +155,7 @@ export class UiSettingsClient implements IUiSettingsClient {
       }
     }
 
-    // write all overridden keys, dropping the userValue is override is null and
+    // write all overridden keys, dropping the userValue if override is null and
     // adding keys for overrides that are not in saved object
     for (const [key, value] of Object.entries(this.overrides)) {
       userProvided[key] =

--- a/src/core/server/ui_settings/ui_settings_config.ts
+++ b/src/core/server/ui_settings/ui_settings_config.ts
@@ -49,7 +49,6 @@ export const DEFAULT_THEME_VERSION = 'v8';
  *
  * The schema below exposes only a limited set of settings to be set in the config file.
  *
- * ToDo: Remove overrides; these were added to force the lock down the theme version.
  * The schema is temporarily relaxed to allow overriding the `darkMode` and setting
  * `defaults`. An upcoming change would relax them further to allow setting them.
  */

--- a/src/legacy/ui/ui_render/bootstrap/template.js.hbs
+++ b/src/legacy/ui/ui_render/bootstrap/template.js.hbs
@@ -2,7 +2,18 @@ var osdCsp = JSON.parse(document.querySelector('osd-csp').getAttribute('data'));
 window.__osdStrictCsp__ = osdCsp.strictCsp;
 window.__osdThemeTag__ = "{{themeTag}}";
 window.__osdPublicPath__ = {{publicPathMap}};
-window.__osdBundles__ = {{osdBundlesLoaderSource}}
+window.__osdBundles__ = {{osdBundlesLoaderSource}};
+
+
+// Handle theme overridden via query-string
+var themeTagOverride = new URLSearchParams(window.location.search).get('themeTag');
+if (themeTagOverride) {
+  if (`{{{validThemeTags}}}`.split(',').includes(themeTagOverride)) {
+    window.__osdThemeTag__ = themeTagOverride;
+  } else {
+    console.warn('Ignoring invalid `themeTag` override');
+  }
+}
 
 if (window.__osdStrictCsp__ && window.__osdCspNotEnforced__) {
   var legacyBrowserError = document.getElementById('osd_legacy_browser_error');
@@ -79,11 +90,8 @@ if (window.__osdStrictCsp__ && window.__osdCspNotEnforced__) {
     ], function () {
       __osdBundles__.get('entry/core/public').__osdBootstrap__();
 
-      load([
-        {{#each styleSheetPaths}}
-          '{{this}}',
-        {{/each}}
-      ]);
+      var styleSheetPaths = JSON.parse(`{{themeTagStyleSheetPaths}}`)[window.__osdThemeTag__];
+      load(styleSheetPaths);
     });
   }
 }


### PR DESCRIPTION
### Description

Allow temporarily overriding the `themeTag`  via the query-string

Also:
* Fix `getOverrideOrDefault` not correctly returning overridden values

Note: This change is only going to `2.x` because the handling of UiSettings in `main` is not back-portable and needs to be revisited.

Note: Tests are yet to be added.

## Changelog
- feat: Allow temporarily overriding the `themeTag`  via the query-string
- fix: Fix `getOverrideOrDefault` not correctly returning overridden values

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
