### PR TITLE
Add SearchOnLoad Preference for dataset

### DIFF
--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -24,6 +24,7 @@ export const indexPatternTypeConfig: DatasetTypeConfig = {
   meta: {
     icon: { type: 'indexPatternApp' },
     tooltip: 'OpenSearch Index Patterns',
+    searchOnLoad: true,
   },
 
   toDataset: (path) => {

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -21,6 +21,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
   meta: {
     icon: { type: 'logoOpenSearch' },
     tooltip: 'OpenSearch Indexes',
+    searchOnLoad: true,
   },
 
   toDataset: (path) => {

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -30,6 +30,8 @@ export interface DatasetTypeConfig {
     icon: EuiIconProps;
     /** Optional tooltip text */
     tooltip?: string;
+    /** Optional preference for search on page load else defaulted to true */
+    searchOnLoad?: boolean;
   };
   /**
    * Converts a DataStructure to a Dataset.

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -24,6 +24,7 @@ export const s3TypeConfig: DatasetTypeConfig = {
   meta: {
     icon: { type: S3_ICON },
     tooltip: 'Amazon S3 Connections',
+    searchOnLoad: true,
   },
 
   toDataset: (path: DataStructure[]): Dataset => {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This introduces a searchOnPageLoad preference for each dataset type. 
- When Advanced setting of searchOnPageLoad is OFF we respect the Advanced setting 
- When Advanced setting of searchOnPageLoad is ON we respect the selected dataset's searchOnLoad preference

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

For this demonstration below I have explicitly updated the `searchOnLoad` preference for indexes to be false.

https://github.com/user-attachments/assets/78cb0c86-959d-4b2a-b6d1-88874ac483eb



## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
