### PR TITLE
[Workspace]Analytics use case overview and essential use case overview crashed

### DIFF
--- a/changelogs/fragments/8524.yml
+++ b/changelogs/fragments/8524.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace]Analytics use case overview and essential use case overview crashed ([#8524](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8524))

--- a/src/plugins/workspace/public/application.tsx
+++ b/src/plugins/workspace/public/application.tsx
@@ -121,7 +121,7 @@ export const renderInitialApp = (
 
 export const renderUseCaseOverviewApp = async (
   { element }: AppMountParameters,
-  services: Services,
+  services: Omit<Services, 'collaboratorTypes'>,
   pageId: string
 ) => {
   ReactDOM.render(

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -466,7 +466,6 @@ export class WorkspacePlugin
             workspaceClient,
             dataSourceManagement,
             contentManagement: contentManagementStart,
-            collaboratorTypes: this.collaboratorTypes,
           };
 
           return renderUseCaseOverviewApp(params, services, ESSENTIAL_OVERVIEW_PAGE_ID);
@@ -502,7 +501,6 @@ export class WorkspacePlugin
             workspaceClient,
             dataSourceManagement,
             contentManagement: contentManagementStart,
-            collaboratorTypes: this.collaboratorTypes,
           };
 
           return renderUseCaseOverviewApp(params, services, ANALYTICS_ALL_OVERVIEW_PAGE_ID);


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR is for fixing page crashed in the analytics use case overview and essential use case overview. The root cause was using `this` inside a normal function. Since use case overview page doesn't need collaboratorTypes service, just remove it from the depend services list. 

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->


- Clone branch code and run `yarn osd bootstrap --single-version loose`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
opensearchDashboards.dashboardAdmin.users: ['admin']
```
- Run `yarn start --no-base-path`
- Login with admin user
- Go to analytics use case overview page, page should not crashed
- Go to essential use case overview page, page should not crashed

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Workspace]Analytics use case overview and essential use case overview crashed

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
