### PR TITLE
Encode searchId as it tends to be decoded after adds into url

### DIFF
--- a/changelogs/fragments/8530.yml
+++ b/changelogs/fragments/8530.yml
@@ -1,2 +1,2 @@
 fix:
-- Fix issue for adding a new visualization, the visualization id would be decoded. ([#8530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530))
+- Encode searchId as it tends to be decoded after adds into url. ([#8530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530))

--- a/changelogs/fragments/8530.yml
+++ b/changelogs/fragments/8530.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix issue for adding a new visualization, the visualization id would be decoded. ([#8530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530))

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -170,6 +170,7 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
     }
 
     params = [`type=${encodeURIComponent(visType.name)}`];
+    searchId = encodeURIComponent(searchId || '');
 
     if (searchType) {
       params.push(`${searchType === 'search' ? 'savedSearchId' : 'indexPattern'}=${searchId}`);


### PR DESCRIPTION
### Description

Fix the issue that when adding a new visualization, the visualization id would be decoded and leads to not found.


## Screenshot

![Screenshot 2024-10-07 at 11 52 58 PM](https://github.com/user-attachments/assets/524f2536-7d5d-451f-80d1-98fb1d122cd2)


## Changelog
- fix: Encode searchId as it tends to be decoded after adds into url.



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
