### PR TITLE
[MDS] Mute the non-mds endpoints for direct query data connections

### DIFF
--- a/changelogs/fragments/8537.yml
+++ b/changelogs/fragments/8537.yml
@@ -1,0 +1,2 @@
+fix:
+- [MDS] Mute the non-mds endpoints for direct query data connections ([#8537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8537))

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -62,7 +62,7 @@ export const getDirectQueryConnections = async (dataSourceId: string, http: Http
 };
 
 export const getLocalClusterConnections = async (http: HttpSetup) => {
-  const res = await http.get(`${DATACONNECTIONS_BASE}`);
+  const res = await http.get(`${DATACONNECTIONS_BASE}/dataSourceMDSId=''`);
   const localClusterConnections: DataSourceTableItem[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataConnection.name}`,

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -62,7 +62,7 @@ export const getDirectQueryConnections = async (dataSourceId: string, http: Http
 };
 
 export const getLocalClusterConnections = async (http: HttpSetup) => {
-  const res = await http.get(`${DATACONNECTIONS_BASE}/dataSourceMDSId=''`);
+  const res = await http.get(`${DATACONNECTIONS_BASE}/dataSourceMDSId=`);
   const localClusterConnections: DataSourceTableItem[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataConnection.name}`,

--- a/src/plugins/data_source_management/server/routes/data_connections_router.ts
+++ b/src/plugins/data_source_management/server/routes/data_connections_router.ts
@@ -16,7 +16,7 @@ import {
   EDIT,
 } from '../../framework/utils/shared';
 
-export function registerDataConnectionsRoute(router: IRouter, dataSourceEnabled: boolean) {
+export function registerNonMdsDataConnectionsRoute(router: IRouter) {
   router.get(
     {
       path: `${DATACONNECTIONS_BASE}/{name}`,
@@ -204,7 +204,9 @@ export function registerDataConnectionsRoute(router: IRouter, dataSourceEnabled:
       }
     }
   );
+}
 
+export function registerDataConnectionsRoute(router: IRouter, dataSourceEnabled: boolean) {
   router.get(
     {
       path: `${DATACONNECTIONS_BASE}/dataSourceMDSId={dataSourceMDSId?}`,

--- a/src/plugins/data_source_management/server/routes/index.ts
+++ b/src/plugins/data_source_management/server/routes/index.ts
@@ -5,7 +5,10 @@
 
 import { IRouter, ILegacyClusterClient } from '../../../../core/server';
 import { registerDslRoute } from './dsl';
-import { registerDataConnectionsRoute } from './data_connections_router';
+import {
+  registerDataConnectionsRoute,
+  registerNonMdsDataConnectionsRoute,
+} from './data_connections_router';
 import { registerDatasourcesRoute } from './datasources_router';
 import { registerPplRoute } from './ppl';
 import { DSLFacet } from '../services/facets/dsl_facet';
@@ -43,6 +46,9 @@ export function setupRoutes({
   // const queryService = new QueryService(client);
   // registerSqlRoute(router, queryService);
 
+  if (!dataSourceEnabled) {
+    registerNonMdsDataConnectionsRoute(router);
+  }
   registerDataConnectionsRoute(router, dataSourceEnabled);
   registerDatasourcesRoute(router, dataSourceEnabled);
 }


### PR DESCRIPTION
### Description
- Mute the non-mds endpoints for direct query data connections when MDS is enabled
- Use mds data connection endpoint instead for fetching local cluster direct query content

### Issues Resolved
* Relate https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8536

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: [MDS] Mute the non-mds endpoints for direct query data connections

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
