### PR TITLE
[workspace]fix the workspace selector jump that occurs when hovering and clicking.

### DIFF
--- a/changelogs/fragments/8541.yml
+++ b/changelogs/fragments/8541.yml
@@ -1,2 +1,2 @@
 fix:
-- The workspace selector jump that occurs when hovering and clicking ([#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541))
+- The workspace selector jump that occurs when hovering and clicking. ([#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541))

--- a/changelogs/fragments/8541.yml
+++ b/changelogs/fragments/8541.yml
@@ -1,2 +1,2 @@
 fix:
-- The workspace selector jump that occurs when hovering ([#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541))
+- The workspace selector jump that occurs when hovering and clicking ([#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541))

--- a/changelogs/fragments/8541.yml
+++ b/changelogs/fragments/8541.yml
@@ -1,0 +1,2 @@
+fix:
+- The workspace selector jump that occurs when hovering ([#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541))

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
@@ -2,8 +2,8 @@
   background-color: $euiSideNavBackgroundColor;
 }
 
-.popoverButton:hover,
-.popoverButton:focus {
+.workspaceSelectorPopoverButton:hover,
+.workspaceSelectorPopoverButton:focus {
   transition: none !important;
   transform: none !important;
 }

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
@@ -1,3 +1,9 @@
 .workspaceNameLabel {
   background-color: $euiSideNavBackgroundColor;
 }
+
+.popoverButton:hover,
+.popoverButton:focus {
+  transition: none !important;
+  transform: none !important;
+}

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -66,6 +66,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   };
   const button = currentWorkspace ? (
     <EuiPanel
+      className="popoverButton"
       paddingSize="none"
       color="transparent"
       hasBorder={false}

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -66,7 +66,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   };
   const button = currentWorkspace ? (
     <EuiPanel
-      className="popoverButton"
+      className="workspaceSelectorPopoverButton"
       paddingSize="none"
       color="transparent"
       hasBorder={false}


### PR DESCRIPTION
### Description

This pr fixes the workspace selector jump that occurs when hovering and clicking.

## Screenshot
Before:

https://github.com/user-attachments/assets/ac72b982-87f1-4fd6-885b-d8c242bb07bd

After:

https://github.com/user-attachments/assets/e3aecc24-9d0b-4934-a8d4-9846f0c83952



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: the workspace selector jump that occurs when hovering and clicking.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff



