### PR TITLE
Refactor workspace datasource association

### DIFF
--- a/changelogs/fragments/8545.yml
+++ b/changelogs/fragments/8545.yml
@@ -1,0 +1,2 @@
+feat:
+- Refactor data source list page to include data source association features for workspace ([#8545](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8545))

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -404,6 +404,7 @@ export {
   WorkspacesService,
   WorkspaceObject,
   IWorkspaceClient,
+  IWorkspaceResponse,
 } from './workspace';
 
 export { debounce } from './utils';

--- a/src/core/public/workspace/index.ts
+++ b/src/core/public/workspace/index.ts
@@ -8,5 +8,6 @@ export {
   WorkspacesService,
   WorkspacesSetup,
   WorkspaceObject,
-  IWorkspaceClient,
 } from './workspaces_service';
+
+export { IWorkspaceClient, IWorkspaceResponse } from './types';

--- a/src/core/public/workspace/index.ts
+++ b/src/core/public/workspace/index.ts
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export {
-  WorkspacesStart,
-  WorkspacesService,
-  WorkspacesSetup,
-  WorkspaceObject,
-} from './workspaces_service';
+export { WorkspacesStart, WorkspacesService, WorkspacesSetup } from './workspaces_service';
 
-export { IWorkspaceClient, IWorkspaceResponse } from './types';
+export { IWorkspaceClient, IWorkspaceResponse, WorkspaceObject } from './types';

--- a/src/core/public/workspace/types.ts
+++ b/src/core/public/workspace/types.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { WorkspaceAttribute } from '../../types';
+
+export type WorkspaceObject = WorkspaceAttribute & { readonly?: boolean };
+
 export type IWorkspaceResponse<T> =
   | {
       result: T;
@@ -45,6 +49,24 @@ export interface IWorkspaceClient {
     savedObjects: Array<{ id: string; type: string }>,
     workspaceId: string
   ): Promise<IWorkspaceResponse<AssociationResult[]>>;
+
+  /**
+   * Dissociates a list of objects from the given workspace ID.
+   *
+   * This method takes a workspace ID and an array of objects, where each object contains
+   * an `id` and `type`. It attempts to dissociate each object from the specified workspace.
+   * If the dissociation succeeds, the object is included in the result without an error.
+   * If there is an issue dissociating an object, an error message is returned for that object.
+   *
+   * @returns A promise that resolves to a response object containing an array of results for each object.
+   *          Each result will include the object's `id` and, if there was an error during dissociation, an `error` field
+   *          with the error message.
+   */
+  dissociate(
+    savedObjects: Array<{ id: string; type: string }>,
+    workspaceId: string
+  ): Promise<IWorkspaceResponse<AssociationResult[]>>;
+
   ui(): WorkspaceUI;
 }
 

--- a/src/core/public/workspace/types.ts
+++ b/src/core/public/workspace/types.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type IWorkspaceResponse<T> =
+  | {
+      result: T;
+      success: true;
+    }
+  | {
+      success: false;
+      error?: string;
+    };
+
+export interface AssociationResult {
+  id: string;
+  error?: string;
+}
+
+export interface IWorkspaceClient {
+  /**
+   * copy saved objects to target workspace
+   *
+   * @param {Array<{ id: string; type: string }>} objects
+   * @param {string} targetWorkspace
+   * @param {boolean} includeReferencesDeep
+   * @returns {Promise<IResponse<any>>} result for this operation
+   */
+  copy(objects: any[], targetWorkspace: string, includeReferencesDeep?: boolean): Promise<any>;
+
+  /**
+   * Associates a list of objects with the given workspace ID.
+   *
+   * This method takes a workspace ID and an array of objects, where each object contains
+   * an `id` and `type`. It attempts to associate each object with the specified workspace.
+   * If the association succeeds, the object is included in the result without an error.
+   * If there is an issue associating an object, an error message is returned for that object.
+   *
+   * @returns A promise that resolves to a response object containing an array of results for each object.
+   *          Each result will include the object's `id` and, if there was an error during association, an `error` field
+   *          with the error message.
+   */
+  associate(
+    savedObjects: Array<{ id: string; type: string }>,
+    workspaceId: string
+  ): Promise<IWorkspaceResponse<AssociationResult[]>>;
+  ui(): WorkspaceUI;
+}
+
+interface DataSourceAssociationProps {
+  excludedDataSourceIds: string[];
+  onComplete?: () => void;
+  onError?: () => void;
+}
+
+export interface WorkspaceUI {
+  DataSourceAssociation: (props: DataSourceAssociationProps) => JSX.Element;
+}

--- a/src/core/public/workspace/types.ts
+++ b/src/core/public/workspace/types.ts
@@ -22,6 +22,12 @@ export interface AssociationResult {
   error?: string;
 }
 
+/**
+ * This interface representing a client for managing workspace-related operations.
+ * Workspace client should implement this interface.
+ *
+ * TODO: Refactor the current workspace client implementation in workspace plugin to add the missing operations to this interface
+ */
 export interface IWorkspaceClient {
   /**
    * copy saved objects to target workspace

--- a/src/core/public/workspace/workspaces_service.mock.ts
+++ b/src/core/public/workspace/workspaces_service.mock.ts
@@ -6,7 +6,8 @@
 import { BehaviorSubject } from 'rxjs';
 import type { PublicMethodsOf } from '@osd/utility-types';
 
-import { WorkspacesService, WorkspaceObject, IWorkspaceClient } from './workspaces_service';
+import { IWorkspaceClient, WorkspaceObject } from './types';
+import { WorkspacesService } from './workspaces_service';
 
 const createWorkspacesSetupContractMock = () => {
   const currentWorkspaceId$ = new BehaviorSubject<string>('');

--- a/src/core/public/workspace/workspaces_service.test.ts
+++ b/src/core/public/workspace/workspaces_service.test.ts
@@ -3,12 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  WorkspacesService,
-  WorkspacesSetup,
-  WorkspacesStart,
-  IWorkspaceClient,
-} from './workspaces_service';
+import { IWorkspaceClient } from './types';
+import { WorkspacesService, WorkspacesSetup, WorkspacesStart } from './workspaces_service';
 
 describe('WorkspacesService', () => {
   let workspaces: WorkspacesService;
@@ -43,7 +39,12 @@ describe('WorkspacesService', () => {
   });
 
   it('client is updated when set client', () => {
-    const client: IWorkspaceClient = { copy: jest.fn() };
+    const client: IWorkspaceClient = {
+      copy: jest.fn(),
+      associate: jest.fn(),
+      dissociate: jest.fn(),
+      ui: jest.fn(),
+    };
     workspacesSetUp.setClient(client);
     expect(workspacesStart.client$.value).toEqual(client);
   });

--- a/src/core/public/workspace/workspaces_service.ts
+++ b/src/core/public/workspace/workspaces_service.ts
@@ -7,12 +7,9 @@ import { BehaviorSubject, combineLatest } from 'rxjs';
 import { isEqual } from 'lodash';
 
 import { CoreService, WorkspaceAttribute } from '../../types';
+import { IWorkspaceClient } from './types';
 
 export type WorkspaceObject = WorkspaceAttribute & { readonly?: boolean };
-
-export interface IWorkspaceClient {
-  copy(objects: any[], targetWorkspace: string, includeReferencesDeep?: boolean): Promise<any>;
-}
 
 interface WorkspaceObservables {
   /**

--- a/src/core/public/workspace/workspaces_service.ts
+++ b/src/core/public/workspace/workspaces_service.ts
@@ -6,10 +6,8 @@
 import { BehaviorSubject, combineLatest } from 'rxjs';
 import { isEqual } from 'lodash';
 
-import { CoreService, WorkspaceAttribute } from '../../types';
-import { IWorkspaceClient } from './types';
-
-export type WorkspaceObject = WorkspaceAttribute & { readonly?: boolean };
+import { CoreService } from '../../types';
+import { IWorkspaceClient, WorkspaceObject } from './types';
 
 interface WorkspaceObservables {
   /**

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
@@ -111,7 +111,7 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
 
   const fetchDataSources = () => {
     setIsLoading(true);
-    getDataSources(savedObjects.client)
+    return getDataSources(savedObjects.client)
       .then((response: DataSourceTableItem[]) => {
         return fetchDataSourceConnections(response, http, notifications, false);
       })
@@ -149,7 +149,10 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
           currentWorkspace.id
         );
       }
-      fetchDataSources();
+      await fetchDataSources();
+      if (defaultDataSourceId === item.id) {
+        setFirstDataSourceAsDefault(savedObjects.client, uiSettings, true);
+      }
     }
   };
 

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.test.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.test.tsx
@@ -14,6 +14,7 @@ import { scopedHistoryMock } from '../../../../../../core/public/mocks';
 import { OpenSearchDashboardsContextProvider } from '../../../../../opensearch_dashboards_react/public';
 import { getMappedDataSources, mockManagementPlugin } from '../../../mocks';
 import { ManageDirectQueryDataConnectionsTable } from './manage_direct_query_data_connections_table';
+import { BehaviorSubject } from 'rxjs';
 
 const deleteButtonIdentifier = '[data-test-subj="deleteDataSourceConnections"]';
 const tableIdentifier = 'EuiInMemoryTable';
@@ -62,7 +63,7 @@ describe('ManageDirectQueryDataConnectionsTable', () => {
         Promise.resolve(getMappedDataSources)
       );
       spyOn(utils, 'getHideLocalCluster').and.returnValue(false);
-      spyOn(uiSettings, 'get').and.returnValue('test1');
+      spyOn(uiSettings, 'get$').and.returnValue(new BehaviorSubject('test1'));
       await act(async () => {
         component = await mount(
           wrapWithIntl(

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.tsx
@@ -238,7 +238,7 @@ export const ManageDirectQueryDataConnectionsTable = ({
       ? getDataSources(savedObjects.client)
       : http.get(`${DATACONNECTIONS_BASE}`);
 
-    fetchConnections
+    return fetchConnections
       .then((response) => {
         return featureFlagStatus
           ? fetchDataSourceConnections(
@@ -406,7 +406,10 @@ export const ManageDirectQueryDataConnectionsTable = ({
           currentWorkspace.id
         );
       }
-      fetchDataSources();
+      await fetchDataSources();
+      if (defaultDataSourceId === item.id) {
+        setFirstDataSourceAsDefault(savedObjects.client, uiSettings, true);
+      }
     }
   };
 

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -30,6 +30,7 @@ import {
   SkippingIndexRowType,
 } from '../framework/types';
 import { AvailableIntegrationsTableProps } from './components/direct_query_data_sources_components/integrations/available_integration_table';
+import { navigationPluginMock } from 'src/plugins/navigation/public/mocks';
 
 /* Mock Types */
 
@@ -54,6 +55,7 @@ const createDataSourceManagementContext = () => {
     uiSettings,
     notifications,
     overlays,
+    workspaces,
   } = coreMock.createStart();
   const { http } = coreMock.createSetup();
 
@@ -64,10 +66,12 @@ const createDataSourceManagementContext = () => {
     uiSettings,
     notifications,
     overlays,
+    workspaces,
     http,
     docLinks,
     setBreadcrumbs: () => {},
     authenticationMethodRegistry,
+    navigation: navigationPluginMock.createStartContract(),
   };
 };
 

--- a/src/plugins/data_source_management/public/mocks.ts
+++ b/src/plugins/data_source_management/public/mocks.ts
@@ -30,7 +30,7 @@ import {
   SkippingIndexRowType,
 } from '../framework/types';
 import { AvailableIntegrationsTableProps } from './components/direct_query_data_sources_components/integrations/available_integration_table';
-import { navigationPluginMock } from 'src/plugins/navigation/public/mocks';
+import { navigationPluginMock } from '../../navigation/public/mocks';
 
 /* Mock Types */
 

--- a/src/plugins/workspace/public/components/data_source_association/data_source_association.test.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/data_source_association.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { coreMock } from '../../../../../core/public/mocks';
+import {
+  useOpenSearchDashboards,
+  toMountPoint,
+} from '../../../../opensearch_dashboards_react/public';
+import { DataSourceAssociation } from './data_source_association';
+import { AssociationDataSourceModalContent } from '../workspace_detail/association_data_source_modal';
+import { DataSourceConnectionType } from 'src/plugins/workspace/common/types';
+import { BehaviorSubject } from 'rxjs';
+import { IWorkspaceClient } from 'opensearch-dashboards/public';
+
+jest.mock('../../../../opensearch_dashboards_react/public', () => ({
+  ...jest.requireActual('../../../../opensearch_dashboards_react/public'),
+  useOpenSearchDashboards: jest.fn(),
+  toMountPoint: jest.fn(),
+}));
+
+jest.mock('../workspace_detail/association_data_source_modal', () => ({
+  AssociationDataSourceModalContent: jest.fn(),
+}));
+
+describe('<DataSourceAssociation />', () => {
+  let servicesMock: ReturnType<typeof coreMock.createStart>;
+  beforeEach(() => {
+    servicesMock = coreMock.createStart();
+    (useOpenSearchDashboards as jest.Mock).mockImplementation(() => {
+      return { services: servicesMock };
+    });
+    (toMountPoint as jest.Mock).mockImplementation((node: React.ReactNode) => {
+      return () => render(<>{node}</>);
+    });
+    servicesMock.overlays.openModal.mockImplementation((fn) => {
+      fn();
+      return { close: jest.fn(), onClose: jest.fn() };
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders Associate data sources button', () => {
+    render(<DataSourceAssociation excludedDataSourceIds={[]} />);
+    expect(screen.getByText('Associate data sources')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('workspaceAssociateDataSourceButton'));
+    expect(screen.getByText('OpenSearch data sources')).toBeInTheDocument();
+    expect(screen.getByText('Direct query data sources')).toBeInTheDocument();
+  });
+
+  it('should open association modal', async () => {
+    (AssociationDataSourceModalContent as jest.Mock).mockImplementation(() => (
+      <div>Mocked association data source modal</div>
+    ));
+    render(<DataSourceAssociation excludedDataSourceIds={[]} />);
+    fireEvent.click(screen.getByTestId('workspaceAssociateDataSourceButton'));
+    fireEvent.click(screen.getByText('OpenSearch data sources'));
+    expect(servicesMock.overlays.openModal).toHaveBeenCalled();
+    expect(screen.getByText('Mocked association data source modal')).toBeInTheDocument();
+  });
+
+  it('should associate data sources successfully', async () => {
+    const associateMock = jest
+      .fn()
+      .mockResolvedValue({ success: true, result: [{ id: 'id1' }, { id: 'id2' }] });
+    servicesMock.workspaces.client$ = new BehaviorSubject<IWorkspaceClient | null>({
+      associate: associateMock,
+      copy: jest.fn(),
+      dissociate: jest.fn(),
+      ui: jest.fn(),
+    });
+    servicesMock.workspaces.currentWorkspaceId$ = new BehaviorSubject<string>('workspace_test');
+
+    (AssociationDataSourceModalContent as jest.Mock).mockImplementation((props: any) => (
+      <button
+        onClick={() =>
+          props.handleAssignDataSourceConnections([
+            { id: 'id1', connectionType: DataSourceConnectionType.OpenSearchConnection },
+            { id: 'id2', connectionType: DataSourceConnectionType.OpenSearchConnection },
+          ])
+        }
+      >
+        Mocked association button
+      </button>
+    ));
+
+    render(<DataSourceAssociation excludedDataSourceIds={[]} />);
+    fireEvent.click(screen.getByTestId('workspaceAssociateDataSourceButton'));
+    fireEvent.click(screen.getByText('OpenSearch data sources'));
+    fireEvent.click(screen.getByText('Mocked association button'));
+    await waitFor(() => {
+      expect(associateMock).toHaveBeenCalled();
+      expect(servicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ title: '2 data sources been associated to the workspace' })
+      );
+    });
+  });
+
+  it('should display error toast when associate data source failed', async () => {
+    const associateMock = jest.fn().mockRejectedValue(new Error());
+    servicesMock.workspaces.client$ = new BehaviorSubject<IWorkspaceClient | null>({
+      associate: associateMock,
+      copy: jest.fn(),
+      dissociate: jest.fn(),
+      ui: jest.fn(),
+    });
+    servicesMock.workspaces.currentWorkspaceId$ = new BehaviorSubject<string>('workspace_test');
+
+    (AssociationDataSourceModalContent as jest.Mock).mockImplementation((props: any) => (
+      <button
+        onClick={() =>
+          props.handleAssignDataSourceConnections([
+            { id: 'id1', connectionType: DataSourceConnectionType.OpenSearchConnection },
+            { id: 'id2', connectionType: DataSourceConnectionType.OpenSearchConnection },
+          ])
+        }
+      >
+        Mocked association button
+      </button>
+    ));
+
+    render(<DataSourceAssociation excludedDataSourceIds={[]} />);
+    fireEvent.click(screen.getByTestId('workspaceAssociateDataSourceButton'));
+    fireEvent.click(screen.getByText('OpenSearch data sources'));
+    fireEvent.click(screen.getByText('Mocked association button'));
+    await waitFor(() => {
+      expect(associateMock).toHaveBeenCalled();
+      expect(servicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Failed to associate 2 data sources to the workspace' })
+      );
+    });
+  });
+
+  it('should display toast when associate data source partially success', async () => {
+    const associateMock = jest.fn().mockResolvedValue({
+      success: true,
+      // id1 failed to associate with error
+      result: [{ id: 'id1', error: new Error() }, { id: 'id2' }],
+    });
+    servicesMock.workspaces.client$ = new BehaviorSubject<IWorkspaceClient | null>({
+      associate: associateMock,
+      copy: jest.fn(),
+      dissociate: jest.fn(),
+      ui: jest.fn(),
+    });
+    servicesMock.workspaces.currentWorkspaceId$ = new BehaviorSubject<string>('workspace_test');
+
+    (AssociationDataSourceModalContent as jest.Mock).mockImplementation((props: any) => (
+      <button
+        onClick={() =>
+          props.handleAssignDataSourceConnections([
+            { id: 'id1', connectionType: DataSourceConnectionType.OpenSearchConnection },
+            { id: 'id2', connectionType: DataSourceConnectionType.OpenSearchConnection },
+          ])
+        }
+      >
+        Mocked association button
+      </button>
+    ));
+
+    render(<DataSourceAssociation excludedDataSourceIds={[]} />);
+    fireEvent.click(screen.getByTestId('workspaceAssociateDataSourceButton'));
+    fireEvent.click(screen.getByText('OpenSearch data sources'));
+    fireEvent.click(screen.getByText('Mocked association button'));
+    await waitFor(() => {
+      expect(associateMock).toHaveBeenCalled();
+      expect(servicesMock.notifications.toasts.addDanger).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Failed to associate 1 data source to the workspace' })
+      );
+      expect(servicesMock.notifications.toasts.addSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ title: '1 data source been associated to the workspace' })
+      );
+    });
+  });
+});

--- a/src/plugins/workspace/public/components/data_source_association/data_source_association.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/data_source_association.tsx
@@ -29,7 +29,7 @@ interface Props {
   onError?: () => void;
 }
 
-export const DataSourceAssociation = (props: Props) => {
+export const DataSourceAssociation = ({ excludedDataSourceIds, onComplete, onError }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const associationModalRef = useRef<OverlayRef>();
 
@@ -69,10 +69,14 @@ export const DataSourceAssociation = (props: Props) => {
             // If failed to workspaceClient.associate, all data sources association is failed
             failedCount = objects.length;
           }
-          props.onComplete?.();
+          if (onComplete) {
+            onComplete();
+          }
         } catch (e) {
           failedCount = objects.length;
-          props.onError?.();
+          if (onError) {
+            onError();
+          }
         } finally {
           associationModalRef.current?.close();
         }
@@ -82,7 +86,7 @@ export const DataSourceAssociation = (props: Props) => {
             id: 'workspace_data_source_association_failed',
             title: i18n.translate('workspace.dataSource.association.failedTitle', {
               defaultMessage:
-                'Failed to associate {failedCount, plural, one {the data source} other {# data sources}} to the workspace',
+                'Failed to associate {failedCount, plural, one {# data source} other {# data sources}} to the workspace',
               values: { failedCount },
             }),
           });
@@ -92,14 +96,14 @@ export const DataSourceAssociation = (props: Props) => {
             id: 'workspace_data_source_association_succeed',
             title: i18n.translate('workspace.dataSource.association.succeedTitle', {
               defaultMessage:
-                '{succeedCount, plural, one {the data source} other {# data sources}} been associated to the workspace',
+                '{succeedCount, plural, one {# data source} other {# data sources}} been associated to the workspace',
               values: { succeedCount: objects.length - failedCount },
             }),
           });
         }
       }
     },
-    [workspaceClient, currentWorkspaceId, notifications]
+    [workspaceClient, currentWorkspaceId, notifications, onComplete, onError]
   );
 
   const showAssociationModal = useCallback(
@@ -112,7 +116,7 @@ export const DataSourceAssociation = (props: Props) => {
               http={http}
               savedObjects={savedObjects}
               notifications={notifications}
-              excludedConnectionIds={props.excludedDataSourceIds}
+              excludedConnectionIds={excludedDataSourceIds}
               closeModal={() => associationModalRef.current?.close()}
               handleAssignDataSourceConnections={onAssociateDataSource}
               mode={mode}
@@ -129,13 +133,20 @@ export const DataSourceAssociation = (props: Props) => {
       notifications,
       savedObjects,
       closePopover,
-      props.excludedDataSourceIds,
+      excludedDataSourceIds,
       onAssociateDataSource,
     ]
   );
 
   const button = (
-    <EuiButton size="s" fill iconType="arrowDown" iconSide="right" onClick={openPopover}>
+    <EuiButton
+      data-test-subj="workspaceAssociateDataSourceButton"
+      size="s"
+      fill
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={openPopover}
+    >
       <EuiIcon type="plusInCircle" />{' '}
       {i18n.translate('workspace.dataSources.associationButton.label', {
         defaultMessage: 'Associate data sources',

--- a/src/plugins/workspace/public/components/data_source_association/data_source_association.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/data_source_association.tsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiIcon,
+  EuiPopover,
+} from '@elastic/eui';
+import React, { useCallback, useState, useRef } from 'react';
+import { i18n } from '@osd/i18n';
+import { useObservable } from 'react-use';
+import { of } from 'rxjs';
+import { OverlayRef } from '../../../../../../src/core/public';
+import {
+  toMountPoint,
+  useOpenSearchDashboards,
+} from '../../../../opensearch_dashboards_react/public';
+import { AssociationDataSourceModalContent } from '../workspace_detail/association_data_source_modal';
+import { AssociationDataSourceModalMode } from '../../../common/constants';
+import { DataSourceConnection, DataSourceConnectionType } from '../../../common/types';
+
+interface Props {
+  excludedDataSourceIds: string[];
+  onComplete?: () => void;
+  onError?: () => void;
+}
+
+export const DataSourceAssociation = (props: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const associationModalRef = useRef<OverlayRef>();
+
+  const {
+    chrome,
+    savedObjects,
+    http,
+    notifications,
+    overlays,
+    workspaces,
+  } = useOpenSearchDashboards().services;
+  const workspaceClient = useObservable(workspaces?.client$ ?? of(null));
+  const currentWorkspaceId = useObservable(workspaces?.currentWorkspaceId$ ?? of(null));
+
+  const closePopover = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const openPopover = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const onAssociateDataSource = useCallback(
+    async (ds: DataSourceConnection[]) => {
+      const objects = ds
+        .filter((d) => d.connectionType === DataSourceConnectionType.OpenSearchConnection)
+        .map((d) => ({ id: d.id, type: 'data-source' }));
+
+      if (workspaceClient && currentWorkspaceId) {
+        let failedCount = 0;
+        try {
+          const res = await workspaceClient.associate(objects, currentWorkspaceId);
+
+          if (res.success) {
+            failedCount = res.result.filter((r) => !!r.error).length;
+          } else {
+            // If failed to workspaceClient.associate, all data sources association is failed
+            failedCount = objects.length;
+          }
+          props.onComplete?.();
+        } catch (e) {
+          failedCount = objects.length;
+          props.onError?.();
+        } finally {
+          associationModalRef.current?.close();
+        }
+
+        if (failedCount > 0) {
+          notifications?.toasts.addDanger({
+            id: 'workspace_data_source_association_failed',
+            title: i18n.translate('workspace.dataSource.association.failedTitle', {
+              defaultMessage:
+                'Failed to associate {failedCount, plural, one {the data source} other {# data sources}} to the workspace',
+              values: { failedCount },
+            }),
+          });
+        }
+        if (failedCount < objects.length) {
+          notifications?.toasts.addSuccess({
+            id: 'workspace_data_source_association_succeed',
+            title: i18n.translate('workspace.dataSource.association.succeedTitle', {
+              defaultMessage:
+                '{succeedCount, plural, one {the data source} other {# data sources}} been associated to the workspace',
+              values: { succeedCount: objects.length - failedCount },
+            }),
+          });
+        }
+      }
+    },
+    [workspaceClient, currentWorkspaceId, notifications]
+  );
+
+  const showAssociationModal = useCallback(
+    (mode: AssociationDataSourceModalMode) => {
+      closePopover();
+      if (overlays && savedObjects && chrome) {
+        associationModalRef.current = overlays.openModal(
+          toMountPoint(
+            <AssociationDataSourceModalContent
+              http={http}
+              savedObjects={savedObjects}
+              notifications={notifications}
+              excludedConnectionIds={props.excludedDataSourceIds}
+              closeModal={() => associationModalRef.current?.close()}
+              handleAssignDataSourceConnections={onAssociateDataSource}
+              mode={mode}
+              logos={chrome.logos}
+            />
+          )
+        );
+      }
+    },
+    [
+      overlays,
+      chrome,
+      http,
+      notifications,
+      savedObjects,
+      closePopover,
+      props.excludedDataSourceIds,
+      onAssociateDataSource,
+    ]
+  );
+
+  const button = (
+    <EuiButton size="s" fill iconType="arrowDown" iconSide="right" onClick={openPopover}>
+      <EuiIcon type="plusInCircle" />{' '}
+      {i18n.translate('workspace.dataSources.associationButton.label', {
+        defaultMessage: 'Associate data sources',
+      })}
+    </EuiButton>
+  );
+
+  const items = [
+    <EuiContextMenuItem
+      key="opensearchDataSources"
+      onClick={() => showAssociationModal(AssociationDataSourceModalMode.OpenSearchConnections)}
+    >
+      {i18n.translate('workspace.dataSources.associationButton.opensearch.label', {
+        defaultMessage: 'OpenSearch data sources',
+      })}
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="directQueryDataSources"
+      onClick={() => showAssociationModal(AssociationDataSourceModalMode.DirectQueryConnections)}
+    >
+      {i18n.translate('workspace.dataSources.associationButton.directQuery.label', {
+        defaultMessage: 'Direct query data sources',
+      })}
+    </EuiContextMenuItem>,
+  ];
+
+  return (
+    <EuiPopover
+      button={button}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenuPanel items={items} />
+    </EuiPopover>
+  );
+};

--- a/src/plugins/workspace/public/components/workspace_detail/association_data_source_modal.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/association_data_source_modal.test.tsx
@@ -18,7 +18,7 @@ import { AssociationDataSourceModalMode } from 'src/plugins/workspace/common/con
 
 const setupAssociationDataSourceModal = ({
   mode,
-  assignedConnections,
+  excludedConnectionIds,
   handleAssignDataSourceConnections,
 }: Partial<AssociationDataSourceModalProps> = {}) => {
   const coreServices = coreMock.createStart();
@@ -69,7 +69,7 @@ const setupAssociationDataSourceModal = ({
         notifications={coreServices.notifications}
         savedObjects={coreServices.savedObjects}
         closeModal={jest.fn()}
-        assignedConnections={assignedConnections ?? []}
+        excludedConnectionIds={excludedConnectionIds ?? []}
         handleAssignDataSourceConnections={handleAssignDataSourceConnections ?? jest.fn()}
       />
     </IntlProvider>
@@ -135,14 +135,7 @@ describe('AssociationDataSourceModal', () => {
 
   it('should hide associated connections', async () => {
     setupAssociationDataSourceModal({
-      assignedConnections: [
-        {
-          id: 'ds2',
-          name: 'Data Source 2',
-          connectionType: DataSourceConnectionType.OpenSearchConnection,
-          type: 'OpenSearch',
-        },
-      ],
+      excludedConnectionIds: ['ds2'],
     });
     expect(
       screen.getByText(

--- a/src/plugins/workspace/public/components/workspace_detail/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/association_data_source_modal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Fragment, useEffect, useState, useCallback } from 'react';
+import { Fragment, useEffect, useState, useCallback, useRef } from 'react';
 import React from 'react';
 import {
   EuiText,
@@ -129,20 +129,19 @@ const convertConnectionsToOptions = ({
   connections,
   showDirectQueryConnections,
   selectedConnectionIds,
-  assignedConnections,
+  excludedConnectionIds,
   logos,
 }: {
   connections: DataSourceConnection[];
-  assignedConnections: DataSourceConnection[];
+  excludedConnectionIds: string[];
   showDirectQueryConnections: boolean;
   selectedConnectionIds: string[];
   logos: Logos;
 }) => {
-  const assignedConnectionIds = assignedConnections.map(({ id }) => id);
   return connections
     .flatMap((connection) => {
       if (
-        assignedConnectionIds.includes(connection.id) ||
+        excludedConnectionIds.includes(connection.id) ||
         connection.connectionType === DataSourceConnectionType.DirectQueryConnection
       ) {
         return [];
@@ -173,20 +172,28 @@ export interface AssociationDataSourceModalProps {
   http: HttpStart | undefined;
   notifications: NotificationsStart | undefined;
   savedObjects: SavedObjectsStart;
-  assignedConnections: DataSourceConnection[];
+  excludedConnectionIds: string[];
   mode: AssociationDataSourceModalMode;
   closeModal: () => void;
-  handleAssignDataSourceConnections: (connections: DataSourceConnection[]) => void;
+  handleAssignDataSourceConnections: (connections: DataSourceConnection[]) => Promise<void> | void;
   logos: Logos;
 }
 
-export const AssociationDataSourceModal = ({
+export const AssociationDataSourceModal = (props: AssociationDataSourceModalProps) => {
+  return (
+    <EuiModal onClose={props.closeModal} style={{ width: 630 }}>
+      <AssociationDataSourceModalContent {...props} />
+    </EuiModal>
+  );
+};
+
+export const AssociationDataSourceModalContent = ({
   mode,
   http,
   notifications,
   closeModal,
   savedObjects,
-  assignedConnections,
+  excludedConnectionIds,
   handleAssignDataSourceConnections,
   logos,
 }: AssociationDataSourceModalProps) => {
@@ -194,6 +201,15 @@ export const AssociationDataSourceModal = ({
   const [selectedConnectionIds, setSelectedConnectionIds] = useState<string[]>([]);
   const [options, setOptions] = useState<DataSourceModalOption[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const handleSelectionChange = useCallback((newOptions: DataSourceModalOption[]) => {
     setSelectedConnectionIds(
@@ -201,10 +217,15 @@ export const AssociationDataSourceModal = ({
     );
   }, []);
 
-  const handleSaveButtonClick = useCallback(() => {
-    handleAssignDataSourceConnections(
+  const handleSaveButtonClick = useCallback(async () => {
+    setIsSaving(true);
+    const res = handleAssignDataSourceConnections(
       allConnections.filter((connection) => selectedConnectionIds.includes(connection.id))
     );
+    await Promise.resolve(res);
+    if (mountedRef.current) {
+      setIsSaving(false);
+    }
   }, [selectedConnectionIds, allConnections, handleAssignDataSourceConnections]);
 
   useEffect(() => {
@@ -223,16 +244,16 @@ export const AssociationDataSourceModal = ({
     setOptions(
       convertConnectionsToOptions({
         connections: allConnections,
-        assignedConnections,
+        excludedConnectionIds,
         selectedConnectionIds,
         showDirectQueryConnections: mode === AssociationDataSourceModalMode.DirectQueryConnections,
         logos,
       })
     );
-  }, [allConnections, assignedConnections, selectedConnectionIds, mode, logos]);
+  }, [allConnections, excludedConnectionIds, selectedConnectionIds, mode, logos]);
 
   return (
-    <EuiModal onClose={closeModal} style={{ width: 630 }}>
+    <>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
           {mode === AssociationDataSourceModalMode.OpenSearchConnections ? (
@@ -292,6 +313,7 @@ export const AssociationDataSourceModal = ({
           data-test-subj="workspace-detail-dataSources-associateModal-save-button"
           onClick={handleSaveButtonClick}
           isDisabled={selectedConnectionIds.length === 0}
+          isLoading={isSaving}
           fill
         >
           <FormattedMessage
@@ -300,6 +322,6 @@ export const AssociationDataSourceModal = ({
           />
         </EuiSmallButton>
       </EuiModalFooter>
-    </EuiModal>
+    </>
   );
 };

--- a/src/plugins/workspace/public/components/workspace_detail/select_data_source_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_detail/select_data_source_panel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import {
   EuiText,
   EuiTitle,
@@ -281,6 +281,10 @@ export const SelectDataSourceDetailPanel = ({
     setIsLoading(loading);
   }, [loading]);
 
+  const excludedConnectionIds = useMemo(() => {
+    return formData.selectedDataSourceConnections.map((c) => c.id);
+  }, [formData.selectedDataSourceConnections]);
+
   return (
     <EuiPanel>
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
@@ -312,7 +316,7 @@ export const SelectDataSourceDetailPanel = ({
           notifications={notifications}
           savedObjects={savedObjects}
           closeModal={() => setIsVisible(false)}
-          assignedConnections={formData.selectedDataSourceConnections}
+          excludedConnectionIds={excludedConnectionIds}
           handleAssignDataSourceConnections={handleAssignDataSourceConnections}
           mode={toggleIdSelected as AssociationDataSourceModalMode}
           logos={chrome.logos}

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   EuiSpacer,
   EuiFlexItem,
@@ -45,6 +45,10 @@ export const SelectDataSourcePanel = ({
   const {
     services: { notifications, http, chrome },
   } = useOpenSearchDashboards<{ CoreStart: CoreStart; workspaceClient: WorkspaceClient }>();
+
+  const excludedConnectionIds = useMemo(() => assignedDataSourceConnections.map((c) => c.id), [
+    assignedDataSourceConnections,
+  ]);
 
   const handleAssignDataSourceConnections = (newDataSourceConnections: DataSourceConnection[]) => {
     setModalVisible(false);
@@ -187,7 +191,7 @@ export const SelectDataSourcePanel = ({
       {modalVisible && chrome && (
         <AssociationDataSourceModal
           savedObjects={savedObjects}
-          assignedConnections={assignedDataSourceConnections}
+          excludedConnectionIds={excludedConnectionIds}
           closeModal={() => setModalVisible(false)}
           handleAssignDataSourceConnections={handleAssignDataSourceConnections}
           http={http}

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -354,6 +354,20 @@ export class WorkspaceClient implements IWorkspaceClient {
     return result;
   }
 
+  public async dissociate(savedObjects: Array<{ id: string; type: string }>, workspaceId: string) {
+    const path = this.getPath('_dissociate');
+    const body = {
+      savedObjects,
+      workspaceId,
+    };
+    const result = await this.safeFetch<Array<{ id: string; type: string }>>(path, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+
+    return result;
+  }
+
   ui() {
     return {
       DataSourceAssociation,

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -11,9 +11,11 @@ import {
   WorkspaceAttribute,
   WorkspacesSetup,
   IWorkspaceClient,
+  IWorkspaceResponse as IResponse,
 } from '../../../core/public';
 import { WorkspacePermissionMode } from '../common/constants';
 import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
+import { DataSourceAssociation } from './components/data_source_association/data_source_association';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -22,16 +24,6 @@ const join = (...uriComponents: Array<string | undefined>) =>
     .filter((comp): comp is string => Boolean(comp))
     .map(encodeURIComponent)
     .join('/');
-
-type IResponse<T> =
-  | {
-      result: T;
-      success: true;
-    }
-  | {
-      success: false;
-      error?: string;
-    };
 
 interface WorkspaceFindOptions {
   page?: number;
@@ -72,7 +64,7 @@ export class WorkspaceClient implements IWorkspaceClient {
    * Add a non-throw-error fetch method,
    * so that consumers only need to care about
    * if the success is false instead of wrapping the call with a try catch
-   * and judge the error both in catch clause and if(!success) cluase.
+   * and judge the error both in catch clause and if(!success) clause.
    */
   private safeFetch = async <T = any>(
     path: string,
@@ -346,6 +338,26 @@ export class WorkspaceClient implements IWorkspaceClient {
     });
 
     return result;
+  }
+
+  public async associate(savedObjects: Array<{ id: string; type: string }>, workspaceId: string) {
+    const path = this.getPath('_associate');
+    const body = {
+      savedObjects,
+      workspaceId,
+    };
+    const result = await this.safeFetch<Array<{ id: string; type: string }>>(path, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+
+    return result;
+  }
+
+  ui() {
+    return {
+      DataSourceAssociation,
+    };
   }
 
   public stop() {

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -283,6 +283,32 @@ export function registerRoutes({
     })
   );
 
+  router.post(
+    {
+      path: `${WORKSPACES_API_BASE_URL}/_associate`,
+      validate: {
+        body: schema.object({
+          workspaceId: schema.string(),
+          savedObjects: schema.arrayOf(
+            schema.object({ id: schema.string(), type: schema.string() })
+          ),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const { workspaceId, savedObjects } = req.body;
+
+      const result = await client.associate(
+        {
+          request: req,
+        },
+        workspaceId,
+        savedObjects
+      );
+      return res.ok({ body: result });
+    })
+  );
+
   // duplicate saved objects among workspaces
   registerDuplicateRoute(router, logger, client, maxImportExportSize);
 }

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -309,6 +309,32 @@ export function registerRoutes({
     })
   );
 
+  router.post(
+    {
+      path: `${WORKSPACES_API_BASE_URL}/_dissociate`,
+      validate: {
+        body: schema.object({
+          workspaceId: schema.string(),
+          savedObjects: schema.arrayOf(
+            schema.object({ id: schema.string(), type: schema.string() })
+          ),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const { workspaceId, savedObjects } = req.body;
+
+      const result = await client.dissociate(
+        {
+          request: req,
+        },
+        workspaceId,
+        savedObjects
+      );
+      return res.ok({ body: result });
+    })
+  );
+
   // duplicate saved objects among workspaces
   registerDuplicateRoute(router, logger, client, maxImportExportSize);
 }

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -122,6 +122,26 @@ export interface IWorkspaceClientImpl {
    * @public
    */
   destroy(): Promise<IResponse<boolean>>;
+
+  /**
+   * Associates a list of objects with the given workspace ID.
+   *
+   * This method takes a workspace ID and an array of objects, where each object contains
+   * an `id` and `type`. It attempts to associate each object with the specified workspace.
+   * If the association succeeds, the object is included in the result without an error.
+   * If there is an issue associating an object, an error message is returned for that object.
+   *
+   * @returns A promise that resolves to a response object containing an array of results for each object.
+   *          Each result will include the object's `id` and, if there was an error during association, an `error` field
+   *          with the error message.
+   *
+   * @public
+   */
+  associate(
+    requestDetail: IRequestDetail,
+    workspaceId: string,
+    objects: Array<{ id: string; type: string }>
+  ): Promise<IResponse<Array<{ id: string; error?: string }>>>;
 }
 
 export type IResponse<T> =

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -142,6 +142,26 @@ export interface IWorkspaceClientImpl {
     workspaceId: string,
     objects: Array<{ id: string; type: string }>
   ): Promise<IResponse<Array<{ id: string; error?: string }>>>;
+
+  /**
+   * Dissociates a list of objects from the given workspace ID.
+   *
+   * This method takes a workspace ID and an array of objects, where each object contains
+   * an `id` and `type`. It attempts to dissociate each object from the specified workspace.
+   * If the dissociation succeeds, the object is included in the result without an error.
+   * If there is an issue dissociating an object, an error message is returned for that object.
+   *
+   * @returns A promise that resolves to a response object containing an array of results for each object.
+   *          Each result will include the object's `id` and, if there was an error during dissociation, an `error` field
+   *          with the error message.
+   *
+   * @public
+   */
+  dissociate(
+    requestDetail: IRequestDetail,
+    workspaceId: string,
+    objects: Array<{ id: string; type: string }>
+  ): Promise<IResponse<Array<{ id: string; error?: string }>>>;
 }
 
 export type IResponse<T> =

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -392,12 +392,41 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
       };
     }
   }
+
+  public async associate(
+    requestDetail: IRequestDetail,
+    workspaceId: string,
+    objects: Array<{ id: string; type: string }>
+  ): Promise<IResponse<Array<{ id: string; error?: string }>>> {
+    const savedObjectClient = this.getSavedObjectClientsFromRequestDetail(requestDetail);
+    const promises = objects.map(async (obj) => {
+      try {
+        await savedObjectClient.addToWorkspaces(obj.type, obj.id, [workspaceId]);
+        return {
+          id: obj.id,
+        };
+      } catch (e) {
+        return {
+          id: obj.id,
+          error: this.formatError(e),
+        };
+      }
+    });
+    const result = await Promise.all(promises);
+    return {
+      success: true,
+      result,
+    };
+  }
+
   public setSavedObjects(savedObjects: SavedObjectsServiceStart) {
     this.savedObjects = savedObjects;
   }
+
   public setUiSettings(uiSettings: UiSettingsServiceStart) {
     this.uiSettings = uiSettings;
   }
+
   public async destroy(): Promise<IResponse<boolean>> {
     return {
       success: true,

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -419,6 +419,32 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
     };
   }
 
+  public async dissociate(
+    requestDetail: IRequestDetail,
+    workspaceId: string,
+    objects: Array<{ id: string; type: string }>
+  ): Promise<IResponse<Array<{ id: string; error?: string }>>> {
+    const savedObjectClient = this.getSavedObjectClientsFromRequestDetail(requestDetail);
+    const promises = objects.map(async (obj) => {
+      try {
+        await savedObjectClient.deleteFromWorkspaces(obj.type, obj.id, [workspaceId]);
+        return {
+          id: obj.id,
+        };
+      } catch (e) {
+        return {
+          id: obj.id,
+          error: this.formatError(e),
+        };
+      }
+    });
+    const result = await Promise.all(promises);
+    return {
+      success: true,
+      result,
+    };
+  }
+
   public setSavedObjects(savedObjects: SavedObjectsServiceStart) {
     this.savedObjects = savedObjects;
   }


### PR DESCRIPTION
### Description
This PR refactored the data source management page to include:
1. Added a button to page header to associate data source to current workspace
2. Added a table action set default data source when inside a workspace
3. Added a table action to dissociate data source from the current workspace

https://github.com/user-attachments/assets/58a0177e-1265-4e67-ae6f-98d210ab394d


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: refactor data source list page to include data source association features for workspace

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
