### PR TITLE
Hide Doc links for Unsupported Langauges

### DIFF
--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -206,9 +206,10 @@ export class DiscoverPlugin
       generateCb: (renderProps: any) => {
         const globalFilters: any = getServices().filterManager.getGlobalFilters();
         const appFilters: any = getServices().filterManager.getAppFilters();
-        const showDocLinks = getServices()
-          .data.query.queryString.getLanguageService()
-          .getUiOverrides().showDocLinks;
+        const queryString = getServices().data.query.queryString;
+        const showDocLinks =
+          queryString.getLanguageService().getLanguage(queryString.getQuery().language)
+            ?.showDocLinks ?? undefined;
 
         const hash = stringify(
           url.encodeQuery({
@@ -242,9 +243,10 @@ export class DiscoverPlugin
         defaultMessage: 'View single document',
       }),
       generateCb: (renderProps) => {
-        const showDocLinks = getServices()
-          .data.query.queryString.getLanguageService()
-          .getUiOverrides().showDocLinks;
+        const queryString = getServices().data.query.queryString;
+        const showDocLinks =
+          queryString.getLanguageService().getLanguage(queryString.getQuery().language)
+            ?.showDocLinks ?? undefined;
 
         const docUrl = `#/doc/${renderProps.indexPattern.id}/${
           renderProps.hit._index


### PR DESCRIPTION
### Description

This PR aims at hiding showDoc links for unsupported Query languages. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

https://github.com/user-attachments/assets/c62b151c-9498-404f-a67e-39b339654d0f

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
