### PR TITLE
Revert "Encode searchId as it tends to be decoded after adds into url…

### DIFF
--- a/changelogs/fragments/8530.yml
+++ b/changelogs/fragments/8530.yml
@@ -1,2 +1,0 @@
-fix:
-- Encode searchId as it tends to be decoded after adds into url. ([#8530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530))

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -170,7 +170,6 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
     }
 
     params = [`type=${encodeURIComponent(visType.name)}`];
-    searchId = encodeURIComponent(searchId || '');
 
     if (searchType) {
       params.push(`${searchType === 'search' ? 'savedSearchId' : 'indexPattern'}=${searchId}`);


### PR DESCRIPTION
### Description

This reverts commit 9eae14851672fad87d077856c2af47a8e181b671. (https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530)

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
- fix: Revert change 9eae14851672fad87d077856c2af47a8e181b671
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
