### PR TITLE
[Async search Discover] Poll for results when current request completes

### DIFF
--- a/changelogs/fragments/8555.yml
+++ b/changelogs/fragments/8555.yml
@@ -1,0 +1,2 @@
+fix:
+- Refactored polling logic to poll for results once current request completes ([#8555](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8555))

--- a/src/plugins/data/common/utils/helpers.ts
+++ b/src/plugins/data/common/utils/helpers.ts
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { i18n } from '@osd/i18n';
 import {
   PollQueryResultsHandler,
   FetchStatusResponse,
@@ -58,7 +59,12 @@ export const handleQueryResults = async <T>(
   if (queryStatus === 'FAILED') {
     throw (
       (queryResultsRes as QueryFailedStatusResponse).body.error ??
-      new Error(`Failed to fetch results ${queryId ?? ''}`)
+      new Error(
+        i18n.translate('data.search.request.failed', {
+          defaultMessage: 'Failed to fetch results for queryId: {queryId}',
+          values: { queryId: queryId ?? '' },
+        })
+      )
     );
   }
 

--- a/src/plugins/data/common/utils/helpers.ts
+++ b/src/plugins/data/common/utils/helpers.ts
@@ -29,11 +29,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import {
-  PollQueryResultsHandler,
-  FetchStatusResponse,
-  QueryFailedStatusResponse,
-} from '../data_frames';
+import { PollQueryResultsHandler, FetchStatusResponse } from '../data_frames';
 
 export interface QueryStatusOptions {
   pollQueryResults: PollQueryResultsHandler;
@@ -46,7 +42,7 @@ export const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 export const handleQueryResults = async <T>(
   options: QueryStatusOptions
 ): Promise<FetchStatusResponse> => {
-  const { pollQueryResults, interval = 5000, queryId } = options;
+  const { pollQueryResults, interval = 5000 } = options;
   let queryResultsRes: FetchStatusResponse;
   let queryStatus;
   do {
@@ -57,14 +53,10 @@ export const handleQueryResults = async <T>(
   } while (queryStatus !== 'SUCCESS' && queryStatus !== 'FAILED');
 
   if (queryStatus === 'FAILED') {
-    throw (
-      (queryResultsRes as QueryFailedStatusResponse).body.error ??
-      new Error(
-        i18n.translate('data.search.request.failed', {
-          defaultMessage: 'Failed to fetch results for queryId: {queryId}',
-          values: { queryId: queryId ?? '' },
-        })
-      )
+    throw new Error(
+      i18n.translate('data.search.request.failed', {
+        defaultMessage: 'An error occurred while executing the search query',
+      })
     );
   }
 


### PR DESCRIPTION
### Description
This PR refactors the polling logic for async search in Discover to poll for the query status once the current call resolves. 
Currently we fire a polling request every 5 seconds irrespective of whether the previous status check call completed or not.
This will ensure we make fewer polling calls

## Screenshot
N/A

## Testing the changes
Tested using local setup

## Changelog
- fix: Refactored polling logic to poll for results once current request completes

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
