### PR TITLE
[workspace]add last admin validation when deleting collaborators

### DIFF
--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.test.tsx
@@ -133,6 +133,33 @@ describe('WorkspaceCollaboratorTable', () => {
     expect(mockOverlays.openModal).toHaveBeenCalled();
   });
 
+  it('should openModal when clicking one selection delete', () => {
+    const permissionSettings = [
+      {
+        id: 0,
+        modes: ['library_write', 'write'],
+        type: 'user',
+        userId: 'admin',
+      },
+      {
+        id: 1,
+        modes: ['library_read', 'read'],
+        type: 'group',
+        group: 'group',
+      },
+    ];
+
+    const { getByText, getByTestId } = render(
+      <Provider>
+        <WorkspaceCollaboratorTable {...mockProps} permissionSettings={permissionSettings} />
+      </Provider>
+    );
+    fireEvent.click(getByTestId('checkboxSelectRow-0'));
+    const deleteCollaborator = getByText('Delete 1 collaborator');
+    fireEvent.click(deleteCollaborator);
+    expect(mockOverlays.openModal).toHaveBeenCalled();
+  });
+
   it('should openModal when clicking multi selection delete', () => {
     const permissionSettings = [
       {

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   EuiSearchBarProps,
   EuiBasicTableColumn,
@@ -124,13 +124,10 @@ export const WorkspaceCollaboratorTable = ({
     });
   }, [permissionSettings, displayedCollaboratorTypes]);
 
-  const findAdmin = useCallback((lists: PermissionSettingWithAccessLevelAndDisplayedType[]) => {
-    return lists.filter((item) => item.accessLevel === 'Admin');
-  }, []);
-
-  const permissionNum = useMemo(() => {
-    return findAdmin(items).length;
-  }, [items, findAdmin]);
+  const adminCollarboratorsNum = useMemo(() => {
+    const admins = items.filter((item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin);
+    return admins.length;
+  }, [items]);
 
   const emptyStateMessage = useMemo(() => {
     return (
@@ -172,9 +169,11 @@ export const WorkspaceCollaboratorTable = ({
     onConfirm: () => void;
     selections: PermissionSettingWithAccessLevelAndDisplayedType[];
   }) => {
-    const adminOfSelection = selections.filter((item) => item.accessLevel === 'Admin').length;
+    const adminOfSelection = selections.filter(
+      (item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin
+    ).length;
     const modal = overlays.openModal(
-      permissionNum === adminOfSelection ? (
+      adminCollarboratorsNum === adminOfSelection && adminCollarboratorsNum !== 0 ? (
         <EuiConfirmModal
           title={i18n.translate('workspace.detail.collaborator.actions.delete', {
             defaultMessage: 'Delete collaborator',
@@ -245,11 +244,10 @@ export const WorkspaceCollaboratorTable = ({
         data-test-subj="confirm-delete-button"
       >
         {i18n.translate('workspace.detail.collaborator.delete', {
-          defaultMessage: `Delete {num} ${
-            selection.length === 1 ? 'collaborator' : 'collaborators'
-          }`,
+          defaultMessage: `Delete {num} collaborator{pluralSuffix}`,
           values: {
             num: selection.length,
+            pluralSuffix: selection.length > 1 ? 's' : '',
           },
         })}
       </EuiButton>

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -243,7 +243,7 @@ export const WorkspaceCollaboratorTable = ({
         onClick={onClick}
         data-test-subj="confirm-delete-button"
       >
-        {i18n.translate('workspace.detail.collaborator.delete', {
+        {i18n.translate('workspace.detail.collaborator.delete.button.info', {
           defaultMessage: `Delete {num} collaborator{pluralSuffix}`,
           values: {
             num: selection.length,

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -62,7 +62,7 @@ const deletionModalCancelButton = i18n.translate(
 );
 
 const deletionModalWarning = i18n.translate(
-  'workspace.workspaceDetail.collaborator.modal.delete.warning',
+  'workspace.workspace.detail.collaborator.modal.delete.warning',
   {
     defaultMessage:
       'Currently you’re the only user who has access to the workspace as an owner. Share this workspace by adding collaborators.',

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -47,6 +47,31 @@ const permissionModeId2WorkspaceAccessLevelMap: {
   [PermissionModeId.ReadAndWrite]: 'readAndWrite',
 };
 
+const deletionModalConfirmButton = i18n.translate(
+  'workspace.detail.collaborator.delete.modal.confirm',
+  {
+    defaultMessage: 'Confirm',
+  }
+);
+
+const deletionModalCancelButton = i18n.translate(
+  'workspace.detail.collaborator.delete.modal.cancel',
+  {
+    defaultMessage: 'Cancel',
+  }
+);
+
+const deletionModalWarning = i18n.translate(
+  'workspace.workspaceDetail.collaborator.modal.delete.warning',
+  {
+    defaultMessage:
+      'Currently you’re the only user who has access to the workspace as an owner. Share this workspace by adding collaborators.',
+  }
+);
+const deletionModalConfirm = i18n.translate('workspace.detail.collaborator.modal.delete.confirm', {
+  defaultMessage: 'Delete collaborator? The collaborators will not have access to the workspace.',
+});
+
 const convertPermissionSettingToWorkspaceCollaborator = (
   permissionSetting: WorkspacePermissionSetting
 ) => ({
@@ -172,46 +197,22 @@ export const WorkspaceCollaboratorTable = ({
     const adminOfSelection = selections.filter(
       (item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin
     ).length;
+    const shouldShowWarning =
+      adminCollarboratorsNum === adminOfSelection && adminCollarboratorsNum !== 0;
     const modal = overlays.openModal(
-      adminCollarboratorsNum === adminOfSelection && adminCollarboratorsNum !== 0 ? (
-        <EuiConfirmModal
-          title={i18n.translate('workspace.detail.collaborator.actions.delete', {
-            defaultMessage: 'Delete collaborator',
-          })}
-          onCancel={() => modal.close()}
-          onConfirm={onConfirm}
-          cancelButtonText="Cancel"
-          confirmButtonText="Confirm"
-        >
-          <EuiText color="danger">
-            <p>
-              {i18n.translate('workspace.detail.collaborator.delete.confirm.warning', {
-                defaultMessage:
-                  'By removing the last administrator, only Application administrators will be able to manage this Workspace',
-              })}
-            </p>
-          </EuiText>
-        </EuiConfirmModal>
-      ) : (
-        <EuiConfirmModal
-          title={i18n.translate('workspace.detail.collaborator.actions.delete', {
-            defaultMessage: 'Delete collaborator',
-          })}
-          onCancel={() => modal.close()}
-          onConfirm={onConfirm}
-          cancelButtonText="Cancel"
-          confirmButtonText="Confirm"
-        >
-          <EuiText>
-            <p>
-              {i18n.translate('workspace.detail.collaborator.delete.confirm', {
-                defaultMessage:
-                  'Delete collaborator? The collaborators will not have access to the workspace.',
-              })}
-            </p>
-          </EuiText>
-        </EuiConfirmModal>
-      )
+      <EuiConfirmModal
+        title={i18n.translate('workspace.detail.collaborator.actions.delete', {
+          defaultMessage: 'Delete collaborator',
+        })}
+        onCancel={() => modal.close()}
+        onConfirm={onConfirm}
+        cancelButtonText={deletionModalCancelButton}
+        confirmButtonText={deletionModalConfirmButton}
+      >
+        <EuiText color={shouldShowWarning ? 'danger' : 'default'}>
+          <p>{shouldShowWarning ? deletionModalWarning : deletionModalConfirm}</p>
+        </EuiText>
+      </EuiConfirmModal>
     );
     return modal;
   };
@@ -244,10 +245,10 @@ export const WorkspaceCollaboratorTable = ({
         data-test-subj="confirm-delete-button"
       >
         {i18n.translate('workspace.detail.collaborator.delete.button.info', {
-          defaultMessage: `Delete {num} collaborator{pluralSuffix}`,
+          defaultMessage: 'Delete {num} collaborator{pluralSuffix, select, true {} other {s}}',
           values: {
             num: selection.length,
-            pluralSuffix: selection.length > 1 ? 's' : '',
+            pluralSuffix: selection.length === 1,
           },
         })}
       </EuiButton>


### PR DESCRIPTION
### Description
This pr adds last admin validation when trying to delete collaborators

## Screenshot
1. if user tries to delete the last admin:
<img width="955" alt="截屏2024-10-12 13 21 48" src="https://github.com/user-attachments/assets/0edb29a0-e5c6-498b-b4f6-9c44d38eaeba">

<img width="1431" alt="截屏2024-10-12 13 22 42" src="https://github.com/user-attachments/assets/6d181f8e-12ea-40c2-b83e-f3bc289387af">

2. other cases:
<img width="1431" alt="截屏2024-10-12 13 23 08" src="https://github.com/user-attachments/assets/b597789c-85e1-4f85-8220-75c087706abe">
<img width="1431" alt="截屏2024-10-12 13 23 12" src="https://github.com/user-attachments/assets/e874c7c3-5926-454a-92f1-675f988ccd25">

## Changelog
- feat: add last admin validation when deleting collaborators


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
