### PR TITLE
[workspace]Fix workspace selector style alignment

### DIFF
--- a/changelogs/fragments/8592.yml
+++ b/changelogs/fragments/8592.yml
@@ -1,0 +1,2 @@
+fix:
+- Workspace selector style alignment ([#8592](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8592))

--- a/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_menu/workspace_menu.test.tsx
@@ -83,7 +83,7 @@ describe('<WorkspaceMenu />', () => {
     const selectButton = screen.getByTestId('workspace-select-button');
     fireEvent.click(selectButton);
 
-    expect(screen.getByText(`viewed ${moment(1234567890).fromNow()}`)).toBeInTheDocument();
+    expect(screen.getByText(`Viewed ${moment(1234567890).fromNow()}`)).toBeInTheDocument();
   });
 
   it('should be able to display empty state when the workspace list is empty', () => {

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -27,18 +27,6 @@ import { WorkspaceUseCase } from '../../types';
 import { validateWorkspaceColor } from '../../../common/utils';
 import { getFirstUseCaseOfFeatureConfigs, getUseCaseUrl } from '../../utils';
 
-function sortBy<T>(getkey: (item: T) => number | undefined) {
-  return (a: T, b: T): number => {
-    const aValue = getkey(a);
-    const bValue = getkey(b);
-
-    if (aValue === undefined) return 1;
-    if (bValue === undefined) return -1;
-
-    return bValue - aValue;
-  };
-}
-
 const searchFieldPlaceholder = i18n.translate('workspace.menu.search.placeholder', {
   defaultMessage: 'Search workspace name',
 });
@@ -57,6 +45,21 @@ interface Props {
   isInTwoLines?: boolean;
 }
 
+const sortByRecentVisitedAndAlphabetical = (
+  ws1: UpdatedWorkspaceObject,
+  ws2: UpdatedWorkspaceObject
+) => {
+  // First, sort by accessTimeStamp in descending order (if both have timestamps)
+  if (ws1?.accessTimeStamp && ws2?.accessTimeStamp) {
+    return ws2.accessTimeStamp - ws1.accessTimeStamp;
+  }
+  // If one has a timestamp and the other does not, prioritize the one with the timestamp
+  if (ws1.accessTimeStamp) return -1;
+  if (ws2.accessTimeStamp) return 1;
+  // If neither has a timestamp, sort alphabetically by name
+  return ws1.name.localeCompare(ws2.name);
+};
+
 export const WorkspacePickerContent = ({
   coreStart,
   registeredUseCases$,
@@ -72,18 +75,16 @@ export const WorkspacePickerContent = ({
     const recentWorkspaces = recentWorkspaceManager.getRecentWorkspaces();
     const updatedList = workspaceList.map((workspace) => {
       const recentWorkspace = recentWorkspaces.find((recent) => recent.id === workspace.id);
-
-      if (recentWorkspace) {
-        return {
-          ...workspace,
-          accessTimeStamp: recentWorkspace.timestamp,
-          accessTime: `viewed ${moment(recentWorkspace.timestamp).fromNow()}`,
-        };
-      }
-      return workspace as UpdatedWorkspaceObject;
+      return {
+        ...workspace,
+        accessTimeStamp: recentWorkspace?.timestamp,
+        accessTime: recentWorkspace
+          ? `Viewed ${moment(recentWorkspace.timestamp).fromNow()}`
+          : `Not visited recently`,
+      };
     });
 
-    return updatedList.sort(sortBy((workspace) => workspace.accessTimeStamp));
+    return updatedList.sort(sortByRecentVisitedAndAlphabetical);
   }, [workspaceList]);
 
   const queryFromList = ({ list, query }: { list: UpdatedWorkspaceObject[]; query: string }) => {

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -80,10 +80,13 @@ export const WorkspacePickerContent = ({
         accessTimeStamp: recentWorkspace?.timestamp,
         accessTimeDescription: recentWorkspace
           ? i18n.translate('workspace.picker.accessTime.description', {
-              defaultMessage: `Viewed ${moment(recentWorkspace.timestamp).fromNow()}`,
+              defaultMessage: 'Viewed {timeLabel}',
+              values: {
+                timeLabel: moment(recentWorkspace.timestamp).fromNow(),
+              },
             })
           : i18n.translate('workspace.picker.accessTime.not.visited', {
-              defaultMessage: `Not visited recently`,
+              defaultMessage: 'Not visited recently',
             }),
       };
     });

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -79,8 +79,12 @@ export const WorkspacePickerContent = ({
         ...workspace,
         accessTimeStamp: recentWorkspace?.timestamp,
         accessTimeDescription: recentWorkspace
-          ? `Viewed ${moment(recentWorkspace.timestamp).fromNow()}`
-          : `Not visited recently`,
+          ? i18n.translate('workspace.picker.accessTime.description', {
+              defaultMessage: `Viewed ${moment(recentWorkspace.timestamp).fromNow()}`,
+            })
+          : i18n.translate('workspace.picker.accessTime.not.visited', {
+              defaultMessage: `Not visited recently`,
+            }),
       };
     });
 

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -36,7 +36,7 @@ const getValidWorkspaceColor = (color?: string) =>
 
 interface UpdatedWorkspaceObject extends WorkspaceObject {
   accessTimeStamp?: number;
-  accessTime?: string;
+  accessTimeDescription?: string;
 }
 interface Props {
   coreStart: CoreStart;
@@ -78,7 +78,7 @@ export const WorkspacePickerContent = ({
       return {
         ...workspace,
         accessTimeStamp: recentWorkspace?.timestamp,
-        accessTime: recentWorkspace
+        accessTimeDescription: recentWorkspace
           ? `Viewed ${moment(recentWorkspace.timestamp).fromNow()}`
           : `Not visited recently`,
       };
@@ -187,7 +187,7 @@ export const WorkspacePickerContent = ({
                       </EuiFlexItem>
                       <EuiFlexItem grow={1} style={{ position: 'absolute', right: '0px' }}>
                         <EuiText size="s" color="subdued">
-                          <small> {workspace.accessTime}</small>
+                          <small> {workspace.accessTimeDescription}</small>
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>
@@ -212,7 +212,7 @@ export const WorkspacePickerContent = ({
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiText size="s" color="subdued">
-                      <small> {workspace.accessTime}</small>
+                      <small> {workspace.accessTimeDescription}</small>
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
@@ -8,9 +8,13 @@
   transform: none !important;
 }
 
+/* Trying to show the border label:
+     * The following style is referenced from data souce selector
+     * see file src/plugins/data_source_management/public/components/popover_button/popover_button.scss
+*/
 .workspaceSelectorPopoverButtonContainer {
   position: relative;
-  background-color: $euiHeaderBackgroundColor;
+  background-color: $euiSideNavBackgroundColor;
   border: 1px solid $euiColorMediumShade;
   border-radius: 4px;
 
@@ -19,24 +23,14 @@
     position: absolute;
     top: -0.2rem;
     left: $euiSizeS;
-    font-size: 0.5rem;
+    font-size: 0.4rem;
     line-height: 0.4rem;
     padding: 0 $euiSizeXS;
 
-    /* Trying to hide the button's border:
-     * The background should start 1px (for the border) higher than at the edge of the button.
-     * When the top is 0.2rem, the gradient should start at 0.2rem - 1.
-     * The value is rounded down to the nearest pixel to avoid partial coverage of the border
-     * we are trying to hide.
+    /* update
+     * Delete the line-gradient and set the background color to euiSideNavBackgroundColor directly
      */
-    --dsm-popover-label-start: round(down, calc(0.2rem - 1px), 1px);
-
-    background:
-      linear-gradient(
-        to bottom,
-        transparent var(--dsm-popover-label-start),
-        $euiHeaderBackgroundColor var(--dsm-popover-label-start)
-      );
+    background-color: $euiSideNavBackgroundColor;
     color: $euiTextColor;
     z-index: 0;
     text-transform: uppercase;

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
@@ -7,3 +7,38 @@
   transition: none !important;
   transform: none !important;
 }
+
+.workspaceSelectorPopoverButtonContainer {
+  position: relative;
+  background-color: $euiHeaderBackgroundColor;
+  border: 1px solid $euiColorMediumShade;
+  border-radius: 4px;
+
+  &::before {
+    content: attr(data-label);
+    position: absolute;
+    top: -0.2rem;
+    left: $euiSizeS;
+    font-size: 0.5rem;
+    line-height: 0.4rem;
+    padding: 0 $euiSizeXS;
+
+    /* Trying to hide the button's border:
+     * The background should start 1px (for the border) higher than at the edge of the button.
+     * When the top is 0.2rem, the gradient should start at 0.2rem - 1.
+     * The value is rounded down to the nearest pixel to avoid partial coverage of the border
+     * we are trying to hide.
+     */
+    --dsm-popover-label-start: round(down, calc(0.2rem - 1px), 1px);
+
+    background:
+      linear-gradient(
+        to bottom,
+        transparent var(--dsm-popover-label-start),
+        $euiHeaderBackgroundColor var(--dsm-popover-label-start)
+      );
+    color: $euiTextColor;
+    z-index: 0;
+    text-transform: uppercase;
+  }
+}

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
@@ -10,13 +10,8 @@ import { WorkspaceSelector } from './workspace_selector';
 import { coreMock } from '../../../../../core/public/mocks';
 import { CoreStart, DEFAULT_NAV_GROUPS, WorkspaceObject } from '../../../../../core/public';
 import { BehaviorSubject } from 'rxjs';
-import { IntlProvider } from 'react-intl';
 import { recentWorkspaceManager } from '../../recent_workspace_manager';
-jest.mock('@osd/i18n', () => ({
-  i18n: {
-    translate: (id: string, { defaultMessage }: { defaultMessage: string }) => defaultMessage,
-  },
-}));
+import { I18nProvider } from '@osd/i18n/react';
 describe('<WorkspaceSelector />', () => {
   let coreStartMock: CoreStart;
   const navigateToApp = jest.fn();
@@ -52,9 +47,9 @@ describe('<WorkspaceSelector />', () => {
 
   const WorkspaceSelectorCreatorComponent = () => {
     return (
-      <IntlProvider locale="en">
+      <I18nProvider>
         <WorkspaceSelector coreStart={coreStartMock} registeredUseCases$={registeredUseCases$} />
-      </IntlProvider>
+      </I18nProvider>
     );
   };
 

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
@@ -68,6 +68,7 @@ describe('<WorkspaceSelector />', () => {
     expect(screen.getByTestId('workspace-selector-current-title')).toBeInTheDocument();
     expect(screen.getByTestId('workspace-selector-current-name')).toBeInTheDocument();
   });
+
   it('should display a list of workspaces in the dropdown', () => {
     jest
       .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')
@@ -82,11 +83,11 @@ describe('<WorkspaceSelector />', () => {
     const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
 
-    expect(screen.getByTestId('workspace-menu-item-workspace-1')).toBeInTheDocument();
-    expect(screen.getByTestId('workspace-menu-item-workspace-2')).toBeInTheDocument();
+    expect(screen.getByText('workspace 1')).toBeInTheDocument();
+    expect(screen.getByText('workspace 2')).toBeInTheDocument();
   });
 
-  it('should display viewed xx ago for recent workspaces', () => {
+  it('should display viewed xx ago for recent workspaces, and Not visited recently for never-visited workspace', () => {
     jest
       .spyOn(recentWorkspaceManager, 'getRecentWorkspaces')
       .mockReturnValue([{ id: 'workspace-1', timestamp: 1234567890 }]);
@@ -95,13 +96,12 @@ describe('<WorkspaceSelector />', () => {
       { id: 'workspace-1', name: 'workspace 1', features: [] },
       { id: 'workspace-2', name: 'workspace 2', features: [] },
     ]);
-
     render(<WorkspaceSelectorCreatorComponent />);
-
     const selectButton = screen.getByTestId('workspace-selector-button');
     fireEvent.click(selectButton);
 
-    expect(screen.getByText(`viewed ${moment(1234567890).fromNow()}`)).toBeInTheDocument();
+    expect(screen.getByText(`Viewed ${moment(1234567890).fromNow()}`)).toBeInTheDocument();
+    expect(screen.getByText('Not visited recently')).toBeInTheDocument();
   });
 
   it('should be able to display empty state when the workspace list is empty', () => {
@@ -127,8 +127,8 @@ describe('<WorkspaceSelector />', () => {
 
     const searchInput = screen.getByRole('searchbox');
     fireEvent.change(searchInput, { target: { value: 'works' } });
-    expect(screen.getByTestId('workspace-menu-item-workspace-1')).toBeInTheDocument();
-    expect(screen.queryByText('workspace-menu-item-workspace-1')).not.toBeInTheDocument();
+    expect(screen.getByText('workspace 1')).toBeInTheDocument();
+    expect(screen.queryByText('test 2')).not.toBeInTheDocument();
   });
 
   it('should be able to display empty state when seach is not found', () => {

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -64,36 +64,21 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   const closePopover = () => {
     setPopover(false);
   };
+
   const button = currentWorkspace ? (
-    <EuiPanel
-      className="workspaceSelectorPopoverButton"
-      paddingSize="none"
-      color="transparent"
-      hasBorder={false}
-      hasShadow={false}
-      data-test-subj="workspace-selector-button"
-      onClick={onButtonClick}
-    >
-      <EuiText
-        size="xs"
-        // TODO: Use standard OuiComponent to achieve the label looks
-        style={{
-          position: 'relative',
-          bottom: '-10px',
-          zIndex: 1,
-          padding: '0 5px',
-        }}
+    <div className="workspaceSelectorPopoverButtonContainer" data-label="Workspace">
+      <EuiPanel
+        className="workspaceSelectorPopoverButton"
+        data-test-subj="workspace-selector-button"
+        paddingSize="s"
+        color="transparent"
+        hasBorder={false}
+        hasShadow={false}
+        onClick={onButtonClick}
       >
-        <small className="workspaceNameLabel">
-          {i18n.translate('workspace.left.nav.selector.label', {
-            defaultMessage: 'WORKSPACE',
-          })}
-        </small>
-      </EuiText>
-      <EuiPanel paddingSize="s" borderRadius="m" color="transparent" hasBorder>
-        <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">
+        <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween" responsive={false}>
           <EuiFlexItem>
-            <EuiFlexGroup gutterSize="s" justifyContent="flexStart">
+            <EuiFlexGroup gutterSize="s" justifyContent="flexStart" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiIcon
                   size="l"
@@ -101,14 +86,14 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
                   color={getValidWorkspaceColor(currentWorkspace.color)}
                 />
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup direction="column" gutterSize="none">
-                  <EuiFlexItem grow={false} style={{ maxWidth: '130px' }}>
+              <EuiFlexItem>
+                <EuiFlexGroup direction="column" gutterSize="none" responsive={false}>
+                  <EuiFlexItem style={{ maxWidth: '130px' }}>
                     <EuiText size="s" data-test-subj="workspace-selector-current-name">
                       <h4 className="eui-textTruncate">{currentWorkspace.name}</h4>
                     </EuiText>
                   </EuiFlexItem>
-                  <EuiFlexItem>
+                  <EuiFlexItem grow={false}>
                     <EuiText
                       size="xs"
                       color="subdued"
@@ -126,7 +111,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPanel>
-    </EuiPanel>
+    </div>
   ) : (
     <EuiButton onClick={onButtonClick}>Select a Workspace</EuiButton>
   );


### PR DESCRIPTION
### Description
This pr addresses following issues to the workspace selector:
1. workspace content are first sorted by most recently visited. Unvisited workspaces will be sorted alphabetically
2. workspace selector has the similar style with data source selector
3. resolve issues affecting the display of the workspace selector on mobile

the background color of the workspace selector takes euiSideNavBackgroundColor
the background color of  data source selector  takes euiHeaderBackgroundColor

## Screenshot
1. workspace content
<img width="326" alt="截屏2024-10-15 14 25 45" src="https://github.com/user-attachments/assets/de457f4b-0872-4369-a131-b8f039ab7ef6">

2. on mobile
<img width="422" alt="截屏2024-10-15 13 46 43" src="https://github.com/user-attachments/assets/966c7314-325c-43af-96e7-f32a10509f12">

3. In theme V7
workspace selector：
<img width="802" alt="v7" src="https://github.com/user-attachments/assets/dbac8a12-7b0d-4d6d-8957-c6cb0d9e4841">

Dark mode: 
<img width="244" alt="截屏2024-10-16 10 03 28" src="https://github.com/user-attachments/assets/bb2c631e-7b8f-4bce-87d6-871eeb2e6fbe">

data source selector：
<img width="802" alt="v7-data" src="https://github.com/user-attachments/assets/74f3f507-6d75-441c-abc0-4092e26c046c">

5. In theme V9
workspace selector：
<img width="804" alt="v9" src="https://github.com/user-attachments/assets/83b1482b-8d9d-495a-85e0-56e8169a810f">

Dark mode: 
<img width="244" alt="9" src="https://github.com/user-attachments/assets/0bc26dde-4a0c-4491-8b81-08ca579524c7">

data source selector：
<img width="804" alt="v9-data" src="https://github.com/user-attachments/assets/f47d516b-7fb7-48ba-922c-78619f04a955">

6. In theme next
workspace selector：
<img width="631" alt="next" src="https://github.com/user-attachments/assets/7409ec9a-9564-4e00-a8f0-bff7aba468e2">

Dark mode: 
<img width="244" alt="截屏2024-10-16 10 02 35" src="https://github.com/user-attachments/assets/3d9a95c6-9256-4290-8dbe-ef5dad23fbaa">

data source selector：
<img width="533" alt="next-data" src="https://github.com/user-attachments/assets/a0ab47b0-949d-4864-b1da-7cdc2aa09d55">


## Changelog
- fix: workspace selector style alignment

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
