### PR TITLE
fix: Fix padding and responsive behavior of page header

### DIFF
--- a/changelogs/fragments/8600.yml
+++ b/changelogs/fragments/8600.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix padding and responsive behavior of page header ([#8600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8600))

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -20461,27 +20461,41 @@ exports[`Header renders page header with application title 1`] = `
           >
             <EuiFlexGroup
               className="secondaryPageHeaderFlexGroup"
-              gutterSize="s"
+              gutterSize="none"
               justifyContent="spaceBetween"
             >
               <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive secondaryPageHeaderFlexGroup"
+                className="euiFlexGroup euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive secondaryPageHeaderFlexGroup"
               >
                 <EuiHeaderSection
+                  grow={true}
                   side="left"
+                  style={
+                    Object {
+                      "flexShrink": 1,
+                    }
+                  }
                 >
                   <div
-                    className="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
+                    className="euiHeaderSection euiHeaderSection--grow euiHeaderSection--left"
+                    style={
+                      Object {
+                        "flexShrink": 1,
+                      }
+                    }
                   >
                     <EuiFlexGroup
+                      className="leftSecondaryPageHeaderFlexGroup"
                       gutterSize="s"
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive leftSecondaryPageHeaderFlexGroup"
                       >
-                        <EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
                           <div
-                            className="euiFlexItem"
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
                             <EuiHeaderSectionItem
                               border="none"
@@ -20496,7 +20510,7 @@ exports[`Header renders page header with application title 1`] = `
                                   size="l"
                                 >
                                   <h1
-                                    className="euiTitle euiTitle--large newTopNavHeaderTitle"
+                                    className="euiTitle euiTitle--large newTopNavHeaderTitle eui-textBreakWord"
                                   >
                                     testTitle
                                   </h1>

--- a/src/core/public/chrome/ui/header/header.scss
+++ b/src/core/public/chrome/ui/header/header.scss
@@ -70,7 +70,7 @@
 }
 
 .newTopNavHeaderTitle {
-  line-height: 1;
+  line-height: $euiButtonHeightSmall; // match button size so title is centered
   font-size: 2rem;
 }
 
@@ -116,5 +116,36 @@
   .secondaryPageHeaderFlexGroup {
     display: flex;
     flex-direction: column;
+
+    // Override eui responsive spacing for header elements
+    // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+    .euiHeaderSection--left,
+    .euiHeaderSection--right {
+      // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+      .euiFlexGroup--responsive > .euiFlexItem {
+        margin: $euiSizeXS 0 !important; // set as !important in eui
+      }
+    }
+  }
+
+  // Add bottom margin to left group to counter-act negative margins from gutters
+  .leftSecondaryPageHeaderFlexGroup {
+    margin-bottom: $euiSizeXS;
+  }
+}
+
+// Make sure there's space betweeen left and right header content on non-mobile screens
+@include euiBreakpoint("m", "l", "xl", "xxl", "xxxl") {
+  .leftSecondaryPageHeaderFlexGroup {
+    margin-right: $euiSizeM;
+  }
+}
+
+// Make badges/health statuses line-height match buttons so its vertically centered
+.leftSecondaryPageHeaderFlexGroup {
+  // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+  .euiBadge,
+  .euiHealth {
+    line-height: $euiButtonHeightSmall !important;
   }
 }

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -560,23 +560,27 @@ export function Header({
       <EuiHeader className="newTopNavHeader">
         <EuiFlexGroup
           justifyContent="spaceBetween"
-          gutterSize="s"
+          gutterSize="none"
           className="secondaryPageHeaderFlexGroup"
         >
           {/* Left Section */}
-          <EuiHeaderSection side="left">
-            <EuiFlexGroup gutterSize="s">
-              <EuiFlexItem>
+          <EuiHeaderSection side="left" grow={true} style={{ flexShrink: 1 }}>
+            <EuiFlexGroup gutterSize="s" className="leftSecondaryPageHeaderFlexGroup">
+              <EuiFlexItem grow={false}>
                 <EuiHeaderSectionItem border="none" data-test-subj="headerApplicationTitle">
                   <EuiTitle size="l" className="newTopNavHeaderTitle">
-                    {breadcrumbs && <h1>{breadcrumbs[breadcrumbs.length - 1]?.text}</h1>}
+                    {breadcrumbs && (
+                      <h1 className="eui-textBreakWord">
+                        {breadcrumbs[breadcrumbs.length - 1]?.text}
+                      </h1>
+                    )}
                   </EuiTitle>
                 </EuiHeaderSectionItem>
               </EuiFlexItem>
 
-              {badge && <EuiFlexItem>{badge}</EuiFlexItem>}
+              {badge && <EuiFlexItem grow={false}>{badge}</EuiFlexItem>}
 
-              {leftControls && <EuiFlexItem>{leftControls}</EuiFlexItem>}
+              {leftControls && <EuiFlexItem grow={false}>{leftControls}</EuiFlexItem>}
             </EuiFlexGroup>
           </EuiHeaderSection>
 


### PR DESCRIPTION
### Description

Fixes padding and responsive behavior of page header on feature pages

### Issues Resolved

- Second row had incorrect right/left margin
- Title was wrapping too quickly
- Titles without breaks won’t wrap
- Noticed title wasn’t aligned vertically center
- Health/Badge isn’t aligned vertically center
- Not spacing between left/right content on larger screens
- Vertical spacing between on smaller screens is large/inconsistent due to eui responsive header behavior

## Screenshot
![os responsive 2](https://github.com/user-attachments/assets/7da7076f-d3ba-4f40-b9eb-37810de94169)


## Testing the changes
Tested locally + had UX validate

## Changelog
- fix: Fix padding and responsive behavior of page header

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
