### PR TITLE
Upgrade JSON11 from 1.1.2 to 2.0.0

### DIFF
--- a/changelogs/fragments/8603.yml
+++ b/changelogs/fragments/8603.yml
@@ -1,0 +1,2 @@
+fix:
+- Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data ([#8603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8603))

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "**/jest-config": "npm:@amoo-miki/jest-config@27.5.1",
     "**/jest-jasmine2": "npm:@amoo-miki/jest-jasmine2@27.5.1",
     "**/joi/hoek": "npm:@amoo-miki/hoek@6.1.3",
-    "**/json11": "^1.1.2",
+    "**/json11": "^2.0.0",
     "**/json-schema": "^0.4.0",
     "**/kind-of": ">=6.0.3",
     "**/load-bmfont/phin": "^3.7.1",

--- a/packages/osd-std/package.json
+++ b/packages/osd-std/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "sideEffects": false,
   "dependencies": {
-    "json11": "^1.1.2",
+    "json11": "^2.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11404,10 +11404,10 @@ json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json11@^1.0.4, json11@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/json11/-/json11-1.1.2.tgz#35ffd3ee5073b0cc09ef826b0a0dc005ebef2b5b"
-  integrity sha512-5r1RHT1/Gr/jsI/XZZj/P6F11BKM8xvTaftRuiLkQI9Z2PFDukM82Ysxw8yDszb3NJP/NKnRlSGmhUdG99rlBw==
+json11@^1.0.4, json11@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/json11/-/json11-2.0.0.tgz#06c4ad0a40b50c5de99a87f6d3028593137e5641"
+  integrity sha512-VuKJKUSPEJape+daTm70Nx7vdcdorf4S6LCyN2z0jUVH4UrQ4ftXo2kC0bnHpCREmxHuHqCNVPA75BjI3CB6Ag==
 
 json5@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
### Description

Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data.

### Issues Resolved

Fixes #7367



## Changelog
- fix: Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety when stringifying JSON data

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
