### PR TITLE
[Workspace] Fix content management render dashboard with duplicate visualizations

### DIFF
--- a/changelogs/fragments/8606.yml
+++ b/changelogs/fragments/8606.yml
@@ -1,2 +1,2 @@
 fix:
-- Fix content management render dashboard with duplicate visualizations ([#8606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8606))
+- [workspace]fix content management render dashboard with duplicate visualizations ([#8606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8606))

--- a/changelogs/fragments/8606.yml
+++ b/changelogs/fragments/8606.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix content management render dashboard with duplicate visualizations ([#8606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8606))

--- a/src/plugins/content_management/public/components/section_input.test.ts
+++ b/src/plugins/content_management/public/components/section_input.test.ts
@@ -305,14 +305,14 @@ test('it should create section with a dashboard as content', async () => {
     savedObjectsClient: clientMock,
   });
   expect(input.panels).toEqual({
-    'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2': {
+    '1': {
       explicitInput: {
-        id: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
+        id: '1',
         savedObjectId: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
       },
       gridData: {
         h: 5,
-        i: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
+        i: '1',
         w: 48,
         x: 0,
         y: 0,
@@ -351,18 +351,90 @@ test('it should create section with a dynamic dashboard as content', async () =>
     savedObjectsClient: clientMock,
   });
   expect(input.panels).toEqual({
-    'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2': {
+    '1': {
       explicitInput: {
-        id: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
+        id: '1',
         savedObjectId: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
       },
       gridData: {
         h: 5,
-        i: 'ce24dd10-eb8a-11ed-8e00-17d7d50cd7b2',
+        i: '1',
         w: 48,
         x: 0,
         y: 0,
       },
+      type: 'visualization',
+    },
+  });
+});
+
+test('it should create section with a dashboard which has duplicate visualization', async () => {
+  const section: Section = { id: 'section1', kind: 'dashboard', order: 10 };
+  const staticDashboard: Content = {
+    id: 'content1',
+    kind: 'dashboard',
+    order: 0,
+    input: {
+      kind: 'static',
+      id: 'dashboard-id-static',
+    },
+  };
+  const clientMock = {
+    ...coreMock.createStart().savedObjects.client,
+    // all three visualization referenced to same object
+    get: jest.fn().mockResolvedValue({
+      id: 'dashboard-id-static',
+      attributes: {
+        panelsJSON:
+          '[{"version":"3.0.0","gridData":{"x":24,"y":0,"w":24,"h":15,"i":"909ee211-fab3-400f-858a-734e6fb52326"},"panelIndex":"909ee211-fab3-400f-858a-734e6fb52326","embeddableConfig":{},"panelRefName":"panel_0"},{"version":"3.0.0","gridData":{"x":0,"y":0,"w":24,"h":15,"i":"d61bbd24-be5d-4422-a522-096be0d5e711"},"panelIndex":"d61bbd24-be5d-4422-a522-096be0d5e711","embeddableConfig":{},"panelRefName":"panel_1"},{"version":"3.0.0","gridData":{"x":24,"y":15,"w":24,"h":15,"i":"111d18c7-788f-4276-b54c-bd7f78ea768d"},"panelIndex":"111d18c7-788f-4276-b54c-bd7f78ea768d","embeddableConfig":{},"panelRefName":"panel_2"}]',
+      },
+      references: [
+        {
+          name: 'panel_0',
+          type: 'visualization',
+          id: '_Chk-0_10f1a240-b891-11e8-a6d9-e546fe2bba5f',
+        },
+        {
+          name: 'panel_1',
+          type: 'visualization',
+          id: '_Chk-0_10f1a240-b891-11e8-a6d9-e546fe2bba5f',
+        },
+        {
+          name: 'panel_2',
+          type: 'visualization',
+          id: '_Chk-0_10f1a240-b891-11e8-a6d9-e546fe2bba5f',
+        },
+      ],
+    }),
+  };
+
+  const input = await createDashboardInput(section, [staticDashboard], {
+    savedObjectsClient: clientMock,
+  });
+  // expect we still have 3 panels with same content
+  expect(input.panels).toEqual({
+    '111d18c7-788f-4276-b54c-bd7f78ea768d': {
+      explicitInput: {
+        id: '111d18c7-788f-4276-b54c-bd7f78ea768d',
+        savedObjectId: '_Chk-0_10f1a240-b891-11e8-a6d9-e546fe2bba5f',
+      },
+      gridData: { h: 15, i: '111d18c7-788f-4276-b54c-bd7f78ea768d', w: 24, x: 24, y: 15 },
+      type: 'visualization',
+    },
+    '909ee211-fab3-400f-858a-734e6fb52326': {
+      explicitInput: {
+        id: '909ee211-fab3-400f-858a-734e6fb52326',
+        savedObjectId: '_Chk-0_10f1a240-b891-11e8-a6d9-e546fe2bba5f',
+      },
+      gridData: { h: 15, i: '909ee211-fab3-400f-858a-734e6fb52326', w: 24, x: 24, y: 0 },
+      type: 'visualization',
+    },
+    'd61bbd24-be5d-4422-a522-096be0d5e711': {
+      explicitInput: {
+        id: 'd61bbd24-be5d-4422-a522-096be0d5e711',
+        savedObjectId: '_Chk-0_10f1a240-b891-11e8-a6d9-e546fe2bba5f',
+      },
+      gridData: { h: 15, i: 'd61bbd24-be5d-4422-a522-096be0d5e711', w: 24, x: 0, y: 0 },
       type: 'visualization',
     },
   });

--- a/src/plugins/content_management/public/components/section_input.ts
+++ b/src/plugins/content_management/public/components/section_input.ts
@@ -124,13 +124,15 @@ export const createDashboardInput = async (
                 if (!panel.panelRefName) {
                   return;
                 }
+                // panelIndex should be unique
+                const panelIndex = panel.panelIndex || panel.panelRefName;
                 const reference = references.find((ref) => ref.name === panel.panelRefName);
                 if (reference) {
-                  panels[reference.id] = {
-                    gridData: { ...panel.gridData, i: reference.id },
+                  panels[panelIndex] = {
+                    gridData: { ...panel.gridData, i: panelIndex },
                     type: reference.type,
                     explicitInput: {
-                      id: reference.id,
+                      id: panelIndex,
                       savedObjectId: reference.id,
                     },
                   };


### PR DESCRIPTION
### Description

Fix content management render dashboard with duplicate visualizations

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8605

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

Before
![image](https://github.com/user-attachments/assets/96f2488e-b2b0-4889-9a24-663476460ba8)


After

![image](https://github.com/user-attachments/assets/87e06209-f6e2-4269-a18a-1f6537ee4bf6)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: [workspace]fix content management render dashboard with duplicate visualizations

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
