### PR TITLE
Improve Empty State Handling: Add No Index Patterns Panel with Data Selection in Discover View

### DIFF
--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -32,7 +32,9 @@ import { includes } from 'lodash';
 import { IndexPatternsContract } from './index_patterns';
 import { UiSettingsCommon } from '../types';
 
-export type EnsureDefaultIndexPattern = () => Promise<unknown> | undefined;
+export type EnsureDefaultIndexPattern = (
+  shouldRedirect?: boolean
+) => Promise<unknown | void> | undefined;
 
 export const createEnsureDefaultIndexPattern = (
   uiSettings: UiSettingsCommon,
@@ -42,7 +44,10 @@ export const createEnsureDefaultIndexPattern = (
    * Checks whether a default index pattern is set and exists and defines
    * one otherwise.
    */
-  return async function ensureDefaultIndexPattern(this: IndexPatternsContract) {
+  return async function ensureDefaultIndexPattern(
+    this: IndexPatternsContract,
+    shouldRedirect: boolean = true
+  ) {
     const patterns = await this.getIds();
     let defaultId = await uiSettings.get('defaultIndex');
     let defined = !!defaultId;
@@ -62,7 +67,8 @@ export const createEnsureDefaultIndexPattern = (
       defaultId = patterns[0];
       await uiSettings.set('defaultIndex', defaultId);
     } else {
-      return onRedirectNoIndexPattern();
+      if (shouldRedirect) return onRedirectNoIndexPattern();
+      else return;
     }
   };
 };

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -62,13 +62,14 @@ import {
 } from '../common';
 
 import { FilterLabel } from './ui';
-
 export {
   createEditor,
   DefaultInput,
   DQLBody,
   SingleLineInput,
   DatasetSelector,
+  AdvancedSelector,
+  NoIndexPatternsPanel,
   DatasetSelectorAppearance,
 } from './ui';
 

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -207,6 +207,11 @@ export class DatasetService {
     return Number(this.sessionStorage.get('lastCacheTime')) || undefined;
   }
 
+  public removeFromRecentDatasets(datasetId: string): void {
+    this.recentDatasets.del(datasetId);
+    this.serializeRecentDatasets();
+  }
+
   private setLastCacheTime(time: number): void {
     this.sessionStorage.set('lastCacheTime', time);
   }

--- a/src/plugins/data/public/ui/_common.scss
+++ b/src/plugins/data/public/ui/_common.scss
@@ -1,0 +1,3 @@
+.dataUI-centerPanel {
+  @include euiLegibilityMaxWidth(100%);
+}

--- a/src/plugins/data/public/ui/_common.scss
+++ b/src/plugins/data/public/ui/_common.scss
@@ -1,3 +1,11 @@
 .dataUI-centerPanel {
-  @include euiLegibilityMaxWidth(100%);
+  height: 100%;
+  width: 100%;
+
+  // Push the centralized child up, just like ouiOverlayMask
+  padding-bottom: 10vh;
+
+  & > * {
+    @include euiLegibilityMaxWidth(100%);
+  }
 }

--- a/src/plugins/data/public/ui/_index.scss
+++ b/src/plugins/data/public/ui/_index.scss
@@ -1,3 +1,4 @@
+@import "./common";
 @import "./filter_bar/index";
 @import "./typeahead/index";
 @import "./saved_query_management/index";

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -20,20 +20,21 @@ import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { BaseDataset, DEFAULT_DATA, Dataset, DatasetField } from '../../../common';
-import { getIndexPatterns, getQueryService } from '../../services';
+import { getIndexPatterns } from '../../services';
 
 export const Configurator = ({
   baseDataset,
   onConfirm,
   onCancel,
   onPrevious,
+  queryService,
 }: {
   baseDataset: BaseDataset;
   onConfirm: (dataset: Dataset) => void;
   onCancel: () => void;
   onPrevious: () => void;
+  queryService: any;
 }) => {
-  const queryService = getQueryService();
   const queryString = queryService.queryString;
   const languageService = queryService.queryString.getLanguageService();
   const indexPatternsService = getIndexPatterns();

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -33,7 +33,9 @@ type EuiSmallButtonEmptyProps = React.ComponentProps<typeof EuiSmallButtonEmpty>
 
 interface DatasetSelectorProps {
   selectedDataset?: Dataset;
-  setSelectedDataset: (dataset: Dataset) => void;
+  setSelectedDataset: (data: Dataset | undefined) => void;
+  setIndexPattern: (id: string | undefined) => void;
+  handleDatasetChange: (dataset: Dataset) => void;
   services: IDataPluginServices;
 }
 
@@ -71,6 +73,8 @@ const RootComponent: React.FC<
 export const DatasetSelector = ({
   selectedDataset,
   setSelectedDataset,
+  setIndexPattern,
+  handleDatasetChange,
   services,
   appearance,
   buttonProps,
@@ -102,7 +106,7 @@ export const DatasetSelector = ({
 
       // If no dataset is selected, select the first one
       if (!selectedDataset && fetchedDatasets.length > 0) {
-        setSelectedDataset(fetchedDatasets[0]);
+        handleDatasetChange(fetchedDatasets[0]);
       }
     };
 
@@ -179,11 +183,11 @@ export const DatasetSelector = ({
           indexPatterns.find((dataset) => dataset.id === selectedOption.key);
         if (foundDataset) {
           closePopover();
-          setSelectedDataset(foundDataset);
+          handleDatasetChange(foundDataset);
         }
       }
     },
-    [recentDatasets, indexPatterns, setSelectedDataset, closePopover]
+    [recentDatasets, indexPatterns, handleDatasetChange, closePopover]
   );
 
   const datasetTitle = useMemo(() => {
@@ -266,10 +270,14 @@ export const DatasetSelector = ({
                   onSelect={(dataset?: Dataset) => {
                     overlay?.close();
                     if (dataset) {
-                      setSelectedDataset(dataset);
+                      handleDatasetChange(dataset);
                     }
                   }}
                   onCancel={() => overlay?.close()}
+                  selectedDataset={undefined}
+                  setSelectedDataset={setSelectedDataset}
+                  setIndexPattern={setIndexPattern}
+                  direct={true}
                 />
               ),
               {

--- a/src/plugins/data/public/ui/dataset_selector/index.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/index.test.tsx
@@ -49,40 +49,77 @@ describe('ConnectedDatasetSelector', () => {
   });
 
   it('should render DatasetSelector with correct props', () => {
-    const wrapper = mount(<ConnectedDatasetSelector onSubmit={mockOnSubmit} />);
+    const wrapper = mount(
+      <ConnectedDatasetSelector
+        onSubmit={mockOnSubmit}
+        selectedDataset={undefined}
+        setSelectedDataset={jest.fn()}
+        setIndexPattern={jest.fn()}
+        services={mockServices}
+      />
+    );
     expect(wrapper.find(DatasetSelector).props()).toEqual({
       selectedDataset: undefined,
       setSelectedDataset: expect.any(Function),
+      setIndexPattern: expect.any(Function),
+      handleDatasetChange: expect.any(Function),
       services: mockServices,
     });
   });
 
   it('should initialize selectedDataset correctly', () => {
     const mockDataset: Dataset = { id: 'initial', title: 'Initial Dataset', type: 'test' };
-    mockQueryString.getQuery.mockReturnValueOnce({ dataset: mockDataset });
 
-    const wrapper = mount(<ConnectedDatasetSelector onSubmit={mockOnSubmit} />);
+    const wrapper = mount(
+      <ConnectedDatasetSelector
+        onSubmit={mockOnSubmit}
+        selectedDataset={mockDataset}
+        setSelectedDataset={jest.fn()}
+        setIndexPattern={jest.fn()}
+        services={mockServices}
+      />
+    );
     expect(wrapper.find(DatasetSelector).prop('selectedDataset')).toEqual(mockDataset);
   });
 
   it('should call handleDatasetChange only once when dataset changes', () => {
-    const wrapper = mount(<ConnectedDatasetSelector onSubmit={mockOnSubmit} />);
-    const setSelectedDataset = wrapper.find(DatasetSelector).prop('setSelectedDataset') as (
+    const setSelectedDataset = jest.fn();
+    const setIndexPattern = jest.fn();
+    const wrapper = mount(
+      <ConnectedDatasetSelector
+        onSubmit={mockOnSubmit}
+        selectedDataset={undefined}
+        setSelectedDataset={setSelectedDataset}
+        setIndexPattern={setIndexPattern}
+        services={mockServices}
+      />
+    );
+    const handleDatasetChange = wrapper.find(DatasetSelector).prop('handleDatasetChange') as (
       dataset?: Dataset
     ) => void;
 
     const newDataset: Dataset = { id: 'test', title: 'Test Dataset', type: 'test' };
     act(() => {
-      setSelectedDataset(newDataset);
+      handleDatasetChange(newDataset);
     });
 
     expect(mockQueryString.getInitialQueryByDataset).toHaveBeenCalledTimes(1);
     expect(mockQueryString.setQuery).toHaveBeenCalledTimes(1);
     expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+    expect(setSelectedDataset).toHaveBeenCalledWith(newDataset);
+    expect(setIndexPattern).toHaveBeenCalledWith(newDataset.id);
   });
 
   it('should subscribe to queryString.getUpdates$ and unsubscribe on unmount', () => {
-    const wrapper = mount(<ConnectedDatasetSelector onSubmit={mockOnSubmit} />);
+    const wrapper = mount(
+      <ConnectedDatasetSelector
+        onSubmit={mockOnSubmit}
+        selectedDataset={undefined}
+        setSelectedDataset={jest.fn()}
+        setIndexPattern={jest.fn()}
+        services={mockServices}
+      />
+    );
 
     expect(mockQueryString.getUpdates$).toHaveBeenCalledTimes(1);
     expect(mockSubscribe).toHaveBeenCalledTimes(1);

--- a/src/plugins/data/public/ui/index.ts
+++ b/src/plugins/data/public/ui/index.ts
@@ -51,4 +51,5 @@ export {
   useQueryStringManager,
 } from './search_bar';
 export { SuggestionsComponent } from './typeahead';
-export { DatasetSelector, DatasetSelectorAppearance } from './dataset_selector';
+export { DatasetSelector, AdvancedSelector, DatasetSelectorAppearance } from './dataset_selector';
+export { NoIndexPatternsPanel } from './no_index_patterns';

--- a/src/plugins/data/public/ui/no_index_patterns/index.ts
+++ b/src/plugins/data/public/ui/no_index_patterns/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './no_index_patterns_panel';

--- a/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
+++ b/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
@@ -24,12 +24,17 @@ interface NoIndexPatternsPanelProps {
 export const NoIndexPatternsPanel: React.FC<NoIndexPatternsPanelProps> = ({
   onOpenDataSelector,
 }) => (
-  <EuiFlexGroup justifyContent="center" alignItems="center" gutterSize="none">
-    <EuiFlexItem grow={false} className="dataUI-centerPanel">
+  <EuiFlexGroup
+    justifyContent="center"
+    alignItems="center"
+    gutterSize="none"
+    className="dataUI-centerPanel"
+  >
+    <EuiFlexItem grow={false}>
       <EuiPanel paddingSize="l">
         <EuiFlexGroup direction="column" alignItems="center" gutterSize="m">
           <EuiFlexItem>
-            <EuiIcon type="dataVisualizer" size="xl" color="subdued" />
+            <EuiIcon type="visBarVertical" size="xl" color="subdued" />
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="m">

--- a/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
+++ b/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiButton,
+  EuiLink,
+  EuiSpacer,
+} from '@elastic/eui';
+
+interface NoIndexPatternsPanelProps {
+  onOpenDataSelector: () => void;
+}
+
+export const NoIndexPatternsPanel: React.FC<NoIndexPatternsPanelProps> = ({
+  onOpenDataSelector,
+}) => (
+  <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: '100%' }}>
+    <EuiFlexItem grow={false} style={{ width: '100%', maxWidth: '500px' }}>
+      <EuiPanel paddingSize="l">
+        <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
+          <EuiFlexItem>
+            <EuiIcon type="dataVisualizer" size="xxl" color="subdued" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText textAlign="center">
+              <h2>Select data</h2>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText textAlign="center" color="subdued" size="s">
+              <p>
+                Select an available data source and choose a query language to use for running
+                queries. You can use the data dropdown or use the enhanced data selector to select
+                data.
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiButton fill onClick={onOpenDataSelector}>
+              Open data selector
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiSpacer size="s" />
+          <EuiFlexItem>
+            <EuiText textAlign="center" size="xs">
+              <p>Learn more about query languages</p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFlexGroup justifyContent="center" gutterSize="s" wrap>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="#" target="_blank">
+                  PPL documentation
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="#" target="_blank">
+                  SQL documentation
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="#" target="_blank">
+                  Lucene documentation
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="#" target="_blank">
+                  DQL documentation
+                </EuiLink>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);

--- a/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
+++ b/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
@@ -10,9 +10,10 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiText,
-  EuiButton,
-  EuiLink,
+  EuiSmallButton,
   EuiSpacer,
+  EuiTitle,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 
 interface NoIndexPatternsPanelProps {
@@ -22,59 +23,85 @@ interface NoIndexPatternsPanelProps {
 export const NoIndexPatternsPanel: React.FC<NoIndexPatternsPanelProps> = ({
   onOpenDataSelector,
 }) => (
-  <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: '100%' }}>
-    <EuiFlexItem grow={false} style={{ width: '100%', maxWidth: '500px' }}>
+  <EuiFlexGroup justifyContent="center" alignItems="center" gutterSize="none">
+    <EuiFlexItem grow={false} className="dataUI-centerPanel">
       <EuiPanel paddingSize="l">
-        <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
+        <EuiFlexGroup direction="column" alignItems="center" gutterSize="m">
           <EuiFlexItem>
-            <EuiIcon type="dataVisualizer" size="xxl" color="subdued" />
+            <EuiIcon type="dataVisualizer" size="xl" color="subdued" />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText textAlign="center">
+            <EuiTitle size="m">
               <h2>Select data</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText textAlign="center" color="subdued" size="xs">
+              Select an available data source and choose a query language to use for running
+              queries. You can use the data dropdown or use the enhanced data selector to select
+              data.
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText textAlign="center" color="subdued" size="s">
-              <p>
-                Select an available data source and choose a query language to use for running
-                queries. You can use the data dropdown or use the enhanced data selector to select
-                data.
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiButton fill onClick={onOpenDataSelector}>
+            <EuiSmallButton fill onClick={onOpenDataSelector}>
               Open data selector
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiSpacer size="s" />
           <EuiFlexItem>
-            <EuiText textAlign="center" size="xs">
-              <p>Learn more about query languages</p>
-            </EuiText>
+            <EuiTitle size="xs">
+              <h4>Learn more about query languages</h4>
+            </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiFlexGroup justifyContent="center" gutterSize="s" wrap>
               <EuiFlexItem grow={false}>
-                <EuiLink href="#" target="_blank">
-                  PPL documentation
-                </EuiLink>
+                <EuiButtonEmpty
+                  href="#"
+                  target="_blank"
+                  size="xs"
+                  iconType="popout"
+                  iconSide="right"
+                  iconGap="s"
+                >
+                  <EuiText size="xs">PPL documentation</EuiText>
+                </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiLink href="#" target="_blank">
-                  SQL documentation
-                </EuiLink>
+                <EuiButtonEmpty
+                  href="#"
+                  target="_blank"
+                  size="xs"
+                  iconType="popout"
+                  iconSide="right"
+                  iconGap="s"
+                >
+                  <EuiText size="xs">SQL documentation</EuiText>
+                </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiLink href="#" target="_blank">
-                  Lucene documentation
-                </EuiLink>
+                <EuiButtonEmpty
+                  href="#"
+                  target="_blank"
+                  size="xs"
+                  iconType="popout"
+                  iconSide="right"
+                  iconGap="s"
+                >
+                  <EuiText size="xs">Lucene documentation</EuiText>
+                </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiLink href="#" target="_blank">
-                  DQL documentation
-                </EuiLink>
+                <EuiButtonEmpty
+                  href="#"
+                  target="_blank"
+                  size="xs"
+                  iconType="popout"
+                  iconSide="right"
+                  iconGap="s"
+                >
+                  <EuiText size="xs">DQL documentation</EuiText>
+                </EuiButtonEmpty>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
+++ b/src/plugins/data/public/ui/no_index_patterns/no_index_patterns_panel.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiPanel,
   EuiFlexGroup,
@@ -32,75 +33,102 @@ export const NoIndexPatternsPanel: React.FC<NoIndexPatternsPanelProps> = ({
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="m">
-              <h2>Select data</h2>
+              <h2>
+                {i18n.translate('data.noIndexPatterns.selectDataTitle', {
+                  defaultMessage: 'Select data',
+                })}
+              </h2>
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiText textAlign="center" color="subdued" size="xs">
-              Select an available data source and choose a query language to use for running
-              queries. You can use the data dropdown or use the enhanced data selector to select
-              data.
+              {i18n.translate('data.noIndexPatterns.selectDataDescription', {
+                defaultMessage:
+                  'Select an available data source and choose a query language to use for running queries. You can use the data dropdown or use the enhanced data selector to select data.',
+              })}
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiSmallButton fill onClick={onOpenDataSelector}>
-              Open data selector
+              {i18n.translate('data.noIndexPatterns.openDataSelectorButton', {
+                defaultMessage: 'Open data selector',
+              })}
             </EuiSmallButton>
           </EuiFlexItem>
           <EuiSpacer size="s" />
           <EuiFlexItem>
             <EuiTitle size="xs">
-              <h4>Learn more about query languages</h4>
+              <h4>
+                {i18n.translate('data.noIndexPatterns.learnMoreAboutQueryLanguages', {
+                  defaultMessage: 'Learn more about query languages',
+                })}
+              </h4>
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiFlexGroup justifyContent="center" gutterSize="s" wrap>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
-                  href="#"
+                  href="https://opensearch.org/docs/latest/search-plugins/sql/ppl/syntax/"
                   target="_blank"
                   size="xs"
                   iconType="popout"
                   iconSide="right"
                   iconGap="s"
                 >
-                  <EuiText size="xs">PPL documentation</EuiText>
+                  <EuiText size="xs">
+                    {i18n.translate('data.noIndexPatterns.pplDocumentation', {
+                      defaultMessage: 'PPL documentation',
+                    })}
+                  </EuiText>
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
-                  href="#"
+                  href="https://opensearch.org/docs/latest/search-plugins/sql/sql/basic/"
                   target="_blank"
                   size="xs"
                   iconType="popout"
                   iconSide="right"
                   iconGap="s"
                 >
-                  <EuiText size="xs">SQL documentation</EuiText>
+                  <EuiText size="xs">
+                    {i18n.translate('data.noIndexPatterns.sqlDocumentation', {
+                      defaultMessage: 'SQL documentation',
+                    })}
+                  </EuiText>
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
-                  href="#"
+                  href="https://opensearch.org/docs/latest/query-dsl/full-text/query-string/"
                   target="_blank"
                   size="xs"
                   iconType="popout"
                   iconSide="right"
                   iconGap="s"
                 >
-                  <EuiText size="xs">Lucene documentation</EuiText>
+                  <EuiText size="xs">
+                    {i18n.translate('data.noIndexPatterns.luceneDocumentation', {
+                      defaultMessage: 'Lucene documentation',
+                    })}
+                  </EuiText>
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
-                  href="#"
+                  href="https://opensearch.org/docs/latest/query-dsl/full-text/query-string/"
                   target="_blank"
                   size="xs"
                   iconType="popout"
                   iconSide="right"
                   iconGap="s"
                 >
-                  <EuiText size="xs">DQL documentation</EuiText>
+                  <EuiText size="xs">
+                    {i18n.translate('data.noIndexPatterns.dqlDocumentation', {
+                      defaultMessage: 'DQL documentation',
+                    })}
+                  </EuiText>
                 </EuiButtonEmpty>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/src/plugins/data_explorer/public/components/sidebar/index.tsx
+++ b/src/plugins/data_explorer/public/components/sidebar/index.tsx
@@ -17,26 +17,35 @@ import {
   DatasetSelector,
   DatasetSelectorAppearance,
 } from '../../../../data/public/';
+import { Dataset } from '../../../../data/common';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { DataExplorerServices } from '../../types';
-import { setIndexPattern, useTypedDispatch, useTypedSelector } from '../../utils/state_management';
+import {
+  setIndexPattern,
+  useTypedDispatch,
+  useTypedSelector,
+  setSelectedDataset,
+} from '../../utils/state_management';
 import './index.scss';
 
+type HandleSetIndexPattern = (id: string | undefined) => void;
+type HandleSelectedDataset = (data: Dataset | undefined) => void;
+
 export const Sidebar: FC = ({ children }) => {
-  const { indexPattern: indexPatternId } = useTypedSelector((state) => state.metadata);
+  const { indexPattern: indexPatternId, selectedDataset } = useTypedSelector(
+    (state) => state.metadata
+  );
   const dispatch = useTypedDispatch();
   const [selectedSources, setSelectedSources] = useState<DataSourceOption[]>([]);
   const [dataSourceOptionList, setDataSourceOptionList] = useState<DataSourceGroup[]>([]);
   const [activeDataSources, setActiveDataSources] = useState<DataSource[]>([]);
-
+  const { services } = useOpenSearchDashboards<DataExplorerServices>();
   const {
-    services: {
-      data: { indexPatterns, dataSources },
-      notifications: { toasts },
-      application,
-      uiSettings,
-    },
-  } = useOpenSearchDashboards<DataExplorerServices>();
+    data: { indexPatterns, dataSources },
+    notifications: { toasts },
+    application,
+    uiSettings,
+  } = services;
 
   const handleDatasetSubmit = useCallback(
     (query: any) => {
@@ -128,6 +137,14 @@ export const Sidebar: FC = ({ children }) => {
     dataSources.dataSourceService.reload();
   }, [dataSources.dataSourceService]);
 
+  const handleSetIndexPattern: HandleSetIndexPattern = (id: string | undefined) => {
+    dispatch(setIndexPattern(id));
+  };
+
+  const handleSelectedDataset: HandleSelectedDataset = (data: Dataset | undefined) => {
+    dispatch(setSelectedDataset(data));
+  };
+
   return (
     <EuiPageSideBar className="deSidebar" sticky>
       <EuiSplitPanel.Outer
@@ -144,6 +161,10 @@ export const Sidebar: FC = ({ children }) => {
           {isEnhancementEnabled ? (
             <DatasetSelector
               onSubmit={handleDatasetSubmit}
+              selectedDataset={selectedDataset}
+              setSelectedDataset={handleSelectedDataset}
+              setIndexPattern={handleSetIndexPattern}
+              services={services}
               appearance={DatasetSelectorAppearance.Button}
               buttonProps={{
                 color: 'text',

--- a/src/plugins/data_explorer/public/index.ts
+++ b/src/plugins/data_explorer/public/index.ts
@@ -18,5 +18,6 @@ export {
   useTypedSelector,
   useTypedDispatch,
   setIndexPattern,
+  setSelectedDataset,
   setDataSet,
 } from './utils/state_management';

--- a/src/plugins/data_explorer/public/utils/state_management/metadata_slice.ts
+++ b/src/plugins/data_explorer/public/utils/state_management/metadata_slice.ts
@@ -6,11 +6,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { DataExplorerServices } from '../../types';
 import { QUERY_ENHANCEMENT_ENABLED_SETTING } from '../../components/constants';
+import { Dataset } from '../../../../data/common';
 
 export interface MetadataState {
   indexPattern?: string;
   originatingApp?: string;
   view?: string;
+  selectedDataset?: Dataset;
 }
 
 const initialState: MetadataState = {};
@@ -26,13 +28,16 @@ export const getPreloadedState = async ({
       .getStateTransfer(scopedHistory)
       .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
   const isQueryEnhancementEnabled = uiSettings.get(QUERY_ENHANCEMENT_ENABLED_SETTING);
-  const defaultIndexPattern = isQueryEnhancementEnabled
-    ? undefined
-    : await data.indexPatterns.getDefault();
+  const defaultIndexPattern = await data.indexPatterns.getDefault();
+  const selectedDataset =
+    data.query.queryString.getQuery().dataset ||
+    data.query.queryString.getDefaultQuery().dataset ||
+    undefined;
   const preloadedState: MetadataState = {
     ...initialState,
     originatingApp,
     indexPattern: defaultIndexPattern?.id,
+    selectedDataset,
   };
 
   return preloadedState;
@@ -51,6 +56,9 @@ export const slice = createSlice({
     setView: (state, action: PayloadAction<string>) => {
       state.view = action.payload;
     },
+    setSelectedDataset: (state, action: PayloadAction<Dataset | undefined>) => {
+      state.selectedDataset = action.payload;
+    },
     setState: (_state, action: PayloadAction<MetadataState>) => {
       return action.payload;
     },
@@ -58,4 +66,10 @@ export const slice = createSlice({
 });
 
 export const { reducer } = slice;
-export const { setIndexPattern, setOriginatingApp, setView, setState } = slice.actions;
+export const {
+  setIndexPattern,
+  setOriginatingApp,
+  setView,
+  setState,
+  setSelectedDataset,
+} = slice.actions;

--- a/src/plugins/data_explorer/public/utils/state_management/redux_persistence.test.tsx
+++ b/src/plugins/data_explorer/public/utils/state_management/redux_persistence.test.tsx
@@ -26,6 +26,7 @@ describe('test redux state persistence', () => {
         "metadata": Object {
           "indexPattern": "id",
           "originatingApp": undefined,
+          "selectedDataset": undefined,
         },
       }
     `);

--- a/src/plugins/data_explorer/public/utils/state_management/store.ts
+++ b/src/plugins/data_explorer/public/utils/state_management/store.ts
@@ -116,4 +116,9 @@ export type RenderState = Omit<RootState, 'metadata'>; // Remaining state after 
 export type Store = ReturnType<typeof configurePreloadedStore>;
 export type AppDispatch = Store['dispatch'];
 
-export { MetadataState, setIndexPattern, setOriginatingApp } from './metadata_slice';
+export {
+  MetadataState,
+  setIndexPattern,
+  setOriginatingApp,
+  setSelectedDataset,
+} from './metadata_slice';

--- a/src/plugins/discover/public/application/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/get_top_nav_links.tsx
@@ -277,7 +277,8 @@ export const getTopNavLinks = (
   services: DiscoverViewServices,
   inspectorAdapters: Adapters,
   savedSearch: SavedSearch,
-  isEnhancementEnabled: boolean = false
+  isEnhancementEnabled: boolean = false,
+  useNoIndexPatternsTopNav: boolean = false
 ) => {
   const {
     history,
@@ -503,8 +504,18 @@ export const getTopNavLinks = (
   // Order their appearance
   return ['save', 'open', 'new', 'inspect', 'share'].reduce((acc, item) => {
     const itemDef = topNavLinksMap.get(item);
-    if (itemDef) acc.push(itemDef);
-
+    if (itemDef) {
+      if (useNoIndexPatternsTopNav && item !== 'open') {
+        // Disable all buttons except 'open' when in no index patterns mode
+        acc.push({
+          ...itemDef,
+          disabled: true,
+          run: () => {}, // Empty function for disabled buttons
+        });
+      } else {
+        acc.push(itemDef);
+      }
+    }
     return acc;
   }, [] as TopNavMenuData[]);
 };

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -166,10 +166,10 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
     );
   };
 
-  const useNoIndexPatternsPanel =
+  const hasNoDataset =
     !currentIndexPattern && !loadedIndexPattern && isEnhancementsEnabled;
 
-  return !useNoIndexPatternsPanel ? (
+  return (
     <EuiPanel
       panelRef={panelRef}
       hasBorder={true}
@@ -186,8 +186,12 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
           optionalRef,
         }}
         showSaveQuery={showSaveQuery}
+        useNoIndexPatternsTopNav={hasNoDataset}
       />
-
+      {hasNoDataset ? (
+        <NoIndexPatternsPanel onOpenDataSelector={handleOpenDataSelector} />
+      ) : (
+        <>
       {fetchState.status === ResultStatus.NO_RESULTS && (
         <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
       )}
@@ -210,9 +214,9 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
           <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
         </EuiPanel>
       )}
+            </>
+            )}
     </EuiPanel>
-  ) : (
-    <NoIndexPatternsPanel onOpenDataSelector={handleOpenDataSelector} />
   );
 }
 

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -166,13 +166,13 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
     );
   };
 
-  const hasNoDataset =
-    !currentIndexPattern && !loadedIndexPattern && isEnhancementsEnabled;
+  const hasNoDataset = !currentIndexPattern && !loadedIndexPattern && isEnhancementsEnabled;
 
   return (
     <EuiPanel
       panelRef={panelRef}
-      hasBorder={true}
+      hasBorder={hasNoDataset ? false : true}
+      color={hasNoDataset ? 'transparent' : 'plain'}
       hasShadow={false}
       paddingSize="s"
       className="dscCanvas"
@@ -192,30 +192,30 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
         <NoIndexPatternsPanel onOpenDataSelector={handleOpenDataSelector} />
       ) : (
         <>
-      {fetchState.status === ResultStatus.NO_RESULTS && (
-        <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
-      )}
-      {fetchState.status === ResultStatus.ERROR && (
-        <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
-      )}
-      {fetchState.status === ResultStatus.UNINITIALIZED && (
-        <DiscoverUninitialized onRefresh={() => refetch$.next()} />
-      )}
-      {fetchState.status === ResultStatus.LOADING && <LoadingSpinner />}
-      {fetchState.status === ResultStatus.READY && isEnhancementsEnabled && (
-        <>
-          <MemoizedDiscoverChartContainer {...fetchState} />
-          <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
+          {fetchState.status === ResultStatus.NO_RESULTS && (
+            <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
+          )}
+          {fetchState.status === ResultStatus.ERROR && (
+            <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
+          )}
+          {fetchState.status === ResultStatus.UNINITIALIZED && (
+            <DiscoverUninitialized onRefresh={() => refetch$.next()} />
+          )}
+          {fetchState.status === ResultStatus.LOADING && <LoadingSpinner />}
+          {fetchState.status === ResultStatus.READY && isEnhancementsEnabled && (
+            <>
+              <MemoizedDiscoverChartContainer {...fetchState} />
+              <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
+            </>
+          )}
+          {fetchState.status === ResultStatus.READY && !isEnhancementsEnabled && (
+            <EuiPanel hasShadow={false} paddingSize="none" className="dscCanvas_results">
+              <MemoizedDiscoverChartContainer {...fetchState} />
+              <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
+            </EuiPanel>
+          )}
         </>
       )}
-      {fetchState.status === ResultStatus.READY && !isEnhancementsEnabled && (
-        <EuiPanel hasShadow={false} paddingSize="none" className="dscCanvas_results">
-          <MemoizedDiscoverChartContainer {...fetchState} />
-          <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
-        </EuiPanel>
-      )}
-            </>
-            )}
     </EuiPanel>
   );
 }

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -35,9 +35,10 @@ export interface TopNavProps {
   };
   showSaveQuery: boolean;
   isEnhancementsEnabled?: boolean;
+  useNoIndexPatternsTopNav?: boolean;
 }
 
-export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavProps) => {
+export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled, useNoIndexPatternsTopNav=false }: TopNavProps) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
   const { data$, inspectorAdapters, savedSearch, indexPattern } = useDiscoverContext();
   const [indexPatterns, setIndexPatterns] = useState<IndexPattern[] | undefined>(undefined);
@@ -62,7 +63,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
   const showActionsInGroup = uiSettings.get('home:useNewHomePage');
 
   const topNavLinks = savedSearch
-    ? getTopNavLinks(services, inspectorAdapters, savedSearch, isEnhancementsEnabled)
+    ? getTopNavLinks(services, inspectorAdapters, savedSearch, isEnhancementsEnabled, useNoIndexPatternsTopNav)
     : [];
 
   connectStorageToQueryState(
@@ -164,18 +165,20 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
       <TopNavMenu
         appName={PLUGIN_ID}
         config={displayToNavLinkInPortal ? [] : topNavLinks}
-        showSearchBar={TopNavMenuItemRenderType.IN_PLACE}
+        showSearchBar={useNoIndexPatternsTopNav ? TopNavMenuItemRenderType.OMITTED : TopNavMenuItemRenderType.IN_PLACE}
         showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
-        showSaveQuery={showSaveQuery}
+        showSaveQuery={useNoIndexPatternsTopNav ? false : showSaveQuery}
         useDefaultBehaviors
         setMenuMountPoint={opts.setHeaderActionMenu}
-        indexPatterns={indexPattern ? [indexPattern] : indexPatterns}
-        onQuerySubmit={opts.onQuerySubmit}
-        savedQueryId={state.savedQuery}
-        onSavedQueryIdChange={updateSavedQueryId}
-        datePickerRef={opts?.optionalRef?.datePickerRef}
+        indexPatterns={useNoIndexPatternsTopNav ? [] : (indexPattern ? [indexPattern] : indexPatterns)}
+        onQuerySubmit={useNoIndexPatternsTopNav ? () => {} : opts.onQuerySubmit}
+        savedQueryId={useNoIndexPatternsTopNav ? undefined : state.savedQuery}
+        onSavedQueryIdChange={useNoIndexPatternsTopNav ? () => {} : updateSavedQueryId}
+        datePickerRef={useNoIndexPatternsTopNav ? undefined : opts?.optionalRef?.datePickerRef}
         groupActions={showActionsInGroup}
-        screenTitle={screenTitle}
+        screenTitle={useNoIndexPatternsTopNav ? i18n.translate('discover.noIndexPatterns.screenTitle', {
+          defaultMessage: 'Select data',
+        }) : screenTitle}
         queryStatus={queryStatus}
       />
     </>

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -38,7 +38,12 @@ export interface TopNavProps {
   useNoIndexPatternsTopNav?: boolean;
 }
 
-export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled, useNoIndexPatternsTopNav=false }: TopNavProps) => {
+export const TopNav = ({
+  opts,
+  showSaveQuery,
+  isEnhancementsEnabled,
+  useNoIndexPatternsTopNav = false,
+}: TopNavProps) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
   const { data$, inspectorAdapters, savedSearch, indexPattern } = useDiscoverContext();
   const [indexPatterns, setIndexPatterns] = useState<IndexPattern[] | undefined>(undefined);
@@ -63,7 +68,13 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled, useNoIndexP
   const showActionsInGroup = uiSettings.get('home:useNewHomePage');
 
   const topNavLinks = savedSearch
-    ? getTopNavLinks(services, inspectorAdapters, savedSearch, isEnhancementsEnabled, useNoIndexPatternsTopNav)
+    ? getTopNavLinks(
+        services,
+        inspectorAdapters,
+        savedSearch,
+        isEnhancementsEnabled,
+        useNoIndexPatternsTopNav
+      )
     : [];
 
   connectStorageToQueryState(
@@ -165,20 +176,30 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled, useNoIndexP
       <TopNavMenu
         appName={PLUGIN_ID}
         config={displayToNavLinkInPortal ? [] : topNavLinks}
-        showSearchBar={useNoIndexPatternsTopNav ? TopNavMenuItemRenderType.OMITTED : TopNavMenuItemRenderType.IN_PLACE}
+        showSearchBar={
+          useNoIndexPatternsTopNav
+            ? TopNavMenuItemRenderType.OMITTED
+            : TopNavMenuItemRenderType.IN_PLACE
+        }
         showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
         showSaveQuery={useNoIndexPatternsTopNav ? false : showSaveQuery}
         useDefaultBehaviors
         setMenuMountPoint={opts.setHeaderActionMenu}
-        indexPatterns={useNoIndexPatternsTopNav ? [] : (indexPattern ? [indexPattern] : indexPatterns)}
+        indexPatterns={
+          useNoIndexPatternsTopNav ? [] : indexPattern ? [indexPattern] : indexPatterns
+        }
         onQuerySubmit={useNoIndexPatternsTopNav ? () => {} : opts.onQuerySubmit}
         savedQueryId={useNoIndexPatternsTopNav ? undefined : state.savedQuery}
         onSavedQueryIdChange={useNoIndexPatternsTopNav ? () => {} : updateSavedQueryId}
         datePickerRef={useNoIndexPatternsTopNav ? undefined : opts?.optionalRef?.datePickerRef}
         groupActions={showActionsInGroup}
-        screenTitle={useNoIndexPatternsTopNav ? i18n.translate('discover.noIndexPatterns.screenTitle', {
-          defaultMessage: 'Select data',
-        }) : screenTitle}
+        screenTitle={
+          useNoIndexPatternsTopNav
+            ? i18n.translate('discover.noIndexPatterns.screenTitle', {
+                defaultMessage: 'Select data',
+              })
+            : screenTitle
+        }
         queryStatus={queryStatus}
       />
     </>

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -88,7 +88,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
   useEffect(() => {
     let isMounted = true;
     const initializeDataset = async () => {
-      await data.indexPatterns.ensureDefaultIndexPattern();
+      await data.indexPatterns.ensureDefaultIndexPattern(isEnhancementsEnabled ? false : true);
       const defaultIndexPattern = await data.indexPatterns.getDefault();
       // TODO: ROCKY do we need this?
       // const queryString = data.query.queryString;
@@ -107,7 +107,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     return () => {
       isMounted = false;
     };
-  }, [data.indexPatterns, data.query]);
+  }, [data.indexPatterns, data.query, isEnhancementsEnabled]);
 
   useEffect(() => {
     const pageTitleSuffix = savedSearch?.id && savedSearch.title ? `: ${savedSearch.title}` : '';

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -162,6 +162,8 @@ export const EditIndexPattern = withRouter(
         }
         if (indexPattern.id) {
           Promise.resolve(data.indexPatterns.delete(indexPattern.id)).then(function () {
+            const datasetService = data.query.queryString.getDatasetService();
+            datasetService.removeFromRecentDatasets(indexPattern.id);
             history.push('');
           });
         }


### PR DESCRIPTION
### Description
This PR primarily addresses the scenario when no index patterns (general) is available in the Discover view.
Instead of redirecting users to the index management page, it introduces a new "No Index Patterns" panel.
This panel provides users with the option to open a data selector and add index patterns
directly from the Discover view, improving the user experience for new or empty deployments.

To achieve, we move the selectedDataset state from ConnectedDatasetSelector to the app container's
state management. This allows the AdvancedSelector, opened from the AppContainer, to update
the dataset state effectively. Key changes include:

* Implementing NoIndexPatternsPanel and AdvancedSelector components.
* Refactoring dataset state management in AppContainer and Sidebar.
* Modifying DiscoverCanvas to conditionally render NoIndexPatternsPanel.
* Updating ConnectedDatasetSelector to use shared state and dataset change handling.

### Issues Resolved
NA

## Screenshot

* when query enhancement is on

https://github.com/user-attachments/assets/550864cb-fea2-417d-bd4c-4caf1379a9ad

* same behavior in the legacy discover 


https://github.com/user-attachments/assets/cc740ef1-5deb-40b7-a43c-ba1dd4b1a57e


## Testing the changes


## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

