### PR TITLE
[Discover]Sample Queries and Saved Queries in No Results Page

### DIFF
--- a/changelogs/fragments/8616.yml
+++ b/changelogs/fragments/8616.yml
@@ -1,0 +1,2 @@
+feat:
+- Adds sample queries and saved queries to Discover no results page ([#8616](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8616))

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -4,6 +4,7 @@
  */
 
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import { i18n } from '@osd/i18n';
 import { DataSourceAttributes } from '../../../../../../data_source/common/data_sources';
 import {
   DEFAULT_DATA,
@@ -69,6 +70,29 @@ export const indexPatternTypeConfig: DatasetTypeConfig = {
       return ['kuery', 'lucene'];
     }
     return ['kuery', 'lucene', 'PPL', 'SQL'];
+  },
+
+  getSampleQueries: (dataset: Dataset, language: string) => {
+    switch (language) {
+      case 'PPL':
+        return [
+          {
+            title: i18n.translate('data.indexPatternType.sampleQuery.basicPPLQuery', {
+              defaultMessage: 'Sample query for PPL',
+            }),
+            query: `source = ${dataset.title}`,
+          },
+        ];
+      case 'SQL':
+        return [
+          {
+            title: i18n.translate('data.indexPatternType.sampleQuery.basicSQLQuery', {
+              defaultMessage: 'Sample query for SQL',
+            }),
+            query: `SELECT * FROM ${dataset.title} LIMIT 10`,
+          },
+        ];
+    }
   },
 };
 

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -5,6 +5,7 @@
 
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { map } from 'rxjs/operators';
+import { i18n } from '@osd/i18n';
 import {
   DEFAULT_DATA,
   DataStructure,
@@ -87,6 +88,29 @@ export const indexTypeConfig: DatasetTypeConfig = {
 
   supportedLanguages: (dataset: Dataset): string[] => {
     return ['SQL', 'PPL'];
+  },
+
+  getSampleQueries: (dataset: Dataset, language: string) => {
+    switch (language) {
+      case 'PPL':
+        return [
+          {
+            title: i18n.translate('data.indexType.sampleQuery.basicPPLQuery', {
+              defaultMessage: 'Sample query for PPL',
+            }),
+            query: `source = ${dataset.title}`,
+          },
+        ];
+      case 'SQL':
+        return [
+          {
+            title: i18n.translate('data.indexType.sampleQuery.basicSQLQuery', {
+              defaultMessage: 'Sample query for SQL',
+            }),
+            query: `SELECT * FROM ${dataset.title} LIMIT 10`,
+          },
+        ];
+    }
   },
 };
 

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -71,4 +71,8 @@ export interface DatasetTypeConfig {
    * @see https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8362.
    */
   combineDataStructures?: (dataStructures: DataStructure[]) => DataStructure | undefined;
+  /**
+   * Returns a list of sample queries for this dataset type
+   */
+  getSampleQueries?: (dataset: Dataset, language: string) => any;
 }

--- a/src/plugins/data/public/query/query_string/language_service/lib/dql_language.ts
+++ b/src/plugins/data/public/query/query_string/language_service/lib/dql_language.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import { LanguageConfig } from '../types';
 import { ISearchInterceptor } from '../../../../search';
 
@@ -25,5 +26,51 @@ export const getDQLLanguageConfig = (
     showDocLinks: true,
     editorSupportedAppNames: ['discover'],
     supportedAppNames: ['discover', 'dashboards', 'visualize', 'data-explorer', 'vis-builder', '*'],
+    sampleQueries: [
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.titleContainsWind', {
+          defaultMessage: 'The title field contains the word wind.',
+        }),
+        query: 'title: wind',
+      },
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.titleContainsWindOrWindy', {
+          defaultMessage: 'The title field contains the word wind or the word windy.',
+        }),
+        query: 'title: (wind OR windy)',
+      },
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.titleContainsPhraseWindRises', {
+          defaultMessage: 'The title field contains the phrase wind rises.',
+        }),
+        query: 'title: "wind rises"',
+      },
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.titleKeywordExactMatch', {
+          defaultMessage: 'The title.keyword field exactly matches The wind rises.',
+        }),
+        query: 'title.keyword: The wind rises',
+      },
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.titleFieldsContainWind', {
+          defaultMessage:
+            'Any field that starts with title (for example, title and title.keyword) contains the word wind',
+        }),
+        query: 'title*: wind',
+      },
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.articleTitleContainsWind', {
+          defaultMessage:
+            'The field that starts with article and ends with title contains the word wind. Matches the field article title.',
+        }),
+        query: 'article*title: wind',
+      },
+      {
+        title: i18n.translate('data.dqlLanguage.sampleQuery.descriptionFieldExists', {
+          defaultMessage: 'Documents in which the field description exists.',
+        }),
+        query: 'description:*',
+      },
+    ],
   };
 };

--- a/src/plugins/data/public/query/query_string/language_service/lib/lucene_language.ts
+++ b/src/plugins/data/public/query/query_string/language_service/lib/lucene_language.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import { LanguageConfig } from '../types';
 import { ISearchInterceptor } from '../../../../search';
 
@@ -25,5 +26,51 @@ export const getLuceneLanguageConfig = (
     showDocLinks: true,
     editorSupportedAppNames: ['discover'],
     supportedAppNames: ['discover', 'dashboards', 'visualize', 'data-explorer', 'vis-builder', '*'],
+    sampleQueries: [
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.titleContainsWind', {
+          defaultMessage: 'The title field contains the word wind.',
+        }),
+        query: 'title: wind',
+      },
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.titleContainsWindOrWindy', {
+          defaultMessage: 'The title field contains the word wind or the word windy.',
+        }),
+        query: 'title: (wind OR windy)',
+      },
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.titleContainsPhraseWindRises', {
+          defaultMessage: 'The title field contains the phrase wind rises.',
+        }),
+        query: 'title: "wind rises"',
+      },
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.titleKeywordExactMatch', {
+          defaultMessage: 'The title.keyword field exactly matches The wind rises.',
+        }),
+        query: 'title.keyword: The wind rises',
+      },
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.titleFieldsContainWind', {
+          defaultMessage:
+            'Any field that starts with title (for example, title and title.keyword) contains the word wind',
+        }),
+        query: 'title*: wind',
+      },
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.articleTitleContainsWind', {
+          defaultMessage:
+            'The field that starts with article and ends with title contains the word wind. Matches the field article title.',
+        }),
+        query: 'article*title: wind',
+      },
+      {
+        title: i18n.translate('data.luceneLanguage.sampleQuery.descriptionFieldExists', {
+          defaultMessage: 'Documents in which the field description exists.',
+        }),
+        query: 'description:*',
+      },
+    ],
   };
 };

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -35,6 +35,11 @@ export interface EditorEnhancements {
   queryEditorExtension?: QueryEditorExtensionConfig;
 }
 
+export interface SampleQuery {
+  title: string;
+  query: string;
+}
+
 export interface LanguageConfig {
   id: string;
   title: string;
@@ -53,4 +58,5 @@ export interface LanguageConfig {
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
   hideDatePicker?: boolean;
+  sampleQueries?: SampleQuery[];
 }

--- a/src/plugins/data/public/ui/_common.scss
+++ b/src/plugins/data/public/ui/_common.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .dataUI-centerPanel {
   height: 100%;
   width: 100%;

--- a/src/plugins/discover/public/application/components/no_results/no_results.scss
+++ b/src/plugins/discover/public/application/components/no_results/no_results.scss
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.discoverNoResults-sampleContainer {
+  @include euiLegibilityMaxWidth(100%);
+
+  margin: 0 auto;
+}

--- a/src/plugins/discover/public/application/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/components/no_results/no_results.tsx
@@ -28,18 +28,17 @@
  * under the License.
  */
 
+import './no_results.scss';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 
 import {
   EuiEmptyPrompt,
-  EuiPanel,
   EuiText,
   EuiTabbedContent,
   EuiCodeBlock,
   EuiSpacer,
-  EuiFlexGroup,
-  EuiFlexItem,
+  EuiPanel,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { Query } from '../../../../../data/common';
@@ -210,16 +209,19 @@ export const DiscoverNoResults = ({
     };
 
     const sampleQueries = [];
-    if (query?.dataset?.type && datasetService.getType(query.dataset.type)?.getSampleQueries) {
-      sampleQueries.push(
-        ...datasetService.getType(query.dataset.type)!.getSampleQueries!(
-          query.dataset,
-          query.language
-        )
-      );
+
+    // Samples for the dataset type
+    if (query?.dataset?.type) {
+      const datasetSampleQueries = datasetService
+        .getType(query.dataset.type)
+        ?.getSampleQueries?.(query.dataset, query.language);
+      if (Array.isArray(datasetSampleQueries)) sampleQueries.push(...datasetSampleQueries);
     }
-    if (query && languageService.getLanguage(query?.language)?.sampleQueries) {
-      sampleQueries.push(...(languageService.getLanguage(query.language)!.sampleQueries ?? []));
+
+    // Samples for the language
+    if (query?.language) {
+      const languageSampleQueries = languageService.getLanguage(query.language)?.sampleQueries;
+      if (Array.isArray(languageSampleQueries)) sampleQueries.push(...languageSampleQueries);
     }
 
     return [
@@ -231,14 +233,14 @@ export const DiscoverNoResults = ({
                 defaultMessage: 'Sample Queries',
               }),
               content: (
-                <Fragment>
+                <EuiPanel hasBorder={false} hasShadow={false}>
                   <EuiSpacer size="s" />
                   {sampleQueries
                     .slice(0, 5)
                     .map((sampleQuery) =>
                       buildSampleQueryBlock(sampleQuery.title, sampleQuery.query)
                     )}
-                </Fragment>
+                </EuiPanel>
               ),
             },
           ]
@@ -266,39 +268,33 @@ export const DiscoverNoResults = ({
 
   return (
     <I18nProvider>
-      <EuiPanel hasBorder={false} hasShadow={false} color="transparent">
-        <EuiFlexGroup alignItems="center" justifyContent="center">
-          <EuiFlexItem grow={false}>
-            <EuiPanel hasBorder={true}>
-              <EuiEmptyPrompt
-                iconType="alert"
-                iconColor="default"
-                data-test-subj="discoverNoResults"
-                title={
-                  <EuiText size="s">
-                    <h2>
-                      {i18n.translate('discover.emptyPrompt.title', {
-                        defaultMessage: 'No Results',
-                      })}
-                    </h2>
-                  </EuiText>
-                }
-                body={
-                  <EuiText size="s" data-test-subj="discoverNoResultsTimefilter">
-                    <p>
-                      {i18n.translate('discover.emptyPrompt.body', {
-                        defaultMessage:
-                          'Try selecting a different data source, expanding your time range or modifying the query & filters.',
-                      })}
-                    </p>
-                  </EuiText>
-                }
-              />
-              <EuiTabbedContent tabs={tabs} />
-            </EuiPanel>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
+      <EuiEmptyPrompt
+        iconType="editorCodeBlock"
+        iconColor="default"
+        data-test-subj="discoverNoResults"
+        title={
+          <EuiText size="s">
+            <h2>
+              {i18n.translate('discover.emptyPrompt.title', {
+                defaultMessage: 'No Results',
+              })}
+            </h2>
+          </EuiText>
+        }
+        body={
+          <EuiText size="s" data-test-subj="discoverNoResultsTimefilter">
+            <p>
+              {i18n.translate('discover.emptyPrompt.body', {
+                defaultMessage:
+                  'Try selecting a different data source, expanding your time range or modifying the query & filters.',
+              })}
+            </p>
+          </EuiText>
+        }
+      />
+      <div className="discoverNoResults-sampleContainer">
+        <EuiTabbedContent tabs={tabs} />
+      </div>
     </I18nProvider>
   );
 };

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -27,6 +27,7 @@ import { OpenSearchSearchHit } from '../../../application/doc_views/doc_views_ty
 import { buildColumns } from '../../utils/columns';
 import './discover_canvas.scss';
 import { HeaderVariant } from '../../../../../../core/public';
+import { Query } from '../../../../../../../src/plugins/data/common/types';
 import { setIndexPattern, setSelectedDataset } from '../../../../../data_explorer/public';
 import { NoIndexPatternsPanel, AdvancedSelector } from '../../../../../data/public';
 import { Dataset } from '../../../../../data/common';
@@ -48,6 +49,9 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
     data,
     overlays,
   } = services;
+  const datasetService = data.query.queryString.getDatasetService();
+  const savedQuery = data.query.savedQueries;
+  const languageService = data.query.queryString.getLanguageService();
   const { columns } = useSelector((state) => {
     const stateColumns = state.discover.columns;
 
@@ -65,6 +69,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
   );
   const dispatch = useDispatch();
   const prevIndexPattern = useRef(indexPattern);
+  const [query, setQuery] = useState<Query>();
 
   const [fetchState, setFetchState] = useState<SearchData>({
     status: data$.getValue().status,
@@ -74,6 +79,9 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
 
   const onQuerySubmit = useCallback(
     (payload, isUpdate) => {
+      if (payload?.query) {
+        setQuery(payload?.query);
+      }
       if (isUpdate === false) {
         refetch$.next();
       }
@@ -136,8 +144,8 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
 
     // Update query and other necessary state
     const queryString = data.query.queryString;
-    const query = queryString.getInitialQueryByDataset(dataset);
-    queryString.setQuery(query);
+    const initialQuery = queryString.getInitialQueryByDataset(dataset);
+    queryString.setQuery(initialQuery);
     queryString.getDatasetService().addRecentDataset(dataset);
   };
 
@@ -193,10 +201,24 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
       ) : (
         <>
           {fetchState.status === ResultStatus.NO_RESULTS && (
-            <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
+            <DiscoverNoResults
+              datasetService={datasetService}
+              savedQuery={savedQuery}
+              languageService={languageService}
+              query={query}
+              timeFieldName={timeField}
+              queryLanguage={''}
+            />
           )}
           {fetchState.status === ResultStatus.ERROR && (
-            <DiscoverNoResults timeFieldName={timeField} queryLanguage={''} />
+            <DiscoverNoResults
+              datasetService={datasetService}
+              savedQuery={savedQuery}
+              languageService={languageService}
+              query={query}
+              timeFieldName={timeField}
+              queryLanguage={''}
+            />
           )}
           {fetchState.status === ResultStatus.UNINITIALIZED && (
             <DiscoverUninitialized onRefresh={() => refetch$.next()} />

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -5,6 +5,7 @@
 
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { trimEnd } from 'lodash';
+import { i18n } from '@osd/i18n';
 import {
   DATA_STRUCTURE_META_TYPES,
   DEFAULT_DATA,
@@ -101,6 +102,29 @@ export const s3TypeConfig: DatasetTypeConfig = {
 
   supportedLanguages: (dataset: Dataset): string[] => {
     return ['SQL'];
+  },
+
+  getSampleQueries: (dataset: Dataset, language: string) => {
+    switch (language) {
+      case 'PPL':
+        return [
+          {
+            title: i18n.translate('queryEnhancements.s3Type.sampleQuery.basicPPLQuery', {
+              defaultMessage: 'Sample query for PPL',
+            }),
+            query: `source = ${dataset.title}`,
+          },
+        ];
+      case 'SQL':
+        return [
+          {
+            title: i18n.translate('queryEnhancements.s3Type.sampleQuery.basicSQLQuery', {
+              defaultMessage: 'Sample query for SQL',
+            }),
+            query: `SELECT * FROM ${dataset.title} LIMIT 10`,
+          },
+        ];
+    }
   },
 };
 

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
 import { ConfigSchema } from '../common/config';
 import { setData, setStorage } from './services';
@@ -100,6 +101,60 @@ export class QueryEnhancementsPlugin
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],
       hideDatePicker: true,
+      sampleQueries: [
+        {
+          title: i18n.translate('queryEnhancements.sqlLanguage.sampleQuery.titleContainsWind', {
+            defaultMessage: 'The title field contains the word wind.',
+          }),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind%'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleContainsWindOrWindy',
+            {
+              defaultMessage: 'The title field contains the word wind or the word windy.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind%' OR title LIKE '%windy%';`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleContainsPhraseWindRises',
+            {
+              defaultMessage: 'The title field contains the phrase wind rises.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind rises%'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleExactMatchWindRises',
+            {
+              defaultMessage: 'The title.keyword field exactly matches The wind rises.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title = 'The wind rises'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleFieldsContainWind',
+            {
+              defaultMessage:
+                'Any field that starts with title (for example, title and title.keyword) contains the word wind',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind%' OR title = 'wind'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.descriptionFieldExists',
+            {
+              defaultMessage: 'Documents in which the field description exists.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE description IS NOT NULL AND description != '';`,
+        },
+      ],
     };
     queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
 


### PR DESCRIPTION
### Description

* Adds support for dataset types to return a list of sample queries
* Update Discover no results page to display listed sample queries and saved queries

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/eec39018-ab3d-44ef-a0a0-9cc3221b53e0">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1002d0e6-faae-40f8-9262-18f498c7ff1a">

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: Adds sample queries and saved queries to Discover no results page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
