### PR TITLE
[Workspace] Update default workspace permission and users config support wildcard

### DIFF
--- a/changelogs/fragments/8617.yml
+++ b/changelogs/fragments/8617.yml
@@ -1,0 +1,2 @@
+refactor:
+- [Workspace] Update default OSD admin config permission and support wildcard. ([#8617](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8617))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -372,6 +372,6 @@
 # Set the backend roles in groups or users, whoever has the backend roles or exactly match the user ids defined in this config will be regard as dashboard admin.
 # Dashboard admin will have the access to all the workspaces(workspace.enabled: true) and objects inside OpenSearch Dashboards.
 # The default config is [], and no one will be dashboard admin. 
-# If the config is set to wildcard ["*"], anyone will be dashboard admin.
+# If the user config is set to wildcard ["*"], anyone will be dashboard admin.
 # opensearchDashboards.dashboardAdmin.groups: ["dashboard_admin"]
 # opensearchDashboards.dashboardAdmin.users: ["dashboard_admin"]

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -371,5 +371,7 @@
 
 # Set the backend roles in groups or users, whoever has the backend roles or exactly match the user ids defined in this config will be regard as dashboard admin.
 # Dashboard admin will have the access to all the workspaces(workspace.enabled: true) and objects inside OpenSearch Dashboards.
+# The default config is [], and no one will be dashboard admin. 
+# If the config is set to wildcard ["*"], anyone will be dashboard admin.
 # opensearchDashboards.dashboardAdmin.groups: ["dashboard_admin"]
 # opensearchDashboards.dashboardAdmin.users: ["dashboard_admin"]

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -176,4 +176,4 @@ export const WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES = [
 
 export const USE_CASE_CARD_GRADIENT_PREFIX = 'workspace-initial-use-case-card';
 
-export const OSD_ADMIN_WILDCARD_MATH_ALL = '*';
+export const OSD_ADMIN_WILDCARD_MATCH_ALL = '*';

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -175,3 +175,5 @@ export const WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES = [
 ];
 
 export const USE_CASE_CARD_GRADIENT_PREFIX = 'workspace-initial-use-case-card';
+
+export const OSD_ADMIN_WILDCARD_MATH_ALL = '*';

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -21,6 +21,7 @@ import {
 import { getWorkspaceState } from '../../../core/server/utils';
 import { Observable, of } from 'rxjs';
 import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../data_source_management/common';
+import { OSD_ADMIN_WILDCARD_MATH_ALL } from '../common/constants';
 
 describe('workspace utils', () => {
   it('should generate id with the specified size', () => {
@@ -76,11 +77,21 @@ describe('workspace utils', () => {
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });
 
-  it('should be dashboard admin when configGroups and configUsers are []', () => {
+  it('should be not dashboard admin when configGroups and configUsers are []', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
     const groups: string[] = ['user1'];
     const users: string[] = [];
     const configGroups: string[] = [];
+    const configUsers: string[] = [];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
+  });
+
+  it('should be dashboard admin when configGroups or configUsers include wildcard *', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = ['user1'];
+    const users: string[] = [];
+    const configGroups: string[] = [OSD_ADMIN_WILDCARD_MATH_ALL];
     const configUsers: string[] = [];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -77,7 +77,7 @@ describe('workspace utils', () => {
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });
 
-  it('should be not dashboard admin when configGroups and configUsers are []', () => {
+  it('should not be dashboard admin when configGroups and configUsers are []', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
     const groups: string[] = [];
     const users: string[] = ['user1'];

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -21,7 +21,7 @@ import {
 import { getWorkspaceState } from '../../../core/server/utils';
 import { Observable, of } from 'rxjs';
 import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../data_source_management/common';
-import { OSD_ADMIN_WILDCARD_MATH_ALL } from '../common/constants';
+import { OSD_ADMIN_WILDCARD_MATCH_ALL } from '../common/constants';
 
 describe('workspace utils', () => {
   it('should generate id with the specified size', () => {
@@ -92,7 +92,7 @@ describe('workspace utils', () => {
     const groups: string[] = [];
     const users: string[] = ['user1'];
     const configGroups: string[] = [];
-    const configUsers: string[] = [OSD_ADMIN_WILDCARD_MATH_ALL];
+    const configUsers: string[] = [OSD_ADMIN_WILDCARD_MATCH_ALL];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -79,8 +79,8 @@ describe('workspace utils', () => {
 
   it('should be not dashboard admin when configGroups and configUsers are []', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
-    const groups: string[] = ['user1'];
-    const users: string[] = [];
+    const groups: string[] = [];
+    const users: string[] = ['user1'];
     const configGroups: string[] = [];
     const configUsers: string[] = [];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
@@ -89,10 +89,10 @@ describe('workspace utils', () => {
 
   it('should be dashboard admin when configGroups or configUsers include wildcard *', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
-    const groups: string[] = ['user1'];
-    const users: string[] = [];
-    const configGroups: string[] = [OSD_ADMIN_WILDCARD_MATH_ALL];
-    const configUsers: string[] = [];
+    const groups: string[] = [];
+    const users: string[] = ['user1'];
+    const configGroups: string[] = [];
+    const configUsers: string[] = [OSD_ADMIN_WILDCARD_MATH_ALL];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -20,6 +20,7 @@ import {
   CURRENT_USER_PLACEHOLDER,
   WorkspacePermissionMode,
   WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
+  OSD_ADMIN_WILDCARD_MATH_ALL,
 } from '../common/constants';
 import { PermissionModeId } from '../../../core/server';
 
@@ -39,17 +40,22 @@ export const updateDashboardAdminStateForRequest = (
 ) => {
   // If the security plugin is not installed, login defaults to OSD Admin
   if (!groups.length && !users.length) {
-    updateWorkspaceState(request, { isDashboardAdmin: true });
-    return;
+    return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
-  // If groups/users are not configured or [], login defaults to OSD Admin
+  // If groups/users are not configured or [], login is not OSD Admin
   if (!configGroups.length && !configUsers.length) {
-    updateWorkspaceState(request, { isDashboardAdmin: true });
-    return;
+    return updateWorkspaceState(request, { isDashboardAdmin: false });
+  }
+  // If config contains wildcard characters '*', login defaults to OSD Admin
+  if (
+    configGroups.includes(OSD_ADMIN_WILDCARD_MATH_ALL) ||
+    configUsers.includes(OSD_ADMIN_WILDCARD_MATH_ALL)
+  ) {
+    return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
   const groupMatchAny = groups.some((group) => configGroups.includes(group));
   const userMatchAny = users.some((user) => configUsers.includes(user));
-  updateWorkspaceState(request, {
+  return updateWorkspaceState(request, {
     isDashboardAdmin: groupMatchAny || userMatchAny,
   });
 };

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -46,11 +46,8 @@ export const updateDashboardAdminStateForRequest = (
   if (!configGroups.length && !configUsers.length) {
     return updateWorkspaceState(request, { isDashboardAdmin: false });
   }
-  // If config contains wildcard characters '*', login defaults to OSD Admin
-  if (
-    configGroups.includes(OSD_ADMIN_WILDCARD_MATH_ALL) ||
-    configUsers.includes(OSD_ADMIN_WILDCARD_MATH_ALL)
-  ) {
+  // If user config contains wildcard characters '*', login defaults to OSD Admin
+  if (configUsers.includes(OSD_ADMIN_WILDCARD_MATH_ALL)) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
   const groupMatchAny = groups.some((group) => configGroups.includes(group));

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -20,7 +20,7 @@ import {
   CURRENT_USER_PLACEHOLDER,
   WorkspacePermissionMode,
   WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
-  OSD_ADMIN_WILDCARD_MATH_ALL,
+  OSD_ADMIN_WILDCARD_MATCH_ALL,
 } from '../common/constants';
 import { PermissionModeId } from '../../../core/server';
 
@@ -43,7 +43,7 @@ export const updateDashboardAdminStateForRequest = (
     return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
   // If user config contains wildcard characters '*', login defaults to OSD Admin
-  if (configUsers.includes(OSD_ADMIN_WILDCARD_MATH_ALL)) {
+  if (configUsers.includes(OSD_ADMIN_WILDCARD_MATCH_ALL)) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
   const groupMatchAny = groups.some((group) => configGroups.includes(group));

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -42,10 +42,6 @@ export const updateDashboardAdminStateForRequest = (
   if (!groups.length && !users.length) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
-  // If groups/users are not configured or [], login is not OSD Admin
-  if (!configGroups.length && !configUsers.length) {
-    return updateWorkspaceState(request, { isDashboardAdmin: false });
-  }
   // If user config contains wildcard characters '*', login defaults to OSD Admin
   if (configUsers.includes(OSD_ADMIN_WILDCARD_MATH_ALL)) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });


### PR DESCRIPTION
### Description

Update default workspace permission and support wildcard.
1. Without configuring OSD admin in the `config.yml`, anyone will not be OSD admin.
2. Support wildcard `*` in users config. With configuring `*` in the `config.yml` (`opensearchDashboards.dashboardAdmin.users: ["*"]`), anyone will be OSD admin.


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
 - refactor: [Workspace] Update default OSD admin config permission and support wildcard.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
