### PR TITLE
[Workspace] fine-tune workspace list page compressed style to align with compressed table

### DIFF
--- a/changelogs/fragments/8619.yml
+++ b/changelogs/fragments/8619.yml
@@ -1,0 +1,2 @@
+refactor:
+- Fine-tune workspace list page compressed style to align with compressed table ([#8619](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8619))

--- a/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_list/__snapshots__/index.test.tsx.snap
@@ -12,20 +12,20 @@ exports[`WorkspaceList should render title and table normally 1`] = `
     >
       <div>
         <div
-          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
         >
           <div
             class="euiFlexItem euiSearchBar__searchHolder"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
-                  class="euiFieldSearch euiFieldSearch--fullWidth"
+                  class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                   placeholder="Search..."
                   type="search"
                   value=""
@@ -60,7 +60,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                     type="button"
                   >
                     <span
@@ -90,7 +90,7 @@ exports[`WorkspaceList should render title and table normally 1`] = `
           </div>
         </div>
         <div
-          class="euiSpacer euiSpacer--l"
+          class="euiSpacer euiSpacer--m"
         />
         <div
           class="euiBasicTable"

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -323,7 +323,7 @@ export const WorkspaceListInner = ({
     return (
       isDashboardAdmin && (
         <>
-          <EuiButton color="danger" iconType="trash" onClick={onClick}>
+          <EuiButton color="danger" iconType="trash" onClick={onClick} size="s">
             Delete {selection.length} Workspace
           </EuiButton>
           {deletedWorkspaces && deletedWorkspaces.length > 0 && (
@@ -346,6 +346,7 @@ export const WorkspaceListInner = ({
       incremental: true,
     },
     query,
+    compressed: true,
     onChange: (args) => setQuery((args.query as unknown) as EuiSearchBarProps['query']),
     filters: [
       {
@@ -354,6 +355,7 @@ export const WorkspaceListInner = ({
         name: 'Use Case',
         multiSelect: false,
         options: useCaseFilterOptions,
+        compressed: true,
       },
     ],
     toolsLeft: renderToolsLeft(),


### PR DESCRIPTION
### Description

fine-tune workspace list page compressed style to align with compressed table

## Screenshot

![image](https://github.com/user-attachments/assets/29354328-e99f-435f-9767-68e54e2ac5c5)

## Testing the changes

Go to workspace list page then see the UI change.

## Changelog

- refactor: Fine-tune workspace list page compressed style to align with compressed table

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
