### PR TITLE
[workspace]add admin validation when changing the last administrator to a lesser access

### DIFF
--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -480,7 +480,6 @@ const Actions = ({
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const {
-    overlays,
     services: { notifications },
   } = useOpenSearchDashboards();
 

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -161,7 +161,7 @@ export const WorkspaceCollaboratorTable = ({
     });
   }, [permissionSettings, displayedCollaboratorTypes]);
 
-  const adminCollarboratorsNum = useMemo(() => {
+  const adminCollaboratorsNum = useMemo(() => {
     const admins = items.filter((item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin);
     return admins.length;
   }, [items]);
@@ -211,7 +211,7 @@ export const WorkspaceCollaboratorTable = ({
       (item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin
     ).length;
     const shouldShowWarning =
-      adminCollarboratorsNum === adminOfSelection && adminCollarboratorsNum !== 0;
+      adminCollaboratorsNum === adminOfSelection && adminCollaboratorsNum !== 0;
     const modal = overlays.openModal(
       <EuiConfirmModal
         data-test-subj="delete-confirm-modal"
@@ -245,8 +245,7 @@ export const WorkspaceCollaboratorTable = ({
       const adminOfSelection = selections.filter(
         (item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin
       ).length;
-      shouldShowWarning =
-        adminCollarboratorsNum - adminOfSelection < 1 && adminCollarboratorsNum > 0;
+      shouldShowWarning = adminCollaboratorsNum - adminOfSelection < 1 && adminCollaboratorsNum > 0;
     }
 
     const modal = overlays.openModal(
@@ -489,7 +488,7 @@ const Actions = ({
     WORKSPACE_ACCESS_LEVEL_NAMES
   ) as WorkspaceCollaboratorAccessLevel[]).map((level) => ({
     name: WORKSPACE_ACCESS_LEVEL_NAMES[level],
-    onClick: async () => {
+    onClick: () => {
       setIsPopoverOpen(false);
       if (selection && openChangeAccessLevelModal) {
         const modal = openChangeAccessLevelModal({

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -493,7 +493,7 @@ const Actions = ({
       setIsPopoverOpen(false);
       if (selection && openChangeAccessLevelModal) {
         const modal = openChangeAccessLevelModal({
-          onConfirm: () => {
+          onConfirm: async () => {
             let newSettings = permissionSettings;
             selection.forEach(({ id }) => {
               newSettings = newSettings.map((item) =>
@@ -505,7 +505,27 @@ const Actions = ({
                   : item
               );
             });
-            handleSubmitPermissionSettings(newSettings as WorkspacePermissionSetting[]);
+
+            const result = await handleSubmitPermissionSettings(
+              newSettings as WorkspacePermissionSetting[]
+            );
+
+            if (result?.success) {
+              notifications?.toasts?.addSuccess({
+                title: i18n.translate('workspace.detail.collaborator.change.access.success.title', {
+                  defaultMessage: 'The access level changed',
+                }),
+                text: i18n.translate('workspace.detail.collaborator.change.access.success.body', {
+                  defaultMessage:
+                    'The access level is changed to {level} for {num} collaborator{pluralSuffix, select, true {} other {s}}.',
+                  values: {
+                    level: WORKSPACE_ACCESS_LEVEL_NAMES[level],
+                    num: selection.length,
+                    pluralSuffix: selection.length === 1 ? '' : 's',
+                  },
+                }),
+              });
+            }
             modal.close();
           },
           selections: selection,

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -65,9 +65,18 @@ const deletionModalWarning = i18n.translate(
   'workspace.workspace.detail.collaborator.modal.delete.warning',
   {
     defaultMessage:
-      'Currently you’re the only user who has access to the workspace as an owner. Share this workspace by adding collaborators.',
+      'By removing the last administrator, only application administrators will be able to manage this workspace',
   }
 );
+
+const changeAccessModalWarning = i18n.translate(
+  'workspace.workspace.detail.collaborator.modal.changeAccessLevel.warning',
+  {
+    defaultMessage:
+      'By changing the last administrator to a lesser access, only application administrators will be able to manage this workspace',
+  }
+);
+
 const deletionModalConfirm = i18n.translate('workspace.detail.collaborator.modal.delete.confirm', {
   defaultMessage: 'Delete collaborator? The collaborators will not have access to the workspace.',
 });
@@ -221,6 +230,57 @@ export const WorkspaceCollaboratorTable = ({
     return modal;
   };
 
+  const openChangeAccessLevelModal = ({
+    onConfirm,
+    selections,
+    type,
+  }: {
+    onConfirm: () => void;
+    selections: PermissionSettingWithAccessLevelAndDisplayedType[];
+    type: WorkspaceCollaboratorAccessLevel;
+  }) => {
+    let shouldShowWarning = false;
+    if (type !== 'admin') {
+      const adminOfSelection = selections.filter(
+        (item) => item.accessLevel === WORKSPACE_ACCESS_LEVEL_NAMES.admin
+      ).length;
+      shouldShowWarning =
+        adminCollarboratorsNum - adminOfSelection < 1 && adminCollarboratorsNum > 0;
+    }
+
+    const modal = overlays.openModal(
+      <EuiConfirmModal
+        title={i18n.translate('workspace.detail.collaborator.table.change.access.level', {
+          defaultMessage: 'Change access level',
+        })}
+        onCancel={() => {
+          modal.close();
+        }}
+        onConfirm={onConfirm}
+        cancelButtonText="Cancel"
+        confirmButtonText="Confirm"
+      >
+        <EuiText color={shouldShowWarning ? 'danger' : 'default'}>
+          <p>
+            {shouldShowWarning
+              ? changeAccessModalWarning
+              : i18n.translate('workspace.detail.collaborator.changeAccessLevel.confirmation', {
+                  defaultMessage:
+                    'Do you want to change access level of {numCollaborators} collaborator{pluralSuffix} to "{accessLevel}"?',
+                  values: {
+                    numCollaborators: selections.length,
+                    pluralSuffix: selections.length > 1 ? 's' : '',
+                    accessLevel: type,
+                  },
+                })}
+          </p>
+        </EuiText>
+      </EuiConfirmModal>
+    );
+
+    return modal;
+  };
+
   const renderToolsLeft = () => {
     if (selection.length === 0) {
       return;
@@ -283,6 +343,7 @@ export const WorkspaceCollaboratorTable = ({
         isTableAction={false}
         selection={selection}
         handleSubmitPermissionSettings={handleSubmitPermissionSettings}
+        openChangeAccessLevelModal={openChangeAccessLevelModal}
       />
     );
   };
@@ -362,6 +423,7 @@ export const WorkspaceCollaboratorTable = ({
           permissionSettings={permissionSettings}
           handleSubmitPermissionSettings={handleSubmitPermissionSettings}
           openDeleteConfirmModal={openDeleteConfirmModal}
+          openChangeAccessLevelModal={openChangeAccessLevelModal}
         />
       ),
     },
@@ -391,6 +453,7 @@ const Actions = ({
   permissionSettings,
   handleSubmitPermissionSettings,
   openDeleteConfirmModal,
+  openChangeAccessLevelModal,
 }: {
   isTableAction: boolean;
   selection?: PermissionSettingWithAccessLevelAndDisplayedType[];
@@ -405,6 +468,15 @@ const Actions = ({
     onConfirm: () => void;
     selections: PermissionSettingWithAccessLevelAndDisplayedType[];
   }) => { close: () => void };
+  openChangeAccessLevelModal?: ({
+    onConfirm,
+    selections,
+    type,
+  }: {
+    onConfirm: () => void;
+    selections: PermissionSettingWithAccessLevelAndDisplayedType[];
+    type: WorkspaceCollaboratorAccessLevel;
+  }) => { close: () => void };
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const {
@@ -418,67 +490,26 @@ const Actions = ({
     name: WORKSPACE_ACCESS_LEVEL_NAMES[level],
     onClick: async () => {
       setIsPopoverOpen(false);
-      if (selection) {
-        const modal = overlays.openModal(
-          <EuiConfirmModal
-            title={i18n.translate('workspace.detail.collaborator.table.change.access.level', {
-              defaultMessage: 'Change access level',
-            })}
-            onCancel={() => modal.close()}
-            onConfirm={async () => {
-              let newSettings = permissionSettings;
-              selection.forEach(({ id }) => {
-                newSettings = newSettings.map((item) =>
-                  id === item.id
-                    ? {
-                        ...item,
-                        modes: accessLevelNameToWorkspacePermissionModesMap[level],
-                      }
-                    : item
-                );
-              });
-              const result = await handleSubmitPermissionSettings(
-                newSettings as WorkspacePermissionSetting[]
-              );
-              if (result?.success) {
-                notifications?.toasts?.addSuccess({
-                  title: i18n.translate(
-                    'workspace.detail.collaborator.change.access.success.title',
-                    {
-                      defaultMessage: 'The access level changed',
+      if (selection && openChangeAccessLevelModal) {
+        const modal = openChangeAccessLevelModal({
+          onConfirm: () => {
+            let newSettings = permissionSettings;
+            selection.forEach(({ id }) => {
+              newSettings = newSettings.map((item) =>
+                id === item.id
+                  ? {
+                      ...item,
+                      modes: accessLevelNameToWorkspacePermissionModesMap[level],
                     }
-                  ),
-                  text: i18n.translate('workspace.detail.collaborator.change.access.success.body', {
-                    defaultMessage:
-                      'The access level is changed to {level} for {num} collaborator{pluralSuffix, select, true {} other {s}}.',
-                    values: {
-                      level: WORKSPACE_ACCESS_LEVEL_NAMES[level],
-                      num: selection.length,
-                      pluralSuffix: selection.length === 1,
-                    },
-                  }),
-                });
-              }
-              modal.close();
-            }}
-            cancelButtonText="Cancel"
-            confirmButtonText="Confirm"
-          >
-            <EuiText>
-              <p>
-                {i18n.translate('workspace.detail.collaborator.changeAccessLevel.confirmation', {
-                  defaultMessage:
-                    'Do you want to change access level to {numCollaborators} collaborator{pluralSuffix, select, true {} other {s}} to "{accessLevel}"?',
-                  values: {
-                    numCollaborators: selection.length,
-                    pluralSuffix: selection.length === 1,
-                    accessLevel: WORKSPACE_ACCESS_LEVEL_NAMES[level],
-                  },
-                })}
-              </p>
-            </EuiText>
-          </EuiConfirmModal>
-        );
+                  : item
+              );
+            });
+            handleSubmitPermissionSettings(newSettings as WorkspacePermissionSetting[]);
+            modal.close();
+          },
+          selections: selection,
+          type: level,
+        });
       }
     },
     icon: '',

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -214,6 +214,7 @@ export const WorkspaceCollaboratorTable = ({
       adminCollarboratorsNum === adminOfSelection && adminCollarboratorsNum !== 0;
     const modal = overlays.openModal(
       <EuiConfirmModal
+        data-test-subj="delete-confirm-modal"
         title={i18n.translate('workspace.detail.collaborator.actions.delete', {
           defaultMessage: 'Delete collaborator',
         })}
@@ -250,6 +251,7 @@ export const WorkspaceCollaboratorTable = ({
 
     const modal = overlays.openModal(
       <EuiConfirmModal
+        data-test-subj="change-access-confirm-modal"
         title={i18n.translate('workspace.detail.collaborator.table.change.access.level', {
           defaultMessage: 'Change access level',
         })}
@@ -257,8 +259,8 @@ export const WorkspaceCollaboratorTable = ({
           modal.close();
         }}
         onConfirm={onConfirm}
-        cancelButtonText="Cancel"
-        confirmButtonText="Confirm"
+        cancelButtonText={deletionModalCancelButton}
+        confirmButtonText={deletionModalConfirmButton}
       >
         <EuiText color={shouldShowWarning ? 'danger' : 'default'}>
           <p>


### PR DESCRIPTION
### Description
This pr adds admin validation when changing the last administrator to a lesser access.

## Screenshot
https://github.com/user-attachments/assets/489a23ec-8f8e-44bb-85cc-652290d51935

## Changelog
- feat: Add admin validation when changing the last administrator to a lesser access

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
