### PR TITLE
[discover-new] fix spelling for localstorage key name

### DIFF
--- a/src/plugins/discover/public/application/components/utils/local_storage.ts
+++ b/src/plugins/discover/public/application/components/utils/local_storage.ts
@@ -5,7 +5,7 @@
 
 import { Storage } from '../../../../../opensearch_dashboards_utils/public';
 
-export const NEW_DISCOVER_KEY = 'discover:newExpereince';
+export const NEW_DISCOVER_KEY = 'discover:newExperience';
 
 export const getNewDiscoverSetting = (storage: Storage): boolean => {
   const storedValue = storage.get(NEW_DISCOVER_KEY);


### PR DESCRIPTION
### Description
Key name was introduced with typo

## Testing the changes
https://dictionary.cambridge.org/dictionary/english/experience


## Changelog
- skip

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] Commits are signed per the DCO using --signoff
