### PR TITLE
[Workspace]Response forbidden error for not permitted workspace

### DIFF
--- a/changelogs/fragments/8641.yml
+++ b/changelogs/fragments/8641.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Response forbidden error for not permitted workspace ([#8641](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8641))

--- a/src/plugins/home/server/services/sample_data/routes/install.test.ts
+++ b/src/plugins/home/server/services/sample_data/routes/install.test.ts
@@ -284,4 +284,58 @@ describe('sample data install route', () => {
       body: expect.stringContaining('Invalid workspace permission'),
     });
   });
+
+  it('handler response internal error when bulkCreate throw error', async () => {
+    const mockClient = jest.fn().mockResolvedValue(true);
+
+    const mockSOClientGetResponse = {
+      saved_objects: [
+        {
+          type: 'dashboard',
+          id: '12345',
+          namespaces: ['default'],
+          attributes: { title: 'dashboard' },
+        },
+      ],
+    };
+    const mockSOClient = {
+      bulkCreate: jest.fn().mockRejectedValue(new Error('Unknown error')),
+      get: jest.fn().mockResolvedValue(mockSOClientGetResponse),
+    };
+
+    const mockContext = {
+      core: {
+        opensearch: {
+          legacy: {
+            client: { callAsCurrentUser: mockClient },
+          },
+        },
+        savedObjects: { client: mockSOClient },
+      },
+    };
+    const mockBody = { id: 'flights' };
+    const mockQuery = {};
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest({
+      params: mockBody,
+      query: mockQuery,
+    });
+    const mockResponse = httpServerMock.createResponseFactory();
+
+    createInstallRoute(
+      mockCoreSetup.http.createRouter(),
+      sampleDatasets,
+      mockLogger,
+      mockUsageTracker
+    );
+
+    const mockRouter = mockCoreSetup.http.createRouter.mock.results[0].value;
+    const handler = mockRouter.post.mock.calls[0][1];
+
+    await handler((mockContext as unknown) as RequestHandlerContext, mockRequest, mockResponse);
+
+    expect(mockResponse.internalError).toBeCalled();
+    expect(mockResponse.internalError.mock.calls[0][0]).toMatchObject({
+      body: expect.stringContaining('Unknown error'),
+    });
+  });
 });

--- a/src/plugins/home/server/services/sample_data/routes/install.test.ts
+++ b/src/plugins/home/server/services/sample_data/routes/install.test.ts
@@ -5,6 +5,7 @@
 
 import { CoreSetup, RequestHandlerContext } from 'src/core/server';
 import { coreMock, httpServerMock } from '../../../../../../core/server/mocks';
+import { SavedObjectsErrorHelpers } from '../../../../../../core/server';
 import { updateWorkspaceState } from '../../../../../../core/server/utils';
 import { flightsSpecProvider } from '../data_sets';
 import { SampleDatasetSchema } from '../lib/sample_dataset_registry_types';
@@ -220,6 +221,67 @@ describe('sample data install route', () => {
         opensearchIndicesCreated: { opensearch_dashboards_sample_data_flights: 13059 },
         opensearchDashboardsSavedObjectsLoaded: 20,
       },
+    });
+  });
+
+  it('handler response forbidden error when bulkCreate forbidden inside workspace', async () => {
+    const mockWorkspaceId = 'workspace';
+
+    const mockClient = jest.fn().mockResolvedValue(true);
+
+    const mockSOClientGetResponse = {
+      saved_objects: [
+        {
+          type: 'dashboard',
+          id: '12345',
+          namespaces: ['default'],
+          attributes: { title: 'dashboard' },
+        },
+      ],
+    };
+    const mockSOClient = {
+      bulkCreate: jest
+        .fn()
+        .mockRejectedValue(
+          SavedObjectsErrorHelpers.decorateForbiddenError(new Error('Invalid workspace permission'))
+        ),
+      get: jest.fn().mockResolvedValue(mockSOClientGetResponse),
+    };
+
+    const mockContext = {
+      core: {
+        opensearch: {
+          legacy: {
+            client: { callAsCurrentUser: mockClient },
+          },
+        },
+        savedObjects: { client: mockSOClient },
+      },
+    };
+    const mockBody = { id: 'flights' };
+    const mockQuery = {};
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest({
+      params: mockBody,
+      query: mockQuery,
+    });
+    updateWorkspaceState(mockRequest, { requestWorkspaceId: mockWorkspaceId });
+    const mockResponse = httpServerMock.createResponseFactory();
+
+    createInstallRoute(
+      mockCoreSetup.http.createRouter(),
+      sampleDatasets,
+      mockLogger,
+      mockUsageTracker
+    );
+
+    const mockRouter = mockCoreSetup.http.createRouter.mock.results[0].value;
+    const handler = mockRouter.post.mock.calls[0][1];
+
+    await handler((mockContext as unknown) as RequestHandlerContext, mockRequest, mockResponse);
+
+    expect(mockResponse.forbidden).toBeCalled();
+    expect(mockResponse.forbidden.mock.calls[0][0]).toMatchObject({
+      body: expect.stringContaining('Invalid workspace permission'),
     });
   });
 });

--- a/src/plugins/home/server/services/sample_data/routes/install.ts
+++ b/src/plugins/home/server/services/sample_data/routes/install.ts
@@ -31,6 +31,7 @@
 import { schema } from '@osd/config-schema';
 import { IRouter, LegacyCallAPIOptions, Logger } from 'src/core/server';
 import { getWorkspaceState } from '../../../../../../core/server/utils';
+import { SavedObjectsErrorHelpers } from '../../../../../../core/server';
 import { SampleDatasetSchema } from '../lib/sample_dataset_registry_types';
 import { createIndexName } from '../lib/create_index_name';
 import {
@@ -217,6 +218,9 @@ export function createInstallRoute(
       } catch (err) {
         const errMsg = `bulkCreate failed, error: ${err.message}`;
         logger.warn(errMsg);
+        if (workspaceId && SavedObjectsErrorHelpers.isForbiddenError(err)) {
+          return res.forbidden({ body: errMsg });
+        }
         return res.internalError({ body: errMsg });
       }
       const errors = createResults.saved_objects.filter((savedObjectCreateResult) => {


### PR DESCRIPTION
### Description

This PR is for fixing 500 error when import sample data to a not permitted workspace. It should return a forbidden error.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/c1ecca4d-5222-4d70-aff4-99bb81835675)
![image](https://github.com/user-attachments/assets/f229c291-746b-4d45-a0be-2d1ab3fb6d60)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Clone branch code and run `yarn osd bootstrap --single-version loose`
- Add below configs in `config/opensearch_dashboards.yml`
```
savedObjects.permission.enabled: true
workspace.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
opensearchDashboards.dashboardAdmin.users: ['admin']
```
- Run `yarn start --no-base-path`
- Login with admin user
- Visit internal users page and create a test-user
- Visit a existing workspace settings page and add test-user as a read-only collaborator
- Open an incognito window and login with test-user
- Goto the sample data page of the same workspace
- Click "Add data" button, it should show error like screenshot below
- Should see "403" response in devtools
 
## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace] Response forbidden error for not permitted workspace

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
