### PR TITLE
[bug] Discover UI stuck on searching after deleting index pattern

### DIFF
--- a/changelogs/fragments/8659.yml
+++ b/changelogs/fragments/8659.yml
@@ -1,0 +1,2 @@
+fix:
+- Discover UI stuck on searching after failing to find deleted index pattern ([#8659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8659))

--- a/src/plugins/discover/public/application/view_components/utils/use_index_pattern.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_index_pattern.ts
@@ -74,25 +74,25 @@ export const useIndexPattern = (services: DiscoverViewServices) => {
             handleIndexPattern();
           }
         } else {
-          try {
-            const ip = await fetchIndexPatternDetails(indexPatternIdFromState);
-            if (isMounted) {
-              setIndexPattern(ip);
-            }
-          } catch (error) {
-            if (isMounted) {
-              const warningMessage = i18n.translate('discover.indexPatternFetchErrorWarning', {
-                defaultMessage: 'Error fetching index pattern: {error}',
-                values: { error: (error as Error).message },
-              });
-              toastNotifications.addWarning(warningMessage);
-            }
+          const ip = await fetchIndexPatternDetails(indexPatternIdFromState);
+          if (isMounted) {
+            setIndexPattern(ip);
           }
         }
       }
     };
 
-    handleIndexPattern();
+    try {
+      handleIndexPattern();
+    } catch (error) {
+      if (isMounted) {
+        const warningMessage = i18n.translate('discover.indexPatternFetchErrorWarning', {
+          defaultMessage: 'Error fetching index pattern: {error}',
+          values: { error: (error as Error).message },
+        });
+        toastNotifications.addWarning(warningMessage);
+      }
+    }
 
     return () => {
       isMounted = false;


### PR DESCRIPTION
### Description

When using Discover with query enhancement enabled, deleting an index pattern from Index Management does not properly update the "Recently selected data" list in Discover. This causes the UI to become stuck in a "Searching" state when attempting to use Discover after deleting an index pattern.

Handle the error case where the use index patterns hook caught error when enhancements was enabled.

Now it goes to the next available index pattern

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8612

## Screenshot

![Screenshot 2024-10-18 at 2 13 56 PM](https://github.com/user-attachments/assets/4e6d070b-1bef-4e17-bb61-df2304fd195e)

## Testing the changes

re-creation steps in issue

## Changelog
- fix: Discover UI stuck on searching after failing to find deleted index pattern

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
