### PR TITLE
Select the correct language when a different one is chosen by the dataset selector

### DIFF
--- a/changelogs/fragments/8671.yml
+++ b/changelogs/fragments/8671.yml
@@ -1,0 +1,2 @@
+fix:
+- Select the correct language when a different one is chosen by the dataset selector ([#8671](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8671))

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -31,7 +31,7 @@
 import { BehaviorSubject } from 'rxjs';
 import { skip } from 'rxjs/operators';
 import { CoreStart, NotificationsSetup } from 'opensearch-dashboards/public';
-import { debounce, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import { i18n } from '@osd/i18n';
 import { Dataset, DataStorage, Query, TimeRange, UI_SETTINGS } from '../../../common';
 import { createHistory, QueryHistory } from './query_history';
@@ -106,8 +106,8 @@ export class QueryStringManager {
     }
   }
 
-  public getUpdates$ = () => {
-    return this.query$.asObservable().pipe(skip(1));
+  public getUpdates$ = (defaultSkip = 1) => {
+    return this.query$.asObservable().pipe(skip(defaultSkip));
   };
 
   public getQuery = (): Query => {

--- a/src/plugins/data/public/ui/query_editor/language_selector.tsx
+++ b/src/plugins/data/public/ui/query_editor/language_selector.tsx
@@ -44,7 +44,7 @@ export const QueryLanguageSelector = (props: QueryLanguageSelectorProps) => {
     : undefined;
 
   useEffect(() => {
-    const subscription = queryString.getUpdates$().subscribe((query: Query) => {
+    const subscription = queryString.getUpdates$(0).subscribe((query: Query) => {
       if (query.language !== currentLanguage) {
         setCurrentLanguage(query.language);
       }

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -240,11 +240,10 @@ export default class QueryEditorUI extends Component<Props, State> {
 
     if (!isEqual(this.props.query.dataset, prevQuery.dataset)) {
       if (this.inputRef) {
-        const newQuery = this.queryString.getInitialQuery();
-        const newQueryString = newQuery.query;
-        if (this.inputRef.getValue() !== newQueryString) {
+        const newQueryString = this.props.query.query;
+        if (this.inputRef.getValue() !== newQueryString && typeof newQueryString === 'string') {
           this.inputRef.setValue(newQueryString);
-          this.onSubmit(newQuery);
+          this.onSubmit(this.props.query);
         }
       }
     }


### PR DESCRIPTION

### Description

Select the correct language when a different one is chosen by the dataset selector



## Changelog
- fix: Select the correct language when a different one is chosen by the dataset selector

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
