### PR TITLE
fix: fixed unsupported language issue due to cached language in localStorage

### DIFF
--- a/changelogs/fragments/8674.yml
+++ b/changelogs/fragments/8674.yml
@@ -1,0 +1,2 @@
+fix:
+- Fixed unsupported language is used from localStorage ([#8674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8674))

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -225,11 +225,25 @@ export class QueryStringManager {
     };
   };
 
-  private getDefaultLanguage() {
-    return (
-      this.storage.get('userQueryLanguage') ||
-      this.uiSettings.get(UI_SETTINGS.SEARCH_QUERY_LANGUAGE)
+  private isLanguageSupported(languageId: string) {
+    const currentAppId = this.getCurrentAppId();
+    if (!currentAppId) {
+      return false;
+    }
+
+    return containsWildcardOrValue(
+      this.languageService.getLanguage(languageId)?.supportedAppNames,
+      currentAppId
     );
+  }
+
+  private getDefaultLanguage() {
+    const lastUsedLanguage = this.storage.get('userQueryLanguage');
+    if (lastUsedLanguage && this.isLanguageSupported(lastUsedLanguage)) {
+      return lastUsedLanguage;
+    }
+
+    return this.uiSettings.get(UI_SETTINGS.SEARCH_QUERY_LANGUAGE);
   }
 
   private getCurrentAppId = () => {


### PR DESCRIPTION
### The issue
The issue happens when for example PPL is selected in discover, then navigate to visualization create page, a warning toast is displayed, see screenshot.
When saving the visualization, the `language: "PPL"` is stored, though the current UI shows DQL is used, see screenshot
![image](https://github.com/user-attachments/assets/66c5d000-6dfb-4d28-9140-dd050a73fbd0)

### The fix:
It will only use the cached language selection from localStorage if the current app supports the language.


### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: fixed unsupported language is used from localStorage


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
