### PR TITLE
[Workspace] Fix non-workspace admin update defaultIndex

### DIFF
--- a/src/core/public/workspace/types.ts
+++ b/src/core/public/workspace/types.ts
@@ -5,7 +5,7 @@
 
 import { WorkspaceAttribute } from '../../types';
 
-export type WorkspaceObject = WorkspaceAttribute & { readonly?: boolean };
+export type WorkspaceObject = WorkspaceAttribute & { readonly?: boolean; owner?: boolean };
 
 export type IWorkspaceResponse<T> =
   | {

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -36,13 +36,18 @@ export type EnsureDefaultIndexPattern = () => Promise<unknown | void> | undefine
 
 export const createEnsureDefaultIndexPattern = (
   uiSettings: UiSettingsCommon,
-  onRedirectNoIndexPattern: () => Promise<unknown> | void
+  onRedirectNoIndexPattern: () => Promise<unknown> | void,
+  isCurrentWorkspaceOwner?: boolean
 ) => {
   /**
    * Checks whether a default index pattern is set and exists and defines
    * one otherwise.
    */
   return async function ensureDefaultIndexPattern(this: IndexPatternsContract) {
+    // If workspace is enabled, only workspace owner can update ui setting.
+    if (isCurrentWorkspaceOwner === false) {
+      return;
+    }
     const patterns = await this.getIds();
     let defaultId = await uiSettings.get('defaultIndex');
     let defined = !!defaultId;

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -74,6 +74,7 @@ interface IndexPatternsServiceDeps {
   onError: OnError;
   onRedirectNoIndexPattern?: () => void;
   onUnsupportedTimePattern: OnUnsupportedTimePattern;
+  isCurrentWorkspaceOwner?: boolean;
 }
 
 export class IndexPatternsService {
@@ -96,6 +97,7 @@ export class IndexPatternsService {
     onError,
     onUnsupportedTimePattern,
     onRedirectNoIndexPattern = () => {},
+    isCurrentWorkspaceOwner,
   }: IndexPatternsServiceDeps) {
     this.apiClient = apiClient;
     this.config = uiSettings;
@@ -106,7 +108,8 @@ export class IndexPatternsService {
     this.onUnsupportedTimePattern = onUnsupportedTimePattern;
     this.ensureDefaultIndexPattern = createEnsureDefaultIndexPattern(
       uiSettings,
-      onRedirectNoIndexPattern
+      onRedirectNoIndexPattern,
+      isCurrentWorkspaceOwner
     );
   }
 

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -193,7 +193,15 @@ export class DataPublicPlugin
   }
 
   public start(core: CoreStart, { uiActions }: DataStartDependencies): DataPublicPluginStart {
-    const { uiSettings, http, notifications, savedObjects, overlays, application } = core;
+    const {
+      uiSettings,
+      http,
+      notifications,
+      savedObjects,
+      overlays,
+      application,
+      workspaces,
+    } = core;
     setNotifications(notifications);
     setOverlays(overlays);
     setUiSettings(uiSettings);
@@ -220,6 +228,9 @@ export class DataPublicPlugin
         notifications.toasts,
         application.navigateToApp
       ),
+      isCurrentWorkspaceOwner:
+        workspaces?.currentWorkspace$.getValue()?.owner ||
+        application.capabilities?.dashboards?.isDashboardAdmin !== false,
     });
     setIndexPatterns(indexPatterns);
 

--- a/src/plugins/workspace/public/workspace_client.test.ts
+++ b/src/plugins/workspace/public/workspace_client.test.ts
@@ -178,6 +178,7 @@ describe('#WorkspaceClient', () => {
     expect(workspaceMock.workspaceList$.getValue()).toEqual([
       {
         id: 'foo',
+        owner: true,
         readonly: false,
       },
     ]);

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -117,13 +117,21 @@ export class WorkspaceClient implements IWorkspaceClient {
         perPage: 999,
         permissionModes: [WorkspacePermissionMode.LibraryWrite],
       });
-      if (resultWithWritePermission?.success) {
+      const resultWithOwnerPermission = await this.list({
+        perPage: 999,
+        permissionModes: [WorkspacePermissionMode.Write],
+      });
+      if (resultWithWritePermission?.success && resultWithOwnerPermission?.success) {
         const workspaceIdsWithWritePermission = resultWithWritePermission.result.workspaces.map(
+          (workspace: WorkspaceAttribute) => workspace.id
+        );
+        const workspaceIdsWithOwnerPermission = resultWithOwnerPermission.result.workspaces.map(
           (workspace: WorkspaceAttribute) => workspace.id
         );
         const workspaces = result.result.workspaces.map((workspace: WorkspaceAttribute) => ({
           ...workspace,
           readonly: !workspaceIdsWithWritePermission.includes(workspace.id),
+          owner: workspaceIdsWithOwnerPermission.includes(workspace.id),
         }));
         this.workspaces.workspaceList$.next(workspaces);
       }


### PR DESCRIPTION
### Description

When no workspace user navigate to Maps/Visualization page, the defaultIndex will be updated and show the error toast.
![image](https://github.com/user-attachments/assets/696374bf-fe89-4563-b1dc-75f59e0d9163)

After fixing, no workspace admin will not update default index.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Workspace] Fix non-workspace admin update defaultIndex

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
