### PR TITLE
[Workspace] Refactor: update change access modal display name

### DIFF
--- a/changelogs/fragments/8680.yml
+++ b/changelogs/fragments/8680.yml
@@ -1,0 +1,2 @@
+refactor:
+- Update change access modal display name ([#8680](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8680))

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -305,7 +305,7 @@ export const WorkspaceCollaboratorTable = ({
                   values: {
                     numCollaborators: selections.length,
                     pluralSuffix: selections.length > 1 ? 's' : '',
-                    accessLevel: type,
+                    accessLevel: WORKSPACE_ACCESS_LEVEL_NAMES[type],
                   },
                 })}
           </p>


### PR DESCRIPTION
### Description

Update change access modal display name from access level value to access level name

## Screenshot
![image](https://github.com/user-attachments/assets/52af94e7-bdff-4d7c-89a6-a64ef7795279)
Before
![image](https://github.com/user-attachments/assets/f7f2ef2e-1b90-4469-8d1f-34dd53685ce6)
After

## Testing the changes

Go to workspace collaborators page.

## Changelog

- refactor: Update change access modal display name

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
