### PR TITLE
[bug] set saved search instance for Discover based on dataset

### DIFF
--- a/src/plugins/data/common/search/search_source/create_search_source.ts
+++ b/src/plugins/data/common/search/search_source/create_search_source.ts
@@ -32,6 +32,7 @@ import { migrateLegacyQuery } from './migrate_legacy_query';
 import { SearchSource, SearchSourceDependencies } from './search_source';
 import { IndexPatternsContract } from '../../index_patterns/index_patterns';
 import { SearchSourceFields } from './types';
+import { DEFAULT_DATA } from '../../constants';
 
 /**
  * Deserializes a json string and a set of referenced objects to a `SearchSource` instance.
@@ -57,8 +58,13 @@ export const createSearchSource = (
   const fields = { ...searchSourceFields };
 
   // hydrating index pattern
-  if (fields.index && typeof fields.index === 'string') {
-    fields.index = await indexPatterns.get(searchSourceFields.index as any);
+  if (
+    fields.index &&
+    typeof fields.index === 'string' &&
+    (!fields.query?.dataset?.type ||
+      fields.query.dataset.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN)
+  ) {
+    fields.index = await indexPatterns.get(fields.index as string);
   }
 
   const searchSource = new SearchSource(fields, searchSourceDependencies);

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -68,8 +68,6 @@ export {
   DQLBody,
   SingleLineInput,
   DatasetSelector,
-  AdvancedSelector,
-  NoIndexPatternsPanel,
   DatasetSelectorAppearance,
 } from './ui';
 

--- a/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
+++ b/src/plugins/discover/public/application/utils/state_management/discover_slice.tsx
@@ -11,7 +11,11 @@ import { RootState, DefaultViewState } from '../../../../../data_explorer/public
 import { buildColumns } from '../columns';
 import * as utils from './common';
 import { SortOrder } from '../../../saved_searches/types';
-import { DEFAULT_COLUMNS_SETTING, PLUGIN_ID } from '../../../../common';
+import {
+  DEFAULT_COLUMNS_SETTING,
+  PLUGIN_ID,
+  QUERY_ENHANCEMENT_ENABLED_SETTING,
+} from '../../../../common';
 
 export interface DiscoverState {
   /**
@@ -90,7 +94,8 @@ export const getPreloadedState = async ({
       const indexPatternId = savedSearchInstance.searchSource.getField('index')?.id;
       preloadedState.root = {
         metadata: {
-          indexPattern: indexPatternId,
+          ...(indexPatternId &&
+            !config.get(QUERY_ENHANCEMENT_ENABLED_SETTING) && { indexPattern: indexPatternId }),
           view: PLUGIN_ID,
         },
       };

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -352,7 +352,6 @@ export const useSearch = (services: DiscoverViewServices) => {
   useEffect(() => {
     (async () => {
       const savedSearchInstance = await getSavedSearchById(savedSearchId);
-      setSavedSearch(savedSearchInstance);
 
       const query =
         savedSearchInstance.searchSource.getField('query') ||
@@ -393,6 +392,7 @@ export const useSearch = (services: DiscoverViewServices) => {
 
       filterManager.setAppFilters(actualFilters);
       data.query.queryString.setQuery(query);
+      setSavedSearch(savedSearchInstance);
 
       if (savedSearchInstance?.id) {
         chrome.recentlyAccessed.add(

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -354,16 +354,34 @@ export const useSearch = (services: DiscoverViewServices) => {
       const savedSearchInstance = await getSavedSearchById(savedSearchId);
       setSavedSearch(savedSearchInstance);
 
-      // if saved search does not exist, do not atempt to sync filters and query from savedObject
-      if (!savedSearch) {
-        return;
+      const query =
+        savedSearchInstance.searchSource.getField('query') ||
+        data.query.queryString.getDefaultQuery();
+
+      const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
+      if (isEnhancementsEnabled && query.dataset) {
+        let pattern = await data.indexPatterns.get(
+          query.dataset.id,
+          query.dataset.type !== 'INDEX_PATTERN'
+        );
+        if (!pattern) {
+          await data.query.queryString.getDatasetService().cacheDataset(query.dataset, {
+            uiSettings: services.uiSettings,
+            savedObjects: services.savedObjects,
+            notifications: services.notifications,
+            http: services.http,
+            data: services.data,
+          });
+          pattern = await data.indexPatterns.get(
+            query.dataset.id,
+            query.dataset.type !== 'INDEX_PATTERN'
+          );
+          savedSearchInstance.searchSource.setField('index', pattern);
+        }
       }
 
       // sync initial app filters from savedObject to filterManager
       const filters = cloneDeep(savedSearchInstance.searchSource.getOwnField('filter'));
-      const query =
-        savedSearchInstance.searchSource.getField('query') ||
-        data.query.queryString.getDefaultQuery();
       const actualFilters = [];
 
       if (filters !== undefined) {
@@ -387,8 +405,6 @@ export const useSearch = (services: DiscoverViewServices) => {
         );
       }
     })();
-
-    return () => {};
     // This effect will only run when getSavedSearchById is called, which is
     // only called when the component is first mounted.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -96,7 +96,7 @@ export class QueryEnhancementsPlugin
       title: 'SQL',
       search: sqlSearchInterceptor,
       getQueryString: (query: Query) => {
-        return `SELECT * FROM ${queryString.getQuery().dataset?.title} LIMIT 10`;
+        return `SELECT * FROM ${query.dataset?.title} LIMIT 10`;
       },
       fields: {
         filterable: false,


### PR DESCRIPTION
### Description

Preventing any errors being thrown because of the index pattern not existing in the case of saved search was created with a dataset.

Also fix issue that prevented saved search instance not being set even though loaded properly.

The original fix that was removed fixed a previous issue but subsequent updates and refactors required an update that was uncaught.

### Issues Resolved

n/a

## Screenshot

![Screenshot 2024-10-23 at 2 22 28 AM](https://github.com/user-attachments/assets/cc9fad55-0673-4897-bf1e-87693859aa37)

## Testing the changes

* verified saved search is loading for PPL
* verified reload working for  non index pattern
* verified short url working for non index pattern
* verified copy url working for non index pattern 

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
