### PR TITLE
[2.x-manual-backport][Discover] Add Footer Bar for Single Line Editor (#8565)

### DIFF
--- a/changelogs/fragments/8565.yml
+++ b/changelogs/fragments/8565.yml
@@ -1,0 +1,2 @@
+feat:
+- Adds editor footer to single line editor on focus ([#8565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565))

--- a/src/plugins/data/common/data_frames/types.ts
+++ b/src/plugins/data/common/data_frames/types.ts
@@ -121,7 +121,7 @@ export type IDataFrameResponse = SearchResponse<any> &
   (IDataFrameDefaultResponse | IDataFramePollingResponse | IDataFrameErrorResponse);
 
 export interface IDataFrameError extends SearchResponse<any> {
-  error: Error;
+  error: Error | string;
 }
 
 export interface PollQueryResultsParams {

--- a/src/plugins/data/common/utils/helpers.ts
+++ b/src/plugins/data/common/utils/helpers.ts
@@ -28,7 +28,6 @@
  * under the License.
  */
 
-import { i18n } from '@osd/i18n';
 import { PollQueryResultsHandler, FetchStatusResponse } from '../data_frames';
 
 export interface QueryStatusOptions {
@@ -53,11 +52,7 @@ export const handleQueryResults = async <T>(
   } while (queryStatus !== 'SUCCESS' && queryStatus !== 'FAILED');
 
   if (queryStatus === 'FAILED') {
-    throw new Error(
-      i18n.translate('data.search.request.failed', {
-        defaultMessage: 'An error occurred while executing the search query',
-      })
-    );
+    throw new Error(queryResultsRes?.body.error);
   }
 
   return queryResultsRes;

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`Query Result show error status with error message 2`] = `
   anchorPosition="downRight"
   button={
     <EuiButtonEmpty
+      className="editor__footerItem"
+      color="danger"
       data-test-subj="queryResultErrorBtn"
       iconSide="left"
       iconType="alert"
@@ -12,7 +14,8 @@ exports[`Query Result show error status with error message 2`] = `
       size="xs"
     >
       <EuiText
-        color="subdued"
+        className="editor__footerItem"
+        color="danger"
         size="xs"
       >
         Error
@@ -43,6 +46,7 @@ exports[`Query Result show error status with error message 2`] = `
       <strong>
         Reasons:
       </strong>
+       
       error reason
     </EuiText>
     <EuiText
@@ -52,6 +56,7 @@ exports[`Query Result show error status with error message 2`] = `
         <strong>
           Details:
         </strong>
+         
         error details
       </p>
     </EuiText>

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Query Result show error status with error message 2`] = `
     ERRORS
   </EuiPopoverTitle>
   <div
+    className="eui-textBreakWord"
     style={
       Object {
         "width": "250px",
@@ -43,21 +44,11 @@ exports[`Query Result show error status with error message 2`] = `
     <EuiText
       size="s"
     >
-      <strong>
-        Reasons:
-      </strong>
-       
-      error reason
-    </EuiText>
-    <EuiText
-      size="s"
-    >
       <p>
         <strong>
-          Details:
+          Message:
         </strong>
          
-        error details
       </p>
     </EuiText>
   </div>

--- a/src/plugins/data/public/query/query_string/language_service/lib/_recent_query.scss
+++ b/src/plugins/data/public/query/query_string/language_service/lib/_recent_query.scss
@@ -7,3 +7,8 @@
     background-color: $euiColorLightestShade;
   }
 }
+
+.editor_footerItem {
+  // Needed so the footer items never have paddings
+  padding: 0 !important;
+}

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -22,10 +22,9 @@ export interface QueryStatus {
   status: ResultStatus;
   body?: {
     error?: {
-      reason?: string;
-      details: string;
+      statusCode?: number;
+      message?: string;
     };
-    statusCode?: number;
   };
   elapsedMs?: number;
   startTime?: number;
@@ -77,6 +76,22 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
         </EuiButtonEmpty>
       );
     }
+    const time = Math.floor(elapsedTime / 1000);
+    return (
+      <EuiButtonEmpty
+        color="text"
+        size="xs"
+        onClick={() => {}}
+        isLoading
+        data-test-subj="queryResultLoading"
+        className="editor__footerItem"
+      >
+        {i18n.translate('data.query.languageService.queryResults.loadTime', {
+          defaultMessage: 'Loading {time} s',
+          values: { time },
+        })}
+      </EuiButtonEmpty>
+    );
   }
 
   if (props.queryStatus.status === ResultStatus.READY) {
@@ -101,7 +116,13 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     }
 
     return (
-      <EuiButtonEmpty iconSide="left" iconType={'checkInCircleEmpty'} size="xs" onClick={() => {}}>
+      <EuiButtonEmpty
+        iconSide="left"
+        iconType={'checkInCircleEmpty'}
+        iconGap="s"
+        size="xs"
+        onClick={() => {}}
+      >
         <EuiText size="xs" color="subdued" data-test-subj="queryResultCompleteMsg">
           {message}
         </EuiText>
@@ -122,8 +143,10 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
           size="xs"
           onClick={onButtonClick}
           data-test-subj="queryResultErrorBtn"
+          className="editor__footerItem"
+          color="danger"
         >
-          <EuiText size="xs" color="subdued">
+          <EuiText size="xs" color="danger" className="editor__footerItem">
             {i18n.translate('data.query.languageService.queryResults.error', {
               defaultMessage: `Error`,
             })}
@@ -137,23 +160,15 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       data-test-subj="queryResultError"
     >
       <EuiPopoverTitle>ERRORS</EuiPopoverTitle>
-      <div style={{ width: '250px' }}>
-        <EuiText size="s">
-          <strong>
-            {i18n.translate('data.query.languageService.queryResults.reasons', {
-              defaultMessage: `Reasons:`,
-            })}
-          </strong>
-          {props.queryStatus.body.error.reason}
-        </EuiText>
+      <div style={{ width: '250px' }} className="eui-textBreakWord">
         <EuiText size="s">
           <p>
             <strong>
-              {i18n.translate('data.query.languageService.queryResults.details', {
-                defaultMessage: `Details:`,
+              {i18n.translate('data.query.languageService.queryResults.message', {
+                defaultMessage: `Message:`,
               })}
-            </strong>
-            {props.queryStatus.body.error.details}
+            </strong>{' '}
+            {props.queryStatus.body.error.message}
           </p>
         </EuiText>
       </div>

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -218,3 +218,40 @@
     display: block;
   }
 }
+
+.queryEditor__footer {
+  display: flex;
+  gap: 4px;
+  background: $euiColorLightestShade;
+  padding: 2px 4px;
+  margin-top: 5px;
+  margin-left: -5px;
+  margin-right: -5px;
+  z-index: 1;
+  position: relative;
+  align-items: center;
+}
+
+.queryEditor__footerSpacer {
+  flex-grow: 1;
+}
+
+.queryEditor__footerItem {
+  // Needed so the footer items never have paddings
+  padding: 0 !important;
+}
+
+// TODO: Temporary workaround to disable padding for single line editor footer
+.euiFormControlLayout--group.euiFormControlLayout--compressed .osdQuerEditor__singleLine .euiText {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.euiFormControlLayout--group .osdQuerEditor__singleLine .euiText {
+  background-color: unset !important;
+  line-height: 21px !important;
+}
+
+.euiFormControlLayout--group .osdQuerEditor__singleLine .euiButtonEmpty {
+  border-right: 0;
+}

--- a/src/plugins/data/public/ui/query_editor/editors/shared.tsx
+++ b/src/plugins/data/public/ui/query_editor/editors/shared.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFieldText } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { monaco } from '@osd/monaco';
-import React from 'react';
+import React, { Fragment, useCallback, useRef, useState } from 'react';
 import { CodeEditor } from '../../../../../opensearch_dashboards_react/public';
 
 interface SingleLineInputProps extends React.JSX.IntrinsicAttributes {
@@ -15,6 +15,7 @@ interface SingleLineInputProps extends React.JSX.IntrinsicAttributes {
   editorDidMount: (editor: any) => void;
   provideCompletionItems: monaco.languages.CompletionItemProvider['provideCompletionItems'];
   prepend?: React.ComponentProps<typeof EuiCompressedFieldText>['prepend'];
+  footerItems?: any;
 }
 
 type CollapsedComponent<T> = React.ComponentType<T>;
@@ -61,56 +62,109 @@ export const SingleLineInput: React.FC<SingleLineInputProps> = ({
   editorDidMount,
   provideCompletionItems,
   prepend,
-}) => (
-  <div className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group osdQueryBar__wrap">
-    {prepend}
-    <div className="osdQuerEditor__singleLine euiFormControlLayout__childrenWrapper">
-      <CodeEditor
-        height={20} // Adjusted to match lineHeight for a single line
-        languageId={languageId}
-        value={value}
-        onChange={onChange}
-        editorDidMount={editorDidMount}
-        options={{
-          lineNumbers: 'off', // Disabled line numbers
-          // lineHeight: 40,
-          fontSize: 14,
-          fontFamily: 'Roboto Mono',
-          minimap: {
-            enabled: false,
-          },
-          scrollBeyondLastLine: false,
-          wordWrap: 'off', // Disabled word wrapping
-          wrappingIndent: 'none', // No indent since wrapping is off
-          folding: false,
-          glyphMargin: false,
-          lineDecorationsWidth: 0,
-          scrollbar: {
-            vertical: 'hidden',
-          },
-          overviewRulerLanes: 0,
-          hideCursorInOverviewRuler: true,
-          cursorStyle: 'line',
-          wordBasedSuggestions: false,
-        }}
-        suggestionProvider={{
-          provideCompletionItems,
-          triggerCharacters: [' '],
-        }}
-        languageConfiguration={{
-          autoClosingPairs: [
-            {
-              open: '(',
-              close: ')',
+  footerItems,
+}) => {
+  const [editorIsFocused, setEditorIsFocused] = useState(false);
+  const blurTimeoutRef = useRef<NodeJS.Timeout | undefined>();
+
+  const handleEditorDidMount = useCallback(
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
+      editorDidMount(editor);
+
+      const focusDisposable = editor.onDidFocusEditorText(() => {
+        if (blurTimeoutRef.current) {
+          clearTimeout(blurTimeoutRef.current);
+        }
+        setEditorIsFocused(true);
+      });
+
+      const blurDisposable = editor.onDidBlurEditorText(() => {
+        blurTimeoutRef.current = setTimeout(() => {
+          setEditorIsFocused(false);
+        }, 500);
+      });
+
+      return () => {
+        focusDisposable.dispose();
+        blurDisposable.dispose();
+        if (blurTimeoutRef.current) {
+          clearTimeout(blurTimeoutRef.current);
+        }
+      };
+    },
+    [editorDidMount]
+  );
+
+  return (
+    <div className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group osdQueryBar__wrap">
+      {prepend}
+      <div
+        className="osdQuerEditor__singleLine euiFormControlLayout__childrenWrapper"
+        data-test-subj="osdQueryEditor__singleLine"
+      >
+        <CodeEditor
+          height={20} // Adjusted to match lineHeight for a single line
+          languageId={languageId}
+          value={value}
+          onChange={onChange}
+          editorDidMount={handleEditorDidMount}
+          options={{
+            lineNumbers: 'off', // Disabled line numbers
+            // lineHeight: 40,
+            fontSize: 14,
+            fontFamily: 'Roboto Mono',
+            minimap: {
+              enabled: false,
             },
-            {
-              open: '"',
-              close: '"',
+            scrollBeyondLastLine: false,
+            wordWrap: 'off', // Disabled word wrapping
+            wrappingIndent: 'none', // No indent since wrapping is off
+            folding: false,
+            glyphMargin: false,
+            lineDecorationsWidth: 0,
+            scrollbar: {
+              vertical: 'hidden',
+              horizontalScrollbarSize: 1,
             },
-          ],
-        }}
-        triggerSuggestOnFocus={true}
-      />
+            overviewRulerLanes: 0,
+            hideCursorInOverviewRuler: true,
+            cursorStyle: 'line',
+            wordBasedSuggestions: false,
+          }}
+          suggestionProvider={{
+            provideCompletionItems,
+            triggerCharacters: [' '],
+          }}
+          languageConfiguration={{
+            autoClosingPairs: [
+              {
+                open: '(',
+                close: ')',
+              },
+              {
+                open: '"',
+                close: '"',
+              },
+            ],
+          }}
+          triggerSuggestOnFocus={true}
+        />
+        {editorIsFocused && (
+          <div className="queryEditor__footer">
+            {footerItems && (
+              <Fragment>
+                {footerItems.start?.map((item) => (
+                  <div className="queryEditor__footerItem">{item}</div>
+                ))}
+                <div className="queryEditor__footerSpacer" />
+                {footerItems.end?.map((item) => (
+                  <div className="queryEditor__footerItem">{item}</div>
+                ))}
+              </Fragment>
+            )}
+          </div>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -376,10 +376,15 @@ export default class QueryEditorUI extends Component<Props, State> {
       },
       footerItems: {
         start: [
-          <EuiText size="xs" color="subdued">
+          <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
             {`${this.state.lineCount} ${this.state.lineCount === 1 ? 'line' : 'lines'}`}
           </EuiText>,
-          <EuiText size="xs" color="subdued">
+          <EuiText
+            size="xs"
+            color="subdued"
+            data-test-subj="queryEditorFooterTimestamp"
+            className="queryEditor__footerItem"
+          >
             {this.props.query.dataset?.timeFieldName || ''}
           </EuiText>,
           <QueryResult queryStatus={this.props.queryStatus!} />,
@@ -390,6 +395,7 @@ export default class QueryEditorUI extends Component<Props, State> {
             iconType="clock"
             size="xs"
             onClick={this.toggleRecentQueries}
+            className="queryEditor__footerItem"
           >
             <EuiText size="xs" color="subdued">
               {'Recent queries'}
@@ -429,6 +435,34 @@ export default class QueryEditorUI extends Component<Props, State> {
       },
       provideCompletionItems: this.provideCompletionItems,
       prepend: this.props.prepend,
+      footerItems: {
+        start: [
+          <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
+            {`${this.state.lineCount ?? 1} ${
+              this.state.lineCount === 1 || !this.state.lineCount ? 'line' : 'lines'
+            }`}
+          </EuiText>,
+          <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
+            {this.props.query.dataset?.timeFieldName || ''}
+          </EuiText>,
+          <QueryResult queryStatus={this.props.queryStatus!} />,
+        ],
+        end: [
+          <EuiButtonEmpty
+            iconSide="left"
+            iconType="clock"
+            iconGap="s"
+            size="xs"
+            onClick={this.toggleRecentQueries}
+            className="queryEditor__footerItem"
+            flush="both"
+          >
+            <EuiText size="xs" color="subdued">
+              {'Recent queries'}
+            </EuiText>
+          </EuiButtonEmpty>,
+        ],
+      },
     };
 
     const languageEditorFunc = this.languageManager.getLanguage(this.props.query.language)!.editor;
@@ -478,13 +512,13 @@ export default class QueryEditorUI extends Component<Props, State> {
         {!this.state.isCollapsed && (
           <>
             <div className="osdQueryEditor__body">{languageEditor.Body()}</div>
-            <RecentQueriesTable
-              isVisible={this.state.isRecentQueryVisible && useQueryEditor}
-              queryString={this.queryString}
-              onClickRecentQuery={this.onClickRecentQuery}
-            />
           </>
         )}
+        <RecentQueriesTable
+          isVisible={this.state.isRecentQueryVisible && useQueryEditor}
+          queryString={this.queryString}
+          onClickRecentQuery={this.onClickRecentQuery}
+        />
 
         {this.renderQueryEditorExtensions()}
       </div>

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -150,6 +150,7 @@ export const useSearch = (services: DiscoverViewServices) => {
     if (!dataset) {
       data$.next({
         status: shouldSearchOnPageLoad() ? ResultStatus.LOADING : ResultStatus.UNINITIALIZED,
+        queryStatus: { startTime },
       });
       return;
     }
@@ -181,7 +182,7 @@ export const useSearch = (services: DiscoverViewServices) => {
     try {
       // Only show loading indicator if we are fetching when the rows are empty
       if (fetchStateRef.current.rows?.length === 0) {
-        data$.next({ status: ResultStatus.LOADING });
+        data$.next({ status: ResultStatus.LOADING, queryStatus: { startTime } });
       }
 
       // Initialize inspect adapter for search source
@@ -272,15 +273,19 @@ export const useSearch = (services: DiscoverViewServices) => {
       }
       let errorBody;
       try {
-        errorBody = JSON.parse(error.message);
+        errorBody = JSON.parse(error.body);
       } catch (e) {
-        errorBody = error.message;
+        if (error.body) {
+          errorBody = error.body;
+        } else {
+          errorBody = error;
+        }
       }
 
       data$.next({
         status: ResultStatus.ERROR,
         queryStatus: {
-          body: errorBody,
+          body: { error: errorBody },
           elapsedMs,
         },
       });
@@ -296,6 +301,7 @@ export const useSearch = (services: DiscoverViewServices) => {
     services,
     sort,
     savedSearch?.searchSource,
+    startTime,
     data$,
     shouldSearchOnPageLoad,
     inspectorAdapters.requests,

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -85,8 +85,14 @@ export function defineSearchStrategyRouteProvider(logger: Logger, router: IRoute
           const queryRes: IDataFrameResponse = await searchStrategy.search(context, req as any, {});
           return res.ok({ body: { ...queryRes } });
         } catch (err) {
+          let error;
+          try {
+            error = JSON.parse(err.message);
+          } catch (e) {
+            error = err;
+          }
           return res.custom({
-            statusCode: err.name,
+            statusCode: error.status,
             body: err.message,
           });
         }

--- a/src/plugins/query_enhancements/server/search/sql_async_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/sql_async_search_strategy.ts
@@ -82,7 +82,7 @@ export const sqlAsyncSearchStrategyProvider = (
               type: DATA_FRAME_TYPES.POLLING,
               status: 'failed',
               body: {
-                error: new Error(`JOB: ${pollQueryResultsParams.queryId} failed`),
+                error: `JOB: ${inProgressQueryId} failed: ${queryStatusResponse.data.error}`,
               },
             } as IDataFrameResponse;
           }


### PR DESCRIPTION
### Backport PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565

### From the original PR:

* initial commit for single line editor footer



* fixing styling and functionality



* Changeset file for PR #8565 created/updated

* fixing bug with error not showing up in footer



* fixing loading state thanks ashwinpc



* trying to surface errors



* adding new error for error state



* Revert "fixing loading state thanks ashwinpc"

This reverts commit 64b5969954a8419dce4c1ccc111147336df7e37b.

* correctly passing async search strat errors



## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
