### PR TITLE
[Sample data] Update otel sample data description

### DIFF
--- a/changelogs/fragments/8693.yml
+++ b/changelogs/fragments/8693.yml
@@ -1,0 +1,2 @@
+fix:
+- Update OTEL sample data description with compatible OS version ([#8693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8693))

--- a/src/plugins/home/server/services/sample_data/data_sets/otel/index.ts
+++ b/src/plugins/home/server/services/sample_data/data_sets/otel/index.ts
@@ -21,7 +21,7 @@ const otelDataName = i18n.translate('home.sampleData.otelSpecTitle', {
 });
 const otelDataDescription = i18n.translate('home.sampleData.otelSpecDescription', {
   defaultMessage:
-    'Correlated observability signals for an e-commerce application in OpenTelemetry standard.',
+    'Correlated observability signals for an e-commerce application in OpenTelemetry standard (Compatible with 2.13+ OpenSearch domains)',
 });
 const initialAppLinks: AppLinkSchema[] = [
   {


### PR DESCRIPTION
### Description

Update otel sample data description

### Issues Resolved

Currently OTEL sample data works only with OS 2.13+ domains, this text adds a line for users to mention the compatible domains. Long term: We'll remove this description warning and make the sample data compatible with all the OS versions. 

## Screenshot

![Screenshot 2024-10-23 at 12 54 39 PM](https://github.com/user-attachments/assets/7c331e5f-48a6-4c93-b1f4-d63fbb3f9274)

## Changelog

- fix: Update OTEL sample data description with compatible OS version

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
