### PR TITLE
Add framework to show related indexed views inside dataset selector and show banner in the Discover canvas for the selected dataset

### DIFF
--- a/changelogs/fragments/8701.yml
+++ b/changelogs/fragments/8701.yml
@@ -1,0 +1,2 @@
+feat:
+- Show banner at the top in discover canvas; show indexed views in dataset selector ([#8701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8701))

--- a/changelogs/fragments/8701.yml
+++ b/changelogs/fragments/8701.yml
@@ -1,2 +1,3 @@
 feat:
-- Show banner at the top in discover canvas; show indexed views in dataset selector ([#8701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8701))
+- Add framework to show banner at the top in discover results canvas ([#8701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8701))
+- Show indexed views in dataset selector ([#8701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8701))

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -247,6 +247,8 @@ export interface Dataset extends BaseDataset {
   timeFieldName?: string;
   /** Optional language to default to from the language selector */
   language?: string;
+  /** Optional name of the indexed view to search data from */
+  indexedView?: string;
 }
 
 export interface DatasetField {
@@ -256,6 +258,30 @@ export interface DatasetField {
   // TODO:  osdFieldType?
 }
 
+export type CanvasBannerProps =
+  | {
+      componentType: 'callout';
+      title: string;
+      iconType?: string;
+      content?: React.ReactNode;
+    }
+  | {
+      componentType: 'callout';
+      title?: string;
+      iconType?: string;
+      content: React.ReactNode;
+    }
+  | {
+      componentType: 'custom';
+      content: React.ReactNode;
+    };
+
 export interface DatasetSearchOptions {
   strategy?: string;
+  /**
+   * Returns props used to render a banner on the Discover canvas/results section
+   */
+  getBannerProps?: (
+    searchStatus: string
+  ) => CanvasBannerProps | Promise<CanvasBannerProps> | undefined;
 }

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -258,21 +258,26 @@ export interface DatasetField {
   // TODO:  osdFieldType?
 }
 
-export type CanvasBannerProps =
+export enum DatasetCanvasBannerComponentType {
+  Callout = 'callout',
+  Custom = 'custom',
+}
+
+export type DatasetCanvasBannerProps =
   | {
-      componentType: 'callout';
+      componentType: DatasetCanvasBannerComponentType.Callout;
       title: string;
       iconType?: string;
       content?: React.ReactNode;
     }
   | {
-      componentType: 'callout';
+      componentType: DatasetCanvasBannerComponentType.Callout;
       title?: string;
       iconType?: string;
       content: React.ReactNode;
     }
   | {
-      componentType: 'custom';
+      componentType: DatasetCanvasBannerComponentType.Custom;
       content: React.ReactNode;
     };
 

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -259,25 +259,25 @@ export interface DatasetField {
 }
 
 export enum DatasetCanvasBannerComponentType {
-  Callout = 'callout',
-  Custom = 'custom',
+  CALLOUT = 'callout',
+  CUSTOM = 'custom',
 }
 
 export type DatasetCanvasBannerProps =
   | {
-      componentType: DatasetCanvasBannerComponentType.Callout;
+      componentType: DatasetCanvasBannerComponentType.CALLOUT;
       title: string;
       iconType?: string;
       content?: React.ReactNode;
     }
   | {
-      componentType: DatasetCanvasBannerComponentType.Callout;
+      componentType: DatasetCanvasBannerComponentType.CALLOUT;
       title?: string;
       iconType?: string;
       content: React.ReactNode;
     }
   | {
-      componentType: DatasetCanvasBannerComponentType.Custom;
+      componentType: DatasetCanvasBannerComponentType.CUSTOM;
       content: React.ReactNode;
     };
 
@@ -288,5 +288,5 @@ export interface DatasetSearchOptions {
    */
   getBannerProps?: (
     searchStatus: string
-  ) => CanvasBannerProps | Promise<CanvasBannerProps> | undefined;
+  ) => DatasetCanvasBannerProps | Promise<DatasetCanvasBannerProps> | undefined;
 }

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -493,6 +493,7 @@ export {
   QueryStart,
   PersistedLog,
   LanguageReference,
+  IndexedViewsService,
 } from './query';
 
 export { AggsStart } from './search/aggs';

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -16,6 +16,14 @@ export interface DataStructureFetchOptions {
   paginationToken?: string;
 }
 
+export interface IndexedView {
+  name: string;
+}
+
+export interface IndexedViewsService {
+  getIndexedViews: (dataset: Dataset) => Promise<IndexedView[]>;
+}
+
 /**
  * Configuration for handling dataset operations.
  */
@@ -72,7 +80,7 @@ export interface DatasetTypeConfig {
    * Retrieves the search options to be used for running the query on the data connection associated
    * with this Dataset
    */
-  getSearchOptions?: () => DatasetSearchOptions;
+  getSearchOptions?: (dataset: Dataset) => DatasetSearchOptions;
   /**
    * Combines a list of user selected data structures into a single one to use in discover.
    * @see https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8362.
@@ -82,4 +90,8 @@ export interface DatasetTypeConfig {
    * Returns a list of sample queries for this dataset type
    */
   getSampleQueries?: (dataset: Dataset, language: string) => any;
+  /**
+   * Service used for indexedViews related operations
+   */
+  indexedViewsService?: IndexedViewsService;
 }

--- a/src/plugins/data/public/query/query_string/index.ts
+++ b/src/plugins/data/public/query/query_string/index.ts
@@ -34,6 +34,7 @@ export {
   DatasetService,
   DatasetServiceContract,
   DatasetTypeConfig,
+  IndexedViewsService,
 } from './dataset_service';
 export {
   LanguageServiceContract,

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -148,7 +148,7 @@ export const Configurator = ({
           >
             <EuiFieldText disabled value={dataset.title} />
           </EuiFormRow>
-          {indexedViews.length > 0 && (
+          {indexedViewsService && (
             <EuiFormRow
               label={i18n.translate(
                 'data.explorer.datasetSelector.advancedSelector.configurator.indexedViewLabel',
@@ -165,12 +165,6 @@ export const Configurator = ({
             >
               <EuiSelect
                 isLoading={loadingIndexedViews}
-                placeholder={i18n.translate(
-                  'data.explorer.datasetSelector.advancedSelector.configurator.indexedViewSelector.placeholder',
-                  {
-                    defaultMessage: 'Select indexed view',
-                  }
-                )}
                 options={indexedViews.map(({ name }) => ({
                   text: name,
                   value: name,

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -67,6 +67,7 @@ export const Configurator = ({
     const currentLanguage = queryString.getQuery().language;
     if (languages.includes(currentLanguage)) {
       setSelectedLanguage(currentLanguage);
+      return;
     }
     setSelectedLanguage(languages[0]);
   }, [languages, queryString]);

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -65,7 +65,7 @@ export const Configurator = ({
 
   useEffect(() => {
     const currentLanguage = queryString.getQuery().language;
-    if (languages.includes(currentLanguage)) {
+    if (Array.isArray(languages) && languages.includes(currentLanguage)) {
       setSelectedLanguage(currentLanguage);
       return;
     }
@@ -116,7 +116,7 @@ export const Configurator = ({
       setTimeFields(dateFields || []);
     };
 
-    if (baseDataset?.dataSource?.meta?.supportsTimeFilter === false && timeFields.length > 0) {
+    if (!baseDataset?.dataSource?.meta?.supportsTimeFilter && timeFields.length > 0) {
       setTimeFields([]);
       return;
     }
@@ -269,7 +269,7 @@ export const Configurator = ({
         <EuiButton
           onClick={async () => {
             await queryString.getDatasetService().cacheDataset(dataset, services);
-            onConfirm({ dataset, language });
+            onConfirm({ dataset, language: selectedLanguage });
           }}
           fill
           disabled={submitDisabled}

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -57,7 +57,7 @@ export const Configurator = ({
   const indexedViewsService = type?.indexedViewsService;
   const [selectedIndexedView, setSelectedIndexedView] = useState<string | undefined>();
   const [indexedViews, setIndexedViews] = useState<IndexedView[]>([]);
-  const [loadingIndexedViews, setLoadingIndexedViews] = useState(false);
+  const [isLoadingIndexedViews, setIsLoadingIndexedViews] = useState(false);
 
   useEffect(() => {
     setLanguages(type?.supportedLanguages(dataset) || []);
@@ -75,9 +75,9 @@ export const Configurator = ({
   useEffect(() => {
     const getIndexedViews = async () => {
       if (indexedViewsService) {
-        setLoadingIndexedViews(true);
+        setIsLoadingIndexedViews(true);
         const fetchedIndexedViews = await indexedViewsService.getIndexedViews(baseDataset);
-        setLoadingIndexedViews(false);
+        setIsLoadingIndexedViews(false);
         setIndexedViews(fetchedIndexedViews || []);
       }
     };
@@ -87,7 +87,7 @@ export const Configurator = ({
 
   const submitDisabled = useMemo(() => {
     return (
-      loadingIndexedViews ||
+      isLoadingIndexedViews ||
       (timeFieldName === undefined &&
         !(
           languageService.getLanguage(selectedLanguage)?.hideDatePicker ||
@@ -96,7 +96,14 @@ export const Configurator = ({
         timeFields &&
         timeFields.length > 0)
     );
-  }, [dataset, selectedLanguage, timeFieldName, timeFields, languageService, loadingIndexedViews]);
+  }, [
+    dataset,
+    selectedLanguage,
+    timeFieldName,
+    timeFields,
+    languageService,
+    isLoadingIndexedViews,
+  ]);
 
   useEffect(() => {
     const fetchFields = async () => {
@@ -165,7 +172,7 @@ export const Configurator = ({
               )}
             >
               <EuiSelect
-                isLoading={loadingIndexedViews}
+                isLoading={isLoadingIndexedViews}
                 options={indexedViews.map(({ name }) => ({
                   text: name,
                   value: name,

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -183,7 +183,7 @@ export const useSearch = (services: DiscoverViewServices) => {
     let elapsedMs;
     try {
       // Only show loading indicator if we are fetching when the rows are empty
-      if (fetchStateRef.current.rows?.length === 0) {
+      if (!fetchStateRef.current.rows || fetchStateRef.current.rows.length === 0) {
         data$.next({ status: ResultStatus.LOADING, queryStatus: { startTime } });
       }
 

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -62,7 +62,11 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title} | head 10`,
+      getQueryString: (currentQuery: Query) => {
+        const dataset = currentQuery.dataset;
+        const source = dataset?.indexedView ?? dataset?.title;
+        return `source = ${source} | head 10`;
+      },
       fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
@@ -127,8 +131,10 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) =>
-        `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
+      getQueryString: (currentQuery: Query) => {
+        const source = currentQuery.dataset?.indexedView ?? currentQuery.dataset?.title;
+        return `SELECT * FROM ${source} LIMIT 10`;
+      },
       fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -67,7 +67,7 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       const datasetTypeConfig = this.queryService.queryString
         .getDatasetService()
         .getType(datasetType);
-      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+      strategy = datasetTypeConfig?.getSearchOptions?.(dataset).strategy ?? strategy;
     }
 
     return this.runSearch(request, options.abortSignal, strategy);

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -61,7 +61,7 @@ export class SQLSearchInterceptor extends SearchInterceptor {
       const datasetTypeConfig = this.queryService.queryString
         .getDatasetService()
         .getType(datasetType);
-      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+      strategy = datasetTypeConfig?.getSearchOptions?.(dataset).strategy ?? strategy;
     }
 
     return this.runSearch(request, options.abortSignal, strategy);


### PR DESCRIPTION
### Description
In this PR we add support for
1. Selecting indexed view inside dataset selector. The indexed view is an Opensearch index which can be created for an external source like S3. When user selects an indexed view, we use this index for querying the data
2. Showing a banner at the top of Discover results canvas. This banner can be used to show actions related to the selected dataset. The first use we will add for this banner would be to show a callout to create an indexed view while searching an external source, or when an indexed view is selected, we can show an entry point to select other indexed view

### Issues Resolved
New feature

## Screenshot
#### Note: Below screenshots were produced by making changes to the S3 type config for testing and are not part of this PR since this PR is only adding the framework.

- Callout for creating indexed view
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/4cd03bb7-5812-4339-85ff-bead0be907a3">

- Action from callout can open the create flyout (this is all handled by the type config provider and not in this PR's code)
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/0653d969-aca1-4601-a57d-4639fbc842ca">


- Create indexed view banner:
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/ade28ea9-afcb-4b0a-ae74-23053263adc5">


## Testing the changes
Set up workspace with query enhancements enabled
- For the banner in Discover canvas
1. [For testing only]: Update the S3 config type to return the banner props based on the fetch status
2. Discover will render the banner based on provided props

- For showing indexed views in dataset selector
1. Update the S3 config type to return implemented instance of IndexedViewsService
2. Dataset selector will show the indexed views in the second step

## Changelog
- feat: Add framework to show banner at the top in discover results canvas
- feat: Show indexed views in dataset selector

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
