### PR TITLE
[BUG][Discover] Ensure save query loaded properly from asset

### DIFF
--- a/changelogs/fragments/8707.yml
+++ b/changelogs/fragments/8707.yml
@@ -1,0 +1,2 @@
+fix:
+- Ensure save query loaded properly from asset ([#8707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8707))

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -86,7 +86,9 @@ export const useSearch = (services: DiscoverViewServices) => {
   const { pathname } = useLocation();
   const initalSearchComplete = useRef(false);
   const [savedSearch, setSavedSearch] = useState<SavedSearch | undefined>(undefined);
-  const { savedSearch: savedSearchId, sort, interval } = useSelector((state) => state.discover);
+  const { savedSearch: savedSearchId, sort, interval, savedQuery } = useSelector(
+    (state) => state.discover
+  );
   const indexPattern = useIndexPattern(services);
   const skipInitialFetch = useRef(false);
   const {
@@ -387,9 +389,12 @@ export const useSearch = (services: DiscoverViewServices) => {
 
       // sync initial app filters from savedObject to filterManager
       const filters = cloneDeep(savedSearchInstance.searchSource.getOwnField('filter'));
-      const actualFilters = [];
 
-      if (filters !== undefined) {
+      let actualFilters: any[] = [];
+
+      if (savedQuery) {
+        actualFilters = data.query.filterManager.getFilters();
+      } else if (filters !== undefined) {
         const result = typeof filters === 'function' ? filters() : filters;
         if (result !== undefined) {
           actualFilters.push(...(Array.isArray(result) ? result : [result]));
@@ -397,7 +402,7 @@ export const useSearch = (services: DiscoverViewServices) => {
       }
 
       filterManager.setAppFilters(actualFilters);
-      data.query.queryString.setQuery(query);
+      data.query.queryString.setQuery(savedQuery ? data.query.queryString.getQuery() : query);
       setSavedSearch(savedSearchInstance);
 
       if (savedSearchInstance?.id) {


### PR DESCRIPTION
### Description

Saved query workflow 
```
useSavedQuery → populateStateFromSavedQuery with new saved query → queryString.setQuery(new saved query)
useSavedQuery → populateStateFromSavedQuery with new saved query → filterManager.setFilters(new saved query)
```
Then they are clean out in use_search
```
useEffect(() => {
    (async () => {
      const savedSearchInstance = await getSavedSearchById(savedSearchId);

      const query =
        savedSearchInstance.searchSource.getField('query') ||
        data.query.queryString.getDefaultQuery();

      const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
      if (isEnhancementsEnabled && query.dataset) {
        let pattern = await data.indexPatterns.get(
          query.dataset.id,
          query.dataset.type !== 'INDEX_PATTERN'
        );
        if (!pattern) {
          await data.query.queryString.getDatasetService().cacheDataset(query.dataset, {
            uiSettings: services.uiSettings,
            savedObjects: services.savedObjects,
            notifications: services.notifications,
            http: services.http,
            data: services.data,
          });
          pattern = await data.indexPatterns.get(
            query.dataset.id,
            query.dataset.type !== 'INDEX_PATTERN'
          );
          savedSearchInstance.searchSource.setField('index', pattern);
        }
      }

      // sync initial app filters from savedObject to filterManager
      const filters = cloneDeep(savedSearchInstance.searchSource.getOwnField('filter'));
      const actualFilters = [];

      if (filters !== undefined) {
        const result = typeof filters === 'function' ? filters() : filters;
        if (result !== undefined) {
          actualFilters.push(...(Array.isArray(result) ? result : [result]));
        }
      }

      filterManager.setAppFilters(actualFilters);
      data.query.queryString.setQuery(query);
      setSavedSearch(savedSearchInstance);

      if (savedSearchInstance?.id) {
        chrome.recentlyAccessed.add(
          savedSearchInstance.getFullPath(),
          savedSearchInstance.title,
          savedSearchInstance.id,
          {
            type: savedSearchInstance.getOpenSearchType(),
          }
        );
      }
    })();
    // This effect will only run when getSavedSearchById is called, which is
    // only called when the component is first mounted.
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [getSavedSearchById, savedSearchId]);
```

After change:

* legacy 

https://github.com/user-attachments/assets/fe203bb8-e752-4995-ba94-4c365c93f5ee



* with enhancement

https://github.com/user-attachments/assets/29228da0-b2e0-408d-ac1d-8b390069abef



### Issues Resolved

NA

## Screenshot

NA

## Testing the changes


## Changelog

- fix: Ensure save query loaded properly from asset



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
