### PR TITLE
[Discover] Modify the search bar info box content for sql/ppl

### DIFF
--- a/changelogs/fragments/8708.yml
+++ b/changelogs/fragments/8708.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover] Modify the search bar info box content for sql/ppl #8708 ([#8708](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8708))

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -632,6 +632,10 @@ export class DocLinksService {
             // https://opensearch.org/docs/latest/search-plugins/sql/sql/basic/
             base: `${OPENSEARCH_WEBSITE_DOCS}/search-plugins/sql/sql/basic/`,
           },
+          sqlPplLimitation: {
+            // https://opensearch.org/docs/latest/search-plugins/sql/limitation/
+            base: `${OPENSEARCH_WEBSITE_DOCS}/search-plugins/sql/limitation/`,
+          },
         },
       },
     });
@@ -981,6 +985,9 @@ export interface DocLinksStart {
         readonly base: string;
       };
       readonly ppl: {
+        readonly base: string;
+      };
+      readonly sqlPplLimitation: {
         readonly base: string;
       };
     };

--- a/src/plugins/advanced_settings/public/management_app/__snapshots__/advanced_settings.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/management_app/__snapshots__/advanced_settings.test.tsx.snap
@@ -197,6 +197,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
         "sql": Object {
           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
         },
+        "sqlPplLimitation": Object {
+          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+        },
         "tutorial": Object {
           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -848,6 +851,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
             },
             "sql": Object {
               "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+            },
+            "sqlPplLimitation": Object {
+              "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
             },
             "tutorial": Object {
               "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -1780,6 +1786,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                         },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                        },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2188,6 +2197,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         },
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                        },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                         },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2598,6 +2610,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                         },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                        },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3006,6 +3021,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         },
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                        },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                         },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3471,6 +3489,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                         },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                        },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3881,6 +3902,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         },
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                        },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                         },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -574,6 +574,9 @@ exports[`Dashboard top nav render in embed mode 1`] = `
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                   },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                  },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                     "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -1652,6 +1655,9 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
                   },
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                  },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                   },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2732,6 +2738,9 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                   },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                  },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                     "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3810,6 +3819,9 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
                   },
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                  },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                   },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -4890,6 +4902,9 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                   },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                  },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                     "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -5968,6 +5983,9 @@ exports[`Dashboard top nav render with all components 1`] = `
                   },
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                  },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                   },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LanguageReference } from './language_reference';
+import { IntlProvider } from 'react-intl';
+
+// Helper to wrap component with IntlProvider
+const renderWithIntl = (ui) => {
+  return render(<IntlProvider locale="en">{ui}</IntlProvider>);
+};
+
+describe('LanguageReference Component', () => {
+  beforeEach(() => {
+    // Clear localStorage and DOM before each test
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('auto-opens the info box on first load if autoShow is true and sets localStorage key', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={true}
+          selectedLanguage="SQL"
+        />
+      );
+    });
+
+    // Check localStorage was set
+    const storageKey = 'hasSeenInfoBox_SQL';
+    expect(localStorage.getItem(storageKey)).toBe('true');
+
+    // Wait for and check if popover content is visible
+    await waitFor(() => {
+      const popoverContent = screen.getByTestId('test-body');
+      expect(popoverContent).toBeInTheDocument();
+    });
+  });
+
+  test('toggles the info box open and close on button click', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={false}
+          selectedLanguage="PPL"
+        />
+      );
+    });
+
+    // Wait for button to be available
+    await waitFor(() => {
+      const button = screen.getByTestId('languageReferenceButton');
+      expect(button).toBeInTheDocument();
+    });
+
+    // Initially closed
+    expect(screen.queryByTestId('test-body')).not.toBeInTheDocument();
+
+    // Click to open
+    const button = screen.getByTestId('languageReferenceButton');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Wait for content to be visible
+    await waitFor(() => {
+      const content = screen.getByTestId('test-body');
+      expect(content).toBeInTheDocument();
+    });
+
+    // Click to close
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Wait for content to be removed
+    await waitFor(() => {
+      expect(screen.queryByTestId('test-body')).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows correct title in popover', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={true}
+          selectedLanguage="SQL"
+        />
+      );
+    });
+
+    // Wait for and check if the title is rendered
+    await waitFor(() => {
+      expect(screen.getByText('Syntax options')).toBeInTheDocument();
+    });
+  });
+
+  test('respects autoShow prop when false', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={false}
+          selectedLanguage="SQL"
+        />
+      );
+    });
+
+    // Wait for component to be fully rendered
+    await waitFor(() => {
+      const button = screen.getByTestId('languageReferenceButton');
+      expect(button).toBeInTheDocument();
+    });
+
+    // Content should not be visible
+    expect(screen.queryByTestId('test-body')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
@@ -21,13 +21,13 @@ export const LanguageReference = (props: {
   useEffect(() => {
     if (
       props.selectedLanguage === 'SQL' &&
-      window.localStorage.getItem('hasSeenSQLInfoBox') === 'false'
+      window.localStorage.getItem('hasSeenSQLInfoBox') === null
     ) {
       setIsLanguageReferenceOpen(true);
       window.localStorage.setItem('hasSeenSQLInfoBox', 'true');
     } else if (
       props.selectedLanguage === 'PPL' &&
-      window.localStorage.getItem('hasSeenPPLInfoBox') === 'false'
+      window.localStorage.getItem('hasSeenPPLInfoBox') === null
     ) {
       setIsLanguageReferenceOpen(true);
       window.localStorage.setItem('hasSeenPPLInfoBox', 'true');

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
@@ -17,22 +17,17 @@ export const LanguageReference = (props: {
 }) => {
   const [isLanguageReferenceOpen, setIsLanguageReferenceOpen] = useState(props.autoShow || false);
 
-  // useEffect hook to auto-open the info box on the first selection of SQL or PPL
   useEffect(() => {
-    if (
-      props.selectedLanguage === 'SQL' &&
-      window.localStorage.getItem('hasSeenSQLInfoBox') === null
-    ) {
-      setIsLanguageReferenceOpen(true);
-      window.localStorage.setItem('hasSeenSQLInfoBox', 'true');
-    } else if (
-      props.selectedLanguage === 'PPL' &&
-      window.localStorage.getItem('hasSeenPPLInfoBox') === null
-    ) {
-      setIsLanguageReferenceOpen(true);
-      window.localStorage.setItem('hasSeenPPLInfoBox', 'true');
+    if (props.autoShow) {
+      const storageKey = `hasSeenInfoBox_${props.selectedLanguage}`;
+      const hasSeenInfoBox = window.localStorage.getItem(storageKey);
+
+      if (hasSeenInfoBox === null && props.autoShow) {
+        setIsLanguageReferenceOpen(true);
+        window.localStorage.setItem(storageKey, 'true');
+      }
     }
-  }, [props.selectedLanguage]);
+  }, [props.selectedLanguage, props.autoShow]);
 
   const button = (
     <div>

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
@@ -7,11 +7,32 @@ import { i18n } from '@osd/i18n';
 
 import { EuiButtonIcon, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
 
-import React, { ReactFragment } from 'react';
+import React, { ReactFragment, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-export const LanguageReference = (props: { body: ReactFragment }) => {
-  const [isLanguageReferenceOpen, setIsLanguageReferenceOpen] = React.useState(false);
+export const LanguageReference = (props: {
+  body: ReactFragment;
+  autoShow?: boolean;
+  selectedLanguage?: string;
+}) => {
+  const [isLanguageReferenceOpen, setIsLanguageReferenceOpen] = useState(props.autoShow || false);
+
+  // useEffect hook to auto-open the info box on the first selection of SQL or PPL
+  useEffect(() => {
+    if (
+      props.selectedLanguage === 'SQL' &&
+      window.localStorage.getItem('hasSeenSQLInfoBox') === 'false'
+    ) {
+      setIsLanguageReferenceOpen(true);
+      window.localStorage.setItem('hasSeenSQLInfoBox', 'true');
+    } else if (
+      props.selectedLanguage === 'PPL' &&
+      window.localStorage.getItem('hasSeenPPLInfoBox') === 'false'
+    ) {
+      setIsLanguageReferenceOpen(true);
+      window.localStorage.setItem('hasSeenPPLInfoBox', 'true');
+    }
+  }, [props.selectedLanguage]);
 
   const button = (
     <div>

--- a/src/plugins/data/public/ui/query_editor/__snapshots__/language_selector.test.tsx.snap
+++ b/src/plugins/data/public/ui/query_editor/__snapshots__/language_selector.test.tsx.snap
@@ -253,6 +253,9 @@ exports[`LanguageSelector should select DQL if language is kuery 1`] = `
             "sql": Object {
               "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
             },
+            "sqlPplLimitation": Object {
+              "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+            },
             "tutorial": Object {
               "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
               "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -848,6 +851,9 @@ exports[`LanguageSelector should select lucene if language is lucene 1`] = `
             },
             "sql": Object {
               "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+            },
+            "sqlPplLimitation": Object {
+              "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
             },
             "tutorial": Object {
               "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -174,7 +174,6 @@ export class QueryEnhancementsPlugin
       queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
     });
 
-    // Enhance data with the query editor extension
     data.__enhance({
       editor: {
         queryEditorExtension: createQueryAssistExtension(
@@ -186,7 +185,6 @@ export class QueryEnhancementsPlugin
       },
     });
 
-    // Register custom dataset type
     queryString.getDatasetService().registerType(s3TypeConfig);
 
     return {};

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -94,7 +94,7 @@ export class QueryEnhancementsPlugin
       // Define and register SQL language configuration
       const sqlLanguageConfig: LanguageConfig = {
         id: 'SQL',
-        title: 'SQL',
+        title: 'OpenSearch SQL',
         search: new SQLSearchInterceptor({
           toasts: core.notifications.toasts,
           http: core.http,

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -43,14 +43,6 @@ export class QueryEnhancementsPlugin
   ): QueryEnhancementsPluginSetup {
     const { queryString } = data.query;
 
-    // Initialize local storage keys when the plugin loads, if they don't exist
-    if (!window.localStorage.getItem('hasSeenSQLInfoBox')) {
-      window.localStorage.setItem('hasSeenSQLInfoBox', 'false');
-    }
-    if (!window.localStorage.getItem('hasSeenPPLInfoBox')) {
-      window.localStorage.setItem('hasSeenPPLInfoBox', 'false');
-    }
-
     // Initialize `selectedLanguage` as undefined to wait for correct language updates
     let selectedLanguage;
 

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -35,14 +35,6 @@ export class QueryEnhancementsPlugin
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<ConfigSchema>();
     this.storage = new DataStorage(window.localStorage, 'discover.queryAssist.');
-
-    // Initialize local storage flags if not already set
-    if (!window.localStorage.getItem('hasSeenSQLInfoBox')) {
-      window.localStorage.setItem('hasSeenSQLInfoBox', 'false');
-    }
-    if (!window.localStorage.getItem('hasSeenPPLInfoBox')) {
-      window.localStorage.setItem('hasSeenPPLInfoBox', 'false');
-    }
   }
 
   public setup(
@@ -51,7 +43,15 @@ export class QueryEnhancementsPlugin
   ): QueryEnhancementsPluginSetup {
     const { queryString } = data.query;
 
-    // Initialize `selectedLanguage` as undefined to wait for the correct language update
+    // Initialize local storage keys when the plugin loads, if they don't exist
+    if (!window.localStorage.getItem('hasSeenSQLInfoBox')) {
+      window.localStorage.setItem('hasSeenSQLInfoBox', 'false');
+    }
+    if (!window.localStorage.getItem('hasSeenPPLInfoBox')) {
+      window.localStorage.setItem('hasSeenPPLInfoBox', 'false');
+    }
+
+    // Initialize `selectedLanguage` as undefined to wait for correct language updates
     let selectedLanguage;
 
     // Subscribe to updates to track language changes

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -43,21 +43,18 @@ export class QueryEnhancementsPlugin
   ): QueryEnhancementsPluginSetup {
     const { queryString } = data.query;
 
-    // Initialize `selectedLanguage` as undefined to wait for correct language updates
-    let selectedLanguage;
-
     // Subscribe to updates to track language changes
     queryString.getUpdates$().subscribe((query) => {
-      selectedLanguage = query.language;
+      const selectedLanguage = query.language;
 
-      // Re-render the controls when `selectedLanguage` is defined
+      // Re-render the controls with updated `autoShow` flags
       const pplControls = [pplLanguageReference(selectedLanguage)];
       const sqlControls = [sqlLanguageReference(selectedLanguage)];
 
       const enhancedPPLQueryEditor = createEditor(SingleLineInput, null, pplControls, DefaultInput);
       const enhancedSQLQueryEditor = createEditor(SingleLineInput, null, sqlControls, DefaultInput);
 
-      // Define and register PPL language configuration
+      // Register PPL language configuration
       const pplLanguageConfig: LanguageConfig = {
         id: 'PPL',
         title: 'PPL',
@@ -83,7 +80,7 @@ export class QueryEnhancementsPlugin
       };
       queryString.getLanguageService().registerLanguage(pplLanguageConfig);
 
-      // Define and register SQL language configuration
+      // Register SQL language configuration
       const sqlLanguageConfig: LanguageConfig = {
         id: 'SQL',
         title: 'OpenSearch SQL',

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -2,7 +2,6 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { i18n } from '@osd/i18n';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
 import { ConfigSchema } from '../common/config';
@@ -43,125 +42,117 @@ export class QueryEnhancementsPlugin
   ): QueryEnhancementsPluginSetup {
     const { queryString } = data.query;
 
-    // Subscribe to updates to track language changes
-    queryString.getUpdates$().subscribe((query) => {
-      const selectedLanguage = query.language;
+    // Define controls once for each language and register language configurations outside of `getUpdates$`
+    const pplControls = [pplLanguageReference('PPL')];
+    const sqlControls = [sqlLanguageReference('SQL')];
 
-      // Re-render the controls with updated `autoShow` flags
-      const pplControls = [pplLanguageReference(selectedLanguage)];
-      const sqlControls = [sqlLanguageReference(selectedLanguage)];
-
-      const enhancedPPLQueryEditor = createEditor(SingleLineInput, null, pplControls, DefaultInput);
-      const enhancedSQLQueryEditor = createEditor(SingleLineInput, null, sqlControls, DefaultInput);
-
-      // Register PPL language configuration
-      const pplLanguageConfig: LanguageConfig = {
-        id: 'PPL',
-        title: 'PPL',
-        search: new PPLSearchInterceptor({
-          toasts: core.notifications.toasts,
-          http: core.http,
-          uiSettings: core.uiSettings,
-          startServices: core.getStartServices(),
-          usageCollector: data.search.usageCollector,
+    // Register PPL language configuration
+    const pplLanguageConfig: LanguageConfig = {
+      id: 'PPL',
+      title: 'PPL',
+      search: new PPLSearchInterceptor({
+        toasts: core.notifications.toasts,
+        http: core.http,
+        uiSettings: core.uiSettings,
+        startServices: core.getStartServices(),
+        usageCollector: data.search.usageCollector,
+      }),
+      getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
+      fields: { filterable: false, visualizable: false },
+      docLink: {
+        title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
+          defaultMessage: 'PPL documentation',
         }),
-        getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
-        fields: { filterable: false, visualizable: false },
-        docLink: {
-          title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
-            defaultMessage: 'PPL documentation',
-          }),
-          url: 'https://opensearch.org/docs/latest/search-plugins/sql/ppl/syntax/',
-        },
-        showDocLinks: false,
-        editor: enhancedPPLQueryEditor,
-        editorSupportedAppNames: ['discover'],
-        supportedAppNames: ['discover', 'data-explorer'],
-      };
-      queryString.getLanguageService().registerLanguage(pplLanguageConfig);
+        url: 'https://opensearch.org/docs/latest/search-plugins/sql/ppl/syntax/',
+      },
+      showDocLinks: false,
+      editor: createEditor(SingleLineInput, null, pplControls, DefaultInput),
+      editorSupportedAppNames: ['discover'],
+      supportedAppNames: ['discover', 'data-explorer'],
+    };
+    queryString.getLanguageService().registerLanguage(pplLanguageConfig);
 
-      // Register SQL language configuration
-      const sqlLanguageConfig: LanguageConfig = {
-        id: 'SQL',
-        title: 'OpenSearch SQL',
-        search: new SQLSearchInterceptor({
-          toasts: core.notifications.toasts,
-          http: core.http,
-          uiSettings: core.uiSettings,
-          startServices: core.getStartServices(),
-          usageCollector: data.search.usageCollector,
+    // Register SQL language configuration
+    const sqlLanguageConfig: LanguageConfig = {
+      id: 'SQL',
+      title: 'OpenSearch SQL',
+      search: new SQLSearchInterceptor({
+        toasts: core.notifications.toasts,
+        http: core.http,
+        uiSettings: core.uiSettings,
+        startServices: core.getStartServices(),
+        usageCollector: data.search.usageCollector,
+      }),
+      getQueryString: (currentQuery: Query) =>
+        `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
+      fields: { filterable: false, visualizable: false },
+      docLink: {
+        title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {
+          defaultMessage: 'SQL documentation',
         }),
-        getQueryString: (currentQuery: Query) =>
-          `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
-        fields: { filterable: false, visualizable: false },
-        docLink: {
-          title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {
-            defaultMessage: 'SQL documentation',
+        url: 'https://opensearch.org/docs/latest/search-plugins/sql/sql/basic/',
+      },
+      showDocLinks: false,
+      editor: createEditor(SingleLineInput, null, sqlControls, DefaultInput),
+      editorSupportedAppNames: ['discover'],
+      supportedAppNames: ['discover', 'data-explorer'],
+      hideDatePicker: true,
+      sampleQueries: [
+        {
+          title: i18n.translate('queryEnhancements.sqlLanguage.sampleQuery.titleContainsWind', {
+            defaultMessage: 'The title field contains the word wind.',
           }),
-          url: 'https://opensearch.org/docs/latest/search-plugins/sql/sql/basic/',
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind%'`,
         },
-        showDocLinks: false,
-        editor: enhancedSQLQueryEditor,
-        editorSupportedAppNames: ['discover'],
-        supportedAppNames: ['discover', 'data-explorer'],
-        hideDatePicker: true,
-        sampleQueries: [
-          {
-            title: i18n.translate('queryEnhancements.sqlLanguage.sampleQuery.titleContainsWind', {
-              defaultMessage: 'The title field contains the word wind.',
-            }),
-            query: `SELECT * FROM your_table WHERE title LIKE '%wind%'`,
-          },
-          {
-            title: i18n.translate(
-              'queryEnhancements.sqlLanguage.sampleQuery.titleContainsWindOrWindy',
-              {
-                defaultMessage: 'The title field contains the word wind or the word windy.',
-              }
-            ),
-            query: `SELECT * FROM your_table WHERE title LIKE '%wind%' OR title LIKE '%windy%';`,
-          },
-          {
-            title: i18n.translate(
-              'queryEnhancements.sqlLanguage.sampleQuery.titleContainsPhraseWindRises',
-              {
-                defaultMessage: 'The title field contains the phrase wind rises.',
-              }
-            ),
-            query: `SELECT * FROM your_table WHERE title LIKE '%wind rises%'`,
-          },
-          {
-            title: i18n.translate(
-              'queryEnhancements.sqlLanguage.sampleQuery.titleExactMatchWindRises',
-              {
-                defaultMessage: 'The title.keyword field exactly matches The wind rises.',
-              }
-            ),
-            query: `SELECT * FROM your_table WHERE title = 'The wind rises'`,
-          },
-          {
-            title: i18n.translate(
-              'queryEnhancements.sqlLanguage.sampleQuery.titleFieldsContainWind',
-              {
-                defaultMessage:
-                  'Any field that starts with title (for example, title and title.keyword) contains the word wind',
-              }
-            ),
-            query: `SELECT * FROM your_table WHERE title LIKE '%wind%' OR title = 'wind'`,
-          },
-          {
-            title: i18n.translate(
-              'queryEnhancements.sqlLanguage.sampleQuery.descriptionFieldExists',
-              {
-                defaultMessage: 'Documents in which the field description exists.',
-              }
-            ),
-            query: `SELECT * FROM your_table WHERE description IS NOT NULL AND description != '';`,
-          },
-        ],
-      };
-      queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
-    });
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleContainsWindOrWindy',
+            {
+              defaultMessage: 'The title field contains the word wind or the word windy.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind%' OR title LIKE '%windy%';`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleContainsPhraseWindRises',
+            {
+              defaultMessage: 'The title field contains the phrase wind rises.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind rises%'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleExactMatchWindRises',
+            {
+              defaultMessage: 'The title.keyword field exactly matches The wind rises.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title = 'The wind rises'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.titleFieldsContainWind',
+            {
+              defaultMessage:
+                'Any field that starts with title (for example, title and title.keyword) contains the word wind',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE title LIKE '%wind%' OR title = 'wind'`,
+        },
+        {
+          title: i18n.translate(
+            'queryEnhancements.sqlLanguage.sampleQuery.descriptionFieldExists',
+            {
+              defaultMessage: 'Documents in which the field description exists.',
+            }
+          ),
+          query: `SELECT * FROM your_table WHERE description IS NOT NULL AND description != '';`,
+        },
+      ],
+    };
+    queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
 
     data.__enhance({
       editor: {

--- a/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
@@ -48,10 +48,13 @@ const PPLReference = () => {
 };
 
 export const pplLanguageReference = (selectedLanguage) => {
+  const hasSeenInfoBox = localStorage.getItem('hasSeenInfoBox_PPL') === 'true';
+  const shouldAutoShow = selectedLanguage === 'PPL' && !hasSeenInfoBox;
+
   return (
     <LanguageReference
       body={<PPLReference />}
-      autoShow={selectedLanguage === 'PPL'}
+      autoShow={shouldAutoShow}
       selectedLanguage={selectedLanguage}
     />
   );

--- a/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
@@ -11,8 +11,13 @@ import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/pu
 const PPLReference = () => {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const pplDocs = opensearchDashboards.services.docLinks?.links.noDocumentation.ppl.base;
+  const limitationDocs =
+    opensearchDashboards.services.docLinks?.links.noDocumentation.sqlPplLimitation.base;
   const pplFullName = (
     <FormattedMessage id="queryEnhancements.queryBar.pplFullLanguageName" defaultMessage="PPL" />
+  );
+  const limitationsLink = (
+    <FormattedMessage id="queryEnhancements.queryBar.pplLimitationDoc" defaultMessage="here" />
   );
 
   return (
@@ -21,11 +26,16 @@ const PPLReference = () => {
         <p>
           <FormattedMessage
             id="queryEnhancements.queryBar.pplSyntaxOptionsDescription"
-            defaultMessage="Piped Processing Language ({docsLink}) is a query language that focuses on processing data in a sequential, step-by-step manner. PPL uses the pipe (|) operator to combine commands to find and retrieve data. It is particularly well suited for analyzing observability data, such as logs, metrics, and traces, due to its ability to handle semi-structured data efficiently."
+            defaultMessage="Piped Processing Language ({pplDocsLink}) is a query language that focuses on processing data in a sequential, step-by-step manner. OpenSearch SQL/PPL language limitations can be found {limitationDocsLink}."
             values={{
-              docsLink: (
+              pplDocsLink: (
                 <EuiLink href={pplDocs} target="_blank">
                   {pplFullName}
+                </EuiLink>
+              ),
+              limitationDocsLink: (
+                <EuiLink href={limitationDocs} target="_blank">
+                  {limitationsLink}
                 </EuiLink>
               ),
             }}
@@ -39,3 +49,10 @@ const PPLReference = () => {
 export const pplLanguageReference = () => {
   return <LanguageReference body={<PPLReference />} />;
 };
+
+// (i) for PPL: Piped Processing Language (PPL) is a query language that focuses on processing data in a sequential, step-by-step manner. OpenSearch SQL/PPL language limitations can be found here.
+// PPL: https://opensearch.org/docs/latest/search-plugins/sql/ppl/index/
+// / HERE: https://opensearch.org/docs/latest/search-plugins/sql/limitation/
+
+// SQL: (i) for SQL: OpenSearch (SQL). OpenSearch SQL/PPL language limitations can be found here.
+// HERE: https://opensearch.org/docs/latest/search-plugins/sql/limitation/

--- a/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
@@ -46,6 +46,14 @@ const PPLReference = () => {
   );
 };
 
-export const pplLanguageReference = () => {
-  return <LanguageReference body={<PPLReference />} />;
+export const pplLanguageReference = (selectedLanguage) => {
+  const isFirstTimePPL = window.localStorage.getItem('hasSeenPPLInfoBox') === 'false';
+
+  return (
+    <LanguageReference
+      body={<PPLReference />}
+      autoShow={isFirstTimePPL && selectedLanguage === 'PPL'}
+      selectedLanguage={selectedLanguage}
+    />
+  );
 };

--- a/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
@@ -49,10 +49,3 @@ const PPLReference = () => {
 export const pplLanguageReference = () => {
   return <LanguageReference body={<PPLReference />} />;
 };
-
-// (i) for PPL: Piped Processing Language (PPL) is a query language that focuses on processing data in a sequential, step-by-step manner. OpenSearch SQL/PPL language limitations can be found here.
-// PPL: https://opensearch.org/docs/latest/search-plugins/sql/ppl/index/
-// / HERE: https://opensearch.org/docs/latest/search-plugins/sql/limitation/
-
-// SQL: (i) for SQL: OpenSearch (SQL). OpenSearch SQL/PPL language limitations can be found here.
-// HERE: https://opensearch.org/docs/latest/search-plugins/sql/limitation/

--- a/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
@@ -8,6 +8,7 @@ import { EuiLink, EuiText } from '@elastic/eui';
 import { IDataPluginServices } from 'src/plugins/data/public';
 import { LanguageReference } from '../../../data/public';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+
 const PPLReference = () => {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const pplDocs = opensearchDashboards.services.docLinks?.links.noDocumentation.ppl.base;
@@ -47,12 +48,10 @@ const PPLReference = () => {
 };
 
 export const pplLanguageReference = (selectedLanguage) => {
-  const isFirstTimePPL = window.localStorage.getItem('hasSeenPPLInfoBox') === 'false';
-
   return (
     <LanguageReference
       body={<PPLReference />}
-      autoShow={isFirstTimePPL && selectedLanguage === 'PPL'}
+      autoShow={selectedLanguage === 'PPL'}
       selectedLanguage={selectedLanguage}
     />
   );

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -48,7 +48,6 @@ const SQLReference = () => {
 };
 
 export const sqlLanguageReference = (selectedLanguage) => {
-  // Only set `autoShow` to true if the selected language is SQL and it hasn't been shown before
   const hasSeenInfoBox = localStorage.getItem('hasSeenInfoBox_SQL') === 'true';
   const shouldAutoShow = selectedLanguage === 'SQL' && !hasSeenInfoBox;
 

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -8,6 +8,7 @@ import { EuiLink, EuiText } from '@elastic/eui';
 import { IDataPluginServices } from 'src/plugins/data/public';
 import { LanguageReference } from '../../../data/public';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+
 const SQLReference = () => {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const sqlDocs = opensearchDashboards.services.docLinks?.links.noDocumentation.sql.base;
@@ -47,12 +48,10 @@ const SQLReference = () => {
 };
 
 export const sqlLanguageReference = (selectedLanguage) => {
-  const isFirstTimeSQL = window.localStorage.getItem('hasSeenSQLInfoBox') === 'false';
-
   return (
     <LanguageReference
       body={<SQLReference />}
-      autoShow={isFirstTimeSQL && selectedLanguage === 'SQL'}
+      autoShow={selectedLanguage === 'SQL'}
       selectedLanguage={selectedLanguage}
     />
   );

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -26,7 +26,7 @@ const SQLReference = () => {
         <p>
           <FormattedMessage
             id="queryEnhancements.queryBar.sqlSyntaxOptionsDescription"
-            defaultMessage="OpenSearch ({sqlDocsLink}). OpenSearch SQL/PPL language limitations can be found {limitationDocsLink}."
+            defaultMessage="OpenSearch {sqlDocsLink}. OpenSearch SQL/PPL language limitations can be found {limitationDocsLink}."
             values={{
               sqlDocsLink: (
                 <EuiLink href={sqlDocs} target="_blank">

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -46,6 +46,14 @@ const SQLReference = () => {
   );
 };
 
-export const sqlLanguageReference = () => {
-  return <LanguageReference body={<SQLReference />} />;
+export const sqlLanguageReference = (selectedLanguage) => {
+  const isFirstTimeSQL = window.localStorage.getItem('hasSeenSQLInfoBox') === 'false';
+
+  return (
+    <LanguageReference
+      body={<SQLReference />}
+      autoShow={isFirstTimeSQL && selectedLanguage === 'SQL'}
+      selectedLanguage={selectedLanguage}
+    />
+  );
 };

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -11,8 +11,13 @@ import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/pu
 const SQLReference = () => {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const sqlDocs = opensearchDashboards.services.docLinks?.links.noDocumentation.sql.base;
+  const limitationDocs =
+    opensearchDashboards.services.docLinks?.links.noDocumentation.sqlPplLimitation.base;
   const sqlFullName = (
     <FormattedMessage id="queryEnhancements.queryBar.sqlFullLanguageName" defaultMessage="SQL" />
+  );
+  const limitationsLink = (
+    <FormattedMessage id="queryEnhancements.queryBar.sqlLimitationDoc" defaultMessage="here" />
   );
 
   return (
@@ -21,11 +26,16 @@ const SQLReference = () => {
         <p>
           <FormattedMessage
             id="queryEnhancements.queryBar.sqlSyntaxOptionsDescription"
-            defaultMessage="{docsLink} in OpenSearch bridges the gap between traditional relational database concepts and the flexibility of OpenSearch’s document-oriented data storage. This integration gives you the ability to use your SQL knowledge to query, analyze, and extract insights from your OpenSearch data."
+            defaultMessage="OpenSearch ({sqlDocsLink}). OpenSearch SQL/PPL language limitations can be found {limitationDocsLink}."
             values={{
-              docsLink: (
+              sqlDocsLink: (
                 <EuiLink href={sqlDocs} target="_blank">
                   {sqlFullName}
+                </EuiLink>
+              ),
+              limitationDocsLink: (
+                <EuiLink href={limitationDocs} target="_blank">
+                  {limitationsLink}
                 </EuiLink>
               ),
             }}

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -48,10 +48,14 @@ const SQLReference = () => {
 };
 
 export const sqlLanguageReference = (selectedLanguage) => {
+  // Only set `autoShow` to true if the selected language is SQL and it hasn't been shown before
+  const hasSeenInfoBox = localStorage.getItem('hasSeenInfoBox_SQL') === 'true';
+  const shouldAutoShow = selectedLanguage === 'SQL' && !hasSeenInfoBox;
+
   return (
     <LanguageReference
       body={<SQLReference />}
-      autoShow={selectedLanguage === 'SQL'}
+      autoShow={shouldAutoShow}
       selectedLanguage={selectedLanguage}
     />
   );


### PR DESCRIPTION
### Description
- Modify the search bar info box content for sql/ppl
- The info box will only show up when it is user's first time to select SQL/PPL
- Change the language picker's title from "SQL" into "OpenSearch SQL" 

### Issues Resolved

* Relate https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8702
* we can close the above since this PR reflects the new design from UIUX

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<!-- 
Version 1:
https://github.com/user-attachments/assets/cd01a611-1a8c-4a3a-94b7-fd5e1cc2209f -->
Version Final:

https://github.com/user-attachments/assets/5a34c5a6-0504-4771-a949-f1bb00bf0d3a



<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- fix: [Discover] Modify the search bar info box content for sql/ppl #8708

<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
