### PR TITLE
[discover] query editor and language selector state fixes

### DIFF
--- a/changelogs/fragments/8712.yml
+++ b/changelogs/fragments/8712.yml
@@ -1,0 +1,2 @@
+refactor:
+- [discover] query editor and language selector state fixes ([#8712](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8712))

--- a/src/plugins/data/public/query/query_string/language_service/language_service.ts
+++ b/src/plugins/data/public/query/query_string/language_service/language_service.ts
@@ -66,7 +66,7 @@ export class LanguageService {
     return Array.from(this.languages.values());
   }
 
-  public getDefaultLanguage(): LanguageConfig {
+  public getDefaultLanguage(): LanguageConfig | undefined {
     return this.languages.get('kuery') || this.languages.values().next().value;
   }
 

--- a/src/plugins/data/public/query/query_string/query_string_manager.test.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.test.ts
@@ -49,7 +49,8 @@ describe('QueryStringManager', () => {
       storage,
       sessionStorage,
       coreMock.createSetup().uiSettings,
-      mockSearchInterceptor
+      mockSearchInterceptor,
+      coreMock.createStart().notifications
     );
   });
 
@@ -138,5 +139,60 @@ describe('QueryStringManager', () => {
     };
     const query = service.getInitialQueryByDataset(dataset);
     expect(query).toHaveProperty('dataset', dataset);
+  });
+
+  describe('getInitialQuery', () => {
+    const mockDataset = {
+      id: 'test-dataset',
+      title: 'Test Dataset',
+      type: DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+      language: 'sql',
+    };
+
+    beforeEach(() => {
+      service.setQuery({
+        query: 'initial query',
+        language: 'kuery',
+        dataset: {
+          id: 'current-dataset',
+          title: 'Current Dataset',
+          type: DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+        },
+      });
+    });
+
+    test('returns current language query when no params provided', () => {
+      const result = service.getInitialQuery();
+      expect(result.language).toBe('kuery');
+      expect(result.dataset).toBeDefined();
+    });
+
+    test('generates new query when both language and dataset provided', () => {
+      const result = service.getInitialQuery({
+        language: 'sql',
+        dataset: mockDataset,
+      });
+
+      expect(result.language).toBe('sql');
+      expect(result.dataset).toBe(mockDataset);
+      expect(result.query).toBeDefined();
+    });
+
+    test('uses dataset preferred language when only dataset provided', () => {
+      const result = service.getInitialQuery({ dataset: mockDataset });
+
+      expect(result.language).toBe(mockDataset.language);
+      expect(result.dataset).toBe(mockDataset);
+      expect(result.query).toBeDefined();
+    });
+
+    test('uses current dataset when only language provided', () => {
+      const currentDataset = service.getQuery().dataset;
+      const result = service.getInitialQuery({ language: 'ppl' });
+
+      expect(result.language).toBe('ppl');
+      expect(result.dataset).toEqual(currentDataset);
+      expect(result.query).toBeDefined();
+    });
   });
 });

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -194,34 +194,85 @@ export class QueryStringManager {
     return this.languageService;
   };
 
-  public getInitialQuery = () => {
-    return this.getInitialQueryByLanguage(this.query$.getValue().language);
+  /**
+   * Gets the initial query based on the provided partial query object.
+   * If both language and dataset are provided, generates a new query without using current state
+   * If only language is provided, uses current dataset
+   * If only dataset is provided, uses current or dataset's preferred language
+   */
+  public getInitialQuery = (partialQuery?: Partial<Query>) => {
+    if (!partialQuery) {
+      return this.getInitialQueryByLanguage(this.query$.getValue().language);
+    }
+
+    const { language, dataset } = partialQuery;
+    const currentQuery = this.query$.getValue();
+
+    // Both language and dataset provided - generate fresh query
+    if (language && dataset) {
+      const languageService = this.languageService.getLanguage(language);
+      const newQuery = {
+        language,
+        dataset,
+        query: '',
+      };
+      newQuery.query = languageService?.getQueryString(newQuery) || '';
+      return newQuery;
+    }
+
+    // Only dataset provided - use dataset's preferred language or current language
+    if (dataset) {
+      return this.getInitialQueryByDataset(dataset);
+    }
+
+    // Only language provided - use current dataset
+    if (language) {
+      return this.getInitialQueryByLanguage(language);
+    }
+
+    // Fallback to current query
+    return currentQuery;
   };
 
+  /**
+   * Gets initial query for a language, preserving current dataset
+   * Called by getInitialQuery when only language changes
+   */
   public getInitialQueryByLanguage = (languageId: string) => {
     const curQuery = this.query$.getValue();
     const language = this.languageService.getLanguage(languageId);
-    const dataset = curQuery.dataset;
-    const input = language?.getQueryString(curQuery) || '';
-    this.languageService.setUserQueryString(input);
-
-    return {
-      query: input,
+    const newQuery = {
+      ...curQuery,
       language: languageId,
-      dataset,
     };
-  };
-
-  public getInitialQueryByDataset = (newDataset: Dataset) => {
-    const curQuery = this.query$.getValue();
-    const languageId = newDataset.language || curQuery.language;
-    const language = this.languageService.getLanguage(languageId);
-    const newQuery = { ...curQuery, language: languageId, dataset: newDataset };
-    const newQueryString = language?.getQueryString(newQuery) || '';
+    const queryString = language?.getQueryString(newQuery) || '';
+    this.languageService.setUserQueryString(queryString);
 
     return {
       ...newQuery,
-      query: newQueryString,
+      query: queryString,
+    };
+  };
+
+  /**
+   * Gets initial query for a dataset, using dataset's preferred language or current language
+   * Called by getInitialQuery when only dataset changes
+   */
+  public getInitialQueryByDataset = (newDataset: Dataset) => {
+    const curQuery = this.query$.getValue();
+    // Use dataset's preferred language or fallback to current language
+    const languageId = newDataset.language || curQuery.language;
+    const language = this.languageService.getLanguage(languageId);
+    const newQuery = {
+      ...curQuery,
+      language: languageId,
+      dataset: newDataset,
+    };
+    const queryString = language?.getQueryString(newQuery) || '';
+
+    return {
+      ...newQuery,
+      query: queryString,
     };
   };
 

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -204,6 +204,7 @@ export class QueryStringManager {
    * If only language is provided, uses current dataset
    * If only dataset is provided, uses current or dataset's preferred language
    */
+  // TODO: claude write jest test for this
   public getInitialQuery = (partialQuery?: Partial<Query>) => {
     if (!partialQuery) {
       return this.getInitialQueryByLanguage(this.query$.getValue().language);
@@ -242,6 +243,7 @@ export class QueryStringManager {
    * Gets initial query for a language, preserving current dataset
    * Called by getInitialQuery when only language changes
    */
+  // TODO: claude write jest test for this
   public getInitialQueryByLanguage = (languageId: string) => {
     const curQuery = this.query$.getValue();
     const language = this.languageService.getLanguage(languageId);
@@ -262,6 +264,7 @@ export class QueryStringManager {
    * Gets initial query for a dataset, using dataset's preferred language or current language
    * Called by getInitialQuery when only dataset changes
    */
+  // TODO: claude write jest test for this
   public getInitialQueryByDataset = (newDataset: Dataset) => {
     const curQuery = this.query$.getValue();
     // Use dataset's preferred language or fallback to current language

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -156,6 +156,10 @@ export class QueryStringManager {
     const curQuery = this.query$.getValue();
     const newQuery = { ...curQuery, ...query };
     if (!isEqual(curQuery, newQuery)) {
+      // Add to recent datasets if dataset has changed
+      if (newQuery.dataset && !isEqual(curQuery.dataset, newQuery.dataset)) {
+        this.datasetService.addRecentDataset(newQuery.dataset);
+      }
       this.query$.next(newQuery);
     }
   };

--- a/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
@@ -7,9 +7,9 @@ import React, { useState } from 'react';
 import {
   BaseDataset,
   DATA_STRUCTURE_META_TYPES,
-  Dataset,
   DataStructure,
   DEFAULT_DATA,
+  Query,
 } from '../../../common';
 import { getQueryService } from '../../services';
 import { IDataPluginServices } from '../../types';
@@ -22,7 +22,7 @@ export const AdvancedSelector = ({
   onCancel,
 }: {
   services: IDataPluginServices;
-  onSelect: (dataset: Dataset) => void;
+  onSelect: (query: Partial<Query>) => void;
   onCancel: () => void;
 }) => {
   const queryString = getQueryService().queryString;

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -19,7 +19,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { BaseDataset, DEFAULT_DATA, Dataset, DatasetField } from '../../../common';
+import { BaseDataset, DEFAULT_DATA, Dataset, DatasetField, Query } from '../../../common';
 import { getIndexPatterns, getQueryService } from '../../services';
 import { IDataPluginServices } from '../../types';
 
@@ -32,7 +32,7 @@ export const Configurator = ({
 }: {
   services: IDataPluginServices;
   baseDataset: BaseDataset;
-  onConfirm: (dataset: Dataset) => void;
+  onConfirm: (query: Partial<Query>) => void;
   onCancel: () => void;
   onPrevious: () => void;
 }) => {
@@ -202,7 +202,7 @@ export const Configurator = ({
         <EuiButton
           onClick={async () => {
             await queryString.getDatasetService().cacheDataset(dataset, services);
-            onConfirm(dataset);
+            onConfirm({ dataset, language });
           }}
           fill
           disabled={submitDisabled}

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.test.tsx
@@ -70,7 +70,7 @@ describe('DatasetSelector', () => {
   it('should fetch datasets once on mount', async () => {
     const props = {
       selectedDataset: undefined as Dataset | undefined,
-      setSelectedDataset: jest.fn(),
+      onSelect: jest.fn(),
       services: mockServices,
     };
 
@@ -83,7 +83,7 @@ describe('DatasetSelector', () => {
   it('should not fetch datasets on re-render', async () => {
     const props = {
       selectedDataset: undefined as Dataset | undefined,
-      setSelectedDataset: jest.fn(),
+      onSelect: jest.fn(),
       services: mockServices,
     };
 
@@ -100,7 +100,7 @@ describe('DatasetSelector', () => {
   it('should not update datasets state on re-render', async () => {
     const props = {
       selectedDataset: undefined as Dataset | undefined,
-      setSelectedDataset: jest.fn(),
+      onSelect: jest.fn(),
       services: mockServices,
     };
 

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -18,7 +18,7 @@ import { FormattedMessage } from '@osd/i18n/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { toMountPoint } from '../../../../opensearch_dashboards_react/public';
-import { Dataset, DEFAULT_DATA } from '../../../common';
+import { Dataset, DEFAULT_DATA, Query } from '../../../common';
 import { getQueryService } from '../../services';
 import { IDataPluginServices } from '../../types';
 import { AdvancedSelector } from './advanced_selector';
@@ -33,7 +33,7 @@ type EuiSmallButtonEmptyProps = React.ComponentProps<typeof EuiSmallButtonEmpty>
 
 interface DatasetSelectorProps {
   selectedDataset?: Dataset;
-  setSelectedDataset: (dataset: Dataset) => void;
+  onSelect: (partialQuery: Partial<Query>) => void;
   services: IDataPluginServices;
 }
 
@@ -70,7 +70,7 @@ const RootComponent: React.FC<
  */
 export const DatasetSelector = ({
   selectedDataset,
-  setSelectedDataset,
+  onSelect,
   services,
   appearance,
   buttonProps,
@@ -102,7 +102,7 @@ export const DatasetSelector = ({
 
       // If no dataset is selected, select the first one
       if (!selectedDataset && fetchedDatasets.length > 0) {
-        setSelectedDataset(fetchedDatasets[0]);
+        onSelect({ dataset: fetchedDatasets[0] });
       }
     };
 
@@ -180,11 +180,11 @@ export const DatasetSelector = ({
           indexPatterns.find((dataset) => dataset.id === selectedOption.key);
         if (foundDataset) {
           closePopover();
-          setSelectedDataset(foundDataset);
+          onSelect({ dataset: foundDataset });
         }
       }
     },
-    [recentDatasets, indexPatterns, setSelectedDataset, closePopover]
+    [recentDatasets, indexPatterns, onSelect, closePopover]
   );
 
   const datasetTitle = useMemo(() => {
@@ -264,10 +264,10 @@ export const DatasetSelector = ({
               toMountPoint(
                 <AdvancedSelector
                   services={services}
-                  onSelect={(dataset?: Dataset) => {
+                  onSelect={(query: Partial<Query>) => {
                     overlay?.close();
-                    if (dataset) {
-                      setSelectedDataset(dataset);
+                    if (query) {
+                      onSelect(query);
                     }
                   }}
                   onCancel={() => overlay?.close()}

--- a/src/plugins/data/public/ui/dataset_selector/index.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/index.test.tsx
@@ -8,7 +8,7 @@ import { mount } from 'enzyme';
 import { DatasetSelector as ConnectedDatasetSelector } from './index';
 import { DatasetSelector } from './dataset_selector';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { Dataset } from '../../../common';
+import { Dataset, Query } from '../../../common';
 
 jest.mock('../../../../opensearch_dashboards_react/public', () => ({
   useOpenSearchDashboards: jest.fn(),
@@ -24,7 +24,7 @@ describe('ConnectedDatasetSelector', () => {
   const mockQueryString = {
     getQuery: jest.fn().mockReturnValue({}),
     getDefaultQuery: jest.fn().mockReturnValue({}),
-    getInitialQueryByDataset: jest.fn().mockReturnValue({}),
+    getInitialQuery: jest.fn().mockReturnValue({}),
     setQuery: jest.fn(),
     getDatasetService: jest.fn().mockReturnValue({
       addRecentDataset: jest.fn(),
@@ -51,7 +51,7 @@ describe('ConnectedDatasetSelector', () => {
     const wrapper = mount(<ConnectedDatasetSelector onSubmit={mockOnSubmit} />);
     expect(wrapper.find(DatasetSelector).props()).toEqual({
       selectedDataset: undefined,
-      setSelectedDataset: expect.any(Function),
+      onSelect: expect.any(Function),
       services: mockServices,
     });
   });
@@ -66,14 +66,14 @@ describe('ConnectedDatasetSelector', () => {
 
   it('should call handleDatasetChange only once when dataset changes', () => {
     const wrapper = mount(<ConnectedDatasetSelector onSubmit={mockOnSubmit} />);
-    const setSelectedDataset = wrapper.find(DatasetSelector).prop('setSelectedDataset') as (
-      dataset?: Dataset
+    const onSelect = wrapper.find(DatasetSelector).prop('onSelect') as (
+      query: Partial<Query>
     ) => void;
 
     const newDataset: Dataset = { id: 'test', title: 'Test Dataset', type: 'test' };
-    setSelectedDataset(newDataset);
+    onSelect(newDataset);
 
-    expect(mockQueryString.getInitialQueryByDataset).toHaveBeenCalledTimes(1);
+    expect(mockQueryString.getInitialQuery).toHaveBeenCalledTimes(1);
     expect(mockQueryString.setQuery).toHaveBeenCalledTimes(1);
     expect(mockOnSubmit).toHaveBeenCalledTimes(1);
   });

--- a/src/plugins/data/public/ui/dataset_selector/index.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/index.tsx
@@ -46,9 +46,6 @@ const ConnectedDatasetSelector = ({
       setSelectedDataset(query.dataset);
       queryString.setQuery(query);
       onSubmit!(query);
-      if (query.dataset) {
-        queryString.getDatasetService().addRecentDataset(query.dataset);
-      }
     },
     [onSubmit, queryString]
   );

--- a/src/plugins/data/public/ui/dataset_selector/index.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/index.tsx
@@ -40,14 +40,14 @@ const ConnectedDatasetSelector = ({
     };
   }, [queryString]);
 
-  const handleDatasetChange = useCallback(
-    (dataset?: Dataset) => {
-      setSelectedDataset(dataset);
-      if (dataset) {
-        const query = queryString.getInitialQueryByDataset(dataset);
-        queryString.setQuery(query);
-        onSubmit!(queryString.getQuery());
-        queryString.getDatasetService().addRecentDataset(dataset);
+  const onSelect = useCallback(
+    (partialQuery: Partial<Query>) => {
+      const query = queryString.getInitialQuery(partialQuery);
+      setSelectedDataset(query.dataset);
+      queryString.setQuery(query);
+      onSubmit!(query);
+      if (query.dataset) {
+        queryString.getDatasetService().addRecentDataset(query.dataset);
       }
     },
     [onSubmit, queryString]
@@ -57,7 +57,7 @@ const ConnectedDatasetSelector = ({
     <DatasetSelector
       {...datasetSelectorProps}
       selectedDataset={selectedDataset}
-      setSelectedDataset={handleDatasetChange}
+      onSelect={onSelect}
       services={services}
     />
   );

--- a/src/plugins/data/public/ui/query_editor/__snapshots__/language_selector.test.tsx.snap
+++ b/src/plugins/data/public/ui/query_editor/__snapshots__/language_selector.test.tsx.snap
@@ -106,6 +106,93 @@ exports[`LanguageSelector should select DQL if language is kuery 1`] = `
   }
   services={
     Object {
+      "data": Object {
+        "query": Object {
+          "queryString": Object {
+            "getDatasetService": [Function],
+            "getLanguageService": [Function],
+            "getQuery": [MockFunction] {
+              "calls": Array [
+                Array [],
+                Array [],
+                Array [],
+                Array [],
+                Array [],
+                Array [],
+                Array [],
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "kuery",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "kuery",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "kuery",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "kuery",
+                    "query": "",
+                  },
+                },
+              ],
+            },
+            "getUpdates$": [MockFunction],
+          },
+        },
+      },
       "docLinks": Object {
         "DOC_LINK_VERSION": "mocked-test-branch",
         "OPENSEARCH_WEBSITE_URL": "https://opensearch.org/",
@@ -474,6 +561,32 @@ exports[`LanguageSelector should select DQL if language is kuery 1`] = `
           },
         },
       },
+      "http": Object {
+        "addLoadingCountSource": [MockFunction],
+        "anonymousPaths": Object {
+          "isAnonymous": [MockFunction],
+          "register": [MockFunction],
+        },
+        "basePath": BasePath {
+          "basePath": "",
+          "clientBasePath": "",
+          "get": [Function],
+          "getBasePath": [Function],
+          "prepend": [Function],
+          "remove": [Function],
+          "serverBasePath": "",
+        },
+        "delete": [MockFunction],
+        "fetch": [MockFunction],
+        "get": [MockFunction],
+        "getLoadingCount$": [MockFunction],
+        "head": [MockFunction],
+        "intercept": [MockFunction],
+        "options": [MockFunction],
+        "patch": [MockFunction],
+        "post": [MockFunction],
+        "put": [MockFunction],
+      },
       "uiSettings": Object {
         "get": [MockFunction],
         "get$": [MockFunction],
@@ -495,12 +608,6 @@ exports[`LanguageSelector should select DQL if language is kuery 1`] = `
 >
   <QueryLanguageSelector
     onSelectLanguage={[MockFunction]}
-    query={
-      Object {
-        "language": "kuery",
-        "query": "",
-      }
-    }
   >
     <EuiPopover
       anchorPosition="downLeft"
@@ -702,6 +809,57 @@ exports[`LanguageSelector should select lucene if language is lucene 1`] = `
   }
   services={
     Object {
+      "data": Object {
+        "query": Object {
+          "queryString": Object {
+            "getDatasetService": [Function],
+            "getLanguageService": [Function],
+            "getQuery": [MockFunction] {
+              "calls": Array [
+                Array [],
+                Array [],
+                Array [],
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+                Object {
+                  "type": "return",
+                  "value": Object {
+                    "dataset": undefined,
+                    "language": "lucene",
+                    "query": "",
+                  },
+                },
+              ],
+            },
+            "getUpdates$": [MockFunction],
+          },
+        },
+      },
       "docLinks": Object {
         "DOC_LINK_VERSION": "mocked-test-branch",
         "OPENSEARCH_WEBSITE_URL": "https://opensearch.org/",
@@ -1070,6 +1228,32 @@ exports[`LanguageSelector should select lucene if language is lucene 1`] = `
           },
         },
       },
+      "http": Object {
+        "addLoadingCountSource": [MockFunction],
+        "anonymousPaths": Object {
+          "isAnonymous": [MockFunction],
+          "register": [MockFunction],
+        },
+        "basePath": BasePath {
+          "basePath": "",
+          "clientBasePath": "",
+          "get": [Function],
+          "getBasePath": [Function],
+          "prepend": [Function],
+          "remove": [Function],
+          "serverBasePath": "",
+        },
+        "delete": [MockFunction],
+        "fetch": [MockFunction],
+        "get": [MockFunction],
+        "getLoadingCount$": [MockFunction],
+        "head": [MockFunction],
+        "intercept": [MockFunction],
+        "options": [MockFunction],
+        "patch": [MockFunction],
+        "post": [MockFunction],
+        "put": [MockFunction],
+      },
       "uiSettings": Object {
         "get": [MockFunction],
         "get$": [MockFunction],
@@ -1091,12 +1275,6 @@ exports[`LanguageSelector should select lucene if language is lucene 1`] = `
 >
   <QueryLanguageSelector
     onSelectLanguage={[MockFunction]}
-    query={
-      Object {
-        "language": "lucene",
-        "query": "",
-      }
-    }
   >
     <EuiPopover
       anchorPosition="downLeft"

--- a/src/plugins/data/public/ui/query_editor/language_selector.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/language_selector.test.tsx
@@ -9,34 +9,62 @@ import { OpenSearchDashboardsContextProvider } from 'src/plugins/opensearch_dash
 import { coreMock } from '../../../../../core/public/mocks';
 import { mountWithIntl } from 'test_utils/enzyme_helpers';
 import { Query } from '../..';
+import { of } from 'rxjs';
 
 const startMock = coreMock.createStart();
 
-jest.mock('../../services', () => ({
-  getQueryService: () => ({
-    queryString: {
-      getLanguageService: () => ({
-        getLanguages: () => [
-          { id: 'lucene', title: 'Lucene' },
-          { id: 'kuery', title: 'DQL' },
-        ],
-        getUserQueryLanguageBlocklist: () => [],
-        setUserQueryLanguage: jest.fn(),
-      }),
-      getUpdates$: () => ({
-        subscribe: () => ({
-          unsubscribe: jest.fn(),
+// Mock the query updates subject
+// TODO: Codeium jest is complaining about reference area and this being out of scope can you fix this?
+
+// Create a more complete mock that matches the service structure
+jest.mock('../../services', () => {
+  const getQueryMock = jest.fn().mockReturnValue({
+    query: '',
+    language: 'kuery',
+    dataset: undefined,
+  } as Query);
+
+  const languageService = {
+    getDefaultLanguage: () => ({ id: 'kuery', title: 'DQL' }),
+    getLanguages: () => [
+      { id: 'lucene', title: 'Lucene' },
+      { id: 'kuery', title: 'DQL' },
+    ],
+    getUserQueryLanguageBlocklist: () => [],
+    setUserQueryLanguage: jest.fn(),
+  };
+
+  const datasetService = {
+    getTypes: () => [{ supportedLanguages: () => ['kuery', 'lucene'] }],
+    getType: () => ({ supportedLanguages: () => ['kuery', 'lucene'] }),
+    addRecentDataset: jest.fn(),
+  };
+
+  return {
+    getQueryService: () => ({
+      queryString: {
+        getQuery: getQueryMock,
+        getLanguageService: () => languageService,
+        getDatasetService: () => datasetService,
+        getUpdates$: jest.fn().mockReturnValue({
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
         }),
-      }),
-    },
-  }),
-}));
+      },
+    }),
+  };
+});
 
 describe('LanguageSelector', () => {
   function wrapInContext(testProps: any) {
     const services = {
       uiSettings: startMock.uiSettings,
       docLinks: startMock.docLinks,
+      http: startMock.http,
+      data: {
+        query: {
+          queryString: jest.requireMock('../../services').getQueryService().queryString,
+        },
+      },
     };
 
     return (
@@ -47,10 +75,16 @@ describe('LanguageSelector', () => {
   }
 
   it('should select lucene if language is lucene', () => {
-    const query: Query = { query: '', language: 'lucene' };
+    // Update the mock query value before mounting
+    const getQueryService = jest.requireMock('../../services').getQueryService;
+    getQueryService().queryString.getQuery.mockReturnValue({
+      query: '',
+      language: 'lucene',
+      dataset: undefined,
+    });
+
     const component = mountWithIntl(
       wrapInContext({
-        query,
         onSelectLanguage: jest.fn(),
       })
     );
@@ -58,10 +92,15 @@ describe('LanguageSelector', () => {
   });
 
   it('should select DQL if language is kuery', () => {
-    const query: Query = { query: '', language: 'kuery' };
+    const getQueryService = jest.requireMock('../../services').getQueryService;
+    getQueryService().queryString.getQuery.mockReturnValue({
+      query: '',
+      language: 'kuery',
+      dataset: undefined,
+    });
+
     const component = mountWithIntl(
       wrapInContext({
-        query,
         onSelectLanguage: jest.fn(),
       })
     );

--- a/src/plugins/data/public/ui/query_editor/language_selector.tsx
+++ b/src/plugins/data/public/ui/query_editor/language_selector.tsx
@@ -11,18 +11,22 @@ import {
   PopoverAnchorPosition,
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Query } from '../..';
+import { isEqual } from 'lodash';
 import { LanguageConfig } from '../../query';
 import { getQueryService } from '../../services';
 
 export interface QueryLanguageSelectorProps {
-  query: Query;
   onSelectLanguage: (newLanguage: string) => void;
   anchorPosition?: PopoverAnchorPosition;
   appName?: string;
 }
 
-const mapExternalLanguageToOptions = (language: LanguageConfig) => {
+interface LanguageOption {
+  label: string;
+  value: string;
+}
+
+const mapExternalLanguageToOptions = (language: LanguageConfig): LanguageOption => {
   return {
     label: language.title,
     value: language.id,
@@ -30,54 +34,62 @@ const mapExternalLanguageToOptions = (language: LanguageConfig) => {
 };
 
 export const QueryLanguageSelector = (props: QueryLanguageSelectorProps) => {
-  const [isPopoverOpen, setPopover] = useState(false);
-  const [currentLanguage, setCurrentLanguage] = useState(props.query.language);
-
   const queryString = getQueryService().queryString;
   const languageService = queryString.getLanguageService();
 
-  const datasetSupportedLanguages = useMemo(() => {
-    const dataset = props.query.dataset;
-    if (!dataset) {
-      return undefined;
-    }
-    const datasetType = queryString.getDatasetService().getType(dataset.type);
-    return datasetType?.supportedLanguages(dataset);
-  }, [props.query.dataset, queryString]);
+  const [isPopoverOpen, setPopover] = useState(false);
+  const [currentLanguage, setCurrentLanguage] = useState<string>(
+    queryString.getQuery()?.language || languageService.getDefaultLanguage()?.id || ''
+  );
+  const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>([]);
 
   useEffect(() => {
-    const subscription = queryString.getUpdates$().subscribe((query: Query) => {
-      if (query.language !== currentLanguage) {
-        setCurrentLanguage(query.language);
+    const updateState = () => {
+      const query = queryString.getQuery();
+      const language = query.language || languageService.getDefaultLanguage()?.id;
+      const dataset = query.dataset;
+
+      // Update current language if changed
+      if (language !== currentLanguage) {
+        setCurrentLanguage(language || '');
       }
+
+      // Get supported languages
+      const languages = !dataset
+        ? languageService.getLanguages().map((l) => l.id)
+        : queryString.getDatasetService().getType(dataset.type)?.supportedLanguages(dataset) ??
+          null;
+
+      if (!languages) {
+        return;
+      }
+
+      // Build new options including app support check
+      const newOptions = languageService
+        .getLanguages()
+        .filter(
+          (lang) =>
+            languages.includes(lang.id) &&
+            (!props.appName || lang.editorSupportedAppNames?.includes(props.appName))
+        )
+        .map(mapExternalLanguageToOptions)
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+      if (!isEqual(newOptions, languageOptions)) {
+        setLanguageOptions(newOptions);
+      }
+    };
+
+    updateState();
+
+    const subscription = queryString.getUpdates$().subscribe(() => {
+      updateState();
     });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [queryString, currentLanguage, props]);
-
-  const onButtonClick = () => {
-    setPopover(!isPopoverOpen);
-  };
-
-  const languageOptions = useMemo(() => {
-    const options: Array<{ label: string; value: string }> = [];
-
-    languageService.getLanguages().forEach((language) => {
-      const isSupported =
-        !datasetSupportedLanguages || datasetSupportedLanguages.includes(language.id);
-      const isBlocklisted = languageService.getUserQueryLanguageBlocklist().includes(language?.id);
-      const isAppSupported =
-        !props.appName || language?.editorSupportedAppNames?.includes(props.appName);
-
-      if (!isSupported || isBlocklisted || !isAppSupported) return;
-
-      options.unshift(mapExternalLanguageToOptions(language));
-    });
-
-    return options.sort((a, b) => a.label.localeCompare(b.label));
-  }, [languageService, props.appName, datasetSupportedLanguages]);
+  }, [currentLanguage, languageOptions, languageService, queryString, props.appName]);
 
   const selectedLanguage = useMemo(
     () => ({
@@ -120,7 +132,7 @@ export const QueryLanguageSelector = (props: QueryLanguageSelectorProps) => {
       button={
         <EuiSmallButtonEmpty
           iconSide="right"
-          onClick={onButtonClick}
+          onClick={() => setPopover(!isPopoverOpen)}
           className="languageSelector__button"
           iconType="arrowDown"
           data-test-subj="queryEditorLanguageSelector"

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -15,15 +15,11 @@ import {
   PopoverAnchorPosition,
 } from '@elastic/eui';
 import classNames from 'classnames';
-import { isEqual } from 'lodash';
-import React, { Component, createRef, RefObject } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { monaco } from '@osd/monaco';
 import {
   IDataPluginServices,
-  IFieldType,
-  IIndexPattern,
   Query,
-  QuerySuggestion,
   TimeRange,
   QueryControls,
   RecentQueriesTable,
@@ -69,224 +65,166 @@ interface Props extends QueryEditorProps {
   opensearchDashboards: OpenSearchDashboardsReactContextValue<IDataPluginServices>;
 }
 
-interface State {
-  isSuggestionsVisible: boolean;
-  index: number | null;
-  suggestions: QuerySuggestion[];
-  indexPatterns: IIndexPattern[];
-  isCollapsed: boolean;
-  timeStamp: IFieldType | null;
-  lineCount: number | undefined;
-  isRecentQueryVisible: boolean;
-}
+export const QueryEditorUI: React.FC<Props> = (props) => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [lineCount, setLineCount] = useState<number | undefined>(undefined);
+  const [isRecentQueryVisible, setIsRecentQueryVisible] = useState(false);
 
-// Needed for React.lazy
-// TODO: MQL export this and let people extended this
-// eslint-disable-next-line import/no-default-export
-export default class QueryEditorUI extends Component<Props, State> {
-  public state: State = {
-    isSuggestionsVisible: false,
-    index: null,
-    suggestions: [],
-    indexPatterns: [],
-    isCollapsed: false, // default to expand mode
-    timeStamp: null,
-    lineCount: undefined,
-    isRecentQueryVisible: false,
-  };
+  const inputRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const bannerRef = useRef<HTMLDivElement>(null);
+  const queryControlsContainer = useRef<HTMLDivElement>(null);
 
-  public inputRef: monaco.editor.IStandaloneCodeEditor | null = null;
+  const queryString = getQueryService().queryString;
+  const languageManager = queryString.getLanguageService();
+  const extensionMap = languageManager.getQueryEditorExtensionMap();
+  const services = props.opensearchDashboards.services;
 
-  private queryString = getQueryService().queryString;
-  private languageManager = this.queryString.getLanguageService();
+  const persistedLogRef = useRef<PersistedLog>();
+  const abortControllerRef = useRef<AbortController>();
 
-  private persistedLog: PersistedLog | undefined;
-  private abortController?: AbortController;
-  private services = this.props.opensearchDashboards.services;
-  private headerRef: RefObject<HTMLDivElement> = createRef();
-  private bannerRef: RefObject<HTMLDivElement> = createRef();
-  private queryControlsContainer: RefObject<HTMLDivElement> = createRef();
-  private extensionMap = this.languageManager.getQueryEditorExtensionMap();
+  const getQueryString = useCallback(() => {
+    return toUser(props.query.query);
+  }, [props.query]);
 
-  private getQueryString = () => {
-    return toUser(this.props.query.query);
-  };
-
-  private setIsCollapsed = (isCollapsed: boolean) => {
-    this.setState({ isCollapsed });
-  };
-
-  private renderQueryEditorExtensions() {
+  const renderQueryEditorExtensions = () => {
     if (
       !(
-        this.headerRef.current &&
-        this.bannerRef.current &&
-        this.queryControlsContainer.current &&
-        this.props.query.language &&
-        this.extensionMap &&
-        Object.keys(this.extensionMap).length > 0
+        headerRef.current &&
+        bannerRef.current &&
+        queryControlsContainer.current &&
+        props.query.language &&
+        extensionMap &&
+        Object.keys(extensionMap).length > 0
       )
     ) {
       return null;
     }
     return (
       <QueryEditorExtensions
-        language={this.props.query.language}
-        onSelectLanguage={this.onSelectLanguage}
-        isCollapsed={this.state.isCollapsed}
-        setIsCollapsed={this.setIsCollapsed}
-        configMap={this.extensionMap}
-        componentContainer={this.headerRef.current}
-        bannerContainer={this.bannerRef.current}
-        queryControlsContainer={this.queryControlsContainer.current}
+        language={props.query.language}
+        onSelectLanguage={onSelectLanguage}
+        isCollapsed={isCollapsed}
+        setIsCollapsed={setIsCollapsed}
+        configMap={extensionMap}
+        componentContainer={headerRef.current}
+        bannerContainer={bannerRef.current}
+        queryControlsContainer={queryControlsContainer.current}
       />
     );
-  }
+  };
 
-  private onSubmit = (query: Query, dateRange?: TimeRange) => {
-    if (this.props.onSubmit) {
-      if (this.persistedLog) {
-        this.persistedLog.add(query.query);
+  const onSubmit = (query: Query, dateRange?: TimeRange) => {
+    if (props.onSubmit) {
+      if (persistedLogRef.current) {
+        persistedLogRef.current.add(query.query);
       }
 
-      this.props.onSubmit({
-        query: fromUser(query.query),
-        language: query.language,
-        dataset: query.dataset,
-      });
+      props.onSubmit(
+        {
+          query: fromUser(query.query),
+          language: query.language,
+          dataset: query.dataset,
+        },
+        dateRange
+      );
     }
   };
 
-  private onChange = (query: Query, dateRange?: TimeRange) => {
-    if (this.props.onChange) {
-      this.props.onChange(
+  const onChange = (query: Query, dateRange?: TimeRange) => {
+    if (props.onChange) {
+      props.onChange(
         { query: fromUser(query.query), language: query.language, dataset: query.dataset },
         dateRange
       );
     }
   };
 
-  private onQueryStringChange = (value: string) => {
-    this.setState({
-      isSuggestionsVisible: true,
-      index: null,
-    });
-
-    this.onChange({
+  const onQueryStringChange = (value: string) => {
+    onChange({
       query: value,
-      language: this.props.query.language,
-      dataset: this.props.query.dataset,
+      language: props.query.language,
+      dataset: props.query.dataset,
     });
   };
 
-  private onClickRecentQuery = (query: Query, timeRange?: TimeRange) => {
-    this.onSubmit(query, timeRange);
+  const onClickRecentQuery = (query: Query, timeRange?: TimeRange) => {
+    onSubmit(query, timeRange);
   };
 
-  private onInputChange = (value: string) => {
-    this.onQueryStringChange(value);
+  const onInputChange = (value: string) => {
+    onQueryStringChange(value);
 
-    if (!this.inputRef) return;
+    if (!inputRef.current) return;
 
-    const currentLineCount = this.inputRef.getModel()?.getLineCount();
-    if (this.state.lineCount === currentLineCount) return;
-    this.setState({ lineCount: currentLineCount });
+    const currentLineCount = inputRef.current.getModel()?.getLineCount();
+    if (lineCount === currentLineCount) return;
+    setLineCount(currentLineCount);
   };
 
-  // TODO: MQL consider moving language select language of setting search source here
-  private onSelectLanguage = (languageId: string) => {
+  const onSelectLanguage = (languageId: string) => {
     // Send telemetry info every time the user opts in or out of kuery
     // As a result it is important this function only ever gets called in the
     // UI component's change handler.
-    this.services.http.post('/api/opensearch-dashboards/dql_opt_in_stats', {
+    services.http.post('/api/opensearch-dashboards/dql_opt_in_stats', {
       body: JSON.stringify({ opt_in: languageId === 'kuery' }),
     });
 
-    const newQuery = this.queryString.getInitialQueryByLanguage(languageId);
+    const newQuery = queryString.getInitialQueryByLanguage(languageId);
 
-    this.onChange(newQuery);
-    this.onSubmit(newQuery);
+    onChange(newQuery);
+    onSubmit(newQuery);
   };
 
-  private initPersistedLog = () => {
-    const { uiSettings, storage, appName } = this.services;
-    this.persistedLog = this.props.persistedLog
-      ? this.props.persistedLog
-      : getQueryLog(uiSettings, storage, appName, this.props.query.language);
+  const initPersistedLog = () => {
+    const { uiSettings, storage, appName } = services;
+    persistedLogRef.current = props.persistedLog
+      ? props.persistedLog
+      : getQueryLog(uiSettings, storage, appName, props.query.language);
   };
 
-  public onMouseEnterSuggestion = (index: number) => {
-    this.setState({ index });
+  const toggleRecentQueries = () => {
+    setIsRecentQueryVisible(!isRecentQueryVisible);
   };
 
-  private toggleRecentQueries = () => {
-    this.setState((prevState) => ({
-      ...prevState,
-      isRecentQueryVisible: !prevState.isRecentQueryVisible,
-    }));
+  const renderToggleIcon = () => {
+    return (
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          iconType={isCollapsed ? 'expand' : 'minimize'}
+          aria-label={i18n.translate('data.queryControls.languageToggle', {
+            defaultMessage: `Language Toggle`,
+          })}
+          onClick={() => setIsCollapsed(!isCollapsed)}
+        />
+      </EuiFlexItem>
+    );
   };
 
-  public componentDidMount() {
-    const parsedQuery = fromUser(toUser(this.props.query.query));
-    if (!isEqual(this.props.query.query, parsedQuery)) {
-      this.onChange({ ...this.props.query, query: parsedQuery });
-    }
-
-    this.initPersistedLog();
-  }
-
-  public componentDidUpdate(prevProps: Props) {
-    const prevQuery = prevProps.query;
-
-    if (!isEqual(this.props.query.dataset, prevQuery.dataset)) {
-      if (this.inputRef) {
-        const newQuery = this.queryString.getInitialQuery();
-        const newQueryString = newQuery.query;
-        if (this.inputRef.getValue() !== newQueryString) {
-          this.inputRef.setValue(newQueryString);
-          this.onSubmit(newQuery);
-        }
-      }
-    }
-
-    const parsedQuery = fromUser(toUser(this.props.query.query));
-    if (!isEqual(this.props.query.query, parsedQuery)) {
-      this.onChange({ ...this.props.query, query: parsedQuery });
-    }
-
-    this.initPersistedLog();
-  }
-
-  public componentWillUnmount() {
-    if (this.abortController) this.abortController.abort();
-  }
-
-  handleOnFocus = () => {
-    if (this.props.onChangeQueryEditorFocus) {
-      this.props.onChangeQueryEditorFocus(true);
-    }
+  const renderQueryControls = (queryControls: React.ReactElement[]) => {
+    return <QueryControls queryControls={queryControls} />;
   };
 
-  private fetchIndexPattern = async () => {
-    const dataset = this.queryString.getQuery().dataset;
+  const fetchIndexPattern = async () => {
+    const dataset = queryString.getQuery().dataset;
     if (!dataset) return undefined;
     const indexPattern = await getIndexPatterns().get(dataset.id);
     return indexPattern;
   };
 
-  provideCompletionItems = async (
+  const provideCompletionItems = async (
     model: monaco.editor.ITextModel,
     position: monaco.Position
   ): Promise<monaco.languages.CompletionList> => {
-    const indexPattern = await this.fetchIndexPattern();
-    const suggestions = await this.services.data.autocomplete.getQuerySuggestions({
-      query: this.getQueryString(),
+    const indexPattern = await fetchIndexPattern();
+    const suggestions = await services.data.autocomplete.getQuerySuggestions({
+      query: getQueryString(),
       selectionStart: model.getOffsetAt(position),
       selectionEnd: model.getOffsetAt(position),
-      language: this.props.query.language,
+      language: props.query.language,
       indexPattern,
       position,
-      services: this.services,
+      services,
     });
 
     // current completion item range being given as last 'word' at pos
@@ -320,175 +258,162 @@ export default class QueryEditorUI extends Component<Props, State> {
     };
   };
 
-  private renderToggleIcon = () => {
-    return (
-      <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          iconType={this.state.isCollapsed ? 'expand' : 'minimize'}
-          aria-label={i18n.translate('data.queryControls.languageToggle', {
-            defaultMessage: `Language Toggle`,
-          })}
-          onClick={() => this.setIsCollapsed(!this.state.isCollapsed)}
-        />
-      </EuiFlexItem>
-    );
+  const useQueryEditor = props.query.language !== 'kuery' && props.query.language !== 'lucene';
+
+  const languageSelector = (
+    <QueryLanguageSelector
+      anchorPosition={props.languageSwitcherPopoverAnchorPosition}
+      onSelectLanguage={onSelectLanguage}
+      appName={services.appName}
+    />
+  );
+
+  const baseInputProps = {
+    languageId: props.query.language,
+    value: getQueryString(),
   };
 
-  private renderQueryControls = (queryControls: React.ReactElement[]) => {
-    return <QueryControls queryControls={queryControls} />;
+  const defaultInputProps: DefaultInputProps = {
+    ...baseInputProps,
+    onChange: onInputChange,
+    editorDidMount: (editor: monaco.editor.IStandaloneCodeEditor) => {
+      editor.setValue(`\n`.repeat(10));
+      setLineCount(editor.getModel()?.getLineCount());
+      inputRef.current = editor;
+      // eslint-disable-next-line no-bitwise
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+        onSubmit(props.query);
+      });
+
+      return () => {
+        if (abortControllerRef.current) abortControllerRef.current.abort();
+      };
+    },
+    footerItems: {
+      start: [
+        <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
+          {`${lineCount} ${lineCount === 1 ? 'line' : 'lines'}`}
+        </EuiText>,
+        <EuiText
+          size="xs"
+          color="subdued"
+          data-test-subj="queryEditorFooterTimestamp"
+          className="queryEditor__footerItem"
+        >
+          {props.query.dataset?.timeFieldName || ''}
+        </EuiText>,
+        <QueryResult queryStatus={props.queryStatus!} />,
+      ],
+      end: [
+        <EuiButtonEmpty
+          iconSide="left"
+          iconType="clock"
+          size="xs"
+          onClick={toggleRecentQueries}
+          className="queryEditor__footerItem"
+        >
+          <EuiText size="xs" color="subdued">
+            {'Recent queries'}
+          </EuiText>
+        </EuiButtonEmpty>,
+      ],
+    },
+    provideCompletionItems,
   };
 
-  public render() {
-    const className = classNames(this.props.className);
+  const singleLineInputProps = {
+    ...baseInputProps,
+    onChange: (value: string) => {
+      // Replace new lines with an empty string to prevent multi-line input
+      onQueryStringChange(value.replace(/[\r\n]+/gm, ''));
+      setLineCount(undefined);
+    },
+    editorDidMount: (editor: monaco.editor.IStandaloneCodeEditor) => {
+      inputRef.current = editor;
 
-    const useQueryEditor =
-      this.props.query.language !== 'kuery' && this.props.query.language !== 'lucene';
+      const handleEnterPress = () => {
+        onSubmit(props.query);
+      };
 
-    const languageSelector = (
-      <QueryLanguageSelector
-        query={this.props.query}
-        anchorPosition={this.props.languageSwitcherPopoverAnchorPosition}
-        onSelectLanguage={this.onSelectLanguage}
-        appName={this.services.appName}
+      const disposable = editor.onKeyDown((e) => {
+        if (e.keyCode === monaco.KeyCode.Enter) {
+          // Prevent default Enter key behavior
+          e.preventDefault();
+          handleEnterPress();
+        }
+      });
+
+      // Optional: Cleanup on component unmount
+      return () => {
+        disposable.dispose();
+      };
+    },
+    provideCompletionItems,
+    prepend: props.prepend,
+    footerItems: {
+      start: [
+        <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
+          {`${lineCount ?? 1} ${lineCount === 1 || !lineCount ? 'line' : 'lines'}`}
+        </EuiText>,
+        <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
+          {props.query.dataset?.timeFieldName || ''}
+        </EuiText>,
+        <QueryResult queryStatus={props.queryStatus!} />,
+      ],
+      end: [
+        <EuiButtonEmpty
+          iconSide="left"
+          iconType="clock"
+          iconGap="s"
+          size="xs"
+          onClick={toggleRecentQueries}
+          className="queryEditor__footerItem"
+          flush="both"
+        >
+          <EuiText size="xs" color="subdued">
+            {'Recent queries'}
+          </EuiText>
+        </EuiButtonEmpty>,
+      ],
+    },
+  };
+
+  const languageEditorFunc = languageManager.getLanguage(props.query.language)!.editor;
+
+  const languageEditor = useQueryEditor
+    ? languageEditorFunc(singleLineInputProps, {}, defaultInputProps)
+    : languageEditorFunc(singleLineInputProps, singleLineInputProps, {
+        filterBar: props.filterBar,
+      });
+
+  return (
+    <div
+      className={classNames(
+        props.className,
+        'osdQueryEditor',
+        isCollapsed ? 'collapsed' : 'expanded',
+        !languageEditor.TopBar.Expanded && 'emptyExpanded'
+      )}
+    >
+      <div
+        ref={bannerRef}
+        className={classNames('osdQueryEditor__banner', props.bannerClassName)}
       />
-    );
-
-    const baseInputProps = {
-      languageId: this.props.query.language,
-      value: this.getQueryString(),
-    };
-
-    const defaultInputProps: DefaultInputProps = {
-      ...baseInputProps,
-      onChange: this.onInputChange,
-      editorDidMount: (editor: monaco.editor.IStandaloneCodeEditor) => {
-        editor.setValue(`\n`.repeat(10));
-        this.setState({ lineCount: editor.getModel()?.getLineCount() });
-        this.inputRef = editor;
-        // eslint-disable-next-line no-bitwise
-        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-          this.onSubmit(this.props.query);
-        });
-
-        return () => {
-          disposable.dispose();
-        };
-      },
-      footerItems: {
-        start: [
-          <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
-            {`${this.state.lineCount} ${this.state.lineCount === 1 ? 'line' : 'lines'}`}
-          </EuiText>,
-          <EuiText
-            size="xs"
-            color="subdued"
-            data-test-subj="queryEditorFooterTimestamp"
-            className="queryEditor__footerItem"
-          >
-            {this.props.query.dataset?.timeFieldName || ''}
-          </EuiText>,
-          <QueryResult queryStatus={this.props.queryStatus!} />,
-        ],
-        end: [
-          <EuiButtonEmpty
-            iconSide="left"
-            iconType="clock"
-            size="xs"
-            onClick={this.toggleRecentQueries}
-            className="queryEditor__footerItem"
-          >
-            <EuiText size="xs" color="subdued">
-              {'Recent queries'}
-            </EuiText>
-          </EuiButtonEmpty>,
-        ],
-      },
-      provideCompletionItems: this.provideCompletionItems,
-    };
-
-    const singleLineInputProps = {
-      ...baseInputProps,
-      onChange: (value: string) => {
-        // Replace new lines with an empty string to prevent multi-line input
-        this.onQueryStringChange(value.replace(/[\r\n]+/gm, ''));
-        this.setState({ lineCount: undefined });
-      },
-      editorDidMount: (editor: monaco.editor.IStandaloneCodeEditor) => {
-        this.inputRef = editor;
-
-        const handleEnterPress = () => {
-          this.onSubmit(this.props.query);
-        };
-
-        const disposable = editor.onKeyDown((e) => {
-          if (e.keyCode === monaco.KeyCode.Enter) {
-            // Prevent default Enter key behavior
-            e.preventDefault();
-            handleEnterPress();
-          }
-        });
-
-        // Optional: Cleanup on component unmount
-        return () => {
-          disposable.dispose();
-        };
-      },
-      provideCompletionItems: this.provideCompletionItems,
-      prepend: this.props.prepend,
-      footerItems: {
-        start: [
-          <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
-            {`${this.state.lineCount ?? 1} ${
-              this.state.lineCount === 1 || !this.state.lineCount ? 'line' : 'lines'
-            }`}
-          </EuiText>,
-          <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
-            {this.props.query.dataset?.timeFieldName || ''}
-          </EuiText>,
-          <QueryResult queryStatus={this.props.queryStatus!} />,
-        ],
-        end: [
-          <EuiButtonEmpty
-            iconSide="left"
-            iconType="clock"
-            iconGap="s"
-            size="xs"
-            onClick={this.toggleRecentQueries}
-            className="queryEditor__footerItem"
-            flush="both"
-          >
-            <EuiText size="xs" color="subdued">
-              {'Recent queries'}
-            </EuiText>
-          </EuiButtonEmpty>,
-        ],
-      },
-    };
-
-    const languageEditorFunc = this.languageManager.getLanguage(this.props.query.language)!.editor;
-
-    const languageEditor = useQueryEditor
-      ? languageEditorFunc(singleLineInputProps, {}, defaultInputProps)
-      : languageEditorFunc(singleLineInputProps, singleLineInputProps, {
-          filterBar: this.props.filterBar,
-        });
-
-    return (
       <div
         className={classNames(
-          className,
+          props.className,
           'osdQueryEditor',
-          this.state.isCollapsed ? 'collapsed' : 'expanded',
+          isCollapsed ? 'collapsed' : 'expanded',
           !languageEditor.TopBar.Expanded && 'emptyExpanded'
         )}
       >
         <div
-          ref={this.bannerRef}
-          className={classNames('osdQueryEditor__banner', this.props.bannerClassName)}
+          ref={bannerRef}
+          className={classNames('osdQueryEditor__banner', props.bannerClassName)}
         />
         <div className="osdQueryEditor__topBar">
           <div className="osdQueryEditor__input">
-            {this.state.isCollapsed
+            {isCollapsed
               ? languageEditor.TopBar.Collapsed()
               : languageEditor.TopBar.Expanded && languageEditor.TopBar.Expanded()}
           </div>
@@ -496,32 +421,35 @@ export default class QueryEditorUI extends Component<Props, State> {
           <div className="osdQueryEditor__querycontrols">
             <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
               <div
-                ref={this.queryControlsContainer}
+                ref={queryControlsContainer}
                 className="osdQueryEditor__extensionQueryControls"
               />
-              {this.renderQueryControls(languageEditor.TopBar.Controls)}
-              {!languageEditor.TopBar.Expanded && this.renderToggleIcon()}
-              {this.props.savedQueryManagement}
+              {renderQueryControls(languageEditor.TopBar.Controls)}
+              {!languageEditor.TopBar.Expanded && renderToggleIcon()}
+              {props.savedQueryManagement}
             </EuiFlexGroup>
           </div>
         </div>
         <div
-          ref={this.headerRef}
-          className={classNames('osdQueryEditor__header', this.props.headerClassName)}
+          ref={headerRef}
+          className={classNames('osdQueryEditor__header', props.headerClassName)}
         />
-        {!this.state.isCollapsed && (
+        {!isCollapsed && (
           <>
             <div className="osdQueryEditor__body">{languageEditor.Body()}</div>
           </>
         )}
         <RecentQueriesTable
-          isVisible={this.state.isRecentQueryVisible && useQueryEditor}
-          queryString={this.queryString}
-          onClickRecentQuery={this.onClickRecentQuery}
+          isVisible={isRecentQueryVisible && useQueryEditor}
+          queryString={queryString}
+          onClickRecentQuery={onClickRecentQuery}
         />
 
-        {this.renderQueryEditorExtensions()}
+        {renderQueryEditorExtensions()}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default QueryEditorUI;

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -404,50 +404,38 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
         ref={bannerRef}
         className={classNames('osdQueryEditor__banner', props.bannerClassName)}
       />
-      <div
-        className={classNames(
-          props.className,
-          'osdQueryEditor',
-          isCollapsed ? 'collapsed' : 'expanded',
-          !languageEditor.TopBar.Expanded && 'emptyExpanded'
-        )}
-      >
-        <div className="osdQueryEditor__topBar">
-          <div className="osdQueryEditor__input">
-            {isCollapsed
-              ? languageEditor.TopBar.Collapsed()
-              : languageEditor.TopBar.Expanded && languageEditor.TopBar.Expanded()}
-          </div>
-          {languageSelector}
-          <div className="osdQueryEditor__querycontrols">
-            <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-              <div
-                ref={queryControlsContainer}
-                className="osdQueryEditor__extensionQueryControls"
-              />
-              {renderQueryControls(languageEditor.TopBar.Controls)}
-              {!languageEditor.TopBar.Expanded && renderToggleIcon()}
-              {props.savedQueryManagement}
-            </EuiFlexGroup>
-          </div>
+      <div className="osdQueryEditor__topBar">
+        <div className="osdQueryEditor__input">
+          {isCollapsed
+            ? languageEditor.TopBar.Collapsed()
+            : languageEditor.TopBar.Expanded && languageEditor.TopBar.Expanded()}
         </div>
-        <div
-          ref={headerRef}
-          className={classNames('osdQueryEditor__header', props.headerClassName)}
-        />
-        {!isCollapsed && (
-          <>
-            <div className="osdQueryEditor__body">{languageEditor.Body()}</div>
-          </>
-        )}
-        <RecentQueriesTable
-          isVisible={isRecentQueryVisible && useQueryEditor}
-          queryString={queryString}
-          onClickRecentQuery={onClickRecentQuery}
-        />
-
-        {renderQueryEditorExtensions()}
+        {languageSelector}
+        <div className="osdQueryEditor__querycontrols">
+          <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+            <div ref={queryControlsContainer} className="osdQueryEditor__extensionQueryControls" />
+            {renderQueryControls(languageEditor.TopBar.Controls)}
+            {!languageEditor.TopBar.Expanded && renderToggleIcon()}
+            {props.savedQueryManagement}
+          </EuiFlexGroup>
+        </div>
       </div>
+      <div
+        ref={headerRef}
+        className={classNames('osdQueryEditor__header', props.headerClassName)}
+      />
+      {!isCollapsed && (
+        <>
+          <div className="osdQueryEditor__body">{languageEditor.Body()}</div>
+        </>
+      )}
+      <RecentQueriesTable
+        isVisible={isRecentQueryVisible && useQueryEditor}
+        queryString={queryString}
+        onClickRecentQuery={onClickRecentQuery}
+      />
+
+      {renderQueryEditorExtensions()}
     </div>
   );
 };


### PR DESCRIPTION
### Description

* Makes the query editor a React functional component which helps with state
* Update language selector to not rely on a props.query to force re-render relying on observers
* Update dataset selector to update the language and dataset instead of just updating the dataset and then the dataset eventually triggering the now removed props.query for the language selector to update intime.
* update recent dataset on query update

### Issues Resolved

n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- refactor: [discover] query editor and language selector state fixes

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
