### PR TITLE
fix: generate short url with workspace info

### DIFF
--- a/changelogs/fragments/8719.yml
+++ b/changelogs/fragments/8719.yml
@@ -1,0 +1,2 @@
+fix:
+- Generate short url with workspace info ([#8719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8719))

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -373,7 +373,12 @@ export {
 } from './metrics';
 
 export { AppCategory, WorkspaceAttribute, PermissionModeId } from '../types';
-export { DEFAULT_APP_CATEGORIES, WORKSPACE_TYPE, DEFAULT_NAV_GROUPS } from '../utils';
+export {
+  DEFAULT_APP_CATEGORIES,
+  WORKSPACE_TYPE,
+  DEFAULT_NAV_GROUPS,
+  WORKSPACE_PATH_PREFIX,
+} from '../utils';
 
 export {
   SavedObject,

--- a/src/plugins/share/public/services/share_menu_manager.tsx
+++ b/src/plugins/share/public/services/share_menu_manager.tsx
@@ -56,7 +56,7 @@ export class ShareMenuManager {
           ...options,
           menuItems,
           post: core.http.post,
-          basePath: core.http.basePath.get(),
+          basePath: core.http.basePath.getBasePath(),
         });
       },
     };

--- a/src/plugins/share/server/routes/lib/short_url_assert_valid.test.ts
+++ b/src/plugins/share/server/routes/lib/short_url_assert_valid.test.ts
@@ -49,6 +49,7 @@ describe('shortUrlAssertValid()', () => {
     ['path with an extra leading slash', '///app/opensearch-dashboards', HOSTNAME_ERROR], // parser detects '' as the hostname
     ['path without app', '/foo/opensearch-dashboards', PATH_ERROR], // fails because first path part is not 'app'
     ['path without appId', '/app/', PATH_ERROR], // fails because there is only one path part (leading and trailing slashes are trimmed)
+    '/w/app/dashboards', // fails because it is not a standard workspace path
   ];
 
   invalid.forEach(([desc, url, error]) => {
@@ -67,6 +68,7 @@ describe('shortUrlAssertValid()', () => {
     '/app/some?with=query',
     '/app/some?with=query#and-a-hash',
     '/app/some/deeper?with=query#and-a-hash',
+    '/w/workspaceid/app/foo',
   ];
 
   valid.forEach((url) => {

--- a/src/plugins/share/server/routes/lib/short_url_assert_valid.ts
+++ b/src/plugins/share/server/routes/lib/short_url_assert_valid.ts
@@ -31,6 +31,7 @@
 import { parse } from 'url';
 import { trim } from 'lodash';
 import Boom from '@hapi/boom';
+import { WORKSPACE_PATH_PREFIX } from '../../../../../core/server';
 
 export function shortUrlAssertValid(url: string) {
   const { protocol, hostname, pathname } = parse(
@@ -47,7 +48,13 @@ export function shortUrlAssertValid(url: string) {
     throw Boom.notAcceptable(`Short url targets cannot have a hostname, found "${hostname}"`);
   }
 
-  const pathnameParts = trim(pathname === null ? undefined : pathname, '/').split('/');
+  let pathnameParts = trim(pathname === null ? undefined : pathname, '/').split('/');
+
+  // Workspace introduced paths like `/w/${workspaceId}/app`
+  // ignore the first 2 elements if it starts with /w
+  if (`/${pathnameParts[0]}` === WORKSPACE_PATH_PREFIX) {
+    pathnameParts = pathnameParts.slice(2);
+  }
   if (pathnameParts[0] !== 'app' || !pathnameParts[1]) {
     throw Boom.notAcceptable(
       `Short url target path must be in the format "/app/{{appId}}", found "${pathname}"`


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR is to fix the issue that short url `goto` router is not supporting workspace.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

### Before fix

https://github.com/user-attachments/assets/4d6a47d9-963c-4478-95c7-c1206db9c461

### After fix

https://github.com/user-attachments/assets/a1696eaf-f2d7-487b-aca9-89b5e972963d

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: generate short url with workspace info

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
