### PR TITLE
fixed ppl polling; save dataset in saved queries

### DIFF
--- a/changelogs/fragments/8724.yml
+++ b/changelogs/fragments/8724.yml
@@ -1,0 +1,2 @@
+fix:
+- Polling for PPL results; Saved dataset to saved queries ([#8724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8724))

--- a/src/plugins/data/public/query/saved_query/saved_query_service.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.ts
@@ -34,6 +34,7 @@ import { first } from 'rxjs/operators';
 import { SavedQueryAttributes, SavedQuery, SavedQueryService } from './types';
 import { QueryStringContract } from '../query_string';
 import { getUseNewSavedQueriesUI } from '../../services';
+import { UI_SETTINGS } from '../../../common';
 
 type SerializedSavedQueryAttributes = SavedObjectAttributes & SavedQueryAttributes;
 
@@ -42,7 +43,8 @@ export const createSavedQueryService = (
   coreStartServices: { application: CoreStart['application']; uiSettings: CoreStart['uiSettings'] },
   queryStringManager?: QueryStringContract
 ): SavedQueryService => {
-  const { application } = coreStartServices;
+  const { application, uiSettings } = coreStartServices;
+  const queryEnhancementEnabled = uiSettings.get(UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED);
 
   const saveQuery = async (attributes: SavedQueryAttributes, { overwrite = false } = {}) => {
     if (!attributes.title.length) {
@@ -58,7 +60,7 @@ export const createSavedQueryService = (
       language: attributes.query.language,
     };
 
-    if (getUseNewSavedQueriesUI() && attributes.query.dataset) {
+    if (queryEnhancementEnabled && attributes.query.dataset) {
       query.dataset = attributes.query.dataset;
     }
 
@@ -182,8 +184,11 @@ export const createSavedQueryService = (
       },
     };
 
-    if (getUseNewSavedQueriesUI()) {
+    if (queryEnhancementEnabled) {
       savedQueryItem.query.dataset = savedQuery.attributes.query.dataset;
+    }
+
+    if (getUseNewSavedQueriesUI()) {
       savedQueryItem.isTemplate = !!savedQuery.attributes.isTemplate;
     }
 

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -47,6 +47,9 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       http: this.deps.http,
       path: trimEnd(`${API.SEARCH}/${strategy}`),
       signal,
+      body: {
+        pollQueryResultsParams: request.params?.pollQueryResultsParams,
+      },
     };
 
     const query = this.buildQuery();


### PR DESCRIPTION
### Description
This PR fixes two issues:
1. Passes required params when polling for PPL results
2. Saves dataset in saved query when query enhancements is enabled

## Changelog
- fix: Polling for PPL results; Saved dataset to saved queries

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
