### PR TITLE
Update connections API error handling to use 503 for service unavailability

### DIFF
--- a/src/plugins/query_enhancements/server/routes/data_source_connection/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/data_source_connection/routes.ts
@@ -31,7 +31,12 @@ export function registerDataSourceConnectionsRoutes(
         if (error.statusCode === 404 || error.statusCode === 400) {
           return response.ok({ body: [] });
         }
-        return response.custom({ statusCode: error.statusCode || 500, body: error.message });
+        // Transform 500 errors to 503 to indicate service availability issues
+        const statusCode = error.statusCode === 500 ? 503 : error.statusCode || 503;
+        return response.custom({
+          statusCode,
+          body: error.message,
+        });
       }
     }
   );


### PR DESCRIPTION
### Description
Update connections API error handling to use 503 for service unavailability. Previously, the API would return 500 Internal Server Error for cases like "No Living connections", which could be misleading to clients. Now it returns 503 Service Unavailable, which more accurately represents the nature of the failure.

### Issues Resolved
NA

## Screenshot
NA

## Testing the changes


## Changelog
- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
