### PR TITLE
[CVE-2024-48948] Bump `elliptic` from 6.5.7 to 6.6.0

### DIFF
--- a/changelogs/fragments/8742.yml
+++ b/changelogs/fragments/8742.yml
@@ -1,0 +1,2 @@
+security:
+- [CVE-2024-48948] Bump `elliptic` from 6.5.7 to 6.6.0 ([#8742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8742))

--- a/yarn.lock
+++ b/yarn.lock
@@ -7428,9 +7428,9 @@ element-resize-detector@^1.2.1:
     batch-processor "1.0.0"
 
 elliptic@^6.5.3, elliptic@^6.5.4:
-  version "6.5.7"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
-  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.0.tgz#5919ec723286c1edf28685aa89261d4761afa210"
+  integrity sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
### Description

[CVE-2024-48948] Bump `elliptic` from 6.5.7 to 6.6.0

NOTE: While this is categorized as a low severity security-wise, the annoyance it could cause administrators of OSD might be big.

## Changelog
- security: [CVE-2024-48948] Bump `elliptic` from 6.5.7 to 6.6.0

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
