### PR TITLE
[Discover] fix error handling in query enhancement facet

### DIFF
--- a/changelogs/fragments/8743.yml
+++ b/changelogs/fragments/8743.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix error handling in query enhancement facet ([#8743](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8743))

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -44,7 +44,8 @@ export const removeKeyword = (queryString: string | undefined) => {
 
 export const handleFacetError = (response: any) => {
   const error = new Error(response.data.body ?? response.data);
-  error.name = response.data.status ?? response.status;
+  error.name = response.data.status ?? response.status ?? response.data.statusCode;
+  (error as any).status = error.name;
   throw error;
 };
 

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
@@ -56,6 +56,7 @@ export const pplSearchStrategyProvider = (
           for (const [key, aggQueryString] of Object.entries(aggConfig.qs)) {
             request.body.query.query = aggQueryString;
             const rawAggs: any = await pplFacet.describeQuery(context, request);
+            if (!rawAggs.success) handleFacetError(rawResponse);
             (dataFrame as IDataFrameWithAggs).aggs = {};
             (dataFrame as IDataFrameWithAggs).aggs[key] = rawAggs.data.datarows?.map((hit: any) => {
               return {

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -100,7 +100,7 @@ export class Facet {
     const response = this.useJobs
       ? await this.fetchJobs(context, request, this.endpoint)
       : await this.fetch(context, request, this.endpoint);
-    if (!this.shimResponse) return response;
+    if (response.success === false || !this.shimResponse) return response;
 
     const { format: dataType } = request.body;
     const shimFunctions: { [key: string]: (data: any) => any } = {


### PR DESCRIPTION
### Description
In query enhancements facet, the fetch errors are caught and returned as 
```js
{ success: false, data: Error }
```
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/c66b698360ee57db1e88d955d5cdb50f00af27aa/src/plugins/query_enhancements/server/utils/facet.ts#L90-L96
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/c66b698360ee57db1e88d955d5cdb50f00af27aa/src/plugins/query_enhancements/server/utils/facet.ts#L64-L70

But `describeQuery` is not checking if success is true, and will process the Error object as `IPPLEventsDataSource` or `IPPLVisualizationDataSource`, causing internal server error.
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/c66b698360ee57db1e88d955d5cdb50f00af27aa/src/plugins/query_enhancements/server/utils/facet.ts#L107-L108

@kavilla @mengweieric @ps48 let me know if this is not a good fix

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: fix error handling in query enhancement facet

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
