### PR TITLE
Revert back to using the official release of `vega-interpreter`

### DIFF
--- a/changelogs/fragments/8744.yml
+++ b/changelogs/fragments/8744.yml
@@ -1,0 +1,2 @@
+chore:
+- Revert back to using the official release of `vega-interpreter` ([#8744](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8744))

--- a/package.json
+++ b/package.json
@@ -488,7 +488,7 @@
     "tree-kill": "^1.2.2",
     "typescript": "4.0.2",
     "vega": "^5.23.0",
-    "vega-interpreter": "npm:@amoo-miki/vega-forced-csp-compliant-interpreter@1.0.6",
+    "vega-interpreter": "^1.0.5",
     "vega-lite": "^5.6.0",
     "vega-schema-url-parser": "^2.1.0",
     "vega-tooltip": "^0.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17654,10 +17654,10 @@ vega-hierarchy@~4.1.1:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-"vega-interpreter@npm:@amoo-miki/vega-forced-csp-compliant-interpreter@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@amoo-miki/vega-forced-csp-compliant-interpreter/-/vega-forced-csp-compliant-interpreter-1.0.6.tgz#5cffdf12b7fe12dc936194edd9e8519506c38716"
-  integrity sha512-9S5nTTVd8JVKobcWp5iwirIeePiamwH1J9uSZPuG5kcF0TUBvGu++ERKjNdst5Qck7e4R6/7vjx2wVf58XUarg==
+vega-interpreter@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/vega-interpreter/-/vega-interpreter-1.0.5.tgz#19e1d1b5f84a4ea9cb25c4e90a05ce16cd058484"
+  integrity sha512-po6oTOmeQqr1tzTCdD15tYxAQLeUnOVirAysgVEemzl+vfmvcEP7jQmlc51jz0jMA+WsbmE6oJywisQPu/H0Bg==
 
 vega-label@~1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Description

Revert back to using the official release of `vega-interpreter`
Note: Our PR was merged into their 1.0.5 release so we can stop using the patched version.


## Changelog
- chore: Revert back to using the official release of `vega-interpreter`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
