### PR TITLE
[Discover] Prevent wrapping of time fields

### DIFF
--- a/changelogs/fragments/8755.yml
+++ b/changelogs/fragments/8755.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix time field wrapping overlap on language change in Discover table ([#8755](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8755))

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_cell.scss
@@ -107,4 +107,9 @@ $osdDocTableCellPadding: calc($euiSizeM / 2); // corresponds to DataGrid medium 
 
 .osdDocTableCell__dataField {
   white-space: pre-wrap;
+
+  // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+  .eui-textNoWrap & {
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
### Description

Prevent wrapping of time fields which causes an overlap when languages are changed in the query editor.

Note: Discover still needs to allow triggering a re-render for a better solution.

### Before

https://github.com/user-attachments/assets/2e90c92c-6a62-4bdc-8b38-0687b12861ba

### After

https://github.com/user-attachments/assets/7b9ce339-b06a-4c37-9f2e-fe9dfe29a186




## Changelog
- fix: Fix time field wrapping overlap on language change in Discover table

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
