### PR TITLE
[Manual Backport 2.x][Discover] Modify the search bar info box content for sql/ppl

### DIFF
--- a/changelogs/fragments/8708.yml
+++ b/changelogs/fragments/8708.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover] Modify the search bar info box content for sql/ppl #8708 ([#8708](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8708))

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -632,6 +632,10 @@ export class DocLinksService {
             // https://opensearch.org/docs/latest/search-plugins/sql/sql/basic/
             base: `${OPENSEARCH_WEBSITE_DOCS}/search-plugins/sql/sql/basic/`,
           },
+          sqlPplLimitation: {
+            // https://opensearch.org/docs/latest/search-plugins/sql/limitation/
+            base: `${OPENSEARCH_WEBSITE_DOCS}/search-plugins/sql/limitation/`,
+          },
         },
       },
     });
@@ -981,6 +985,9 @@ export interface DocLinksStart {
         readonly base: string;
       };
       readonly ppl: {
+        readonly base: string;
+      };
+      readonly sqlPplLimitation: {
         readonly base: string;
       };
     };

--- a/src/plugins/advanced_settings/public/management_app/__snapshots__/advanced_settings.test.tsx.snap
+++ b/src/plugins/advanced_settings/public/management_app/__snapshots__/advanced_settings.test.tsx.snap
@@ -197,6 +197,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
         "sql": Object {
           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
         },
+        "sqlPplLimitation": Object {
+          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+        },
         "tutorial": Object {
           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -842,6 +845,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
             },
             "sql": Object {
               "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+            },
+            "sqlPplLimitation": Object {
+              "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
             },
             "tutorial": Object {
               "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -1754,6 +1760,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                         },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                        },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2161,6 +2170,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         },
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                        },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                         },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2570,6 +2582,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                         },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                        },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2977,6 +2992,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         },
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                        },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                         },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3441,6 +3459,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                         },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                        },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                           "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3850,6 +3871,9 @@ exports[`AdvancedSettings should render normally when use updated UX 1`] = `
                         },
                         "sql": Object {
                           "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                        },
+                        "sqlPplLimitation": Object {
+                          "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                         },
                         "tutorial": Object {
                           "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -574,6 +574,9 @@ exports[`Dashboard top nav render in embed mode 1`] = `
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                   },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                  },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                     "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -1652,6 +1655,9 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
                   },
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                  },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                   },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -2732,6 +2738,9 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                   },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                  },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                     "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -3810,6 +3819,9 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
                   },
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                  },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                   },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -4890,6 +4902,9 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
                   },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+                  },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
                     "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -5968,6 +5983,9 @@ exports[`Dashboard top nav render with all components 1`] = `
                   },
                   "sql": Object {
                     "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+                  },
+                  "sqlPplLimitation": Object {
+                    "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
                   },
                   "tutorial": Object {
                     "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LanguageReference } from './language_reference';
+import { IntlProvider } from 'react-intl';
+
+// Helper to wrap component with IntlProvider
+const renderWithIntl = (ui) => {
+  return render(<IntlProvider locale="en">{ui}</IntlProvider>);
+};
+
+describe('LanguageReference Component', () => {
+  beforeEach(() => {
+    // Clear localStorage and DOM before each test
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('auto-opens the info box on first load if autoShow is true and sets localStorage key', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={true}
+          selectedLanguage="SQL"
+        />
+      );
+    });
+
+    // Check localStorage was set
+    const storageKey = 'hasSeenInfoBox_SQL';
+    expect(localStorage.getItem(storageKey)).toBe('true');
+
+    // Wait for and check if popover content is visible
+    await waitFor(() => {
+      const popoverContent = screen.getByTestId('test-body');
+      expect(popoverContent).toBeInTheDocument();
+    });
+  });
+
+  test('toggles the info box open and close on button click', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={false}
+          selectedLanguage="PPL"
+        />
+      );
+    });
+
+    // Wait for button to be available
+    await waitFor(() => {
+      const button = screen.getByTestId('languageReferenceButton');
+      expect(button).toBeInTheDocument();
+    });
+
+    // Initially closed
+    expect(screen.queryByTestId('test-body')).not.toBeInTheDocument();
+
+    // Click to open
+    const button = screen.getByTestId('languageReferenceButton');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Wait for content to be visible
+    await waitFor(() => {
+      const content = screen.getByTestId('test-body');
+      expect(content).toBeInTheDocument();
+    });
+
+    // Click to close
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Wait for content to be removed
+    await waitFor(() => {
+      expect(screen.queryByTestId('test-body')).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows correct title in popover', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={true}
+          selectedLanguage="SQL"
+        />
+      );
+    });
+
+    // Wait for and check if the title is rendered
+    await waitFor(() => {
+      expect(screen.getByText('Syntax options')).toBeInTheDocument();
+    });
+  });
+
+  test('respects autoShow prop when false', async () => {
+    await act(async () => {
+      renderWithIntl(
+        <LanguageReference
+          body={<div data-test-subj="test-body">Test Body</div>}
+          autoShow={false}
+          selectedLanguage="SQL"
+        />
+      );
+    });
+
+    // Wait for component to be fully rendered
+    await waitFor(() => {
+      const button = screen.getByTestId('languageReferenceButton');
+      expect(button).toBeInTheDocument();
+    });
+
+    // Content should not be visible
+    expect(screen.queryByTestId('test-body')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
@@ -37,6 +37,7 @@ export const LanguageReference = (props: {
           defaultMessage: `Language Reference`,
         })}
         onClick={() => setIsLanguageReferenceOpen(!isLanguageReferenceOpen)}
+        data-test-subj="languageReferenceButton"
       />
     </div>
   );

--- a/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/language_reference.tsx
@@ -7,11 +7,27 @@ import { i18n } from '@osd/i18n';
 
 import { EuiButtonIcon, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
 
-import React, { ReactFragment } from 'react';
+import React, { ReactFragment, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-export const LanguageReference = (props: { body: ReactFragment }) => {
-  const [isLanguageReferenceOpen, setIsLanguageReferenceOpen] = React.useState(false);
+export const LanguageReference = (props: {
+  body: ReactFragment;
+  autoShow?: boolean;
+  selectedLanguage?: string;
+}) => {
+  const [isLanguageReferenceOpen, setIsLanguageReferenceOpen] = useState(props.autoShow || false);
+
+  useEffect(() => {
+    if (props.autoShow) {
+      const storageKey = `hasSeenInfoBox_${props.selectedLanguage}`;
+      const hasSeenInfoBox = window.localStorage.getItem(storageKey);
+
+      if (hasSeenInfoBox === null && props.autoShow) {
+        setIsLanguageReferenceOpen(true);
+        window.localStorage.setItem(storageKey, 'true');
+      }
+    }
+  }, [props.selectedLanguage, props.autoShow]);
 
   const button = (
     <div>

--- a/src/plugins/data/public/ui/query_editor/__snapshots__/language_selector.test.tsx.snap
+++ b/src/plugins/data/public/ui/query_editor/__snapshots__/language_selector.test.tsx.snap
@@ -340,6 +340,9 @@ exports[`LanguageSelector should select DQL if language is kuery 1`] = `
             "sql": Object {
               "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
             },
+            "sqlPplLimitation": Object {
+              "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
+            },
             "tutorial": Object {
               "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",
               "visualizeTutorial": "https://opensearch.org/docs/mocked-test-branch",
@@ -1002,6 +1005,9 @@ exports[`LanguageSelector should select lucene if language is lucene 1`] = `
             },
             "sql": Object {
               "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/sql/basic/",
+            },
+            "sqlPplLimitation": Object {
+              "base": "https://opensearch.org/docs/mocked-test-branch/search-plugins/sql/limitation/",
             },
             "tutorial": Object {
               "loadDataTutorial": "https://opensearch.org/docs/mocked-test-branch",

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -2,7 +2,6 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { i18n } from '@osd/i18n';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
 import { ConfigSchema } from '../common/config';
@@ -42,41 +41,24 @@ export class QueryEnhancementsPlugin
     { data, usageCollection }: QueryEnhancementsPluginSetupDependencies
   ): QueryEnhancementsPluginSetup {
     const { queryString } = data.query;
-    const pplSearchInterceptor = new PPLSearchInterceptor({
-      toasts: core.notifications.toasts,
-      http: core.http,
-      uiSettings: core.uiSettings,
-      startServices: core.getStartServices(),
-      usageCollector: data.search.usageCollector,
-    });
 
-    const sqlSearchInterceptor = new SQLSearchInterceptor({
-      toasts: core.notifications.toasts,
-      http: core.http,
-      uiSettings: core.uiSettings,
-      startServices: core.getStartServices(),
-      usageCollector: data.search.usageCollector,
-    });
+    // Define controls once for each language and register language configurations outside of `getUpdates$`
+    const pplControls = [pplLanguageReference('PPL')];
+    const sqlControls = [sqlLanguageReference('SQL')];
 
-    const pplControls = [pplLanguageReference()];
-    const sqlControls = [sqlLanguageReference()];
-
-    const enhancedPPLQueryEditor = createEditor(SingleLineInput, null, pplControls, DefaultInput);
-
-    const enhancedSQLQueryEditor = createEditor(SingleLineInput, null, sqlControls, DefaultInput);
-
-    // Register PPL language
+    // Register PPL language configuration
     const pplLanguageConfig: LanguageConfig = {
       id: 'PPL',
       title: 'PPL',
-      search: pplSearchInterceptor,
-      getQueryString: (query: Query) => {
-        return `source = ${query.dataset?.title}`;
-      },
-      fields: {
-        filterable: false,
-        visualizable: false,
-      },
+      search: new PPLSearchInterceptor({
+        toasts: core.notifications.toasts,
+        http: core.http,
+        uiSettings: core.uiSettings,
+        startServices: core.getStartServices(),
+        usageCollector: data.search.usageCollector,
+      }),
+      getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
+      fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
           defaultMessage: 'PPL documentation',
@@ -84,24 +66,26 @@ export class QueryEnhancementsPlugin
         url: 'https://opensearch.org/docs/latest/search-plugins/sql/ppl/syntax/',
       },
       showDocLinks: false,
-      editor: enhancedPPLQueryEditor,
+      editor: createEditor(SingleLineInput, null, pplControls, DefaultInput),
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],
     };
     queryString.getLanguageService().registerLanguage(pplLanguageConfig);
 
-    // Register SQL language
+    // Register SQL language configuration
     const sqlLanguageConfig: LanguageConfig = {
       id: 'SQL',
-      title: 'SQL',
-      search: sqlSearchInterceptor,
-      getQueryString: (query: Query) => {
-        return `SELECT * FROM ${query.dataset?.title} LIMIT 10`;
-      },
-      fields: {
-        filterable: false,
-        visualizable: false,
-      },
+      title: 'OpenSearch SQL',
+      search: new SQLSearchInterceptor({
+        toasts: core.notifications.toasts,
+        http: core.http,
+        uiSettings: core.uiSettings,
+        startServices: core.getStartServices(),
+        usageCollector: data.search.usageCollector,
+      }),
+      getQueryString: (currentQuery: Query) =>
+        `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
+      fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {
           defaultMessage: 'SQL documentation',
@@ -109,7 +93,7 @@ export class QueryEnhancementsPlugin
         url: 'https://opensearch.org/docs/latest/search-plugins/sql/sql/basic/',
       },
       showDocLinks: false,
-      editor: enhancedSQLQueryEditor,
+      editor: createEditor(SingleLineInput, null, sqlControls, DefaultInput),
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],
       hideDatePicker: true,

--- a/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/ppl_language_reference.tsx
@@ -8,11 +8,17 @@ import { EuiLink, EuiText } from '@elastic/eui';
 import { IDataPluginServices } from 'src/plugins/data/public';
 import { LanguageReference } from '../../../data/public';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+
 const PPLReference = () => {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const pplDocs = opensearchDashboards.services.docLinks?.links.noDocumentation.ppl.base;
+  const limitationDocs =
+    opensearchDashboards.services.docLinks?.links.noDocumentation.sqlPplLimitation.base;
   const pplFullName = (
     <FormattedMessage id="queryEnhancements.queryBar.pplFullLanguageName" defaultMessage="PPL" />
+  );
+  const limitationsLink = (
+    <FormattedMessage id="queryEnhancements.queryBar.pplLimitationDoc" defaultMessage="here" />
   );
 
   return (
@@ -21,11 +27,16 @@ const PPLReference = () => {
         <p>
           <FormattedMessage
             id="queryEnhancements.queryBar.pplSyntaxOptionsDescription"
-            defaultMessage="Piped Processing Language ({docsLink}) is a query language that focuses on processing data in a sequential, step-by-step manner. PPL uses the pipe (|) operator to combine commands to find and retrieve data. It is particularly well suited for analyzing observability data, such as logs, metrics, and traces, due to its ability to handle semi-structured data efficiently."
+            defaultMessage="Piped Processing Language ({pplDocsLink}) is a query language that focuses on processing data in a sequential, step-by-step manner. OpenSearch SQL/PPL language limitations can be found {limitationDocsLink}."
             values={{
-              docsLink: (
+              pplDocsLink: (
                 <EuiLink href={pplDocs} target="_blank">
                   {pplFullName}
+                </EuiLink>
+              ),
+              limitationDocsLink: (
+                <EuiLink href={limitationDocs} target="_blank">
+                  {limitationsLink}
                 </EuiLink>
               ),
             }}
@@ -36,6 +47,15 @@ const PPLReference = () => {
   );
 };
 
-export const pplLanguageReference = () => {
-  return <LanguageReference body={<PPLReference />} />;
+export const pplLanguageReference = (selectedLanguage) => {
+  const hasSeenInfoBox = localStorage.getItem('hasSeenInfoBox_PPL') === 'true';
+  const shouldAutoShow = selectedLanguage === 'PPL' && !hasSeenInfoBox;
+
+  return (
+    <LanguageReference
+      body={<PPLReference />}
+      autoShow={shouldAutoShow}
+      selectedLanguage={selectedLanguage}
+    />
+  );
 };

--- a/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
+++ b/src/plugins/query_enhancements/public/query_editor_extensions/sql_language_reference.tsx
@@ -8,11 +8,17 @@ import { EuiLink, EuiText } from '@elastic/eui';
 import { IDataPluginServices } from 'src/plugins/data/public';
 import { LanguageReference } from '../../../data/public';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+
 const SQLReference = () => {
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
   const sqlDocs = opensearchDashboards.services.docLinks?.links.noDocumentation.sql.base;
+  const limitationDocs =
+    opensearchDashboards.services.docLinks?.links.noDocumentation.sqlPplLimitation.base;
   const sqlFullName = (
     <FormattedMessage id="queryEnhancements.queryBar.sqlFullLanguageName" defaultMessage="SQL" />
+  );
+  const limitationsLink = (
+    <FormattedMessage id="queryEnhancements.queryBar.sqlLimitationDoc" defaultMessage="here" />
   );
 
   return (
@@ -21,11 +27,16 @@ const SQLReference = () => {
         <p>
           <FormattedMessage
             id="queryEnhancements.queryBar.sqlSyntaxOptionsDescription"
-            defaultMessage="{docsLink} in OpenSearch bridges the gap between traditional relational database concepts and the flexibility of OpenSearch’s document-oriented data storage. This integration gives you the ability to use your SQL knowledge to query, analyze, and extract insights from your OpenSearch data."
+            defaultMessage="OpenSearch {sqlDocsLink}. OpenSearch SQL/PPL language limitations can be found {limitationDocsLink}."
             values={{
-              docsLink: (
+              sqlDocsLink: (
                 <EuiLink href={sqlDocs} target="_blank">
                   {sqlFullName}
+                </EuiLink>
+              ),
+              limitationDocsLink: (
+                <EuiLink href={limitationDocs} target="_blank">
+                  {limitationsLink}
                 </EuiLink>
               ),
             }}
@@ -36,6 +47,15 @@ const SQLReference = () => {
   );
 };
 
-export const sqlLanguageReference = () => {
-  return <LanguageReference body={<SQLReference />} />;
+export const sqlLanguageReference = (selectedLanguage) => {
+  const hasSeenInfoBox = localStorage.getItem('hasSeenInfoBox_SQL') === 'true';
+  const shouldAutoShow = selectedLanguage === 'SQL' && !hasSeenInfoBox;
+
+  return (
+    <LanguageReference
+      body={<SQLReference />}
+      autoShow={shouldAutoShow}
+      selectedLanguage={selectedLanguage}
+    />
+  );
 };


### PR DESCRIPTION
### Description 
Manual backport: [Discover] Modify the search bar info box content for sql/ppl

### Issues Resolved
* Relate #8708 
* Close #8715 

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
