### PR TITLE
[Discover] fix error handling for sql and jobs APIs

### DIFF
--- a/src/plugins/query_enhancements/server/routes/data_source_connection/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/data_source_connection/routes.ts
@@ -52,14 +52,20 @@ export function registerDataSourceConnectionsRoutes(
       },
     },
     async (context, request, response) => {
-      const client = request.query.id
-        ? context.dataSource.opensearch.legacy.getClient(request.query.id).callAPI
-        : defaultClient.asScoped(request).callAsCurrentUser;
+      try {
+        const client = request.query.id
+          ? context.dataSource.opensearch.legacy.getClient(request.query.id).callAPI
+          : defaultClient.asScoped(request).callAsCurrentUser;
 
-      const resp = await client('enhancements.getJobStatus', {
-        queryId: request.query.queryId,
-      });
-      return response.ok({ body: resp });
+        const resp = await client('enhancements.getJobStatus', {
+          queryId: request.query.queryId,
+        });
+        return response.ok({ body: resp });
+      } catch (error) {
+        // Transform 500 errors to 503 to indicate service availability issues
+        const statusCode = error.statusCode === 500 ? 503 : error.statusCode || 503;
+        return response.custom({ statusCode, body: error.message });
+      }
     }
   );
 
@@ -79,12 +85,18 @@ export function registerDataSourceConnectionsRoutes(
       },
     },
     async (context, request, response) => {
-      const client = request.query.id
-        ? context.dataSource.opensearch.legacy.getClient(request.query.id).callAPI
-        : defaultClient.asScoped(request).callAsCurrentUser;
+      try {
+        const client = request.query.id
+          ? context.dataSource.opensearch.legacy.getClient(request.query.id).callAPI
+          : defaultClient.asScoped(request).callAsCurrentUser;
 
-      const resp = await client('enhancements.runDirectQuery', { body: request.body });
-      return response.ok({ body: resp });
+        const resp = await client('enhancements.runDirectQuery', { body: request.body });
+        return response.ok({ body: resp });
+      } catch (error) {
+        // Transform 500 errors to 503 to indicate service availability issues
+        const statusCode = error.statusCode === 500 ? 503 : error.statusCode || 503;
+        return response.custom({ statusCode, body: error.message });
+      }
     }
   );
 }

--- a/src/plugins/query_enhancements/server/search/sql_async_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/sql_async_search_strategy.ts
@@ -59,6 +59,9 @@ export const sqlAsyncSearchStrategyProvider = (
         } else {
           request.params = { queryId: inProgressQueryId };
           const queryStatusResponse: any = await sqlAsyncJobsFacet.describeQuery(context, request);
+
+          if (!queryStatusResponse.success) handleFacetError(queryStatusResponse);
+
           const queryStatus = queryStatusResponse?.data?.status;
           logger.info(`sqlAsyncSearchStrategy: JOB: ${inProgressQueryId} - STATUS: ${queryStatus}`);
 

--- a/src/plugins/query_enhancements/server/search/sql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/sql_search_strategy.ts
@@ -13,7 +13,7 @@ import {
   Query,
   createDataFrame,
 } from '../../../data/common';
-import { getFields } from '../../common/utils';
+import { getFields, handleFacetError } from '../../common/utils';
 import { Facet } from '../utils';
 
 export const sqlSearchStrategyProvider = (
@@ -36,11 +36,7 @@ export const sqlSearchStrategyProvider = (
         const query: Query = request.body.query;
         const rawResponse: any = await sqlFacet.describeQuery(context, request);
 
-        if (!rawResponse.success) {
-          const error = new Error(rawResponse.data.body);
-          error.name = rawResponse.data.status;
-          throw error;
-        }
+        if (!rawResponse.success) handleFacetError(rawResponse);
 
         const dataFrame = createDataFrame({
           name: query.dataset?.id,

--- a/src/plugins/query_enhancements/server/utils/facet.test.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.test.ts
@@ -8,6 +8,7 @@ import { Facet, FacetProps } from './facet';
 
 describe('Facet', () => {
   let facet: Facet;
+  let facetWithShimEnabled: Facet;
   let mockClient: jest.Mock;
   let mockLogger: jest.Mocked<Logger>;
   let mockContext: any;
@@ -26,6 +27,7 @@ describe('Facet', () => {
     };
 
     facet = new Facet(props);
+    facetWithShimEnabled = new Facet({ ...props, shimResponse: true });
 
     mockContext = {
       dataSource: {
@@ -109,6 +111,18 @@ describe('Facet', () => {
       mockClient.mockRejectedValue(error);
 
       const result = await facet.describeQuery(mockContext, mockRequest);
+
+      expect(result).toEqual({ success: false, data: error });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Facet fetch: test-endpoint: Error: Test error'
+      );
+    });
+
+    it('should handle errors with shim enabled', async () => {
+      const error = new Error('Test error');
+      mockClient.mockRejectedValue(error);
+
+      const result = await facetWithShimEnabled.describeQuery(mockContext, mockRequest);
 
       expect(result).toEqual({ success: false, data: error });
       expect(mockLogger.error).toHaveBeenCalledWith(


### PR DESCRIPTION
### Description

This is a followup PR for https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8743 and https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8725. There are more APIs not correctly handling errors and throws the default 500 internal server error code, and this PR fixes `/api/enhancements/jobs` and SQL search strategy to throw the correct error

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
