### PR TITLE
[ciGroup6 fix] add data-test-subj for refresh data button in discover

### DIFF
--- a/src/plugins/discover/public/application/components/uninitialized/uninitialized.tsx
+++ b/src/plugins/discover/public/application/components/uninitialized/uninitialized.tsx
@@ -62,7 +62,12 @@ export const DiscoverUninitialized = ({ onRefresh }: Props) => {
                 </p>
               }
               actions={
-                <EuiSmallButton color="primary" fill onClick={onRefresh}>
+                <EuiSmallButton
+                  color="primary"
+                  fill
+                  onClick={onRefresh}
+                  data-test-subj="discover-refreshDataButton"
+                >
                   <FormattedMessage
                     id="discover.uninitializedRefreshButtonText"
                     defaultMessage="Refresh data"


### PR DESCRIPTION
### Description

ciGroup6 sometimes failed to find refresh data button though this element is on DOM.

<img width="1306" alt="Screenshot 2024-10-31 at 7 58 20 PM" src="https://github.com/user-attachments/assets/2fd328e1-b737-4468-9529-590414d14778">

I tried a different way to find the element https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1615 but seems still flaky. Among 3 times running, see 1 failure and 2 success. Seems the ultimate robust way to fix it is to add `data-test-subj`. I also test 3 times, all success.


### Issues Resolved

NA

## Screenshot

## Testing the changes

## Changelog
- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
