### PR TITLE
fix: staled closure inside chrome_service

### DIFF
--- a/changelogs/fragments/8783.yml
+++ b/changelogs/fragments/8783.yml
@@ -1,0 +1,2 @@
+fix:
+- Staled closure inside chrome_service ([#8783](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8783))

--- a/src/core/public/chrome/chrome_service.test.ts
+++ b/src/core/public/chrome/chrome_service.test.ts
@@ -46,6 +46,7 @@ import { HeaderVariant } from './constants';
 
 class FakeApp implements App {
   public title: string;
+  public appRoute: string;
   public mount = () => () => {};
 
   constructor(
@@ -54,6 +55,7 @@ class FakeApp implements App {
     public headerVariant?: HeaderVariant
   ) {
     this.title = `${this.id} App`;
+    this.appRoute = this.id;
   }
 }
 const store = new Map();
@@ -78,12 +80,18 @@ function defaultStartDeps(availableApps?: App[]) {
     uiSettings: uiSettingsServiceMock.createStartContract(),
     overlays: overlayServiceMock.createStartContract(),
     workspaces: workspacesServiceMock.createStartContract(),
+    updateApplications: (() => {}) as (applications?: App[]) => void,
   };
 
   if (availableApps) {
-    deps.application.applications$ = new Rx.BehaviorSubject<Map<string, PublicAppInfo>>(
+    const applications$ = new Rx.BehaviorSubject<Map<string, PublicAppInfo>>(
       new Map(availableApps.map((app) => [app.id, getAppInfo(app) as PublicAppInfo]))
     );
+    deps.application.applications$ = applications$;
+    deps.updateApplications = (applications?: App[]) =>
+      applications$.next(
+        new Map(applications?.map((app) => [app.id, getAppInfo(app) as PublicAppInfo]))
+      );
   }
 
   return deps;
@@ -284,6 +292,31 @@ describe('start', () => {
                         false,
                       ]
                   `);
+    });
+
+    it('should use correct current app id to tell if hidden', async () => {
+      const apps = [new FakeApp('alpha', true), new FakeApp('beta', false)];
+      const startDeps = defaultStartDeps(apps);
+      const { navigateToApp } = startDeps.application;
+      const { chrome } = await start({ startDeps });
+      const visibleChangedArray: boolean[] = [];
+      const visible$ = chrome.getIsVisible$();
+      visible$.subscribe((visible) => visibleChangedArray.push(visible));
+
+      await navigateToApp('alpha');
+
+      await navigateToApp('beta');
+      startDeps.updateApplications(apps);
+
+      expect(visibleChangedArray).toMatchInlineSnapshot(`
+        Array [
+          false,
+          false,
+          true,
+          true,
+          true,
+        ]
+      `);
     });
   });
 

--- a/src/core/public/chrome/chrome_service.test.ts
+++ b/src/core/public/chrome/chrome_service.test.ts
@@ -314,7 +314,6 @@ describe('start', () => {
           false,
           true,
           true,
-          true,
         ]
       `);
     });

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -166,7 +166,7 @@ export class ChromeService {
       of(true),
       application.currentAppId$.pipe(
         /**
-         * There is a staled closure issue here.
+         * Using flatMap here will introduce staled closure issue.
          * For example, when currentAppId$ is going through A -> B -> C and
          * the application.applications$ just get changed in B, then it will always use B as the currentAppId
          * even though the latest appId now is C.

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -173,10 +173,9 @@ export class ChromeService {
          */
         switchMap((appId) =>
           application.applications$.pipe(
-            map(
-              (applications) =>
-                !!appId && applications.has(appId) && !!applications.get(appId)!.chromeless
-            )
+            map((applications) => {
+              return !!appId && applications.has(appId) && !!applications.get(appId)!.chromeless;
+            })
           )
         )
       )


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Fix staled closure issue inside chrome_service. The staled closure is toggling the chrome from visible to unvisible and visible in a short time and it makes the page header remount multiple times.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Before fix

https://github.com/user-attachments/assets/59ebc932-0157-47fa-859b-fcdfa4fd7359

### After fix

https://github.com/user-attachments/assets/3cc608bd-0427-4623-af6a-462816514754

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: staled closure inside chrome_service

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
