### PR TITLE
[Discover] Update Version Filter for Data Sources

### DIFF
--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -6,6 +6,7 @@
 import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import { map } from 'rxjs/operators';
 import { i18n } from '@osd/i18n';
+import semver from 'semver';
 import {
   DEFAULT_DATA,
   DataStructure,
@@ -120,11 +121,10 @@ const fetchDataSources = async (client: SavedObjectsClientContract) => {
     perPage: 10000,
   });
   const dataSources: DataStructure[] = response.savedObjects
-    .filter(
-      (savedObject) =>
-        typeof savedObject.attributes?.dataSourceEngineType === 'string' &&
-        !savedObject.attributes?.dataSourceEngineType?.includes('OpenSearch Serverless')
-    )
+    .filter((savedObject) => {
+      const coercedVersion = semver.coerce(savedObject.attributes.dataSourceVersion);
+      return coercedVersion ? semver.satisfies(coercedVersion, '>=1.0.0') : false;
+    })
     .map((savedObject) => ({
       id: savedObject.id,
       title: savedObject.attributes.title,

--- a/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
@@ -142,7 +142,7 @@ describe('s3TypeConfig', () => {
     it('should fetch data sources for unknown type', async () => {
       mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
         savedObjects: [
-          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceEngineType: 'OpenSearch' } },
+          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '3.0' } },
         ],
       });
 
@@ -150,20 +150,24 @@ describe('s3TypeConfig', () => {
         { id: 'unknown', title: 'Unknown', type: 'UNKNOWN' },
       ]);
 
-      expect(result.children).toHaveLength(1); // Including DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE
+      expect(result.children).toHaveLength(1);
       expect(result.children?.[0].title).toBe('DataSource 1');
       expect(result.hasNext).toBe(true);
     });
 
-    it('should filter out OpenSearch Serverless data sources', async () => {
+    it('should filter out data sources with versions lower than 1.0.0', async () => {
       mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
         savedObjects: [
-          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceEngineType: 'OpenSearch' } },
+          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '1.0' } },
           {
             id: 'ds2',
-            attributes: { title: 'DataSource 2', dataSourceEngineType: 'OpenSearch Serverless' },
+            attributes: { title: 'DataSource 2', dataSourceVersion: '' },
           },
-          { id: 'ds3', attributes: { title: 'DataSource 3', dataSourceEngineType: 'OpenSearch' } },
+          { id: 'ds3', attributes: { title: 'DataSource 3', dataSourceVersion: '2.17.0' } },
+          {
+            id: 'ds4',
+            attributes: { title: 'DataSource 4', dataSourceVersion: '.0' },
+          },
         ],
       });
 
@@ -171,7 +175,7 @@ describe('s3TypeConfig', () => {
         { id: 'unknown', title: 'Unknown', type: 'UNKNOWN' },
       ]);
 
-      expect(result.children).toHaveLength(2); // Including DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE
+      expect(result.children).toHaveLength(2);
       expect(result.children?.[0].title).toBe('DataSource 1');
       expect(result.children?.[1].title).toBe('DataSource 3');
       expect(result.children?.some((child) => child.title === 'DataSource 2')).toBe(false);

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -6,6 +6,7 @@
 import { i18n } from '@osd/i18n';
 import { trimEnd } from 'lodash';
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import semver from 'semver';
 import {
   DATA_STRUCTURE_META_TYPES,
   DEFAULT_DATA,
@@ -197,11 +198,10 @@ const fetchDataSources = async (client: SavedObjectsClientContract): Promise<Dat
     perPage: 10000,
   });
   const dataSources: DataStructure[] = resp.savedObjects
-    .filter(
-      (savedObject) =>
-        typeof savedObject.attributes?.dataSourceEngineType === 'string' &&
-        !savedObject.attributes?.dataSourceEngineType?.includes('OpenSearch Serverless')
-    )
+    .filter((savedObject) => {
+      const coercedVersion = semver.coerce(savedObject.attributes.dataSourceVersion);
+      return coercedVersion ? semver.satisfies(coercedVersion, '>=1.0.0') : false;
+    })
     .map((savedObject) => ({
       id: savedObject.id,
       title: savedObject.attributes.title,


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

* Uses `semver` to filter out data sources with invalid versions or versions that are lower than `1.0.0`.
* Adding tests for `index_type.ts`

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
