### PR TITLE
[Discover] Get value of query from query editor instead of props

### DIFF
--- a/changelogs/fragments/8795.yml
+++ b/changelogs/fragments/8795.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover] get query value from editor on submit instead of query state ([#8795](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8795))

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -287,7 +287,12 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
       inputRef.current = editor;
       // eslint-disable-next-line no-bitwise
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-        onSubmit(props.query);
+        const newQuery = {
+          ...props.query,
+          query: editor.getValue(),
+        };
+
+        onSubmit(newQuery);
       });
 
       return () => {


### PR DESCRIPTION
### Description

Not able to recreate the issue where if in DQL and press `Enter` then the text field is automatically cleared out. Not positive if this will resolve this issue but it feels inaccurate to submit the props.query instead of relying on the value of the query

### Issues Resolved

n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Discover] get query value from editor on submit instead of query state 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
