### PR TITLE
[Discover] Makes caching dataset options optional

### DIFF
--- a/changelogs/fragments/8799.yml
+++ b/changelogs/fragments/8799.yml
@@ -1,0 +1,2 @@
+fix:
+- [Discover] Makes cachign dataset options optional and configurable by the dataset type ([#8799](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8799))

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -275,7 +275,7 @@ export class DatasetService {
             ? {
                 id: dataSource.id,
                 title: dataSource.attributes?.title,
-                type: dataSource.attributes?.dataSourceEngineType,
+                type: dataSource.attributes?.dataSourceEngineType || '',
               }
             : undefined,
         },

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -161,14 +161,17 @@ export class DatasetService {
       .join('&');
     const cacheKey =
       `${dataType}.${lastPathItem.id}` + (fetchOptionsKey.length ? `?${fetchOptionsKey}` : '');
-
-    const cachedDataStructure = this.sessionStorage.get<CachedDataStructure>(cacheKey);
-    if (cachedDataStructure?.children?.length > 0) {
-      return this.cacheToDataStructure(dataType, cachedDataStructure);
+    if (type.meta.cacheOptions) {
+      const cachedDataStructure = this.sessionStorage.get<CachedDataStructure>(cacheKey);
+      if (cachedDataStructure?.children?.length > 0) {
+        return this.cacheToDataStructure(dataType, cachedDataStructure);
+      }
     }
 
     const fetchedDataStructure = await type.fetch(services, path, options);
-    this.cacheDataStructure(dataType, fetchedDataStructure);
+    if (type.meta.cacheOptions) {
+      this.cacheDataStructure(dataType, fetchedDataStructure);
+    }
     return fetchedDataStructure;
   }
 

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -36,6 +36,8 @@ export interface DatasetTypeConfig {
     supportsTimeFilter?: boolean;
     /** Optional isFieldLoadAsync determines if field loads are async */
     isFieldLoadAsync?: boolean;
+    /** Optional cacheOptions determines if the data structure is cacheable. Defaults to false */
+    cacheOptions?: boolean;
   };
   /**
    * Converts a DataStructure to a Dataset.

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -36,6 +36,7 @@ export const s3TypeConfig: DatasetTypeConfig = {
     searchOnLoad: true,
     supportsTimeFilter: false,
     isFieldLoadAsync: true,
+    cacheOptions: true,
   },
 
   toDataset: (path: DataStructure[]): Dataset => {

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
@@ -100,6 +100,7 @@ describe('CreateExtension', () => {
     `);
     expect(httpMock.get).toBeCalledWith('/api/enhancements/assist/languages', {
       query: { dataSourceId: 'mock-data-source-id2' },
+      signal: new AbortController().signal,
     });
   });
 

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -32,20 +32,28 @@ const [getAvailableLanguagesForDataSource, clearCache] = (() => {
   const pendingRequests: Map<string | undefined, Promise<string[]>> = new Map();
 
   return [
-    async (http: HttpSetup, dataSourceId: string | undefined) => {
+    async (http: HttpSetup, dataSourceId: string | undefined, timeout?: number) => {
       const cached = availableLanguagesByDataSource.get(dataSourceId);
       if (cached !== undefined) return cached;
 
       const pendingRequest = pendingRequests.get(dataSourceId);
       if (pendingRequest !== undefined) return pendingRequest;
 
+      const controller = timeout ? new AbortController() : undefined;
+      const timeoutId = timeout ? setTimeout(() => controller?.abort(), timeout) : undefined;
+
       const languagesPromise = http
         .get<{ configuredLanguages: string[] }>(API.QUERY_ASSIST.LANGUAGES, {
           query: { dataSourceId },
+          signal: controller?.signal,
         })
         .then((response) => response.configuredLanguages)
         .catch(() => [])
-        .finally(() => pendingRequests.delete(dataSourceId));
+        .finally(() => {
+          pendingRequests.delete(dataSourceId);
+          if (timeoutId) clearTimeout(timeoutId);
+        });
+
       pendingRequests.set(dataSourceId, languagesPromise);
 
       const languages = await languagesPromise;
@@ -98,9 +106,9 @@ export const createQueryAssistExtension = (
     id: 'query-assist',
     order: 1000,
     getDataStructureMeta: async (dataSourceId) => {
-      const isEnabled = await getAvailableLanguagesForDataSource(http, dataSourceId).then(
-        (languages) => languages.length > 0
-      );
+      // [TODO] - The timmeout exists because the loading of the Datasource menu is prevented until this request completes. This if a single cluster is down the request holds the whole menu level in a loading state. We should make this call non blocking and load the datasource meta in the background.
+      const isEnabled = await getAvailableLanguagesForDataSource(http, dataSourceId, 3000) // 3s timeout for quick check
+        .then((languages) => languages.length > 0);
       if (isEnabled) {
         return {
           type: DATA_STRUCTURE_META_TYPES.FEATURE,


### PR DESCRIPTION
### Description

Makes caching dataset options optional. Enables it only for s3 since its metadtata calls are slower.

Additinal fix: When caching was no longer optional, qury assist api calls held the Clusters menu in a perpetual loading state causing the menu to not load. This fixes that by timing out only the is enabled queries to not prevent that menu from loading.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
See unit test.

Or for Manual testing:
- Open Discover
- Open the advanced data selector
- Select index patterns, the menu shoud always fire a network request
- Select Indices, the menu should always fire a network request
- Select S3, the menu should only fire the query oince

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: [Discover] Makes cachign dataset options optional and configurable by the dataset type

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
