### PR TITLE
[BUG] Fix DQL & PPL Autocomplete Regression Issues

### DIFF
--- a/changelogs/fragments/8800.yml
+++ b/changelogs/fragments/8800.yml
@@ -1,2 +1,2 @@
 fix:
-- Fix DQL & PPL Autocomplete Regression Issues ([#8800](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8800))
+- [Discover] Fix DQL & PPL Autocomplete Regression Issues ([#8800](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8800))

--- a/changelogs/fragments/8800.yml
+++ b/changelogs/fragments/8800.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix DQL & PPL Autocomplete Regression Issues ([#8800](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8800))

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -127,7 +127,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   };
 
   const onSubmit = (query: Query, dateRange?: TimeRange) => {
-    // TODO: this is a hack to get the current query string as getQueryString() is not fetching the updated query string
+    // TODO: this is a hack to get the current query string as query.query in some use cases are empty
     const currentQuery = query.query || inputRef.current?.getModel()?.getValue();
     if (!currentQuery || currentQuery.trim() === '') return;
     if (props.onSubmit) {

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -127,6 +127,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   };
 
   const onSubmit = (query: Query, dateRange?: TimeRange) => {
+    // TODO: this is a hack to get the current query string as getQueryString() is not fetching the updated query string
     const currentQuery = query.query || inputRef.current?.getModel()?.getValue();
     if (!currentQuery || currentQuery.trim() === '') return;
     if (props.onSubmit) {

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -128,7 +128,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
 
   const onSubmit = (query: Query, dateRange?: TimeRange) => {
     // TODO: this is a hack to get the current query string as query.query in some use cases are empty
-    const currentQuery = query.query || inputRef.current?.getModel()?.getValue();
+    const currentQuery = inputRef.current?.getModel()?.getValue() ?? query.query;
     if (!currentQuery || currentQuery.trim() === '') return;
     if (props.onSubmit) {
       if (persistedLogRef.current) {

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -225,7 +225,8 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   ): Promise<monaco.languages.CompletionList> => {
     const indexPattern = await fetchIndexPattern();
     const suggestions = await services.data.autocomplete.getQuerySuggestions({
-      query: getQueryString(),
+      // TODO: this is a hack to get the current query string as getQueryString() is not fetching the updated query string
+      query: inputRef.current?.getModel()?.getValue() ?? getQueryString(),
       selectionStart: model.getOffsetAt(position),
       selectionEnd: model.getOffsetAt(position),
       language: props.query.language,

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -127,6 +127,8 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   };
 
   const onSubmit = (query: Query, dateRange?: TimeRange) => {
+    const currentQuery = inputRef.current?.getModel()?.getValue();
+    if (!currentQuery || currentQuery.trim() === '') return;
     if (props.onSubmit) {
       if (persistedLogRef.current) {
         persistedLogRef.current.add(query.query);
@@ -134,7 +136,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
 
       props.onSubmit(
         {
-          query: fromUser(query.query),
+          query: currentQuery,
           language: query.language,
           dataset: query.dataset,
         },

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -127,7 +127,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   };
 
   const onSubmit = (query: Query, dateRange?: TimeRange) => {
-    const currentQuery = inputRef.current?.getModel()?.getValue();
+    const currentQuery = query.query || inputRef.current?.getModel()?.getValue();
     if (!currentQuery || currentQuery.trim() === '') return;
     if (props.onSubmit) {
       if (persistedLogRef.current) {


### PR DESCRIPTION
### Description

Regressions issues fixed
- query.query for onSubmit of query editor is empty on suggestion select therefore causes the entire query to be cleared out as selecting a suggestion triggers query submit
- query retrieved from getQueryString() is never being updated with query changes in query editor

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: [Discover] Fix DQL & PPL Autocomplete Regression Issues
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
