### PR TITLE
[Discover] fix missing key browser warnings

### DIFF
--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -247,7 +247,8 @@ const DefaultDiscoverTableUI = ({
               (row: OpenSearchSearchHit, index: number) => {
                 return (
                   <TableRow
-                    key={row._id}
+                    // TODO: use the id from the row._id when all languages support retreving it
+                    key={index}
                     row={row}
                     columns={displayedColumnNames}
                     indexPattern={indexPattern}

--- a/src/plugins/discover/public/application/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/components/no_results/no_results.tsx
@@ -189,12 +189,12 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
   const tabs = useMemo(() => {
     const buildSampleQueryBlock = (sampleTitle: string, sampleQuery: string) => {
       return (
-        <>
+        <React.Fragment key={sampleTitle}>
           <EuiText size="s">{sampleTitle}</EuiText>
           <EuiSpacer size="s" />
           <EuiCodeBlock isCopyable>{sampleQuery}</EuiCodeBlock>
           <EuiSpacer size="s" />
-        </>
+        </React.Fragment>
       );
     };
 


### PR DESCRIPTION
### Description

Adds missing keys that cause browser warnigns in Discover

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Open discover and play with it
- You should not see any browser warnings because of a missing key

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
