### PR TITLE
[Discover] Query editor state sync fixes

### DIFF
--- a/changelogs/fragments/8803.yml
+++ b/changelogs/fragments/8803.yml
@@ -1,0 +1,2 @@
+fix:
+- Query Editor state sync issues in Discover ([#8803](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8803))

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -25,6 +25,7 @@ import {
   RecentQueriesTable,
   QueryResult,
   QueryStatus,
+  useQueryStringManager,
 } from '../..';
 import { OpenSearchDashboardsReactContextValue } from '../../../../opensearch_dashboards_react/public';
 import { fromUser, getQueryLog, PersistedLog, toUser } from '../../query';
@@ -74,15 +75,22 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const headerRef = useRef<HTMLDivElement>(null);
   const bannerRef = useRef<HTMLDivElement>(null);
   const queryControlsContainer = useRef<HTMLDivElement>(null);
+  // TODO: There should only be one source of truth for query state and it should match the app query state. Firing the query should be restricted to when the user is ready, but should not prevent the app query from changing.
+  const editorQuery = props.query; // local query state managed by the editor. Not to be confused by the app query state.
 
   const queryString = getQueryService().queryString;
   const languageManager = queryString.getLanguageService();
   const extensionMap = languageManager.getQueryEditorExtensionMap();
   const services = props.opensearchDashboards.services;
+  const { query } = useQueryStringManager({
+    queryString,
+  });
+
+  // console.log('QueryEditorUI', query);
 
   const persistedLogRef = useRef<PersistedLog>(
     props.persistedLog ||
-      getQueryLog(services.uiSettings, services.storage, services.appName, props.query.language)
+      getQueryLog(services.uiSettings, services.storage, services.appName, query.language)
   );
   const abortControllerRef = useRef<AbortController>();
 
@@ -95,17 +103,13 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     };
   }, []);
 
-  const getQueryString = useCallback(() => {
-    return toUser(props.query.query);
-  }, [props.query]);
-
   const renderQueryEditorExtensions = () => {
     if (
       !(
         headerRef.current &&
         bannerRef.current &&
         queryControlsContainer.current &&
-        props.query.language &&
+        query.language &&
         extensionMap &&
         Object.keys(extensionMap).length > 0
       )
@@ -114,7 +118,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     }
     return (
       <QueryEditorExtensions
-        language={props.query.language}
+        language={query.language}
         onSelectLanguage={onSelectLanguage}
         isCollapsed={isCollapsed}
         setIsCollapsed={setIsCollapsed}
@@ -126,27 +130,29 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     );
   };
 
-  const onSubmit = (query: Query, dateRange?: TimeRange) => {
+  const onSubmit = (currentQuery: Query, dateRange?: TimeRange) => {
     if (props.onSubmit) {
       if (persistedLogRef.current) {
-        persistedLogRef.current.add(query.query);
+        persistedLogRef.current.add(currentQuery.query);
       }
 
       props.onSubmit(
         {
-          query: fromUser(query.query),
-          language: query.language,
-          dataset: query.dataset,
+          ...currentQuery,
+          query: fromUser(currentQuery.query),
         },
         dateRange
       );
     }
   };
 
-  const onChange = (query: Query, dateRange?: TimeRange) => {
+  const onChange = (currentQuery: Query, dateRange?: TimeRange) => {
     if (props.onChange) {
       props.onChange(
-        { query: fromUser(query.query), language: query.language, dataset: query.dataset },
+        {
+          ...currentQuery,
+          query: fromUser(currentQuery.query),
+        },
         dateRange
       );
     }
@@ -155,13 +161,14 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const onQueryStringChange = (value: string) => {
     onChange({
       query: value,
-      language: props.query.language,
-      dataset: props.query.dataset,
+      // Its fiune to reference the query state her since it is not updated yet
+      language: query.language,
+      dataset: query.dataset,
     });
   };
 
-  const onClickRecentQuery = (query: Query, timeRange?: TimeRange) => {
-    onSubmit(query, timeRange);
+  const onClickRecentQuery = (currentQuery: Query, timeRange?: TimeRange) => {
+    onSubmit(currentQuery, timeRange);
   };
 
   const onInputChange = (value: string) => {
@@ -175,13 +182,6 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   };
 
   const onSelectLanguage = (languageId: string) => {
-    // Send telemetry info every time the user opts in or out of kuery
-    // As a result it is important this function only ever gets called in the
-    // UI component's change handler.
-    services.http.post('/api/opensearch-dashboards/dql_opt_in_stats', {
-      body: JSON.stringify({ opt_in: languageId === 'kuery' }),
-    });
-
     const newQuery = queryString.getInitialQueryByLanguage(languageId);
 
     onChange(newQuery);
@@ -223,10 +223,10 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   ): Promise<monaco.languages.CompletionList> => {
     const indexPattern = await fetchIndexPattern();
     const suggestions = await services.data.autocomplete.getQuerySuggestions({
-      query: getQueryString(),
+      query: inputRef.current?.getValue() ?? '',
       selectionStart: model.getOffsetAt(position),
       selectionEnd: model.getOffsetAt(position),
-      language: props.query.language,
+      language: query.language,
       indexPattern,
       position,
       services,
@@ -263,7 +263,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     };
   };
 
-  const useQueryEditor = props.query.language !== 'kuery' && props.query.language !== 'lucene';
+  const useQueryEditor = query.language !== 'kuery' && query.language !== 'lucene';
 
   const languageSelector = (
     <QueryLanguageSelector
@@ -274,8 +274,8 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   );
 
   const baseInputProps = {
-    languageId: props.query.language,
-    value: getQueryString(),
+    languageId: query.language,
+    value: toUser(editorQuery.query),
   };
 
   const defaultInputProps: DefaultInputProps = {
@@ -287,7 +287,13 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
       inputRef.current = editor;
       // eslint-disable-next-line no-bitwise
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-        onSubmit(props.query);
+        // debugger
+        const newQuery = {
+          ...query,
+          query: editor.getValue(),
+        };
+
+        onSubmit(newQuery);
       });
 
       return () => {
@@ -305,7 +311,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
           data-test-subj="queryEditorFooterTimestamp"
           className="queryEditor__footerItem"
         >
-          {props.query.dataset?.timeFieldName || ''}
+          {query.dataset?.timeFieldName || ''}
         </EuiText>,
         <QueryResult queryStatus={props.queryStatus!} />,
       ],
@@ -336,21 +342,37 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     editorDidMount: (editor: monaco.editor.IStandaloneCodeEditor) => {
       inputRef.current = editor;
 
-      const handleEnterPress = () => {
-        onSubmit(props.query);
-      };
+      editor.addCommand(monaco.KeyCode.Enter, () => {
+        const newQuery = {
+          ...query,
+          query: editor.getValue(),
+        };
 
-      const disposable = editor.onKeyDown((e) => {
-        if (e.keyCode === monaco.KeyCode.Enter) {
-          // Prevent default Enter key behavior
-          e.preventDefault();
-          handleEnterPress();
-        }
+        onSubmit(newQuery);
       });
+
+      // const handleEnterPress = () => {
+      //   const newQuery = {
+      //     ...props.query,
+      //     query: editor.getValue(),
+      //   };
+
+      //   debugger
+
+      //   onSubmit(newQuery);
+      // };
+
+      // const disposable = editor.onKeyDown((e) => {
+      //   if (e.keyCode === monaco.KeyCode.Enter) {
+      //     // Prevent default Enter key behavior
+      //     e.preventDefault();
+      //     handleEnterPress();
+      //   }
+      // });
 
       // Optional: Cleanup on component unmount
       return () => {
-        disposable.dispose();
+        // disposable.dispose();
       };
     },
     provideCompletionItems,
@@ -361,7 +383,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
           {`${lineCount ?? 1} ${lineCount === 1 || !lineCount ? 'line' : 'lines'}`}
         </EuiText>,
         <EuiText size="xs" color="subdued" className="queryEditor__footerItem">
-          {props.query.dataset?.timeFieldName || ''}
+          {query.dataset?.timeFieldName || ''}
         </EuiText>,
         <QueryResult queryStatus={props.queryStatus!} />,
       ],
@@ -383,7 +405,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     },
   };
 
-  const languageEditorFunc = languageManager.getLanguage(props.query.language)!.editor;
+  const languageEditorFunc = languageManager.getLanguage(query.language)!.editor;
 
   const languageEditor = useQueryEditor
     ? languageEditorFunc(singleLineInputProps, {}, defaultInputProps)

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -85,8 +85,12 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const { query } = useQueryStringManager({
     queryString,
   });
+  const queryRef = useRef(query);
 
-  // console.log('QueryEditorUI', query);
+  // Monaco editor commands dont reference the query state directly since the commands are registered at startup, so we need to keep a ref to the query state that it can use when needed
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query]);
 
   const persistedLogRef = useRef<PersistedLog>(
     props.persistedLog ||
@@ -226,7 +230,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
       query: inputRef.current?.getValue() ?? '',
       selectionStart: model.getOffsetAt(position),
       selectionEnd: model.getOffsetAt(position),
-      language: query.language,
+      language: queryRef.current.language,
       indexPattern,
       position,
       services,
@@ -287,9 +291,8 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
       inputRef.current = editor;
       // eslint-disable-next-line no-bitwise
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-        // debugger
         const newQuery = {
-          ...query,
+          ...queryRef.current,
           query: editor.getValue(),
         };
 
@@ -350,30 +353,6 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
 
         onSubmit(newQuery);
       });
-
-      // const handleEnterPress = () => {
-      //   const newQuery = {
-      //     ...props.query,
-      //     query: editor.getValue(),
-      //   };
-
-      //   debugger
-
-      //   onSubmit(newQuery);
-      // };
-
-      // const disposable = editor.onKeyDown((e) => {
-      //   if (e.keyCode === monaco.KeyCode.Enter) {
-      //     // Prevent default Enter key behavior
-      //     e.preventDefault();
-      //     handleEnterPress();
-      //   }
-      // });
-
-      // Optional: Cleanup on component unmount
-      return () => {
-        // disposable.dispose();
-      };
     },
     provideCompletionItems,
     prepend: props.prepend,

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -75,7 +75,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const headerRef = useRef<HTMLDivElement>(null);
   const bannerRef = useRef<HTMLDivElement>(null);
   const queryControlsContainer = useRef<HTMLDivElement>(null);
-  // TODO: There should only be one source of truth for query state and it should match the app query state. Firing the query should be restricted to when the user is ready, but should not prevent the app query from changing.
+  // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8801
   const editorQuery = props.query; // local query state managed by the editor. Not to be confused by the app query state.
 
   const queryString = getQueryService().queryString;
@@ -87,7 +87,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   });
   const queryRef = useRef(query);
 
-  // Monaco editor commands dont reference the query state directly since the commands are registered at startup, so we need to keep a ref to the query state that it can use when needed
+  // Monaco commands are registered once at startup, we need a ref to access the latest query state inside command callbacks
   useEffect(() => {
     queryRef.current = query;
   }, [query]);
@@ -165,7 +165,6 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const onQueryStringChange = (value: string) => {
     onChange({
       query: value,
-      // Its fiune to reference the query state her since it is not updated yet
       language: query.language,
       dataset: query.dataset,
     });


### PR DESCRIPTION
### Description

The Query editor and similarly auto complete use the query state to corretcly query the Datasource. However the query state value used by different parts of the editor UI are out of sync. This PR clearly demarcates which instance of the query you are using and calls out why that is the rught query object to reference.

It also addresses a quirk of monaco which after initialization does not use the latest value of the query object resulting in incorrect  values being used for language and dataset. This is fixed by using useRef to store a referenc of the object that the monaco callback can use when the shortcut commands are fired.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

1. When the user is using the single line editor, they type a word and hit enter, the query clears the current value. Ths is because the monaco callback on`Enter` did not use the vlue from the editor. Fixed by using the editor value directly
2. When the page is loaded and the query states are changed e.g. langauge is changed. When `Cmd+Enter` is hit, the language and datasource revert back to the default values when the app was loaded. Thsi is fixed using the ref hack

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Query Editor state sync issues in Discover

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
