### PR TITLE
[Discover] fix error construction and retrieving status

### DIFF
--- a/src/plugins/query_enhancements/common/utils.test.ts
+++ b/src/plugins/query_enhancements/common/utils.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { handleFacetError } from './utils';
+
+describe('handleFacetError', () => {
+  const error = new Error('mock-error');
+  (error as any).body = {
+    message: 'test error message',
+  };
+  (error as any).status = '400';
+  it('should throw an error with message from response.data.body.message', () => {
+    const response = {
+      data: error,
+    };
+
+    expect(() => handleFacetError(response)).toThrowError();
+    try {
+      handleFacetError(response);
+    } catch (err: any) {
+      expect(err.message).toBe('test error message');
+      expect(err.name).toBe('400');
+      expect(err.status).toBe('400');
+    }
+  });
+});

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -43,7 +43,7 @@ export const removeKeyword = (queryString: string | undefined) => {
 };
 
 export const handleFacetError = (response: any) => {
-  const error = new Error(response.data.body ?? response.data);
+  const error = new Error(response.data.body?.message ?? response.data.body ?? response.data);
   error.name = response.data.status ?? response.status ?? response.data.statusCode;
   (error as any).status = error.name;
   throw error;

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -92,7 +92,7 @@ export function defineSearchStrategyRouteProvider(logger: Logger, router: IRoute
             error = err;
           }
           return res.custom({
-            statusCode: error.status,
+            statusCode: error.status || err.status,
             body: err.message,
           });
         }


### PR DESCRIPTION
### Description

This is a follow up fix for https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565, in case `response.data.body` is an Error object, passing it to Error constructor calls `String(Error)` which returns `[object object]`. Additionally, if `error.message` is a valid JSON, the route will get status code from `JSON.parse(error.message).status`, which is not always present.

The PR changes error construction to use `response.data.body.message` if available, and uses `error.status` if `status` is not available in parsed JSON.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
