### PR TITLE
[discover] temporarily disable recent datasets

### DIFF
--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
@@ -197,9 +197,11 @@ describe('DatasetService', () => {
 
     service.addRecentDataset(mockDataset1);
     const recents = service.getRecentDatasets();
-    expect(recents).toContainEqual(mockDataset1);
-    expect(recents.length).toEqual(1);
-    expect(sessionStorage.get('recentDatasets')).toContainEqual(mockDataset1);
+    // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8814
+    expect(recents.length).toEqual(0);
+    // expect(recents).toContainEqual(mockDataset1);
+    // expect(recents.length).toEqual(1);
+    // expect(sessionStorage.get('recentDatasets')).toContainEqual(mockDataset1);
   });
 
   test('getRecentDatasets returns all datasets', () => {
@@ -211,17 +213,19 @@ describe('DatasetService', () => {
         timeFieldName: 'timestamp',
       });
     }
-    expect(service.getRecentDatasets().length).toEqual(4);
-    for (let i = 0; i < 4; i++) {
-      const mockDataset = {
-        id: `dataset${i}`,
-        title: `Dataset ${i}`,
-        type: 'test-type',
-        timeFieldName: 'timestamp',
-      };
-      expect(service.getRecentDatasets()).toContainEqual(mockDataset);
-      expect(sessionStorage.get('recentDatasets')).toContainEqual(mockDataset);
-    }
+    // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8814
+    expect(service.getRecentDatasets().length).toEqual(0);
+    // expect(service.getRecentDatasets().length).toEqual(4);
+    // for (let i = 0; i < 4; i++) {
+    //   const mockDataset = {
+    //     id: `dataset${i}`,
+    //     title: `Dataset ${i}`,
+    //     type: 'test-type',
+    //     timeFieldName: 'timestamp',
+    //   };
+    //   expect(service.getRecentDatasets()).toContainEqual(mockDataset);
+    //   expect(sessionStorage.get('recentDatasets')).toContainEqual(mockDataset);
+    // }
   });
 
   test('addRecentDatasets respects max size', () => {
@@ -233,7 +237,9 @@ describe('DatasetService', () => {
         timeFieldName: 'timestamp',
       });
     }
-    expect(service.getRecentDatasets().length).toEqual(4);
+    // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8814
+    expect(service.getRecentDatasets().length).toEqual(0);
+    // expect(service.getRecentDatasets().length).toEqual(4);
   });
 
   test('test get default dataset ', async () => {

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -80,7 +80,9 @@ export class DatasetService {
   }
 
   public getRecentDatasets(): Dataset[] {
-    return this.recentDatasets.values();
+    // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8814
+    return [];
+    // return this.recentDatasets.values();
   }
 
   public addRecentDataset(dataset: Dataset | undefined, serialize: boolean = true): void {


### PR DESCRIPTION
### Description

With workspaces disabled, recent datasets works fine. However the dataset service does not have the concept of workspaces yet so instead of adding a new feature we are opting for recent datasets not yielding any results. The dataset selector already handles displaying or not if no recent datasets.

Follow up issue:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8814


### Issues Resolved

n/a

## Screenshot

![Screenshot 2024-11-05 at 3 25 34 PM](https://github.com/user-attachments/assets/b92de68e-8332-4918-a89a-c85d4567ad4a)

## Testing the changes

locally and jest tests

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
