### PR TITLE
[Discover] Fix discover query loading state

### DIFF
--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -27,6 +27,17 @@ describe('Query Result', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('should not render if status is uninitialized', () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.UNINITIALIZED,
+        startTime: Number.NEGATIVE_INFINITY,
+      },
+    };
+    const component = shallowWithIntl(<QueryResult {...props} />);
+    expect(component.isEmptyRender()).toBe(true);
+  });
+
   it('shows ready status with complete message', () => {
     const props = {
       queryStatus: {

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -58,24 +58,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     };
   }, [props.queryStatus.startTime]);
 
-  if (elapsedTime > BUFFER_TIME) {
-    if (props.queryStatus.status === ResultStatus.LOADING) {
-      const time = Math.floor(elapsedTime / 1000);
-      return (
-        <EuiButtonEmpty
-          color="text"
-          size="xs"
-          onClick={() => {}}
-          isLoading
-          data-test-subj="queryResultLoading"
-        >
-          {i18n.translate('data.query.languageService.queryResults.loadTime', {
-            defaultMessage: 'Loading {time} s',
-            values: { time },
-          })}
-        </EuiButtonEmpty>
-      );
-    }
+  if (elapsedTime > BUFFER_TIME && props.queryStatus.status === ResultStatus.LOADING) {
     const time = Math.floor(elapsedTime / 1000);
     return (
       <EuiButtonEmpty
@@ -130,7 +113,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     );
   }
 
-  if (!props.queryStatus.body || !props.queryStatus.body.error) {
+  if (props.queryStatus.status === ResultStatus.UNINITIALIZED || !props.queryStatus.body?.error) {
     return null;
   }
 

--- a/src/plugins/discover/public/application/view_components/utils/use_search.test.tsx
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.test.tsx
@@ -140,7 +140,19 @@ describe('useSearch', () => {
     });
 
     act(() => {
+      mockDatasetUpdates$.next({
+        dataset: { id: 'new-dataset-id', title: 'New Dataset', type: 'INDEX_PATTERN' },
+      });
+    });
+
+    act(() => {
       result.current.data$.next({ status: ResultStatus.READY });
+    });
+
+    act(() => {
+      mockDatasetUpdates$.next({
+        dataset: { id: 'new-dataset-id', title: 'New Dataset', type: 'INDEX_PATTERN' },
+      });
     });
 
     expect(result.current.data$.getValue()).toEqual(
@@ -149,13 +161,7 @@ describe('useSearch', () => {
 
     act(() => {
       mockDatasetUpdates$.next({
-        dataset: { id: 'new-dataset-id', title: 'New Dataset', type: 'INDEX_PATTERN' },
-      });
-      mockDatasetUpdates$.next({
-        dataset: { id: 'new-dataset-id', title: 'New Dataset', type: 'INDEX_PATTERN' },
-      });
-      mockDatasetUpdates$.next({
-        dataset: { id: 'new-dataset-id2', title: 'New Dataset', type: 'INDEX_PATTERN' },
+        dataset: { id: 'different-dataset-id', title: 'New Dataset', type: 'INDEX_PATTERN' },
       });
     });
 
@@ -164,7 +170,7 @@ describe('useSearch', () => {
     });
 
     expect(result.current.data$.getValue()).toEqual(
-      expect.objectContaining({ status: ResultStatus.LOADING })
+      expect.objectContaining({ status: ResultStatus.LOADING, rows: [] })
     );
   });
 });


### PR DESCRIPTION
### Description

Duplicated code was introduced by https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565 to run the same logic regardless of `if` condition, possibly due to merge conflict? https://github.com/opensearch-project/OpenSearch-Dashboards/blob/c8278f3729cacaa6d77985adbc67920b2663877f/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx#L62-L94

It causes UI to show loading even when status is not loading. This PR fixes it

Additionally, this PR changes loading behavior to be
1. when there are no results, running the query shows loading in query editor footer and below
2. when there are results, running the query shows loading in query editor footer with previous query results

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
