### PR TITLE
Fix a typo while inspecting values for large numerals in OSD and the JS client

### DIFF
--- a/changelogs/fragments/8839.yml
+++ b/changelogs/fragments/8839.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix a typo while inspecting values for large numerals in OSD and the JS client ([#8839](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8839))

--- a/packages/osd-std/src/json.ts
+++ b/packages/osd-std/src/json.ts
@@ -69,7 +69,7 @@ export const parse = (
       numeralsAreNumbers &&
       typeof val === 'number' &&
       isFinite(val) &&
-      (val < Number.MAX_SAFE_INTEGER || val > Number.MAX_SAFE_INTEGER)
+      (val < Number.MIN_SAFE_INTEGER || val > Number.MAX_SAFE_INTEGER)
     ) {
       numeralsAreNumbers = false;
     }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -84,6 +84,15 @@ const run = async () => {
       },
     ])
   );
+  //ToDo: Remove when opensearch-js is released to include https://github.com/opensearch-project/opensearch-js/pull/889
+  promises.push(
+    patchFile('node_modules/@opensearch-project/opensearch/lib/Serializer.js', [
+      {
+        from: 'val < Number.MAX_SAFE_INTEGER',
+        to: 'val < Number.MIN_SAFE_INTEGER',
+      },
+    ])
+  );
 
   await Promise.all(promises);
 };


### PR DESCRIPTION
### Description

Fix a typo while inspecting values for large numerals in OSD and the JS client

Note:
Since JS client 2.x has breaking changes, we cannot adopt it immediately and cannot wait for it to be fixed; hence the client is patched with the commit.


## Changelog
- fix: Fix a typo while inspecting values for large numerals in OSD and the JS client

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
