### PR TITLE
[Workspace]Fix error toasts in sample data page

### DIFF
--- a/changelogs/fragments/8842.yml
+++ b/changelogs/fragments/8842.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace]Fix error toasts in sample data page ([#8842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8842))

--- a/src/plugins/home/public/application/opensearch_dashboards_services.ts
+++ b/src/plugins/home/public/application/opensearch_dashboards_services.ts
@@ -37,6 +37,7 @@ import {
   SavedObjectsClientContract,
   IUiSettingsClient,
   ApplicationStart,
+  WorkspacesSetup,
 } from 'opensearch-dashboards/public';
 import { UiStatsMetricType } from '@osd/analytics';
 import { TelemetryPluginStart } from '../../../telemetry/public';
@@ -77,6 +78,7 @@ export interface HomeOpenSearchDashboardsServices {
   };
   dataSource?: DataSourcePluginStart;
   sectionTypes: SectionTypeService;
+  workspaces?: WorkspacesSetup;
 }
 
 let services: HomeOpenSearchDashboardsServices | null = null;

--- a/src/plugins/home/public/application/sample_data_client.js
+++ b/src/plugins/home/public/application/sample_data_client.js
@@ -41,11 +41,16 @@ export async function listSampleDataSets(dataSourceId) {
   return await getServices().http.get(sampleDataUrl, { query });
 }
 
+const isWorkspaceEnabled = () => {
+  const workspaces = getServices().application.capabilities.workspaces;
+  return !!(workspaces && workspaces.enabled);
+};
+
 export async function installSampleDataSet(id, sampleDataDefaultIndex, dataSourceId) {
   const query = buildQuery(dataSourceId);
   await getServices().http.post(`${sampleDataUrl}/${id}`, { query });
 
-  if (getServices().uiSettings.isDefault('defaultIndex')) {
+  if (!isWorkspaceEnabled() && getServices().uiSettings.isDefault('defaultIndex')) {
     getServices().uiSettings.set('defaultIndex', sampleDataDefaultIndex);
   }
 
@@ -59,6 +64,7 @@ export async function uninstallSampleDataSet(id, sampleDataDefaultIndex, dataSou
   const uiSettings = getServices().uiSettings;
 
   if (
+    !isWorkspaceEnabled() &&
     !uiSettings.isDefault('defaultIndex') &&
     uiSettings.get('defaultIndex') === sampleDataDefaultIndex
   ) {

--- a/src/plugins/home/public/application/sample_data_client.test.js
+++ b/src/plugins/home/public/application/sample_data_client.test.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { setServices } from '../application/opensearch_dashboards_services';
+import { installSampleDataSet, uninstallSampleDataSet } from './sample_data_client';
+
+const mockHttp = {
+  post: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockUiSettings = {
+  isDefault: jest.fn(),
+  set: jest.fn(),
+  get: jest.fn(),
+};
+
+const mockApplication = {
+  capabilities: {
+    workspaces: {
+      enabled: false,
+      permissionEnabled: false,
+    },
+  },
+};
+
+const mockIndexPatternService = {
+  clearCache: jest.fn(),
+};
+
+const mockWorkspace = {
+  currentWorkspace$: new BehaviorSubject(),
+};
+
+const mockServices = {
+  workspaces: mockWorkspace,
+  http: mockHttp,
+  uiSettings: mockUiSettings,
+  application: mockApplication,
+  indexPatternService: mockIndexPatternService,
+};
+
+setServices(mockServices);
+
+describe('installSampleDataSet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUiSettings.isDefault.mockReturnValue(true);
+    setServices(mockServices);
+  });
+
+  it('should install the sample data set and set the default index', async () => {
+    const id = 'sample-data-id';
+    const sampleDataDefaultIndex = 'sample-data-index';
+    const dataSourceId = 'data-source-id';
+
+    await installSampleDataSet(id, sampleDataDefaultIndex, dataSourceId);
+
+    expect(mockHttp.post).toHaveBeenCalledWith(`/api/sample_data/${id}`, {
+      query: expect.anything(),
+    });
+    expect(mockUiSettings.set).toHaveBeenCalledWith('defaultIndex', sampleDataDefaultIndex);
+    expect(mockIndexPatternService.clearCache).toHaveBeenCalled();
+  });
+
+  it('should install the sample data set and not set the default index when workspace is enabled', async () => {
+    const id = 'sample-data-id';
+    const sampleDataDefaultIndex = 'sample-data-index';
+    const dataSourceId = 'data-source-id';
+
+    setServices({
+      ...mockServices,
+      workspaces: {
+        currentWorkspace$: new BehaviorSubject(),
+      },
+      application: {
+        capabilities: {
+          workspaces: {
+            enabled: true,
+            permissionEnabled: true,
+          },
+        },
+      },
+    });
+
+    await installSampleDataSet(id, sampleDataDefaultIndex, dataSourceId);
+
+    expect(mockHttp.post).toHaveBeenCalledWith(`/api/sample_data/${id}`, {
+      query: expect.anything(),
+    });
+    expect(mockUiSettings.set).not.toHaveBeenCalled();
+    expect(mockIndexPatternService.clearCache).toHaveBeenCalled();
+  });
+});
+
+describe('uninstallSampleDataSet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUiSettings.isDefault.mockReturnValue(false);
+    setServices(mockServices);
+  });
+
+  it('should uninstall the sample data set and clear the default index', async () => {
+    const id = 'sample-data-id';
+    const sampleDataDefaultIndex = 'sample-data-index';
+    const dataSourceId = 'data-source-id';
+
+    mockUiSettings.get.mockReturnValue(sampleDataDefaultIndex);
+
+    await uninstallSampleDataSet(id, sampleDataDefaultIndex, dataSourceId);
+
+    expect(mockHttp.delete).toHaveBeenCalledWith(`/api/sample_data/${id}`, {
+      query: expect.anything(),
+    });
+    expect(mockUiSettings.set).toHaveBeenCalledWith('defaultIndex', null);
+    expect(mockIndexPatternService.clearCache).toHaveBeenCalled();
+  });
+
+  it('should uninstall the sample data set and not clear the default index when workspace is enabled', async () => {
+    const id = 'sample-data-id';
+    const sampleDataDefaultIndex = 'sample-data-index';
+    const dataSourceId = 'data-source-id';
+
+    setServices({
+      ...mockServices,
+      workspaces: {
+        currentWorkspace$: new BehaviorSubject(),
+      },
+      application: {
+        capabilities: {
+          workspaces: {
+            enabled: true,
+            permissionEnabled: true,
+          },
+        },
+      },
+    });
+
+    await uninstallSampleDataSet(id, sampleDataDefaultIndex, dataSourceId);
+
+    expect(mockHttp.delete).toHaveBeenCalledWith(`/api/sample_data/${id}`, {
+      query: expect.anything(),
+    });
+    expect(mockUiSettings.set).not.toHaveBeenCalled();
+    expect(mockIndexPatternService.clearCache).toHaveBeenCalled();
+  });
+
+  it('should uninstall the sample data set and not clear the default index when it is not the sample data index', async () => {
+    const id = 'sample-data-id';
+    const sampleDataDefaultIndex = 'sample-data-index';
+    const dataSourceId = 'data-source-id';
+
+    mockUiSettings.isDefault.mockReturnValue(false);
+    mockUiSettings.get.mockReturnValue('other-index');
+
+    await uninstallSampleDataSet(id, sampleDataDefaultIndex, dataSourceId);
+
+    expect(mockHttp.delete).toHaveBeenCalledWith(`/api/sample_data/${id}`, {
+      query: expect.anything(),
+    });
+    expect(mockUiSettings.set).not.toHaveBeenCalled();
+    expect(mockIndexPatternService.clearCache).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -156,6 +156,7 @@ export class HomePublicPlugin
         injectedMetadata: coreStart.injectedMetadata,
         dataSource,
         sectionTypes: this.sectionTypeService,
+        workspaces: core.workspaces,
         ...homeOpenSearchDashboardsServices,
       });
     };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR addresses the issue of error toasts appearing on the sample data page when installing or uninstalling sample data. The root cause was that the user did not have permission to update UI settings at the workspace level. The changes in this PR include:

1. Remove saved objects first when uninstalling sample data.
2. Disable the behavior of updating the default index pattern UI setting for non workspace admin when installing or uninstalling sample data inside a workspace.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
No UI Changes

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->


1. Clone the branch and run `yarn osd bootstrap --single-version loose`.
2. Add the following configurations to `config/opensearch_dashboards.yml`:
   ```
   savedObjects.permission.enabled: true
   workspace.enabled: true
   uiSettings:
     overrides:
       'home:useNewHomePage': true
   ```
3. Run `yarn start --no-base-path`.
4. Log in with the admin user and create a new workspace named "test1".
5. Visit the sample data page of the "test1" workspace.
6. Click the "Add data" and "Remove" buttons on the sample data cards to ensure you can install and uninstall sample data without any issues.
7. Create a new user with the "admin" backend_role in the "Internal users" page.
8. Assign the "Read and write" access level to the new user inside the "test1" workspace.
9. Open an incognito window and log in with the new user.
10. Visit the sample data page of the "test1" workspace and click the "Add data" button. Verify that no error toasts appear.
11. Switch back to the admin user tab, visit the same workspace, and set the "flights" sample data as the default index pattern in the index patterns page.
12. Switch to the new user tab and click the "Remove" button on the "flights" sample data card. Verify that an error toast appears, similar to the provided screenshot.
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/532b6c90-d6ce-4c80-a541-aa083a4048f6">
13. Click the "Remove" buttons on other sample data cards and ensure no error toasts appear.
14. Switch to the admin user tab and set the new user as an "Admin" of the "test1" workspace.
15. Switch to the new user tab and click the "Remove" button on the "flights" sample data card. Verify that no error toasts appear.
16. Test with the workspace disabled (for regression testing):
    - Remove the newly added configurations.
    - Visit the home page and click the "Add sample data" button.
    - Click the "Add data" buttons. Sample data should be installed without error toasts.
    - Click the "Remove" buttons. Sample data should be uninstalled without error toasts.


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Workspace]Fix error toasts in sample data page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
