### PR TITLE
Fix template queries loading and update getSampleQuery interface

### DIFF
--- a/changelogs/fragments/8848.yml
+++ b/changelogs/fragments/8848.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix saved query loading and update getSampleQuery interface ([#8848](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8848))

--- a/changelogs/fragments/8848.yml
+++ b/changelogs/fragments/8848.yml
@@ -1,2 +1,2 @@
 fix:
-- Fix saved query loading and update getSampleQuery interface ([#8848](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8848))
+- Fix template queries loading and update getSampleQuery interface ([#8848](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8848))

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -83,5 +83,5 @@ export interface DatasetTypeConfig {
   /**
    * Returns a list of sample queries for this dataset type
    */
-  getSampleQueries?: (dataset: Dataset, language: string) => any;
+  getSampleQueries?: (dataset?: Dataset, language?: string) => Promise<any> | any;
 }

--- a/src/plugins/data/public/ui/filter_bar/filter_options.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_options.tsx
@@ -59,7 +59,7 @@ import {
 import { FilterEditor } from './filter_editor';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { SavedQueryManagementComponent } from '../saved_query_management';
-import { SavedQuery, SavedQueryService } from '../../query';
+import { QueryStringManager, SavedQuery, SavedQueryService } from '../../query';
 import { SavedQueryMeta } from '../saved_query_form';
 import { getUseNewSavedQueriesUI } from '../../services';
 
@@ -79,6 +79,7 @@ interface Props {
   useSaveQueryMenu: boolean;
   isQueryEditorControl: boolean;
   saveQuery: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
+  queryStringManager: QueryStringManager;
 }
 const maxFilterWidth = 600;
 
@@ -310,6 +311,7 @@ const FilterOptionsUI = (props: Props) => {
           key={'savedQueryManagement'}
           useNewSavedQueryUI={getUseNewSavedQueriesUI()}
           saveQuery={props.saveQuery}
+          queryStringManager={props.queryStringManager}
         />,
       ]}
       data-test-subj="save-query-panel"

--- a/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.test.tsx
+++ b/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.test.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { OpenSavedQueryFlyout } from './open_saved_query_flyout';
+import { createSavedQueryService } from '../../../public/query/saved_query/saved_query_service';
+import { applicationServiceMock, uiSettingsServiceMock } from '../../../../../core/public/mocks';
+import { SavedQueryAttributes } from '../../../public/query/saved_query/types';
+import '@testing-library/jest-dom';
+import { queryStringManagerMock } from '../../../../data/public/query/query_string/query_string_manager.mock';
+
+const savedQueryAttributesWithTemplate: SavedQueryAttributes = {
+  title: 'foo',
+  description: 'bar',
+  query: {
+    language: 'kuery',
+    query: 'response:200',
+    dataset: 'my_dataset',
+  },
+};
+
+const mockSavedObjectsClient = {
+  create: jest.fn(),
+  error: jest.fn(),
+  find: jest.fn(),
+  get: jest.fn(),
+  delete: jest.fn(),
+};
+
+mockSavedObjectsClient.create.mockReturnValue({
+  id: 'foo',
+  attributes: {
+    ...savedQueryAttributesWithTemplate,
+    query: {
+      ...savedQueryAttributesWithTemplate.query,
+    },
+  },
+});
+
+jest.mock('./saved_query_card', () => ({
+  SavedQueryCard: ({
+    savedQuery = {
+      id: 'foo1',
+      attributes: savedQueryAttributesWithTemplate,
+    },
+    onSelect,
+    handleQueryDelete,
+  }) => (
+    <div>
+      <div>{savedQuery?.attributes?.title}</div>
+      <button onClick={() => onSelect(savedQuery)}>Select</button>
+      <button onClick={() => handleQueryDelete(savedQuery)}>Delete</button>
+    </div>
+  ),
+}));
+
+jest.mock('@osd/i18n', () => ({
+  i18n: {
+    translate: jest.fn((id, { defaultMessage }) => defaultMessage),
+  },
+}));
+
+const mockSavedQueryService = createSavedQueryService(
+  // @ts-ignore
+  mockSavedObjectsClient,
+  {
+    application: applicationServiceMock.create(),
+    uiSettings: uiSettingsServiceMock.createStartContract(),
+  }
+);
+
+const mockHandleQueryDelete = jest.fn();
+const mockOnQueryOpen = jest.fn();
+const mockOnClose = jest.fn();
+
+const savedQueries = [
+  {
+    id: '1',
+    attributes: {
+      title: 'Saved Query 1',
+      description: 'Description for Query 1',
+      query: { query: 'SELECT * FROM table1', language: 'sql' },
+    },
+  },
+  {
+    id: '2',
+    attributes: {
+      title: 'Saved Query 2',
+      description: 'Description for Query 2',
+      query: { query: 'SELECT * FROM table2', language: 'sql' },
+    },
+  },
+];
+
+jest.spyOn(mockSavedQueryService, 'getAllSavedQueries').mockResolvedValue(savedQueries);
+
+describe('OpenSavedQueryFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the flyout with correct tabs and content', async () => {
+    render(
+      <OpenSavedQueryFlyout
+        savedQueryService={mockSavedQueryService}
+        onClose={mockOnClose}
+        onQueryOpen={mockOnQueryOpen}
+        handleQueryDelete={mockHandleQueryDelete}
+        queryStringManager={queryStringManagerMock.createSetupContract()}
+      />
+    );
+
+    const savedQueriesTextElements = screen.getAllByText('Saved queries');
+
+    expect(savedQueriesTextElements).toHaveLength(2);
+
+    await waitFor(() => screen.getByPlaceholderText('Search'));
+
+    await waitFor(() => screen.getByText('Saved Query 1'));
+    await waitFor(() => screen.getByText('Saved Query 2'));
+
+    const openQueryButton = screen.getByText('Open query');
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'Saved Query 1' } });
+
+    await waitFor(() => screen.getByText('Saved Query 1'));
+    expect(screen.queryByText('Saved Query 2')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Saved Query 1'));
+
+    expect(openQueryButton).toBeEnabled();
+  });
+
+  it('should filter saved queries based on search input', async () => {
+    render(
+      <OpenSavedQueryFlyout
+        savedQueryService={mockSavedQueryService}
+        onClose={mockOnClose}
+        onQueryOpen={mockOnQueryOpen}
+        handleQueryDelete={mockHandleQueryDelete}
+        queryStringManager={queryStringManagerMock.createSetupContract()}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Saved Query 1'));
+    await waitFor(() => screen.getByText('Saved Query 2'));
+
+    const searchBar = screen.getByPlaceholderText('Search');
+    fireEvent.change(searchBar, { target: { value: 'Saved Query 1' } });
+
+    expect(screen.getByText('Saved Query 1')).toBeInTheDocument();
+    expect(screen.queryByText('Saved Query 2')).toBeNull();
+  });
+
+  it('should select a query when clicking on it and enable the "Open query" button', async () => {
+    render(
+      <OpenSavedQueryFlyout
+        savedQueryService={mockSavedQueryService}
+        onClose={mockOnClose}
+        onQueryOpen={mockOnQueryOpen}
+        handleQueryDelete={mockHandleQueryDelete}
+        queryStringManager={queryStringManagerMock.createSetupContract()}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Saved Query 1'));
+
+    fireEvent.click(screen.getByText('Saved Query 1'));
+
+    expect(screen.getByText('Open query')).toBeEnabled();
+  });
+
+  it('should call handleQueryDelete when deleting a query', async () => {
+    mockHandleQueryDelete.mockResolvedValueOnce();
+    render(
+      <OpenSavedQueryFlyout
+        savedQueryService={mockSavedQueryService}
+        onClose={mockOnClose}
+        onQueryOpen={mockOnQueryOpen}
+        handleQueryDelete={mockHandleQueryDelete}
+        queryStringManager={queryStringManagerMock.createSetupContract()}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Saved Query 1'));
+
+    const deleteButtons = screen.getAllByText('Delete');
+
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(mockHandleQueryDelete).toHaveBeenCalledWith({
+        id: '1',
+        attributes: {
+          description: 'Description for Query 1',
+          query: {
+            language: 'sql',
+            query: 'SELECT * FROM table1',
+          },
+          title: 'Saved Query 1',
+        },
+      });
+    });
+    expect(mockHandleQueryDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle pagination controls correctly', async () => {
+    render(
+      <OpenSavedQueryFlyout
+        savedQueryService={mockSavedQueryService}
+        onClose={mockOnClose}
+        onQueryOpen={mockOnQueryOpen}
+        handleQueryDelete={mockHandleQueryDelete}
+        queryStringManager={queryStringManagerMock.createSetupContract()}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Saved Query 1'));
+
+    const pageSizeButton = await screen.findByText(/10/);
+    fireEvent.click(pageSizeButton);
+
+    expect(mockSavedQueryService.getAllSavedQueries).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.tsx
+++ b/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiLoadingSpinner,
   EuiSearchBar,
   EuiSearchBarProps,
   EuiSpacer,
@@ -62,10 +63,11 @@ export function OpenSavedQueryFlyout({
   const [languageFilterOptions, setLanguageFilterOptions] = useState<string[]>([]);
   const [selectedQuery, setSelectedQuery] = useState<SavedQuery | undefined>(undefined);
   const [searchQuery, setSearchQuery] = useState(EuiSearchBar.Query.MATCH_ALL);
-
+  const [isLoading, setIsLoading] = useState(false);
   const currentTabIdRef = useRef(selectedTabId);
 
   const fetchAllSavedQueriesForSelectedTab = useCallback(async () => {
+    setIsLoading(true);
     if (queryStringManager.getQuery()?.dataset?.type === 'SECURITY_LAKE') {
       setHasTemplateQueries(true);
     }
@@ -85,6 +87,7 @@ export function OpenSavedQueryFlyout({
         if (Array.isArray(templateQueries)) setSavedQueries(templateQueries);
       }
     }
+    setIsLoading(false);
   }, [savedQueryService, currentTabIdRef, setSavedQueries, queryStringManager]);
 
   const updatePageIndex = useCallback((index: number) => {
@@ -194,7 +197,13 @@ export function OpenSavedQueryFlyout({
         onChange={onChange}
       />
       <EuiSpacer />
-      {queriesOnCurrentPage.length > 0 ? (
+      {isLoading ? (
+        <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: '200px' }}>
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="xl" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : queriesOnCurrentPage.length > 0 ? (
         queriesOnCurrentPage.map((query) => (
           <SavedQueryCard
             key={query.id}
@@ -220,7 +229,7 @@ export function OpenSavedQueryFlyout({
         />
       )}
       <EuiSpacer />
-      {queriesOnCurrentPage.length > 0 && (
+      {!isLoading && queriesOnCurrentPage.length > 0 && (
         <EuiTablePagination
           itemsPerPageOptions={[5, 10, 20]}
           itemsPerPage={itemsPerPage}

--- a/src/plugins/data/public/ui/saved_query_management/saved_query_management_component.tsx
+++ b/src/plugins/data/public/ui/saved_query_management/saved_query_management_component.tsx
@@ -45,7 +45,7 @@ import {
 import { i18n } from '@osd/i18n';
 import React, { useCallback, useEffect, useState, Fragment, useRef } from 'react';
 import { sortBy } from 'lodash';
-import { SavedQuery, SavedQueryService } from '../..';
+import { QueryStringManager, SavedQuery, SavedQueryService } from '../..';
 import { SavedQueryListItem } from './saved_query_list_item';
 import {
   toMountPoint,
@@ -70,6 +70,7 @@ interface Props {
   onClearSavedQuery: () => void;
   closeMenuPopover: () => void;
   saveQuery: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
+  queryStringManager: QueryStringManager;
 }
 
 export function SavedQueryManagementComponent({
@@ -83,6 +84,7 @@ export function SavedQueryManagementComponent({
   closeMenuPopover,
   useNewSavedQueryUI,
   saveQuery,
+  queryStringManager,
 }: Props) {
   const [savedQueries, setSavedQueries] = useState([] as SavedQuery[]);
   const [count, setTotalCount] = useState(0);
@@ -256,6 +258,7 @@ export function SavedQueryManagementComponent({
                   onClose={() => openSavedQueryFlyout?.close().then()}
                   onQueryOpen={onLoad}
                   handleQueryDelete={handleDelete}
+                  queryStringManager={queryStringManager}
                 />
               )
             );

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -202,6 +202,7 @@ export function createSearchBar({ core, storage, data }: StatefulSearchBarDeps) 
           isRefreshPaused={refreshInterval.pause}
           filters={filters}
           query={query}
+          queryStringManager={data.query.queryString}
           onFiltersUpdated={defaultFiltersUpdated(data.query)}
           onRefreshChange={defaultOnRefreshChange(data.query)}
           savedQuery={savedQuery}

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -38,7 +38,13 @@ import {
   withOpenSearchDashboards,
 } from '../../../../opensearch_dashboards_react/public';
 import { Filter, IIndexPattern, Query, TimeRange, UI_SETTINGS } from '../../../common';
-import { SavedQuery, SavedQueryAttributes, TimeHistoryContract, QueryStatus } from '../../query';
+import {
+  SavedQuery,
+  SavedQueryAttributes,
+  TimeHistoryContract,
+  QueryStatus,
+  QueryStringManager,
+} from '../../query';
 import { IDataPluginServices } from '../../types';
 import { FilterBar } from '../filter_bar/filter_bar';
 import { QueryEditorTopRow } from '../query_editor';
@@ -95,6 +101,7 @@ export interface SearchBarOwnProps {
   onRefresh?: (payload: { dateRange: TimeRange }) => void;
   indicateNoData?: boolean;
   queryStatus?: QueryStatus;
+  queryStringManager: QueryStringManager;
 }
 
 export type SearchBarProps = SearchBarOwnProps & SearchBarInjectedDeps;
@@ -467,6 +474,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             useSaveQueryMenu={useSaveQueryMenu}
             isQueryEditorControl={isQueryEditorControl}
             saveQuery={this.onSave}
+            queryStringManager={this.props.queryStringManager}
           />
         )
       );

--- a/src/plugins/discover/public/application/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/components/no_results/no_results.tsx
@@ -174,6 +174,7 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
   // }
 
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
+  const [sampleQueries, setSampleQueries] = useState<any>([]);
 
   useEffect(() => {
     const fetchSavedQueries = async () => {
@@ -186,6 +187,39 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
     fetchSavedQueries();
   }, [setSavedQueries, query, savedQuery]);
 
+  useEffect(() => {
+    // Samples for the language
+    const newSampleQueries: any = [];
+    if (query?.language) {
+      const languageSampleQueries = queryString.getLanguageService()?.getLanguage(query.language)
+        ?.sampleQueries;
+      if (Array.isArray(languageSampleQueries)) {
+        newSampleQueries.push(...languageSampleQueries);
+      }
+    }
+
+    // Samples for the dataset type
+    if (query?.dataset?.type) {
+      const datasetType = queryString.getDatasetService()?.getType(query.dataset.type);
+      if (datasetType?.getSampleQueries) {
+        const sampleQueriesResponse = datasetType.getSampleQueries(query.dataset, query.language);
+        if (Array.isArray(sampleQueriesResponse)) {
+          setSampleQueries([...sampleQueriesResponse, ...newSampleQueries]);
+        } else if (sampleQueriesResponse instanceof Promise) {
+          sampleQueriesResponse
+            .then((datasetSampleQueries: any) => {
+              if (Array.isArray(datasetSampleQueries)) {
+                setSampleQueries([...datasetSampleQueries, ...newSampleQueries]);
+              }
+            })
+            .catch((error: any) => {
+              // noop
+            });
+        }
+      }
+    }
+  }, [queryString, query]);
+
   const tabs = useMemo(() => {
     const buildSampleQueryBlock = (sampleTitle: string, sampleQuery: string) => {
       return (
@@ -197,25 +231,6 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
         </>
       );
     };
-
-    const sampleQueries = [];
-
-    // Samples for the dataset type
-    if (query?.dataset?.type) {
-      const datasetSampleQueries = queryString
-        .getDatasetService()
-        ?.getType(query.dataset.type)
-        ?.getSampleQueries?.(query.dataset, query.language);
-      if (Array.isArray(datasetSampleQueries)) sampleQueries.push(...datasetSampleQueries);
-    }
-
-    // Samples for the language
-    if (query?.language) {
-      const languageSampleQueries = queryString.getLanguageService()?.getLanguage(query.language)
-        ?.sampleQueries;
-      if (Array.isArray(languageSampleQueries)) sampleQueries.push(...languageSampleQueries);
-    }
-
     return [
       ...(sampleQueries.length > 0
         ? [
@@ -229,7 +244,7 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
                   <EuiSpacer size="s" />
                   {sampleQueries
                     .slice(0, 5)
-                    .map((sampleQuery) =>
+                    .map((sampleQuery: any) =>
                       buildSampleQueryBlock(sampleQuery.title, sampleQuery.query)
                     )}
                 </EuiPanel>
@@ -256,7 +271,7 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
           ]
         : []),
     ];
-  }, [queryString, query, savedQueries]);
+  }, [savedQueries, sampleQueries]);
 
   return (
     <I18nProvider>


### PR DESCRIPTION
### Description
- Instead of loading template queries through saved objects api, this pr changes it so that we can load template queries in through the getSampleQuery function directly
- Updates URL state when opening a saved query so datapicker state is correct
- Updates getSampleQuery interface so it can also return a promise

```
 PASS  src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.test.tsx
  OpenSavedQueryFlyout
    ✓ should render the flyout with correct tabs and content (58 ms)
    ✓ should filter saved queries based on search input (29 ms)
    ✓ should select a query when clicking on it and enable the "Open query" button (14 ms)
    ✓ should call handleQueryDelete when deleting a query (21 ms)
    ✓ should handle pagination controls correctly (43 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        3.351 s
Ran all test suites matching /src\/plugins\/data\/public\/ui\/saved_query_flyouts\/open_saved_query_flyout.test.tsx/i.
```

![Screenshot 2024-11-11 at 10 52 01 PM](https://github.com/user-attachments/assets/609ef338-67db-49ba-9af6-934356126819)
![Screenshot 2024-11-11 at 10 51 54 PM](https://github.com/user-attachments/assets/8d4aa568-e0e0-4026-b0a4-3fffbf027839)
![Screenshot 2024-11-12 at 9 23 49 AM](https://github.com/user-attachments/assets/5e0b40eb-57a2-4191-8fe0-57e1e990e891)
![Screenshot 2024-11-11 at 10 51 48 PM](https://github.com/user-attachments/assets/d751b1a0-0233-43b5-acad-2dbdee1c4d96)
![Screenshot 2024-11-11 at 10 51 42 PM](https://github.com/user-attachments/assets/27601a15-5240-4c61-a570-dc03809a89f8)

https://github.com/user-attachments/assets/c43d7a51-4740-4c85-8e64-bfc2281db62f


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Fix template queries loading and update getSampleQuery interface

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
