### PR TITLE
Indexed views framework

### DIFF
--- a/changelogs/fragments/8818.yml
+++ b/changelogs/fragments/8818.yml
@@ -1,0 +1,3 @@
+feat:
+- Add framework to show banner at the top in discover results canvas ([#8818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8818))
+- Show indexed views in dataset selector ([#8818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8818))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -339,6 +339,15 @@
 
 # Set the value of this setting to true to enable plugin augmentation on Dashboard
 # vis_augmenter.pluginAugmentationEnabled: true
+dashboardsPlugin.validateJwt: false
+dashboardsPlugin.dqsEnabled: true
+  
+uiSettings:
+  overrides:
+    "home:useNewHomePage": true
+    "query:enhancements:enabled": true
+  defaults:
+    "theme:version": 'v9'
 
 # Set the value to true to enable permission control for saved objects
 # Permission control depends on OpenSearch Dashboards has authentication enabled, set it to false when the security plugin is not installed,

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -247,8 +247,13 @@ export interface Dataset extends BaseDataset {
   timeFieldName?: string;
   /** Optional language to default to from the language selector */
   language?: string;
-  /** Optional name of the indexed view to search data from */
-  indexedView?: string;
+  /** Optional reference to the source dataset. Example usage is for indexed views to store the
+   * reference to the table dataset 
+   */
+  ref?: {
+    id: string;
+    type: string;
+  };
 }
 
 export interface DatasetField {
@@ -257,29 +262,6 @@ export interface DatasetField {
   displayName?: string;
   // TODO:  osdFieldType?
 }
-
-export enum DatasetCanvasBannerComponentType {
-  CALLOUT = 'CALLOUT',
-  CUSTOM = 'custom',
-}
-
-export type DatasetCanvasBannerProps =
-  | {
-      componentType: DatasetCanvasBannerComponentType.CALLOUT;
-      title: string;
-      iconType?: string;
-      content?: React.ReactNode;
-    }
-  | {
-      componentType: DatasetCanvasBannerComponentType.CALLOUT;
-      title?: string;
-      iconType?: string;
-      content: React.ReactNode;
-    }
-  | {
-      componentType: DatasetCanvasBannerComponentType.CUSTOM;
-      content: React.ReactNode;
-    };
 
 export interface DatasetSearchOptions {
   strategy?: string;

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -247,6 +247,8 @@ export interface Dataset extends BaseDataset {
   timeFieldName?: string;
   /** Optional language to default to from the language selector */
   language?: string;
+  /** Optional name of the indexed view to search data from */
+  indexedView?: string;
 }
 
 export interface DatasetField {
@@ -255,6 +257,29 @@ export interface DatasetField {
   displayName?: string;
   // TODO:  osdFieldType?
 }
+
+export enum DatasetCanvasBannerComponentType {
+  CALLOUT = 'CALLOUT',
+  CUSTOM = 'custom',
+}
+
+export type DatasetCanvasBannerProps =
+  | {
+      componentType: DatasetCanvasBannerComponentType.CALLOUT;
+      title: string;
+      iconType?: string;
+      content?: React.ReactNode;
+    }
+  | {
+      componentType: DatasetCanvasBannerComponentType.CALLOUT;
+      title?: string;
+      iconType?: string;
+      content: React.ReactNode;
+    }
+  | {
+      componentType: DatasetCanvasBannerComponentType.CUSTOM;
+      content: React.ReactNode;
+    };
 
 export interface DatasetSearchOptions {
   strategy?: string;

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -493,6 +493,7 @@ export {
   QueryStart,
   PersistedLog,
   LanguageReference,
+  IndexedViewsService,
 } from './query';
 
 export { AggsStart } from './search/aggs';

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -493,7 +493,7 @@ export {
   QueryStart,
   PersistedLog,
   LanguageReference,
-  IndexedViewsService,
+  DatasetIndexedViewsService,
 } from './query';
 
 export { AggsStart } from './search/aggs';

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -196,6 +196,7 @@ export class DataPublicPlugin
         if (enhancements.search) searchService.__enhance(enhancements.search);
         if (enhancements.editor)
           queryService.queryString.getLanguageService().__enhance(enhancements.editor);
+        if (enhancements.queryResults) queryService.queryString.getQueryResultService().__enhance(enhancements.queryResults);
       },
     };
   }

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { EuiIconProps } from '@elastic/eui';
-import { Dataset, DatasetField, DatasetSearchOptions, DataStructure } from '../../../../common';
+import {
+  Dataset,
+  DatasetCanvasBannerProps,
+  DatasetField,
+  DatasetSearchOptions,
+  DataStructure,
+} from '../../../../common';
 import { IDataPluginServices } from '../../../types';
 
 /**
@@ -14,6 +20,14 @@ export interface DataStructureFetchOptions {
   search?: string;
   /** Token for paginated results */
   paginationToken?: string;
+}
+
+export interface DatasetIndexedView {
+  name: string;
+}
+
+export interface DatasetIndexedViewsService {
+  getIndexedViews: (dataset: Dataset) => Promise<DatasetIndexedView[]>;
 }
 
 /**
@@ -74,7 +88,7 @@ export interface DatasetTypeConfig {
    * Retrieves the search options to be used for running the query on the data connection associated
    * with this Dataset
    */
-  getSearchOptions?: () => DatasetSearchOptions;
+  getSearchOptions?: (dataset: Dataset) => DatasetSearchOptions;
   /**
    * Combines a list of user selected data structures into a single one to use in discover.
    * @see https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8362.
@@ -84,4 +98,15 @@ export interface DatasetTypeConfig {
    * Returns a list of sample queries for this dataset type
    */
   getSampleQueries?: (dataset: Dataset, language: string) => any;
+  /**
+   * Service used for indexedViews related operations
+   */
+  indexedViewsService?: DatasetIndexedViewsService;
+  /**
+   * Returns props used to render a banner on the Discover canvas/results section
+   */
+  getSearchBannerProps?: (
+    searchStatus: string,
+    dataset: Dataset
+  ) => DatasetCanvasBannerProps | Promise<DatasetCanvasBannerProps> | undefined;
 }

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -5,10 +5,10 @@
 import { EuiIconProps } from '@elastic/eui';
 import {
   Dataset,
-  DatasetCanvasBannerProps,
   DatasetField,
   DatasetSearchOptions,
   DataStructure,
+  SavedObject,
 } from '../../../../common';
 import { IDataPluginServices } from '../../../types';
 
@@ -28,6 +28,12 @@ export interface DatasetIndexedView {
 
 export interface DatasetIndexedViewsService {
   getIndexedViews: (dataset: Dataset) => Promise<DatasetIndexedView[]>;
+  /**
+   * Returns the data source saved object connected with the data connection object
+   * @param dataConnectionId Id of the data-connection saved object for which we want the data-source
+   * @returns Data source saved object for the Collection/Cluster attached with the data-connection
+   */
+  getConnectedDataSource: (dataConnectionId: string) => Promise<SavedObject>;
 }
 
 /**
@@ -102,11 +108,4 @@ export interface DatasetTypeConfig {
    * Service used for indexedViews related operations
    */
   indexedViewsService?: DatasetIndexedViewsService;
-  /**
-   * Returns props used to render a banner on the Discover canvas/results section
-   */
-  getSearchBannerProps?: (
-    searchStatus: string,
-    dataset: Dataset
-  ) => DatasetCanvasBannerProps | Promise<DatasetCanvasBannerProps> | undefined;
 }

--- a/src/plugins/data/public/query/query_string/index.ts
+++ b/src/plugins/data/public/query/query_string/index.ts
@@ -34,7 +34,7 @@ export {
   DatasetService,
   DatasetServiceContract,
   DatasetTypeConfig,
-  DatasetIndexedViewsService as IndexedViewsService,
+  DatasetIndexedViewsService,
 } from './dataset_service';
 export {
   LanguageServiceContract,
@@ -47,3 +47,7 @@ export {
   QueryStatus,
   LanguageReference,
 } from './language_service';
+export {
+  QueryResultService,
+  QueryResultEnhancements
+} from './query_results_service';

--- a/src/plugins/data/public/query/query_string/index.ts
+++ b/src/plugins/data/public/query/query_string/index.ts
@@ -34,6 +34,7 @@ export {
   DatasetService,
   DatasetServiceContract,
   DatasetTypeConfig,
+  DatasetIndexedViewsService as IndexedViewsService,
 } from './dataset_service';
 export {
   LanguageServiceContract,

--- a/src/plugins/data/public/query/query_string/query_results_service/index.ts
+++ b/src/plugins/data/public/query/query_string/query_results_service/index.ts
@@ -1,0 +1,7 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+export * from './query_result_service';
+export * from './types';

--- a/src/plugins/data/public/query/query_string/query_results_service/query_result_service.ts
+++ b/src/plugins/data/public/query/query_string/query_results_service/query_result_service.ts
@@ -1,0 +1,26 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import { QueryResultEnhancements, QueryResultExtensionConfig } from "./types";
+
+
+export class QueryResultService {
+  private queryResultsExtensionMap: Record<string, QueryResultExtensionConfig>;
+
+  constructor() {
+    this.queryResultsExtensionMap = {};
+  }
+
+  public __enhance = (enhancements: QueryResultEnhancements) => {
+    if (enhancements.queryResultExtension) {
+      this.queryResultsExtensionMap[enhancements.queryResultExtension.id] =
+        enhancements.queryResultExtension;
+    }
+  };
+
+  public getQueryResultExtensionMap = () => {
+    return this.queryResultsExtensionMap;
+  }
+}

--- a/src/plugins/data/public/query/query_string/query_results_service/types.ts
+++ b/src/plugins/data/public/query/query_string/query_results_service/types.ts
@@ -1,0 +1,37 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import { PublicMethodsOf } from "packages/osd-utility-types/target";
+import { QueryResultService } from "./query_result_service";
+import { Query } from "../../../../common";
+
+export interface QueryResultExtensionConfig {
+  /**
+   * The id for the discover results extension.
+   */
+  id: string;
+  /**
+   * Lower order indicates higher position on UI.
+   */
+  order: number;
+  /**
+   * A function that returns the discover results extension banner. The banner is a
+   * component that will be displayed above the results.
+   * @param dependencies - The dependencies required for the extension.
+   * @returns The component to display the banner.
+   */
+  getBanner?: (dependencies: QueryResultExtensionDependencies) => React.ReactElement | null;
+}
+
+export interface QueryResultExtensionDependencies {
+  query: Query;
+  queryStatus: string;
+}
+
+export interface QueryResultEnhancements {
+  queryResultExtension?: QueryResultExtensionConfig;
+}
+
+export type QueryResultServiceContract = PublicMethodsOf<QueryResultService>;

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -39,12 +39,14 @@ import { DatasetService, DatasetServiceContract } from './dataset_service';
 import { LanguageService, LanguageServiceContract } from './language_service';
 import { ISearchInterceptor } from '../../search';
 import { getApplication } from '../../services';
+import { QueryResultService, QueryResultServiceContract } from './query_results_service';
 
 export class QueryStringManager {
   private query$: BehaviorSubject<Query>;
   private queryHistory: QueryHistory;
   private datasetService!: DatasetServiceContract;
   private languageService!: LanguageServiceContract;
+  private queryResultService!: QueryResultServiceContract;
 
   constructor(
     private readonly storage: DataStorage,
@@ -57,6 +59,7 @@ export class QueryStringManager {
     this.queryHistory = createHistory({ storage: this.sessionStorage });
     this.datasetService = new DatasetService(uiSettings, this.sessionStorage);
     this.languageService = new LanguageService(this.defaultSearchInterceptor, this.storage);
+    this.queryResultService = new QueryResultService();
   }
 
   private getDefaultQueryString() {
@@ -227,6 +230,10 @@ export class QueryStringManager {
   public getLanguageService = () => {
     return this.languageService;
   };
+
+  public getQueryResultService = () => {
+    return this.queryResultService;
+  }
 
   /**
    * Gets the initial query based on the provided partial query object.

--- a/src/plugins/data/public/types.ts
+++ b/src/plugins/data/public/types.ts
@@ -41,10 +41,12 @@ import { UsageCollectionSetup } from '../../usage_collection/public';
 import { DataSourceStart } from './data_sources/datasource_services/types';
 import { IUiStart } from './ui';
 import { DataStorage } from '../common';
+import { QueryResultEnhancements } from './query/query_string/query_results_service/types';
 
 export interface DataPublicPluginEnhancements {
   search?: SearchEnhancements;
   editor?: EditorEnhancements;
+  queryResults?: QueryResultEnhancements;
 }
 
 export interface DataSetupDependencies {

--- a/src/plugins/data/public/ui/dataset_selector/configurator.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.test.tsx
@@ -1,0 +1,318 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Configurator } from './configurator';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { setQueryService, setIndexPatterns } from '../../services';
+import { IntlProvider } from 'react-intl';
+import { Query } from '../../../../data/public';
+
+const getQueryMock = jest.fn().mockReturnValue({
+  query: '',
+  language: 'lucene',
+  dataset: undefined,
+} as Query);
+
+const languageService = {
+  getDefaultLanguage: () => ({ id: 'lucene', title: 'Lucene' }),
+  getLanguages: () => [
+    { id: 'lucene', title: 'Lucene' },
+    { id: 'kuery', title: 'DQL' },
+  ],
+  getLanguage: (languageId: string) => {
+    const languages = [
+      { id: 'lucene', title: 'Lucene' },
+      { id: 'kuery', title: 'DQL' },
+    ];
+    return languages.find((lang) => lang.id === languageId);
+  },
+  setUserQueryLanguage: jest.fn(),
+};
+
+const datasetService = {
+  getType: jest.fn().mockReturnValue({
+    fetchFields: jest.fn(),
+    supportedLanguages: jest.fn().mockReturnValue(['kuery', 'lucene']),
+    indexedViewsService: {
+      getIndexedViews: jest.fn().mockResolvedValue([
+        { name: 'view1', type: 'type1' },
+        { name: 'view2', type: 'type2' },
+      ]),
+    },
+  }),
+  addRecentDataset: jest.fn(),
+};
+
+const fetchFieldsMock = jest.fn().mockResolvedValue([]);
+
+const mockServices = {
+  getQueryService: () => ({
+    queryString: {
+      getQuery: getQueryMock,
+      getLanguageService: () => languageService,
+      getDatasetService: () => datasetService,
+      fetchFields: fetchFieldsMock,
+      getUpdates$: jest.fn().mockReturnValue({
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      }),
+    },
+  }),
+  getIndexPatterns: jest.fn().mockResolvedValue([
+    {
+      id: 'indexPattern1',
+      attributes: {
+        title: 'indexPattern1',
+      },
+    },
+    {
+      id: 'indexPattern2',
+      attributes: {
+        title: 'indexPattern2',
+      },
+    },
+  ]),
+};
+
+const mockBaseDataset = {
+  title: 'Sample Dataset',
+  type: 'index-pattern',
+  timeFieldName: 'timestamp',
+  dataSource: { meta: { supportsTimeFilter: true } },
+};
+
+const messages = {
+  'app.welcome': 'Welcome to our application!',
+  'app.logout': 'Log Out',
+};
+
+const mockOnConfirm = jest.fn();
+const mockOnCancel = jest.fn();
+const mockOnPrevious = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setQueryService(mockServices.getQueryService());
+  setIndexPatterns(mockServices.getIndexPatterns());
+});
+
+describe('Configurator Component', () => {
+  it('should render the component with the correct title and description', () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        {/* Wrap with IntlProvider */}
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    expect(screen.getByText('Step 2: Configure data')).toBeInTheDocument();
+    expect(
+      screen.getByText('Configure selected data based on parameters available.')
+    ).toBeInTheDocument();
+  });
+
+  it('should call onCancel when cancel button is clicked', () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onPrevious when previous button is clicked', () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    fireEvent.click(screen.getByText('Back'));
+
+    expect(mockOnPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable the submit button when conditions are not met', async () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    const submitButton = screen.getByTestId('advancedSelectorConfirmButton');
+    expect(submitButton).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Time field'), {
+      target: { value: 'valid-time-field' },
+    });
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+  });
+
+  it('should update state correctly when language is selected', async () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+    const languageSelect = screen.getByText('Lucene');
+    expect(languageSelect).toBeInTheDocument();
+    expect(languageSelect.value).toBe('lucene');
+    fireEvent.change(languageSelect, { target: { value: 'kuery' } });
+    await waitFor(() => {
+      expect(languageSelect.value).toBe('kuery');
+    });
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('should fetch indexed views on mount and display them', async () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        mockServices.getQueryService().queryString.getDatasetService().getType().indexedViewsService
+          .getIndexedViews
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('view1')).toBeInTheDocument();
+      expect(screen.getByText('view2')).toBeInTheDocument();
+    });
+  });
+
+  it('should initialize selectedLanguage with the current language from queryString', async () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lucene')).toBeInTheDocument();
+    });
+  });
+
+  it('should default selectedLanguage to the first language if currentLanguage is not supported', async () => {
+    mockServices.getQueryService().queryString.getQuery.mockReturnValue({ language: 'de' });
+
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lucene')).toBeInTheDocument(); // Should default to 'Lucene'
+    });
+  });
+
+  it('should display the supported language dropdown correctly', async () => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lucene')).toBeInTheDocument();
+      expect(screen.getByText('DQL')).toBeInTheDocument();
+    });
+  });
+
+  it('should disable the confirm button when submit is disabled', async () => {
+    const mockIndexedViewsService = {
+      getIndexedViews: jest.fn().mockResolvedValue([]),
+    };
+
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockBaseDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    const submitButton = screen.getByRole('button', { name: /select data/i });
+
+    expect(submitButton).toBeDisabled();
+
+    const languageSelect = screen.getByLabelText('Language');
+    fireEvent.change(languageSelect, { target: { value: 'kuery' } });
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+
+    const timeFieldSelect = screen.getByLabelText('Time field');
+    fireEvent.change(timeFieldSelect, { target: { value: 'timestamp' } });
+
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+  });
+});

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -82,7 +82,8 @@ export const DatasetSelector = ({
   const { overlays } = services;
   const datasetService = getQueryService().queryString.getDatasetService();
   const datasetIcon =
-    datasetService.getType(selectedDataset?.type || '')?.meta.icon.type || 'database';
+    datasetService.getType(selectedDataset?.ref?.type || selectedDataset?.type || '')?.meta.icon
+    .type || 'database';
 
   useEffect(() => {
     isMounted.current = true;

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { EuiPanel, EuiSpacer } from '@elastic/eui';
+import { EuiCallOut, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { TopNav } from './top_nav';
 import { ViewProps } from '../../../../../data_explorer/public';
 import { DiscoverTable } from './discover_table';
@@ -28,6 +28,7 @@ import { OpenSearchSearchHit } from '../../../application/doc_views/doc_views_ty
 import { buildColumns } from '../../utils/columns';
 import './discover_canvas.scss';
 import { HeaderVariant } from '../../../../../../core/public';
+import { CanvasBannerProps } from '../../../../../data/common';
 
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalRef }: ViewProps) {
@@ -41,6 +42,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
       data,
     },
   } = useOpenSearchDashboards<DiscoverViewServices>();
+  const [canvasBanner, setCanvasBanner] = useState<React.ReactNode>(null);
   const { columns } = useSelector((state) => {
     const stateColumns = state.discover.columns;
 
@@ -50,10 +52,11 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
     };
   });
   const isEnhancementsEnabled = uiSettings.get(QUERY_ENHANCEMENT_ENABLED_SETTING);
+  const defaultColumns = uiSettings.get(DEFAULT_COLUMNS_SETTING) || [];
   const filteredColumns = filterColumns(
     columns,
     indexPattern,
-    uiSettings.get(DEFAULT_COLUMNS_SETTING),
+    defaultColumns,
     uiSettings.get(MODIFY_COLUMNS_ON_SWITCH)
   );
   const dispatch = useDispatch();
@@ -123,6 +126,50 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
     }
   };
   const showSaveQuery = !!capabilities.discover?.saveQuery;
+  const query = data.query.queryString.getQuery();
+
+  const updateCanvasBanner = useCallback(
+    (bannerData: CanvasBannerProps) => {
+      switch (bannerData.componentType) {
+        case 'callout':
+          setCanvasBanner(
+            <>
+              <EuiSpacer size="s" />
+              <EuiCallOut title={bannerData.title} iconType={bannerData.iconType}>
+                {bannerData.content}
+              </EuiCallOut>
+            </>
+          );
+          break;
+        case 'custom':
+          setCanvasBanner(bannerData.content);
+          break;
+        default:
+          setCanvasBanner(null);
+      }
+    },
+    [setCanvasBanner]
+  );
+
+  useEffect(() => {
+    if (query.dataset) {
+      const typeConfig = data.query.queryString.getDatasetService().getType(query.dataset.type);
+      let bannerData;
+      if ((bannerData = typeConfig?.getSearchBannerProps?.(fetchState.status, query.dataset))) {
+        if (bannerData instanceof Promise) {
+          bannerData
+            .then((newBannerData) => updateCanvasBanner(newBannerData))
+            .catch(() => {
+              // No-op
+            });
+        } else if (bannerData) {
+          updateCanvasBanner(bannerData);
+        } else {
+          setCanvasBanner(null);
+        }
+      }
+    }
+  }, [query.dataset, data, fetchState.status, updateCanvasBanner, setCanvasBanner]);
 
   return (
     <EuiPanel
@@ -145,15 +192,9 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
 
       {indexPattern ? (
         <>
-          {fetchState.status === ResultStatus.NO_RESULTS && (
-            <DiscoverNoResults
-              queryString={data.query.queryString}
-              query={data.query.queryString.getQuery()}
-              savedQuery={data.query.savedQueries}
-              timeFieldName={timeField}
-            />
-          )}
-          {fetchState.status === ResultStatus.ERROR && (
+          {isEnhancementsEnabled && canvasBanner}
+          {(fetchState.status === ResultStatus.NO_RESULTS ||
+            fetchState.status === ResultStatus.ERROR) && (
             <DiscoverNoResults
               queryString={data.query.queryString}
               query={data.query.queryString.getQuery()}

--- a/src/plugins/discover/public/application/view_components/canvas/query_result_extensions/query_result_extension.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/query_result_extensions/query_result_extension.tsx
@@ -1,0 +1,43 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import { EuiErrorBoundary } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import ReactDOM from 'react-dom';
+import { QueryResultExtensionConfig, QueryResultExtensionDependencies } from '../../../../../../data/public/query/query_string/query_results_service';
+
+export interface QueryResultExtensionProps {
+  config: QueryResultExtensionConfig;
+  dependencies: QueryResultExtensionDependencies;
+  bannerContainer: Element;
+}
+
+const QueryResultExtensionPortal: React.FC<{ container: Element }> = (props) => {
+  if (!props.children) return null;
+
+  return ReactDOM.createPortal(
+    <EuiErrorBoundary>{props.children}</EuiErrorBoundary>,
+    props.container
+  );
+};
+
+export const QueryResultExtension = ({
+  config,
+  dependencies,
+  bannerContainer
+}: QueryResultExtensionProps) => {
+  const banner = useMemo(() => config.getBanner?.(dependencies), [
+    config,
+    dependencies,
+  ]);
+
+  return (
+    <QueryResultExtensionPortal
+      container={bannerContainer}
+    >
+      {banner}
+    </QueryResultExtensionPortal>
+  )
+}

--- a/src/plugins/discover/public/application/view_components/canvas/query_result_extensions/query_result_extensions.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/query_result_extensions/query_result_extensions.tsx
@@ -1,0 +1,41 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import React, { useMemo } from 'react';
+import { QueryResultExtensionConfig, QueryResultExtensionDependencies } from "../../../../../../data/public/query/query_string/query_results_service";
+import { QueryResultExtension } from "./query_result_extension";
+
+export interface QueryResultExtensionsProps {
+  configMap?: Record<string, QueryResultExtensionConfig>;
+  bannerContainer: Element;
+  dependencies: QueryResultExtensionDependencies
+}
+
+export const QueryResultExtensions = ({
+  bannerContainer,
+  configMap,
+  dependencies
+}: QueryResultExtensionsProps) => {
+  const sortedConfigs = useMemo(() => {
+    if (!configMap || Object.keys(configMap).length === 0) return [];
+    return Object.values(configMap).sort((a, b) => a.order - b.order);
+  }, [configMap]);
+
+  return (
+    <>
+        {Object.values(sortedConfigs).map((config) => {
+        return (
+          <QueryResultExtension 
+            config={config}
+            bannerContainer={bannerContainer}
+            dependencies={dependencies}
+            key={config.id}
+          />
+        )
+      })}
+    </>
+  )
+}
+

--- a/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
+++ b/src/plugins/discover/public/application/view_components/utils/filter_columns.ts
@@ -27,7 +27,7 @@ export function filterColumns(
     return columns.length > 0 ? columns : ['_source'];
   }
   // if true, we keep columns that exist in the new index pattern
-  const fieldsName = indexPattern?.fields.getAll().map((fld) => fld.name) || [];
+  const fieldsName = indexPattern?.fields?.getAll().map((fld) => fld.name) || [];
   // combine columns and defaultColumns without duplicates
   const combinedColumns = [...new Set([...columns, ...defaultColumns])];
   const filteredColumns = combinedColumns.filter((column) => fieldsName.includes(column));

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -127,10 +127,8 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) => {
-        const source = currentQuery.dataset?.indexedView ?? currentQuery.dataset?.title;
-        return `SELECT * FROM ${source} LIMIT 10`;
-      },
+      getQueryString: (currentQuery: Query) =>
+        `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
       fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -62,7 +62,7 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
+      getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title} | head 10`,
       fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
@@ -127,8 +127,10 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) =>
-        `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
+      getQueryString: (currentQuery: Query) => {
+        const source = currentQuery.dataset?.indexedView ?? currentQuery.dataset?.title;
+        return `SELECT * FROM ${source} LIMIT 10`;
+      },
       fields: { filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -67,7 +67,7 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       const datasetTypeConfig = this.queryService.queryString
         .getDatasetService()
         .getType(datasetType);
-      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+      strategy = datasetTypeConfig?.getSearchOptions?.(dataset).strategy ?? strategy;
     }
 
     return this.runSearch(request, options.abortSignal, strategy);

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -61,7 +61,7 @@ export class SQLSearchInterceptor extends SearchInterceptor {
       const datasetTypeConfig = this.queryService.queryString
         .getDatasetService()
         .getType(datasetType);
-      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+      strategy = datasetTypeConfig?.getSearchOptions?.(dataset).strategy ?? strategy;
     }
 
     return this.runSearch(request, options.abortSignal, strategy);

--- a/src/plugins/vis_builder/public/application/components/data_tab/field_selector.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field_selector.tsx
@@ -33,7 +33,7 @@ export const FieldSelector = () => {
   const [filteredFields, setFilteredFields] = useState<IndexPatternField[]>([]);
 
   useEffect(() => {
-    const indexFields = indexPattern?.fields.getAll() ?? [];
+    const indexFields = indexPattern?.fields?.getAll() ?? [];
     const filteredSubset = getAvailableFields(indexFields).filter((field) =>
       // case-insensitive field search
       field.displayName.toLowerCase().includes(fieldSearchValue.toLowerCase())


### PR DESCRIPTION
### Description
In this PR we add support for
1. Selecting indexed view inside dataset selector. The indexed view is an Opensearch index which can be created for an external source like S3. When user selects an indexed view, we use this index for querying the data
2. Showing a banner at the top of Discover results canvas. This banner can be used to show actions related to the selected dataset. The first use we will add for this banner would be to show a callout to create an indexed view while searching an external source, or when an indexed view is selected, we can show an entry point to select other indexed view

### Issues Resolved
New feature

## Screenshot
#### Note: Below screenshots were produced by making changes to the S3 type config for testing and are not part of this PR since this PR is only adding the framework.

- Callout for creating indexed view
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/4cd03bb7-5812-4339-85ff-bead0be907a3">

- Action from callout can open the create flyout (this is all handled by the type config provider and not in this PR's code)
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/0653d969-aca1-4601-a57d-4639fbc842ca">


- Create indexed view banner:
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/ade28ea9-afcb-4b0a-ae74-23053263adc5">


## Testing the changes
Set up workspace with query enhancements enabled
- For the banner in Discover canvas
1. [For testing only]: Update the S3 config type to return the banner props based on the fetch status
2. Discover will render the banner based on provided props

- For showing indexed views in dataset selector
1. Update the S3 config type to return implemented instance of IndexedViewsService
2. Dataset selector will show the indexed views in the second step

## Changelog
- feat: Add framework to show banner at the top in discover results canvas
- feat: Show indexed views in dataset selector

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
