### PR TITLE
[chore]upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -282,7 +282,7 @@ jobs:
           JOB: ci${{ matrix.group }}
           CACHE_DIR: ciGroup${{ matrix.group }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failure-artifacts-ci${{ matrix.group }}
@@ -393,7 +393,7 @@ jobs:
         id: plugin-ftr-tests
         run: node scripts/functional_tests.js --config test/plugin_functional/config.ts
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failure-artifacts-plugin-functional-${{ matrix.os }}
@@ -506,7 +506,7 @@ jobs:
       - name: Build `${{ matrix.name }}`
         run: yarn ${{ matrix.script }} --release
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: ${{ matrix.suffix }}-${{ env.VERSION }}
@@ -595,7 +595,7 @@ jobs:
         run: |
           ./bwctest.sh -s false -o ${{ env.OPENSEARCH_URL }} -d ${{ steps.download.outputs.download-path }}/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.verify-opensearch-exists.outputs.version-exists == 'true' }}
         with:
           name: ${{ matrix.version }}-test-failures

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -265,50 +265,50 @@ jobs:
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - name: Upload FT repo screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && matrix.test_location == 'ftr'
         with:
-          name: ftr-cypress-screenshots
+          name: ftr-cypress-screenshots-${{ matrix.group }}
           path: ${{ env.FTR_PATH }}/cypress/screenshots
           retention-days: 1
 
       - name: Upload FT repo videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && matrix.test_location == 'ftr'
         with:
-          name: ftr-cypress-videos
+          name: ftr-cypress-videos-${{ matrix.group }}
           path: ${{ env.FTR_PATH }}/cypress/videos
           retention-days: 1
 
       - name: Upload FT repo results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && matrix.test_location == 'ftr'
         with:
-          name: ftr-cypress-results
+          name: ftr-cypress-results-${{ matrix.group }}
           path: ${{ env.FTR_PATH }}/cypress/results
           retention-days: 1
 
       - name: Upload Dashboards screenshots
         if: failure() && matrix.test_location == 'source'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dashboards-cypress-screenshots
+          name: dashboards-cypress-screenshots-${{ matrix.group }}
           path: cypress/screenshots
           retention-days: 1
 
       - name: Upload Dashboards repo videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && matrix.test_location == 'source'
         with:
-          name: dashboards-cypress-videos
+          name: dashboards-cypress-videos-${{ matrix.group }}
           path: cypress/videos
           retention-days: 1
 
       - name: Upload Dashboards repo results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && matrix.test_location == 'source'
         with:
-          name: dashboards-cypress-results
+          name: dashboards-cypress-results-${{ matrix.group }}
           path: cypress/results
           retention-days: 1
 
@@ -346,6 +346,6 @@ jobs:
             '${{ env.SPEC }}'
             ```
 
-            #### Link to results: 
+            #### Link to results:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           edit-mode: replace

--- a/.github/workflows/release_cypress_workflow.yml
+++ b/.github/workflows/release_cypress_workflow.yml
@@ -72,7 +72,7 @@ jobs:
       CI: 1
       # avoid warnings like "tput: No value for $TERM and no -T specified"
       TERM: xterm
-    name: Run cypress tests (osd:ciGroup${{ matrix.spec_group }}) ${{ inputs.UNIQUE_ID}} 
+    name: Run cypress tests (osd:ciGroup${{ matrix.spec_group }}) ${{ inputs.UNIQUE_ID}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -130,7 +130,7 @@ jobs:
           mkdir -p $CWD/${{ env.OPENSEARCH_DIR }}
           source ${{ env.OSD_PATH }}/scripts/common/utils.sh
           open_artifact $CWD/${{ env.OPENSEARCH_DIR }} ${{ env.OPENSEARCH }}
-      
+
       - name: Download and extract OpenSearch Dashboards artifacts
         run: |
           CWD=$(pwd)
@@ -138,22 +138,22 @@ jobs:
           source ${{ env.OSD_PATH }}/scripts/common/utils.sh
           open_artifact $CWD/${{ env.DASHBOARDS_DIR }} ${{ env.DASHBOARDS }}
 
-      - name: Run Cypress tests 
+      - name: Run Cypress tests
         run: |
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "source ${{ env.OSD_PATH }}/scripts/cypress_tests.sh && run_dashboards_cypress_tests"
 
       # Screenshots are only captured on failures
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: release-osd-cypress-screenshots
+          name: release-osd-cypress-screenshots-${{ matrix.spec_group }}
           path: ${{ env.OSD_PATH }}/cypress/screenshots
           retention-days: 1
-      
-      - uses: actions/upload-artifact@v3
+
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: release-osd-cypress-videos
+          name: release-osd-cypress-videos-${{ matrix.spec_group }}
           path: ${{ env.OSD_PATH }}/cypress/videos
           retention-days: 1

--- a/changelogs/fragments/8855.yml
+++ b/changelogs/fragments/8855.yml
@@ -1,0 +1,2 @@
+fix:
+- Upgrade actions/upload-artifact to v4 ([#8855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8855))


### PR DESCRIPTION
### Description

actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024, upgrade it to v4.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8823

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: upgrade actions/upload-artifact to v4

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
