### PR TITLE
Keep previous query result if current query result in error

### DIFF
--- a/changelogs/fragments/8861.yml
+++ b/changelogs/fragments/8861.yml
@@ -1,0 +1,2 @@
+fix:
+- Keep previous query result if current query result in error ([#8861](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8861))

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -153,22 +153,17 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
               timeFieldName={timeField}
             />
           )}
-          {fetchState.status === ResultStatus.ERROR && (
-            <>
-              <MemoizedDiscoverChartContainer {...fetchState} />
-              <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
-            </>
-          )}
           {fetchState.status === ResultStatus.UNINITIALIZED && (
             <DiscoverUninitialized onRefresh={() => refetch$.next()} />
           )}
           {fetchState.status === ResultStatus.LOADING && <LoadingSpinner />}
-          {fetchState.status === ResultStatus.READY && isEnhancementsEnabled && (
-            <>
-              <MemoizedDiscoverChartContainer {...fetchState} />
-              <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
-            </>
-          )}
+          {(fetchState.status === ResultStatus.READY || fetchState.status === ResultStatus.ERROR) &&
+            isEnhancementsEnabled && (
+              <>
+                <MemoizedDiscoverChartContainer {...fetchState} />
+                <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
+              </>
+            )}
           {fetchState.status === ResultStatus.READY && !isEnhancementsEnabled && (
             <EuiPanel hasShadow={false} paddingSize="none" className="dscCanvas_results">
               <MemoizedDiscoverChartContainer {...fetchState} />

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -154,12 +154,10 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
             />
           )}
           {fetchState.status === ResultStatus.ERROR && (
-            <DiscoverNoResults
-              queryString={data.query.queryString}
-              query={data.query.queryString.getQuery()}
-              savedQuery={data.query.savedQueries}
-              timeFieldName={timeField}
-            />
+            <>
+              <MemoizedDiscoverChartContainer {...fetchState} />
+              <MemoizedDiscoverTable rows={rows} scrollToTop={scrollToTop} />
+            </>
           )}
           {fetchState.status === ResultStatus.UNINITIALIZED && (
             <DiscoverUninitialized onRefresh={() => refetch$.next()} />


### PR DESCRIPTION
### Description

Currently, an error query will display no result. 
This PR change to keep previous query result if current query result in error.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Keep previous query result if current query result in error

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
