### PR TITLE
Keep previous query result if current query result in error

### DIFF
--- a/changelogs/fragments/8863.yml
+++ b/changelogs/fragments/8863.yml
@@ -1,0 +1,2 @@
+fix:
+- Keep previous query result if current query result in error ([#8863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8863))

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -85,7 +85,12 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
         shouldUpdateState = true;
       if (next.chartData && next.chartData !== fetchState.chartData) shouldUpdateState = true;
       // we still want to show rows from the previous query while current query is loading
-      if (next.status !== ResultStatus.LOADING && next.rows && next.rows !== fetchState.rows) {
+      if (
+        next.status !== ResultStatus.LOADING &&
+        next.status !== ResultStatus.ERROR &&
+        next.rows &&
+        next.rows !== fetchState.rows
+      ) {
         shouldUpdateState = true;
         setRows(next.rows);
       }
@@ -152,20 +157,13 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
               timeFieldName={timeField}
             />
           )}
-          {fetchState.status === ResultStatus.ERROR && (
-            <DiscoverNoResults
-              queryString={data.query.queryString}
-              query={data.query.queryString.getQuery()}
-              savedQuery={data.query.savedQueries}
-              timeFieldName={timeField}
-            />
-          )}
           {fetchState.status === ResultStatus.UNINITIALIZED && (
             <DiscoverUninitialized onRefresh={() => refetch$.next()} />
           )}
           {fetchState.status === ResultStatus.LOADING && !rows?.length && <LoadingSpinner />}
           {(fetchState.status === ResultStatus.READY ||
-            (fetchState.status === ResultStatus.LOADING && !!rows?.length)) &&
+            (fetchState.status === ResultStatus.LOADING && !!rows?.length) ||
+            fetchState.status === ResultStatus.ERROR) &&
             (isEnhancementsEnabled ? (
               <>
                 <MemoizedDiscoverChartContainer {...fetchState} />

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -84,7 +84,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
       if (next.bucketInterval && next.bucketInterval !== fetchState.bucketInterval)
         shouldUpdateState = true;
       if (next.chartData && next.chartData !== fetchState.chartData) shouldUpdateState = true;
-      // we still want to show rows from the previous query while current query is loading
+      // we still want to show rows from the previous query while current query is loading or the current query results in error
       if (
         next.status !== ResultStatus.LOADING &&
         next.status !== ResultStatus.ERROR &&

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -161,9 +161,12 @@ export default function DiscoverCanvas({ setHeaderActionMenu, history, optionalR
             <DiscoverUninitialized onRefresh={() => refetch$.next()} />
           )}
           {fetchState.status === ResultStatus.LOADING && !rows?.length && <LoadingSpinner />}
+          {fetchState.status === ResultStatus.ERROR && !rows?.length && (
+            <DiscoverUninitialized onRefresh={() => refetch$.next()} />
+          )}
           {(fetchState.status === ResultStatus.READY ||
             (fetchState.status === ResultStatus.LOADING && !!rows?.length) ||
-            fetchState.status === ResultStatus.ERROR) &&
+            (fetchState.status === ResultStatus.ERROR && !!rows?.length)) &&
             (isEnhancementsEnabled ? (
               <>
                 <MemoizedDiscoverChartContainer {...fetchState} />


### PR DESCRIPTION
### Description

Currently, an error query will display no result.
This PR change to keep previous query result if current query result in error.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

If the query result in error, it will keep the previous query result without updating the canvas
https://github.com/user-attachments/assets/f72b8a74-ad71-4261-8493-fc5e3b24a74b

If the first query result in error, it will show the refresh data screen. 


https://github.com/user-attachments/assets/3bb6aa48-5707-4ba3-8044-954b02d41d79


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Keep previous query result if current query result in error

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
