### PR TITLE
[Discover] Hide Date Picker For Unsupported Types

### DIFF
--- a/changelogs/fragments/8866.yml
+++ b/changelogs/fragments/8866.yml
@@ -1,0 +1,2 @@
+fix:
+- Hide Date Picker for Unsupported Types ([#8866](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8866))

--- a/src/plugins/data/public/query/query_string/language_service/language_service.mock.ts
+++ b/src/plugins/data/public/query/query_string/language_service/language_service.mock.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createEditor, DQLBody, SingleLineInput } from '../../../ui';
 import { LanguageServiceContract } from './language_service';
 import { LanguageConfig } from './types';
 
@@ -14,7 +15,7 @@ const createSetupLanguageServiceMock = (): jest.Mocked<LanguageServiceContract> 
     title: 'DQL',
     search: {} as any,
     getQueryString: jest.fn(),
-    editor: {} as any,
+    editor: createEditor(SingleLineInput, SingleLineInput, [], DQLBody),
     fields: {
       filterable: true,
       visualizable: true,
@@ -28,7 +29,7 @@ const createSetupLanguageServiceMock = (): jest.Mocked<LanguageServiceContract> 
     title: 'Lucene',
     search: {} as any,
     getQueryString: jest.fn(),
-    editor: {} as any,
+    editor: createEditor(SingleLineInput, SingleLineInput, [], DQLBody),
     fields: {
       filterable: true,
       visualizable: true,
@@ -42,7 +43,9 @@ const createSetupLanguageServiceMock = (): jest.Mocked<LanguageServiceContract> 
 
   return {
     __enhance: jest.fn(),
-    registerLanguage: jest.fn(),
+    registerLanguage: jest.fn((language: LanguageConfig) => {
+      languages.set(language.id, language);
+    }),
     getLanguage: jest.fn((id: string) => languages.get(id)),
     getLanguages: jest.fn(() => Array.from(languages.values())),
     getDefaultLanguage: jest.fn(() => languages.get('kuery') || languages.values().next().value),

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Query, UI_SETTINGS } from '../../../common';
+import { coreMock } from '../../../../../core/public/mocks';
+import { dataPluginMock } from '../../mocks';
+import React from 'react';
+import { I18nProvider } from '@osd/i18n/react';
+import { createEditor, DQLBody, QueryEditorTopRow, SingleLineInput } from '../';
+import { OpenSearchDashboardsContextProvider } from 'src/plugins/opensearch_dashboards_react/public';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { LanguageConfig } from '../../query';
+import { getQueryService } from '../../services';
+
+const startMock = coreMock.createStart();
+
+jest.mock('../../services', () => ({
+  getQueryService: jest.fn(),
+}));
+
+startMock.uiSettings.get.mockImplementation((key: string) => {
+  switch (key) {
+    case UI_SETTINGS.TIMEPICKER_QUICK_RANGES:
+      return [
+        {
+          from: 'now/d',
+          to: 'now/d',
+          display: 'Today',
+        },
+      ];
+    case 'dateFormat':
+      return 'MMM D, YYYY @ HH:mm:ss.SSS';
+    case UI_SETTINGS.HISTORY_LIMIT:
+      return 10;
+    case UI_SETTINGS.TIMEPICKER_TIME_DEFAULTS:
+      return {
+        from: 'now-15m',
+        to: 'now',
+      };
+    case UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED:
+      return true;
+    case 'theme:darkMode':
+      return true;
+    default:
+      throw new Error(`Unexpected config key: ${key}`);
+  }
+});
+
+const createMockWebStorage = () => ({
+  clear: jest.fn(),
+  getItem: jest.fn(),
+  key: jest.fn(),
+  removeItem: jest.fn(),
+  setItem: jest.fn(),
+  length: 0,
+});
+
+const createMockStorage = () => ({
+  storage: createMockWebStorage(),
+  get: jest.fn(),
+  set: jest.fn(),
+  remove: jest.fn(),
+  clear: jest.fn(),
+});
+
+const dataPlugin = dataPluginMock.createStartContract(true);
+
+function wrapQueryEditorTopRowInContext(testProps: any) {
+  const defaultOptions = {
+    onSubmit: jest.fn(),
+    onChange: jest.fn(),
+    isDirty: true,
+    screenTitle: 'Another Screen',
+  };
+
+  const mockLanguage: LanguageConfig = {
+    id: 'test-language',
+    title: 'Test Language',
+    search: {} as any,
+    getQueryString: jest.fn(),
+    editor: createEditor(SingleLineInput, SingleLineInput, [], DQLBody),
+    fields: {},
+    showDocLinks: true,
+    editorSupportedAppNames: ['discover'],
+    hideDatePicker: true,
+  };
+  dataPlugin.query.queryString.getLanguageService().registerLanguage(mockLanguage);
+
+  const services = {
+    ...startMock,
+    data: dataPlugin,
+    appName: 'discover',
+    storage: createMockStorage(),
+  };
+
+  return (
+    <I18nProvider>
+      <OpenSearchDashboardsContextProvider services={services}>
+        <QueryEditorTopRow {...defaultOptions} {...testProps} />
+      </OpenSearchDashboardsContextProvider>
+    </I18nProvider>
+  );
+}
+
+describe('QueryEditorTopRow', () => {
+  const QUERY_EDITOR = '.osdQueryEditor';
+  const DATE_PICKER = '.osdQueryEditor__datePickerWrapper';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getQueryService as jest.Mock).mockReturnValue(dataPlugin.query);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.resetModules();
+  });
+
+  it('Should render query editor', async () => {
+    const { container } = render(
+      wrapQueryEditorTopRowInContext({
+        showQueryEditor: true,
+      })
+    );
+    await waitFor(() => expect(container.querySelector(QUERY_EDITOR)).toBeTruthy());
+    expect(container.querySelector(DATE_PICKER)).toBeTruthy();
+  });
+
+  it('Should not render date picker if showDatePicker is false', async () => {
+    const { container } = render(
+      wrapQueryEditorTopRowInContext({
+        showQueryEditor: true,
+        showDatePicker: false,
+      })
+    );
+    await waitFor(() => expect(container.querySelector(QUERY_EDITOR)).toBeTruthy());
+    expect(container.querySelector(DATE_PICKER)).toBeFalsy();
+  });
+
+  it('Should not render date picker if language does not support time field', async () => {
+    const query: Query = {
+      query: 'test query',
+      language: 'test-language',
+    };
+    dataPlugin.query.queryString.getQuery = jest.fn().mockReturnValue(query);
+    const { container } = render(
+      wrapQueryEditorTopRowInContext({
+        query,
+        showQueryEditor: false,
+        showDatePicker: true,
+      })
+    );
+    await waitFor(() => expect(container.querySelector(QUERY_EDITOR)).toBeTruthy());
+    expect(container.querySelector(DATE_PICKER)).toBeFalsy();
+  });
+});

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -72,7 +72,7 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
   const [isDateRangeInvalid, setIsDateRangeInvalid] = useState(false);
   const [isQueryEditorFocused, setIsQueryEditorFocused] = useState(false);
   const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
-  const { uiSettings, storage, appName } = opensearchDashboards.services;
+  const { uiSettings, storage, appName, data } = opensearchDashboards.services;
 
   const queryLanguage = props.query && props.query.language;
   const persistedLog: PersistedLog | undefined = React.useMemo(
@@ -225,7 +225,17 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
   }
 
   function shouldRenderDatePicker(): boolean {
-    return Boolean(props.showDatePicker ?? true) ?? (props.showAutoRefreshOnly && true);
+    return (
+      Boolean(props.showDatePicker ?? true) &&
+      !(
+        queryLanguage &&
+        data.query.queryString.getLanguageService().getLanguage(queryLanguage)?.hideDatePicker
+      ) &&
+      (props.query?.dataset
+        ? data.query.queryString.getDatasetService().getType(props.query.dataset.type)?.meta
+            ?.supportsTimeFilter !== false
+        : true)
+    );
   }
 
   function shouldRenderQueryEditor(): boolean {

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -226,7 +226,7 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
 
   function shouldRenderDatePicker(): boolean {
     return (
-      Boolean(props.showDatePicker ?? true) &&
+      Boolean((props.showDatePicker || props.showAutoRefreshOnly) ?? true) &&
       !(
         queryLanguage &&
         data.query.queryString.getLanguageService().getLanguage(queryLanguage)?.hideDatePicker


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Hides date picker in situations where it is unsupported (when using languages/dataset types that explicitly say that it's not supported)

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/b33de83b-cfda-4016-9616-766ffc285df1


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Hide Date Picker for Unsupported Types

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
