### PR TITLE
[Discover] Add max height and scroll to error message body

### DIFF
--- a/changelogs/fragments/8867.yml
+++ b/changelogs/fragments/8867.yml
@@ -1,0 +1,2 @@
+fix:
+- Add max height and scroll to error message body ([#8867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8867))

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -37,6 +37,8 @@ exports[`Query Result show error status with error message 2`] = `
     className="eui-textBreakWord"
     style={
       Object {
+        "maxHeight": "250px",
+        "overflowY": "auto",
         "width": "250px",
       }
     }

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -143,7 +143,14 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       data-test-subj="queryResultError"
     >
       <EuiPopoverTitle>ERRORS</EuiPopoverTitle>
-      <div style={{ width: '250px' }} className="eui-textBreakWord">
+      <div
+        style={{
+          width: '250px',
+          maxHeight: '250px',
+          overflowY: 'auto',
+        }}
+        className="eui-textBreakWord"
+      >
         <EuiText size="s">
           <p>
             <strong>

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -144,11 +144,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     >
       <EuiPopoverTitle>ERRORS</EuiPopoverTitle>
       <div
-        style={{
-          width: '250px',
-          maxHeight: '250px',
-          overflowY: 'auto',
-        }}
+        style={{ width: '250px', maxHeight: '250px', overflowY: 'auto' }}
         className="eui-textBreakWord"
       >
         <EuiText size="s">


### PR DESCRIPTION
### Description
If an error message is too long, the message body overflows. PR adds a max height and a scroll wheel to error message body.

https://github.com/user-attachments/assets/aed34dec-aee7-41f4-bba0-a1c2f474b0ba

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Add max height and scroll to error message body

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
