### PR TITLE
Fix SurroundingDocsView with URI encoded chars in document id

### DIFF
--- a/src/plugins/discover/public/application/components/doc_views/surrounding_docs_app.tsx
+++ b/src/plugins/discover/public/application/components/doc_views/surrounding_docs_app.tsx
@@ -52,7 +52,7 @@ export function SurroundingDocsApp() {
         text: i18n.translate('discover.context.breadcrumb', {
           defaultMessage: `Context of #{docId}`,
           values: {
-            docId: id,
+            docId: decodeURIComponent(id),
           },
         }),
       },
@@ -66,5 +66,5 @@ export function SurroundingDocsApp() {
   if (!indexPattern) {
     return <div>Index pattern loading</div>;
   }
-  return <SurroundingDocsView id={id} indexPattern={indexPattern} />;
+  return <SurroundingDocsView id={decodeURIComponent(id)} indexPattern={indexPattern} />;
 }


### PR DESCRIPTION
When viewing surrounding documents of a document which id contains chars
such as `@` or `+`, these chars are encoded, preventing OpenSearch from
finding the requested document.

Decode the id to transform back the URI encoded chars to the actual
chars in the document id to find it and unbreak the feature.

Fixes #5711

Signed-off-by: Romain Tartière <romain@blogreen.org>

## Changelog

- skip