### PR TITLE
[Discover] Dataset search on page load issues

### DIFF
--- a/changelogs/fragments/8871.yml
+++ b/changelogs/fragments/8871.yml
@@ -1,0 +1,2 @@
+fix:
+- Search on page load out of sync state when clicking submit. ([#8871](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8871))

--- a/src/plugins/discover/public/application/view_components/utils/use_search.test.tsx
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.test.tsx
@@ -110,6 +110,48 @@ describe('useSearch', () => {
     });
   });
 
+  it('should initialize with uninitialized state when dataset type config search on page load is disabled', async () => {
+    const services = createMockServices();
+    (services.uiSettings.get as jest.Mock).mockReturnValueOnce(true);
+    (services.data.query.queryString.getDatasetService as jest.Mock).mockReturnValue({
+      meta: { searchOnLoad: false },
+    });
+    (services.data.query.timefilter.timefilter.getRefreshInterval as jest.Mock).mockReturnValue({
+      pause: true,
+      value: 10,
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() => useSearch(services), { wrapper });
+    expect(result.current.data$.getValue()).toEqual(
+      expect.objectContaining({ status: ResultStatus.UNINITIALIZED })
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+  });
+
+  it('should initialize with uninitialized state when dataset type config search on page load is enabled but the UI setting is disabled', async () => {
+    const services = createMockServices();
+    (services.uiSettings.get as jest.Mock).mockReturnValueOnce(false);
+    (services.data.query.queryString.getDatasetService as jest.Mock).mockReturnValue({
+      meta: { searchOnLoad: true },
+    });
+    (services.data.query.timefilter.timefilter.getRefreshInterval as jest.Mock).mockReturnValue({
+      pause: true,
+      value: 10,
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() => useSearch(services), { wrapper });
+    expect(result.current.data$.getValue()).toEqual(
+      expect.objectContaining({ status: ResultStatus.UNINITIALIZED })
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+  });
+
   it('should update startTime when hook rerenders', async () => {
     const services = createMockServices();
 

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -127,11 +127,11 @@ export const useSearch = (services: DiscoverViewServices) => {
     // previously saved search or if it is just transient
     return (
       datasetPreference ||
-      services.uiSettings.get(SEARCH_ON_PAGE_LOAD_SETTING) ||
+      uiSettings.get(SEARCH_ON_PAGE_LOAD_SETTING) ||
       savedSearch?.id !== undefined ||
       timefilter.getRefreshInterval().pause === false
     );
-  }, [data.query, savedSearch?.id, services.uiSettings, timefilter, uiSettings]);
+  }, [data.query, savedSearch, uiSettings, timefilter]);
 
   const startTime = Date.now();
   const data$ = useMemo(

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -345,9 +345,6 @@ export const useSearch = (services: DiscoverViewServices) => {
   ]);
 
   useEffect(() => {
-    if (!getDatasetAutoSearchOnPageLoadPreference()) {
-      skipInitialFetch.current = true;
-    }
     const fetch$ = merge(
       refetch$,
       filterManager.getFetches$(),
@@ -378,8 +375,6 @@ export const useSearch = (services: DiscoverViewServices) => {
     return () => {
       subscription.unsubscribe();
     };
-    // disabling the eslint since we are not adding getDatasetAutoSearchOnPageLoadPreference since this changes when dataset changes and these chnages are already part of data.query.queryString
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     data$,
     data.query.queryString,


### PR DESCRIPTION
### Description

Required a double click on search and then also potentially loading issue.

### Issues Resolved

n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

Unit tests. Also was able to recreate the bug. Switch the index pattern type config to not search on page load then switch off settings. I was able to run into the bug that required me to click twice to actually get results

## Changelog

- fix: Search on page load out of sync state when clicking submit.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
