### PR TITLE
Remove filter out serverless cluster and add support to extract index name

### DIFF
--- a/changelogs/fragments/8872.yml
+++ b/changelogs/fragments/8872.yml
@@ -1,0 +1,2 @@
+fix:
+- Remove filter out serverless cluster and add support to extract index name ([#8872](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8872))

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -16,6 +16,8 @@ import { DatasetTypeConfig } from '../types';
 import { getSearchService, getIndexPatterns } from '../../../../services';
 import { injectMetaToDataStructures } from './utils';
 
+export const DELIMITER = '::';
+
 export const indexTypeConfig: DatasetTypeConfig = {
   id: DEFAULT_DATA.SET_TYPES.INDEX,
   title: 'Indexes',
@@ -158,13 +160,10 @@ const fetchIndices = async (dataStructure: DataStructure): Promise<string[]> => 
 
     return rawResponse.aggregations.indices.buckets.map((bucket: { key: string }) => {
       const key = bucket.key;
-      // Handle the case of serverless cluster where key format is either:
-      // - datasource-id::TIMESERIES::<index-name>:0
-      // - datasource-id::<index-name>:0
       // Note: Index names cannot contain ':' or '::' in OpenSearch, so these delimiters
-      // are guaranteed to be part of the serverless format, not the index name
-      const parts = key.split('::');
-      const lastPart = parts[parts.length - 1] || '';
+      // are guaranteed not to be part of the regular format of index name
+      const parts = key.split(DELIMITER);
+      const lastPart = parts[parts.length - 1] || key;
       // extract index name or return original key if pattern doesn't match
       return lastPart.split(':')[0] || key;
     });

--- a/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
@@ -141,9 +141,7 @@ describe('s3TypeConfig', () => {
 
     it('should fetch data sources for unknown type', async () => {
       mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
-        savedObjects: [
-          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '3.0' } },
-        ],
+        savedObjects: [{ id: 'ds1', attributes: { title: 'DataSource 1' } }],
       });
 
       const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
@@ -152,33 +150,6 @@ describe('s3TypeConfig', () => {
 
       expect(result.children).toHaveLength(1);
       expect(result.children?.[0].title).toBe('DataSource 1');
-      expect(result.hasNext).toBe(true);
-    });
-
-    it('should filter out data sources with versions lower than 1.0.0', async () => {
-      mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
-        savedObjects: [
-          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '1.0' } },
-          {
-            id: 'ds2',
-            attributes: { title: 'DataSource 2', dataSourceVersion: '' },
-          },
-          { id: 'ds3', attributes: { title: 'DataSource 3', dataSourceVersion: '2.17.0' } },
-          {
-            id: 'ds4',
-            attributes: { title: 'DataSource 4', dataSourceVersion: '.0' },
-          },
-        ],
-      });
-
-      const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
-        { id: 'unknown', title: 'Unknown', type: 'UNKNOWN' },
-      ]);
-
-      expect(result.children).toHaveLength(2);
-      expect(result.children?.[0].title).toBe('DataSource 1');
-      expect(result.children?.[1].title).toBe('DataSource 3');
-      expect(result.children?.some((child) => child.title === 'DataSource 2')).toBe(false);
       expect(result.hasNext).toBe(true);
     });
   });

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -6,7 +6,6 @@
 import { i18n } from '@osd/i18n';
 import { trimEnd } from 'lodash';
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
-import semver from 'semver';
 import {
   DATA_STRUCTURE_META_TYPES,
   DEFAULT_DATA,
@@ -198,22 +197,17 @@ const fetchDataSources = async (client: SavedObjectsClientContract): Promise<Dat
     type: 'data-source',
     perPage: 10000,
   });
-  const dataSources: DataStructure[] = resp.savedObjects
-    .filter((savedObject) => {
-      const coercedVersion = semver.coerce(savedObject.attributes.dataSourceVersion);
-      return coercedVersion ? semver.satisfies(coercedVersion, '>=1.0.0') : false;
-    })
-    .map((savedObject) => ({
-      id: savedObject.id,
-      title: savedObject.attributes.title,
-      type: 'DATA_SOURCE',
-      meta: {
-        query: {
-          id: savedObject.id,
-        },
-        type: DATA_STRUCTURE_META_TYPES.CUSTOM,
-      } as DataStructureCustomMeta,
-    }));
+  const dataSources: DataStructure[] = resp.savedObjects.map((savedObject) => ({
+    id: savedObject.id,
+    title: savedObject.attributes.title,
+    type: 'DATA_SOURCE',
+    meta: {
+      query: {
+        id: savedObject.id,
+      },
+      type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+    } as DataStructureCustomMeta,
+  }));
   return dataSources;
 };
 


### PR DESCRIPTION
### Description
Allow extract index name for both serverless and non-serverless clusters Allow different key formats:
- datasource-id::TIMESERIES::<index-name>:0
- datasource-id::<index-name>:0
- <index-name> (non-serverless case)

### Issues Resolved
NA

## Screenshot
https://github.com/user-attachments/assets/127b851c-23db-4d65-9751-63b307332b3c

## Testing the changes
NA 

## Changelog
- fix: Remove filter out serverless cluster and add support to extract index name


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
