### PR TITLE
[Query enhancements] use status 503 if search strategy throws 500

### DIFF
--- a/src/plugins/query_enhancements/server/routes/index.test.ts
+++ b/src/plugins/query_enhancements/server/routes/index.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coerceStatusCode } from '.';
+
+describe('coerceStatusCode', () => {
+  it('should return 503 when input is 500', () => {
+    expect(coerceStatusCode(500)).toBe(503);
+  });
+
+  it('should return the input status code when it is not 500', () => {
+    expect(coerceStatusCode(404)).toBe(404);
+  });
+
+  it('should return 503 when input is undefined or null', () => {
+    expect(coerceStatusCode((undefined as unknown) as number)).toBe(503);
+    expect(coerceStatusCode((null as unknown) as number)).toBe(503);
+  });
+});

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -91,8 +91,9 @@ export function defineSearchStrategyRouteProvider(logger: Logger, router: IRoute
           } catch (e) {
             error = err;
           }
+          const statusCode = error.status || err.status;
           return res.custom({
-            statusCode: error.status || err.status,
+            statusCode: statusCode === 500 ? 503 : statusCode || 503,
             body: err.message,
           });
         }

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -17,6 +17,15 @@ import { registerQueryAssistRoutes } from './query_assist';
 import { registerDataSourceConnectionsRoutes } from './data_source_connection';
 
 /**
+ * Coerce status code to 503 for 500 errors from dependency services. Only use
+ * this function to handle errors throw by other services, and not from OSD.
+ */
+export const coerceStatusCode = (statusCode: number) => {
+  if (statusCode === 500) return 503;
+  return statusCode || 503;
+};
+
+/**
  * @experimental
  *
  * This method creates a function that will setup the routes for a search strategy by encapsulating the
@@ -91,9 +100,8 @@ export function defineSearchStrategyRouteProvider(logger: Logger, router: IRoute
           } catch (e) {
             error = err;
           }
-          const statusCode = error.status || err.status;
           return res.custom({
-            statusCode: statusCode === 500 ? 503 : statusCode || 503,
+            statusCode: coerceStatusCode(error.status || err.status),
             body: err.message,
           });
         }


### PR DESCRIPTION
### Description

use status 503 if search strategy throws 500 to indicate downstream service failure

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

when opensearch is down, send a request to enhancements api:
before
```sh
❯ curl -X POST 'http://localhost:5601/api/enhancements/search/sql' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -d '{"query":{ "query": "b", "language": "language", "format": "format" }}'
{"statusCode":500,"error":"Internal Server Error","message":"An internal server error occurred."}%
```
after
```sh
❯ curl -X POST 'http://localhost:5601/api/enhancements/search/sql' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -d '{"query":{ "query": "b", "language": "language", "format": "format" }}'
{"statusCode":503,"error":"Service Unavailable","message":"Error: No Living connections"}%
```

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
