### PR TITLE
Remove DQL telemetry endpoint call from QueryStringInput component

### DIFF
--- a/changelogs/fragments/8878.yml
+++ b/changelogs/fragments/8878.yml
@@ -1,0 +1,2 @@
+fix:
+- Remove DQL telemetry endpoint call from QueryStringInput component ([#8878](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8878))

--- a/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
@@ -462,13 +462,6 @@ export default class QueryStringInputUI extends Component<Props, State> {
   };
 
   private onSelectLanguage = (language: string) => {
-    // Send telemetry info every time the user opts in or out of kuery
-    // As a result it is important this function only ever gets called in the
-    // UI component's change handler.
-    this.services.http.post('/api/opensearch-dashboards/dql_opt_in_stats', {
-      body: JSON.stringify({ opt_in: language === 'kuery' }),
-    });
-
     this.services.storage.set('userQueryLanguage', language);
 
     const newQuery = { query: '', language };


### PR DESCRIPTION
### Description
The QueryStringInput component makes an unconditional API call to `/api/opensearch-dashboards/dql_opt_in_stats` endpoint when switching query languages. This causes 403 errors when telemetry is disabled, as the endpoint is not accessible.

This PR
- Removed the telemetry endpoint call from `onSelectLanguage` method in QueryStringInput component
- The telemetry data had limited usefulness as it didn't track the actual language being selected


### Issues Resolved

NA

## Screenshot

NA

## Testing the changes

NA

## Changelog

- fix: Remove DQL telemetry endpoint call from QueryStringInput component



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
