### PR TITLE
Use currently selected data source when no source attached to saved query

### DIFF
--- a/changelogs/fragments/8883.yml
+++ b/changelogs/fragments/8883.yml
@@ -1,0 +1,2 @@
+fix:
+- Retain currently selected dataset when opening saved query without dataset info ([#8883](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8883))

--- a/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.tsx
+++ b/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.tsx
@@ -26,7 +26,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { SavedQuery, SavedQueryService } from '../../query';
 import { SavedQueryCard } from './saved_query_card';
-import { Query } from '../../../common';
 import { getQueryService } from '../../services';
 
 export interface OpenSavedQueryFlyoutProps {
@@ -306,21 +305,16 @@ export function OpenSavedQueryFlyout({
               fill
               onClick={() => {
                 if (selectedQuery) {
-                  if (
-                    // Template queries are not associated with data sources. Apply data source from current query
-                    selectedQuery.attributes.isTemplate ||
-                    // Associating a saved query with a data source is optional. If no data source is present, keep the current source.
-                    !selectedQuery.attributes.query.dataset?.dataSource
-                  ) {
-                    const updatedQuery: Query = {
-                      ...queryStringManager?.getQuery(),
-                      query: selectedQuery.attributes.query.query,
-                      language: selectedQuery.attributes.query.language,
-                    };
-                    queryStringManager.setQuery(updatedQuery);
-                  } else {
-                    onQueryOpen(selectedQuery);
-                  }
+                  onQueryOpen({
+                    ...selectedQuery,
+                    attributes: {
+                      ...selectedQuery.attributes,
+                      query: {
+                        ...selectedQuery.attributes.query,
+                        dataset: queryStringManager.getQuery().dataset,
+                      },
+                    },
+                  });
                   onClose();
                 }
               }}

--- a/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.tsx
+++ b/src/plugins/data/public/ui/saved_query_flyouts/open_saved_query_flyout.tsx
@@ -308,7 +308,9 @@ export function OpenSavedQueryFlyout({
                 if (selectedQuery) {
                   if (
                     // Template queries are not associated with data sources. Apply data source from current query
-                    selectedQuery.attributes.isTemplate
+                    selectedQuery.attributes.isTemplate ||
+                    // Associating a saved query with a data source is optional. If no data source is present, keep the current source.
+                    !selectedQuery.attributes.query.dataset?.dataSource
                   ) {
                     const updatedQuery: Query = {
                       ...queryStringManager?.getQuery(),

--- a/src/plugins/data/public/ui/saved_query_flyouts/save_query_flyout.tsx
+++ b/src/plugins/data/public/ui/saved_query_flyouts/save_query_flyout.tsx
@@ -43,7 +43,6 @@ export function SaveQueryFlyout({
       savedQueryService={savedQueryService}
       showFilterOption={showFilterOption}
       showTimeFilterOption={showTimeFilterOption}
-      showDataSourceOption={true}
       setSaveAsNew={(shouldSaveAsNew) => setSaveAsNew(shouldSaveAsNew)}
       savedQuery={saveAsNew ? undefined : savedQuery}
       saveAsNew={saveAsNew}

--- a/src/plugins/data/public/ui/saved_query_form/helpers.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/helpers.tsx
@@ -1,6 +1,31 @@
 /*
- * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 import React, { useEffect, useState, useCallback } from 'react';

--- a/src/plugins/data/public/ui/saved_query_form/helpers.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/helpers.tsx
@@ -1,31 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
  */
 
 import React, { useEffect, useState, useCallback } from 'react';
@@ -57,7 +32,6 @@ interface Props {
   formUiType: 'Modal' | 'Flyout';
   showFilterOption?: boolean;
   showTimeFilterOption?: boolean;
-  showDataSourceOption?: boolean;
   saveAsNew?: boolean;
   setSaveAsNew?: (shouldSaveAsNew: boolean) => void;
   cannotBeOverwritten?: boolean;
@@ -70,7 +44,6 @@ export function useSaveQueryFormContent({
   onClose,
   showFilterOption = true,
   showTimeFilterOption = true,
-  showDataSourceOption = false,
   formUiType,
   saveAsNew,
   setSaveAsNew,
@@ -81,7 +54,6 @@ export function useSaveQueryFormContent({
   const [description, setDescription] = useState('');
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
   const [shouldIncludeFilters, setShouldIncludeFilters] = useState(true);
-  const [shouldIncludeDataSource, setShouldIncludeDataSource] = useState(true);
   // Defaults to false because saved queries are meant to be as portable as possible and loading
   // a saved query with a time filter will override whatever the current value of the global timepicker
   // is. We expect this option to be used rarely and only when the user knows they want this behavior.
@@ -96,7 +68,6 @@ export function useSaveQueryFormContent({
     setDescription(savedQuery?.description || '');
     setShouldIncludeFilters(savedQuery ? !!savedQuery.filters : true);
     setIncludeTimefilter(!!savedQuery?.timefilter);
-    setShouldIncludeDataSource(savedQuery ? !!savedQuery.query.dataset : true);
     setFormErrors([]);
   }, [savedQuery]);
 
@@ -147,18 +118,9 @@ export function useSaveQueryFormContent({
         description,
         shouldIncludeFilters,
         shouldIncludeTimeFilter,
-        shouldIncludeDataSource,
       });
     }
-  }, [
-    validate,
-    onSave,
-    title,
-    description,
-    shouldIncludeFilters,
-    shouldIncludeTimeFilter,
-    shouldIncludeDataSource,
-  ]);
+  }, [validate, onSave, title, description, shouldIncludeFilters, shouldIncludeTimeFilter]);
 
   const onInputChange = useCallback((event) => {
     setEnabledSaveButton(Boolean(event.target.value));
@@ -229,21 +191,6 @@ export function useSaveQueryFormContent({
           data-test-subj="saveQueryFormDescription"
         />
       </EuiCompressedFormRow>
-      {showDataSourceOption && (
-        <EuiCompressedFormRow>
-          <EuiCompressedSwitch
-            name="shouldIncludeDataSource"
-            label={i18n.translate('data.search.searchBar.savedQueryIncludeDatasourceLabelText', {
-              defaultMessage: 'Include data source',
-            })}
-            checked={shouldIncludeDataSource}
-            onChange={() => {
-              setShouldIncludeDataSource(!shouldIncludeDataSource);
-            }}
-            data-test-subj="saveQueryFormIncludeDataSourceOption"
-          />
-        </EuiCompressedFormRow>
-      )}
       {showFilterOption && (
         <EuiCompressedFormRow>
           <EuiCompressedSwitch

--- a/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
@@ -53,7 +53,6 @@ interface Props {
   setSaveAsNew?: (shouldSaveAsNew: boolean) => void;
   showFilterOption?: boolean;
   showTimeFilterOption?: boolean;
-  showDataSourceOption?: boolean;
   saveAsNew?: boolean;
   cannotBeOverwritten?: boolean;
 }
@@ -63,7 +62,6 @@ export interface SavedQueryMeta {
   description: string;
   shouldIncludeFilters: boolean;
   shouldIncludeTimeFilter: boolean;
-  shouldIncludeDataSource: boolean;
 }
 
 export function SaveQueryForm({
@@ -74,7 +72,6 @@ export function SaveQueryForm({
   onClose,
   showFilterOption = true,
   showTimeFilterOption = true,
-  showDataSourceOption = false,
   saveAsNew,
   setSaveAsNew,
   cannotBeOverwritten,
@@ -87,7 +84,6 @@ export function SaveQueryForm({
     onClose,
     showFilterOption,
     showTimeFilterOption,
-    showDataSourceOption,
     saveAsNew,
     setSaveAsNew,
     cannotBeOverwritten,

--- a/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.test.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.test.ts
@@ -47,6 +47,11 @@ describe('populateStateFromSavedQuery', () => {
       query: {
         query: 'test',
         language: 'kuery',
+        dataset: {
+          id: 'saved-query-dataset',
+          title: 'saved-query-dataset',
+          type: 'INDEX',
+        },
       },
     },
   };
@@ -57,12 +62,15 @@ describe('populateStateFromSavedQuery', () => {
     dataMock.query.filterManager.getGlobalFilters = jest.fn().mockReturnValue([]);
   });
 
-  it('should set query', async () => {
+  it('should set query with current dataset', async () => {
     const savedQuery: SavedQuery = {
       ...baseSavedQuery,
     };
     populateStateFromSavedQuery(dataMock.query, savedQuery);
-    expect(dataMock.query.queryString.setQuery).toHaveBeenCalled();
+    expect(dataMock.query.queryString.setQuery).toHaveBeenCalledWith({
+      ...savedQuery.attributes.query,
+      dataset: dataMock.query.queryString.getQuery().dataset,
+    });
   });
 
   it('should set filters', async () => {

--- a/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.ts
@@ -48,7 +48,11 @@ export const populateStateFromSavedQuery = (queryService: QueryStart, savedQuery
   }
 
   // query string
-  queryString.setQuery(savedQuery.attributes.query);
+  queryString.setQuery({
+    ...savedQuery.attributes.query,
+    // We should keep the currently selected dataset intact
+    dataset: queryString.getQuery().dataset,
+  });
 
   // filters
   const savedQueryFilters = savedQuery.attributes.filters || [];

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -45,7 +45,6 @@ import { QueryEditorTopRow } from '../query_editor';
 import QueryBarTopRow from '../query_string_input/query_bar_top_row';
 import { SavedQueryMeta, SaveQueryForm } from '../saved_query_form';
 import { FilterOptions } from '../filter_bar/filter_options';
-import { getUseNewSavedQueriesUI } from '../../services';
 
 interface SearchBarInjectedDeps {
   opensearchDashboards: OpenSearchDashboardsReactContextValue<IDataPluginServices>;
@@ -285,11 +284,8 @@ class SearchBarUI extends Component<SearchBarProps, State> {
 
   public onSave = async (savedQueryMeta: SavedQueryMeta, saveAsNew = false) => {
     if (!this.state.query) return;
-
     const query = cloneDeep(this.state.query);
-    if (getUseNewSavedQueriesUI() && !savedQueryMeta.shouldIncludeDataSource) {
-      delete query.dataset;
-    }
+    delete query.dataset;
 
     const savedQueryAttributes: SavedQueryAttributes = {
       title: savedQueryMeta.title,


### PR DESCRIPTION
### Description
Opening a saved query that has no dataset stored with it, resets the currently selected dataset in the picker which breaks the query experience since the user will need to reselect the dataset which will then reset the query.

This PR adds a check for this case and retains the currently selected dataset

## Testing the changes
Tested using local setup


https://github.com/user-attachments/assets/0637bb93-5db6-40d5-82bd-ad31ae917b62



## Changelog
- fix: Retain currently selected dataset when opening saved query without dataset info

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
