### PR TITLE
Fix openApi doc for bulk saved object API http method

### DIFF
--- a/docs/openapi/saved_objects/saved_objects.yml
+++ b/docs/openapi/saved_objects/saved_objects.yml
@@ -423,7 +423,7 @@ paths:
               schema:
                 type: object
   /api/saved_objects/_bulk_update:
-    post:
+    put:
       tags:
         - saved objects
       summary: Bulk update saved objects
@@ -489,7 +489,7 @@ paths:
               schema:
                 type: object
   /api/saved_objects/_bulk_get:
-    get:
+    post:
       tags:
         - saved objects
       summary: Bulk get saved objects


### PR DESCRIPTION
### Description

This change is to fix OpenAPI doc for 2 bulk saved objects API

### Issues Resolved

NA

## Screenshot

![Screenshot 2024-11-18 at 9 35 48 AM](https://github.com/user-attachments/assets/5e3cc9f3-2b16-47ff-bc86-cf4e7b48fe97)


## Testing the changes

Ran `npx serve` under docs/openapi and will see updated documentation

## Changelog
- doc: Fix OpenAPI documentation

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
