### PR TITLE
Added framework to get default query string using dataset and language combination

### DIFF
--- a/changelogs/fragments/8896.yml
+++ b/changelogs/fragments/8896.yml
@@ -1,0 +1,2 @@
+feat:
+- Added framework to get default query string using dataset and language combination ([#8896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8896))

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -106,4 +106,8 @@ export interface DatasetTypeConfig {
    * Service used for indexedViews related operations
    */
   indexedViewsService?: DatasetIndexedViewsService;
+  /**
+   * Returns the default query that is added to the query editor when a dataset is selected.
+   */
+  getDefaultQueryString?: (dataset: Dataset, language: string) => string | void;
 }

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -8,6 +8,7 @@ import {
   DatasetField,
   DatasetSearchOptions,
   DataStructure,
+  Query,
   SavedObject,
 } from '../../../../common';
 import { IDataPluginServices } from '../../../types';
@@ -107,7 +108,7 @@ export interface DatasetTypeConfig {
    */
   indexedViewsService?: DatasetIndexedViewsService;
   /**
-   * Returns the default query that is added to the query editor when a dataset is selected.
+   * Returns the initial query that is added to the query editor when a dataset is selected.
    */
-  getDefaultQueryString?: (dataset: Dataset, language: string) => string | void;
+  getInitialQueryString?: (query: Query) => string | void;
 }

--- a/src/plugins/data/public/query/query_string/query_string_manager.test.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.test.ts
@@ -308,5 +308,37 @@ describe('QueryStringManager', () => {
       expect(result.dataset).toEqual(currentDataset);
       expect(result.query).toBeDefined();
     });
+
+    test('getInitialQueryByLanguage returns the initial query from the dataset config if present', () => {
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn(),
+        getInitialQueryString: jest.fn().mockImplementation(({ language }) => {
+          switch (language) {
+            case 'sql':
+              return 'default sql dataset query';
+            case 'ppl':
+              return 'default ppl dataset query';
+          }
+        }),
+      });
+
+      const sqlQuery = service.getInitialQueryByLanguage('sql');
+      expect(sqlQuery).toHaveProperty('query', 'default sql dataset query');
+
+      const pplQuery = service.getInitialQueryByLanguage('ppl');
+      expect(pplQuery).toHaveProperty('query', 'default ppl dataset query');
+    });
+
+    test('getInitialQueryByLanguage returns the initial query from the language config if dataset does not provide one', () => {
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn(),
+      });
+      service.getLanguageService().getLanguage = jest.fn().mockReturnValue({
+        getQueryString: jest.fn().mockReturnValue('default-language-service-query'),
+      });
+
+      const sqlQuery = service.getInitialQueryByLanguage('sql');
+      expect(sqlQuery).toHaveProperty('query', 'default-language-service-query');
+    });
   });
 });

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -63,11 +63,16 @@ export class QueryStringManager {
     return this.storage.get('userQueryString') || '';
   }
 
-  private getInitialDatasetQueryString(query: Query, dataset: Dataset) {
-    const { language } = query;
+  private getInitialDatasetQueryString(query: Query) {
+    const { language, dataset } = query;
 
     const languageConfig = this.languageService.getLanguage(language);
-    const typeConfig = this.datasetService.getType(dataset.type);
+    let typeConfig;
+
+    if (dataset) {
+      typeConfig = this.datasetService.getType(dataset.type);
+    }
+
     return (
       typeConfig?.getInitialQueryString?.(query) ?? (languageConfig?.getQueryString(query) || '')
     );
@@ -93,7 +98,7 @@ export class QueryStringManager {
 
       return {
         ...newQuery,
-        query: this.getInitialDatasetQueryString(newQuery, defaultDataset),
+        query: this.getInitialDatasetQueryString(newQuery),
       };
     }
 
@@ -257,7 +262,7 @@ export class QueryStringManager {
         dataset,
         query: '',
       };
-      newQuery.query = this.getInitialDatasetQueryString(newQuery, dataset);
+      newQuery.query = this.getInitialDatasetQueryString(newQuery);
       return newQuery;
     }
 
@@ -281,16 +286,12 @@ export class QueryStringManager {
    */
   public getInitialQueryByLanguage = (languageId: string) => {
     const curQuery = this.query$.getValue();
-    const language = this.languageService.getLanguage(languageId);
     const newQuery = {
       ...curQuery,
       language: languageId,
     };
-    let queryString = language?.getQueryString(newQuery) || '';
 
-    if (curQuery.dataset) {
-      queryString = this.getInitialDatasetQueryString(newQuery, curQuery.dataset) ?? queryString;
-    }
+    const queryString = this.getInitialDatasetQueryString(newQuery);
     this.languageService.setUserQueryString(queryString);
 
     return {


### PR DESCRIPTION
### Description
This PR adds framework to get the default query for a dataset and language combination from the dataset. If not provided we fallback to the defaults from the language service for each language.


## Testing the changes
Tested using local setup

## Changelog
- feat: Added framework to get default query string using dataset and language combination

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
