### PR TITLE
[Workspace] feat: optimize recent items and filter out items whose workspace is deleted

### DIFF
--- a/changelogs/fragments/8900.yml
+++ b/changelogs/fragments/8900.yml
@@ -1,0 +1,2 @@
+feat:
+- Optimize recent items and filter out items whose workspace is deleted ([#8900](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8900))

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -18,7 +18,7 @@ jest.mock('./nav_link', () => ({
   }),
 }));
 
-const mockRecentlyAccessed = new BehaviorSubject([
+const mockRecentlyAccessed$ = new BehaviorSubject([
   {
     id: '6ef856c0-5f86-11ef-b7df-1bb1cf26ce5b',
     label: 'visualizeMock',
@@ -28,7 +28,7 @@ const mockRecentlyAccessed = new BehaviorSubject([
   },
 ]);
 
-const mockWorkspaceList = new BehaviorSubject([
+const mockWorkspaceList$ = new BehaviorSubject([
   {
     id: 'workspace_1',
     name: 'WorkspaceMock_1',
@@ -49,7 +49,14 @@ const defaultMockProps = {
   navigateToUrl: applicationServiceMock.createStartContract().navigateToUrl,
   workspaceList$: new BehaviorSubject([]),
   recentlyAccessed$: new BehaviorSubject([]),
-  navLinks$: new BehaviorSubject([]),
+  navLinks$: new BehaviorSubject([
+    {
+      id: '',
+      title: '',
+      baseUrl: '',
+      href: '',
+    },
+  ]),
   basePath: httpServiceMock.createStartContract().basePath,
   http: httpServiceMock.createSetupContract(),
   renderBreadcrumbs: <></>,
@@ -85,7 +92,8 @@ describe('Recent items', () => {
   it('should be able to render recent works', async () => {
     const mockProps = {
       ...defaultMockProps,
-      recentlyAccessed$: mockRecentlyAccessed,
+      recentlyAccessed$: mockRecentlyAccessed$,
+      workspaceList$: mockWorkspaceList$,
     };
 
     await act(async () => {
@@ -97,11 +105,11 @@ describe('Recent items', () => {
     expect(screen.getByText('visualizeMock')).toBeInTheDocument();
   });
 
-  it('shoulde be able to display workspace name if the asset is attched to a workspace and render it with brackets wrapper ', async () => {
+  it('should be able to display workspace name if the asset is attched to a workspace and render it with brackets wrapper ', async () => {
     const mockProps = {
       ...defaultMockProps,
-      recentlyAccessed$: mockRecentlyAccessed,
-      workspaceList$: mockWorkspaceList,
+      recentlyAccessed$: mockRecentlyAccessed$,
+      workspaceList$: mockWorkspaceList$,
     };
 
     await act(async () => {
@@ -116,8 +124,8 @@ describe('Recent items', () => {
   it('should call navigateToUrl with link generated from createRecentNavLink when clicking a recent item', async () => {
     const mockProps = {
       ...defaultMockProps,
-      recentlyAccessed$: mockRecentlyAccessed,
-      workspaceList$: mockWorkspaceList,
+      recentlyAccessed$: mockRecentlyAccessed$,
+      workspaceList$: mockWorkspaceList$,
     };
 
     const navigateToUrl = jest.fn();
@@ -137,7 +145,7 @@ describe('Recent items', () => {
   it('should be able to display the preferences popover setting when clicking Preferences button', async () => {
     const mockProps = {
       ...defaultMockProps,
-      recentlyAccessed$: mockRecentlyAccessed,
+      recentlyAccessed$: mockRecentlyAccessed$,
     };
 
     await act(async () => {
@@ -157,5 +165,10 @@ describe('Recent items', () => {
       <RecentItems {...defaultMockProps} loadingCount$={new BehaviorSubject(1)} />
     );
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should show not display item if it is in a workspace which is not available', () => {
+    render(<RecentItems {...defaultMockProps} recentlyAccessed$={mockRecentlyAccessed$} />);
+    expect(screen.queryByText('visualizeMock')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Description

1. optimize recent items 
2. filter out items whose workspace is deleted

## Screenshot

No UI change

## Testing the changes

1. Update internal users to emit app updaters and recent items would not send extra request
2. Filter out items whose workspace is deleted

## Changelog

- feat: Optimize recent items and filter out items whose workspace is deleted

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
