### PR TITLE
removed extra param

### DIFF
--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -316,7 +316,7 @@ export class QueryStringManager {
 
     return {
       ...newQuery,
-      query: this.getInitialDatasetQueryString(newQuery, newDataset),
+      query: this.getInitialDatasetQueryString(newQuery),
     };
   };
 


### PR DESCRIPTION
### Description
Removed extra param passed to getInitialDatasetQueryString in query_string_manager 


## Screenshot
N/A

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
