### PR TITLE
[Workspace]Update default index pattern setting before index pattern deleted

### DIFF
--- a/changelogs/fragments/8908.yml
+++ b/changelogs/fragments/8908.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace]Update default index pattern setting before index pattern deleted ([#8908](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8908))


### PR DESCRIPTION
### Description

This PR will update workspace default index pattern setting before index pattern deleted to prevent default index pattern missing after index pattern removed.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
No UI changes.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace]Update default index pattern setting before index pattern deleted

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
