### PR TITLE
Reenable filter for s3

### DIFF
--- a/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.test.ts
@@ -141,7 +141,9 @@ describe('s3TypeConfig', () => {
 
     it('should fetch data sources for unknown type', async () => {
       mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
-        savedObjects: [{ id: 'ds1', attributes: { title: 'DataSource 1' } }],
+        savedObjects: [
+          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '3.0' } },
+        ],
       });
 
       const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
@@ -152,37 +154,33 @@ describe('s3TypeConfig', () => {
       expect(result.children?.[0].title).toBe('DataSource 1');
       expect(result.hasNext).toBe(true);
     });
-  });
 
-  it('should NOT filter out data sources regardless of version', async () => {
-    mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
-      savedObjects: [
-        { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '1.0' } },
-        {
-          id: 'ds2',
-          attributes: { title: 'DataSource 2', dataSourceVersion: '' }, // empty version
-        },
-        { id: 'ds3', attributes: { title: 'DataSource 3', dataSourceVersion: '2.17.0' } },
-        {
-          id: 'ds4',
-          attributes: { title: 'DataSource 4', dataSourceVersion: '.0' }, // invalid version
-        },
-      ],
+    it('should filter out data sources with versions lower than 1.0.0', async () => {
+      mockSavedObjectsClient.find = jest.fn().mockResolvedValue({
+        savedObjects: [
+          { id: 'ds1', attributes: { title: 'DataSource 1', dataSourceVersion: '1.0' } },
+          {
+            id: 'ds2',
+            attributes: { title: 'DataSource 2', dataSourceVersion: '' },
+          },
+          { id: 'ds3', attributes: { title: 'DataSource 3', dataSourceVersion: '2.17.0' } },
+          {
+            id: 'ds4',
+            attributes: { title: 'DataSource 4', dataSourceVersion: '.0' },
+          },
+        ],
+      });
+
+      const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
+        { id: 'unknown', title: 'Unknown', type: 'UNKNOWN' },
+      ]);
+
+      expect(result.children).toHaveLength(2);
+      expect(result.children?.[0].title).toBe('DataSource 1');
+      expect(result.children?.[1].title).toBe('DataSource 3');
+      expect(result.children?.some((child) => child.title === 'DataSource 2')).toBe(false);
+      expect(result.hasNext).toBe(true);
     });
-
-    const result = await s3TypeConfig.fetch(mockServices as IDataPluginServices, [
-      { id: 'unknown', title: 'Unknown', type: 'UNKNOWN' },
-    ]);
-
-    // Verify all data sources are included
-    expect(result.children).toHaveLength(4);
-    expect(result.children?.map((child) => child.title)).toEqual([
-      'DataSource 1',
-      'DataSource 2',
-      'DataSource 3',
-      'DataSource 4',
-    ]);
-    expect(result.hasNext).toBe(true);
   });
 
   test('fetchFields returns table fields', async () => {

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -6,6 +6,7 @@
 import { i18n } from '@osd/i18n';
 import { trimEnd } from 'lodash';
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import semver from 'semver';
 import {
   DATA_STRUCTURE_META_TYPES,
   DEFAULT_DATA,
@@ -197,17 +198,22 @@ const fetchDataSources = async (client: SavedObjectsClientContract): Promise<Dat
     type: 'data-source',
     perPage: 10000,
   });
-  const dataSources: DataStructure[] = resp.savedObjects.map((savedObject) => ({
-    id: savedObject.id,
-    title: savedObject.attributes.title,
-    type: 'DATA_SOURCE',
-    meta: {
-      query: {
-        id: savedObject.id,
-      },
-      type: DATA_STRUCTURE_META_TYPES.CUSTOM,
-    } as DataStructureCustomMeta,
-  }));
+  const dataSources: DataStructure[] = resp.savedObjects
+    .filter((savedObject) => {
+      const coercedVersion = semver.coerce(savedObject.attributes.dataSourceVersion);
+      return coercedVersion ? semver.satisfies(coercedVersion, '>=1.0.0') : false;
+    })
+    .map((savedObject) => ({
+      id: savedObject.id,
+      title: savedObject.attributes.title,
+      type: 'DATA_SOURCE',
+      meta: {
+        query: {
+          id: savedObject.id,
+        },
+        type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+      } as DataStructureCustomMeta,
+    }));
   return dataSources;
 };
 


### PR DESCRIPTION
### Description

Reenable filter for s3

### Issues Resolved

na

## Screenshot

na

## Testing the changes

na

## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
