### PR TITLE
[augmenter] do not support datasources with no version

### DIFF
--- a/changelogs/fragments/8915.yml
+++ b/changelogs/fragments/8915.yml
@@ -1,0 +1,2 @@
+fix:
+- Do not support data sources with no version for vis augmenter ([#8915](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8915))

--- a/src/plugins/vis_augmenter/public/plugin.ts
+++ b/src/plugins/vis_augmenter/public/plugin.ts
@@ -13,6 +13,7 @@ import {
   setUiActions,
   setEmbeddable,
   setQueryService,
+  setIndexPatterns,
   setVisualizations,
   setCore,
 } from './services';
@@ -62,6 +63,7 @@ export class VisAugmenterPlugin
     setUiActions(uiActions);
     setEmbeddable(embeddable);
     setQueryService(data.query);
+    setIndexPatterns(data.indexPatterns);
     setVisualizations(visualizations);
     setCore(core);
     setFlyoutState(VIEW_EVENTS_FLYOUT_STATE.CLOSED);

--- a/src/plugins/vis_augmenter/public/services.ts
+++ b/src/plugins/vis_augmenter/public/services.ts
@@ -8,7 +8,7 @@ import { IUiSettingsClient } from '../../../core/public';
 import { SavedObjectLoaderAugmentVis } from './saved_augment_vis';
 import { EmbeddableStart } from '../../embeddable/public';
 import { UiActionsStart } from '../../ui_actions/public';
-import { DataPublicPluginStart } from '../../../plugins/data/public';
+import { DataPublicPluginStart, IndexPatternsContract } from '../../../plugins/data/public';
 import { VisualizationsStart } from '../../visualizations/public';
 import { CoreStart } from '../../../core/public';
 
@@ -25,6 +25,10 @@ export const [getEmbeddable, setEmbeddable] = createGetterSetter<EmbeddableStart
 export const [getQueryService, setQueryService] = createGetterSetter<
   DataPublicPluginStart['query']
 >('Query');
+
+export const [getIndexPatterns, setIndexPatterns] = createGetterSetter<IndexPatternsContract>(
+  'IndexPatterns'
+);
 
 export const [getVisualizations, setVisualizations] = createGetterSetter<VisualizationsStart>(
   'visualizations'

--- a/src/plugins/vis_augmenter/public/utils/utils.test.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.test.ts
@@ -664,6 +664,9 @@ describe('utils', () => {
   });
 
   describe('isEligibleForDataSource', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
     it('returns true if the Vis indexPattern does not have a dataSourceRef', async () => {
       const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
       indexPatternsMock.getDataSource = jest.fn().mockReturnValue(undefined);
@@ -698,11 +701,57 @@ describe('utils', () => {
       } as Vis;
       expect(await isEligibleForDataSource(vis)).toEqual(true);
     });
-    it.skip('returns false if the Vis indexPattern has a dataSourceRef with an incompatible version', async () => {
+    it('returns false if the Vis indexPattern has a dataSourceRef with an incompatible version', async () => {
       const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
       indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
         id: '456',
+        attributes: {
+          dataSourceVersion: '.0',
+        },
       });
+      setIndexPatterns(indexPatternsMock);
+      const vis = {
+        data: {
+          indexPattern: {
+            id: '123',
+            dataSourceRef: {
+              id: '456',
+            },
+          },
+        },
+      } as Vis;
+      expect(await isEligibleForDataSource(vis)).toEqual(false);
+    });
+    it('returns false if the Vis indexPattern has a dataSourceRef with an undefined version', async () => {
+      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
+      indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
+        id: '456',
+        attributes: {
+          dataSourceVersion: undefined,
+        },
+      });
+      setIndexPatterns(indexPatternsMock);
+      const vis = {
+        data: {
+          indexPattern: {
+            id: '123',
+            dataSourceRef: {
+              id: '456',
+            },
+          },
+        },
+      } as Vis;
+      expect(await isEligibleForDataSource(vis)).toEqual(false);
+    });
+    it('returns false if the Vis indexPattern has a dataSourceRef with an empty string version', async () => {
+      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
+      indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
+        id: '456',
+        attributes: {
+          dataSourceVersion: '',
+        },
+      });
+      setIndexPatterns(indexPatternsMock);
       const vis = {
         data: {
           indexPattern: {

--- a/src/plugins/vis_augmenter/public/utils/utils.test.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.test.ts
@@ -698,7 +698,7 @@ describe('utils', () => {
       } as Vis;
       expect(await isEligibleForDataSource(vis)).toEqual(true);
     });
-    it('returns false if the Vis indexPattern has a dataSourceRef with an incompatible version', async () => {
+    it.skip('returns false if the Vis indexPattern has a dataSourceRef with an incompatible version', async () => {
       const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
       indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
         id: '456',

--- a/src/plugins/vis_augmenter/public/utils/utils.test.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.test.ts
@@ -62,7 +62,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(vis)).toEqual(false);
+      expect(await isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with no date_histogram', async () => {
       const invalidConfigStates = [
@@ -89,7 +89,7 @@ describe('utils', () => {
           invalidAggs,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(vis)).toEqual(false);
+      expect(await isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with invalid aggs counts', async () => {
       const invalidConfigStates = [
@@ -113,7 +113,7 @@ describe('utils', () => {
           invalidAggs,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(vis)).toEqual(false);
+      expect(await isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with no metric aggs', async () => {
       const invalidConfigStates = [
@@ -135,7 +135,7 @@ describe('utils', () => {
           invalidAggs,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(vis)).toEqual(false);
+      expect(await isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with series param is not line type', async () => {
       const vis = ({
@@ -156,7 +156,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(vis)).toEqual(false);
+      expect(await isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with series param not all being line type', async () => {
       const vis = ({
@@ -180,7 +180,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(vis)).toEqual(false);
+      expect(await isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with invalid x-axis due to no segment aggregation', async () => {
       const badConfigStates = [
@@ -218,7 +218,7 @@ describe('utils', () => {
           badAggs,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(invalidVis)).toEqual(false);
+      expect(await isEligibleForVisLayers(invalidVis)).toEqual(false);
     });
     it('vis is ineligible with xaxis not on bottom', async () => {
       const invalidVis = ({
@@ -239,7 +239,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(invalidVis)).toEqual(false);
+      expect(await isEligibleForVisLayers(invalidVis)).toEqual(false);
     });
     it('vis is ineligible with no seriesParams', async () => {
       const invalidVis = ({
@@ -255,16 +255,16 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(isEligibleForVisLayers(invalidVis)).toEqual(false);
+      expect(await isEligibleForVisLayers(invalidVis)).toEqual(false);
     });
     it('vis is ineligible with valid type and disabled setting', async () => {
       uiSettingsMock.get.mockImplementation((key: string) => {
         return key !== PLUGIN_AUGMENTATION_ENABLE_SETTING;
       });
-      expect(isEligibleForVisLayers(VALID_VIS)).toEqual(false);
+      expect(await isEligibleForVisLayers(VALID_VIS)).toEqual(false);
     });
     it('vis is eligible with valid type', async () => {
-      expect(isEligibleForVisLayers(VALID_VIS)).toEqual(true);
+      expect(await isEligibleForVisLayers(VALID_VIS)).toEqual(true);
     });
   });
 

--- a/src/plugins/vis_augmenter/public/utils/utils.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.ts
@@ -24,7 +24,10 @@ import { PLUGIN_AUGMENTATION_ENABLE_SETTING } from '../../common/constants';
 import { getUISettings, getIndexPatterns } from '../services';
 import { IUiSettingsClient } from '../../../../core/public';
 
-export const isEligibleForVisLayers = (vis: Vis, uiSettingsClient?: IUiSettingsClient): boolean => {
+export const isEligibleForVisLayers = async (
+  vis: Vis,
+  uiSettingsClient?: IUiSettingsClient
+): Promise<boolean> => {
   // Only support a date histogram
   const dateHistograms = vis.data?.aggs?.byTypeName?.('date_histogram');
   if (!Array.isArray(dateHistograms) || dateHistograms.length !== 1) return false;
@@ -55,7 +58,7 @@ export const isEligibleForVisLayers = (vis: Vis, uiSettingsClient?: IUiSettingsC
     return false;
 
   // Check if the vis datasource is eligible for the augmentation
-  if (!isEligibleForDataSource(vis)) return false;
+  if (!(await isEligibleForDataSource(vis))) return false;
 
   // Checks if the augmentation setting is enabled
   const config = uiSettingsClient ?? getUISettings();

--- a/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
@@ -46,7 +46,7 @@ export class ViewEventsOptionAction implements Action<EmbeddableContext> {
     const vis = (embeddable as VisualizeEmbeddable).vis;
     return (
       vis !== undefined &&
-      isEligibleForVisLayers(vis) &&
+      (await isEligibleForVisLayers(vis)) &&
       !isEmpty((embeddable as VisualizeEmbeddable).visLayers)
     );
   }

--- a/src/plugins/vis_type_vislib/public/line_to_expression.ts
+++ b/src/plugins/vis_type_vislib/public/line_to_expression.ts
@@ -32,7 +32,7 @@ export const toExpressionAst = async (vis: Vis, params: any) => {
   if (
     params.visLayers == null ||
     Object.keys(params.visLayers).length === 0 ||
-    !isEligibleForVisLayers(vis)
+    !(await isEligibleForVisLayers(vis))
   ) {
     // Render using vislib instead of vega-lite
     const visConfig = { ...vis.params, dimensions };

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -541,7 +541,7 @@ export class VisualizeEmbeddable
         this.visAugmenterConfig?.visLayerResourceIds
       );
 
-      if (!isEmpty(augmentVisSavedObjs) && !aborted && isEligibleForVisLayers(this.vis)) {
+      if (!isEmpty(augmentVisSavedObjs) && !aborted && (await isEligibleForVisLayers(this.vis))) {
         const visLayersPipeline = buildPipelineFromAugmentVisSavedObjs(augmentVisSavedObjs);
         // The initial input for the pipeline will just be an empty arr of VisLayers. As plugin
         // expression functions are ran, they will incrementally append their generated VisLayers to it.


### PR DESCRIPTION
### Description

Do not display if the datasource attached to the index pattern has a not compatible engine version. In this case we expect `.0` utilizing semver checking by version 1.0.0 should be sufficient to solving this problem since the data source we want to filter returns version `.0` which we first released on 1.0.0

### Issues Resolved

n/a

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes
- unit tests
- verified on machine pointing to this data source with this version number

## Changelog
- fix: do not support data sources with no version for vis augmenter

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
