### PR TITLE
[Workspace]Support search dev tools by its category name

### DIFF
--- a/src/plugins/dev_tools/public/global_search/search_devtool_command.test.tsx
+++ b/src/plugins/dev_tools/public/global_search/search_devtool_command.test.tsx
@@ -32,6 +32,17 @@ describe('DevtoolSearchCommand', () => {
     expect(searchResult).toHaveLength(0);
   });
 
+  it('searchForDevTools matches category', async () => {
+    const searchResult = await searchForDevTools('dev', {
+      devTools: devToolsFn,
+      title: 'Dev tools',
+      uiActionsApi: uiActionsApiFn,
+    });
+
+    // match all sub apps
+    expect(searchResult).toHaveLength(2);
+  });
+
   it('searchForDevTools with match tool', async () => {
     const searchResult = await searchForDevTools('console', {
       devTools: devToolsFn,
@@ -56,7 +67,11 @@ describe('DevtoolSearchCommand', () => {
                   />
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  Dev tools
+                  <EuiHighlight
+                    search="console"
+                  >
+                    Dev tools
+                  </EuiHighlight>
                 </EuiFlexItem>
               </EuiFlexGroup>,
             },

--- a/src/plugins/dev_tools/public/global_search/search_devtool_command.tsx
+++ b/src/plugins/dev_tools/public/global_search/search_devtool_command.tsx
@@ -33,12 +33,18 @@ export const searchForDevTools = async (
       <EuiFlexItem>
         <EuiIcon type="consoleApp" color="text" />
       </EuiFlexItem>
-      <EuiFlexItem>{props.title}</EuiFlexItem>
+      <EuiFlexItem>
+        <EuiHighlight search={query}>{props.title}</EuiHighlight>
+      </EuiFlexItem>
     </EuiFlexGroup>
   );
 
   return tools
-    .filter((tool) => tool.title.toLowerCase().includes(query.toLowerCase()))
+    .filter(
+      (tool) =>
+        tool.title.toLowerCase().includes(query.toLowerCase()) ||
+        props.title.toLowerCase().includes(query.toLowerCase())
+    )
     .map((tool) => ({
       breadcrumbs: [
         {


### PR DESCRIPTION
### Description
Support search dev tools by category name

![image](https://github.com/user-attachments/assets/b42eb929-8027-49c3-b956-934bf4a26081)


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
1. enable workspace and new home page setting in your opensearch_dashboards.yml file
```yaml
workspace.enabled: true
uiSettings:
  overrides:
    "home:useNewHomePage": true
```
3. start OSD  `yarn start --no-base-path`
4. go to settings/data administration page or any workspace, search with `dev tools` it will match all sub apps under dev tool category

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [workspace]support search dev tools by its category name

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
