### PR TITLE
Revert "[augmenter] do not support datasources with no version (#8915)"

### DIFF
--- a/changelogs/fragments/8915.yml
+++ b/changelogs/fragments/8915.yml
@@ -1,2 +1,0 @@
-fix:
-- Do not support data sources with no version for vis augmenter ([#8915](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8915))

--- a/src/plugins/vis_augmenter/public/plugin.ts
+++ b/src/plugins/vis_augmenter/public/plugin.ts
@@ -13,7 +13,6 @@ import {
   setUiActions,
   setEmbeddable,
   setQueryService,
-  setIndexPatterns,
   setVisualizations,
   setCore,
 } from './services';
@@ -63,7 +62,6 @@ export class VisAugmenterPlugin
     setUiActions(uiActions);
     setEmbeddable(embeddable);
     setQueryService(data.query);
-    setIndexPatterns(data.indexPatterns);
     setVisualizations(visualizations);
     setCore(core);
     setFlyoutState(VIEW_EVENTS_FLYOUT_STATE.CLOSED);

--- a/src/plugins/vis_augmenter/public/services.ts
+++ b/src/plugins/vis_augmenter/public/services.ts
@@ -8,7 +8,7 @@ import { IUiSettingsClient } from '../../../core/public';
 import { SavedObjectLoaderAugmentVis } from './saved_augment_vis';
 import { EmbeddableStart } from '../../embeddable/public';
 import { UiActionsStart } from '../../ui_actions/public';
-import { DataPublicPluginStart, IndexPatternsContract } from '../../../plugins/data/public';
+import { DataPublicPluginStart } from '../../../plugins/data/public';
 import { VisualizationsStart } from '../../visualizations/public';
 import { CoreStart } from '../../../core/public';
 
@@ -25,10 +25,6 @@ export const [getEmbeddable, setEmbeddable] = createGetterSetter<EmbeddableStart
 export const [getQueryService, setQueryService] = createGetterSetter<
   DataPublicPluginStart['query']
 >('Query');
-
-export const [getIndexPatterns, setIndexPatterns] = createGetterSetter<IndexPatternsContract>(
-  'IndexPatterns'
-);
 
 export const [getVisualizations, setVisualizations] = createGetterSetter<VisualizationsStart>(
   'visualizations'

--- a/src/plugins/vis_augmenter/public/utils/utils.test.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.test.ts
@@ -21,12 +21,11 @@ import {
   PluginResource,
   VisLayerErrorTypes,
   SavedObjectLoaderAugmentVis,
-  isEligibleForDataSource,
 } from '../';
 import { PLUGIN_AUGMENTATION_ENABLE_SETTING } from '../../common/constants';
 import { AggConfigs } from '../../../data/common';
 import { uiSettingsServiceMock } from '../../../../core/public/mocks';
-import { setIndexPatterns, setUISettings } from '../services';
+import { setUISettings } from '../services';
 import {
   STUB_INDEX_PATTERN_WITH_FIELDS,
   TYPES_REGISTRY,
@@ -36,7 +35,6 @@ import {
   createPointInTimeEventsVisLayer,
   createVisLayer,
 } from '../mocks';
-import { dataPluginMock } from 'src/plugins/data/public/mocks';
 
 describe('utils', () => {
   const uiSettingsMock = uiSettingsServiceMock.createStartContract();
@@ -62,7 +60,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(vis)).toEqual(false);
+      expect(isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with no date_histogram', async () => {
       const invalidConfigStates = [
@@ -89,7 +87,7 @@ describe('utils', () => {
           invalidAggs,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(vis)).toEqual(false);
+      expect(isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with invalid aggs counts', async () => {
       const invalidConfigStates = [
@@ -113,7 +111,7 @@ describe('utils', () => {
           invalidAggs,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(vis)).toEqual(false);
+      expect(isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with no metric aggs', async () => {
       const invalidConfigStates = [
@@ -135,7 +133,7 @@ describe('utils', () => {
           invalidAggs,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(vis)).toEqual(false);
+      expect(isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with series param is not line type', async () => {
       const vis = ({
@@ -156,7 +154,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(vis)).toEqual(false);
+      expect(isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with series param not all being line type', async () => {
       const vis = ({
@@ -180,7 +178,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(vis)).toEqual(false);
+      expect(isEligibleForVisLayers(vis)).toEqual(false);
     });
     it('vis is ineligible with invalid x-axis due to no segment aggregation', async () => {
       const badConfigStates = [
@@ -218,7 +216,7 @@ describe('utils', () => {
           badAggs,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(invalidVis)).toEqual(false);
+      expect(isEligibleForVisLayers(invalidVis)).toEqual(false);
     });
     it('vis is ineligible with xaxis not on bottom', async () => {
       const invalidVis = ({
@@ -239,7 +237,7 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(invalidVis)).toEqual(false);
+      expect(isEligibleForVisLayers(invalidVis)).toEqual(false);
     });
     it('vis is ineligible with no seriesParams', async () => {
       const invalidVis = ({
@@ -255,16 +253,16 @@ describe('utils', () => {
           aggs: VALID_AGGS,
         },
       } as unknown) as Vis;
-      expect(await isEligibleForVisLayers(invalidVis)).toEqual(false);
+      expect(isEligibleForVisLayers(invalidVis)).toEqual(false);
     });
     it('vis is ineligible with valid type and disabled setting', async () => {
       uiSettingsMock.get.mockImplementation((key: string) => {
         return key !== PLUGIN_AUGMENTATION_ENABLE_SETTING;
       });
-      expect(await isEligibleForVisLayers(VALID_VIS)).toEqual(false);
+      expect(isEligibleForVisLayers(VALID_VIS)).toEqual(false);
     });
     it('vis is eligible with valid type', async () => {
-      expect(await isEligibleForVisLayers(VALID_VIS)).toEqual(true);
+      expect(isEligibleForVisLayers(VALID_VIS)).toEqual(true);
     });
   });
 
@@ -660,109 +658,6 @@ describe('utils', () => {
       cleanupStaleObjects(augmentVisObjs, visLayers, augmentVisLoader);
 
       expect(mockDeleteFn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('isEligibleForDataSource', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-    it('returns true if the Vis indexPattern does not have a dataSourceRef', async () => {
-      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
-      indexPatternsMock.getDataSource = jest.fn().mockReturnValue(undefined);
-      setIndexPatterns(indexPatternsMock);
-      const vis = {
-        data: {
-          indexPattern: {
-            id: '123',
-          },
-        },
-      } as Vis;
-      expect(await isEligibleForDataSource(vis)).toEqual(true);
-    });
-    it('returns true if the Vis indexPattern has a dataSourceRef with a compatible version', async () => {
-      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
-      indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
-        id: '456',
-        attributes: {
-          dataSourceVersion: '1.2.3',
-        },
-      });
-      setIndexPatterns(indexPatternsMock);
-      const vis = {
-        data: {
-          indexPattern: {
-            id: '123',
-            dataSourceRef: {
-              id: '456',
-            },
-          },
-        },
-      } as Vis;
-      expect(await isEligibleForDataSource(vis)).toEqual(true);
-    });
-    it('returns false if the Vis indexPattern has a dataSourceRef with an incompatible version', async () => {
-      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
-      indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
-        id: '456',
-        attributes: {
-          dataSourceVersion: '.0',
-        },
-      });
-      setIndexPatterns(indexPatternsMock);
-      const vis = {
-        data: {
-          indexPattern: {
-            id: '123',
-            dataSourceRef: {
-              id: '456',
-            },
-          },
-        },
-      } as Vis;
-      expect(await isEligibleForDataSource(vis)).toEqual(false);
-    });
-    it('returns false if the Vis indexPattern has a dataSourceRef with an undefined version', async () => {
-      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
-      indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
-        id: '456',
-        attributes: {
-          dataSourceVersion: undefined,
-        },
-      });
-      setIndexPatterns(indexPatternsMock);
-      const vis = {
-        data: {
-          indexPattern: {
-            id: '123',
-            dataSourceRef: {
-              id: '456',
-            },
-          },
-        },
-      } as Vis;
-      expect(await isEligibleForDataSource(vis)).toEqual(false);
-    });
-    it('returns false if the Vis indexPattern has a dataSourceRef with an empty string version', async () => {
-      const indexPatternsMock = dataPluginMock.createStartContract().indexPatterns;
-      indexPatternsMock.getDataSource = jest.fn().mockReturnValue({
-        id: '456',
-        attributes: {
-          dataSourceVersion: '',
-        },
-      });
-      setIndexPatterns(indexPatternsMock);
-      const vis = {
-        data: {
-          indexPattern: {
-            id: '123',
-            dataSourceRef: {
-              id: '456',
-            },
-          },
-        },
-      } as Vis;
-      expect(await isEligibleForDataSource(vis)).toEqual(false);
     });
   });
 });

--- a/src/plugins/vis_augmenter/public/utils/utils.ts
+++ b/src/plugins/vis_augmenter/public/utils/utils.ts
@@ -4,7 +4,6 @@
  */
 
 import { get, isEmpty } from 'lodash';
-import semver from 'semver';
 import { Vis } from '../../../../plugins/visualizations/public';
 import {
   formatExpression,
@@ -21,13 +20,10 @@ import {
   VisLayerErrorTypes,
 } from '../';
 import { PLUGIN_AUGMENTATION_ENABLE_SETTING } from '../../common/constants';
-import { getUISettings, getIndexPatterns } from '../services';
+import { getUISettings } from '../services';
 import { IUiSettingsClient } from '../../../../core/public';
 
-export const isEligibleForVisLayers = async (
-  vis: Vis,
-  uiSettingsClient?: IUiSettingsClient
-): Promise<boolean> => {
+export const isEligibleForVisLayers = (vis: Vis, uiSettingsClient?: IUiSettingsClient): boolean => {
   // Only support a date histogram
   const dateHistograms = vis.data?.aggs?.byTypeName?.('date_histogram');
   if (!Array.isArray(dateHistograms) || dateHistograms.length !== 1) return false;
@@ -56,9 +52,6 @@ export const isEligibleForVisLayers = async (
     vis.params.seriesParams.some((seriesParam: { type: string }) => seriesParam.type !== 'line')
   )
     return false;
-
-  // Check if the vis datasource is eligible for the augmentation
-  if (!(await isEligibleForDataSource(vis))) return false;
 
   // Checks if the augmentation setting is enabled
   const config = uiSettingsClient ?? getUISettings();
@@ -170,6 +163,7 @@ export const getAnyErrors = (visLayers: VisLayer[], visTitle: string): Error | u
  * @param visLayers the produced VisLayers containing details if the resource has been deleted
  * @param visualizationsLoader the visualizations saved object loader to handle deletion
  */
+
 export const cleanupStaleObjects = (
   augmentVisSavedObjs: ISavedAugmentVis[],
   visLayers: VisLayer[],
@@ -192,18 +186,4 @@ export const cleanupStaleObjects = (
     });
     loader?.delete(objIdsToDelete);
   }
-};
-
-/**
- * Returns true if the Vis is eligible to be used with the DataSource feature.
- * @param vis - The Vis to check
- * @returns true if the Vis is eligible for the DataSource feature, false otherwise
- */
-export const isEligibleForDataSource = async (vis: Vis) => {
-  const dataSourceRef = vis.data.indexPattern?.dataSourceRef;
-  if (!dataSourceRef) return true;
-  const dataSource = await getIndexPatterns().getDataSource(dataSourceRef.id);
-  if (!dataSource || !dataSource.attributes) return false;
-  const version = semver.coerce(dataSource.attributes.dataSourceVersion);
-  return version ? semver.satisfies(version, '>=1.0.0') : false;
 };

--- a/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
+++ b/src/plugins/vis_augmenter/public/view_events_flyout/actions/view_events_option_action.tsx
@@ -46,7 +46,7 @@ export class ViewEventsOptionAction implements Action<EmbeddableContext> {
     const vis = (embeddable as VisualizeEmbeddable).vis;
     return (
       vis !== undefined &&
-      (await isEligibleForVisLayers(vis)) &&
+      isEligibleForVisLayers(vis) &&
       !isEmpty((embeddable as VisualizeEmbeddable).visLayers)
     );
   }

--- a/src/plugins/vis_type_vislib/public/line_to_expression.ts
+++ b/src/plugins/vis_type_vislib/public/line_to_expression.ts
@@ -32,7 +32,7 @@ export const toExpressionAst = async (vis: Vis, params: any) => {
   if (
     params.visLayers == null ||
     Object.keys(params.visLayers).length === 0 ||
-    !(await isEligibleForVisLayers(vis))
+    !isEligibleForVisLayers(vis)
   ) {
     // Render using vislib instead of vega-lite
     const visConfig = { ...vis.params, dimensions };

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -541,7 +541,7 @@ export class VisualizeEmbeddable
         this.visAugmenterConfig?.visLayerResourceIds
       );
 
-      if (!isEmpty(augmentVisSavedObjs) && !aborted && (await isEligibleForVisLayers(this.vis))) {
+      if (!isEmpty(augmentVisSavedObjs) && !aborted && isEligibleForVisLayers(this.vis)) {
         const visLayersPipeline = buildPipelineFromAugmentVisSavedObjs(augmentVisSavedObjs);
         // The initial input for the pipeline will just be an empty arr of VisLayers. As plugin
         // expression functions are ran, they will incrementally append their generated VisLayers to it.


### PR DESCRIPTION
This reverts commit 539675e688061e689b362801bcb05a3ef78431b2.

There is a known issue with the bundled JS after this change, when trying to render eligible visualizations. The AD/Alerting options fail to render, due to issues fetching the underlying `getIndexPatterns` fn within `isEligibleForVisLayers`. This is due to how the JS modules are bundled along with a mismatch on when these functions are defined in `setup()`/`start()` phases of the plugins.

Future work to add this functionality in a safe manner is tracked in #8924.

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
