### PR TITLE
Ensure discover table headers have a min width

### DIFF
--- a/changelogs/fragments/8927.yml
+++ b/changelogs/fragments/8927.yml
@@ -1,0 +1,2 @@
+fix:
+- Add min-width to discover table header ([#8927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8927))

--- a/src/plugins/discover/public/application/components/default_discover_table/_table_header.scss
+++ b/src/plugins/discover/public/application/components/default_discover_table/_table_header.scss
@@ -5,6 +5,7 @@
   // nested for specificity
   .docTableHeaderField {
     padding: $euiSizeS;
+    min-width: 210px;
   }
 }
 


### PR DESCRIPTION
### Description
This is a stopgap measure to ensure a minimum header width in the Discover table have enough space to properly render.

## Screenshot

### Before
<img width="1144" alt="Screenshot 2024-11-25 at 7 09 03 PM" src="https://github.com/user-attachments/assets/7ef5e552-6af4-4e79-896f-649d25b5492e">

### After
<img width="1144" alt="Screenshot 2024-11-25 at 7 07 35 PM" src="https://github.com/user-attachments/assets/3e13c9d2-4237-453b-8d3a-69c29f804e49">

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: add min-width to discover table header

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
