### PR TITLE
Mitigate the incorrect layout of Discover due to a race condition between loading column definition and data

### DIFF
--- a/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/default_discover_table.tsx
@@ -186,6 +186,17 @@ const DefaultDiscoverTableUI = ({
   // Allow auto column-sizing using the initially rendered rows and then convert to fixed
   const tableLayoutRequestFrameRef = useRef<number>(0);
 
+  /* In asynchronous data loading, column metadata may arrive before the corresponding data, resulting in
+     layout being calculated for the new column definitions using the old data. To mitigate this issue, we
+     additionally trigger a recalculation when a change is observed in the index that the data attributes
+     itself to. This ensures a re-layout is performed when new data is loaded or the column definitions
+     change, effectively addressing the symptoms of the race condition.
+   */
+  const indexOfRenderedData = rows?.[0]?._index;
+  const timeFromFirstRow =
+    typeof indexPattern?.timeFieldName === 'string' &&
+    rows?.[0]?._source?.[indexPattern.timeFieldName];
+
   useEffect(() => {
     if (tableElement) {
       // Load the first batch of rows and adjust the columns to the contents
@@ -214,7 +225,7 @@ const DefaultDiscoverTableUI = ({
     }
 
     return () => cancelAnimationFrame(tableLayoutRequestFrameRef.current);
-  }, [columns, tableElement]);
+  }, [columns, tableElement, indexOfRenderedData, timeFromFirstRow]);
 
   return (
     indexPattern && (


### PR DESCRIPTION
### Description

Mitigate the incorrect layout of Discover due to a race condition between loading column definition and data.

Note: This is not a final solution and simply masks the race condition which needs to be fixed separately. Perhaps a better UX would contrast `indexOfRenderedData` with `indexPattern` and prevent the re-layout. I did not do that because its potential unknown impact on all the scenarios.

## Screenshot

### Before


https://github.com/user-attachments/assets/3554f300-a125-4e84-a483-5dd159d8a21f


### After


https://github.com/user-attachments/assets/f2a24f8b-3993-4ed6-b250-03d1a3f0e2d3


## Changelog
- fix: Fix incorrect layout of Discover due to a race condition between loading column definition and data

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff
