### PR TITLE
[Discover] Fix Initialization if No Saved Query

### DIFF
--- a/changelogs/fragments/8930.yml
+++ b/changelogs/fragments/8930.yml
@@ -1,0 +1,2 @@
+fix:
+- Update saved search initialization logic to use current query instead of default query ([#8930](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8930))

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -392,8 +392,7 @@ export const useSearch = (services: DiscoverViewServices) => {
       const savedSearchInstance = await getSavedSearchById(savedSearchId);
 
       const query =
-        savedSearchInstance.searchSource.getField('query') ||
-        data.query.queryString.getDefaultQuery();
+        savedSearchInstance.searchSource.getField('query') || data.query.queryString.getQuery();
 
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       if (isEnhancementsEnabled && query.dataset) {
@@ -432,7 +431,7 @@ export const useSearch = (services: DiscoverViewServices) => {
       }
 
       filterManager.setAppFilters(actualFilters);
-      data.query.queryString.setQuery(savedQuery ? data.query.queryString.getQuery() : query);
+      data.query.queryString.setQuery(query);
       setSavedSearch(savedSearchInstance);
 
       if (savedSearchInstance?.id) {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Upon Discover mount (when `getSavedSearchById` is called), we were either setting the query to be the saved search, if it exists, or the default query. In this PR, I updated the logic such that we use the current query instead, which should be the single entry point that also handles the default query state.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Update saved search initialization logic to use current query instead of default query

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
