### PR TITLE
[Discover] Support custom logic to insert time filter based on dataset type

### DIFF
--- a/changelogs/fragments/8932.yml
+++ b/changelogs/fragments/8932.yml
@@ -1,0 +1,2 @@
+feat:
+- Support custom logic to insert time filter based on dataset type ([#8932](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8932))

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.mock.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.mock.ts
@@ -43,6 +43,9 @@ const createSetupDatasetServiceMock = (): jest.Mocked<DatasetServiceContract> =>
     fetchOptions: jest.fn(),
     getRecentDatasets: jest.fn(),
     addRecentDataset: jest.fn(),
+    clearCache: jest.fn(),
+    getLastCacheTime: jest.fn(),
+    removeFromRecentDatasets: jest.fn(),
   };
 };
 

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -45,8 +45,8 @@ export interface DatasetTypeConfig {
   title: string;
   languageOverrides?: {
     [language: string]: {
-      /** The overrides transfer the responsibility of handling the input from
-       * the language interceptor to the dataset types strategy. */
+      /** The override transfers the responsibility of handling the input from
+       * the language interceptor to the dataset type search strategy. */
       hideDatePicker?: boolean;
     };
   };

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -43,6 +43,13 @@ export interface DatasetTypeConfig {
   id: string;
   /** Human-readable title for the dataset type */
   title: string;
+  languageOverrides?: {
+    [language: string]: {
+      /** The overrides transfer the responsibility of handling the input from
+       * the language interceptor to the dataset types strategy. */
+      hideDatePicker?: boolean;
+    };
+  };
   /** Metadata for UI representation */
   meta: {
     /** Icon to represent the dataset type */
@@ -51,7 +58,7 @@ export interface DatasetTypeConfig {
     tooltip?: string;
     /** Optional preference for search on page load else defaulted to true */
     searchOnLoad?: boolean;
-    /** Optional supportsTimeFilter determines if a time filter is needed */
+    /** Optional supportsTimeFilter determines if a time field is supported */
     supportsTimeFilter?: boolean;
     /** Optional isFieldLoadAsync determines if field loads are async */
     isFieldLoadAsync?: boolean;

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -61,6 +61,11 @@ export interface LanguageConfig {
   };
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
+  /**
+   * @deprecated
+   *
+   * Use `datasetTypeConfig.supportsTimeFilter` instead
+   */
   hideDatePicker?: boolean;
   sampleQueries?: SampleQuery[];
 }

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -61,11 +61,6 @@ export interface LanguageConfig {
   };
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
-  /**
-   * @deprecated
-   *
-   * Use `datasetTypeConfig.supportsTimeFilter` instead
-   */
   hideDatePicker?: boolean;
   sampleQueries?: SampleQuery[];
 }

--- a/src/plugins/data/public/ui/dataset_selector/configurator.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.test.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { Configurator } from './configurator';
 import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { setQueryService, setIndexPatterns } from '../../services';
 import { IntlProvider } from 'react-intl';
-import { Query } from '../../../../data/public';
 import { Dataset } from 'src/plugins/data/common';
+import { Query } from '../../../../data/public';
+import { setIndexPatterns, setQueryService } from '../../services';
+import { Configurator } from './configurator';
 
 const getQueryMock = jest.fn().mockReturnValue({
   query: '',
@@ -357,5 +357,69 @@ describe('Configurator Component', () => {
     await waitFor(() => {
       expect(submitButton).toBeEnabled();
     });
+  });
+
+  it('should show the date picker if supportsTimeFilter is undefined', async () => {
+    const mockDataset = {
+      ...mockBaseDataset,
+      timeFieldName: undefined,
+      type: 'index',
+    };
+    const { container } = render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="advancedSelectorTimeFieldSelect"]`)
+    ).toBeTruthy();
+  });
+
+  it('should hide the date picker if supportsTimeFilter is false', async () => {
+    const mockDataset = {
+      ...mockBaseDataset,
+      timeFieldName: undefined,
+      type: 'index',
+    };
+    const datasetTypeConfig = mockServices
+      .getQueryService()
+      .queryString.getDatasetService()
+      .getType();
+    mockServices
+      .getQueryService()
+      .queryString.getDatasetService()
+      .getType.mockReturnValue({
+        ...datasetTypeConfig,
+        meta: {
+          supportsTimeFilter: false,
+        },
+      });
+    const { container } = render(
+      <IntlProvider locale="en" messages={messages}>
+        <Configurator
+          services={mockServices}
+          baseDataset={mockDataset}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          onPrevious={mockOnPrevious}
+        />
+      </IntlProvider>
+    );
+
+    expect(
+      container.querySelector(`[data-test-subj="advancedSelectorTimeFieldSelect"]`)
+    ).toBeFalsy();
+
+    mockServices
+      .getQueryService()
+      .queryString.getDatasetService()
+      .getType.mockReturnValue(datasetTypeConfig);
   });
 });

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -236,26 +236,16 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
    * If isDatePickerEnabled is false, returns false immediately
    *
    * Dataset Type permutations (datasetType?.meta?.supportsTimeFilter):
-   * - supportsTimeFilter=true => true
    * - supportsTimeFilter=false => false
-   * - supportsTimeFilter=undefined && dataset exists => falls through to language check
-   * - no dataset => falls through to language check
    *
-   * Language permutations (when dataset.meta.supportsTimeFilter is undefined):
+   * Language permutations (when dataset.meta.supportsTimeFilter is undefined or true):
    * - queryLanguage=undefined => true (shows date picker)
    * - queryLanguage exists:
+   *   - languageOverrides[queryLanguage].hideDatePicker=true => false
+   *   - languageOverrides[queryLanguage].hideDatePicker=false => true
    *   - hideDatePicker=true => false
    *   - hideDatePicker=false => true
    *   - hideDatePicker=undefined => true
-   *
-   * Example scenarios:
-   * 1. {showDatePicker: false} => false
-   * 2. {dataset: {type: 'x', meta: {supportsTimeFilter: true}}} => true
-   * 3. {dataset: {type: 'x', meta: {supportsTimeFilter: false}}} => false
-   * 4. {dataset: {type: 'x'}, queryLanguage: 'sql', hideDatePicker: true} => false
-   * 5. {dataset: {type: 'x'}, queryLanguage: 'sql', hideDatePicker: false} => true
-   * 6. {dataset: {type: 'x'}, queryLanguage: undefined} => true (no language restrictions)
-   * 7. No configuration => true (default behavior shows date picker)
    */
   function shouldRenderDatePicker(): boolean {
     const { queryString } = data.query;

--- a/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor_top_row.tsx
@@ -224,18 +224,63 @@ export default function QueryEditorTopRow(props: QueryEditorTopRowProps) {
     );
   }
 
+  /**
+   * Determines if the date picker should be rendered based on UI settings, dataset configuration, and language settings.
+   *
+   * @returns {boolean} Whether the date picker should be rendered
+   *
+   * UI Settings permutations (isDatePickerEnabled):
+   * - showDatePicker=true || showAutoRefreshOnly=true => true
+   * - showDatePicker=false && showAutoRefreshOnly=false => false
+   * - both undefined => true (default)
+   * If isDatePickerEnabled is false, returns false immediately
+   *
+   * Dataset Type permutations (datasetType?.meta?.supportsTimeFilter):
+   * - supportsTimeFilter=true => true
+   * - supportsTimeFilter=false => false
+   * - supportsTimeFilter=undefined && dataset exists => falls through to language check
+   * - no dataset => falls through to language check
+   *
+   * Language permutations (when dataset.meta.supportsTimeFilter is undefined):
+   * - queryLanguage=undefined => true (shows date picker)
+   * - queryLanguage exists:
+   *   - hideDatePicker=true => false
+   *   - hideDatePicker=false => true
+   *   - hideDatePicker=undefined => true
+   *
+   * Example scenarios:
+   * 1. {showDatePicker: false} => false
+   * 2. {dataset: {type: 'x', meta: {supportsTimeFilter: true}}} => true
+   * 3. {dataset: {type: 'x', meta: {supportsTimeFilter: false}}} => false
+   * 4. {dataset: {type: 'x'}, queryLanguage: 'sql', hideDatePicker: true} => false
+   * 5. {dataset: {type: 'x'}, queryLanguage: 'sql', hideDatePicker: false} => true
+   * 6. {dataset: {type: 'x'}, queryLanguage: undefined} => true (no language restrictions)
+   * 7. No configuration => true (default behavior shows date picker)
+   */
   function shouldRenderDatePicker(): boolean {
-    return (
-      Boolean((props.showDatePicker || props.showAutoRefreshOnly) ?? true) &&
-      !(
-        queryLanguage &&
-        data.query.queryString.getLanguageService().getLanguage(queryLanguage)?.hideDatePicker
-      ) &&
-      (props.query?.dataset
-        ? data.query.queryString.getDatasetService().getType(props.query.dataset.type)?.meta
-            ?.supportsTimeFilter !== false
-        : true)
+    const { queryString } = data.query;
+    const datasetService = queryString.getDatasetService();
+    const languageService = queryString.getLanguageService();
+    const isDatePickerEnabled = Boolean(
+      (props.showDatePicker || props.showAutoRefreshOnly) ?? true
     );
+    if (!isDatePickerEnabled) return false;
+
+    // Get dataset type configuration
+    const datasetType = props.query?.dataset
+      ? datasetService.getType(props.query?.dataset.type)
+      : undefined;
+    // Check if dataset type explicitly configures the `supportsTimeFilter` option
+    if (datasetType?.meta?.supportsTimeFilter === false) return false;
+
+    if (
+      queryLanguage &&
+      datasetType?.languageOverrides?.[queryLanguage]?.hideDatePicker !== undefined
+    ) {
+      return Boolean(!datasetType.languageOverrides[queryLanguage].hideDatePicker);
+    }
+
+    return Boolean(!(queryLanguage && languageService.getLanguage(queryLanguage)?.hideDatePicker));
   }
 
   function shouldRenderQueryEditor(): boolean {

--- a/src/plugins/query_enhancements/common/types.ts
+++ b/src/plugins/query_enhancements/common/types.ts
@@ -4,7 +4,7 @@
  */
 
 import { CoreSetup } from 'opensearch-dashboards/public';
-import { PollQueryResultsParams } from '../../data/common';
+import { PollQueryResultsParams, TimeRange } from '../../data/common';
 
 export interface QueryAggConfig {
   [key: string]: {
@@ -26,7 +26,10 @@ export interface EnhancedFetchContext {
   http: CoreSetup['http'];
   path: string;
   signal?: AbortSignal;
-  body?: { pollQueryResultsParams: PollQueryResultsParams };
+  body?: {
+    pollQueryResultsParams?: PollQueryResultsParams;
+    timeRange?: TimeRange;
+  };
 }
 
 export interface QueryStatusOptions<T> {

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -55,6 +55,7 @@ export const fetch = (context: EnhancedFetchContext, query: Query, aggConfig?: Q
     query: { ...query, format: 'jdbc' },
     aggConfig,
     pollQueryResultsParams: context.body?.pollQueryResultsParams,
+    timeRange: context.body?.timeRange,
   });
   return from(
     http.fetch({

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -42,6 +42,7 @@ export class SQLSearchInterceptor extends SearchInterceptor {
       signal,
       body: {
         pollQueryResultsParams: request.params?.pollQueryResultsParams,
+        timeRange: request.params?.body?.timeRange,
       },
     };
 
@@ -62,6 +63,16 @@ export class SQLSearchInterceptor extends SearchInterceptor {
         .getDatasetService()
         .getType(datasetType);
       strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+
+      if (datasetTypeConfig?.languageOverrides?.SQL?.hideDatePicker === false) {
+        request.params = {
+          ...request.params,
+          body: {
+            ...request.params.body,
+            timeRange: this.queryService.timefilter.timefilter.getTime(),
+          },
+        };
+      }
     }
 
     return this.runSearch(request, options.abortSignal, strategy);

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -77,6 +77,7 @@ export function defineSearchStrategyRouteProvider(logger: Logger, router: IRoute
                 sessionId: schema.maybe(schema.string()),
               })
             ),
+            timeRange: schema.maybe(schema.object({}, { unknowns: 'allow' })),
           }),
         },
       },


### PR DESCRIPTION
### Description

Continue on https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8917

This PR
- allows dataset to override `hideDatePicker` per language for custom logic to insert time filter into query
- disables submit button if time field is not selected in dataset configurator

### Issues Resolved

closes https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8917

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: Support custom logic to insert time filter based on dataset type

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
