### PR TITLE
[Discover] Fix roundUp when converting timestamp for PPL

### DIFF
--- a/packages/opensearch-datemath/index.d.ts
+++ b/packages/opensearch-datemath/index.d.ts
@@ -47,6 +47,8 @@ declare const datemath: {
 
   /**
    * Parses a string into a moment object. The string can be something like "now - 15m".
+   * @param options.roundUp - If true, rounds the parsed date to the end of the
+   * unit. Only works for string with "/" like "now/d".
    * @param options.forceNow If this optional parameter is supplied, "now" will be treated as this
    * date, rather than the real "now".
    */

--- a/src/plugins/data/common/data_frames/utils.test.ts
+++ b/src/plugins/data/common/data_frames/utils.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import datemath from '@opensearch/datemath';
+import { formatTimePickerDate } from '.';
+
+describe('formatTimePickerDate', () => {
+  const mockDateFormat = 'YYYY-MM-DD HH:mm:ss';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle date range with rounding', () => {
+    jest.spyOn(datemath, 'parse');
+
+    const result = formatTimePickerDate({ from: 'now/d', to: 'now/d' }, mockDateFormat);
+
+    expect(result.fromDate).not.toEqual(result.toDate);
+
+    expect(datemath.parse).toHaveBeenCalledTimes(2);
+    expect(datemath.parse).toHaveBeenCalledWith('now/d', { roundUp: undefined });
+    expect(datemath.parse).toHaveBeenCalledWith('now/d', { roundUp: true });
+  });
+});

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -156,13 +156,13 @@ export const getTimeField = (
  * the `dateFormat` parameter
  */
 export const formatTimePickerDate = (dateRange: TimeRange, dateFormat: string) => {
-  const dateMathParse = (date: string) => {
-    const parsedDate = datemath.parse(date);
+  const dateMathParse = (date: string, roundUp?: boolean) => {
+    const parsedDate = datemath.parse(date, { roundUp });
     return parsedDate ? parsedDate.utc().format(dateFormat) : '';
   };
 
   const fromDate = dateMathParse(dateRange.from);
-  const toDate = dateMathParse(dateRange.to);
+  const toDate = dateMathParse(dateRange.to, true);
 
   return { fromDate, toDate };
 };


### PR DESCRIPTION
### Description

When selecting Today, the time range would be `now/d` to `now/d`, which currently resolves to the same timestamp. This PR fixes it so that `toDate` is resolved while rounding up.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Fix roundUp when converting timestamp for PPL

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
