### PR TITLE
fix: support imports without extensions in cypress webpack build

### DIFF
--- a/changelogs/fragments/8993.yml
+++ b/changelogs/fragments/8993.yml
@@ -1,0 +1,2 @@
+fix:
+- Support imports without extensions in cypress webpack build ([#8993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8993))

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,5 +27,35 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5601',
     specPattern: 'cypress/integration/**/*_spec.{js,jsx,ts,tsx}',
+    setupNodeEvents: setupNodeEvents,
   },
 });
+
+function setupNodeEvents(on, config) {
+  const webpackPreprocessor = require('@cypress/webpack-preprocessor');
+  const webpackOptions = webpackPreprocessor.defaultOptions.webpackOptions;
+
+  /**
+   * By default, cypress' internal webpack preprocessor doesn't allow imports without file extensions.
+   * This makes our life a bit hard since if any file in our testing dependency graph has an import without
+   * the .js extension our cypress build will fail.
+   *
+   * This extra rule relaxes this a bit by allowing imports without file extension
+   *     ex. import module from './module'
+   */
+  webpackOptions.module.rules.unshift({
+    test: /\.m?js/,
+    resolve: {
+      enforceExtension: false,
+    },
+  });
+
+  on(
+    'file:preprocessor',
+    webpackPreprocessor({
+      webpackOptions: webpackOptions,
+    })
+  );
+
+  return config;
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const { defineConfig } = require('cypress');
+import { defineConfig } from 'cypress';
+import webpackPreprocessor from '@cypress/webpack-preprocessor';
 
 module.exports = defineConfig({
   defaultCommandTimeout: 60000,
@@ -31,9 +32,11 @@ module.exports = defineConfig({
   },
 });
 
-function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): Cypress.PluginConfigOptions {
-  const webpackPreprocessor = require('@cypress/webpack-preprocessor');
-  const webpackOptions = webpackPreprocessor.defaultOptions.webpackOptions;
+function setupNodeEvents(
+  on: Cypress.PluginEvents,
+  config: Cypress.PluginConfigOptions
+): Cypress.PluginConfigOptions {
+  const { webpackOptions } = webpackPreprocessor.defaultOptions;
 
   /**
    * By default, cypress' internal webpack preprocessor doesn't allow imports without file extensions.
@@ -43,7 +46,7 @@ function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigO
    * This extra rule relaxes this a bit by allowing imports without file extension
    *     ex. import module from './module'
    */
-  webpackOptions.module.rules.unshift({
+  webpackOptions!.module!.rules.unshift({
     test: /\.m?js/,
     resolve: {
       enforceExtension: false,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -28,6 +28,7 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5601',
     specPattern: 'cypress/integration/**/*_spec.{js,jsx,ts,tsx}',
+    testIsolation: false,
     setupNodeEvents,
   },
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -27,11 +27,11 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5601',
     specPattern: 'cypress/integration/**/*_spec.{js,jsx,ts,tsx}',
-    setupNodeEvents: setupNodeEvents,
+    setupNodeEvents,
   },
 });
 
-function setupNodeEvents(on, config) {
+function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): Cypress.PluginConfigOptions {
   const webpackPreprocessor = require('@cypress/webpack-preprocessor');
   const webpackOptions = webpackPreprocessor.defaultOptions.webpackOptions;
 
@@ -53,7 +53,7 @@ function setupNodeEvents(on, config) {
   on(
     'file:preprocessor',
     webpackPreprocessor({
-      webpackOptions: webpackOptions,
+      webpackOptions,
     })
   );
 

--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
     "@babel/plugin-transform-class-static-block": "^7.24.4",
     "@babel/register": "^7.22.9",
     "@babel/types": "^7.22.9",
+    "@cypress/webpack-preprocessor": "^5.17.1",
     "@elastic/apm-rum": "^5.6.1",
     "@elastic/charts": "31.1.0",
     "@elastic/ems-client": "7.10.0",


### PR DESCRIPTION
### Description
When migrating to cypress v12, we saw a small number of regressions due compilation failures in cypress. This change is to resolve this class of issue. Once resolved in this branch I'll create a PR to merge the cypress 12 upgrade in main.

**Details**
By default, cypress' internal webpack preprocessor doesn't allow imports without file extensions. This makes our life a bit hard since if any file in our testing dependency graph has an import without the .js extension our cypress build will fail.

This configuration relaxes this a bit by allowing imports without file extension
     ex. import module from './module'

## Changelog
- fix: support imports without extensions in cypress webpack build

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
