### PR TITLE
fix: update the osd-plugin-generator template to reference the correct button

### DIFF
--- a/packages/osd-plugin-generator/template/public/components/app.tsx.ejs
+++ b/packages/osd-plugin-generator/template/public/components/app.tsx.ejs
@@ -88,7 +88,7 @@ import { CoreStart } from '<%= importFromRoot('src/core/public') %>';
                                           defaultMessage="Last timestamp: {time}" values={{ time: timestamp ? timestamp
                                           : 'Unknown' }} />
                                       </p>
-                                      <EuiSmallButton type="primary" size="s" onClick={onClickHandler}>
+                                      <EuiSmallButton type="primary" onClick={onClickHandler}>
                                         <FormattedMessage id="<%= camelCase(name) %>.buttonText"
                                           defaultMessage="<%= hasServer ? 'Get data' : 'Click me' %>" />
                                       </EuiSmallButton>

--- a/packages/osd-plugin-generator/template/public/components/app.tsx.ejs
+++ b/packages/osd-plugin-generator/template/public/components/app.tsx.ejs
@@ -4,7 +4,7 @@ import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import {
-EuiSmallButton,
+EuiButton,
 EuiHorizontalRule,
 EuiPage,
 EuiPageBody,
@@ -88,10 +88,10 @@ import { CoreStart } from '<%= importFromRoot('src/core/public') %>';
                                           defaultMessage="Last timestamp: {time}" values={{ time: timestamp ? timestamp
                                           : 'Unknown' }} />
                                       </p>
-                                      <EuiSmallButton type="primary" onClick={onClickHandler}>
+                                      <EuiButton type="primary" size="s" onClick={onClickHandler}>
                                         <FormattedMessage id="<%= camelCase(name) %>.buttonText"
                                           defaultMessage="<%= hasServer ? 'Get data' : 'Click me' %>" />
-                                      </EuiSmallButton>
+                                      </EuiButton>
                                     </EuiText>
                                   </EuiPageContentBody>
                                 </EuiPageContent>

--- a/packages/osd-plugin-generator/template/public/components/app.tsx.ejs
+++ b/packages/osd-plugin-generator/template/public/components/app.tsx.ejs
@@ -88,10 +88,10 @@ import { CoreStart } from '<%= importFromRoot('src/core/public') %>';
                                           defaultMessage="Last timestamp: {time}" values={{ time: timestamp ? timestamp
                                           : 'Unknown' }} />
                                       </p>
-                                      <EuiButton type="primary" size="s" onClick={onClickHandler}>
+                                      <EuiSmallButton type="primary" size="s" onClick={onClickHandler}>
                                         <FormattedMessage id="<%= camelCase(name) %>.buttonText"
                                           defaultMessage="<%= hasServer ? 'Get data' : 'Click me' %>" />
-                                      </EuiButton>
+                                      </EuiSmallButton>
                                     </EuiText>
                                   </EuiPageContentBody>
                                 </EuiPageContent>


### PR DESCRIPTION
### Description

- following the [plugin generator guide](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/packages/osd-plugin-generator/README.md), once you have created a plugin, navigate to your plugin on the dashboard, and you will see a blank page:

<img width="1107" alt="Screenshot 2024-12-05 at 3 41 31 PM" src="https://github.com/user-attachments/assets/e1d73f35-b634-4199-a615-07a091a0ea05">

- Inspecting the console will reveal the issue

<img width="829" alt="Screenshot 2024-12-05 at 3 41 56 PM" src="https://github.com/user-attachments/assets/3c942d83-e87d-4db4-9c53-167c0294cdfa">



### Issues Resolved

fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8918


## Testing the changes

- After making this change, i have created a plugin again via `node scripts/generate_plugin --name my_plugin_name -y`, and upon navigating to my new plugin's page, the page correctly renders:

<img width="1163" alt="Screenshot 2024-12-05 at 3 44 16 PM" src="https://github.com/user-attachments/assets/5217b294-ace9-468e-8391-141caa5c0715">


## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
