### PR TITLE
[Workspace] fix:Prevent user from visiting dashboards / visualizations when out of a workspace

### DIFF
--- a/changelogs/fragments/9024.yml
+++ b/changelogs/fragments/9024.yml
@@ -1,0 +1,2 @@
+fix:
+- Prevent user from visiting dashboards / visualizations when out of a workspace ([#9024](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9024))

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -34,6 +34,9 @@ import { filter, map } from 'rxjs/operators';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 
+import { UrlForwardingSetup, UrlForwardingStart } from 'src/plugins/url_forwarding/public';
+import { isEmpty } from 'lodash';
+import { createHashHistory } from 'history';
 import {
   App,
   AppMountParameters,
@@ -43,11 +46,9 @@ import {
   Plugin,
   PluginInitializerContext,
   SavedObjectsClientContract,
+  WorkspaceAvailability,
   ScopedHistory,
-} from 'src/core/public';
-import { UrlForwardingSetup, UrlForwardingStart } from 'src/plugins/url_forwarding/public';
-import { isEmpty } from 'lodash';
-import { createHashHistory } from 'history';
+} from '../../../../src/core/public';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import {
   CONTEXT_MENU_TRIGGER,
@@ -367,6 +368,7 @@ export class DashboardPlugin
       id: DashboardConstants.DASHBOARDS_ID,
       title: 'Dashboards',
       order: 2500,
+      workspaceAvailability: WorkspaceAvailability.insideWorkspace,
       euiIconType: 'inputOutput',
       defaultPath: `#${DashboardConstants.LANDING_PAGE_PATH}`,
       updater$: this.appStateUpdater,

--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -42,6 +42,7 @@ import {
   ScopedHistory,
 } from 'opensearch-dashboards/public';
 
+import { WorkspaceAvailability } from '../../../../src/core/public';
 import {
   Storage,
   createOsdUrlTracker,
@@ -158,6 +159,7 @@ export class VisualizePlugin
       title: 'Visualize',
       order: 8000,
       euiIconType: 'inputOutput',
+      workspaceAvailability: WorkspaceAvailability.insideWorkspace,
       defaultPath: '#/',
       category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
       updater$: this.appStateUpdater.asObservable(),

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -532,11 +532,6 @@ describe('Workspace plugin', () => {
     };
 
     const appUpdater$ = setupMock.application.registerAppUpdater.mock.calls[0][0];
-    appUpdater$.next((app) => {
-      if (app.workspaceAvailability === WorkspaceAvailability.insideWorkspace) {
-        return { status: AppStatus.inaccessible };
-      }
-    });
 
     const appState = await appUpdater$.pipe(first()).toPromise();
     expect(appState(mockApp)).toEqual({ status: AppStatus.inaccessible });

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -526,11 +526,10 @@ describe('Workspace plugin', () => {
 
     workspacePlugin.start(coreStart, getMockDependencies());
 
-    const mockApps = [
-      { id: 'dashboards', workspaceAvailability: WorkspaceAvailability.insideWorkspace },
-      { id: 'visualize', workspaceAvailability: WorkspaceAvailability.insideWorkspace },
-      { id: 'other', workspaceAvailability: WorkspaceAvailability.outsideWorkspace },
-    ];
+    const mockApp = {
+      id: 'dashboards',
+      workspaceAvailability: WorkspaceAvailability.insideWorkspace,
+    };
 
     const appUpdater$ = setupMock.application.registerAppUpdater.mock.calls[0][0];
 
@@ -541,19 +540,14 @@ describe('Workspace plugin', () => {
       ) {
         return { status: AppStatus.inaccessible };
       }
-
       return { status: AppStatus.accessible };
     });
+
     appUpdater$.subscribe(appUpdaterChangeMock);
 
-    mockApps.forEach((app) => {
-      const result = appUpdaterChangeMock(app);
-      if (app.workspaceAvailability === WorkspaceAvailability.insideWorkspace) {
-        expect(result).toEqual({ status: AppStatus.inaccessible });
-      } else {
-        expect(result).toEqual({ status: AppStatus.accessible });
-      }
-    });
+    const result = appUpdaterChangeMock(mockApp);
+    expect(result).toEqual({ status: AppStatus.inaccessible });
+    expect(appUpdaterChangeMock).toHaveBeenCalledWith(mockApp);
   });
 
   it('#stop should call unregisterNavGroupUpdater', async () => {

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -162,6 +162,12 @@ export class WorkspacePlugin
            */
           return { status: AppStatus.inaccessible };
         });
+      } else {
+        this.appUpdater$.next((app) => {
+          if (app.workspaceAvailability === WorkspaceAvailability.insideWorkspace) {
+            return { status: AppStatus.inaccessible };
+          }
+        });
       }
     });
 


### PR DESCRIPTION
### Description

This pr addresses:
1. Prevent user from visiting dashboards / visualizations when out of a workspace by setting WorkspaceAvailability


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Prevent user from visiting dashboards / visualizations when out of a workspace
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
