### PR TITLE
Disable buttons in sample data cards for read-only users

### DIFF
--- a/src/plugins/home/public/application/components/sample_data_set_card.js
+++ b/src/plugins/home/public/application/components/sample_data_set_card.js
@@ -129,7 +129,6 @@ export const SampleDataSetCard = (props) => {
                 name={props.name}
                 overviewDashboard={props.overviewDashboard}
                 appLinks={props.appLinks}
-                isReadOnly={isReadOnly}
               />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/src/plugins/home/public/application/components/sample_data_set_card.js
+++ b/src/plugins/home/public/application/components/sample_data_set_card.js
@@ -53,13 +53,7 @@ export const SampleDataSetCard = (props) => {
   const {
     services: { workspaces },
   } = useOpenSearchDashboards();
-  const isInstalled = () => {
-    if (props.status === INSTALLED_STATUS) {
-      return true;
-    }
-
-    return false;
-  };
+  const isInstalled = props.status === INSTALLED_STATUS;
   const currentWorkspace = useObservable(workspaces.currentWorkspace$);
   const isReadOnly = !!(currentWorkspace && currentWorkspace.readonly);
 
@@ -214,7 +208,6 @@ export const SampleDataSetCard = (props) => {
     }
   };
 
-  // render() {
   return (
     <EuiCard
       textAlign="left"
@@ -222,12 +215,11 @@ export const SampleDataSetCard = (props) => {
       image={props.previewUrl}
       title={props.name}
       description={props.description}
-      betaBadgeLabel={isInstalled() ? 'INSTALLED' : null}
+      betaBadgeLabel={isInstalled ? 'INSTALLED' : null}
       footer={renderBtn()}
       data-test-subj={`sampleDataSetCard${props.id}`}
     />
   );
-  // }
 };
 
 SampleDataSetCard.propTypes = {

--- a/src/plugins/home/public/application/components/sample_data_set_card.js
+++ b/src/plugins/home/public/application/components/sample_data_set_card.js
@@ -29,6 +29,7 @@
  */
 
 import React from 'react';
+import useObservable from 'react-use/lib/useObservable';
 import PropTypes from 'prop-types';
 import {
   EuiCard,
@@ -46,62 +47,69 @@ import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 
 import { SampleDataViewDataButton } from './sample_data_view_data_button';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 
-export class SampleDataSetCard extends React.Component {
-  isInstalled = () => {
-    if (this.props.status === INSTALLED_STATUS) {
+export const SampleDataSetCard = (props) => {
+  const {
+    services: { workspaces },
+  } = useOpenSearchDashboards();
+  const isInstalled = () => {
+    if (props.status === INSTALLED_STATUS) {
       return true;
     }
 
     return false;
   };
+  const currentWorkspace = useObservable(workspaces.currentWorkspace$);
+  const isReadOnly = !!(currentWorkspace && currentWorkspace.readonly);
 
-  install = () => {
-    this.props.onInstall(this.props.id, this.props.dataSourceId);
+  const install = () => {
+    props.onInstall(props.id, props.dataSourceId);
   };
 
-  uninstall = () => {
-    this.props.onUninstall(this.props.id, this.props.dataSourceId);
+  const uninstall = () => {
+    props.onUninstall(props.id, props.dataSourceId);
   };
 
-  renderBtn = () => {
-    const dataSourceEnabled = this.props.isDataSourceEnabled;
-    const hideLocalCluster = this.props.isLocalClusterHidden;
-    const dataSourceId = this.props.dataSourceId;
+  const renderBtn = () => {
+    const dataSourceEnabled = props.isDataSourceEnabled;
+    const hideLocalCluster = props.isLocalClusterHidden;
+    const dataSourceId = props.dataSourceId;
 
     let buttonDisabled = false;
     if (dataSourceEnabled && hideLocalCluster) {
       buttonDisabled = dataSourceId === undefined;
     }
 
-    switch (this.props.status) {
+    switch (props.status) {
       case INSTALLED_STATUS:
         return (
           <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
               <EuiSmallButtonEmpty
-                isLoading={this.props.isProcessing}
-                onClick={this.uninstall}
+                isDisabled={isReadOnly}
+                isLoading={props.isProcessing}
+                onClick={uninstall}
                 color="danger"
-                data-test-subj={`removeSampleDataSet${this.props.id}`}
+                data-test-subj={`removeSampleDataSet${props.id}`}
                 flush="left"
                 aria-label={
-                  this.props.isProcessing
+                  props.isProcessing
                     ? i18n.translate('home.sampleDataSetCard.removingButtonAriaLabel', {
                         defaultMessage: 'Removing {datasetName}',
                         values: {
-                          datasetName: this.props.name,
+                          datasetName: props.name,
                         },
                       })
                     : i18n.translate('home.sampleDataSetCard.removeButtonAriaLabel', {
                         defaultMessage: 'Remove {datasetName}',
                         values: {
-                          datasetName: this.props.name,
+                          datasetName: props.name,
                         },
                       })
                 }
               >
-                {this.props.isProcessing ? (
+                {props.isProcessing ? (
                   <FormattedMessage
                     id="home.sampleDataSetCard.removingButtonLabel"
                     defaultMessage="Removing"
@@ -116,11 +124,12 @@ export class SampleDataSetCard extends React.Component {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <SampleDataViewDataButton
-                id={this.props.id}
-                dataSourceId={this.props.dataSourceId}
-                name={this.props.name}
-                overviewDashboard={this.props.overviewDashboard}
-                appLinks={this.props.appLinks}
+                id={props.id}
+                dataSourceId={props.dataSourceId}
+                name={props.name}
+                overviewDashboard={props.overviewDashboard}
+                appLinks={props.appLinks}
+                isReadOnly={isReadOnly}
               />
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -131,27 +140,27 @@ export class SampleDataSetCard extends React.Component {
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
               <EuiSmallButton
-                isDisabled={buttonDisabled}
-                isLoading={this.props.isProcessing}
-                onClick={this.install}
-                data-test-subj={`addSampleDataSet${this.props.id}`}
+                isDisabled={buttonDisabled || isReadOnly}
+                isLoading={props.isProcessing}
+                onClick={install}
+                data-test-subj={`addSampleDataSet${props.id}`}
                 aria-label={
-                  this.props.isProcessing
+                  props.isProcessing
                     ? i18n.translate('home.sampleDataSetCard.addingButtonAriaLabel', {
                         defaultMessage: 'Adding {datasetName}',
                         values: {
-                          datasetName: this.props.name,
+                          datasetName: props.name,
                         },
                       })
                     : i18n.translate('home.sampleDataSetCard.addButtonAriaLabel', {
                         defaultMessage: 'Add {datasetName}',
                         values: {
-                          datasetName: this.props.name,
+                          datasetName: props.name,
                         },
                       })
                 }
               >
-                {this.props.isProcessing ? (
+                {props.isProcessing ? (
                   <FormattedMessage
                     id="home.sampleDataSetCard.addingButtonLabel"
                     defaultMessage="Adding"
@@ -178,18 +187,18 @@ export class SampleDataSetCard extends React.Component {
                     <FormattedMessage
                       id="home.sampleDataSetCard.default.unableToVerifyErrorMessage"
                       defaultMessage="Unable to verify dataset status, error: {statusMsg}"
-                      values={{ statusMsg: this.props.statusMsg }}
+                      values={{ statusMsg: props.statusMsg }}
                     />
                   </p>
                 }
               >
                 <EuiSmallButton
-                  isDisabled={buttonDisabled}
-                  data-test-subj={`addSampleDataSet${this.props.id}`}
+                  isDisabled={buttonDisabled || isReadOnly}
+                  data-test-subj={`addSampleDataSet${props.id}`}
                   aria-label={i18n.translate('home.sampleDataSetCard.default.addButtonAriaLabel', {
                     defaultMessage: 'Add {datasetName}',
                     values: {
-                      datasetName: this.props.name,
+                      datasetName: props.name,
                     },
                   })}
                 >
@@ -206,21 +215,21 @@ export class SampleDataSetCard extends React.Component {
     }
   };
 
-  render() {
-    return (
-      <EuiCard
-        textAlign="left"
-        className="homSampleDataSetCard"
-        image={this.props.previewUrl}
-        title={this.props.name}
-        description={this.props.description}
-        betaBadgeLabel={this.isInstalled() ? 'INSTALLED' : null}
-        footer={this.renderBtn()}
-        data-test-subj={`sampleDataSetCard${this.props.id}`}
-      />
-    );
-  }
-}
+  // render() {
+  return (
+    <EuiCard
+      textAlign="left"
+      className="homSampleDataSetCard"
+      image={props.previewUrl}
+      title={props.name}
+      description={props.description}
+      betaBadgeLabel={isInstalled() ? 'INSTALLED' : null}
+      footer={renderBtn()}
+      data-test-subj={`sampleDataSetCard${props.id}`}
+    />
+  );
+  // }
+};
 
 SampleDataSetCard.propTypes = {
   id: PropTypes.string.isRequired,

--- a/src/plugins/home/public/application/components/sample_data_view_data_button.js
+++ b/src/plugins/home/public/application/components/sample_data_view_data_button.js
@@ -76,7 +76,6 @@ export class SampleDataViewDataButton extends React.Component {
     if (this.props.appLinks.length === 0 && this.props.overviewDashboard !== '') {
       return (
         <EuiSmallButton
-          isDisabled={this.props.isReadOnly}
           onClick={createAppNavigationHandler(dashboardPath)}
           data-test-subj={`launchSampleDataSet${this.props.id}`}
           aria-label={viewDataButtonAriaLabel}

--- a/src/plugins/home/public/application/components/sample_data_view_data_button.js
+++ b/src/plugins/home/public/application/components/sample_data_view_data_button.js
@@ -76,6 +76,7 @@ export class SampleDataViewDataButton extends React.Component {
     if (this.props.appLinks.length === 0 && this.props.overviewDashboard !== '') {
       return (
         <EuiSmallButton
+          isDisabled={this.props.isReadOnly}
           onClick={createAppNavigationHandler(dashboardPath)}
           data-test-subj={`launchSampleDataSet${this.props.id}`}
           aria-label={viewDataButtonAriaLabel}


### PR DESCRIPTION
### Description
This PR disables "add" button and "remove" button at sample data card for read-only users.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
![Screenshot 2024-12-17 at 11 29 48](https://github.com/user-attachments/assets/15a80bec-5e1f-4c2d-a697-1dfb7402036c)
![Screenshot 2024-12-17 at 11 29 28](https://github.com/user-attachments/assets/995572d8-07b7-4461-ba98-dcc297b95a31)
<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: Disable buttons in sample data cards for read-only users

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
