### PR TITLE
[workspace] fix: manage link does not do anything

### DIFF
--- a/changelogs/fragments/9059.yml
+++ b/changelogs/fragments/9059.yml
@@ -1,0 +1,2 @@
+fix:
+- Inactive manage link in the data source selector when opening DevTools ([#9059](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9059))

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -19,7 +19,14 @@ import {
 import { DataSourceSelectable } from '../data_source_selectable';
 
 export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement | null {
-  const { componentType, componentConfig, uiSettings, hideLocalCluster, application } = props;
+  const {
+    componentType,
+    componentConfig,
+    uiSettings,
+    hideLocalCluster,
+    application,
+    onChangeDevToolsModalVisible,
+  } = props;
 
   function renderDataSourceView(config: DataSourceViewConfig): ReactElement | null {
     const {
@@ -74,6 +81,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
     } = config;
     return (
       <DataSourceSelectable
+        onChangeDevToolsModalVisible={onChangeDevToolsModalVisible}
         savedObjectsClient={savedObjects!}
         notifications={notifications!.toasts}
         onSelectedDataSources={onSelectedDataSources}

--- a/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_menu/data_source_menu.tsx
@@ -25,7 +25,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
     uiSettings,
     hideLocalCluster,
     application,
-    onChangeDevToolsModalVisible,
+    onManageDataSource,
   } = props;
 
   function renderDataSourceView(config: DataSourceViewConfig): ReactElement | null {
@@ -81,7 +81,7 @@ export function DataSourceMenu<T>(props: DataSourceMenuProps<T>): ReactElement |
     } = config;
     return (
       <DataSourceSelectable
-        onChangeDevToolsModalVisible={onChangeDevToolsModalVisible}
+        onManageDataSource={onManageDataSource}
         savedObjectsClient={savedObjects!}
         notifications={notifications!.toasts}
         onSelectedDataSources={onSelectedDataSources}

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -40,7 +40,7 @@ export interface DataSourceMenuProps<T = any> {
   uiSettings?: IUiSettingsClient;
   application?: ApplicationStart;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
-  onChangeDevToolsModalVisible: () => void;
+  onManageDataSource: () => void;
 }
 
 export const DataSourceComponentType = {
@@ -82,7 +82,7 @@ export interface DataSourceSelectableConfig extends DataSourceBaseConfig {
   notifications: NotificationsStart;
   activeOption?: DataSourceOption[];
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
-  onChangeDevToolsModalVisible: () => void;
+  onManageDataSource: () => void;
 }
 
 export interface DataSourceMultiSelectableConfig extends DataSourceBaseConfig {

--- a/src/plugins/data_source_management/public/components/data_source_menu/types.ts
+++ b/src/plugins/data_source_management/public/components/data_source_menu/types.ts
@@ -40,6 +40,7 @@ export interface DataSourceMenuProps<T = any> {
   uiSettings?: IUiSettingsClient;
   application?: ApplicationStart;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
+  onChangeDevToolsModalVisible: () => void;
 }
 
 export const DataSourceComponentType = {
@@ -81,6 +82,7 @@ export interface DataSourceSelectableConfig extends DataSourceBaseConfig {
   notifications: NotificationsStart;
   activeOption?: DataSourceOption[];
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
+  onChangeDevToolsModalVisible: () => void;
 }
 
 export interface DataSourceMultiSelectableConfig extends DataSourceBaseConfig {

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -52,7 +52,7 @@ interface DataSourceSelectableProps {
   selectedOption?: DataSourceOption[];
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
   uiSettings?: IUiSettingsClient;
-  onChangeDevToolsModalVisible: () => void;
+  onManageDataSource: () => void;
 }
 
 interface DataSourceSelectableState extends DataSourceBaseState {
@@ -294,7 +294,7 @@ export class DataSourceSelectable extends React.Component<
         data-test-subj={'dataSourceSelectableContextMenuPopover'}
       >
         <DataSourceDropDownHeader
-          onChangeDevToolsModalVisible={this.props.onChangeDevToolsModalVisible}
+          onManageDataSource={this.props.onManageDataSource}
           totalDataSourceCount={this.state.dataSourceOptions.length}
           application={this.props.application}
         />

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -52,6 +52,7 @@ interface DataSourceSelectableProps {
   selectedOption?: DataSourceOption[];
   dataSourceFilter?: (dataSource: SavedObject<DataSourceAttributes>) => boolean;
   uiSettings?: IUiSettingsClient;
+  onChangeDevToolsModalVisible: () => void;
 }
 
 interface DataSourceSelectableState extends DataSourceBaseState {
@@ -293,6 +294,7 @@ export class DataSourceSelectable extends React.Component<
         data-test-subj={'dataSourceSelectableContextMenuPopover'}
       >
         <DataSourceDropDownHeader
+          onChangeDevToolsModalVisible={this.props.onChangeDevToolsModalVisible}
           totalDataSourceCount={this.state.dataSourceOptions.length}
           application={this.props.application}
         />

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.test.tsx
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.test.tsx
@@ -51,12 +51,12 @@ describe('DataSourceDropDownHeader', () => {
     const totalDataSourceCount = 5;
     const applicationMock = coreMock.createStart().application;
     const navigateToAppMock = applicationMock.navigateToApp;
-    const onChangeDevToolsModalVisibleMock = jest.fn();
+    const onManageDataSourceMock = jest.fn();
     const wrapper = mount(
       <DataSourceDropDownHeader
         totalDataSourceCount={totalDataSourceCount}
         application={applicationMock}
-        onChangeDevToolsModalVisible={onChangeDevToolsModalVisibleMock}
+        onManageDataSource={onManageDataSourceMock}
       />
     );
 
@@ -64,6 +64,6 @@ describe('DataSourceDropDownHeader', () => {
     expect(navigateToAppMock).toHaveBeenCalledWith('management', {
       path: `opensearch-dashboards/${DSM_APP_ID}`,
     });
-    expect(onChangeDevToolsModalVisibleMock).toHaveBeenCalled();
+    expect(onManageDataSourceMock).toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.test.tsx
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.test.tsx
@@ -47,15 +47,16 @@ describe('DataSourceDropDownHeader', () => {
     expect(wrapper.text()).toContain(`${activeDataSourceCount}/${totalDataSourceCount}`);
   });
 
-  it('should call application.navigateToApp when the "Manage" link is clicked', () => {
+  it('should call application.navigateToApp and close the modal mask when the "Manage" link is clicked', () => {
     const totalDataSourceCount = 5;
     const applicationMock = coreMock.createStart().application;
     const navigateToAppMock = applicationMock.navigateToApp;
-
+    const onChangeDevToolsModalVisibleMock = jest.fn();
     const wrapper = mount(
       <DataSourceDropDownHeader
         totalDataSourceCount={totalDataSourceCount}
         application={applicationMock}
+        onChangeDevToolsModalVisible={onChangeDevToolsModalVisibleMock}
       />
     );
 
@@ -63,5 +64,6 @@ describe('DataSourceDropDownHeader', () => {
     expect(navigateToAppMock).toHaveBeenCalledWith('management', {
       path: `opensearch-dashboards/${DSM_APP_ID}`,
     });
+    expect(onChangeDevToolsModalVisibleMock).toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.tsx
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.tsx
@@ -13,14 +13,14 @@ interface DataSourceOptionItemProps {
   totalDataSourceCount: number;
   activeDataSourceCount?: number;
   application?: ApplicationStart;
-  onChangeDevToolsModalVisible: () => void;
+  onManageDataSource: () => void;
 }
 
 export const DataSourceDropDownHeader: React.FC<DataSourceOptionItemProps> = ({
   activeDataSourceCount,
   totalDataSourceCount,
   application,
-  onChangeDevToolsModalVisible,
+  onManageDataSource,
 }) => {
   const dataSourceCounterPrefix = totalDataSourceCount === 1 ? 'DATA SOURCE' : 'DATA SOURCES';
   const dataSourceCounter =
@@ -38,7 +38,7 @@ export const DataSourceDropDownHeader: React.FC<DataSourceOptionItemProps> = ({
         <EuiFlexItem grow={false}>
           <EuiLink
             onClick={() => {
-              onChangeDevToolsModalVisible();
+              onManageDataSource();
               application?.navigateToApp('management', {
                 path: `opensearch-dashboards/${DSM_APP_ID}`,
               });

--- a/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.tsx
+++ b/src/plugins/data_source_management/public/components/drop_down_header/drop_down_header.tsx
@@ -13,12 +13,14 @@ interface DataSourceOptionItemProps {
   totalDataSourceCount: number;
   activeDataSourceCount?: number;
   application?: ApplicationStart;
+  onChangeDevToolsModalVisible: () => void;
 }
 
 export const DataSourceDropDownHeader: React.FC<DataSourceOptionItemProps> = ({
   activeDataSourceCount,
   totalDataSourceCount,
   application,
+  onChangeDevToolsModalVisible,
 }) => {
   const dataSourceCounterPrefix = totalDataSourceCount === 1 ? 'DATA SOURCE' : 'DATA SOURCES';
   const dataSourceCounter =
@@ -35,11 +37,12 @@ export const DataSourceDropDownHeader: React.FC<DataSourceOptionItemProps> = ({
         <div tabIndex={0} className="dataSourceDropDownHeaderInvisibleFocusable" />
         <EuiFlexItem grow={false}>
           <EuiLink
-            onClick={() =>
+            onClick={() => {
+              onChangeDevToolsModalVisible();
               application?.navigateToApp('management', {
                 path: `opensearch-dashboards/${DSM_APP_ID}`,
-              })
-            }
+              });
+            }}
           >
             Manage
           </EuiLink>

--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -59,7 +59,7 @@ interface DevToolsWrapperProps {
   dataSourceManagement?: DataSourceManagementPluginSetup;
   useUpdatedUX?: boolean;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
-  onChangeDevToolsModalVisible: () => void;
+  onManageDataSource: () => void;
 }
 
 interface MountedDevToolDescriptor {
@@ -69,7 +69,7 @@ interface MountedDevToolDescriptor {
 }
 
 function DevToolsWrapper({
-  onChangeDevToolsModalVisible,
+  onManageDataSource,
   devTools,
   activeDevTool,
   updateRoute,
@@ -127,7 +127,7 @@ function DevToolsWrapper({
       const DataSourceMenu = dataSourceManagement!.ui.getDataSourceMenu();
       return (
         <DataSourceMenu
-          onChangeDevToolsModalVisible={onChangeDevToolsModalVisible}
+          onManageDataSource={onManageDataSource}
           setMenuMountPoint={setMenuMountPoint}
           componentType={'DataSourceSelectable'}
           componentConfig={{
@@ -244,7 +244,7 @@ function setBreadcrumbs(chrome: ChromeStart) {
 
 export function MainApp(
   props: {
-    onChangeDevToolsModalVisible: () => void;
+    onManageDataSource: () => void;
     devTools: readonly DevToolApp[];
     RouterComponent?: React.ComponentClass;
     defaultRoute?: string;
@@ -259,7 +259,7 @@ export function MainApp(
   >
 ) {
   const {
-    onChangeDevToolsModalVisible,
+    onManageDataSource,
     devTools,
     savedObjects,
     notifications,
@@ -285,7 +285,7 @@ export function MainApp(
                 exact={!devTool.enableRouting}
                 render={(routeProps) => (
                   <DevToolsWrapper
-                    onChangeDevToolsModalVisible={onChangeDevToolsModalVisible}
+                    onManageDataSource={onManageDataSource}
                     updateRoute={routeProps.history.push}
                     activeDevTool={devTool}
                     devTools={devTools}

--- a/src/plugins/dev_tools/public/application.tsx
+++ b/src/plugins/dev_tools/public/application.tsx
@@ -59,6 +59,7 @@ interface DevToolsWrapperProps {
   dataSourceManagement?: DataSourceManagementPluginSetup;
   useUpdatedUX?: boolean;
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
+  onChangeDevToolsModalVisible: () => void;
 }
 
 interface MountedDevToolDescriptor {
@@ -68,6 +69,7 @@ interface MountedDevToolDescriptor {
 }
 
 function DevToolsWrapper({
+  onChangeDevToolsModalVisible,
   devTools,
   activeDevTool,
   updateRoute,
@@ -125,6 +127,7 @@ function DevToolsWrapper({
       const DataSourceMenu = dataSourceManagement!.ui.getDataSourceMenu();
       return (
         <DataSourceMenu
+          onChangeDevToolsModalVisible={onChangeDevToolsModalVisible}
           setMenuMountPoint={setMenuMountPoint}
           componentType={'DataSourceSelectable'}
           componentConfig={{
@@ -241,6 +244,7 @@ function setBreadcrumbs(chrome: ChromeStart) {
 
 export function MainApp(
   props: {
+    onChangeDevToolsModalVisible: () => void;
     devTools: readonly DevToolApp[];
     RouterComponent?: React.ComponentClass;
     defaultRoute?: string;
@@ -255,6 +259,7 @@ export function MainApp(
   >
 ) {
   const {
+    onChangeDevToolsModalVisible,
     devTools,
     savedObjects,
     notifications,
@@ -280,6 +285,7 @@ export function MainApp(
                 exact={!devTool.enableRouting}
                 render={(routeProps) => (
                   <DevToolsWrapper
+                    onChangeDevToolsModalVisible={onChangeDevToolsModalVisible}
                     updateRoute={routeProps.history.push}
                     activeDevTool={devTool}
                     devTools={devTools}

--- a/src/plugins/dev_tools/public/dev_tools_icon.tsx
+++ b/src/plugins/dev_tools/public/dev_tools_icon.tsx
@@ -68,6 +68,10 @@ export function DevToolsIcon({
     };
   }, [modalVisible]);
 
+  const closeModalVisible = () => {
+    setModalVisible(false);
+  };
+
   return (
     <>
       <EuiToolTip
@@ -130,6 +134,7 @@ export function DevToolsIcon({
                     setMenuMountPoint={setMountPoint}
                     RouterComponent={MemoryRouter}
                     defaultRoute={devToolTab}
+                    onChangeDevToolsModalVisible={closeModalVisible}
                   />
                   <EuiSpacer size="s" />
                   <EuiSmallButton

--- a/src/plugins/dev_tools/public/dev_tools_icon.tsx
+++ b/src/plugins/dev_tools/public/dev_tools_icon.tsx
@@ -134,7 +134,7 @@ export function DevToolsIcon({
                     setMenuMountPoint={setMountPoint}
                     RouterComponent={MemoryRouter}
                     defaultRoute={devToolTab}
-                    onChangeDevToolsModalVisible={closeModalVisible}
+                    onManageDataSource={closeModalVisible}
                   />
                   <EuiSpacer size="s" />
                   <EuiSmallButton


### PR DESCRIPTION
### Description
This pr addresses the issue of inactive "Manage" link in the data source selector when opening DevTools. Now, clicking the link will direct users to opensearch-dashboards/dataSources.


## Screenshot

https://github.com/user-attachments/assets/0d5572e6-078d-4fab-8709-ece38c990246


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: inactive manage link in the data source selector when opening DevTools


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
