### PR TITLE
Fix memory leaks of Vega charts on refresh

### DIFF
--- a/src/plugins/vis_type_vega/public/vega_inspector/vega_adapter.ts
+++ b/src/plugins/vis_type_vega/public/vega_inspector/vega_adapter.ts
@@ -78,7 +78,7 @@ const serializeColumns = (item: Record<string, unknown>, columns: string[]) => {
 };
 
 export class VegaAdapter {
-  private debugValuesSubject = new ReplaySubject<DebugValues>();
+  private debugValuesSubject = new ReplaySubject<DebugValues>(1);
 
   bindInspectValues(debugValues: DebugValues) {
     this.debugValuesSubject.next(debugValues);

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -130,6 +130,7 @@ export class VegaBaseView {
           this._view.finalize();
         }
         this._view = null;
+        this._vegaViewConfig = null;
       });
 
       this._vegaViewConfig = this.createViewConfig();
@@ -507,6 +508,9 @@ export class VegaBaseView {
       this._addDestroyHandler(() => {
         if (debugObj === window.VEGA_DEBUG) {
           window.VEGA_DEBUG = null;
+          window.VEGA_DEBUG.view = null;
+          window.VEGA_DEBUG.vega_spec = null;
+          window.VEGA_DEBUG.vegalite_spec = null;
         }
       });
     }

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -508,7 +508,6 @@ export class VegaBaseView {
       this._addDestroyHandler(() => {
         if (debugObj === window.VEGA_DEBUG) {
           window.VEGA_DEBUG = null;
-          window.VEGA_DEBUG.view = null;
           window.VEGA_DEBUG.vega_spec = null;
           window.VEGA_DEBUG.vegalite_spec = null;
         }

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -507,9 +507,10 @@ export class VegaBaseView {
       // On dispose, clean up, but don't use undefined to prevent repeated debug statements
       this._addDestroyHandler(() => {
         if (debugObj === window.VEGA_DEBUG) {
-          window.VEGA_DEBUG = null;
+          window.VEGA_DEBUG.view = null;
           window.VEGA_DEBUG.vega_spec = null;
           window.VEGA_DEBUG.vegalite_spec = null;
+          window.VEGA_DEBUG = null;
         }
       });
     }


### PR DESCRIPTION
### Description

See https://github.com/elastic/kibana/issues/146170 and https://github.com/elastic/kibana/pull/147309 for details.

This fix is originally created by @alexwizp.


## Changelog

- fix: Memory leaks of Vega charts on refresh

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
