### PR TITLE
refactor some query-enhancement utility functions, add some missing typings

### DIFF
--- a/changelogs/fragments/9074.yml
+++ b/changelogs/fragments/9074.yml
@@ -1,0 +1,2 @@
+test:
+- Query-enhancements testing utility updates and additions ([#9074](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9074))

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/a_check.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/a_check.spec.js
@@ -47,7 +47,7 @@ describe('No Index Pattern Check Test', () => {
   describe('empty state', () => {
     it('no index pattern', function () {
       // Go to the Discover page
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.getElementByTestId('discoverNoIndexPatterns');
     });
   });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/dataset_selector.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/dataset_selector.spec.js
@@ -19,7 +19,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
         `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
       );
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.getElementByTestId('discoverNoIndexPatterns');
     });
   });
@@ -52,7 +52,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       // Go to the Discover page
       miscUtils.visitPage(`app/data-explorer/discover#/`);
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
     });
 
     it('with SQL as default language', function () {
@@ -70,11 +70,11 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       cy.getElementByTestId(`advancedSelectorTimeFieldSelect`).select('timestamp');
       cy.getElementByTestId('advancedSelectorConfirmButton').click();
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
 
       // SQL should already be selected
       cy.getElementByTestId('queryEditorLanguageSelector').should('contain', 'OpenSearch SQL');
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
 
       // SQL query should be executed and sending back result
       cy.get(`[data-test-subj="queryResultCompleteMsg"]`).should('be.visible');
@@ -85,7 +85,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       const toTime = 'Sep 21, 2019 @ 00:00:00.000';
       cy.setTopNavDate(fromTime, toTime);
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.get(`[data-test-subj="queryResultCompleteMsg"]`).should('be.visible');
     });
 
@@ -105,7 +105,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       cy.getElementByTestId(`advancedSelectorTimeFieldSelect`).select('timestamp');
       cy.getElementByTestId('advancedSelectorConfirmButton').click();
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
 
       // PPL should already be selected
       cy.getElementByTestId('queryEditorLanguageSelector').should('contain', 'PPL');
@@ -114,7 +114,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       const toTime = 'Sep 21, 2019 @ 00:00:00.000';
       cy.setTopNavDate(fromTime, toTime);
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
 
       // Query should finish running with timestamp and finish time in the footer
       cy.getElementByTestId('queryResultCompleteMsg').should('be.visible');
@@ -123,7 +123,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       // Switch language to SQL
       cy.setQueryLanguage('OpenSearch SQL');
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.getElementByTestId('queryResultCompleteMsg').should('be.visible');
       cy.getElementByTestId('queryEditorFooterTimestamp').should('contain', 'timestamp');
     });
@@ -148,7 +148,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       cy.get(`[title="logstash-*"]`).click();
       cy.getElementByTestId('datasetSelectorNext').click();
 
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.waitForSearch();
       cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');
     });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
@@ -32,7 +32,7 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
     cy.get(`[class~="datasetSelector__button"]`).click();
     cy.get(`[data-test-subj="datasetOption-timestamp-*"]`).click();
 
-    cy.waitForLoaderNewHeader();
+    cy.waitForLoader(true);
     cy.waitForSearch();
   });
 
@@ -40,7 +40,7 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
     it('with DQL', function () {
       const query = `_id:1`;
       cy.setSingleLineQueryEditor(query);
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.waitForSearch();
       cy.verifyHitCount(1);
 
@@ -54,7 +54,7 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
 
       const query = `_id:1`;
       cy.setSingleLineQueryEditor(query);
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.waitForSearch();
       cy.verifyHitCount(1);
 
@@ -67,7 +67,7 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
       cy.setQueryLanguage('OpenSearch SQL');
 
       // default SQL query should be set
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.getElementByTestId(`osdQueryEditor__multiLine`).contains(
         `SELECT * FROM timestamp-* LIMIT 10`
       );
@@ -87,7 +87,7 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
       cy.setQueryLanguage('PPL');
 
       // default PPL query should be set
-      cy.waitForLoaderNewHeader();
+      cy.waitForLoader(true);
       cy.getElementByTestId(`osdQueryEditor__multiLine`).contains(`source = timestamp-*`);
       cy.waitForSearch();
       cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');

--- a/cypress/utils/apps/commands.js
+++ b/cypress/utils/apps/commands.js
@@ -6,7 +6,7 @@
 import './data_explorer/commands';
 import './query_enhancements/commands';
 
-Cypress.Commands.add('waitForLoader', () => {
+Cypress.Commands.add('waitForLoader', (isEnhancement = false) => {
   const opts = { log: false };
 
   Cypress.log({
@@ -14,20 +14,11 @@ Cypress.Commands.add('waitForLoader', () => {
     displayName: 'wait',
     message: 'page load',
   });
-  cy.wait(Cypress.env('WAIT_FOR_LOADER_BUFFER_MS'));
-  cy.getElementByTestId('homeIcon', opts); // Update to `homeLoader` once useExpandedHeader is enabled
-});
 
-Cypress.Commands.add('waitForLoaderNewHeader', () => {
-  const opts = { log: false };
-
-  Cypress.log({
-    name: 'waitForPageLoad',
-    displayName: 'wait',
-    message: 'page load',
-  });
-  cy.wait(Cypress.env('WAIT_FOR_LOADER_BUFFER_MS'));
-  cy.getElementByTestId('recentItemsSectionButton', opts);
+  // Use recentItemsSectionButton for query enhancement, otherwise use homeIcon
+  cy.getElementByTestId(isEnhancement ? 'recentItemsSectionButton' : 'homeIcon', opts).should(
+    'be.visible'
+  );
 });
 
 Cypress.Commands.add('setTopNavQuery', (value, submit = true) => {

--- a/cypress/utils/apps/index.d.ts
+++ b/cypress/utils/apps/index.d.ts
@@ -10,14 +10,7 @@ declare namespace Cypress {
      * @example
      * cy.waitForLoader()
      */
-    waitForLoader(): Chainable<any>;
-
-    /**
-     * Wait for Dashboards page to load with new header
-     * @example
-     * cy.waitForLoaderNewHeader()
-     */
-    waitForLoaderNewHeader(): Chainable<any>;
+    waitForLoader(isEnhancement?: boolean): Chainable<any>;
 
     /**
      * Set the top nav query value

--- a/cypress/utils/apps/query_enhancements/commands.js
+++ b/cypress/utils/apps/query_enhancements/commands.js
@@ -68,8 +68,8 @@ Cypress.Commands.add('addDataSource', (options) => {
     cy.get('[name="password"]').type(credentials.password);
   }
 
-  // Submit form
-  cy.getElementByTestId('createDataSourceButton').click();
+  // Submit form. Adding 'force' as sometimes a popover hides the button
+  cy.getElementByTestId('createDataSourceButton').click({ force: true });
 
   // Wait for successful creation
   cy.wait('@createDataSourceRequest').then((interception) => {

--- a/cypress/utils/apps/query_enhancements/index.d.ts
+++ b/cypress/utils/apps/query_enhancements/index.d.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+declare namespace Cypress {
+  interface Chainable<Subject> {
+    setSingleLineQueryEditor(value: string, submit?: boolean): Chainable<any>;
+    setQueryLanguage(value: 'DQL' | 'Lucene' | 'OpenSearch SQL' | 'PPL'): Chainable<any>;
+    addDataSource(opts: {
+      name: string;
+      url: string;
+      auth_type?: string;
+      credentials?: { username: string; password: string };
+    }): Chainable<any>;
+    deleteDataSourceByName(dataSourceName: string): Chainable<any>;
+  }
+}

--- a/cypress/utils/dashboards/commands.js
+++ b/cypress/utils/dashboards/commands.js
@@ -59,20 +59,30 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   //navigate to workspace specific pages
   'navigateToWorkSpaceSpecificPage',
-  (url, workspaceName, page) => {
+  (opts) => {
+    const { url, workspaceName, page, isEnhancement = false } = opts;
+
     // Navigating to the WorkSpace Home Page
     cy.navigateToWorkSpaceHomePage(url, workspaceName);
 
     // Opening the side panel
-    cy.getElementByTestId('toggleNavButton').then((ele) => {
-      if (ele.length > 0) {
-        ele.first().click();
-      }
-    });
+    cy.getElementByTestId('toggleNavButton')
+      .should('be.visible')
+      .then((ele) => {
+        if (ele.length > 0) {
+          ele.first().click();
+        }
+      });
 
-    cy.getElementByTestId(`collapsibleNavAppLink-${page}`).click();
+    cy.getElementByTestId(`collapsibleNavAppLink-${page}`).should('be.visible').click();
 
-    cy.waitForLoader();
+    // wait until page loads and close side panel
+    cy.waitForLoader(isEnhancement);
+
+    // close the nav menu
+    if (isEnhancement) {
+      cy.getElementByTestId('collapsibleNavShrinkButton').should('be.visible').click();
+    }
   }
 );
 
@@ -80,27 +90,76 @@ Cypress.Commands.add(
   // creates an index pattern within the workspace
   // Don't use * in the indexPattern it adds it by default at the end of name
   'createWorkspaceIndexPatterns',
-  (url, workspaceName, indexPattern, dataSource, timefieldName = '') => {
+  (opts) => {
+    const {
+      url,
+      workspaceName,
+      indexPattern,
+      timefieldName,
+      indexPatternHasTimefield = true,
+      dataSource,
+      isEnhancement = false,
+    } = opts;
+
     // Navigate to Workspace Specific IndexPattern Page
-    cy.navigateToWorkSpaceSpecificPage(url, workspaceName, 'indexPatterns');
+    cy.navigateToWorkSpaceSpecificPage({
+      url,
+      workspaceName,
+      page: 'indexPatterns',
+      isEnhancement,
+    });
+    cy.getElementByTestId('createIndexPatternButton').click();
 
-    cy.getElementByTestId('createIndexPatternButton').click({ force: true });
+    if (dataSource) {
+      cy.get('[type="data-source"]').contains(dataSource).click();
+    }
 
-    cy.get('[type="data-source"]').contains(dataSource).click();
     cy.getElementByTestId('createIndexPatternStepDataSourceNextStepButton').click();
 
-    cy.wait(1000); // Intentional Wait
-
-    cy.getElementByTestId('createIndexPatternNameInput').clear().type(indexPattern);
+    cy.getElementByTestId('createIndexPatternNameInput')
+      .should('be.visible')
+      .clear()
+      .type(indexPattern);
     cy.getElementByTestId('createIndexPatternGoToStep2Button').click();
 
-    if (timefieldName !== '') {
+    // wait for the select input if it exists
+    if (indexPatternHasTimefield || timefieldName) {
+      cy.getElementByTestId('createIndexPatternTimeFieldSelect').should('be.visible');
+    }
+
+    if (indexPatternHasTimefield && !!timefieldName) {
       cy.getElementByTestId('createIndexPatternTimeFieldSelect').select(timefieldName);
-    } else {
+    } else if (indexPatternHasTimefield && !timefieldName) {
       cy.getElementByTestId('createIndexPatternTimeFieldSelect').select(
         "I don't want to use the time filter"
       );
     }
-    cy.getElementByTestId('createIndexPatternButton').click();
+
+    cy.getElementByTestId('createIndexPatternButton').should('be.visible').click();
+    cy.getElementByTestId('headerApplicationTitle').contains(indexPattern);
+  }
+);
+
+Cypress.Commands.add(
+  // deletes an index pattern within the workspace
+  // Don't use * in the indexPattern it adds it by default at the end of name
+  'deleteWorkspaceIndexPatterns',
+  (opts) => {
+    const { url, workspaceName, indexPattern, isEnhancement = false } = opts;
+
+    // Navigate to Workspace Specific IndexPattern Page
+    cy.navigateToWorkSpaceSpecificPage({
+      url,
+      workspaceName,
+      page: 'indexPatterns',
+      isEnhancement,
+    });
+
+    cy.contains('a', indexPattern).click();
+    cy.getElementByTestId('deleteIndexPatternButton').should('be.visible').click();
+    cy.getElementByTestId('confirmModalConfirmButton').should('be.visible').click();
+
+    // wait until delete is done
+    cy.getElementByTestId('headerApplicationTitle').should('be.visible');
   }
 );

--- a/cypress/utils/dashboards/index.d.ts
+++ b/cypress/utils/dashboards/index.d.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+declare namespace Cypress {
+  interface Chainable<Subject> {
+    navigateToWorkSpaceHomePage(url: string, workspaceName: string): Chainable<any>;
+    navigateToWorkSpaceSpecificPage(opts: {
+      url: string;
+      workspaceName: string;
+      page: string;
+      isEnhancement?: boolean;
+    }): Chainable<any>;
+    createWorkspaceIndexPatterns(opts: {
+      url: string;
+      workspaceName: string;
+      indexPattern: string;
+      timefieldName?: string;
+      indexPatternHasTimefield?: boolean;
+      dataSource?: string;
+      isEnhancement?: boolean;
+    }): Chainable<any>;
+    deleteWorkspaceIndexPatterns(opts: {
+      url: string;
+      workspaceName: string;
+      indexPattern: string;
+      isEnhancement?: boolean;
+    }): Chainable<any>;
+  }
+}


### PR DESCRIPTION
### Description

Refactors/additions for Cypress Query Enhancements

- update the custom command `waitForLoader` to take optional arg `isEnhancement: boolean`
- remove the `cy.wait()` within `waitForLoader` to speed up the command
- remove the now redundant `waitForLoaderNewHeader` command and refactor its' usage to be `waitForLoader(true)`
- add typescript typings to some of our custom commands
- refactor createWorkspaceIndexPatterns
    - conditionally call `cy.get('[type="data-source"]').contains(dataSource).click();` if `dataSource` prop is provided. This is because if your ws only has one data source, then this step is not visible in the UI, and this utility will fail
    - add optional arg `indexPatternHasTimefield: boolean`. This is needed because if the index pattern you select does not have a timefield, then the option of choosing a timestamp field does not appear, causing the test to fail
    - add the `isEnhancement: boolean` prop
 - add `deleteWorkspaceIndexPatterns` utility
 - refactor `navigateToWorkSpaceSpecificPage` to be less flaky
    - one thing to call out. I noticed a lot of flaky tests due to the nature of our left menu bar. The left menu bar's `open` state persists through navigation and refreshes. Therefore, in order to maintain consistent state before & after a function is run, if a function opens the bar, we should also add a step that closes it. This way we do not have to keep track of it's `open` state.

### Issues Resolved

-n/a

## Testing the changes

- ran cypress tests

## Changelog

- test: query-enhancements testing utility updates and additions

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
