### PR TITLE
Re-enable dataset_selector.spec.js and queries.spec.js under workspace

### DIFF
--- a/changelogs/fragments/9082.yml
+++ b/changelogs/fragments/9082.yml
@@ -1,0 +1,2 @@
+test:
+- Re-enable dataset_selector.spec.js under workspace in ciGroup10 ([#9082](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9082))

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/constants.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/constants.js
@@ -5,3 +5,5 @@
 
 export const DATASOURCE_NAME = 'query-cluster';
 export const WORKSPACE_NAME = 'query-workspace';
+export const START_TIME = 'Dec 31, 2020 @ 00:00:00.000';
+export const END_TIME = 'Dec 31, 2022 @ 23:59:59.999';

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/constants.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/constants.js
@@ -5,5 +5,5 @@
 
 export const DATASOURCE_NAME = 'query-cluster';
 export const WORKSPACE_NAME = 'query-workspace';
-export const START_TIME = 'Dec 31, 2020 @ 00:00:00.000';
-export const END_TIME = 'Dec 31, 2022 @ 23:59:59.999';
+export const START_TIME = 'Jan 1, 2020 @ 00:00:00.000';
+export const END_TIME = 'Jan 1, 2024 @ 00:00:00.000';

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/dataset_selector.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/dataset_selector.spec.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
 import { WORKSPACE_NAME, DATASOURCE_NAME, START_TIME, END_TIME } from './constants';
 import { BASE_PATH, SECONDARY_ENGINE } from '../../../../../utils/constants';
-
-const miscUtils = new MiscUtils(cy);
 
 describe('dataset selector', { scrollBehavior: false }, () => {
   before(() => {
@@ -31,7 +28,7 @@ describe('dataset selector', { scrollBehavior: false }, () => {
   beforeEach(() => {
     // Create workspace
     cy.deleteWorkspaceByName(`${WORKSPACE_NAME}`);
-    miscUtils.visitPage('/app/home');
+    cy.visit('/app/home');
     cy.createInitialWorkspaceWithDataSource(`${DATASOURCE_NAME}`, `${WORKSPACE_NAME}`);
   });
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/dataset_selector.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/dataset_selector.spec.js
@@ -2,65 +2,50 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-  MiscUtils,
-  TestFixtureHandler,
-} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
-import { PATHS, SECONDARY_ENGINE } from '../../../../../utils/constants';
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { WORKSPACE_NAME, DATASOURCE_NAME, START_TIME, END_TIME } from './constants';
+import { BASE_PATH, SECONDARY_ENGINE } from '../../../../../utils/constants';
 
 const miscUtils = new MiscUtils(cy);
-const testFixtureHandler = new TestFixtureHandler(cy, PATHS.ENGINE);
 
-describe.skip('dataset selector', { scrollBehavior: false }, () => {
-  describe('empty state', () => {
-    it('no index pattern', function () {
-      // Go to the Discover page
-      miscUtils.visitPage(
-        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
-      );
+describe('dataset selector', { scrollBehavior: false }, () => {
+  before(() => {
+    cy.setupTestData(
+      SECONDARY_ENGINE.url,
+      ['cypress/fixtures/query_enhancements/data-logs-1/data_logs_small_time_1.mapping.json'],
+      ['cypress/fixtures/query_enhancements/data-logs-1/data_logs_small_time_1.data.ndjson']
+    );
 
-      cy.waitForLoader(true);
-      cy.getElementByTestId('discoverNoIndexPatterns');
+    // Add data source
+    cy.addDataSource({
+      name: `${DATASOURCE_NAME}`,
+      url: `${SECONDARY_ENGINE.url}`,
+      authType: 'no_auth',
     });
+  });
+  after(() => {
+    cy.deleteDataSourceByName(`${DATASOURCE_NAME}`);
+    cy.deleteIndex('data_logs_small_time_1');
+  });
+  beforeEach(() => {
+    // Create workspace
+    cy.deleteWorkspaceByName(`${WORKSPACE_NAME}`);
+    miscUtils.visitPage('/app/home');
+    cy.createInitialWorkspaceWithDataSource(`${DATASOURCE_NAME}`, `${WORKSPACE_NAME}`);
+  });
+
+  afterEach(() => {
+    cy.deleteWorkspaceByName(`${WORKSPACE_NAME}`);
   });
 
   describe('select indices', () => {
-    before(() => {
-      testFixtureHandler.importJSONMapping('cypress/fixtures/timestamp/mappings.json.txt');
-
-      testFixtureHandler.importJSONDoc('cypress/fixtures/timestamp/data.json.txt');
-
-      // Since default cluster is removed, need to create a data source connection if needed
-      miscUtils.visitPage('app/management/opensearch-dashboards/dataSources/create');
-      cy.intercept('POST', '/api/saved_objects/data-source').as('createDataSourceRequest');
-      cy.getElementByTestId(`datasource_card_opensearch`).click();
-      cy.get('[name="dataSourceTitle"]').type(SECONDARY_ENGINE.name);
-      cy.get('[name="endpoint"]').type(SECONDARY_ENGINE.url);
-      cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
-      cy.get(`button[id="no_auth"]`).click();
-
-      cy.getElementByTestId('createDataSourceButton').click();
-
-      cy.wait('@createDataSourceRequest').then((interception) => {
-        expect(interception.response.statusCode).to.equal(200);
-      });
-      cy.location('pathname', { timeout: 6000 }).should(
-        'include',
-        'app/management/opensearch-dashboards/dataSources'
-      );
-
-      // Go to the Discover page
-      miscUtils.visitPage(`app/data-explorer/discover#/`);
-
-      cy.waitForLoader(true);
-    });
-
     it('with SQL as default language', function () {
       cy.getElementByTestId(`datasetSelectorButton`).click();
       cy.getElementByTestId(`datasetSelectorAdvancedButton`).click();
       cy.get(`[title="Indexes"]`).click();
-      cy.get(`[title=${SECONDARY_ENGINE.name}]`).click();
-      cy.get(`[title="timestamp-nanos"]`).click();
+      cy.get(`[title=${DATASOURCE_NAME}]`).click();
+      cy.get(`[title="data_logs_small_time_1"]`).click(); // Updated to match loaded data
       cy.getElementByTestId('datasetSelectorNext').click();
 
       cy.get(`[class="euiModalHeader__title"]`).should('contain', 'Step 2: Configure data');
@@ -81,9 +66,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
 
       // Switch language to PPL
       cy.setQueryLanguage('PPL');
-      const fromTime = 'Sep 19, 2018 @ 00:00:00.000';
-      const toTime = 'Sep 21, 2019 @ 00:00:00.000';
-      cy.setTopNavDate(fromTime, toTime);
+      cy.setTopNavDate(START_TIME, END_TIME);
 
       cy.waitForLoader(true);
       cy.get(`[data-test-subj="queryResultCompleteMsg"]`).should('be.visible');
@@ -93,8 +76,8 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       cy.getElementByTestId(`datasetSelectorButton`).click();
       cy.getElementByTestId(`datasetSelectorAdvancedButton`).click();
       cy.get(`[title="Indexes"]`).click();
-      cy.get(`[title=${SECONDARY_ENGINE.name}]`).click();
-      cy.get(`[title="timestamp-nanos"]`).click();
+      cy.get(`[title=${DATASOURCE_NAME}]`).click();
+      cy.get(`[title="data_logs_small_time_1"]`).click(); // Updated to match loaded data
       cy.getElementByTestId('datasetSelectorNext').click();
 
       cy.get(`[class="euiModalHeader__title"]`).should('contain', 'Step 2: Configure data');
@@ -110,9 +93,7 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
       // PPL should already be selected
       cy.getElementByTestId('queryEditorLanguageSelector').should('contain', 'PPL');
 
-      const fromTime = 'Sep 19, 2018 @ 00:00:00.000';
-      const toTime = 'Sep 21, 2019 @ 00:00:00.000';
-      cy.setTopNavDate(fromTime, toTime);
+      cy.setTopNavDate(START_TIME, END_TIME);
 
       cy.waitForLoader(true);
 
@@ -131,30 +112,28 @@ describe.skip('dataset selector', { scrollBehavior: false }, () => {
 
   describe('index pattern', () => {
     it('create index pattern and select it', function () {
-      testFixtureHandler.importJSONMapping('cypress/fixtures/logstash/mappings.json.txt');
-      testFixtureHandler.importJSONDoc('cypress/fixtures/logstash/data.json.txt');
+      // Create and select index pattern for data_logs_small_time_1*
+      cy.createWorkspaceIndexPatterns({
+        url: `${BASE_PATH}`,
+        workspaceName: `${WORKSPACE_NAME}`,
+        indexPattern: 'data_logs_small_time_1',
+        timefieldName: 'timestamp',
+        indexPatternHasTimefield: true,
+        dataSource: DATASOURCE_NAME,
+        isEnhancement: true,
+      });
 
-      testFixtureHandler.importJSONMapping('cypress/fixtures/discover/mappings.json.txt');
-      testFixtureHandler.importJSONDoc('cypress/fixtures/discover/data.json.txt');
+      cy.navigateToWorkSpaceHomePage(`${BASE_PATH}`, `${WORKSPACE_NAME}`);
 
-      // Go to the Discover page
-      miscUtils.visitPage(
-        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
-      );
-
+      cy.waitForLoader(true);
       cy.getElementByTestId(`datasetSelectorButton`).click();
       cy.getElementByTestId(`datasetSelectorAdvancedButton`).click();
       cy.get(`[title="Index Patterns"]`).click();
-      cy.get(`[title="logstash-*"]`).click();
-      cy.getElementByTestId('datasetSelectorNext').click();
+      cy.get(`[title="${DATASOURCE_NAME}::data_logs_small_time_1*"]`).should('exist');
 
       cy.waitForLoader(true);
       cy.waitForSearch();
       cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');
     });
-  });
-
-  after(() => {
-    cy.deleteIndex('timestamp-nanos');
   });
 });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
@@ -113,6 +113,7 @@ describe('query enhancement queries', { scrollBehavior: false }, () => {
       //query should persist across refresh
       cy.reload();
       cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');
+      cy.verifyHitCount('10,000');
     });
   });
 });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
 import { WORKSPACE_NAME, DATASOURCE_NAME, START_TIME, END_TIME } from './constants';
 import { BASE_PATH, SECONDARY_ENGINE } from '../../../../../utils/constants';
-
-const miscUtils = new MiscUtils(cy);
 
 describe('query enhancement queries', { scrollBehavior: false }, () => {
   before(() => {
@@ -27,7 +24,7 @@ describe('query enhancement queries', { scrollBehavior: false }, () => {
 
     // Create workspace and set up index pattern
     cy.deleteWorkspaceByName(`${WORKSPACE_NAME}`);
-    miscUtils.visitPage('/app/home');
+    cy.visit('/app/home');
     cy.createInitialWorkspaceWithDataSource(`${DATASOURCE_NAME}`, `${WORKSPACE_NAME}`);
 
     // Create and select index pattern for data_logs_small_time_1*

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/queries.spec.js
@@ -2,49 +2,68 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-  MiscUtils,
-  TestFixtureHandler,
-} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
-import { PATHS } from '../../../../../utils/constants';
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { WORKSPACE_NAME, DATASOURCE_NAME, START_TIME, END_TIME } from './constants';
+import { BASE_PATH, SECONDARY_ENGINE } from '../../../../../utils/constants';
 
 const miscUtils = new MiscUtils(cy);
-const testFixtureHandler = new TestFixtureHandler(cy, PATHS.ENGINE);
 
-describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
+describe('query enhancement queries', { scrollBehavior: false }, () => {
   before(() => {
-    testFixtureHandler.importJSONMapping('cypress/fixtures/timestamp/mappings.json.txt');
-
-    testFixtureHandler.importJSONDoc('cypress/fixtures/timestamp/data_with_index_pattern.json.txt');
-
-    // Go to the Discover page
-    miscUtils.visitPage(`app/data-explorer/discover#/`);
-
-    cy.setAdvancedSetting({
-      defaultIndex: 'timestamp-*',
-    });
-
-    // Go to the Discover page
-    miscUtils.visitPage(
-      `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2018-09-19T13:31:44.000Z',to:'2019-09-24T01:31:44.000Z'))`
+    // Load test data
+    cy.setupTestData(
+      SECONDARY_ENGINE.url,
+      ['cypress/fixtures/query_enhancements/data-logs-1/data_logs_small_time_1.mapping.json'],
+      ['cypress/fixtures/query_enhancements/data-logs-1/data_logs_small_time_1.data.ndjson']
     );
 
-    cy.get(`[class~="datasetSelector__button"]`).click();
-    cy.get(`[data-test-subj="datasetOption-timestamp-*"]`).click();
+    // Add data source
+    cy.addDataSource({
+      name: `${DATASOURCE_NAME}`,
+      url: `${SECONDARY_ENGINE.url}`,
+      authType: 'no_auth',
+    });
 
+    // Create workspace and set up index pattern
+    cy.deleteWorkspaceByName(`${WORKSPACE_NAME}`);
+    miscUtils.visitPage('/app/home');
+    cy.createInitialWorkspaceWithDataSource(`${DATASOURCE_NAME}`, `${WORKSPACE_NAME}`);
+
+    // Create and select index pattern for data_logs_small_time_1*
+    cy.createWorkspaceIndexPatterns({
+      url: `${BASE_PATH}`,
+      workspaceName: `${WORKSPACE_NAME}`,
+      indexPattern: 'data_logs_small_time_1',
+      timefieldName: 'timestamp',
+      indexPatternHasTimefield: true,
+      dataSource: DATASOURCE_NAME,
+      isEnhancement: true,
+    });
+
+    // Go to workspace home
+    cy.navigateToWorkSpaceHomePage(`${BASE_PATH}`, `${WORKSPACE_NAME}`);
+    cy.setTopNavDate(START_TIME, END_TIME);
     cy.waitForLoader(true);
-    cy.waitForSearch();
+  });
+
+  after(() => {
+    cy.deleteWorkspaceByName(`${WORKSPACE_NAME}`);
+    cy.deleteDataSourceByName(`${DATASOURCE_NAME}`);
+    cy.deleteIndex('data_logs_small_time_1');
   });
 
   describe('send queries', () => {
     it('with DQL', function () {
+      cy.setQueryLanguage('DQL');
+
       const query = `_id:1`;
       cy.setSingleLineQueryEditor(query);
       cy.waitForLoader(true);
       cy.waitForSearch();
       cy.verifyHitCount(1);
 
-      //query should persist across refresh
+      // query should persist across refresh
       cy.reload();
       cy.verifyHitCount(1);
     });
@@ -69,7 +88,7 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
       // default SQL query should be set
       cy.waitForLoader(true);
       cy.getElementByTestId(`osdQueryEditor__multiLine`).contains(
-        `SELECT * FROM timestamp-* LIMIT 10`
+        `SELECT * FROM data_logs_small_time_1* LIMIT 10`
       );
       cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');
 
@@ -88,21 +107,15 @@ describe.skip('query enhancement queries', { scrollBehavior: false }, () => {
 
       // default PPL query should be set
       cy.waitForLoader(true);
-      cy.getElementByTestId(`osdQueryEditor__multiLine`).contains(`source = timestamp-*`);
+      cy.getElementByTestId(`osdQueryEditor__multiLine`).contains(
+        `source = data_logs_small_time_1*`
+      );
       cy.waitForSearch();
       cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');
-      cy.get('[class="euiText euiText--small"]').then((text) => cy.log(text));
-      cy.verifyHitCount(4);
 
       //query should persist across refresh
       cy.reload();
-      cy.verifyHitCount(4);
-    });
-
-    after(() => {
-      cy.deleteIndex('timestamp-nanos');
-      cy.deleteIndex('timestamp-milis');
-      cy.deleteSavedObject('index-pattern', 'index-pattern:timestamp-*');
+      cy.getElementByTestId(`queryResultCompleteMsg`).should('be.visible');
     });
   });
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -7,3 +7,12 @@ import '../utils/commands';
 import '../utils/apps/commands';
 import '../utils/dashboards/workspace-plugin/commands';
 import '../utils/dashboards/commands';
+
+// TODO: Remove this after https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5476 is resolved
+const scopedHistoryNavigationError = /^[^(ScopedHistory instance has fell out of navigation scope)]/;
+Cypress.on('uncaught:exception', (err) => {
+  /* returning false here prevents Cypress from failing the test */
+  if (scopedHistoryNavigationError.test(err.message)) {
+    return false;
+  }
+});

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -311,13 +311,14 @@ Cypress.Commands.add('createInitialWorkspaceWithDataSource', (dataSourceTitle, w
   cy.getElementByTestId('workspaceForm-workspaceDetails-nameInputText')
     .should('be.visible')
     .type(workspaceName);
-  cy.getElementByTestId('workspace-creator-dataSources-assign-button').should('be.visible').click();
+  cy.getElementByTestId('workspace-creator-dataSources-assign-button')
+    .scrollIntoView()
+    .should('be.visible')
+    .click();
   cy.get(`.euiSelectableListItem[title="${dataSourceTitle}"]`)
     .should('be.visible')
     .trigger('click');
-  cy.getElementByTestId('workspace-detail-dataSources-associateModal-save-button')
-    .should('be.visible')
-    .click();
+  cy.getElementByTestId('workspace-detail-dataSources-associateModal-save-button').click();
   cy.getElementByTestId('workspaceForm-bottomBar-createButton').should('be.visible').click();
   cy.contains(/successfully/);
 });

--- a/cypress/utils/constants.js
+++ b/cypress/utils/constants.js
@@ -5,7 +5,7 @@
 
 export * from './apps/constants';
 
-export const BASE_PATH = Cypress.env('baseUrl');
+export const BASE_PATH = Cypress.config('baseUrl');
 export const BASE_ENGINE = Cypress.env('ENGINE');
 export const SECONDARY_ENGINE = Cypress.env('SECONDARY_ENGINE');
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "release_note:generate": "scripts/use_node scripts/generate_release_note",
     "cypress:run-without-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --env SECURITY_ENABLED=false",
     "cypress:run-with-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=500",
-    "osd:ciGroup10": "echo \"cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/a_check.spec.js\"",
+    "osd:ciGroup10": "echo \"cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/query_enhancements/*.js\"",
     "osd:ciGroup11": "echo \"cypress/integration/dashboard_sanity_test.spec.js\"",
     "generate:opensearchsqlantlr": "./node_modules/antlr4ng-cli/index.js -Dlanguage=TypeScript -o ./src/plugins/data/public/antlr/opensearch_sql/.generated -visitor -no-listener -Xexact-output-dir ./src/plugins/data/public/antlr/opensearch_sql/grammar/OpenSearchSQLLexer.g4 ./src/plugins/data/public/antlr/opensearch_sql/grammar/OpenSearchSQLParser.g4",
     "generate:opensearchpplantlr": "./node_modules/antlr4ng-cli/index.js -Dlanguage=TypeScript -o ./src/plugins/data/public/antlr/opensearch_ppl/.generated -visitor -no-listener -Xexact-output-dir ./src/plugins/data/public/antlr/opensearch_ppl/grammar/OpenSearchPPLLexer.g4 ./src/plugins/data/public/antlr/opensearch_ppl/grammar/OpenSearchPPLParser.g4"


### PR DESCRIPTION
### Description

* dataset_selector.spec.js

https://github.com/user-attachments/assets/214f8b2c-d6f0-4302-8073-8f141849e92f

* queries.spec.js

https://github.com/user-attachments/assets/d5b3006c-4d71-4af0-9f8a-0ebf21467a6f


Note:
```
const scopedHistoryNavigationError = /^[^(ScopedHistory instance has fell out of navigation scope)]/;
Cypress.on('uncaught:exception', (err) => {
  /* returning false here prevents Cypress from failing the test */
  if (scopedHistoryNavigationError.test(err.message)) {
    return false;
  }
});
```
is from https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9047

### Issues Resolved

NA



## Changelog

- test: Re-enable dataset_selector.spec.js under workspace in ciGroup10



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
