### PR TITLE
[Workspace] fix: hide collaborators page on nav when newHomePage is disabled

### DIFF
--- a/changelogs/fragments/9116.yml
+++ b/changelogs/fragments/9116.yml
@@ -1,0 +1,2 @@
+fix:
+- Hide collaborators page on nav when newHomePage is disabled ([#9116](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9116))

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -596,7 +596,12 @@ export class WorkspacePlugin
     this.coreStart = core;
     const isPermissionEnabled = core?.application?.capabilities.workspaces.permissionEnabled;
     this.collaboratorsAppUpdater$.next(() => {
-      return { status: isPermissionEnabled ? AppStatus.accessible : AppStatus.inaccessible };
+      return {
+        status: isPermissionEnabled ? AppStatus.accessible : AppStatus.inaccessible,
+        navLinkStatus: core.chrome.navGroup.getNavGroupEnabled()
+          ? AppNavLinkStatus.visible
+          : AppNavLinkStatus.hidden,
+      };
     });
 
     this.currentWorkspaceIdSubscription = this._changeSavedObjectCurrentWorkspace();


### PR DESCRIPTION
### Description

Hide collaborators page on nav when newHomePage is disabled

## Screenshot
![image](https://github.com/user-attachments/assets/b94140e5-6e6d-44c5-8ac6-890f589f0230)
Before
![image](https://github.com/user-attachments/assets/019b2a0f-7640-4971-be86-273f18ca44a1)
After
## Testing the changes
Disable new home page, then go to home page navigation, the collaborator nav link will be hidden.
## Changelog
- fix: Hide collaborators page on nav when newHomePage is disabled

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
