### PR TITLE
Add identity source service for customizing identity APIs

### DIFF
--- a/changelogs/fragments/9137.yml
+++ b/changelogs/fragments/9137.yml
@@ -1,0 +1,2 @@
+feat:
+- [Workspace] Add APIs for getting users and roles ([#9137](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9137))

--- a/src/core/server/security/identity_source_service.test.ts
+++ b/src/core/server/security/identity_source_service.test.ts
@@ -35,20 +35,17 @@ describe('IdentitySourceService', () => {
       expect(logger.info).toHaveBeenCalledWith('Register sourceA type identity source handler');
     });
 
-    it('should override an existing handler when registering with the same source', () => {
+    it('should throw an error when registering with the same source', () => {
       const logger = loggingSystemMock.create().get();
       const service = new IdentitySourceService(logger);
       const mockHandler1 = createMockHandler();
       const mockHandler2 = createMockHandler();
 
       service.registerIdentitySourceHandler(sourceA, mockHandler1);
-      service.registerIdentitySourceHandler(sourceA, mockHandler2);
 
-      const handler = service.getIdentitySourceHandler(sourceA);
-
-      expect(handler).toBe(mockHandler2);
-      expect(handler).not.toBe(mockHandler1);
-      expect(logger.info).toHaveBeenCalledTimes(2);
+      expect(() => {
+        service.registerIdentitySourceHandler(sourceA, mockHandler2);
+      }).toThrow("Identity source 'sourceA' has already been registered");
     });
 
     it('should support registering multiple different sources', () => {

--- a/src/core/server/security/identity_source_service.test.ts
+++ b/src/core/server/security/identity_source_service.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { loggingSystemMock } from '../mocks';
+import { IdentitySourceService } from './identity_source_service';
+import { IdentitySourceHandler } from './types';
+
+describe('IdentitySourceService', () => {
+  const sourceA = 'sourceA';
+  const sourceB = 'sourceB';
+
+  const createMockHandler = (
+    options: Partial<IdentitySourceHandler> = {}
+  ): IdentitySourceHandler => ({
+    getIdentityEntries: jest.fn(),
+    getIdentityEntriesByIds: jest.fn(),
+    ...options,
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('registerIdentitySourceHandler', () => {
+    it('should register a handler and log the registration', () => {
+      const logger = loggingSystemMock.create().get();
+      const service = new IdentitySourceService(logger);
+      const mockHandler = createMockHandler();
+
+      service.registerIdentitySourceHandler(sourceA, mockHandler);
+
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith('Register sourceA type identity source handler');
+    });
+
+    it('should override an existing handler when registering with the same source', () => {
+      const logger = loggingSystemMock.create().get();
+      const service = new IdentitySourceService(logger);
+      const mockHandler1 = createMockHandler();
+      const mockHandler2 = createMockHandler();
+
+      service.registerIdentitySourceHandler(sourceA, mockHandler1);
+      service.registerIdentitySourceHandler(sourceA, mockHandler2);
+
+      const handler = service.getIdentitySourceHandler(sourceA);
+
+      expect(handler).toBe(mockHandler2);
+      expect(handler).not.toBe(mockHandler1);
+      expect(logger.info).toHaveBeenCalledTimes(2);
+    });
+
+    it('should support registering multiple different sources', () => {
+      const logger = loggingSystemMock.create().get();
+      const service = new IdentitySourceService(logger);
+      const mockHandlerA = createMockHandler();
+      const mockHandlerB = createMockHandler();
+
+      service.registerIdentitySourceHandler(sourceA, mockHandlerA);
+      service.registerIdentitySourceHandler(sourceB, mockHandlerB);
+
+      expect(service.getIdentitySourceHandler(sourceA)).toBe(mockHandlerA);
+      expect(service.getIdentitySourceHandler(sourceB)).toBe(mockHandlerB);
+    });
+  });
+
+  describe('getIdentitySourceHandler', () => {
+    it('should return the correct handler when the source is registered', () => {
+      const logger = loggingSystemMock.create().get();
+      const service = new IdentitySourceService(logger);
+      const mockHandler = createMockHandler();
+
+      service.registerIdentitySourceHandler(sourceA, mockHandler);
+      const handler = service.getIdentitySourceHandler(sourceA);
+
+      expect(handler).toBe(mockHandler);
+    });
+
+    it('should throw an error when the source is not registered', () => {
+      const logger = loggingSystemMock.create().get();
+      const service = new IdentitySourceService(logger);
+
+      expect(() => {
+        service.getIdentitySourceHandler(sourceB);
+      }).toThrow("Identity source 'sourceB' has not been registered");
+    });
+
+    it('should throw an error with the correct source name in the message', () => {
+      const logger = loggingSystemMock.create().get();
+      const service = new IdentitySourceService(logger);
+      const unknownSource = 'unknown-source';
+
+      expect(() => {
+        service.getIdentitySourceHandler(unknownSource);
+      }).toThrow(`Identity source 'unknown-source' has not been registered`);
+    });
+  });
+});

--- a/src/core/server/security/identity_source_service.ts
+++ b/src/core/server/security/identity_source_service.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from '..';
+import { IdentitySourceHandler } from './types';
+
+export class IdentitySourceService {
+  // A identity source to store all registered identity source handlers.
+  private identitySource: Record<string, IdentitySourceHandler> = {};
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * Register a new identity source handler
+   */
+  public registerIdentitySourceHandler(source: string, handler: IdentitySourceHandler): void {
+    this.identitySource[source] = handler;
+    this.logger.info(`Register ${source} type identity source handler`);
+  }
+
+  /**
+   * Get the handler for the identity source
+   */
+  public getIdentitySourceHandler(source: string): IdentitySourceHandler {
+    const handler = this.identitySource[source];
+    if (!handler) {
+      throw new Error(`Identity source '${source}' has not been registered`);
+    }
+    return handler;
+  }
+}

--- a/src/core/server/security/identity_source_service.ts
+++ b/src/core/server/security/identity_source_service.ts
@@ -19,6 +19,9 @@ export class IdentitySourceService {
    * Register a new identity source handler
    */
   public registerIdentitySourceHandler(source: string, handler: IdentitySourceHandler): void {
+    if (this.identitySource[source]) {
+      throw new Error(`Identity source '${source}' has already been registered`);
+    }
     this.identitySource[source] = handler;
     this.logger.info(`Register ${source} type identity source handler`);
   }

--- a/src/core/server/security/router/index.test.ts
+++ b/src/core/server/security/router/index.test.ts
@@ -41,14 +41,14 @@ describe('Security router', () => {
       expect(router.get).toHaveBeenCalledTimes(1);
       expect(router.get).toHaveBeenCalledWith(
         expect.objectContaining({
-          path: 'identity/_entries',
+          path: '/identity/_entries',
         }),
         expect.any(Function)
       );
       expect(router.post).toHaveBeenCalledTimes(1);
       expect(router.post).toHaveBeenCalledWith(
         expect.objectContaining({
-          path: 'identity/_entries',
+          path: '/identity/_entries',
         }),
         expect.any(Function)
       );

--- a/src/core/server/security/router/index.test.ts
+++ b/src/core/server/security/router/index.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IdentitySourceService } from '../identity_source_service';
+import { registerRoutes } from '.';
+import { IRouter } from '../../http';
+import { mockRouter } from '../../http/router/router.mock';
+import { OpenSearchDashboardsRequest } from 'opensearch-dashboards/server';
+import { coreMock, httpResourcesMock } from '../../mocks';
+describe('Security router', () => {
+  let router: jest.Mocked<IRouter>;
+  let identitySourceService: jest.Mocked<IdentitySourceService>;
+  let mockHandler: {
+    getIdentityEntries: jest.Mock;
+    getIdentityEntriesByIds: jest.Mock;
+  };
+  const context = { core: coreMock.createRequestHandlerContext() };
+  const responseFactory = httpResourcesMock.createResponseFactory();
+
+  beforeEach(async () => {
+    router = mockRouter.create();
+    mockHandler = {
+      getIdentityEntries: jest.fn(),
+      getIdentityEntriesByIds: jest.fn(),
+    };
+
+    identitySourceService = ({
+      getIdentitySourceHandler: jest.fn().mockReturnValue(mockHandler),
+    } as unknown) as jest.Mocked<IdentitySourceService>;
+    registerRoutes({ router, identitySourceService });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('route registration', () => {
+    it('should register GET and POST routes for identity/_entries', () => {
+      expect(router.get).toHaveBeenCalledTimes(1);
+      expect(router.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: 'identity/_entries',
+        }),
+        expect.any(Function)
+      );
+      expect(router.post).toHaveBeenCalledTimes(1);
+      expect(router.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: 'identity/_entries',
+        }),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('GET identity/_entries', () => {
+    it('should call getIdentityEntries with correct parameters', async () => {
+      const mockResult = [{ id: 'user1', name: 'User 1' }];
+      mockHandler.getIdentityEntries!.mockResolvedValue(mockResult);
+
+      const routeHandler = router.get.mock.calls[0][1];
+      const mockRequest = {
+        query: { perPage: 10, page: 1, source: 'test', type: 'users', keyword: 'admin' },
+      };
+
+      await routeHandler(
+        context,
+        mockRequest as OpenSearchDashboardsRequest<unknown, unknown, unknown, 'get'>,
+        responseFactory
+      );
+
+      expect(identitySourceService.getIdentitySourceHandler).toHaveBeenCalledWith('test');
+      expect(mockHandler.getIdentityEntries).toHaveBeenCalledWith(
+        { perPage: 10, page: 1, source: 'test', type: 'users', keyword: 'admin' },
+        expect.anything(),
+        expect.anything()
+      );
+      expect(responseFactory.ok).toHaveBeenCalledWith({
+        body: mockResult,
+      });
+    });
+
+    it('should throw error when getIdentityEntries method is not implemented', async () => {
+      const handlerWithoutMethod = {};
+      identitySourceService.getIdentitySourceHandler.mockReturnValue(handlerWithoutMethod);
+
+      const routeHandler = router.get.mock.calls[0][1];
+      const mockRequest = {
+        query: { perPage: 10, page: 1, source: 'test', type: 'users' },
+      };
+
+      await expect(
+        routeHandler(
+          context,
+          mockRequest as OpenSearchDashboardsRequest<unknown, unknown, unknown, 'get'>,
+          responseFactory
+        )
+      ).rejects.toThrow('getIdentityEntries method has not been implemented');
+    });
+  });
+
+  describe('POST identity/_entries', () => {
+    it('should call getIdentityEntriesByIds with correct parameters', async () => {
+      const mockResult = [
+        { id: 'id1', name: 'User 1' },
+        { id: 'id2', name: 'User 2' },
+      ];
+      mockHandler.getIdentityEntriesByIds!.mockResolvedValue(mockResult);
+
+      const routeHandler = router.post.mock.calls[0][1];
+      const mockRequest = {
+        body: { ids: ['id1', 'id2'], source: 'test', type: 'users' },
+      };
+
+      await routeHandler(
+        context,
+        mockRequest as OpenSearchDashboardsRequest<unknown, unknown, unknown, 'post'>,
+        responseFactory
+      );
+
+      expect(identitySourceService.getIdentitySourceHandler).toHaveBeenCalledWith('test');
+      expect(mockHandler.getIdentityEntriesByIds).toHaveBeenCalledWith(
+        { ids: ['id1', 'id2'], source: 'test', type: 'users' },
+        expect.anything(),
+        expect.anything()
+      );
+      expect(responseFactory.ok).toHaveBeenCalledWith({
+        body: mockResult,
+      });
+    });
+
+    it('should throw error when getIdentityEntriesByIds method is not implemented', async () => {
+      const handlerWithoutMethod = {};
+      identitySourceService.getIdentitySourceHandler.mockReturnValue(handlerWithoutMethod);
+
+      const routeHandler = router.post.mock.calls[0][1];
+      const mockRequest = {
+        body: { ids: ['id1', 'id2'], source: 'test', type: 'users' },
+      };
+
+      await expect(
+        routeHandler(
+          context,
+          mockRequest as OpenSearchDashboardsRequest<unknown, unknown, unknown, 'post'>,
+          responseFactory
+        )
+      ).rejects.toThrow('getIdentityEntriesByIds method has not been implemented');
+    });
+  });
+});

--- a/src/core/server/security/router/index.ts
+++ b/src/core/server/security/router/index.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import { IRouter } from '../../../../core/server';
+import { IdentitySourceService } from '../identity_source_service';
+
+/**
+ * Registers routes for retrieving identity entries according to the type from identity sources.
+ *
+ * @param router - The router instance to register the routes.
+ * @param identitySourceService - The identity source service instance.
+ */
+export function registerRoutes({
+  router,
+  identitySourceService,
+}: {
+  router: IRouter;
+  identitySourceService: IdentitySourceService;
+}) {
+  // Register a GET route for retrieving identity entries with pagination and filtering
+  router.get(
+    {
+      path: 'identity/_entries',
+      validate: {
+        query: schema.object({
+          source: schema.string(),
+          type: schema.string(),
+          perPage: schema.number({ min: 0, defaultValue: 20 }),
+          page: schema.number({ min: 0, defaultValue: 1 }),
+          keyword: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const handler = identitySourceService.getIdentitySourceHandler(req.query.source);
+
+      if (!handler.getIdentityEntries) {
+        throw new Error(`getIdentityEntries method has not been implemented`);
+      }
+      const result = await handler.getIdentityEntries(req.query, req, context);
+
+      return res.ok({
+        body: result,
+      });
+    })
+  );
+
+  // Register a POST route for retrieving identity entries by IDs
+  router.post(
+    {
+      path: 'identity/_entries',
+      validate: {
+        body: schema.object({
+          source: schema.string(),
+          type: schema.string(),
+          ids: schema.arrayOf(schema.string()),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      const handler = identitySourceService.getIdentitySourceHandler(req.body.source);
+
+      if (!handler.getIdentityEntriesByIds) {
+        throw new Error(`getIdentityEntriesByIds method has not been implemented`);
+      }
+      const result = await handler.getIdentityEntriesByIds(req.body, req, context);
+
+      return res.ok({
+        body: result,
+      });
+    })
+  );
+}

--- a/src/core/server/security/router/index.ts
+++ b/src/core/server/security/router/index.ts
@@ -23,7 +23,7 @@ export function registerRoutes({
   // Register a GET route for retrieving identity entries with pagination and filtering
   router.get(
     {
-      path: 'identity/_entries',
+      path: '/identity/_entries',
       validate: {
         query: schema.object({
           source: schema.string(),
@@ -51,7 +51,7 @@ export function registerRoutes({
   // Register a POST route for retrieving identity entries by IDs
   router.post(
     {
-      path: 'identity/_entries',
+      path: '/identity/_entries',
       validate: {
         body: schema.object({
           source: schema.string(),

--- a/src/core/server/security/security_service.mock.ts
+++ b/src/core/server/security/security_service.mock.ts
@@ -9,6 +9,7 @@ const createSetupContractMock = () => {
   const setupContract: jest.Mocked<SecurityServiceSetup> = {
     readonlyService: jest.fn(),
     registerReadonlyService: jest.fn(),
+    registerIdentitySourceHandler: jest.fn(),
   };
   return setupContract;
 };

--- a/src/core/server/security/security_service.test.ts
+++ b/src/core/server/security/security_service.test.ts
@@ -8,15 +8,19 @@ import { mockCoreContext } from '../core_context.mock';
 import { SecurityService } from './security_service';
 import { httpServerMock } from '../http/http_server.mocks';
 import { IReadOnlyService } from './types';
+import { httpServiceMock } from '../mocks';
+import { InternalHttpServiceSetupMock } from '../http/http_service.mock';
 
 describe('SecurityService', () => {
   let securityService: SecurityService;
   let request: OpenSearchDashboardsRequest;
+  let http: InternalHttpServiceSetupMock;
 
   beforeEach(() => {
     const coreContext = mockCoreContext.create();
     securityService = new SecurityService(coreContext);
     request = httpServerMock.createOpenSearchDashboardsRequest();
+    http = httpServiceMock.createInternalSetupContract();
   });
 
   afterEach(() => {
@@ -25,12 +29,12 @@ describe('SecurityService', () => {
 
   describe('#readonlyService', () => {
     it("uses core's readonly service by default", () => {
-      const setupContext = securityService.setup();
+      const setupContext = securityService.setup({ http });
       expect(setupContext.readonlyService().isReadonly(request)).resolves.toBeFalsy();
     });
 
     it('registers custom readonly service and it uses it', () => {
-      const setupContext = securityService.setup();
+      const setupContext = securityService.setup({ http });
       const readonlyServiceMock: jest.Mocked<IReadOnlyService> = {
         isReadonly: jest.fn(),
         hideForReadonly: jest.fn(),
@@ -40,6 +44,22 @@ describe('SecurityService', () => {
       setupContext.readonlyService().isReadonly(request);
 
       expect(readonlyServiceMock.isReadonly).toBeCalledTimes(1);
+    });
+  });
+
+  describe('#identitySourceService', () => {
+    it('should register identity source service and uses it', () => {
+      const setupContext = securityService.setup({ http });
+      const mockIdentitySourceHandler = { getIdentityEntries: jest.fn() };
+      const registerIdentitySourceHandlerMock = jest.fn();
+      setupContext.registerIdentitySourceHandler = registerIdentitySourceHandlerMock;
+      setupContext.registerIdentitySourceHandler('source1', mockIdentitySourceHandler);
+
+      expect(registerIdentitySourceHandlerMock).toBeCalledTimes(1);
+      expect(registerIdentitySourceHandlerMock).toHaveBeenCalledWith(
+        'source1',
+        mockIdentitySourceHandler
+      );
     });
   });
 });

--- a/src/core/server/security/security_service.ts
+++ b/src/core/server/security/security_service.ts
@@ -4,24 +4,39 @@
  */
 
 import { CoreService } from '../../types';
-import { IReadOnlyService, InternalSecurityServiceSetup } from './types';
+import { IReadOnlyService, IdentitySourceHandler, InternalSecurityServiceSetup } from './types';
 import { CoreContext } from '../core_context';
 import { Logger } from '../logging';
 import { ReadonlyService } from './readonly_service';
+import { IdentitySourceService } from './identity_source_service';
+import { InternalHttpServiceSetup } from '../http';
+import { registerRoutes } from './router';
+
+export interface SecuritySetupDeps {
+  http: InternalHttpServiceSetup;
+}
 
 export class SecurityService implements CoreService<InternalSecurityServiceSetup> {
   private logger: Logger;
   private readonlyService: IReadOnlyService;
+  private identitySourceService: IdentitySourceService;
 
   constructor(coreContext: CoreContext) {
     this.logger = coreContext.logger.get('security-service');
     this.readonlyService = new ReadonlyService();
+    this.identitySourceService = new IdentitySourceService(this.logger);
   }
 
-  public setup() {
+  public setup(setupDeps: SecuritySetupDeps) {
     this.logger.debug('Setting up Security service');
 
     const securityService = this;
+    const router = setupDeps.http.createRouter('/api/security/');
+
+    registerRoutes({
+      router,
+      identitySourceService: this.identitySourceService,
+    });
 
     return {
       registerReadonlyService(service: IReadOnlyService) {
@@ -29,6 +44,9 @@ export class SecurityService implements CoreService<InternalSecurityServiceSetup
       },
       readonlyService() {
         return securityService.readonlyService;
+      },
+      registerIdentitySourceHandler(source: string, handler: IdentitySourceHandler) {
+        securityService.identitySourceService.registerIdentitySourceHandler(source, handler);
       },
     };
   }

--- a/src/core/server/security/security_service.ts
+++ b/src/core/server/security/security_service.ts
@@ -31,7 +31,7 @@ export class SecurityService implements CoreService<InternalSecurityServiceSetup
     this.logger.debug('Setting up Security service');
 
     const securityService = this;
-    const router = setupDeps.http.createRouter('/api/security/');
+    const router = setupDeps.http.createRouter('/api/security');
 
     registerRoutes({
       router,

--- a/src/core/server/security/types.ts
+++ b/src/core/server/security/types.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Capabilities, OpenSearchDashboardsRequest } from '../index';
+import { Capabilities, OpenSearchDashboardsRequest, RequestHandlerContext } from '../index';
 
 export interface SecurityServiceSetup {
   registerReadonlyService(service: IReadOnlyService): void;
   readonlyService(): IReadOnlyService;
+  registerIdentitySourceHandler(source: string, handler: IdentitySourceHandler): void;
 }
 
 export type InternalSecurityServiceSetup = SecurityServiceSetup;
@@ -19,4 +20,27 @@ export interface IReadOnlyService {
     capabilites: Capabilities,
     hideCapabilities: Partial<Capabilities>
   ): Promise<Partial<Capabilities>>;
+}
+
+export interface IdentityEntry {
+  name: string;
+  id: string;
+  error?: string;
+}
+
+/**
+ *  The identitySource handler primarily facilitates role-based authentication as the OpenSearch Security plugin employs this approach.
+ *  In role-based authentication, there are two main types: internalusers/roles, and the handler is designed to primarily handle these terms.
+ **/
+export interface IdentitySourceHandler {
+  getIdentityEntries?: (
+    params: { page?: number; perPage?: number; keyword?: string; type: string },
+    request: OpenSearchDashboardsRequest,
+    context: RequestHandlerContext
+  ) => Promise<IdentityEntry[]>;
+  getIdentityEntriesByIds?: (
+    params: { ids: string[]; type: string },
+    request: OpenSearchDashboardsRequest,
+    context: RequestHandlerContext
+  ) => Promise<IdentityEntry[]>;
 }

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -233,7 +233,9 @@ export class Server {
       loggingSystem: this.loggingSystem,
     });
 
-    const securitySetup = this.security.setup();
+    const securitySetup = this.security.setup({
+      http: httpSetup,
+    });
 
     this.coreUsageData.setup({ metrics: metricsSetup });
 


### PR DESCRIPTION
### Description

The identity source service enables dynamic identity management by allowing the registration of customized `getIdentityEntries` and `getIdentityEntriesByIds` APIs for different identity sources and types. By specifying a source (e.g., `local_cluster`) and type (e.g., `roles`, `internalusers`), the system intelligently routes API calls to the appropriate implementation, ensuring that identity operations are seamlessly adapted to the selected source. This flexibility simplifies the integration of diverse identity providers, streamlining user and role management across varying environments.

By default, users and roles are retrieved through the identity source registered within the `security-dashboard-plugin`. This ensures a seamless integration with the default identity management system, providing a consistent and secure mechanism for handling user and role data.

### Issues Resolved
N/A

## Screenshot

Only backend changes

## Testing the changes
Assuming that the identity source has already been registered in the security plugins.

```
core.security.registerIdentitySourceHandler('local_cluster', {
      getIdentityEntries: async ({type}, request, context) => {
        try {
          const typeMap: Record<string, string> = {
            internalusers: '/_plugins/_security/api/internalusers',
            roles: '/_plugins/_security/api/roles',
          };

          if (!typeMap[type]) {
            throw new Error(`This type "${type}" does not exist.`);
          }

          const client = context.core.opensearch.client.asCurrentUser;
          const response = await client.transport.request({
            method: 'GET',
            path: typeMap[type],
          });
          const result = Object.keys(response.body).map((name) => ({ name: name, id: name }));
          return result;
        } catch (error) {
          throw new Error(`Failed to get ${type}: ${error.message}`)
        }
      }
    });
```

Get all users
```zsh
curl -X GET -H "osd-xsrf: string" -H "Content-Type: application/json" -d '{}' "http://localhost:5601/api/security/identity/_entries?source=local_cluster&type=internalusers" -u 'admin:myStrongPassword123!' --insecure

[
    {
        "name": "logstash",
        "id": "logstash"
    },
    {
        "name": "test",
        "id": "test"
    },
    {
        "name": "snapshotrestore",
        "id": "snapshotrestore"
    },
    {
        "name": "admin",
        "id": "admin"
    },
    {
        "name": "kibanaserver",
        "id": "kibanaserver"
    },
    {
        "name": "kibanaro",
        "id": "kibanaro"
    },
    {
        "name": "readall",
        "id": "readall"
    },
    {
        "name": "anomalyadmin",
        "id": "anomalyadmin"
    }
]
```

Get all roles
```zsh
curl -X GET -H "osd-xsrf: string" -H "Content-Type: application/json" -d '{}' "http://localhost:5601/api/security/identity/_entries?source=local_cluster&type=roles" -u 'admin:myStrongPassword123!' --insecure

[
    {
        "name": "logstash",
        "id": "logstash"
    },
    {
        "name": "snapshotrestore",
        "id": "snapshotrestore"
    },
    {
        "name": "admin",
        "id": "admin"
    },
    {
        "name": "kibanauser",
        "id": "kibanauser"
    },
    {
        "name": "readall",
        "id": "readall"
    }
]
```


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: [Workspace] Add APIs for getting users and roles

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
