### PR TITLE
Upgrading `opensearch` client to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@hapi/vision": "^6.1.0",
     "@hapi/wreck": "^17.1.0",
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.6.tar.gz",
-    "@opensearch-project/opensearch": "^2.13.0",
+    "@opensearch-project/opensearch": "^3.0.0-beta.9",
     "@opensearch/datemath": "5.0.3",
     "@osd/ace": "1.0.0",
     "@osd/analytics": "1.0.0",

--- a/packages/osd-opensearch-archiver/package.json
+++ b/packages/osd-opensearch-archiver/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@osd/dev-utils": "1.0.0",
     "@osd/std": "1.0.0",
-    "@opensearch-project/opensearch": "^2.13.0"
+    "@osd/test": "1.0.0",
+    "@opensearch-project/opensearch": "^3.0.0-beta.9"
   },
   "devDependencies": {}
 }

--- a/packages/osd-opensearch-archiver/src/lib/docs/generate_doc_records_stream.ts
+++ b/packages/osd-opensearch-archiver/src/lib/docs/generate_doc_records_stream.ts
@@ -53,7 +53,7 @@ export function createGenerateDocRecordsStream({
     async transform(index, enc, callback) {
       try {
         let remainingHits = 0;
-        let resp: ApiResponse<any> | null = null;
+        let resp: ApiResponse | null = null;
 
         while (!resp || remainingHits > 0) {
           if (!resp) {

--- a/packages/osd-opensearch-archiver/src/lib/indices/opensearch_dashboards_index.ts
+++ b/packages/osd-opensearch-archiver/src/lib/indices/opensearch_dashboards_index.ts
@@ -143,7 +143,7 @@ export async function cleanOpenSearchDashboardsIndices({
       },
     });
 
-    if (resp.body.total !== resp.body.deleted) {
+    if ('total' in resp.body && resp.body.total !== resp.body.deleted) {
       log.warning(
         'delete by query deleted %d of %d total documents, trying again',
         resp.body.deleted,

--- a/packages/osd-opensearch/package.json
+++ b/packages/osd-opensearch/package.json
@@ -12,7 +12,7 @@
     "osd:watch": "../../scripts/use_node scripts/build --watch"
   },
   "dependencies": {
-    "@opensearch-project/opensearch": "^2.13.0",
+    "@opensearch-project/opensearch": "^3.0.0-beta.9",
     "@osd/dev-utils": "1.0.0",
     "abort-controller": "^3.0.0",
     "chalk": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,10 +2608,10 @@
   version "1.0.6"
   resolved "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.6.tar.gz#f2f489832a75191e243c6d2b42d49047265d9ce3"
 
-"@opensearch-project/opensearch@^2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@opensearch-project/opensearch/-/opensearch-2.13.0.tgz#e60c1a3a3dd059562f1d901aa8d3659035cb1781"
-  integrity sha512-Bu3jJ7pKzumbMMeefu7/npAWAvFu5W9SlbBow1ulhluqUpqc7QoXe0KidDrMy7Dy3BQrkI6llR3cWL4lQTZOFw==
+"@opensearch-project/opensearch@^3.0.0-beta.9":
+  version "3.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@opensearch-project/opensearch/-/opensearch-3.0.0-beta.9.tgz#347acffe6fa2cb83e301450059f9673eadbb2932"
+  integrity sha512-RJhkf9gvU0aVuZtIfGOxFNsfkLOCtJMtN9seHsA8JgftmDTm0p77tfo2uvpKMGQzRqRKbQR6HpZLtfQKtT32PA==
   dependencies:
     aws4 "^1.11.0"
     debug "^4.3.1"


### PR DESCRIPTION
### Description

Upgrading the OpenSearch Client dependency from 2.x to 3.x

### Changelog
- skip

(This change does not affect the end user of OSD)
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
