### PR TITLE
feat(vis_type_vega): support reading time field

### DIFF
--- a/changelogs/fragments/9152.yml
+++ b/changelogs/fragments/9152.yml
@@ -1,0 +1,2 @@
+feat:
+- Vega visualization with ppl now supports reading time field ([#9152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9152))

--- a/src/plugins/vis_type_vega/public/data_model/ppl_parser.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/ppl_parser.test.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { timefilterServiceMock } from '../../../data/public/query/timefilter/timefilter_service.mock';
 import { PPLQueryParser } from './ppl_parser';
+import { TimeCache } from './time_cache';
 
 test('it should throw error if with invalid url object', () => {
   const searchApiMock = {
@@ -11,7 +13,8 @@ test('it should throw error if with invalid url object', () => {
       toPromise: jest.fn(() => Promise.resolve({})),
     })),
   };
-  const parser = new PPLQueryParser(searchApiMock);
+  const timeCache = new TimeCache(timefilterServiceMock.createStartContract().timefilter, 100);
+  const parser = new PPLQueryParser(timeCache, searchApiMock);
   expect(() => parser.parseUrl({}, {})).toThrowError();
   expect(() => parser.parseUrl({}, { body: {} })).toThrowError();
   expect(() => parser.parseUrl({}, { body: { query: {} } })).toThrowError();
@@ -23,13 +26,60 @@ test('it should parse url object', () => {
       toPromise: jest.fn(() => Promise.resolve({})),
     })),
   };
-  const parser = new PPLQueryParser(searchApiMock);
+  const timeCache = new TimeCache(timefilterServiceMock.createStartContract().timefilter, 100);
+  const parser = new PPLQueryParser(timeCache, searchApiMock);
   const result = parser.parseUrl({}, { body: { query: 'source=test_index' } });
   expect(result.dataObject).toEqual({});
   expect(result.url).toEqual({ body: { query: 'source=test_index' } });
 });
 
-it('should populate data to request', async () => {
+test('it should parse url object with %timefield% with injecting time filter to ppl query', () => {
+  const from = new Date('2024-10-07T05:03:22.548Z');
+  const to = new Date('2025-01-08T05:03:30.981Z');
+  jest
+    .spyOn(TimeCache.prototype, 'getTimeBounds')
+    .mockReturnValue({ max: from.valueOf(), min: to.valueOf() });
+
+  const searchApiMock = {
+    search: jest.fn(() => ({
+      toPromise: jest.fn(() => Promise.resolve({})),
+    })),
+  };
+  const timeCache = new TimeCache(timefilterServiceMock.createStartContract().timefilter, 100);
+  timeCache.setTimeRange({
+    from: from.toISOString(),
+    to: to.toISOString(),
+    mode: 'absolute',
+  });
+
+  const parser = new PPLQueryParser(timeCache, searchApiMock);
+  const result1 = parser.parseUrl(
+    {},
+    { body: { query: 'source=test_index' }, '%timefield%': 'timestamp' }
+  );
+  expect(result1.url).toEqual({
+    body: {
+      query:
+        "source=test_index | where `timestamp` >= '2025-01-08 13:03:30.981' and `timestamp` <= '2024-10-07 13:03:22.548'",
+    },
+  });
+
+  const result2 = parser.parseUrl(
+    {},
+    {
+      body: { query: 'source=test_index | stats count() as doc_count' },
+      '%timefield%': 'timestamp',
+    }
+  );
+  expect(result2.url).toEqual({
+    body: {
+      query:
+        "source=test_index | where `timestamp` >= '2025-01-08 13:03:30.981' and `timestamp` <= '2024-10-07 13:03:22.548' | stats count() as doc_count",
+    },
+  });
+});
+
+test('it should populate data to request', async () => {
   const searchApiMock = {
     search: jest.fn(() => ({
       toPromise: jest.fn(() =>
@@ -37,7 +87,8 @@ it('should populate data to request', async () => {
       ),
     })),
   };
-  const parser = new PPLQueryParser(searchApiMock);
+  const timeCache = new TimeCache(timefilterServiceMock.createStartContract().timefilter, 100);
+  const parser = new PPLQueryParser(timeCache, searchApiMock);
   const request = {
     url: { body: { query: 'source=test_index' } },
     dataObject: {

--- a/src/plugins/vis_type_vega/public/data_model/ppl_parser.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/ppl_parser.test.ts
@@ -60,7 +60,7 @@ test('it should parse url object with %timefield% with injecting time filter to 
   expect(result1.url).toEqual({
     body: {
       query:
-        "source=test_index | where `timestamp` >= '2025-01-08 13:03:30.981' and `timestamp` <= '2024-10-07 13:03:22.548'",
+        "source=test_index | where `timestamp` >= '2025-01-08 05:03:30.981' and `timestamp` <= '2024-10-07 05:03:22.548'",
     },
   });
 
@@ -74,7 +74,7 @@ test('it should parse url object with %timefield% with injecting time filter to 
   expect(result2.url).toEqual({
     body: {
       query:
-        "source=test_index | where `timestamp` >= '2025-01-08 13:03:30.981' and `timestamp` <= '2024-10-07 13:03:22.548' | stats count() as doc_count",
+        "source=test_index | where `timestamp` >= '2025-01-08 05:03:30.981' and `timestamp` <= '2024-10-07 05:03:22.548' | stats count() as doc_count",
     },
   });
 });

--- a/src/plugins/vis_type_vega/public/data_model/ppl_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/ppl_parser.ts
@@ -28,8 +28,8 @@ export class PPLQueryParser {
     if (this.timeCache._timeRange) {
       const [source, ...others] = query.split('|');
       const bounds = this.timeCache.getTimeBounds();
-      const from = moment(bounds.min).format('YYYY-MM-DD HH:mm:ss.SSS');
-      const to = moment(bounds.max).format('YYYY-MM-DD HH:mm:ss.SSS');
+      const from = moment.utc(bounds.min).format('YYYY-MM-DD HH:mm:ss.SSS');
+      const to = moment.utc(bounds.max).format('YYYY-MM-DD HH:mm:ss.SSS');
       const timeFilter = `where \`${timefield}\` >= '${from}' and \`${timefield}\` <= '${to}'`;
       if (others.length > 0) {
         return `${source.trim()} | ${timeFilter} | ${others.map((s) => s.trim()).join(' | ')}`;

--- a/src/plugins/vis_type_vega/public/data_model/ppl_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/ppl_parser.ts
@@ -4,8 +4,13 @@
  */
 
 import { i18n } from '@osd/i18n';
+import moment from 'moment';
+
 import { Data, UrlObject, PPLQueryRequest } from './types';
 import { SearchAPI } from './search_api';
+import { TimeCache } from './time_cache';
+
+const TIMEFIELD = '%timefield%';
 
 const getRequestName = (request: PPLQueryRequest, index: number) =>
   request.dataObject.name ||
@@ -15,13 +20,29 @@ const getRequestName = (request: PPLQueryRequest, index: number) =>
   });
 
 export class PPLQueryParser {
-  searchAPI: SearchAPI;
-
-  constructor(searchAPI: SearchAPI) {
+  constructor(private readonly timeCache: TimeCache, private readonly searchAPI: SearchAPI) {
     this.searchAPI = searchAPI;
   }
 
+  injectTimeFilter(query: string, timefield: string) {
+    if (this.timeCache._timeRange) {
+      const [source, ...others] = query.split('|');
+      const bounds = this.timeCache.getTimeBounds();
+      const from = moment(bounds.min).format('YYYY-MM-DD HH:mm:ss.SSS');
+      const to = moment(bounds.max).format('YYYY-MM-DD HH:mm:ss.SSS');
+      const timeFilter = `where \`${timefield}\` >= '${from}' and \`${timefield}\` <= '${to}'`;
+      if (others.length > 0) {
+        return `${source.trim()} | ${timeFilter} | ${others.map((s) => s.trim()).join(' | ')}`;
+      }
+      return `${source.trim()} | ${timeFilter}`;
+    }
+    return query;
+  }
+
   parseUrl(dataObject: Data, url: UrlObject) {
+    const timefield = url[TIMEFIELD];
+    delete url[TIMEFIELD];
+
     // data.url.body.query must be defined
     if (!url.body || !url.body.query || typeof url.body.query !== 'string') {
       throw new Error(
@@ -32,6 +53,11 @@ export class PPLQueryParser {
           },
         })
       );
+    }
+
+    if (timefield) {
+      const query = this.injectTimeFilter(url.body.query, timefield);
+      url.body.query = query;
     }
 
     return { dataObject, url };

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -656,7 +656,7 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
         opensearch: new OpenSearchQueryParser(this.timeCache, this.searchAPI, this.filters, onWarn),
         emsfile: new EmsFileParser(serviceSettings),
         url: new UrlParser(onWarn),
-        ppl: new PPLQueryParser(this.searchAPI),
+        ppl: new PPLQueryParser(this.timeCache, this.searchAPI),
       };
     }
     const pending: PendingType = {};


### PR DESCRIPTION
### Description

This PR introduces time range filter support to Vega visualizations with PPL queries. When `"%timefield%"` is specified, the time range filter from the dashboard will be applied to the PPL query automatically.

#### Before This PR
Vega visualizations with PPL queries did not respect the time range set on the dashboard. Regardless of the selected time range, the query remained unaffected.

#### After This PR
With the addition of `"%timefield%"`, changing the time range filter on a dashboard now impacts Vega visualizations with PPL queries.

#### Example
```diff
{
    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
    "data": {
        "url": {
+            "%timefield%": "timestamp",
            "%type%": "ppl",
            "body": {
                "query": "source=opensearch_dashboards_sample_data_logs | stats count() as request_count by extension | sort -request_count"
            }
        }
    }
}
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9169
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: vega visualization with ppl now supports reading time field

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
