### PR TITLE
fix: 0 rendered in discover when there are no results

### DIFF
--- a/changelogs/fragments/9153.yml
+++ b/changelogs/fragments/9153.yml
@@ -1,0 +1,2 @@
+fix:
+- 0 rendered in discover when there are no results ([#9153](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9153))

--- a/src/plugins/discover/public/application/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/components/no_results/no_results.tsx
@@ -300,7 +300,7 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
             </EuiText>
           }
         />
-        {tabs.length && (
+        {tabs.length > 0 && (
           <div
             className="discoverNoResults-sampleContainer"
             data-test-subj="discoverNoResultsSampleContainer"


### PR DESCRIPTION
### Description
This is to resolve a bug where a `0` is rendered in discover when there are no results. This is due to the following logic
`{tabs.length && (...` which leads the `0` to be rendered as React will only skip rendering `false`, `null`, or `undefined` values in the render template.

## Screenshot
### Before
<img width="1289" alt="Screenshot 2025-01-07 at 12 35 33 PM" src="https://github.com/user-attachments/assets/7528892c-3121-4900-b84a-35dc6215823b" />

### After
<img width="1289" alt="Screenshot 2025-01-07 at 12 36 16 PM" src="https://github.com/user-attachments/assets/9564f489-e607-4422-8a70-8e6f225738fe" />

## Changelog
- fix: 0 rendered in discover when there are no results

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
