### PR TITLE
Disable query assistant when dataset type is not supported

### DIFF
--- a/changelogs/fragments/9157.yml
+++ b/changelogs/fragments/9157.yml
@@ -1,0 +1,2 @@
+fix:
+- Disable query assistant when dataset type is not supported ([#9157](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9157))

--- a/src/plugins/query_enhancements/public/query_assist/utils/constant.ts
+++ b/src/plugins/query_enhancements/public/query_assist/utils/constant.ts
@@ -3,4 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_DATA } from '../../../../data/common';
+
 export const DATA2SUMMARY_AGENT_CONFIG_ID = 'os_data2summary';
+
+export const QUERY_ASSISTANT_SUPPORT_DATASET_TYPES = [
+  DEFAULT_DATA.SET_TYPES.INDEX,
+  DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+];

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
@@ -239,4 +239,22 @@ describe('CreateExtension', () => {
 
     expect(screen.getByText('QueryAssistSummary')).toBeInTheDocument();
   });
+
+  it('should return disabled when dataset is not supported', async () => {
+    httpMock.get.mockResolvedValueOnce({ configuredLanguages: ['PPL'] });
+    const extension = createQueryAssistExtension(coreSetupMock, dataMock, config);
+    const isEnabled = await firstValueFrom(
+      extension.isEnabled$({
+        ...dependencies,
+        query: {
+          ...mockQueryWithIndexPattern,
+          dataset: {
+            ...mockQueryWithIndexPattern.dataset,
+            type: 'S3',
+          },
+        },
+      })
+    );
+    expect(isEnabled).toBeFalsy();
+  });
 });

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -89,6 +89,8 @@ const getAvailableLanguages$ = (http: HttpSetup, data: DataPublicPluginSetup) =>
     })
   );
 
+const queryAssistantSupportedDatasetTypes = ['INDEXES', 'INDEX_PATTERN'];
+
 export const createQueryAssistExtension = (
   core: CoreSetup,
   data: DataPublicPluginSetup,
@@ -120,8 +122,13 @@ export const createQueryAssistExtension = (
         };
       }
     },
-    isEnabled$: () =>
-      getAvailableLanguages$(http, data).pipe(map((languages) => languages.length > 0)),
+    isEnabled$: (dependencies) => {
+      const query = dependencies.query;
+      if (!queryAssistantSupportedDatasetTypes.includes(query.dataset?.type || '')) {
+        return new BehaviorSubject(false);
+      }
+      return getAvailableLanguages$(http, data).pipe(map((languages) => languages.length > 0));
+    },
     getComponent: (dependencies) => {
       // only show the component if user is on a supported language.
       return (

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -22,6 +22,7 @@ import { QueryAssistBanner, QueryAssistBar, QueryAssistSummary } from '../compon
 import { UsageCollectionSetup } from '../../../../usage_collection/public';
 import { QueryAssistContext, QueryAssistState } from '../hooks/use_query_assist';
 import { CoreSetup } from '../../../../../core/public';
+import { QUERY_ASSISTANT_SUPPORT_DATASET_TYPES } from './constant';
 
 const [getAvailableLanguagesForDataSource, clearCache] = (() => {
   const availableLanguagesByDataSource: Map<string | undefined, string[]> = new Map();
@@ -80,7 +81,7 @@ const getAvailableLanguages$ = (http: HttpSetup, data: DataPublicPluginSetup) =>
       if (
         query.dataset?.dataSource?.type !== DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH && // datasource is MDS OpenSearch
         query.dataset?.dataSource?.type !== 'DATA_SOURCE' && // datasource is MDS OpenSearch when using indexes
-        query.dataset?.type !== DEFAULT_DATA.SET_TYPES.INDEX_PATTERN // dataset is index pattern
+        !QUERY_ASSISTANT_SUPPORT_DATASET_TYPES.includes(query.dataset?.type || '')
       )
         return [];
 
@@ -88,11 +89,6 @@ const getAvailableLanguages$ = (http: HttpSetup, data: DataPublicPluginSetup) =>
       return getAvailableLanguagesForDataSource(http, dataSourceId);
     })
   );
-
-const queryAssistantSupportedDatasetTypes = [
-  DEFAULT_DATA.SET_TYPES.INDEX,
-  DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
-];
 
 export const createQueryAssistExtension = (
   core: CoreSetup,
@@ -127,7 +123,7 @@ export const createQueryAssistExtension = (
     },
     isEnabled$: (dependencies) => {
       const query = dependencies.query;
-      if (!queryAssistantSupportedDatasetTypes.includes(query.dataset?.type || '')) {
+      if (!QUERY_ASSISTANT_SUPPORT_DATASET_TYPES.includes(query.dataset?.type || '')) {
         return of(false);
       }
       return getAvailableLanguages$(http, data).pipe(map((languages) => languages.length > 0));

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -128,7 +128,7 @@ export const createQueryAssistExtension = (
     isEnabled$: (dependencies) => {
       const query = dependencies.query;
       if (!queryAssistantSupportedDatasetTypes.includes(query.dataset?.type || '')) {
-        return new BehaviorSubject(false);
+        return of(false);
       }
       return getAvailableLanguages$(http, data).pipe(map((languages) => languages.length > 0));
     },

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -89,7 +89,10 @@ const getAvailableLanguages$ = (http: HttpSetup, data: DataPublicPluginSetup) =>
     })
   );
 
-const queryAssistantSupportedDatasetTypes = ['INDEXES', 'INDEX_PATTERN'];
+const queryAssistantSupportedDatasetTypes = [
+  DEFAULT_DATA.SET_TYPES.INDEX,
+  DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+];
 
 export const createQueryAssistExtension = (
   core: CoreSetup,


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Discover with query enhancement now supports varies of dataset: INDEX_PATTERN / INDEXES / S3, while the PPL query generated by query assistant are only supported by opensearch engine, so that we need to disable query assistant for S3 dataset for now.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

### Before

![image](https://github.com/user-attachments/assets/3b48df0a-841f-4057-af95-a9abd86266ba)

### After

https://github.com/user-attachments/assets/2602ae7f-0d56-45e1-894a-78587f9e831c

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Disable query assistant when dataset type is not supported

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
