### PR TITLE
[Workspace] Support to dissociate data connection object since DSM list has supported to display

### DIFF
--- a/changelogs/fragments/9164.yml
+++ b/changelogs/fragments/9164.yml
@@ -1,0 +1,2 @@
+feat:
+- Support to dissociate data connection object since DSM list has supported to display ([#9164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9164))

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/__snapshots__/manage_direct_query_data_connections_table.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/__snapshots__/manage_direct_query_data_connections_table.test.tsx.snap
@@ -110,11 +110,13 @@ exports[`ManageDirectQueryDataConnectionsTable fetch security lake and cloudwatc
                     Array [
                       Object {
                         "id": "connection1",
+                        "objectType": "data-connection",
                         "title": "Connection 1",
                         "type": "AWS CloudWatch",
                       },
                       Object {
                         "id": "connection2",
+                        "objectType": "data-connection",
                         "title": "Connection 2",
                         "type": "AWS Security Lake",
                       },
@@ -595,11 +597,13 @@ exports[`ManageDirectQueryDataConnectionsTable fetch security lake and cloudwatc
                         Array [
                           Object {
                             "id": "connection1",
+                            "objectType": "data-connection",
                             "title": "Connection 1",
                             "type": "AWS CloudWatch",
                           },
                           Object {
                             "id": "connection2",
+                            "objectType": "data-connection",
                             "title": "Connection 2",
                             "type": "AWS Security Lake",
                           },
@@ -2110,11 +2114,13 @@ exports[`ManageDirectQueryDataConnectionsTable fetch security lake and cloudwatc
                     Array [
                       Object {
                         "id": "connection1",
+                        "objectType": "data-connection",
                         "title": "Connection 1",
                         "type": "AWS CloudWatch",
                       },
                       Object {
                         "id": "connection2",
+                        "objectType": "data-connection",
                         "title": "Connection 2",
                         "type": "AWS Security Lake",
                       },
@@ -2595,11 +2601,13 @@ exports[`ManageDirectQueryDataConnectionsTable fetch security lake and cloudwatc
                         Array [
                           Object {
                             "id": "connection1",
+                            "objectType": "data-connection",
                             "title": "Connection 1",
                             "type": "AWS CloudWatch",
                           },
                           Object {
                             "id": "connection2",
+                            "objectType": "data-connection",
                             "title": "Connection 2",
                             "type": "AWS Security Lake",
                           },

--- a/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.tsx
+++ b/src/plugins/data_source_management/public/components/direct_query_data_sources_components/direct_query_data_connection/manage_direct_query_data_connections_table.tsx
@@ -47,7 +47,10 @@ import { LoadingMask } from '../../loading_mask';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DATACONNECTIONS_BASE, LOCAL_CLUSTER } from '../../../constants';
 import { DatasourceTypeToDisplayName, DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../constants';
-import { DataConnectionType } from '../../../../../data_source/common';
+import {
+  DataConnectionType,
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+} from '../../../../../data_source/common';
 
 interface DirectQueryDataConnectionsProps extends RouteComponentProps {
   featureFlagStatus: boolean;
@@ -179,6 +182,8 @@ export const ManageDirectQueryDataConnectionsTable = ({
           id: obj.id,
           title: obj.attributes.connectionId,
           type: obj.attributes.type,
+          // This represents this is data connection type saved object not data source type saved object
+          objectType: DATA_CONNECTION_SAVED_OBJECT_TYPE,
         }));
       } catch (error: any) {
         return [];
@@ -236,7 +241,13 @@ export const ManageDirectQueryDataConnectionsTable = ({
   const onDissociate = useCallback(
     async (item: DataSourceTableItem | DataSourceTableItem[]) => {
       const itemsToDissociate = Array<DataSourceTableItem>().concat(item);
-      const payload = itemsToDissociate.map((ds) => ({ id: ds.id, type: 'data-source' }));
+      const payload = itemsToDissociate.map((ds) => ({
+        id: ds.id,
+        type:
+          ds?.objectType === DATA_CONNECTION_SAVED_OBJECT_TYPE
+            ? DATA_CONNECTION_SAVED_OBJECT_TYPE
+            : 'data-source',
+      }));
       const confirmed = await overlays.openConfirm('', {
         title: i18n.translate('dataSourcesManagement.dataSourcesTable.removeAssociation', {
           defaultMessage:

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -55,6 +55,8 @@ export interface DataSourceTableItem {
   description?: string;
   sort?: string;
   relatedConnections?: DataSourceTableItem[];
+  // This is used to identify the type of the data connection saved object
+  objectType?: string;
 }
 
 /**


### PR DESCRIPTION
### Description

Support to dissociate data connection object since DSM list has supported to display

## Screenshot
![image](https://github.com/user-attachments/assets/12f370ca-83cb-49aa-a887-b3932bbe0534)
There is no UI changes in this PR, after this PR users could dissociate DQS in workspace DSM list direct query connections tab.

## Testing the changes

Go to data source management list page in workspace, then you could associate and dissociate DQS object.
This change has been tested in local and related unit tests have been added.

## Changelog

- feat: Support to dissociate data connection object since DSM list has supported to display

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
