### PR TITLE
Fix visualization chart not expanded after legend toggle

### DIFF
--- a/changelogs/fragments/9170.yml
+++ b/changelogs/fragments/9170.yml
@@ -1,0 +1,2 @@
+fix:
+- Visualization chart not expanded after legend toggle ([#9170](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9170))

--- a/src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
+++ b/src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { unmountComponentAtNode } from 'react-dom';
+import { setTypes } from '../services';
+import { TypesService } from '../vis_types';
+import { PersistedState } from '../persisted_state';
+import { ExprVis } from './vis';
+import { visualization } from './visualization_renderer';
+
+jest.mock('../components', () => ({
+  Visualization: ({ visData, visParams, uiState, listenOnChange }) => (
+    <div>
+      <span>Visualization</span>
+      <span>{JSON.stringify(visData)}</span>
+      <span>{JSON.stringify(visParams)}</span>
+      <span>{JSON.stringify(uiState)}</span>
+      <span>{listenOnChange.toString()}</span>
+    </div>
+  ),
+}));
+
+describe('visualization', () => {
+  let domNode: HTMLDivElement;
+  let handlers: Parameters<ReturnType<typeof visualization>['render']>[2];
+
+  beforeAll(() => {
+    const typeService = new TypesService();
+    const typeSetup = typeService.setup();
+    const typeStart = typeService.start();
+    typeSetup.createReactVisualization({
+      name: 'pie',
+      title: 'Controls',
+      icon: 'controlsHorizontal',
+      stage: 'experimental',
+      visConfig: {
+        defaults: {
+          controls: [],
+          updateFiltersOnChange: false,
+          useTimeFilter: false,
+          pinFilters: false,
+        },
+        component: () => <div />,
+      },
+      inspectorAdapters: {},
+      requestHandler: 'none',
+      responseHandler: 'none',
+    });
+    setTypes(typeStart);
+  });
+
+  beforeEach(() => {
+    domNode = document.createElement('div');
+    handlers = {
+      event: jest.fn(),
+      done: jest.fn(),
+      onDestroy: jest.fn(),
+      reload: jest.fn(),
+      update: jest.fn(),
+    };
+    document.body.appendChild(domNode);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    unmountComponentAtNode(domNode);
+    document.body.removeChild(domNode);
+  });
+
+  it('should render the Visualization component', async () => {
+    const config = {
+      visType: '',
+      visData: { data: [1, 2, 3] },
+      visConfig: { type: 'pie' },
+      params: { listenOnChange: true },
+    };
+
+    await act(async () => {
+      await visualization().render(domNode, config, handlers);
+    });
+
+    expect(domNode.textContent).toContain('Visualization');
+    expect(domNode.textContent).toContain('{"data":[1,2,3]}');
+    expect(domNode.textContent).toContain('true');
+  });
+
+  it('should call setUiState if vis uiState not matched', async () => {
+    const config = {
+      visType: 'pie',
+      visData: { data: [1, 2, 3] },
+      visConfig: { type: 'pie' },
+      params: { listenOnChange: false },
+    };
+    const uiState = new PersistedState({ vis: { colors: { brand: '#000' } } });
+    handlers.uiState = uiState;
+
+    const getUiStateMock = jest.spyOn(ExprVis.prototype, 'getUiState').mockReturnValueOnce(uiState);
+    const setUiStateMock = jest.spyOn(ExprVis.prototype, 'setUiState');
+
+    await act(async () => {
+      await visualization().render(domNode, config, handlers);
+    });
+    const newUIState = new PersistedState();
+
+    handlers.uiState = newUIState;
+    await act(async () => {
+      await visualization().render(domNode, config, handlers);
+    });
+    getUiStateMock.mockReturnValueOnce(newUIState);
+    expect(setUiStateMock).toHaveBeenCalledWith(newUIState);
+  });
+
+  it('should unmount the component on destroy', async () => {
+    let destroyFn: Function;
+    jest.spyOn(handlers, 'onDestroy').mockImplementationOnce((fn) => {
+      destroyFn = fn;
+    });
+    const config = {
+      visType: '',
+      visData: { data: [1, 2, 3] },
+      visConfig: { type: 'pie' },
+      params: { listenOnChange: false },
+    };
+
+    await act(async () => {
+      await visualization().render(domNode, config, handlers);
+    });
+
+    await act(async () => {
+      destroyFn();
+    });
+
+    expect(domNode.textContent).not.toContain('Visualization');
+  });
+});

--- a/src/plugins/visualizations/public/expressions/visualization_renderer.tsx
+++ b/src/plugins/visualizations/public/expressions/visualization_renderer.tsx
@@ -57,6 +57,10 @@ export const visualization = (): ExpressionRenderDefinition<VisRenderValue> => (
       unmountComponentAtNode(domNode);
     });
 
+    if (vis.getUiState() !== uiState) {
+      vis.setUiState(uiState);
+    }
+
     const listenOnChange = params ? params.listenOnChange : false;
     render(
       <Visualization


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

This PR fixes an issue where the chart was not expanding after hiding the legend. The root cause was that the `VisLegend` component was using `vis.getUiState()` as the `uiState` in the [vis_controller](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/vis_type_vislib/public/vis_controller.tsx), which was different from the `uiState` in the `VisualizationChart` component. According to the code in [visualization_chart](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/visualizations/public/components/visualization_chart.tsx#L119), it was using `this.props.uiState`. Therefore, changes to `vis.legendOpen` were not triggering a re-render in `VisualizationChart`.

To resolve this issue, I added a `uiState` synchronization logic in `src/plugins/visualizations/public/expressions/visualization_renderer.tsx`. This logic compares the `visState` in `vis` and calls `setState` to ensure that the two `uiState` instances are the same. As a result, the chart will be resized correctly.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
#9143 

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
1. Import "Sample web logs" sample data
2. Create a new dashboard with "(Line) Avg bytes over time"
3. Update a close time range like "15 seconds ago", the chart will become no results like screenshot below
![image](https://github.com/user-attachments/assets/eaabb860-138e-4771-934c-cfde140838a5)
4. Update time range to very early like "15 years ago"
5. Click "Toggle legend" on the bottom left, the chart should expanded after legend hide
![image](https://github.com/user-attachments/assets/1a654536-74a5-454c-bfac-98602f15d789)


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Visualization chart not expanded after legend toggle

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
