### PR TITLE
[workspace] fix set as default error in data source and index pattern

### DIFF
--- a/changelogs/fragments/9187.yml
+++ b/changelogs/fragments/9187.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix set as default error in data source and index pattern ([#9187](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9187))

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/edit_form/edit_data_source_form.tsx
@@ -61,7 +61,7 @@ export interface EditDataSourceProps {
   handleSubmit: (formValues: DataSourceAttributes) => Promise<void>;
   handleTestConnection: (formValues: DataSourceAttributes) => Promise<void>;
   onDeleteDataSource?: () => Promise<void>;
-  onSetDefaultDataSource: () => Promise<void>;
+  onSetDefaultDataSource: () => Promise<boolean>;
   displayToastMessage: (info: DataSourceManagementToastMessageItem) => void;
   canManageDataSource: boolean;
 }
@@ -412,9 +412,7 @@ export class EditDataSourceForm extends React.Component<EditDataSourceProps, Edi
   };
 
   setDefaultDataSource = async () => {
-    if (this.props.onSetDefaultDataSource) {
-      await this.props.onSetDefaultDataSource();
-    }
+    return await this.props.onSetDefaultDataSource();
   };
 
   onClickTestConnection = async () => {

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.test.tsx
@@ -133,6 +133,14 @@ describe('Datasource Management: Edit Datasource Header', () => {
     test('should render normally', () => {
       expect(component.find(setDefaultButtonIdentifier).exists()).toBe(true);
     });
+    test('should not change to default if onClickSetDefault returns false', async () => {
+      onClickSetDefault.mockReturnValue(false);
+      expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Set as default');
+      component.find(setDefaultButtonIdentifier).first().simulate('click');
+      expect(onClickSetDefault).toHaveBeenCalled();
+      component.update();
+      expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Set as default');
+    });
     test('default button should show as "Set as default" and should be clickable', () => {
       expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Set as default');
       expect(component.find(setDefaultButtonIdentifier).first().prop('disabled')).toBe(false);

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.test.tsx
@@ -141,6 +141,19 @@ describe('Datasource Management: Edit Datasource Header', () => {
       component.update();
       expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Set as default');
     });
+
+    test('should update isDefaultDataSourceState to true if onClickSetDefault returns true', async () => {
+      onClickSetDefault.mockReturnValue(true);
+      expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Set as default');
+
+      await act(async () => {
+        component.find(setDefaultButtonIdentifier).first().simulate('click');
+      });
+
+      expect(onClickSetDefault).toHaveBeenCalled();
+      component.update();
+      expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Default');
+    });
     test('default button should show as "Set as default" and should be clickable', () => {
       expect(component.find(setDefaultButtonIdentifier).first().text()).toBe('Set as default');
       expect(component.find(setDefaultButtonIdentifier).first().prop('disabled')).toBe(false);

--- a/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/components/header/header.tsx
@@ -46,7 +46,7 @@ export const Header = ({
   isFormValid: boolean;
   onClickDeleteIcon: () => void;
   onClickTestConnection: () => void;
-  onClickSetDefault: () => void;
+  onClickSetDefault: () => Promise<boolean>;
   dataSourceName: string;
   isDefault: boolean;
   canManageDataSource: boolean;
@@ -70,9 +70,10 @@ export const Header = ({
   const renderDefaultIcon = () => {
     return (
       <EuiSmallButtonEmpty
-        onClick={() => {
-          onClickSetDefault();
-          setIsDefaultDataSourceState(!isDefaultDataSourceState);
+        onClick={async () => {
+          if (await onClickSetDefault()) {
+            setIsDefaultDataSourceState(!isDefaultDataSourceState);
+          }
         }}
         disabled={isDefaultDataSourceState}
         iconType={isDefaultDataSourceState ? 'starFilled' : 'starEmpty'}

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.test.tsx
@@ -23,17 +23,10 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../../types';
-import { NotificationsStart } from 'opensearch-dashboards/public';
 const formIdentifier = 'EditDataSourceForm';
 const notFoundIdentifier = '[data-test-subj="dataSourceNotFound"]';
 
 describe('Datasource Management: Edit Datasource Wizard', () => {
-  const mockNotifications = ({
-    toasts: {
-      addSuccess: jest.fn(),
-      addDanger: jest.fn(),
-    },
-  } as unknown) as NotificationsStart;
   const mockedContext = {
     ...mockManagementPlugin.createDataSourceManagementContext(),
     application: { capabilities: { dataSource: { canManage: true } } },

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.test.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.test.tsx
@@ -23,11 +23,17 @@ import {
   sigV4AuthMethod,
   usernamePasswordAuthMethod,
 } from '../../types';
-
+import { NotificationsStart } from 'opensearch-dashboards/public';
 const formIdentifier = 'EditDataSourceForm';
 const notFoundIdentifier = '[data-test-subj="dataSourceNotFound"]';
 
 describe('Datasource Management: Edit Datasource Wizard', () => {
+  const mockNotifications = ({
+    toasts: {
+      addSuccess: jest.fn(),
+      addDanger: jest.fn(),
+    },
+  } as unknown) as NotificationsStart;
   const mockedContext = {
     ...mockManagementPlugin.createDataSourceManagementContext(),
     application: { capabilities: { dataSource: { canManage: true } } },
@@ -139,6 +145,19 @@ describe('Datasource Management: Edit Datasource Wizard', () => {
       });
       expect(uiSettings.set).toHaveBeenCalled();
     });
+
+    test('should not set default data source if no permission', async () => {
+      spyOn(uiSettings, 'set').and.returnValue(Promise.resolve(false));
+      await act(async () => {
+        // @ts-ignore
+        const result = await component.find(formIdentifier).first().prop('onSetDefaultDataSource')(
+          mockDataSourceAttributesWithAuth
+        );
+        expect(result).toBe(false);
+      });
+      expect(uiSettings.set).toHaveBeenCalled();
+    });
+
     test('should delete datasource successfully', async () => {
       spyOn(utils, 'deleteDataSourceById').and.returnValue({});
       spyOn(utils, 'setFirstDataSourceAsDefault').and.returnValue({});

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
@@ -96,7 +96,8 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
   };
 
   const handleSetDefault = async () => {
-    await uiSettings.set(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, dataSourceID);
+    const isSuccess = await uiSettings.set(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, dataSourceID);
+    return isSuccess;
   };
 
   const isDefaultDataSource = getDefaultDataSourceId(uiSettings) === dataSourceID;

--- a/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
+++ b/src/plugins/data_source_management/public/components/edit_data_source/edit_data_source.tsx
@@ -96,8 +96,7 @@ export const EditDataSource: React.FunctionComponent<RouteComponentProps<{ id: s
   };
 
   const handleSetDefault = async () => {
-    const isSuccess = await uiSettings.set(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, dataSourceID);
-    return isSuccess;
+    return await uiSettings.set(DEFAULT_DATA_SOURCE_UI_SETTINGS_ID, dataSourceID);
   };
 
   const isDefaultDataSource = getDefaultDataSourceId(uiSettings) === dataSourceID;

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -250,7 +250,7 @@ export const EditIndexPattern = withRouter(
           ...(Boolean(indexPattern.timeFieldName)
             ? [<EuiBadge color="warning">{timeFilterHeader}</EuiBadge>]
             : []),
-          ...tags.map((tag: any) => <EuiBadge color="warning">{tag.name}</EuiBadge>),
+          ...tags.map((tag: any) => <EuiBadge color="hollow">{tag.name}</EuiBadge>),
         ];
         const controls = components.map((component) => ({
           renderComponent: component,

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -128,9 +128,11 @@ export const EditIndexPattern = withRouter(
       setTags(indexPatternTags);
     }, [defaultIndex, indexPattern, indexPatternManagementStart.list]);
 
-    const setDefaultPattern = useCallback(() => {
-      uiSettings.set('defaultIndex', indexPattern.id);
-      setDefaultIndex(indexPattern.id || '');
+    const setDefaultPattern = useCallback(async () => {
+      const isSuccess = await uiSettings.set('defaultIndex', indexPattern.id);
+      if (isSuccess) {
+        setDefaultIndex(indexPattern.id || '');
+      }
     }, [uiSettings, indexPattern.id]);
 
     const refreshFields = () => {
@@ -248,7 +250,7 @@ export const EditIndexPattern = withRouter(
           ...(Boolean(indexPattern.timeFieldName)
             ? [<EuiBadge color="warning">{timeFilterHeader}</EuiBadge>]
             : []),
-          ...tags.map((tag: any) => <EuiBadge color="hollow">{tag.name}</EuiBadge>),
+          ...tags.map((tag: any) => <EuiBadge color="warning">{tag.name}</EuiBadge>),
         ];
         const controls = components.map((component) => ({
           renderComponent: component,


### PR DESCRIPTION
### Description
When a user has read-only access to a workspace
the user shouldn't:
1. set an index pattern as default
2. set a data source as default

## Screenshot
1. read-only user try to set an index pattern as default

https://github.com/user-attachments/assets/73318f86-ed78-464f-985c-3a779d2883c1


3.  read-only user try to set a data source as default

https://github.com/user-attachments/assets/ac1b7483-d647-43b8-9e39-2b6a81a9b694

## Changelog
- fix: fix set as default error in data source and index pattern
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
