### PR TITLE
[Fix] Saved Search Integ Test Update: update saving a new saved search test spec

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search.spec.js
@@ -117,7 +117,7 @@ export const runSavedSearchTests = () => {
             cy.setIndexPatternAsDataset(INDEX_PATTERN_WITH_TIME, datasourceName);
 
             cy.setQueryLanguage(startingLanguage);
-            cy.loadSaveSearch(config.saveName, false);
+            cy.loadSaveSearch(config.saveName);
             setDatePickerDatesAndSearchIfRelevant(config.language);
             verifyDiscoverPageState(config);
           });

--- a/cypress/utils/apps/data_explorer/commands.js
+++ b/cypress/utils/apps/data_explorer/commands.js
@@ -30,31 +30,19 @@ Cypress.Commands.add('saveSearch', (name, saveAsNew = false) => {
 
   cy.getElementByTestId('confirmSaveSavedObjectButton').click({ force: true });
 
-  // if saving as new save search, you need to click confirm twice;
-  if (saveAsNew) {
-    cy.getElementByTestId('confirmSaveSavedObjectButton').click();
-  }
-
   // Wait for page to load
   cy.getElementByTestId('euiToastHeader').contains(/was saved/);
 });
 
-Cypress.Commands.add('loadSaveSearch', (name, selectDuplicate = false) => {
+Cypress.Commands.add('loadSaveSearch', (name) => {
   const opts = {
     log: false,
     force: true,
   };
 
   cy.getElementByTestId('discoverOpenButton', opts).click(opts);
-  if (selectDuplicate) {
-    cy.getElementByTestId(`savedObjectTitle${toTestId(name)}`)
-      .last()
-      .click();
-  } else {
-    cy.getElementByTestId(`savedObjectTitle${toTestId(name)}`)
-      .first()
-      .click();
-  }
+
+  cy.getElementByTestId(`savedObjectTitle${toTestId(name)}`).click();
 
   cy.get('h1').contains(name).should('be.visible');
 });

--- a/cypress/utils/apps/data_explorer/index.d.ts
+++ b/cypress/utils/apps/data_explorer/index.d.ts
@@ -7,7 +7,7 @@ declare namespace Cypress {
   interface Chainable<Subject> {
     verifyTimeConfig(start: string, end: string): Chainable<any>;
     saveSearch(name: string, saveAsNew?: boolean): Chainable<any>;
-    loadSaveSearch(name: string, selectDuplicate?: boolean): Chainable<any>;
+    loadSaveSearch(name: string): Chainable<any>;
     verifyHitCount(count: string): Chainable<any>;
     waitForSearch(): Chainable<any>;
     prepareTest(fromTime: string, toTime: string, interval: string): Chainable<any>;

--- a/cypress/utils/apps/query_enhancements/saved_search.js
+++ b/cypress/utils/apps/query_enhancements/saved_search.js
@@ -528,6 +528,8 @@ export const updateSavedSearchAndSaveAndVerify = (config, saveAsNew) => {
 
   // Load updated saved search and verify
   cy.getElementByTestId('discoverNewButton').click();
+  // wait for the new tab to load
+  cy.getElementByTestId('docTableHeader').should('be.visible');
   cy.loadSaveSearch(saveName, saveAsNew);
   setDatePickerDatesAndSearchIfRelevant(newConfig.language);
   verifyDiscoverPageState(newConfig);

--- a/cypress/utils/apps/query_enhancements/saved_search.js
+++ b/cypress/utils/apps/query_enhancements/saved_search.js
@@ -497,14 +497,12 @@ export const postRequestSaveSearch = (config) => {
  * @param {boolean} saveAsNew - flag to determine whether to overwrite the saved search (false) or save as a new saved search (true)
  */
 export const updateSavedSearchAndSaveAndVerify = (config, saveAsNew) => {
-  const saveName = config.saveName;
-
   cy.navigateToWorkSpaceSpecificPage({
     workspaceName: workspaceName,
     page: 'discover',
     isEnhancement: true,
   });
-  cy.loadSaveSearch(saveName);
+  cy.loadSaveSearch(config.saveName);
 
   // Change the dataset type to use
   const [newDataset, newDatasetType] =
@@ -524,13 +522,14 @@ export const updateSavedSearchAndSaveAndVerify = (config, saveAsNew) => {
     // only select field if previous config did not select it, because otherwise it is already selected
     selectFields: !config.selectFields ? newConfig.selectFields : false,
   });
-  cy.saveSearch(saveName, saveAsNew);
+  const saveNameToUse = saveAsNew ? newConfig.saveName : config.saveName;
+  cy.saveSearch(saveNameToUse, saveAsNew);
 
   // Load updated saved search and verify
   cy.getElementByTestId('discoverNewButton').click();
   // wait for the new tab to load
   cy.getElementByTestId('docTableHeader').should('be.visible');
-  cy.loadSaveSearch(saveName, saveAsNew);
+  cy.loadSaveSearch(saveNameToUse);
   setDatePickerDatesAndSearchIfRelevant(newConfig.language);
   verifyDiscoverPageState(newConfig);
 };


### PR DESCRIPTION
### Description

[This test case under Saved Search](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search.spec.js#L132) have been flaky and failing more often than not for the permutation: `DatasetType: INDEX_PATTERN, language: OpenSearch SQL`. This is not reproducible for me locally, however looking at the videos, the issue seem to appear that the query language is changing to SQL automatically for some reason instead of staying as PPL. I am adding a step in the test to wait for the page to be loaded before loading.


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
