### PR TITLE
Support path alias for webpack and babel

### DIFF
--- a/packages/osd-babel-preset/node_preset.js
+++ b/packages/osd-babel-preset/node_preset.js
@@ -28,6 +28,8 @@
  * under the License.
  */
 
+const path = require('path');
+
 module.exports = (_, options = {}) => {
   return {
     presets: [
@@ -59,6 +61,19 @@ module.exports = (_, options = {}) => {
         },
       ],
       require('./common_preset'),
+    ],
+    plugins: [
+      [
+        require.resolve('babel-plugin-module-resolver'),
+        {
+          root: [path.resolve(__dirname, '../..')],
+          cwd: path.resolve(__dirname, '../..'),
+          alias: {
+            'opensearch-dashboards/server': './src/core/server',
+            'opensearch-dashboards/public': './src/core/public',
+          },
+        },
+      ],
     ],
   };
 };

--- a/packages/osd-babel-preset/package.json
+++ b/packages/osd-babel-preset/package.json
@@ -15,6 +15,7 @@
     "@babel/preset-react": "^7.22.9",
     "@babel/preset-typescript": "^7.22.9",
     "babel-plugin-add-module-exports": "^1.0.4",
+    "babel-plugin-module-resolver": "^5.0.1",
     "babel-plugin-styled-components": "^2.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "browserslist": "^4.21.10",

--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -274,6 +274,7 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
       mainFields: ['browser', 'main'],
       alias: {
         core_app_image_assets: Path.resolve(worker.repoRoot, 'src/core/public/core_app/images'),
+        'opensearch-dashboards/public': Path.resolve(worker.repoRoot, 'src/core/public'),
       },
     },
 

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -4,9 +4,8 @@
  */
 
 import { BehaviorSubject } from 'rxjs';
-import { waitFor } from '@testing-library/dom';
 import { first } from 'rxjs/operators';
-import { coreMock } from '../../../core/public/mocks';
+import { coreMock } from 'opensearch-dashboards/public/mocks';
 import {
   ChromeBreadcrumb,
   NavGroupStatus,
@@ -15,7 +14,7 @@ import {
   WorkspaceAvailability,
   AppStatus,
   WorkspaceError,
-} from '../../../core/public';
+} from 'opensearch-dashboards/public';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_DETAIL_APP_ID } from '../common/constants';
 import { savedObjectsManagementPluginMock } from '../../saved_objects_management/public/mocks';
 import { managementPluginMock } from '../../management/public/mocks';

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -22,7 +22,8 @@ import {
   DEFAULT_NAV_GROUPS,
   NavGroupType,
   ALL_USE_CASE_ID,
-} from '../../../core/public';
+} from 'opensearch-dashboards/public';
+import { getWorkspaceIdFromUrl } from 'opensearch-dashboards/public/utils';
 import {
   WORKSPACE_FATAL_ERROR_APP_ID,
   WORKSPACE_DETAIL_APP_ID,
@@ -32,7 +33,6 @@ import {
   WORKSPACE_NAVIGATION_APP_ID,
   WORKSPACE_COLLABORATORS_APP_ID,
 } from '../common/constants';
-import { getWorkspaceIdFromUrl } from '../../../core/public/utils';
 import { Services, WorkspaceUseCase, WorkspacePluginSetup } from './types';
 import { WorkspaceClient } from './workspace_client';
 import { SavedObjectsManagementPluginSetup } from '../../../plugins/saved_objects_management/public';

--- a/src/plugins/workspace/server/plugin.test.ts
+++ b/src/plugins/workspace/server/plugin.test.ts
@@ -4,15 +4,19 @@
  */
 
 import { OnPostAuthHandler, OnPreRoutingHandler } from 'src/core/server';
-import { coreMock, httpServerMock, uiSettingsServiceMock } from '../../../core/server/mocks';
+import {
+  coreMock,
+  httpServerMock,
+  uiSettingsServiceMock,
+} from 'opensearch-dashboards/server/mocks';
 import { WorkspacePlugin, WorkspacePluginDependencies } from './plugin';
 import {
   getACLAuditor,
   getClientCallAuditor,
   getWorkspaceState,
   updateWorkspaceState,
-} from '../../../core/server/utils';
-import * as serverUtils from '../../../core/server/utils/auth_info';
+} from 'opensearch-dashboards/server/utils';
+import * as serverUtils from 'opensearch-dashboards/server/utils/auth_info';
 import { SavedObjectsPermissionControl } from './permission_control/client';
 import { DataSourcePluginSetup } from '../../data_source/server';
 import { DataSourceError } from '../../data_source/common/data_sources';

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -13,7 +13,18 @@ import {
   Logger,
   CoreStart,
   SharedGlobalConfig,
-} from '../../../core/server';
+} from 'opensearch-dashboards/server';
+import {
+  cleanWorkspaceId,
+  cleanUpACLAuditor,
+  cleanUpClientCallAuditor,
+  getACLAuditor,
+  getWorkspaceIdFromUrl,
+  getWorkspaceState,
+  initializeACLAuditor,
+  initializeClientCallAuditor,
+  updateWorkspaceState,
+} from 'opensearch-dashboards/server/utils';
 import {
   WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
   WORKSPACE_CONFLICT_CONTROL_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
@@ -33,17 +44,6 @@ import { IWorkspaceClientImpl, WorkspacePluginSetup, WorkspacePluginStart } from
 import { WorkspaceClient } from './workspace_client';
 import { registerRoutes } from './routes';
 import { WorkspaceSavedObjectsClientWrapper } from './saved_objects';
-import {
-  cleanWorkspaceId,
-  cleanUpACLAuditor,
-  cleanUpClientCallAuditor,
-  getACLAuditor,
-  getWorkspaceIdFromUrl,
-  getWorkspaceState,
-  initializeACLAuditor,
-  initializeClientCallAuditor,
-  updateWorkspaceState,
-} from '../../../core/server/utils';
 import { WorkspaceConflictSavedObjectsClientWrapper } from './saved_objects/saved_objects_wrapper_for_check_workspace_conflict';
 import {
   SavedObjectsPermissionControl,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,11 +5,11 @@
       // Allows for importing from `opensearch-dashboards` package for the exported types.
       "opensearch-dashboards": ["./opensearch_dashboards"],
       "opensearch-dashboards/public": ["src/core/public"],
+      "opensearch-dashboards/public/*": ["src/core/public/*"],
       "opensearch-dashboards/server": ["src/core/server"],
+      "opensearch-dashboards/server/*": ["src/core/server/*"],
       "plugins/*": ["src/legacy/core_plugins/*/public/"],
-      "test_utils/*": [
-        "src/test_utils/public/*"
-      ],
+      "test_utils/*": ["src/test_utils/public/*"],
       "fixtures/*": ["src/fixtures/*"],
       "@opensearch-project/opensearch": ["node_modules/@opensearch-project/opensearch/api/new"],
       "@opensearch-project/opensearch/lib/*": ["node_modules/@opensearch-project/opensearch/lib/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9266,6 +9266,17 @@ babel-plugin-macros@^3.0.1:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
+babel-plugin-module-resolver@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz#cdeac5d4aaa3b08dd1ac23ddbf516660ed2d293e"
+  integrity sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==
+  dependencies:
+    find-babel-config "^2.1.1"
+    glob "^9.3.3"
+    pkg-up "^3.1.0"
+    reselect "^4.1.7"
+    resolve "^1.22.8"
+
 babel-plugin-polyfill-corejs2@^0.4.10:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz#7d445f0e0607ebc8fb6b01d7e8fb02069b91dd8b"
@@ -14017,6 +14028,13 @@ finalhandler@1.3.1:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+find-babel-config@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-2.1.2.tgz#2841b1bfbbbcdb971e1e39df8cbc43dafa901716"
+  integrity sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==
+  dependencies:
+    json5 "^2.2.3"
+
 find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -14743,6 +14761,16 @@ glob@^8.1.0:
     inherits "2"
     minimatch "^5.0.1"
     once "^1.3.0"
+
+glob@^9.3.3:
+  version "9.3.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.5.tgz#ca2ed8ca452781a3009685607fdf025a899dfe21"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
 
 glob@~5.0.0:
   version "5.0.15"
@@ -19268,6 +19296,13 @@ minimatch@^5.0.1, minimatch@^5.1.6:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^8.0.2:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
+  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^9.0.4:
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
@@ -19323,6 +19358,11 @@ minipass@^3.0.0, minipass@^3.1.1:
   integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
   dependencies:
     yallist "^4.0.0"
+
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
 
 minipass@^5.0.0:
   version "5.0.0"
@@ -20742,7 +20782,7 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
-path-scurry@^1.11.1:
+path-scurry@^1.11.1, path-scurry@^1.6.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
   integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
@@ -22677,6 +22717,11 @@ reselect@^4.0.0, reselect@^4.1.5:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.6.tgz#19ca2d3d0b35373a74dc1c98692cdaffb6602656"
   integrity sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==
+
+reselect@^4.1.7:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.2"


### PR DESCRIPTION
### Description
This PR add path alias support for webpack and babel. Previously, path alias only works for importing typescript types.

1. webpack now supports `opensearch-dashboards/public` path alias
2. Refactor the current in-house path resolution in BundleRefsPlugin to use webpack internal `compiler.resolverFactory` to work with webpack path alias
3. Introduced `babel-plugin-module-resolver` to enable path alias support for babel so that we can use path alias in server side code and jest tests.

#### Examples:
For `public` code
```
// before
import { formatUrlWithWorkspaceId } from '../../../../../src/core/public/utils';
// after
import { formatUrlWithWorkspaceId } from 'opensearch-dashboards/public/utils';
```
For `server` code
```
// before
import { fromRoot } from '../../../core/server/utils';
// after
import { fromRoot } from 'opensearch-dashboards/server/utils';
```

For jest tests:
```
// before
import { applicationServiceMock } from '../../../src/core/public/mocks';
// after
import { applicationServiceMock } from 'opensearch-dashboards/public/mocks'
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9184

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- infra: add path alias support for webpack and babel

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
