### PR TITLE
Remove bypass of getting cypress cache

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -184,13 +184,11 @@ jobs:
           echo "DASHBOARDS_SPEC=${DASHBOARDS_SPEC}"
 
       - name: Get Cypress version
-        if: ${{ matrix.test_location == 'ftr' }}
         id: cypress_version
         run: |
           echo "name=cypress_version::$(cat ./${{ env.FTR_PATH }}/package.json | jq '.devDependencies.cypress' | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: Cache Cypress
-        if: ${{ matrix.test_location == 'ftr' }}
         id: cache-cypress
         uses: actions/cache@v1
         with:

--- a/changelogs/fragments/9209.yml
+++ b/changelogs/fragments/9209.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix cypress version error on ciGroup11 ([#9209](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9209))


### PR DESCRIPTION
### Description

Cypress should only install the version defined in package.json. 

### Issues Resolved

Cigroup11 failture on main and 2.x because `env: 'cypress': Permission denied` because cypress is installing version 14

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Fix cypress version error on ciGroup11

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
