### PR TITLE
add data-test-subjs that are required for TESTID-51

### DIFF
--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -209,6 +209,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
             defaultMessage: `Language Toggle`,
           })}
           onClick={() => setIsCollapsed(!isCollapsed)}
+          data-test-subj="osdQueryEditorLanguageToggle"
         />
       </EuiFlexItem>
     );


### PR DESCRIPTION
### Description

Adds the necessary `data-test-subj` required for TESTID-51

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
