### PR TITLE
Support AILogo branding config

### DIFF
--- a/changelogs/fragments/9231.yml
+++ b/changelogs/fragments/9231.yml
@@ -1,0 +1,2 @@
+feat:
+- Support AILogo branding config ([#9231](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9231))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -253,6 +253,9 @@
 #   faviconUrl: ""
 #   applicationTitle: ""
 #   useExpandedHeader: false
+#   AILogo:
+#     grayUrl: ''
+#     gradientUrl: ''
 
 # Set the value of this setting to true to capture region denied warnings and errors
 # for your map rendering services.

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -85,6 +85,14 @@ export const config = {
       useExpandedHeader: schema.boolean({
         defaultValue: true,
       }),
+      AILogo: schema.object({
+        grayUrl: schema.string({
+          defaultValue: '/',
+        }),
+        gradientUrl: schema.string({
+          defaultValue: '/',
+        }),
+      }),
     }),
     survey: schema.object({
       url: schema.string({

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -6,6 +6,7 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
     "loadingLogo": Object {},
@@ -58,6 +59,7 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
     "loadingLogo": Object {},
@@ -110,6 +112,7 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
     "loadingLogo": Object {},
@@ -162,6 +165,7 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
     "loadingLogo": Object {},
@@ -218,6 +222,7 @@ Object {
   "basePath": "",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/ui/default_branding",
     "loadingLogo": Object {},
@@ -270,6 +275,7 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
     "loadingLogo": Object {},
@@ -322,6 +328,7 @@ Object {
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
   "branding": Object {
+    "AILogo": Object {},
     "applicationTitle": "OpenSearch Dashboards",
     "assetFolderUrl": "/mock-server-basepath/ui/default_branding",
     "loadingLogo": Object {},

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -166,6 +166,10 @@ export class RenderingService {
               faviconUrl: brandingAssignment.favicon,
               applicationTitle: brandingAssignment.applicationTitle,
               useExpandedHeader: brandingAssignment.useExpandedHeader,
+              AILogo: {
+                grayUrl: brandingAssignment.AILogoGrayUrl,
+                gradientUrl: brandingAssignment.AILogoGradientUrl,
+              },
             },
             survey: opensearchDashboardsConfig.survey.url,
           },
@@ -254,6 +258,15 @@ export class RenderingService {
     // use expanded menu by default unless explicitly set to false
     const { useExpandedHeader = true } = branding;
 
+    // assign AI logo grayUrl and gradientUrl based on brandingValidation function result
+    const AILogoGrayUrl = brandingValidation.isAILogoGrayUrlValid
+      ? branding.AILogo.grayUrl
+      : undefined;
+
+    const AILogoGradientUrl = brandingValidation.isAILogoGradientUrlValid
+      ? branding.AILogo.gradientUrl
+      : undefined;
+
     const brandingAssignment: BrandingAssignment = {
       logoDefault,
       logoDarkmode,
@@ -264,6 +277,8 @@ export class RenderingService {
       favicon,
       applicationTitle,
       useExpandedHeader,
+      AILogoGrayUrl,
+      AILogoGradientUrl,
     };
 
     return brandingAssignment;
@@ -301,6 +316,13 @@ export class RenderingService {
 
     const isFaviconValid = await this.isUrlValid(branding.faviconUrl, 'favicon');
 
+    const isAILogoGrayUrlValid = await this.isUrlValid(branding.AILogo.grayUrl, 'AI logo grayUrl');
+
+    const isAILogoGradientUrlValid = await this.isUrlValid(
+      branding.AILogo.gradientUrl,
+      'AI logo gradientUrl'
+    );
+
     const isTitleValid = this.isTitleValid(branding.applicationTitle, 'applicationTitle');
 
     const brandingValidation: BrandingValidation = {
@@ -312,6 +334,8 @@ export class RenderingService {
       isLoadingLogoDarkmodeValid,
       isFaviconValid,
       isTitleValid,
+      isAILogoGrayUrlValid,
+      isAILogoGradientUrlValid,
     };
 
     return brandingValidation;

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -135,6 +135,8 @@ export interface BrandingValidation {
   isLoadingLogoDarkmodeValid: boolean;
   isFaviconValid: boolean;
   isTitleValid: boolean;
+  isAILogoGrayUrlValid: boolean;
+  isAILogoGradientUrlValid: boolean;
 }
 
 /**
@@ -152,4 +154,6 @@ export interface BrandingAssignment {
   favicon?: string;
   applicationTitle?: string;
   useExpandedHeader?: boolean;
+  AILogoGrayUrl?: string;
+  AILogoGradientUrl?: string;
 }

--- a/src/core/types/custom_branding.ts
+++ b/src/core/types/custom_branding.ts
@@ -59,4 +59,9 @@ export interface Branding {
   applicationTitle?: string;
   /** Whether to use expanded menu (true) or condensed menu (false) */
   useExpandedHeader?: boolean;
+  /** AI logo that will be rendered on different AI features */
+  AILogo?: {
+    grayUrl?: string;
+    gradientUrl?: string;
+  };
 }

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -248,6 +248,10 @@ export default () =>
         faviconUrl: Joi.any().default('/'),
         applicationTitle: Joi.any().default(''),
         useExpandedHeader: Joi.boolean().default(true),
+        AILogo: Joi.object({
+          grayUrl: Joi.any().default('/'),
+          gradientUrl: Joi.any().default('/'),
+        }),
       }),
       survey: Joi.object({
         url: Joi.any().default('/'),

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -107,6 +107,7 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
               selectedIndex={selectedIndex}
               previousQuestion={previousQuestionRef.current}
               error={agentError}
+              branding={services.injectedMetadata?.getBranding()}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_input.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_input.tsx
@@ -11,6 +11,7 @@ import assistantMark from '../../assets/sparkle_mark.svg';
 import { getData } from '../../services';
 import { AgentError } from '../utils';
 import { WarningBadge } from './warning_badge';
+import { Branding } from '../../../../../core/public';
 
 interface QueryAssistInputProps {
   inputRef: React.RefObject<HTMLInputElement>;
@@ -20,6 +21,7 @@ interface QueryAssistInputProps {
   selectedIndex?: string;
   previousQuestion?: string;
   error?: AgentError;
+  branding?: Branding;
 }
 
 export const QueryAssistInput: React.FC<QueryAssistInputProps> = (props) => {
@@ -29,6 +31,10 @@ export const QueryAssistInput: React.FC<QueryAssistInputProps> = (props) => {
   const [isSuggestionsVisible, setIsSuggestionsVisible] = useState(false);
   const [suggestionIndex, setSuggestionIndex] = useState<number | null>(null);
   const [value, setValue] = useState(props.initialValue ?? '');
+
+  const markUrl = useMemo(() => {
+    return props.branding?.AILogo?.grayUrl ?? assistantMark;
+  }, [props.branding]);
 
   const sampleDataSuggestions = useMemo(() => {
     switch (props.selectedIndex) {
@@ -98,7 +104,7 @@ export const QueryAssistInput: React.FC<QueryAssistInputProps> = (props) => {
                   defaultMessage: 'Select an index to ask a question',
                 }))
           }
-          prepend={<EuiIcon type={assistantMark} />}
+          prepend={<EuiIcon type={markUrl} />}
           append={<WarningBadge error={props.error} />}
           fullWidth
         />


### PR DESCRIPTION
### Description

1. Support AILogo branding config.
 Because of different color style of logo and different plugins usage, will add config in `opensearchDashboards.branding` and support gray and gradient styles.
2. Update logo in query enhancements plugin.

## Screenshot
![image](https://github.com/user-attachments/assets/9961e46f-e8e6-4148-bf71-9fb9cbbafdc9)



## Testing the changes

1. Copy SVG assets in `src/core/server/core_app/assets/logos`
3. Update yml config AILogo with SVG path, `/ui/logos/*.svg`
4. Then plugin side could read this file.

## Changelog

- feat: Support AILogo branding config

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
