### PR TITLE
[Query assistant]feat: add error callout when dataset is not supported

### DIFF
--- a/src/plugins/query_enhancements/public/query_assist/components/__snapshots__/query_assist_bar.test.tsx.snap
+++ b/src/plugins/query_enhancements/public/query_assist/components/__snapshots__/query_assist_bar.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`QueryAssistBar matches snapshot 1`] = `
       >
         <div
           class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          id="generated-id"
         >
           <div
             class="euiFlexItem"

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
@@ -53,6 +53,15 @@ const dependencies: QueryEditorExtensionDependencies = {
   onSelectLanguage: jest.fn(),
   isCollapsed: false,
   setIsCollapsed: jest.fn(),
+  query: {
+    query: '',
+    language: '',
+    dataset: {
+      type: 'INDEX_PATTERN',
+      id: '',
+      title: '',
+    },
+  },
 };
 
 type Props = ComponentProps<typeof QueryAssistBar>;
@@ -226,5 +235,26 @@ describe('QueryAssistBar', () => {
       query: 'generated query',
     });
     expect(screen.getByTestId('query-assist-query-generated-callout')).toBeInTheDocument();
+  });
+
+  it('should render callout when dataset is not supported', async () => {
+    const { component } = renderQueryAssistBar({
+      dependencies: {
+        ...dependencies,
+        query: {
+          query: '',
+          language: 'kuery',
+          dataset: {
+            id: 'foo',
+            title: 'mock',
+            type: 'S3',
+          },
+        },
+      },
+    });
+
+    await component.findByText(
+      'The selected datasource mock is not supported for Amazon Q query assistance. Please select another data source that is compatible.'
+    );
   });
 });

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow } from '@elastic/eui';
+import { EuiCallOut, EuiFlexGroup, EuiFlexItem, EuiForm, EuiFormRow } from '@elastic/eui';
 import React, { SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import { Dataset } from '../../../../data/common';
 import {
   IDataPluginServices,
@@ -20,6 +21,7 @@ import { QueryAssistCallOut, QueryAssistCallOutType } from './call_outs';
 import { QueryAssistInput } from './query_assist_input';
 import { QueryAssistSubmitButton } from './submit_button';
 import { useQueryAssist } from '../hooks';
+import { PPL_SUPPORT_DATASET_TYPES } from '../utils/constant';
 
 interface QueryAssistInputProps {
   dependencies: QueryEditorExtensionDependencies;
@@ -95,24 +97,47 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
 
   if (props.dependencies.isCollapsed || isQueryAssistCollapsed) return null;
 
+  const { dependencies } = props;
+
+  const datasetSupported = PPL_SUPPORT_DATASET_TYPES.includes(
+    dependencies.query.dataset?.type || ''
+  );
+
   return (
     <EuiForm component="form" onSubmit={onSubmit} className="queryAssist queryAssist__form">
       <EuiFormRow fullWidth>
-        <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
-          <EuiFlexItem>
-            <QueryAssistInput
-              inputRef={inputRef}
-              persistedLog={persistedLog}
-              isDisabled={loading}
-              selectedIndex={selectedIndex}
-              previousQuestion={previousQuestionRef.current}
-              error={agentError}
+        <>
+          <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
+            <EuiFlexItem>
+              <QueryAssistInput
+                inputRef={inputRef}
+                persistedLog={persistedLog}
+                isDisabled={loading || !datasetSupported}
+                selectedIndex={selectedIndex}
+                previousQuestion={previousQuestionRef.current}
+                error={agentError}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <QueryAssistSubmitButton isDisabled={loading || !datasetSupported} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          {!datasetSupported && dependencies.query.dataset?.title ? (
+            <EuiCallOut
+              color="danger"
+              iconType="alert"
+              title={i18n.translate('queryEnhancements.query_assist_bar.unsupported.dataset', {
+                defaultMessage:
+                  'The selected datasource {datasource} is not supported for Amazon Q query assistance. Please select another data source that is compatible.',
+                values: {
+                  datasource: dependencies.query.dataset.title,
+                },
+              })}
+              size="s"
+              data-test-subj="queryAssistUnsupportedDataset"
             />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <QueryAssistSubmitButton isDisabled={loading} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+          ) : null}
+        </>
       </EuiFormRow>
       <QueryAssistCallOut
         language={props.dependencies.language}

--- a/src/plugins/query_enhancements/public/query_assist/utils/constant.ts
+++ b/src/plugins/query_enhancements/public/query_assist/utils/constant.ts
@@ -3,4 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_DATA } from '../../../../data/common';
+
 export const DATA2SUMMARY_AGENT_CONFIG_ID = 'os_data2summary';
+
+export const PPL_SUPPORT_DATASET_TYPES = [
+  DEFAULT_DATA.SET_TYPES.INDEX,
+  DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+];

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -26,6 +26,7 @@ import {
 import { UsageCollectionSetup } from '../../../../usage_collection/public';
 import { QueryAssistContext } from '../hooks/use_query_assist';
 import { CoreSetup } from '../../../../../core/public';
+import { PPL_SUPPORT_DATASET_TYPES } from './constant';
 
 const [getAvailableLanguagesForDataSource, clearCache] = (() => {
   const availableLanguagesByDataSource: Map<string | undefined, string[]> = new Map();
@@ -84,7 +85,7 @@ const getAvailableLanguages$ = (http: HttpSetup, data: DataPublicPluginSetup) =>
       if (
         query.dataset?.dataSource?.type !== DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH && // datasource is MDS OpenSearch
         query.dataset?.dataSource?.type !== 'DATA_SOURCE' && // datasource is MDS OpenSearch when using indexes
-        query.dataset?.type !== DEFAULT_DATA.SET_TYPES.INDEX_PATTERN // dataset is index pattern
+        !PPL_SUPPORT_DATASET_TYPES.includes(query.dataset?.type || '')
       )
         return [];
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Add a error callout and disable input and button to tell users that current selected dataset is not supported for query generation.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Normal index pattern
![image](https://github.com/user-attachments/assets/c89a9c04-f9c2-497b-9d42-861f29169ebe)

### Not supported dataset
![image](https://github.com/user-attachments/assets/778e0998-8c5f-4910-889c-59cc87f40c2b)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: add error callout when dataset is not supported

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
