### PR TITLE
Fix react warnings during sidecar DOM cleanup

### DIFF
--- a/changelogs/fragments/9233.yml
+++ b/changelogs/fragments/9233.yml
@@ -1,0 +1,2 @@
+fix:
+- Not set innerHTML during sidecar DOM cleanup ([#9233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9233))

--- a/src/core/public/overlays/sidecar/sidecar_service.test.tsx
+++ b/src/core/public/overlays/sidecar/sidecar_service.test.tsx
@@ -63,6 +63,17 @@ describe('SidecarService', () => {
       expect(mockReactDomUnmount).not.toHaveBeenCalled();
     });
 
+    it('should unmount after sidecar close', async () => {
+      const sidecarRef = new SidecarService().start({
+        i18n: i18nMock,
+        targetDomElement: document.createElement('div'),
+      });
+      const ref = sidecarRef.open(mountText('Sidecar content'), options);
+      mount(mockReactDomRender.mock.calls[0][0]);
+      await ref.close();
+      expect(mockReactDomUnmount).toHaveBeenCalled();
+    });
+
     describe('with a currently active sidecar', () => {
       let ref1: OverlayRef;
       beforeEach(() => {

--- a/src/core/public/overlays/sidecar/sidecar_service.tsx
+++ b/src/core/public/overlays/sidecar/sidecar_service.tsx
@@ -191,7 +191,6 @@ export class SidecarService {
   private cleanupDom(): void {
     if (this.targetDomElement != null) {
       unmountComponentAtNode(this.targetDomElement);
-      this.targetDomElement.innerHTML = '';
     }
     this.activeSidecar = null;
   }


### PR DESCRIPTION
### Description

This PR is for remove innerHTML set code when clean sidecar DOM. 
![image](https://github.com/user-attachments/assets/cc67df2b-c6eb-4c3a-b386-1296ab044df7)
It will avoid warning like screenshot above. After that, the dom element can be used to render react elements again. 

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Not set innerHTML during sidecar DOM cleanup

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
