### PR TITLE
[workspace]fix the bug that mistakenly classify data connection

### DIFF
--- a/changelogs/fragments/9237.yml
+++ b/changelogs/fragments/9237.yml
@@ -1,0 +1,2 @@
+fix:
+- Bug that mistakenly classify data connection ([#9237](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9237))

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.test.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.test.tsx
@@ -15,80 +15,56 @@ import {
   AssociationDataSourceModalProps,
 } from './association_data_source_modal';
 import { AssociationDataSourceModalMode } from 'src/plugins/workspace/common/constants';
-import { DataSourceEngineType } from '../../../../data_source/common/data_sources';
-const dataSourcesList = [
-  {
-    id: 'ds1',
-    title: 'Data Source 1',
-    description: 'Description of data source 1',
-    auth: '',
-    dataSourceEngineType: '' as DataSourceEngineType,
-    workspaces: [],
-    // This is used for mocking saved object function
-    get: () => {
-      return 'Data Source 1';
-    },
-  },
-  {
-    id: 'dqs1',
-    title: 'Data Connection 1',
-    description: 'Description of data connection 1',
-    auth: '',
-    dataSourceEngineType: '' as DataSourceEngineType,
-    workspaces: [],
-    get: () => {
-      return 'Data Connection 1';
-    },
-  },
-];
 
-const openSearchAndDataConnectionsMock = {
-  openSearchConnections: [
-    {
-      id: 'ds1',
-      name: 'Data Source 1',
-      type: 'OpenSearch',
-      connectionType: DataSourceConnectionType.OpenSearchConnection,
-      relatedConnections: [],
-    },
-  ],
-  dataConnections: [
-    {
-      id: 'dqs1',
-      name: 'Data Connection 1',
-      connectionType: DataSourceConnectionType.DataConnection,
-      type: 'AWS Security Lake',
-    },
-  ],
-};
 const setupAssociationDataSourceModal = ({
   mode,
   excludedConnectionIds,
   handleAssignDataSourceConnections,
 }: Partial<AssociationDataSourceModalProps> = {}) => {
   const coreServices = coreMock.createStart();
-  jest.spyOn(utilsExports, 'getDataSourcesList').mockResolvedValue(dataSourcesList);
-
-  jest
-    .spyOn(utilsExports, 'convertDataSourcesToOpenSearchAndDataConnections')
-    .mockReturnValue(openSearchAndDataConnectionsMock);
-
-  jest.spyOn(utilsExports, 'fetchDirectQueryConnectionsByIDs').mockResolvedValue([
+  jest.spyOn(utilsExports, 'getDataSourcesList').mockResolvedValue([]);
+  jest.spyOn(utilsExports, 'fetchDataSourceConnections').mockResolvedValue([
+    {
+      id: 'ds1',
+      name: 'Data Source 1',
+      connectionType: DataSourceConnectionType.OpenSearchConnection,
+      type: 'OpenSearch',
+      relatedConnections: [
+        {
+          id: 'ds1-dqc1',
+          name: 'dqc1',
+          parentId: 'ds1',
+          connectionType: DataSourceConnectionType.DirectQueryConnection,
+          type: 'Amazon S3',
+        },
+      ],
+    },
     {
       id: 'ds1-dqc1',
       name: 'dqc1',
-      type: 'Amazon S3',
-      connectionType: DataSourceConnectionType.DirectQueryConnection,
       parentId: 'ds1',
+      connectionType: DataSourceConnectionType.DirectQueryConnection,
+      type: 'Amazon S3',
+    },
+    {
+      id: 'ds2',
+      name: 'Data Source 2',
+      connectionType: DataSourceConnectionType.OpenSearchConnection,
+      type: 'OpenSearch',
+    },
+    {
+      id: 'dqs1',
+      name: 'Data Connection 1',
+      connectionType: DataSourceConnectionType.DataConnection,
+      type: 'AWS Security Lake',
     },
   ]);
-
   const { logos } = chromeServiceMock.createStartContract();
   render(
     <IntlProvider locale="en">
       <AssociationDataSourceModal
         logos={logos}
-        mode={mode ?? AssociationDataSourceModalMode.DirectQueryConnections}
+        mode={mode ?? AssociationDataSourceModalMode.OpenSearchConnections}
         http={coreServices.http}
         notifications={coreServices.notifications}
         savedObjects={coreServices.savedObjects}
@@ -131,15 +107,40 @@ describe('AssociationDataSourceModal', () => {
     );
   });
 
-  it('should display opensearch connections', async () => {
-    setupAssociationDataSourceModal({ mode: AssociationDataSourceModalMode.OpenSearchConnections });
+  it('should display opensearch connections and should not display data connection when associating OpenSearch data sources', async () => {
+    setupAssociationDataSourceModal();
     expect(screen.getByText('Associate OpenSearch data sources')).toBeInTheDocument();
     expect(
       screen.getByText(
         'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
       )
     ).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByText('Data Source 1')).toBeInTheDocument());
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Data Source 1' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Data Source 2' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Data Connection 1' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display data connection when associating direct query data sources', async () => {
+    setupAssociationDataSourceModal({
+      mode: AssociationDataSourceModalMode.DirectQueryConnections,
+    });
+    expect(screen.getByText('Associate direct query data sources')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Data Connection 1' })).toBeInTheDocument();
+    });
+  });
+
+  it('should not render the second step fetching dqc when associating OpenSearch data sources', async () => {
+    setupAssociationDataSourceModal();
+    expect(screen.getByText('Associate OpenSearch data sources')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Data Source 1' })).toBeInTheDocument();
+      expect(screen.queryByText('+ 1 related')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('option', { name: 'Data Source 1' }));
+      expect(screen.queryByRole('option', { name: 'dqc1' })).not.toBeInTheDocument();
+    });
   });
 
   it('should display direct query connections after opensearch connection selected', async () => {
@@ -148,7 +149,7 @@ describe('AssociationDataSourceModal', () => {
     });
     expect(screen.getByText('Associate direct query data sources')).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByText('Data Source 1')).toBeInTheDocument();
+      expect(screen.getByText('+ 1 related')).toBeInTheDocument();
       expect(screen.queryByRole('option', { name: 'dqc1' })).not.toBeInTheDocument();
       fireEvent.click(screen.getByRole('option', { name: 'Data Source 1' }));
       expect(screen.getByRole('option', { name: 'dqc1' })).toBeInTheDocument();
@@ -157,14 +158,17 @@ describe('AssociationDataSourceModal', () => {
 
   it('should hide associated connections', async () => {
     setupAssociationDataSourceModal({
-      excludedConnectionIds: ['ds1'],
+      excludedConnectionIds: ['ds2'],
     });
     expect(
       screen.getByText(
         'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
       )
     ).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'Data Source 1' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Data Source 1' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Data Source 2' })).not.toBeInTheDocument();
+    });
   });
 
   it('should call handleAssignDataSourceConnections with opensearch connections after assigned', async () => {
@@ -172,13 +176,11 @@ describe('AssociationDataSourceModal', () => {
     setupAssociationDataSourceModal({
       handleAssignDataSourceConnections: handleAssignDataSourceConnectionsMock,
     });
-    await waitFor(() => {
-      expect(screen.getByText('Data Source 1')).toBeInTheDocument();
-      expect(screen.getByText('Associate data sources')).toBeInTheDocument();
-    });
 
-    fireEvent.click(screen.getByText('Data Source 1'));
-    fireEvent.click(screen.getByText('Associate data sources'));
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('option', { name: 'Data Source 1' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Associate data sources' }));
+    });
 
     expect(handleAssignDataSourceConnectionsMock).toHaveBeenCalledWith([
       {
@@ -203,16 +205,13 @@ describe('AssociationDataSourceModal', () => {
     const handleAssignDataSourceConnectionsMock = jest.fn();
     setupAssociationDataSourceModal({
       handleAssignDataSourceConnections: handleAssignDataSourceConnectionsMock,
-      mode: AssociationDataSourceModalMode.OpenSearchConnections,
-    });
-    await waitFor(() => {
-      expect(screen.getByText('Data Source 1')).toBeInTheDocument();
-      expect(screen.getByText('Data Connection 1')).toBeInTheDocument();
+      mode: AssociationDataSourceModalMode.DirectQueryConnections,
     });
 
-    expect(screen.getByText('Associate data sources')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Data Connection 1'));
-    fireEvent.click(screen.getByText('Associate data sources'));
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('option', { name: 'Data Connection 1' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Associate data sources' }));
+    });
 
     expect(handleAssignDataSourceConnectionsMock).toHaveBeenCalledWith([
       {

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.test.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.test.tsx
@@ -15,56 +15,80 @@ import {
   AssociationDataSourceModalProps,
 } from './association_data_source_modal';
 import { AssociationDataSourceModalMode } from 'src/plugins/workspace/common/constants';
+import { DataSourceEngineType } from '../../../../data_source/common/data_sources';
+const dataSourcesList = [
+  {
+    id: 'ds1',
+    title: 'Data Source 1',
+    description: 'Description of data source 1',
+    auth: '',
+    dataSourceEngineType: '' as DataSourceEngineType,
+    workspaces: [],
+    // This is used for mocking saved object function
+    get: () => {
+      return 'Data Source 1';
+    },
+  },
+  {
+    id: 'dqs1',
+    title: 'Data Connection 1',
+    description: 'Description of data connection 1',
+    auth: '',
+    dataSourceEngineType: '' as DataSourceEngineType,
+    workspaces: [],
+    get: () => {
+      return 'Data Connection 1';
+    },
+  },
+];
 
-const setupAssociationDataSourceModal = ({
-  mode,
-  excludedConnectionIds,
-  handleAssignDataSourceConnections,
-}: Partial<AssociationDataSourceModalProps> = {}) => {
-  const coreServices = coreMock.createStart();
-  jest.spyOn(utilsExports, 'getDataSourcesList').mockResolvedValue([]);
-  jest.spyOn(utilsExports, 'fetchDataSourceConnections').mockResolvedValue([
+const openSearchAndDataConnectionsMock = {
+  openSearchConnections: [
     {
       id: 'ds1',
       name: 'Data Source 1',
-      connectionType: DataSourceConnectionType.OpenSearchConnection,
       type: 'OpenSearch',
-      relatedConnections: [
-        {
-          id: 'ds1-dqc1',
-          name: 'dqc1',
-          parentId: 'ds1',
-          connectionType: DataSourceConnectionType.DirectQueryConnection,
-          type: 'Amazon S3',
-        },
-      ],
-    },
-    {
-      id: 'ds1-dqc1',
-      name: 'dqc1',
-      parentId: 'ds1',
-      connectionType: DataSourceConnectionType.DirectQueryConnection,
-      type: 'Amazon S3',
-    },
-    {
-      id: 'ds2',
-      name: 'Data Source 2',
       connectionType: DataSourceConnectionType.OpenSearchConnection,
-      type: 'OpenSearch',
+      relatedConnections: [],
     },
+  ],
+  dataConnections: [
     {
       id: 'dqs1',
       name: 'Data Connection 1',
       connectionType: DataSourceConnectionType.DataConnection,
       type: 'AWS Security Lake',
     },
+  ],
+};
+const setupAssociationDataSourceModal = ({
+  mode,
+  excludedConnectionIds,
+  handleAssignDataSourceConnections,
+}: Partial<AssociationDataSourceModalProps> = {}) => {
+  const coreServices = coreMock.createStart();
+  jest.spyOn(utilsExports, 'getDataSourcesList').mockResolvedValue(dataSourcesList);
+
+  jest
+    .spyOn(utilsExports, 'convertDataSourcesToOpenSearchAndDataConnections')
+    .mockReturnValue(openSearchAndDataConnectionsMock);
+
+  jest.spyOn(utilsExports, 'fetchDirectQueryConnectionsByIDs').mockResolvedValue([
+    {
+      id: 'ds1-dqc1',
+      name: 'dqc1',
+      type: 'Amazon S3',
+      connectionType: DataSourceConnectionType.DirectQueryConnection,
+      parentId: 'ds1',
+    },
   ]);
+
   const { logos } = chromeServiceMock.createStartContract();
   render(
     <IntlProvider locale="en">
       <AssociationDataSourceModal
         logos={logos}
-        mode={mode ?? AssociationDataSourceModalMode.OpenSearchConnections}
+        mode={mode ?? AssociationDataSourceModalMode.DirectQueryConnections}
         http={coreServices.http}
         notifications={coreServices.notifications}
         savedObjects={coreServices.savedObjects}
@@ -158,17 +182,14 @@ describe('AssociationDataSourceModal', () => {
 
   it('should hide associated connections', async () => {
     setupAssociationDataSourceModal({
-      excludedConnectionIds: ['ds2'],
+      excludedConnectionIds: ['ds1'],
     });
     expect(
       screen.getByText(
         'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
       )
     ).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByRole('option', { name: 'Data Source 1' })).toBeInTheDocument();
-      expect(screen.queryByRole('option', { name: 'Data Source 2' })).not.toBeInTheDocument();
-    });
+    expect(screen.queryByRole('option', { name: 'Data Source 1' })).not.toBeInTheDocument();
   });
 
   it('should call handleAssignDataSourceConnections with opensearch connections after assigned', async () => {
@@ -176,11 +197,13 @@ describe('AssociationDataSourceModal', () => {
     setupAssociationDataSourceModal({
       handleAssignDataSourceConnections: handleAssignDataSourceConnectionsMock,
     });
-
     await waitFor(() => {
-      fireEvent.click(screen.getByRole('option', { name: 'Data Source 1' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Associate data sources' }));
+      expect(screen.getByText('Data Source 1')).toBeInTheDocument();
+      expect(screen.getByText('Associate data sources')).toBeInTheDocument();
     });
+
+    fireEvent.click(screen.getByText('Data Source 1'));
+    fireEvent.click(screen.getByText('Associate data sources'));
 
     expect(handleAssignDataSourceConnectionsMock).toHaveBeenCalledWith([
       {
@@ -205,13 +228,16 @@ describe('AssociationDataSourceModal', () => {
     const handleAssignDataSourceConnectionsMock = jest.fn();
     setupAssociationDataSourceModal({
       handleAssignDataSourceConnections: handleAssignDataSourceConnectionsMock,
-      mode: AssociationDataSourceModalMode.DirectQueryConnections,
+      mode: AssociationDataSourceModalMode.OpenSearchConnections,
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Data Source 1')).toBeInTheDocument();
+      expect(screen.getByText('Data Connection 1')).toBeInTheDocument();
     });
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByRole('option', { name: 'Data Connection 1' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Associate data sources' }));
-    });
+    expect(screen.getByText('Associate data sources')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Data Connection 1'));
+    fireEvent.click(screen.getByText('Associate data sources'));
 
     expect(handleAssignDataSourceConnectionsMock).toHaveBeenCalledWith([
       {

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
@@ -117,15 +117,7 @@ const convertConnectionToOption = ({
     selectedConnectionIds.includes(connection.id)
       ? ('on' as const)
       : undefined,
-  prepend:
-    connection.connectionType === DataSourceConnectionType.DirectQueryConnection ? (
-      <>
-        <div style={{ width: 16 }} />
-        <ConnectionIcon connection={connection} logos={logos} />
-      </>
-    ) : (
-      <ConnectionIcon connection={connection} logos={logos} />
-    ),
+  prepend: <ConnectionIcon connection={connection} logos={logos} />,
   parentId: connection.parentId,
 });
 
@@ -316,8 +308,8 @@ export const AssociationDataSourceModalContent = ({
       <EuiModalFooter>
         <EuiSmallButton onClick={closeModal}>
           <FormattedMessage
-            id="workspace.detail.dataSources.associateModal.close.button"
-            defaultMessage="Close"
+            id="workspace.detail.dataSources.associateModal.cancel.button"
+            defaultMessage="Cancel"
           />
         </EuiSmallButton>
         <EuiSmallButton

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
@@ -25,17 +25,12 @@ import {
 import { FormattedMessage } from 'react-intl';
 import { i18n } from '@osd/i18n';
 
-import {
-  getDataSourcesList,
-  fetchDirectQueryConnectionsByIDs,
-  convertDataSourcesToOpenSearchAndDataConnections,
-} from '../../utils';
+import { getDataSourcesList, fetchDataSourceConnections } from '../../utils';
 import { DataSourceConnection, DataSourceConnectionType } from '../../../common/types';
 import { HttpStart, NotificationsStart, SavedObjectsStart } from '../../../../../core/public';
 import { AssociationDataSourceModalMode } from '../../../common/constants';
 import { Logos } from '../../../../../core/common';
 import { ConnectionTypeIcon } from '../workspace_form/connection_type_icon';
-import './association_data_source_modal.scss';
 
 const ConnectionIcon = ({
   connection: { connectionType, type },
@@ -93,39 +88,46 @@ const convertConnectionToOption = ({
   connection,
   selectedConnectionIds,
   logos,
-  showDirectQueryConnections,
+  mode,
 }: {
   connection: DataSourceConnection;
   selectedConnectionIds: string[];
   logos: Logos;
-  showDirectQueryConnections: boolean;
-}) => {
-  return {
-    label: connection.name,
-    key: connection.id,
-    description: connection.description,
-    append: showDirectQueryConnections &&
-      connection.relatedConnections &&
-      connection.relatedConnections.length > 0 && (
-        <EuiBadge>
-          {i18n.translate('workspace.form.selectDataSource.optionBadge', {
-            defaultMessage: '+ {relatedConnections} related',
-            values: {
-              relatedConnections: connection.relatedConnections.length,
-            },
-          })}
-        </EuiBadge>
-      ),
-    disabled: connection.connectionType === DataSourceConnectionType.DirectQueryConnection,
-    checked:
-      connection.connectionType !== DataSourceConnectionType.DirectQueryConnection &&
-      selectedConnectionIds.includes(connection.id)
-        ? ('on' as const)
-        : undefined,
-    prepend: <ConnectionIcon connection={connection} logos={logos} />,
-    parentId: connection.parentId,
-  };
-};
+  mode: AssociationDataSourceModalMode;
+}) => ({
+  label: connection.name,
+  key: connection.id,
+  description: connection.description,
+  append:
+    mode === AssociationDataSourceModalMode.DirectQueryConnections &&
+    connection.relatedConnections &&
+    connection.relatedConnections.length > 0 ? (
+      <EuiBadge>
+        {i18n.translate('workspace.form.selectDataSource.optionBadge', {
+          defaultMessage: '+ {relatedConnections} related',
+          values: {
+            relatedConnections: connection.relatedConnections.length,
+          },
+        })}
+      </EuiBadge>
+    ) : undefined,
+  disabled: connection.connectionType === DataSourceConnectionType.DirectQueryConnection,
+  checked:
+    connection.connectionType !== DataSourceConnectionType.DirectQueryConnection &&
+    selectedConnectionIds.includes(connection.id)
+      ? ('on' as const)
+      : undefined,
+  prepend:
+    connection.connectionType === DataSourceConnectionType.DirectQueryConnection ? (
+      <>
+        <div style={{ width: 16 }} />
+        <ConnectionIcon connection={connection} logos={logos} />
+      </>
+    ) : (
+      <ConnectionIcon connection={connection} logos={logos} />
+    ),
+  parentId: connection.parentId,
+});
 
 const convertConnectionsToOptions = ({
   connections,
@@ -133,12 +135,14 @@ const convertConnectionsToOptions = ({
   selectedConnectionIds,
   excludedConnectionIds,
   logos,
+  mode,
 }: {
   connections: DataSourceConnection[];
   excludedConnectionIds: string[];
   showDirectQueryConnections: boolean;
   selectedConnectionIds: string[];
   logos: Logos;
+  mode: AssociationDataSourceModalMode;
 }) => {
   return connections
     .flatMap((connection) => {
@@ -150,32 +154,25 @@ const convertConnectionsToOptions = ({
       }
 
       if (connection.connectionType === DataSourceConnectionType.DataConnection) {
-        if (!showDirectQueryConnections) {
+        if (showDirectQueryConnections) {
           return [connection];
         }
         return [];
       }
 
-      if (connection.connectionType === DataSourceConnectionType.OpenSearchConnection) {
-        if (showDirectQueryConnections) {
-          return [
-            connection,
-            ...(selectedConnectionIds.includes(connection.id)
-              ? connection.relatedConnections ?? []
-              : []),
-          ];
+      if (showDirectQueryConnections) {
+        if (!connection.relatedConnections || connection.relatedConnections.length === 0) {
+          return [];
         }
+        return [
+          connection,
+          ...(selectedConnectionIds.includes(connection.id) ? connection.relatedConnections : []),
+        ];
       }
-
       return [connection];
     })
     .map((connection) =>
-      convertConnectionToOption({
-        connection,
-        selectedConnectionIds,
-        logos,
-        showDirectQueryConnections,
-      })
+      convertConnectionToOption({ connection, selectedConnectionIds, logos, mode })
     );
 };
 
@@ -239,78 +236,19 @@ export const AssociationDataSourceModalContent = ({
     }
   }, [selectedConnectionIds, allConnections, handleAssignDataSourceConnections]);
 
-  const handleDirectQueryConnections = useCallback(
-    async (
-      openSearchConnections: DataSourceConnection[],
-      dataConnections: DataSourceConnection[]
-    ) => {
-      if (mode === AssociationDataSourceModalMode.OpenSearchConnections) {
-        return [...openSearchConnections, ...dataConnections];
-      }
-
-      const fetchDqcConnectionsPromises = openSearchConnections.map((ds) =>
-        fetchDirectQueryConnectionsByIDs([ds.id], http, notifications)
-          .then((directQueryConnections) => ({
-            id: ds.id,
-            relatedConnections: directQueryConnections,
-          }))
-          .catch(() => ({
-            id: ds.id,
-            relatedConnections: [],
-          }))
-      );
-      const dqcConnections = await Promise.all(fetchDqcConnectionsPromises);
-
-      const allConnectionsWithDQC = openSearchConnections
-        .filter((connection) => {
-          const filteredData = dqcConnections.find((c) => c.id === connection.id);
-          return filteredData && filteredData.relatedConnections.length > 0;
-        })
-        .map((connection) => {
-          const relatedDQC = dqcConnections.find((c) => c.id === connection.id);
-          return {
-            ...connection,
-            relatedConnections: relatedDQC?.relatedConnections,
-          } as DataSourceConnection;
-        });
-
-      return allConnectionsWithDQC;
-    },
-    [http, mode, notifications]
-  );
-
   useEffect(() => {
-    const fetchDataSources = async () => {
-      const dataSourcesList = await getDataSourcesList(savedObjects.client, ['*']);
-      const {
-        openSearchConnections,
-        dataConnections,
-      } = convertDataSourcesToOpenSearchAndDataConnections(dataSourcesList);
-      return { openSearchConnections, dataConnections };
-    };
-
-    const fetchDataSourcesAndHandleRelatedConnections = async () => {
-      setIsLoading(true);
-      try {
-        const { openSearchConnections, dataConnections } = await fetchDataSources();
-        const connections = await handleDirectQueryConnections(
-          openSearchConnections,
-          dataConnections
-        );
+    setIsLoading(true);
+    getDataSourcesList(savedObjects.client, ['*'])
+      .then((dataSourcesList) =>
+        fetchDataSourceConnections(dataSourcesList, http, notifications, mode)
+      )
+      .then((connections) => {
         setAllConnections(connections);
-      } catch {
-        notifications?.toasts.addDanger(
-          i18n.translate('workspace.detail.dataSources.associateModal.fetchDataSourcesError', {
-            defaultMessage: 'Failed to get data sources',
-          })
-        );
-      } finally {
+      })
+      .finally(() => {
         setIsLoading(false);
-      }
-    };
-
-    fetchDataSourcesAndHandleRelatedConnections();
-  }, [savedObjects.client, notifications, http, mode, handleDirectQueryConnections]);
+      });
+  }, [savedObjects.client, http, notifications, mode]);
 
   useEffect(() => {
     setOptions(
@@ -320,9 +258,10 @@ export const AssociationDataSourceModalContent = ({
         selectedConnectionIds,
         showDirectQueryConnections: mode === AssociationDataSourceModalMode.DirectQueryConnections,
         logos,
+        mode,
       })
     );
-  }, [excludedConnectionIds, selectedConnectionIds, mode, allConnections, logos]);
+  }, [allConnections, excludedConnectionIds, selectedConnectionIds, mode, logos]);
 
   return (
     <>
@@ -359,7 +298,6 @@ export const AssociationDataSourceModalContent = ({
               'workspace.detail.dataSources.associateModal.searchPlaceholder',
               { defaultMessage: 'Search' }
             ),
-            compressed: true,
           }}
           options={options}
           onChange={handleSelectionChange}
@@ -378,8 +316,8 @@ export const AssociationDataSourceModalContent = ({
       <EuiModalFooter>
         <EuiSmallButton onClick={closeModal}>
           <FormattedMessage
-            id="workspace.detail.dataSources.associateModal.cancel.button"
-            defaultMessage="Cancel"
+            id="workspace.detail.dataSources.associateModal.close.button"
+            defaultMessage="Close"
           />
         </EuiSmallButton>
         <EuiSmallButton

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
@@ -25,11 +25,7 @@ import {
 import { FormattedMessage } from 'react-intl';
 import { i18n } from '@osd/i18n';
 
-import {
-  getDataSourcesList,
-  fetchDirectQueryConnectionsByIDs,
-  convertDataSourcesToOpenSearchAndDataConnections,
-} from '../../utils';
+import { getDataSourcesList, fetchDataSourceConnections } from '../../utils';
 import { DataSourceConnection, DataSourceConnectionType } from '../../../common/types';
 import { HttpStart, NotificationsStart, SavedObjectsStart } from '../../../../../core/public';
 import { AssociationDataSourceModalMode } from '../../../common/constants';
@@ -158,23 +154,21 @@ const convertConnectionsToOptions = ({
       }
 
       if (connection.connectionType === DataSourceConnectionType.DataConnection) {
-        if (!showDirectQueryConnections) {
+        if (showDirectQueryConnections) {
           return [connection];
         }
         return [];
       }
 
-      if (connection.connectionType === DataSourceConnectionType.OpenSearchConnection) {
-        if (showDirectQueryConnections) {
-          return [
-            connection,
-            ...(selectedConnectionIds.includes(connection.id)
-              ? connection.relatedConnections ?? []
-              : []),
-          ];
+      if (showDirectQueryConnections) {
+        if (!connection.relatedConnections || connection.relatedConnections.length === 0) {
+          return [];
         }
+        return [
+          connection,
+          ...(selectedConnectionIds.includes(connection.id) ? connection.relatedConnections : []),
+        ];
       }
-
       return [connection];
     })
     .map((connection) =>
@@ -242,46 +236,6 @@ export const AssociationDataSourceModalContent = ({
     }
   }, [selectedConnectionIds, allConnections, handleAssignDataSourceConnections]);
 
-  const handleDirectQueryConnections = useCallback(
-    async (
-      openSearchConnections: DataSourceConnection[],
-      dataConnections: DataSourceConnection[]
-    ) => {
-      if (mode === AssociationDataSourceModalMode.OpenSearchConnections) {
-        return [...openSearchConnections, ...dataConnections];
-      }
-
-      const fetchDqcConnectionsPromises = openSearchConnections.map((ds) =>
-        fetchDirectQueryConnectionsByIDs([ds.id], http, notifications)
-          .then((directQueryConnections) => ({
-            id: ds.id,
-            relatedConnections: directQueryConnections,
-          }))
-          .catch(() => ({
-            id: ds.id,
-            relatedConnections: [],
-          }))
-      );
-      const dqcConnections = await Promise.all(fetchDqcConnectionsPromises);
-
-      const allConnectionsWithDQC = openSearchConnections
-        .filter((connection) => {
-          const filteredData = dqcConnections.find((c) => c.id === connection.id);
-          return filteredData && filteredData.relatedConnections.length > 0;
-        })
-        .map((connection) => {
-          const relatedDQC = dqcConnections.find((c) => c.id === connection.id);
-          return {
-            ...connection,
-            relatedConnections: relatedDQC?.relatedConnections,
-          } as DataSourceConnection;
-        });
-
-      return allConnectionsWithDQC;
-    },
-    [http, mode, notifications]
-  );
-
   useEffect(() => {
     setIsLoading(true);
     getDataSourcesList(savedObjects.client, ['*'])
@@ -290,19 +244,11 @@ export const AssociationDataSourceModalContent = ({
       )
       .then((connections) => {
         setAllConnections(connections);
-      } catch {
-        notifications?.toasts.addDanger(
-          i18n.translate('workspace.detail.dataSources.associateModal.fetchDataSourcesError', {
-            defaultMessage: 'Failed to get data sources',
-          })
-        );
-      } finally {
+      })
+      .finally(() => {
         setIsLoading(false);
-      }
-    };
-
-    fetchDataSourcesAndHandleRelatedConnections();
-  }, [savedObjects.client, notifications, http, mode, handleDirectQueryConnections]);
+      });
+  }, [savedObjects.client, http, notifications, mode]);
 
   useEffect(() => {
     setOptions(
@@ -315,7 +261,7 @@ export const AssociationDataSourceModalContent = ({
         mode,
       })
     );
-  }, [excludedConnectionIds, selectedConnectionIds, mode, allConnections, logos]);
+  }, [allConnections, excludedConnectionIds, selectedConnectionIds, mode, logos]);
 
   return (
     <>

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
@@ -290,6 +290,7 @@ export const AssociationDataSourceModalContent = ({
               'workspace.detail.dataSources.associateModal.searchPlaceholder',
               { defaultMessage: 'Search' }
             ),
+            compressed: true,
           }}
           options={options}
           onChange={handleSelectionChange}

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -44,31 +44,31 @@ const PublicAPPInfoMap = new Map([
 
 const dataSourcesList = [
   {
-    id: 'ds1',
-    title: 'Data Source 1',
+    id: 'id1',
+    title: 'ds1',
     description: 'Description of data source 1',
     auth: '',
     dataSourceEngineType: '' as DataSourceEngineType,
     workspaces: [],
     // This is used for mocking saved object function
     get: () => {
-      return 'Data Source 1';
+      return 'ds1';
     },
   },
   {
-    id: 'ds2',
-    title: 'Data Source 2',
-    description: 'Description of data source 2',
+    id: 'id2',
+    title: 'ds2',
+    description: 'Description of data source 1',
     auth: '',
     dataSourceEngineType: '' as DataSourceEngineType,
     workspaces: [],
     get: () => {
-      return 'Data Source 2';
+      return 'ds2';
     },
   },
   {
-    id: 'ds3',
-    title: 'Data connection 1',
+    id: 'id3',
+    title: 'dqs1',
     description: 'Description of data connection 1',
     auth: '',
     dataSourceEngineType: '' as DataSourceEngineType,
@@ -80,69 +80,36 @@ const dataSourcesList = [
     },
   },
 ];
-
-const directQueryConnectionsMock = [
-  {
-    id: 'ds1-dqc1',
-    name: 'dqc1',
-    parentId: 'ds1',
-    connectionType: DataSourceConnectionType.DirectQueryConnection,
-    type: 'Amazon S3',
-  },
-];
 const dataSourceConnectionsList = [
   {
-    id: 'ds1',
-    name: 'Data Source 1',
+    id: 'id1',
+    name: 'ds1',
     connectionType: DataSourceConnectionType.OpenSearchConnection,
     type: 'OpenSearch',
     relatedConnections: [],
   },
   {
-    id: 'ds2',
-    name: 'Data Source 2',
+    id: 'id2',
+    name: 'ds2',
     connectionType: DataSourceConnectionType.OpenSearchConnection,
     type: 'OpenSearch',
   },
-];
-
-const dataConnectionsList = [
   {
-    id: 'ds3',
-    name: 'Data connection 1',
+    id: 'id3',
+    name: 'dqs1',
     description: 'Description of data connection 1',
     connectionType: DataSourceConnectionType.DataConnection,
     type: 'AWS Security Lake',
   },
 ];
 
-jest.spyOn(utils, 'convertDataSourcesToOpenSearchAndDataConnections').mockReturnValue({
-  openSearchConnections: [...dataSourceConnectionsList],
-  dataConnections: [...dataConnectionsList],
-});
-
-jest.spyOn(utils, 'getDataSourcesList').mockResolvedValue(dataSourcesList);
-jest.spyOn(utils, 'fulfillRelatedConnections').mockReturnValue([
-  {
-    id: 'ds1',
-    name: 'Data Source 1',
-    type: 'OpenSearch',
-    connectionType: 0,
-    relatedConnections: [
-      {
-        id: 'ds1-dqc1',
-        name: 'dqc1',
-        type: 'Amazon S3',
-        connectionType: 1,
-        parentId: 'ds1',
-      },
-    ],
-  },
-]);
-
-jest.spyOn(utils, 'fetchDirectQueryConnectionsByIDs').mockResolvedValue(directQueryConnectionsMock);
-
 const mockCoreStart = coreMock.createStart();
+
+jest.spyOn(utils, 'fetchDataSourceConnections').mockImplementation(async (passedDataSources) => {
+  return dataSourceConnectionsList.filter(({ id }) =>
+    passedDataSources.some((dataSource) => dataSource.id === id)
+  );
+});
 
 const WorkspaceCreator = ({
   isDashboardAdmin = false,
@@ -415,7 +382,7 @@ describe('WorkspaceCreator', () => {
       }),
       expect.objectContaining({
         dataConnections: [],
-        dataSources: ['ds1'],
+        dataSources: ['id1'],
       })
     );
     await waitFor(() => {
@@ -446,14 +413,14 @@ describe('WorkspaceCreator', () => {
       target: { value: 'test workspace name' },
     });
     fireEvent.click(getByTestId('workspaceUseCase-observability'));
-    fireEvent.click(getByTestId('workspace-creator-dataSources-assign-button'));
-    expect(
-      getByText(
-        'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
-      )
-    ).toBeInTheDocument();
+    fireEvent.click(getByTestId('workspace-creator-dqc-assign-button'));
 
     await waitFor(() => {
+      expect(
+        getByText(
+          'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
+        )
+      ).toBeInTheDocument();
       expect(getByText(dataSourcesList[2].title)).toBeInTheDocument();
     });
     fireEvent.click(getByText(dataSourcesList[2].title));
@@ -465,7 +432,7 @@ describe('WorkspaceCreator', () => {
         name: 'test workspace name',
       }),
       expect.objectContaining({
-        dataConnections: ['ds3'],
+        dataConnections: ['id3'],
         dataSources: [],
       })
     );

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
@@ -224,7 +224,7 @@ describe('SelectDataSourcePanel', () => {
           'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
         )
       ).toBeInTheDocument();
-      fireEvent.click(getByText('Close'));
+      fireEvent.click(getByText('Cancel'));
     });
     expect(
       queryByText(

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
@@ -14,30 +14,29 @@ import { DataSourceConnectionType } from '../../../common/types';
 
 import { SelectDataSourcePanel, SelectDataSourcePanelProps } from './select_data_source_panel';
 
-const directQueryConnectionsMock = [
-  {
-    id: 'ds1-dqc1',
-    name: 'dqc1',
-    parentId: 'ds1',
-    connectionType: DataSourceConnectionType.DirectQueryConnection,
-    type: 'Amazon S3',
-  },
-];
-const dataSourceConnectionsMock = [
-  {
-    id: 'ds1',
-    name: 'Data Source 1',
-    connectionType: DataSourceConnectionType.OpenSearchConnection,
-    type: 'OpenSearch',
-    relatedConnections: [],
-  },
-  {
-    id: 'ds2',
-    name: 'Data Source 2',
-    connectionType: DataSourceConnectionType.OpenSearchConnection,
-    type: 'OpenSearch',
-  },
-];
+//   {
+//     id: 'ds1-dqc1',
+//     name: 'dqc1',
+//     parentId: 'ds1',
+//     connectionType: DataSourceConnectionType.DirectQueryConnection,
+//     type: 'Amazon S3',
+//   },
+// ];
+// const dataSourceConnectionsMock = [
+//   {
+//     id: 'ds1',
+//     name: 'Data Source 1',
+//     connectionType: DataSourceConnectionType.OpenSearchConnection,
+//     type: 'OpenSearch',
+//     relatedConnections: [],
+//   },
+//   {
+//     id: 'ds2',
+//     name: 'Data Source 2',
+//     connectionType: DataSourceConnectionType.OpenSearchConnection,
+//     type: 'OpenSearch',
+//   },
+// ];
 
 const dataSources = [
   {
@@ -57,13 +56,51 @@ const dataSources = [
     workspaces: [],
   },
 ];
+
+const dataSourceConnectionsMock = [
+  {
+    id: 'ds1',
+    name: 'Data Source 1',
+    connectionType: DataSourceConnectionType.OpenSearchConnection,
+    type: 'OpenSearch',
+    relatedConnections: [
+      {
+        id: 'ds1-dqc1',
+        name: 'dqc1',
+        parentId: 'ds1',
+        connectionType: DataSourceConnectionType.DirectQueryConnection,
+        type: 'Amazon S3',
+      },
+    ],
+  },
+  {
+    id: 'ds1-dqc1',
+    name: 'dqc1',
+    parentId: 'ds1',
+    connectionType: DataSourceConnectionType.DirectQueryConnection,
+    type: 'Amazon S3',
+  },
+  {
+    id: 'ds2',
+    name: 'Data Source 2',
+    connectionType: DataSourceConnectionType.OpenSearchConnection,
+    type: 'OpenSearch',
+    relatedConnections: [],
+  },
+  {
+    id: 'dqs1',
+    name: 'Data Connection 1',
+    connectionType: DataSourceConnectionType.DataConnection,
+    type: 'AWS Security Lake',
+  },
+];
+const assignedDataSourcesConnections = [dataSourceConnectionsMock[0], dataSourceConnectionsMock[2]];
 jest.spyOn(utils, 'getDataSourcesList').mockResolvedValue(dataSources);
-
-jest
-  .spyOn(utils, 'convertDataSourcesToOpenSearchAndDataConnections')
-  .mockReturnValue({ openSearchConnections: [...dataSourceConnectionsMock], dataConnections: [] });
-
-jest.spyOn(utils, 'fetchDirectQueryConnectionsByIDs').mockResolvedValue(directQueryConnectionsMock);
+jest.spyOn(utils, 'fetchDataSourceConnections').mockImplementation(async (passedDataSources) => {
+  return dataSourceConnectionsMock.filter(({ id }) =>
+    passedDataSources.some((dataSource) => dataSource.id === id)
+  );
+});
 
 const mockCoreStart = coreMock.createStart();
 
@@ -137,56 +174,11 @@ describe('SelectDataSourcePanel', () => {
 
   it('should call onChange when updating data sources', async () => {
     const onChangeMock = jest.fn();
-    const { getByTestId, getByText, findByText } = setup({
+    const { getByTestId, getByText } = setup({
       onChange: onChangeMock,
       assignedDataSourceConnections: [],
     });
-
     expect(onChangeMock).not.toHaveBeenCalled();
-    fireEvent.click(getByTestId('workspace-creator-dataSources-assign-button'));
-    expect(
-      getByText(
-        'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
-      )
-    ).toBeInTheDocument();
-    await findByText('Data Source 1');
-    fireEvent.click(getByText('Data Source 1'));
-    fireEvent.click(getByText('Associate data sources'));
-    expect(onChangeMock).toHaveBeenCalledWith([expect.objectContaining({ id: 'ds1' })]);
-  });
-
-  it('should call onChange when deleting selected data source', async () => {
-    const onChangeMock = jest.fn();
-    const { getByText, getByTestId } = setup({
-      onChange: onChangeMock,
-      assignedDataSourceConnections: dataSourceConnectionsMock,
-    });
-    fireEvent.click(getByTestId('workspace-creator-dataSources-assign-button'));
-
-    await waitFor(() => {
-      expect(getByText(dataSourceConnectionsMock[0].name)).toBeInTheDocument();
-      expect(getByText(dataSourceConnectionsMock[1].name)).toBeInTheDocument();
-    });
-
-    fireEvent.click(getByText(dataSourceConnectionsMock[0].name));
-    fireEvent.click(getByText(dataSourceConnectionsMock[1].name));
-
-    expect(onChangeMock).not.toHaveBeenCalled();
-
-    fireEvent.click(getByText('Associate data sources'));
-
-    await waitFor(() => {
-      fireEvent.click(getByTestId('checkboxSelectRow-' + dataSources[1].id));
-      fireEvent.click(getByText('Remove selected'));
-    });
-    expect(onChangeMock).toHaveBeenCalledWith([dataSourceConnectionsMock[0]]);
-  });
-
-  it('should close associate data sources modal', async () => {
-    const { getByText, queryByText, getByTestId } = setup({
-      assignedDataSourceConnections: [],
-    });
-
     fireEvent.click(getByTestId('workspace-creator-dataSources-assign-button'));
     await waitFor(() => {
       expect(
@@ -194,8 +186,70 @@ describe('SelectDataSourcePanel', () => {
           'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
         )
       ).toBeInTheDocument();
+      expect(getByText(assignedDataSourcesConnections[1].name)).toBeInTheDocument();
     });
-    fireEvent.click(getByText('Cancel'));
+
+    fireEvent.click(getByText(assignedDataSourcesConnections[1].name));
+    fireEvent.click(getByText('Associate data sources'));
+    expect(onChangeMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: assignedDataSourcesConnections[1].id,
+      }),
+    ]);
+
+    fireEvent.click(getByTestId('workspace-creator-dqc-assign-button'));
+    await waitFor(() => {
+      expect(getByText(assignedDataSourcesConnections[0].name)).toBeInTheDocument();
+    });
+    fireEvent.click(getByText(assignedDataSourcesConnections[0].name));
+    fireEvent.click(getByText('Associate data sources'));
+    expect(onChangeMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: assignedDataSourcesConnections[0].id,
+      }),
+    ]);
+  });
+
+  it('should call onChange when deleting selected data source', async () => {
+    const onChangeMock = jest.fn();
+    const { getByText, getByTestId } = setup({
+      onChange: onChangeMock,
+      assignedDataSourceConnections: assignedDataSourcesConnections,
+    });
+    fireEvent.click(getByTestId('workspace-creator-dataSources-assign-button'));
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
+        )
+      ).toBeInTheDocument();
+      expect(getByText(assignedDataSourcesConnections[0].name)).toBeInTheDocument();
+      expect(getByText(assignedDataSourcesConnections[1].name)).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByText(assignedDataSourcesConnections[1].name));
+    fireEvent.click(getByText('Associate data sources'));
+
+    fireEvent.click(getByTestId('checkboxSelectRow-' + dataSources[1].id));
+    fireEvent.click(getByText('Remove selected'));
+
+    expect(onChangeMock).toHaveBeenCalledWith([assignedDataSourcesConnections[0]]);
+  });
+
+  it('should close associate data sources modal', async () => {
+    const { getByText, queryByText, getByTestId } = setup({
+      assignedDataSourceConnections: [],
+    });
+    fireEvent.click(getByTestId('workspace-creator-dataSources-assign-button'));
+    await waitFor(() => {
+      expect(
+        getByText(
+          'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
+        )
+      ).toBeInTheDocument();
+      fireEvent.click(getByText('Cancel'));
+    });
     expect(
       queryByText(
         'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'

--- a/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/select_data_source_panel.test.tsx
@@ -14,30 +14,6 @@ import { DataSourceConnectionType } from '../../../common/types';
 
 import { SelectDataSourcePanel, SelectDataSourcePanelProps } from './select_data_source_panel';
 
-//   {
-//     id: 'ds1-dqc1',
-//     name: 'dqc1',
-//     parentId: 'ds1',
-//     connectionType: DataSourceConnectionType.DirectQueryConnection,
-//     type: 'Amazon S3',
-//   },
-// ];
-// const dataSourceConnectionsMock = [
-//   {
-//     id: 'ds1',
-//     name: 'Data Source 1',
-//     connectionType: DataSourceConnectionType.OpenSearchConnection,
-//     type: 'OpenSearch',
-//     relatedConnections: [],
-//   },
-//   {
-//     id: 'ds2',
-//     name: 'Data Source 2',
-//     connectionType: DataSourceConnectionType.OpenSearchConnection,
-//     type: 'OpenSearch',
-//   },
-// ];
-
 const dataSources = [
   {
     id: 'ds1',
@@ -248,7 +224,7 @@ describe('SelectDataSourcePanel', () => {
           'Add data sources that will be available in the workspace. If a selected data source has related Direct Query data sources, they will also be available in the workspace.'
         )
       ).toBeInTheDocument();
-      fireEvent.click(getByText('Cancel'));
+      fireEvent.click(getByText('Close'));
     });
     expect(
       queryByText(

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -332,36 +332,6 @@ describe('workspace utils: filterWorkspaceConfigurableApps', () => {
   });
 });
 
-describe('workspace utils: fetchDirectQueryConnectionsByIDs', () => {
-  it('should successfully retrieve direct query connections by Ids', async () => {
-    const coreStart = coreMock.createStart();
-    const httpMock = coreStart.http;
-    const notificationsMock = coreStart.notifications;
-    httpMock.get.mockResolvedValue([
-      { name: 'Connection A', description: 'Test A', connector: 'S3GLUE' },
-    ]);
-
-    const dataSourceIds = ['1'];
-    const result = await fetchDirectQueryConnectionsByIDs(
-      dataSourceIds,
-      httpMock,
-      notificationsMock
-    );
-    expect(result).toEqual([
-      {
-        id: '1-Connection A',
-        name: 'Connection A',
-        parentId: '1',
-        type: 'Amazon S3',
-        connectionType: DataSourceConnectionType.DirectQueryConnection,
-        description: 'Test A',
-      },
-    ]);
-    expect(httpMock.get).toHaveBeenCalledWith(expect.stringContaining('dataSourceMDSId=1'));
-    expect(notificationsMock.toasts.addDanger).not.toHaveBeenCalled();
-  });
-});
-
 describe('workspace utils: isFeatureIdInsideUseCase', () => {
   it('should return false for invalid use case', () => {
     expect(isFeatureIdInsideUseCase('discover', 'invalid', [])).toBe(false);

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -16,12 +16,12 @@ import {
   prependWorkspaceToBreadcrumbs,
   getIsOnlyAllowEssentialUseCase,
   mergeDataSourcesWithConnections,
-  fetchDirectQueryConnectionsByIDs,
+  fetchDataSourceConnections,
   getUseCaseUrl,
 } from './utils';
 import { WorkspaceAvailability } from '../../../core/public';
 import { coreMock } from '../../../core/public/mocks';
-import { USE_CASE_PREFIX } from '../common/constants';
+import { USE_CASE_PREFIX, AssociationDataSourceModalMode } from '../common/constants';
 import {
   SigV4ServiceName,
   DataSourceEngineType,
@@ -765,7 +765,11 @@ describe('workspace utils: mergeDataSourcesWithConnections', () => {
         connectionType: DataSourceConnectionType.DirectQueryConnection,
       },
     ];
-    const result = mergeDataSourcesWithConnections(dataSources, directQueryConnections);
+    const result = mergeDataSourcesWithConnections(
+      dataSources,
+      directQueryConnections,
+      AssociationDataSourceModalMode.DirectQueryConnections
+    );
     expect(result).toStrictEqual([
       {
         connectionType: 1,
@@ -805,6 +809,104 @@ describe('workspace utils: mergeDataSourcesWithConnections', () => {
     ]);
   });
 
+  it('should not merge data connection when mode is OpenSearchConnections', () => {
+    const dataSources = [
+      {
+        id: 'id1',
+        title: 'title1',
+        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
+        description: '',
+      },
+      {
+        id: 'idc2',
+        title: 'title2',
+        type: DATA_CONNECTION_SAVED_OBJECT_TYPE,
+        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
+        description: '',
+      },
+    ];
+    const directQueryConnections = [
+      {
+        id: 'id3',
+        title: 'title3',
+        name: 'name1',
+        parentId: 'id1',
+        description: 'direct_query_connections_1',
+        type: 'Amazon S3',
+        connectionType: DataSourceConnectionType.DirectQueryConnection,
+      },
+    ];
+    const result = mergeDataSourcesWithConnections(
+      dataSources,
+      directQueryConnections,
+      AssociationDataSourceModalMode.OpenSearchConnections
+    );
+    expect(result).toStrictEqual([
+      {
+        connectionType: 0,
+        description: '',
+        id: 'id1',
+        name: 'title1',
+        relatedConnections: [],
+        type: 'OpenSearch',
+      },
+    ]);
+  });
+
+  it('should return only OpenSearch connections when mode is OpenSearchConnections', () => {
+    const dataSources = [
+      {
+        id: 'id1',
+        title: 'title1',
+        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
+        description: '',
+      },
+      {
+        id: 'id2',
+        title: 'title2',
+        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
+        description: '',
+      },
+    ];
+    const directQueryConnections = [
+      {
+        id: 'id3',
+        title: 'title3',
+        name: 'name1',
+        parentId: 'id1',
+        description: 'direct_query_connections_1',
+        type: 'Amazon S3',
+        connectionType: DataSourceConnectionType.DirectQueryConnection,
+      },
+    ];
+    const result = mergeDataSourcesWithConnections(
+      dataSources,
+      directQueryConnections,
+      AssociationDataSourceModalMode.OpenSearchConnections
+    );
+    expect(result).toStrictEqual([
+      {
+        connectionType: 0,
+        description: '',
+        id: 'id1',
+        name: 'title1',
+        relatedConnections: [],
+        type: 'OpenSearch',
+      },
+      {
+        connectionType: 0,
+        description: '',
+        id: 'id2',
+        name: 'title2',
+        relatedConnections: [],
+        type: 'OpenSearch',
+      },
+    ]);
+  });
+
   it('should not merge data sources or data connections if no direct query connections', () => {
     const dataSources = [
       {
@@ -823,7 +925,11 @@ describe('workspace utils: mergeDataSourcesWithConnections', () => {
       },
     ];
 
-    const result = mergeDataSourcesWithConnections(dataSources, []);
+    const result = mergeDataSourcesWithConnections(
+      dataSources,
+      [],
+      AssociationDataSourceModalMode.DirectQueryConnections
+    );
     expect(result).toStrictEqual([
       {
         connectionType: 0,
@@ -855,5 +961,94 @@ describe('workspace utils: getUseCaseUrl', () => {
     startMock.application.getUrlForApp.mockImplementation((id) => `http://localhost/${id}`);
     const url = getUseCaseUrl(undefined, 'foo', startMock.application, startMock.http);
     expect(url).toEqual('http://localhost/w/foo/workspace_detail');
+  });
+});
+
+describe('workspace utils: fetchDataSourceConnections', () => {
+  it('should successfully retrieve direct query connections and merge direct query connections with data source ', async () => {
+    const coreStart = coreMock.createStart();
+    const httpMock = coreStart.http;
+    const notificationsMock = coreStart.notifications;
+    httpMock.get.mockResolvedValue([
+      { name: 'Connection A', description: 'Test A', connector: 'S3GLUE' },
+    ]);
+
+    const dataSources = [
+      {
+        id: 'id1',
+        title: 'title1',
+        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
+        description: '',
+        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+      },
+    ];
+    const result = await fetchDataSourceConnections(
+      dataSources,
+      httpMock,
+      notificationsMock,
+      AssociationDataSourceModalMode.DirectQueryConnections
+    );
+    expect(result).toEqual([
+      {
+        id: 'id1-Connection A',
+        name: 'Connection A',
+        type: 'Amazon S3',
+        connectionType: 1,
+        description: 'Test A',
+        parentId: 'id1',
+      },
+      {
+        id: 'id1',
+        type: 'OpenSearch',
+        connectionType: 0,
+        name: 'title1',
+        description: '',
+        relatedConnections: [
+          {
+            id: 'id1-Connection A',
+            name: 'Connection A',
+            type: 'Amazon S3',
+            connectionType: 1,
+            description: 'Test A',
+            parentId: 'id1',
+          },
+        ],
+      },
+    ]);
+    expect(httpMock.get).toHaveBeenCalledWith(expect.stringContaining('dataSourceMDSId=id1'));
+    expect(notificationsMock.toasts.addDanger).not.toHaveBeenCalled();
+  });
+  it('should not retrieve direct query connections if mode is opensearch connection', async () => {
+    const coreStart = coreMock.createStart();
+    const httpMock = coreStart.http;
+    const notificationsMock = coreStart.notifications;
+
+    const dataSources = [
+      {
+        id: 'id1',
+        title: 'title1',
+        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
+        description: '',
+        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
+      },
+    ];
+    const result = await fetchDataSourceConnections(
+      dataSources,
+      httpMock,
+      notificationsMock,
+      AssociationDataSourceModalMode.OpenSearchConnections
+    );
+    expect(result).toEqual([
+      {
+        id: 'id1',
+        type: 'OpenSearch',
+        connectionType: 0,
+        name: 'title1',
+        description: '',
+        relatedConnections: [],
+      },
+    ]);
+    expect(httpMock.get).not.toHaveBeenCalledWith(expect.stringContaining('dataSourceMDSId=id1'));
+    expect(notificationsMock.toasts.addDanger).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -809,7 +809,7 @@ describe('workspace utils: mergeDataSourcesWithConnections', () => {
     ]);
   });
 
-  it('should not merge data connection when mode is OpenSearchConnections', () => {
+  it('should return only OpenSearch connections when mode is OpenSearchConnections', () => {
     const dataSources = [
       {
         id: 'id1',
@@ -854,60 +854,7 @@ describe('workspace utils: mergeDataSourcesWithConnections', () => {
     ]);
   });
 
-  it('should return only OpenSearch connections when mode is OpenSearchConnections', () => {
-    const dataSources = [
-      {
-        id: 'id1',
-        title: 'title1',
-        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
-        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
-        description: '',
-      },
-      {
-        id: 'id2',
-        title: 'title2',
-        type: DATA_SOURCE_SAVED_OBJECT_TYPE,
-        dataSourceEngineType: 'OpenSearch' as DataSourceEngineType,
-        description: '',
-      },
-    ];
-    const directQueryConnections = [
-      {
-        id: 'id3',
-        title: 'title3',
-        name: 'name1',
-        parentId: 'id1',
-        description: 'direct_query_connections_1',
-        type: 'Amazon S3',
-        connectionType: DataSourceConnectionType.DirectQueryConnection,
-      },
-    ];
-    const result = mergeDataSourcesWithConnections(
-      dataSources,
-      directQueryConnections,
-      AssociationDataSourceModalMode.OpenSearchConnections
-    );
-    expect(result).toStrictEqual([
-      {
-        connectionType: 0,
-        description: '',
-        id: 'id1',
-        name: 'title1',
-        relatedConnections: [],
-        type: 'OpenSearch',
-      },
-      {
-        connectionType: 0,
-        description: '',
-        id: 'id2',
-        name: 'title2',
-        relatedConnections: [],
-        type: 'OpenSearch',
-      },
-    ]);
-  });
-
-  it('should not merge data sources or data connections if no direct query connections', () => {
+  it('should not merge data sources if no direct query connections', () => {
     const dataSources = [
       {
         id: 'id1',

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -25,7 +25,11 @@ import {
   DEFAULT_NAV_GROUPS,
 } from '../../../core/public';
 
-import { WORKSPACE_DETAIL_APP_ID, USE_CASE_PREFIX } from '../common/constants';
+import {
+  WORKSPACE_DETAIL_APP_ID,
+  USE_CASE_PREFIX,
+  AssociationDataSourceModalMode,
+} from '../common/constants';
 import { getUseCaseFeatureConfig } from '../common/utils';
 import { WorkspaceUseCase, WorkspaceUseCaseFeature } from './types';
 import { formatUrlWithWorkspaceId } from '../../../core/public/utils';
@@ -333,17 +337,25 @@ export const fulfillRelatedConnections = (
 // Helper function to merge data sources with direct query connections
 export const mergeDataSourcesWithConnections = (
   dataSources: DataSource[] | DataConnection[],
-  directQueryConnections: DataSourceConnection[]
+  directQueryConnections: DataSourceConnection[],
+  mode: AssociationDataSourceModalMode
 ): DataSourceConnection[] => {
   const {
     openSearchConnections,
     dataConnections,
   } = convertDataSourcesToOpenSearchAndDataConnections(dataSources);
-  const result = [
-    ...fulfillRelatedConnections(openSearchConnections, directQueryConnections),
-    ...directQueryConnections,
-    ...dataConnections,
-  ].sort((a, b) => a.name.localeCompare(b.name));
+  let result;
+  // if the mode is set to OpenSearchConnections, then only display OpenSearch connections
+  if (mode === AssociationDataSourceModalMode.OpenSearchConnections) {
+    result = openSearchConnections.sort((a, b) => a.name.localeCompare(b.name));
+  } else {
+    // if the mode is set to DirectQueryConnections, then will display Direct Query connections and data connections
+    result = [
+      ...fulfillRelatedConnections(openSearchConnections, directQueryConnections),
+      ...directQueryConnections,
+      ...dataConnections,
+    ].sort((a, b) => a.name.localeCompare(b.name));
+  }
 
   return result;
 };
@@ -520,15 +532,19 @@ export const fetchDataSourceConnectionsByDataSourceIds = async (
 export const fetchDataSourceConnections = async (
   dataSources: DataSource[],
   http: HttpSetup | undefined,
-  notifications: NotificationsStart | undefined
+  notifications: NotificationsStart | undefined,
+  mode: AssociationDataSourceModalMode
 ) => {
   try {
-    const directQueryConnections = await fetchDataSourceConnectionsByDataSourceIds(
-      // Only data source saved object type needs to fetch data source connections, data connection type object not.
-      dataSources.filter((ds) => ds.type === DATA_SOURCE_SAVED_OBJECT_TYPE).map((ds) => ds.id),
-      http
-    );
-    return mergeDataSourcesWithConnections(dataSources, directQueryConnections);
+    let directQueryConnections: DataSourceConnection[] = [];
+    if (mode === AssociationDataSourceModalMode.DirectQueryConnections) {
+      directQueryConnections = await fetchDataSourceConnectionsByDataSourceIds(
+        // Only data source saved object type needs to fetch data source connections, data connection type object not.
+        dataSources.filter((ds) => ds.type === DATA_SOURCE_SAVED_OBJECT_TYPE).map((ds) => ds.id),
+        http
+      );
+    }
+    return mergeDataSourcesWithConnections(dataSources, directQueryConnections, mode);
   } catch (error) {
     notifications?.toasts.addDanger(
       i18n.translate('workspace.detail.dataSources.error.message', {

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -555,29 +555,6 @@ export const fetchDataSourceConnections = async (
   }
 };
 
-export const fetchDirectQueryConnectionsByIDs = async (
-  dataSourceIds: string[],
-  http: HttpSetup | undefined,
-  notifications: NotificationsStart | undefined
-) => {
-  try {
-    const directQueryConnections = await fetchDataSourceConnectionsByDataSourceIds(
-      // Only data source saved object type needs to fetch data source connections, data connection type object not.
-      dataSourceIds,
-      http
-    );
-
-    return directQueryConnections.sort((a, b) => a.name.localeCompare(b.name));
-  } catch (error) {
-    notifications?.toasts.addDanger(
-      i18n.translate('workspace.detail.dataSources.error.message', {
-        defaultMessage: 'Cannot fetch direct query connections',
-      })
-    );
-    return [];
-  }
-};
-
 export const getUseCase = (workspace: WorkspaceObject, availableUseCases: WorkspaceUseCase[]) => {
   if (!workspace.features) {
     return;

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -126,6 +126,9 @@ export class WorkspaceIdConsumerWrapper {
       if (!object.workspaces || object.workspaces.length === 0) {
         return false;
       }
+      if (!!getWorkspaceState(request).isDashboardAdmin) {
+        return true;
+      }
     }
     /*
      * Allow access if the requested workspace matches one of the object's assigned workspaces
@@ -221,7 +224,6 @@ export class WorkspaceIdConsumerWrapper {
         }
 
         const objectToGet = await wrapperOptions.client.get<T>(type, id, options);
-
         if (
           workspaces?.length === 1 &&
           !this.validateObjectInAWorkspace(objectToGet, workspaces[0], wrapperOptions.request)

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -126,9 +126,6 @@ export class WorkspaceIdConsumerWrapper {
       if (!object.workspaces || object.workspaces.length === 0) {
         return false;
       }
-      if (!!getWorkspaceState(request).isDashboardAdmin) {
-        return true;
-      }
     }
     /*
      * Allow access if the requested workspace matches one of the object's assigned workspaces


### PR DESCRIPTION
### Description
This  pr fixes the bug of incorrect classification for data connections and optimizes operations by removing the fetching DQC when user associates an OpenSearch data source(only one step)

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
https://github.com/user-attachments/assets/fae29ee2-65ca-48fb-bfc2-2087c0139da9

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: bug that mistakenly classify data connection
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
