### PR TITLE
[Discover] Query Editor Shortcut Fires Incorrect Query

### DIFF
--- a/changelogs/fragments/9248.yml
+++ b/changelogs/fragments/9248.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix Discover query editor enter shortcuts reverting date range ([#9248](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9248))

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -80,6 +80,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const editorQuery = props.query; // local query state managed by the editor. Not to be confused by the app query state.
 
   const queryString = getQueryService().queryString;
+  const timefilter = getQueryService().timefilter.timefilter;
   const languageManager = queryString.getLanguageService();
   const extensionMap = languageManager.getQueryEditorExtensionMap();
   const services = props.opensearchDashboards.services;
@@ -297,7 +298,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
           query: editor.getValue(),
         };
 
-        onSubmit(newQuery);
+        onSubmit(newQuery, timefilter.getTime());
       });
 
       return () => {
@@ -354,11 +355,11 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
 
       editor.addCommand(monaco.KeyCode.Enter, () => {
         const newQuery = {
-          ...query,
+          ...queryRef.current,
           query: editor.getValue(),
         };
 
-        onSubmit(newQuery);
+        onSubmit(newQuery, timefilter.getTime());
       });
     },
     provideCompletionItems,


### PR DESCRIPTION
### Description

* When using keyboard shortcuts to run a query in Discover 2.0, the date range gets reverted to Discover's last date range state. Since there is no date range passed into the `onSubmit()` function from the editor shortcut, the `QueryEditorTopRow` uses the props passed from the search bar as dates, which may be out of sync compared to the query service state. This PR passes in the correct date form the query service.
* Additionally, in the multiline editor, the `query` object was being used to construct the new query. This PR updates it to match the single line editor, which uses the `queryRef` defined in the same file.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
-fix: Fix Discover query editor enter shortcuts reverting date range

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
