### PR TITLE
[Workspace]DQC can not be assigned to a workspace due to validation 

### DIFF
--- a/changelogs/fragments/9259.yml
+++ b/changelogs/fragments/9259.yml
@@ -1,0 +1,2 @@
+fix:
+- DQC can not be assigned to a workspace due to validation ([#9259](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9259))

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -150,9 +150,7 @@ export class Fetch {
 
     const url = format({
       pathname: shouldPrependBasePath
-        ? this.params.basePath.prepend(options.path, {
-            withoutClientBasePath: options.withoutClientBasePath,
-          })
+        ? this.params.basePath.prepend(options.path, options.PrependOptions)
         : options.path,
       query: removedUndefined(query),
     });

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -150,7 +150,7 @@ export class Fetch {
 
     const url = format({
       pathname: shouldPrependBasePath
-        ? this.params.basePath.prepend(options.path, options.PrependOptions)
+        ? this.params.basePath.prepend(options.path, options.prependOptions)
         : options.path,
       query: removedUndefined(query),
     });

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -40,6 +40,7 @@ import {
   HttpFetchOptions,
   HttpResponse,
   HttpFetchOptionsWithPath,
+  PrependOptions,
 } from './types';
 import { HttpFetchError } from './http_fetch_error';
 import { HttpInterceptController } from './http_intercept_controller';
@@ -148,10 +149,19 @@ export class Fetch {
       }),
     };
 
-    const url = format({
-      pathname: shouldPrependBasePath ? this.params.basePath.prepend(options.path) : options.path,
-      query: removedUndefined(query),
-    });
+    let url;
+    if (options.headers?.withoutClientBasePath) {
+      const theoptions: PrependOptions = { withoutClientBasePath: true };
+      url = format({
+        pathname: this.params.basePath.remove(options.path, theoptions),
+        query: removedUndefined(query),
+      });
+    } else {
+      url = format({
+        pathname: shouldPrependBasePath ? this.params.basePath.prepend(options.path) : options.path,
+        query: removedUndefined(query),
+      });
+    }
 
     // Make sure the system request header is only present if `asSystemRequest` is true.
     if (asSystemRequest) {

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -148,12 +148,11 @@ export class Fetch {
       }),
     };
 
-    const prependOptions = options.withoutClientBasePath
-      ? { withoutClientBasePath: options.withoutClientBasePath }
-      : undefined;
     const url = format({
       pathname: shouldPrependBasePath
-        ? this.params.basePath.prepend(options.path, prependOptions)
+        ? this.params.basePath.prepend(options.path, {
+            withoutClientBasePath: options.withoutClientBasePath,
+          })
         : options.path,
       query: removedUndefined(query),
     });

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -40,7 +40,6 @@ import {
   HttpFetchOptions,
   HttpResponse,
   HttpFetchOptionsWithPath,
-  PrependOptions,
 } from './types';
 import { HttpFetchError } from './http_fetch_error';
 import { HttpInterceptController } from './http_intercept_controller';
@@ -149,19 +148,15 @@ export class Fetch {
       }),
     };
 
-    let url;
-    if (options.headers?.withoutClientBasePath) {
-      const theoptions: PrependOptions = { withoutClientBasePath: true };
-      url = format({
-        pathname: this.params.basePath.remove(options.path, theoptions),
-        query: removedUndefined(query),
-      });
-    } else {
-      url = format({
-        pathname: shouldPrependBasePath ? this.params.basePath.prepend(options.path) : options.path,
-        query: removedUndefined(query),
-      });
-    }
+    const prependOptions = options.withoutClientBasePath
+      ? { withoutClientBasePath: options.withoutClientBasePath }
+      : undefined;
+    const url = format({
+      pathname: shouldPrependBasePath
+        ? this.params.basePath.prepend(options.path, prependOptions)
+        : options.path,
+      query: removedUndefined(query),
+    });
 
     // Make sure the system request header is only present if `asSystemRequest` is true.
     if (asSystemRequest) {

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -285,7 +285,7 @@ export interface HttpFetchOptions extends HttpRequestInit {
   /** @deprecated use {@link withLongNumeralsSupport} instead */
   withLongNumerals?: boolean;
 
-  PrependOptions?: PrependOptions;
+  prependOptions?: PrependOptions;
 }
 
 /**

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -285,7 +285,7 @@ export interface HttpFetchOptions extends HttpRequestInit {
   /** @deprecated use {@link withLongNumeralsSupport} instead */
   withLongNumerals?: boolean;
 
-  withoutClientBasePath?: boolean;
+  PrependOptions?: PrependOptions;
 }
 
 /**

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -284,6 +284,8 @@ export interface HttpFetchOptions extends HttpRequestInit {
 
   /** @deprecated use {@link withLongNumeralsSupport} instead */
   withLongNumerals?: boolean;
+
+  withoutClientBasePath?: boolean;
 }
 
 /**

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -962,7 +962,10 @@ describe('workspace utils: fetchDataSourceConnections', () => {
         ],
       },
     ]);
-    expect(httpMock.get).toHaveBeenCalledWith(expect.stringContaining('dataSourceMDSId=id1'));
+    expect(httpMock.get).toHaveBeenCalledWith(
+      expect.stringContaining('dataSourceMDSId=id1'),
+      expect.objectContaining({ withoutClientBasePath: true })
+    );
     expect(notificationsMock.toasts.addDanger).not.toHaveBeenCalled();
   });
   it('should not retrieve direct query connections if mode is opensearch connection', async () => {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -964,7 +964,7 @@ describe('workspace utils: fetchDataSourceConnections', () => {
     ]);
     expect(httpMock.get).toHaveBeenCalledWith(
       expect.stringContaining('dataSourceMDSId=id1'),
-      expect.objectContaining({ withoutClientBasePath: true })
+      expect.objectContaining({ prependOptions: { withoutClientBasePath: true } })
     );
     expect(notificationsMock.toasts.addDanger).not.toHaveBeenCalled();
   });

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -273,7 +273,7 @@ export const getDataSourcesList = (
 
 export const getDirectQueryConnections = async (dataSourceId: string, http: HttpSetup) => {
   const endpoint = `${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceId}`;
-  const res = await http.get(endpoint);
+  const res = await http.get(endpoint, { prependBasePath: false });
   const directQueryConnections: DataSourceConnection[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataSourceId}-${dataConnection.name}`,

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -274,7 +274,7 @@ export const getDataSourcesList = (
 export const getDirectQueryConnections = async (dataSourceId: string, http: HttpSetup) => {
   const endpoint = `${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceId}`;
   const res = await http.get(endpoint, {
-    PrependOptions: { withoutClientBasePath: true },
+    prependOptions: { withoutClientBasePath: true },
   });
   const directQueryConnections: DataSourceConnection[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -273,8 +273,10 @@ export const getDataSourcesList = (
 
 export const getDirectQueryConnections = async (dataSourceId: string, http: HttpSetup) => {
   const endpoint = `${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceId}`;
-  const res = await http.get(endpoint, { prependBasePath: false });
-  const directQueryConnections: DataSourceConnection[] = res.map(
+  const newBasePath = http.basePath.prepend(endpoint, { withoutClientBasePath: true });
+  const res = await fetch(newBasePath);
+  const data = await res.json();
+  const directQueryConnections: DataSourceConnection[] = data.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataSourceId}-${dataConnection.name}`,
       name: dataConnection.name,

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -273,7 +273,9 @@ export const getDataSourcesList = (
 
 export const getDirectQueryConnections = async (dataSourceId: string, http: HttpSetup) => {
   const endpoint = `${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceId}`;
-  const res = await http.get(endpoint, { withoutClientBasePath: true });
+  const res = await http.get(endpoint, {
+    PrependOptions: { withoutClientBasePath: true },
+  });
   const directQueryConnections: DataSourceConnection[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataSourceId}-${dataConnection.name}`,

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -273,7 +273,7 @@ export const getDataSourcesList = (
 
 export const getDirectQueryConnections = async (dataSourceId: string, http: HttpSetup) => {
   const endpoint = `${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceId}`;
-  const res = await http.get(endpoint, { headers: { withoutClientBasePath: true } });
+  const res = await http.get(endpoint, { withoutClientBasePath: true });
   const directQueryConnections: DataSourceConnection[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataSourceId}-${dataConnection.name}`,

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -273,10 +273,8 @@ export const getDataSourcesList = (
 
 export const getDirectQueryConnections = async (dataSourceId: string, http: HttpSetup) => {
   const endpoint = `${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceId}`;
-  const newBasePath = http.basePath.prepend(endpoint, { withoutClientBasePath: true });
-  const res = await fetch(newBasePath);
-  const data = await res.json();
-  const directQueryConnections: DataSourceConnection[] = data.map(
+  const res = await http.get(endpoint, { headers: { withoutClientBasePath: true } });
+  const directQueryConnections: DataSourceConnection[] = res.map(
     (dataConnection: DirectQueryDatasourceDetails) => ({
       id: `${dataSourceId}-${dataConnection.name}`,
       name: dataConnection.name,


### PR DESCRIPTION
### Description
Fix bug: In a workspace, and try to associate direct query connection, it will fail to get dqc and return 403 error


### Issues Resolved
Issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9257

## Screenshot
https://github.com/user-attachments/assets/3bfc7f73-e5d9-4bc2-98ec-77b5a8988a53

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: DQC can not be assigned to a workspace due to validation 
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
