### PR TITLE
update cy.createInitialWorkspaceWithDataSource -> cy.osd.createInitialWorkspaceWithDataSource

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_queries_flyout.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_queries_flyout.spec.js
@@ -50,7 +50,7 @@ export const runSavedQueriesFlyoutUITests = () => {
       // Create workspace
       cy.deleteWorkspaceByName(workspaceName);
       cy.visit('/app/home');
-      cy.createInitialWorkspaceWithDataSource(datasourceName, workspaceName);
+      cy.osd.createInitialWorkspaceWithDataSource(datasourceName, workspaceName);
       cy.createWorkspaceIndexPatterns({
         workspaceName: workspaceName,
         indexPattern: INDEX_PATTERN_WITH_TIME.replace('*', ''),

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_queries_popover.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_queries_popover.spec.js
@@ -51,7 +51,7 @@ export const runSavedQueriesPopoverUITests = () => {
       // Create workspace
       cy.deleteWorkspaceByName(workspaceName);
       cy.visit('/app/home');
-      cy.createInitialWorkspaceWithDataSource(datasourceName, workspaceName);
+      cy.osd.createInitialWorkspaceWithDataSource(datasourceName, workspaceName);
       cy.createWorkspaceIndexPatterns({
         workspaceName: workspaceName,
         indexPattern: INDEX_PATTERN_WITH_TIME.replace('*', ''),


### PR DESCRIPTION
### Description

This PR #9150 updated the namespace of some of our cypress utils, but there were some changes that happened in parallel did not get updated, which will cause all tests to fail (ex: https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/12932986740/job/36070528788?pr=9261)


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
