### PR TITLE
[Discover]chore: disable sorting on columns header for PPL and SQL

### DIFF
--- a/changelogs/fragments/9263.yml
+++ b/changelogs/fragments/9263.yml
@@ -1,0 +1,2 @@
+chore:
+- Disable sorting on Discover table columns header for PPL and SQL ([#9263](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9263))

--- a/src/plugins/data/common/osd_field_types/osd_field_types.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types.ts
@@ -78,7 +78,7 @@ export const getFilterableOsdTypeNames = (): string[] =>
   registeredOsdTypes.filter((type) => type.filterable).map((type) => type.name);
 
 export const setOsdFieldOverrides = (newOverrides: { [key: string]: any } | undefined) => {
-  osdFieldOverrides = newOverrides ? Object.assign({}, newOverrides) : {};
+  osdFieldOverrides = { ...newOverrides };
 };
 
 export const getOsdFieldOverrides = (): { [key: string]: any } => {

--- a/src/plugins/data/common/osd_field_types/osd_field_types.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types.ts
@@ -78,7 +78,7 @@ export const getFilterableOsdTypeNames = (): string[] =>
   registeredOsdTypes.filter((type) => type.filterable).map((type) => type.name);
 
 export const setOsdFieldOverrides = (newOverrides: { [key: string]: any } | undefined) => {
-  osdFieldOverrides = newOverrides ? Object.assign({}, osdFieldOverrides, newOverrides) : {};
+  osdFieldOverrides = newOverrides ? Object.assign({}, newOverrides) : {};
 };
 
 export const getOsdFieldOverrides = (): { [key: string]: any } => {

--- a/src/plugins/data/public/query/query_string/language_service/language_service.ts
+++ b/src/plugins/data/public/query/query_string/language_service/language_service.ts
@@ -3,16 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LanguageConfig } from './types';
+import { EditorEnhancements, LanguageConfig } from './types';
 import { getDQLLanguageConfig, getLuceneLanguageConfig } from './lib';
 import { ISearchInterceptor } from '../../../search';
-import {
-  createEditor,
-  DQLBody,
-  QueryEditorExtensionConfig,
-  SingleLineInput,
-  UiEnhancements,
-} from '../../../ui';
+import { createEditor, DQLBody, QueryEditorExtensionConfig, SingleLineInput } from '../../../ui';
 import { DataStorage, setOverrides as setFieldOverrides } from '../../../../common';
 import { dqlLanguageReference } from './lib/dql_language_reference';
 import { luceneLanguageReference } from './lib/lucene_language_reference';
@@ -29,7 +23,7 @@ export class LanguageService {
     this.queryEditorExtensionMap = {};
   }
 
-  public __enhance = (enhancements: UiEnhancements) => {
+  public __enhance = (enhancements: EditorEnhancements) => {
     if (enhancements.queryEditorExtension) {
       this.queryEditorExtensionMap[enhancements.queryEditorExtension.id] =
         enhancements.queryEditorExtension;

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -51,6 +51,7 @@ export interface LanguageConfig {
     bodyProps: any
   ) => EditorInstance<any, any, any>;
   fields?: {
+    sortable?: boolean;
     filterable?: boolean;
     visualizable?: boolean;
   };

--- a/src/plugins/discover/public/application/components/default_discover_table/helper.test.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/helper.test.tsx
@@ -5,8 +5,11 @@
 
 import { getLegacyDisplayedColumns } from './helper';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { getOsdFieldOverrides } from 'src/plugins/data/common/osd_field_types/osd_field_types';
 
 const mockGetFieldByName = jest.fn();
+jest.mock('src/plugins/data/common/osd_field_types/osd_field_types');
+const mockedGetOsdFieldOverrides = jest.mocked(getOsdFieldOverrides);
 
 describe('getLegacyDisplayedColumns', () => {
   let indexPattern: IndexPattern;
@@ -17,10 +20,12 @@ describe('getLegacyDisplayedColumns', () => {
       timeFieldName: 'timestamp',
     } as unknown) as IndexPattern;
     mockGetFieldByName.mockReset();
+    mockedGetOsdFieldOverrides.mockReset();
   });
 
   it('should return correct column properties without time column', () => {
     mockGetFieldByName.mockReturnValue({ sortable: true });
+    mockedGetOsdFieldOverrides.mockReturnValue({});
     const result = getLegacyDisplayedColumns(['column1'], indexPattern, true, false);
     expect(result).toEqual([
       {
@@ -36,6 +41,7 @@ describe('getLegacyDisplayedColumns', () => {
 
   it('should prepend time column if not hidden, indexPattern has timeFieldName, and columns do not include timeFieldName', () => {
     mockGetFieldByName.mockReturnValue({ sortable: true });
+    mockedGetOsdFieldOverrides.mockReturnValue({});
     const result = getLegacyDisplayedColumns(['column1'], indexPattern, false, false);
     expect(result).toEqual([
       {
@@ -59,6 +65,7 @@ describe('getLegacyDisplayedColumns', () => {
 
   it('should not prepend time column if hideTimeField is true', () => {
     mockGetFieldByName.mockReturnValue({ sortable: true });
+    mockedGetOsdFieldOverrides.mockReturnValue({});
     const result = getLegacyDisplayedColumns(['column1'], indexPattern, true, false);
     expect(result).toEqual([
       {
@@ -74,6 +81,7 @@ describe('getLegacyDisplayedColumns', () => {
 
   it('should not prepend time column if timeFieldName is included in columns', () => {
     mockGetFieldByName.mockReturnValue({ sortable: true });
+    mockedGetOsdFieldOverrides.mockReturnValue({});
     const result = getLegacyDisplayedColumns(['column1', 'timestamp'], indexPattern, false, false);
     expect(result).toEqual([
       {
@@ -97,6 +105,7 @@ describe('getLegacyDisplayedColumns', () => {
 
   it('should shorten dotted string in displayName if isShortDots is true', () => {
     mockGetFieldByName.mockReturnValue({ sortable: true });
+    mockedGetOsdFieldOverrides.mockReturnValue({});
     const result = getLegacyDisplayedColumns(['column.with.dots'], indexPattern, false, true);
     expect(result).toEqual([
       {
@@ -111,6 +120,22 @@ describe('getLegacyDisplayedColumns', () => {
         name: 'column.with.dots',
         displayName: 'c.w.dots',
         isSortable: true,
+        isRemoveable: true,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      },
+    ]);
+  });
+
+  it('should override column Sortable with OsdFieldOverrides value', () => {
+    mockGetFieldByName.mockReturnValue({ sortable: true });
+    mockedGetOsdFieldOverrides.mockReturnValue({ sortable: false });
+    const result = getLegacyDisplayedColumns(['column1'], indexPattern, true, false);
+    expect(result).toEqual([
+      {
+        name: 'column1',
+        displayName: 'column1',
+        isSortable: false,
         isRemoveable: true,
         colLeftIdx: -1,
         colRightIdx: -1,

--- a/src/plugins/discover/public/application/components/default_discover_table/helper.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/helper.tsx
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { getOsdFieldOverrides } from 'src/plugins/data/common';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { shortenDottedString } from '../../helpers';
 
@@ -85,10 +86,12 @@ export function getLegacyDisplayedColumns(
   }
   const columnProps = columns.map((column, idx) => {
     const field = indexPattern.getFieldByName(column);
+    const osdFieldOverrides = getOsdFieldOverrides();
     return {
       name: column,
       displayName: isShortDots ? shortenDottedString(column) : column,
-      isSortable: field && field.sortable ? true : false,
+      isSortable:
+        osdFieldOverrides.sortable == null ? !!field?.sortable : osdFieldOverrides.sortable,
       isRemoveable: column !== '_source' || columns.length > 1,
       colLeftIdx: idx - 1 < 0 ? -1 : idx - 1,
       colRightIdx: idx + 1 >= columns.length ? -1 : idx + 1,

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -66,7 +66,7 @@ export class QueryEnhancementsPlugin
         usageCollector: data.search.usageCollector,
       }),
       getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
-      fields: { filterable: false, visualizable: false },
+      fields: { sortable: false, filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
           defaultMessage: 'PPL documentation',
@@ -132,7 +132,7 @@ export class QueryEnhancementsPlugin
       }),
       getQueryString: (currentQuery: Query) =>
         `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
-      fields: { filterable: false, visualizable: false },
+      fields: { sortable: false, filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {
           defaultMessage: 'SQL documentation',


### PR DESCRIPTION
### Description

Disable sorting on columns header for PPL and SQL, 

### Issues Resolved

Currently sorting on Discover table columns header does not support PPL and SQL, disable it until we build sorting support for PPL and SQL.

## Screenshot

[<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->](https://github.com/user-attachments/assets/54af55a3-1ec4-4b60-a060-13cec4403e24)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: Disable sorting on Discover table columns header for PPL and SQL

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
