### PR TITLE
style: Update sidecar style to align with new page header

### DIFF
--- a/changelogs/fragments/9269.yml
+++ b/changelogs/fragments/9269.yml
@@ -1,0 +1,2 @@
+fix:
+- Update sidecar style to align with new page header ([#9269](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9269))

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -19527,22 +19527,18 @@ exports[`Header renders page header with application title 1`] = `
     <div
       id="globalHeaderBars"
     >
-      <div>
+      <div
+        style={
+          Object {
+            "paddingRight": 640,
+          }
+        }
+      >
         <EuiHeader
           className="primaryHeader newTopNavHeader"
-          style={
-            Object {
-              "paddingRight": 640,
-            }
-          }
         >
           <div
             className="euiHeader euiHeader--default euiHeader--static primaryHeader newTopNavHeader"
-            style={
-              Object {
-                "paddingRight": 640,
-              }
-            }
           >
             <EuiHeaderSectionItemButton
               aria-controls="mockId"

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -553,8 +553,8 @@ export function Header({
   );
 
   const renderPageHeader = () => (
-    <div>
-      <EuiHeader className="primaryHeader newTopNavHeader" style={sidecarPaddingStyle}>
+    <div style={sidecarPaddingStyle}>
+      <EuiHeader className="primaryHeader newTopNavHeader">
         {renderNavToggle()}
 
         <EuiHeaderSection grow={false}>{renderRecentItems()}</EuiHeaderSection>

--- a/src/core/public/overlays/sidecar/components/sidecar.scss
+++ b/src/core/public/overlays/sidecar/components/sidecar.scss
@@ -29,7 +29,8 @@
   }
 
   &.osdSidecarFlyout--dockedTakeover {
-    width: 100vw !important;
+    left: 0;
+    right: 0;
     bottom: 0;
     flex-direction: column;
     padding-top: 8px;


### PR DESCRIPTION
### Description

update sidecar style to align with new page header

## Screenshot

Old page header is still working well.

![image](https://github.com/user-attachments/assets/facbad15-91d8-46b0-9f63-e9705cd3c1da)
Before
![image](https://github.com/user-attachments/assets/43ba4af4-2ff2-48d9-b93f-7912098ab9d0)
After

![image](https://github.com/user-attachments/assets/92980f00-a749-4329-8bf2-717037c3f867)
Before
![image](https://github.com/user-attachments/assets/c1ceb004-7736-4883-83a2-bc9f83f11078)
After

## Testing the changes

Install assistant and switch dock mode to verify.

## Changelog

- fix: Update sidecar style to align with new page header

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
