### PR TITLE
[Workspace]fix: recent item links are not correctly constructed

### DIFF
--- a/changelogs/fragments/9275.yml
+++ b/changelogs/fragments/9275.yml
@@ -1,0 +1,2 @@
+fix:
+- Recent item links are not correctly constructed ([#9275](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9275))

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -502,6 +502,7 @@ export function Header({
         renderBreadcrumbs={renderBreadcrumbs(true, true)}
         buttonSize={useApplicationHeader ? 's' : 'xs'}
         loadingCount$={observables.loadingCount$}
+        workspaceEnabled={application.capabilities.workspaces.enabled}
       />
     </EuiHeaderSectionItem>
   );

--- a/src/core/public/chrome/ui/header/recent_items.test.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.test.tsx
@@ -9,6 +9,7 @@ import { BehaviorSubject } from 'rxjs';
 import { applicationServiceMock, httpServiceMock } from '../../../mocks';
 import { SavedObjectWithMetadata } from './recent_items';
 import { RecentItems } from './recent_items';
+import { createRecentNavLink } from './nav_link';
 
 jest.mock('./nav_link', () => ({
   createRecentNavLink: jest.fn().mockImplementation(() => {
@@ -170,5 +171,27 @@ describe('Recent items', () => {
   it('should show not display item if it is in a workspace which is not available', () => {
     render(<RecentItems {...defaultMockProps} recentlyAccessed$={mockRecentlyAccessed$} />);
     expect(screen.queryByText('visualizeMock')).not.toBeInTheDocument();
+  });
+
+  it('workspace feature flag should be passed to createRecentNavLink correctly', async () => {
+    jest.clearAllMocks();
+    const { getByTestId, findByText, getByText } = render(
+      <RecentItems
+        {...defaultMockProps}
+        workspaceEnabled
+        recentlyAccessed$={mockRecentlyAccessed$}
+        workspaceList$={mockWorkspaceList$}
+      />
+    );
+    fireEvent.click(getByTestId('recentItemsSectionButton'));
+    await findByText('Recent assets');
+    fireEvent.click(getByText('visualizeMock'));
+    expect(createRecentNavLink).toBeCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      true
+    );
   });
 });

--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -45,6 +45,7 @@ export interface Props {
   buttonSize?: EuiHeaderSectionItemButtonProps['size'];
   http: HttpStart;
   loadingCount$: Rx.Observable<number>;
+  workspaceEnabled?: boolean;
 }
 
 interface SavedObjectMetadata {
@@ -112,6 +113,7 @@ export const RecentItems = ({
   buttonSize = 's',
   http,
   loadingCount$,
+  workspaceEnabled,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isPreferencesPopoverOpen, setIsPreferencesPopoverOpen] = useState(false);
@@ -143,6 +145,9 @@ export const RecentItems = ({
           }}
           iconType="managementApp"
           data-test-subj="preferencesSettingButton"
+          aria-label={i18n.translate('core.header.recent.preferences.buttonAriaLabel', {
+            defaultMessage: 'Preferences setting',
+          })}
         />
       }
       isOpen={isPreferencesPopoverOpen}
@@ -296,7 +301,8 @@ export const RecentItems = ({
                       item,
                       navLinks.filter((link) => !link.hidden),
                       basePath,
-                      navigateToUrl
+                      navigateToUrl,
+                      !!workspaceEnabled
                     ).href
                   )
                 }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
When constructing the link for recent items, workspace feature flag is required. This PR is to pass workspace feature flag to all the places calling `createRecentNavLink`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

### Before fix

https://github.com/user-attachments/assets/2d1c239d-5c63-4086-bd71-23ec8a4f8d72


### After fix

https://github.com/user-attachments/assets/9aa9347a-d2d6-49cf-bfe6-61ea8819305a


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Recent item links are not correctly constructed

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
