### PR TITLE
add a check for the sort visibility in language_specific_display

### DIFF
--- a/changelogs/fragments/9314.yml
+++ b/changelogs/fragments/9314.yml
@@ -1,0 +1,2 @@
+test:
+- Test sort in language_specific_display ([#9314](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9314))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/language_specific_display.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/language_specific_display.spec.js
@@ -118,6 +118,11 @@ export const runDisplayTests = () => {
           cy.getElementByTestId('dscTimechart').should('be.visible');
         }
 
+        // testing whether sort appears or not
+        cy.getElementByTestId('docTableHeaderFieldSort_timestamp').should(
+          config.sort ? 'exist' : 'not.exist'
+        );
+
         // testing the language information popup button
         cy.getElementByTestId('languageReferenceButton').click();
         cy.get('.euiPopoverTitle').contains('Syntax options').should('be.visible');


### PR DESCRIPTION
### Description

- @maosaic recently fixed a bug to hide sorting options for PPL and SQL language: #9263
- This is adding to the `language_specific_display` test to ensure that the sort only appears for appropriate languages

## Changelog

- test: test sort in language_specific_display

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
