### PR TITLE
Add Justin as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi @mengweieric @LDrago27 @virajsanghvi @sejli @joshuali925 @huyaboo
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi @mengweieric @LDrago27 @virajsanghvi @sejli @joshuali925 @huyaboo @angle943

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -31,6 +31,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Joshua Li                 | [joshuali925](https://github.com/joshuali925)       | Amazon      |
 | Huy Nguyen                | [huyaboo](https://github.com/huyaboo)               | Amazon      |
 | Hailong Cui               | [Hailong-am](https://github.com/Hailong-am)         | Amazon      |
+| Justin Kim                | [angle943](https://github.com/angle943)             | Amazon      |
 
 ## Emeritus
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -171,6 +171,7 @@
     - [Opensearch dashboards.release notes 2.17.0](../release-notes/opensearch-dashboards.release-notes-2.17.0.md)
     - [Opensearch dashboards.release notes 2.17.1](../release-notes/opensearch-dashboards.release-notes-2.17.1.md)
     - [Opensearch dashboards.release notes 2.18.0](../release-notes/opensearch-dashboards.release-notes-2.18.0.md)
+    - [Opensearch dashboards.release notes 2.19.0](../release-notes/opensearch-dashboards.release-notes-2.19.0.md)
     - [Opensearch dashboards.release notes 2.2.0](../release-notes/opensearch-dashboards.release-notes-2.2.0.md)
     - [Opensearch dashboards.release notes 2.2.1](../release-notes/opensearch-dashboards.release-notes-2.2.1.md)
     - [Opensearch dashboards.release notes 2.3.0](../release-notes/opensearch-dashboards.release-notes-2.3.0.md)


### PR DESCRIPTION
### Description

Add Justin (angle943) as a maintainer


## Changelog

- doc: Add Justin (angle943) as maintainer

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
