### PR TITLE
[TEST] update tests to use only data-logs-1

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/dataset_selector.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/dataset_selector.spec.js
@@ -37,11 +37,11 @@ export const runDatasetSelectorTests = () => {
         PATHS.SECONDARY_ENGINE,
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.mapping.json`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.mapping.json`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.mapping.json`,
         ],
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.data.ndjson`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.data.ndjson`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.data.ndjson`,
         ]
       );
       // Add data source

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/field_display_filtering.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/field_display_filtering.spec.js
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  DATASOURCE_NAME,
-  INDEX_PATTERN_WITH_TIME,
-  INDEX_WITH_TIME_1,
-} from '../../../../../utils/apps/constants';
+import { DATASOURCE_NAME, INDEX_WITH_TIME_1 } from '../../../../../utils/apps/constants';
 import * as docTable from '../../../../../utils/apps/query_enhancements/doc_table.js';
 import { generateFieldDisplayFilteringTestConfiguration } from '../../../../../utils/apps/query_enhancements/field_display_filtering.js';
 import { PATHS, BASE_PATH } from '../../../../../utils/constants';
@@ -44,7 +40,7 @@ const fieldDisplayFilteringTestSuite = () => {
       cy.wait(2000);
       cy.createWorkspaceIndexPatterns({
         workspaceName: workspace,
-        indexPattern: INDEX_PATTERN_WITH_TIME.replace('*', ''),
+        indexPattern: INDEX_WITH_TIME_1,
         timefieldName: 'timestamp',
         indexPatternHasTimefield: true,
         dataSource: DATASOURCE_NAME,
@@ -66,167 +62,165 @@ const fieldDisplayFilteringTestSuite = () => {
       cy.osd.deleteIndex(INDEX_WITH_TIME_1);
     });
 
-    generateAllTestConfigurations(generateFieldDisplayFilteringTestConfiguration).forEach(
-      (config) => {
-        it(`filter actions in table field for ${config.testName}`, () => {
-          cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
-          cy.setQueryLanguage(config.language);
-          setDatePickerDatesAndSearchIfRelevant(config.language);
+    generateAllTestConfigurations(generateFieldDisplayFilteringTestConfiguration, {
+      index: INDEX_WITH_TIME_1,
+      indexPattern: `${INDEX_WITH_TIME_1}*`,
+    }).forEach((config) => {
+      it(`filter actions in table field for ${config.testName}`, () => {
+        cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
+        cy.setQueryLanguage(config.language);
+        setDatePickerDatesAndSearchIfRelevant(config.language);
 
-          cy.getElementByTestId('docTable').get('tbody tr').should('have.length.above', 3); // To ensure it waits until a full table is loaded into the DOM, instead of a bug where table only has 1 hit.
+        cy.getElementByTestId('docTable').get('tbody tr').should('have.length.above', 3); // To ensure it waits until a full table is loaded into the DOM, instead of a bug where table only has 1 hit.
 
-          const shouldText = config.isFilterButtonsEnabled ? 'exist' : 'not.exist';
-          docTable.getDocTableField(0, 0).within(() => {
-            cy.getElementByTestId('filterForValue').should(shouldText);
-            cy.getElementByTestId('filterOutValue').should(shouldText);
+        const shouldText = config.isFilterButtonsEnabled ? 'exist' : 'not.exist';
+        docTable.getDocTableField(0, 0).within(() => {
+          cy.getElementByTestId('filterForValue').should(shouldText);
+          cy.getElementByTestId('filterOutValue').should(shouldText);
+        });
+
+        if (config.isFilterButtonsEnabled) {
+          docTable.verifyDocTableFilterAction(0, 'filterForValue', '10,000', '1', true);
+          docTable.verifyDocTableFilterAction(0, 'filterOutValue', '10,000', '9,999', false);
+        }
+      });
+
+      it(`filter actions in expanded table for ${config.testName}`, () => {
+        // Check if the first expanded Doc Table Field's first row's Filter For, Filter Out and Exists Filter buttons are disabled.
+        const verifyFirstExpandedFieldFilterForFilterOutFilterExistsButtons = () => {
+          const shouldText = config.isFilterButtonsEnabled ? 'be.enabled' : 'be.disabled';
+          docTable.getExpandedDocTableRow(0, 0).within(() => {
+            cy.getElementByTestId('addInclusiveFilterButton').should(shouldText);
+            cy.getElementByTestId('removeInclusiveFilterButton').should(shouldText);
+            cy.getElementByTestId('addExistsFilterButton').should(shouldText);
           });
+        };
 
-          if (config.isFilterButtonsEnabled) {
-            docTable.verifyDocTableFilterAction(0, 'filterForValue', '10,000', '1', true);
-            docTable.verifyDocTableFilterAction(0, 'filterOutValue', '10,000', '9,999', false);
+        /**
+         * Check the Filter For or Out buttons in the expandedDocumentRowNumberth field in the expanded Document filters the correct value.
+         * @param {string} filterButton For or Out
+         * @param {number} docTableRowNumber Integer starts from 0 for the first row
+         * @param {number} expandedDocumentRowNumber Integer starts from 0 for the first row
+         * @param {string} expectedQueryHitsWithoutFilter expected number of hits in string after the filter is removed Note you should add commas when necessary e.g. 9,999
+         * @param {string} expectedQueryHitsAfterFilterApplied expected number of hits in string after the filter is applied. Note you should add commas when necessary e.g. 9,999
+         * @example verifyDocTableFirstExpandedFieldFirstRowFilterForButtonFiltersCorrectField('for', 0, 0, '10,000', '1');
+         */
+        const verifyDocTableFirstExpandedFieldFirstRowFilterForOutButtonFiltersCorrectField = (
+          filterButton,
+          docTableRowNumber,
+          expandedDocumentRowNumber,
+          expectedQueryHitsWithoutFilter,
+          expectedQueryHitsAfterFilterApplied
+        ) => {
+          if (filterButton !== 'for' || filterButton !== 'out') {
+            cy.log('Filter button must be for or or.');
+            return;
           }
-        });
 
-        it(`filter actions in expanded table for ${config.testName}`, () => {
-          // Check if the first expanded Doc Table Field's first row's Filter For, Filter Out and Exists Filter buttons are disabled.
-          const verifyFirstExpandedFieldFilterForFilterOutFilterExistsButtons = () => {
-            const shouldText = config.isFilterButtonsEnabled ? 'be.enabled' : 'be.disabled';
-            docTable.getExpandedDocTableRow(0, 0).within(() => {
-              cy.getElementByTestId('addInclusiveFilterButton').should(shouldText);
-              cy.getElementByTestId('removeInclusiveFilterButton').should(shouldText);
-              cy.getElementByTestId('addExistsFilterButton').should(shouldText);
+          const filterButtonElement =
+            filterButton === 'for' ? 'addInclusiveFilterButton' : 'removeInclusiveFilterButton';
+          const shouldText = filterButton === 'for' ? 'have.text' : 'not.have.text';
+
+          docTable
+            .getExpandedDocTableRowValue(docTableRowNumber, expandedDocumentRowNumber)
+            .then(($expandedDocumentRowValue) => {
+              const filterFieldText = $expandedDocumentRowValue.text();
+              docTable
+                .getExpandedDocTableRow(docTableRowNumber, expandedDocumentRowNumber)
+                .within(() => {
+                  cy.getElementByTestId(filterButtonElement).click();
+                });
+              // Verify pill text
+              cy.getElementByTestId('globalFilterLabelValue').should('have.text', filterFieldText);
+              cy.getElementByTestId('discoverQueryHits').should(
+                'have.text',
+                expectedQueryHitsAfterFilterApplied
+              ); // checkQueryHitText must be in front of checking first line text to give time for DocTable to update.
+              docTable
+                .getExpandedDocTableRowValue(docTableRowNumber, expandedDocumentRowNumber)
+                .should(shouldText, filterFieldText);
             });
-          };
+          cy.getElementByTestId('globalFilterBar').find('[aria-label="Delete"]').click();
+          cy.getElementByTestId('discoverQueryHits').should(
+            'have.text',
+            expectedQueryHitsWithoutFilter
+          );
+        };
 
-          /**
-           * Check the Filter For or Out buttons in the expandedDocumentRowNumberth field in the expanded Document filters the correct value.
-           * @param {string} filterButton For or Out
-           * @param {number} docTableRowNumber Integer starts from 0 for the first row
-           * @param {number} expandedDocumentRowNumber Integer starts from 0 for the first row
-           * @param {string} expectedQueryHitsWithoutFilter expected number of hits in string after the filter is removed Note you should add commas when necessary e.g. 9,999
-           * @param {string} expectedQueryHitsAfterFilterApplied expected number of hits in string after the filter is applied. Note you should add commas when necessary e.g. 9,999
-           * @example verifyDocTableFirstExpandedFieldFirstRowFilterForButtonFiltersCorrectField('for', 0, 0, '10,000', '1');
-           */
-          const verifyDocTableFirstExpandedFieldFirstRowFilterForOutButtonFiltersCorrectField = (
-            filterButton,
-            docTableRowNumber,
-            expandedDocumentRowNumber,
-            expectedQueryHitsWithoutFilter,
-            expectedQueryHitsAfterFilterApplied
-          ) => {
-            if (filterButton !== 'for' || filterButton !== 'out') {
-              cy.log('Filter button must be for or or.');
-              return;
-            }
+        /**
+         * Check the first expanded Doc Table Field's first row's Exists Filter button filters the correct Field.
+         * @param {number} docTableRowNumber Integer starts from 0 for the first row
+         * @param {number} expandedDocumentRowNumber Integer starts from 0 for the first row
+         * @param {string} expectedQueryHitsWithoutFilter expected number of hits in string after the filter is removed Note you should add commas when necessary e.g. 9,999
+         * @param {string} expectedQueryHitsAfterFilterApplied expected number of hits in string after the filter is applied. Note you should add commas when necessary e.g. 9,999
+         */
+        const verifyDocTableFirstExpandedFieldFirstRowExistsFilterButtonFiltersCorrectField = (
+          docTableRowNumber,
+          expandedDocumentRowNumber,
+          expectedQueryHitsWithoutFilter,
+          expectedQueryHitsAfterFilterApplied
+        ) => {
+          docTable
+            .getExpandedDocTableRowFieldName(docTableRowNumber, expandedDocumentRowNumber)
+            .then(($expandedDocumentRowField) => {
+              const filterFieldText = $expandedDocumentRowField.text();
+              docTable
+                .getExpandedDocTableRow(docTableRowNumber, expandedDocumentRowNumber)
+                .within(() => {
+                  cy.getElementByTestId('addExistsFilterButton').click();
+                });
+              // Verify full pill text
+              // globalFilterLabelValue gives the inner element, but we may want all the text in the filter pill
+              cy.getElementByTestId('globalFilterLabelValue', {
+                timeout: 10000,
+              })
+                .parent()
+                .should('have.text', filterFieldText + ': ' + 'exists');
+              cy.getElementByTestId('discoverQueryHits').should(
+                'have.text',
+                expectedQueryHitsAfterFilterApplied
+              );
+            });
+          cy.getElementByTestId('globalFilterBar').find('[aria-label="Delete"]').click();
+          cy.getElementByTestId('discoverQueryHits').should(
+            'have.text',
+            expectedQueryHitsWithoutFilter
+          );
+        };
 
-            const filterButtonElement =
-              filterButton === 'for' ? 'addInclusiveFilterButton' : 'removeInclusiveFilterButton';
-            const shouldText = filterButton === 'for' ? 'have.text' : 'not.have.text';
+        cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
+        cy.setQueryLanguage(config.language);
+        setDatePickerDatesAndSearchIfRelevant(config.language);
 
-            docTable
-              .getExpandedDocTableRowValue(docTableRowNumber, expandedDocumentRowNumber)
-              .then(($expandedDocumentRowValue) => {
-                const filterFieldText = $expandedDocumentRowValue.text();
-                docTable
-                  .getExpandedDocTableRow(docTableRowNumber, expandedDocumentRowNumber)
-                  .within(() => {
-                    cy.getElementByTestId(filterButtonElement).click();
-                  });
-                // Verify pill text
-                cy.getElementByTestId('globalFilterLabelValue').should(
-                  'have.text',
-                  filterFieldText
-                );
-                cy.getElementByTestId('discoverQueryHits').should(
-                  'have.text',
-                  expectedQueryHitsAfterFilterApplied
-                ); // checkQueryHitText must be in front of checking first line text to give time for DocTable to update.
-                docTable
-                  .getExpandedDocTableRowValue(docTableRowNumber, expandedDocumentRowNumber)
-                  .should(shouldText, filterFieldText);
-              });
-            cy.getElementByTestId('globalFilterBar').find('[aria-label="Delete"]').click();
-            cy.getElementByTestId('discoverQueryHits').should(
-              'have.text',
-              expectedQueryHitsWithoutFilter
-            );
-          };
+        cy.getElementByTestId('docTable').get('tbody tr').should('have.length.above', 3); // To ensure it waits until a full table is loaded into the DOM, instead of a bug where table only has 1 hit.
+        docTable.toggleDocTableRow(0);
+        verifyFirstExpandedFieldFilterForFilterOutFilterExistsButtons();
+        docTable.verifyDocTableFirstExpandedFieldFirstRowToggleColumnButtonHasIntendedBehavior();
 
-          /**
-           * Check the first expanded Doc Table Field's first row's Exists Filter button filters the correct Field.
-           * @param {number} docTableRowNumber Integer starts from 0 for the first row
-           * @param {number} expandedDocumentRowNumber Integer starts from 0 for the first row
-           * @param {string} expectedQueryHitsWithoutFilter expected number of hits in string after the filter is removed Note you should add commas when necessary e.g. 9,999
-           * @param {string} expectedQueryHitsAfterFilterApplied expected number of hits in string after the filter is applied. Note you should add commas when necessary e.g. 9,999
-           */
-          const verifyDocTableFirstExpandedFieldFirstRowExistsFilterButtonFiltersCorrectField = (
-            docTableRowNumber,
-            expandedDocumentRowNumber,
-            expectedQueryHitsWithoutFilter,
-            expectedQueryHitsAfterFilterApplied
-          ) => {
-            docTable
-              .getExpandedDocTableRowFieldName(docTableRowNumber, expandedDocumentRowNumber)
-              .then(($expandedDocumentRowField) => {
-                const filterFieldText = $expandedDocumentRowField.text();
-                docTable
-                  .getExpandedDocTableRow(docTableRowNumber, expandedDocumentRowNumber)
-                  .within(() => {
-                    cy.getElementByTestId('addExistsFilterButton').click();
-                  });
-                // Verify full pill text
-                // globalFilterLabelValue gives the inner element, but we may want all the text in the filter pill
-                cy.getElementByTestId('globalFilterLabelValue', {
-                  timeout: 10000,
-                })
-                  .parent()
-                  .should('have.text', filterFieldText + ': ' + 'exists');
-                cy.getElementByTestId('discoverQueryHits').should(
-                  'have.text',
-                  expectedQueryHitsAfterFilterApplied
-                );
-              });
-            cy.getElementByTestId('globalFilterBar').find('[aria-label="Delete"]').click();
-            cy.getElementByTestId('discoverQueryHits').should(
-              'have.text',
-              expectedQueryHitsWithoutFilter
-            );
-          };
-
-          cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
-          cy.setQueryLanguage(config.language);
-          setDatePickerDatesAndSearchIfRelevant(config.language);
-
-          cy.getElementByTestId('docTable').get('tbody tr').should('have.length.above', 3); // To ensure it waits until a full table is loaded into the DOM, instead of a bug where table only has 1 hit.
-          docTable.toggleDocTableRow(0);
-          verifyFirstExpandedFieldFilterForFilterOutFilterExistsButtons();
-          docTable.verifyDocTableFirstExpandedFieldFirstRowToggleColumnButtonHasIntendedBehavior();
-
-          if (config.isFilterButtonsEnabled) {
-            verifyDocTableFirstExpandedFieldFirstRowFilterForOutButtonFiltersCorrectField(
-              'for',
-              0,
-              0,
-              '10,000',
-              '1'
-            );
-            verifyDocTableFirstExpandedFieldFirstRowFilterForOutButtonFiltersCorrectField(
-              'out',
-              0,
-              0,
-              '10,000',
-              '9,999'
-            );
-            verifyDocTableFirstExpandedFieldFirstRowExistsFilterButtonFiltersCorrectField(
-              0,
-              0,
-              '10,000',
-              '10,000'
-            );
-          }
-        });
-      }
-    );
+        if (config.isFilterButtonsEnabled) {
+          verifyDocTableFirstExpandedFieldFirstRowFilterForOutButtonFiltersCorrectField(
+            'for',
+            0,
+            0,
+            '10,000',
+            '1'
+          );
+          verifyDocTableFirstExpandedFieldFirstRowFilterForOutButtonFiltersCorrectField(
+            'out',
+            0,
+            0,
+            '10,000',
+            '9,999'
+          );
+          verifyDocTableFirstExpandedFieldFirstRowExistsFilterButtonFiltersCorrectField(
+            0,
+            0,
+            '10,000',
+            '10,000'
+          );
+        }
+      });
+    });
   });
 };
 

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/language_specific_display.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/language_specific_display.spec.js
@@ -32,11 +32,11 @@ export const runDisplayTests = () => {
         SECONDARY_ENGINE.url,
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.mapping.json`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.mapping.json`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.mapping.json`,
         ],
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.data.ndjson`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.data.ndjson`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.data.ndjson`,
         ]
       );
       // Add data source

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_queries.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_queries.spec.js
@@ -110,11 +110,11 @@ const runSavedQueriesUITests = () => {
         PATHS.SECONDARY_ENGINE,
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.mapping.json`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.mapping.json`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.mapping.json`,
         ],
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.data.ndjson`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.data.ndjson`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.data.ndjson`,
         ]
       );
       // Add data source

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search.spec.js
@@ -36,11 +36,11 @@ const runSavedSearchTests = () => {
         PATHS.SECONDARY_ENGINE,
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.mapping.json`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.mapping.json`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.mapping.json`,
         ],
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.data.ndjson`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.data.ndjson`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.data.ndjson`,
         ]
       );
       // Add data source

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search_in_dashboards.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/saved_search_in_dashboards.spec.js
@@ -36,11 +36,11 @@ export const runSavedSearchTests = () => {
         PATHS.SECONDARY_ENGINE,
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.mapping.json`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.mapping.json`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.mapping.json`,
         ],
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.data.ndjson`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.data.ndjson`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.data.ndjson`,
         ]
       );
       // Add data source
@@ -113,7 +113,7 @@ export const runSavedSearchTests = () => {
         START_TIME,
         'Oct 1, 2022 @ 00:00:00.000'
       );
-      cy.getElementByTestId('osdDocTablePagination').contains(/of 13/);
+      cy.getElementByTestId('osdDocTablePagination').contains(/of 11/);
     });
 
     it('Show valid saved searches', () => {

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/time_range_selection.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/time_range_selection.spec.js
@@ -27,11 +27,11 @@ export const runTimeRangeSelectionTests = () => {
         PATHS.SECONDARY_ENGINE,
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.mapping.json`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.mapping.json`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.mapping.json`,
         ],
         [
           `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_1}.data.ndjson`,
-          `cypress/fixtures/query_enhancements/data_logs_2/${INDEX_WITH_TIME_2}.data.ndjson`,
+          `cypress/fixtures/query_enhancements/data_logs_1/${INDEX_WITH_TIME_2}.data.ndjson`,
         ]
       );
       // Add data source

--- a/cypress/utils/apps/query_enhancements/dataset_selector.js
+++ b/cypress/utils/apps/query_enhancements/dataset_selector.js
@@ -72,7 +72,7 @@ export const verifyBaseState = (dataset) => {
     dataset: dataset,
     queryString: query,
     language: language,
-    hitCount: '2,217',
+    hitCount: '2,278',
   });
 };
 

--- a/cypress/utils/apps/query_enhancements/saved.js
+++ b/cypress/utils/apps/query_enhancements/saved.js
@@ -83,9 +83,9 @@ export const getExpectedHitCount = (datasetType, language) => {
     case DatasetTypes.INDEX_PATTERN.name:
       switch (language) {
         case QueryLanguages.DQL.name:
-          return 23;
+          return 26;
         case QueryLanguages.Lucene.name:
-          return 23;
+          return 26;
         case QueryLanguages.SQL.name:
           return undefined;
         case QueryLanguages.PPL.name:

--- a/cypress/utils/apps/query_enhancements/saved_queries.js
+++ b/cypress/utils/apps/query_enhancements/saved_queries.js
@@ -85,9 +85,9 @@ const getAlternateExpectedHitCount = (datasetType, language) => {
     case DatasetTypes.INDEX_PATTERN.name:
       switch (language) {
         case QueryLanguages.DQL.name:
-          return 21;
+          return 29;
         case QueryLanguages.Lucene.name:
-          return 21;
+          return 29;
         case QueryLanguages.SQL.name:
           return undefined;
         case QueryLanguages.PPL.name:

--- a/cypress/utils/constants.js
+++ b/cypress/utils/constants.js
@@ -11,8 +11,8 @@ export const SECONDARY_ENGINE = Cypress.env('SECONDARY_ENGINE');
 
 export const PATHS = {
   BASE: BASE_PATH,
-  ENGINE: BASE_ENGINE.url,
-  SECONDARY_ENGINE: SECONDARY_ENGINE.url,
+  ENGINE: BASE_ENGINE?.url,
+  SECONDARY_ENGINE: SECONDARY_ENGINE?.url,
   STACK_MANAGEMENT: BASE_PATH + '/app/management',
   SECURITY_PLUGIN: BASE_PATH + '/app/security-dashboards-plugin#/',
   TENANTS_MANAGE: BASE_PATH + '/app/security-dashboards-plugin#/tenants',

--- a/cypress/utils/constants.js
+++ b/cypress/utils/constants.js
@@ -11,8 +11,8 @@ export const SECONDARY_ENGINE = Cypress.env('SECONDARY_ENGINE');
 
 export const PATHS = {
   BASE: BASE_PATH,
-  ENGINE: BASE_ENGINE?.url,
-  SECONDARY_ENGINE: SECONDARY_ENGINE?.url,
+  ENGINE: BASE_ENGINE ? BASE_ENGINE.url : undefined,
+  SECONDARY_ENGINE: SECONDARY_ENGINE ? SECONDARY_ENGINE.url : undefined,
   STACK_MANAGEMENT: BASE_PATH + '/app/management',
   SECURITY_PLUGIN: BASE_PATH + '/app/security-dashboards-plugin#/',
   TENANTS_MANAGE: BASE_PATH + '/app/security-dashboards-plugin#/tenants',


### PR DESCRIPTION
### Description

Update tests to only use data-logs-1.

This is done because there are issues with migration to Neo when using data-logs-2


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
