### PR TITLE
[Workspace]bugfix: remove workspace prefix when calling `get` in recent assets

### DIFF
--- a/src/core/public/chrome/ui/header/recent_items.tsx
+++ b/src/core/public/chrome/ui/header/recent_items.tsx
@@ -73,7 +73,12 @@ const bulkGetDetail = (savedObjects: Array<Pick<SavedObject, 'type' | 'id'>>, ht
         .get<SavedObjectWithMetadata>(
           `/api/opensearch-dashboards/management/saved_objects/${encodeURIComponent(
             obj.type
-          )}/${encodeURIComponent(obj.id)}`
+          )}/${encodeURIComponent(obj.id)}`,
+          {
+            prependOptions: {
+              withoutClientBasePath: true,
+            },
+          }
         )
         .catch((error) => ({
           id: obj.id,


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Recent assets is a global component sitting in page header, and it will call get to retrieve metadata of objects inside / outside workspace. As we introduce a more strict rule that will deny cross-workspace calls, we need to remove the workspace prefix inside the calls from recent assets.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
### Before fix

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/ed7a21a7-ba06-4a5c-a6f8-4b0e50b7b32d" />

### After fix

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/6ff2dbaf-f772-4262-ae27-08cba6fb7108" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
