### PR TITLE
Change from `Cluster` to `Data sources` for Indexes type in dataset selector column

### DIFF
--- a/changelogs/fragments/9343.yml
+++ b/changelogs/fragments/9343.yml
@@ -1,0 +1,2 @@
+fix:
+- Change from cluster to data sources for dataset selector column ([#9343](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9343))

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -20,9 +20,7 @@ export const DELIMITER = '::';
 
 export const indexTypeConfig: DatasetTypeConfig = {
   id: DEFAULT_DATA.SET_TYPES.INDEX,
-  title: i18n.translate('data.datasetType.indexes', {
-    defaultMessage: 'Indexes',
-  }),
+  title: 'Indexes',
   meta: {
     icon: { type: 'logoOpenSearch' },
     tooltip: 'OpenSearch Indexes',
@@ -57,9 +55,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
         return {
           ...dataStructure,
           hasNext: false,
-          columnHeader: i18n.translate('data.dataset.columnHeader.indexes', {
-            defaultMessage: 'Indexes',
-          }),
+          columnHeader: 'Indexes',
           children: indices.map((indexName) => ({
             id: `${dataStructure.id}::${indexName}`,
             title: indexName,
@@ -72,9 +68,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
         const dataSources = await fetchDataSources(services.savedObjects.client);
         return {
           ...dataStructure,
-          columnHeader: i18n.translate('data.dataset.columnHeader.dataSources', {
-            defaultMessage: 'Data Sources',
-          }),
+          columnHeader: 'Data sources',
           hasNext: true,
           children: dataSources,
         };

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -20,7 +20,9 @@ export const DELIMITER = '::';
 
 export const indexTypeConfig: DatasetTypeConfig = {
   id: DEFAULT_DATA.SET_TYPES.INDEX,
-  title: 'Indexes',
+  title: i18n.translate('data.datasetType.indexes', {
+    defaultMessage: 'Indexes',
+  }),
   meta: {
     icon: { type: 'logoOpenSearch' },
     tooltip: 'OpenSearch Indexes',
@@ -55,7 +57,9 @@ export const indexTypeConfig: DatasetTypeConfig = {
         return {
           ...dataStructure,
           hasNext: false,
-          columnHeader: 'Indexes',
+          columnHeader: i18n.translate('data.dataset.columnHeader.indexes', {
+            defaultMessage: 'Indexes',
+          }),
           children: indices.map((indexName) => ({
             id: `${dataStructure.id}::${indexName}`,
             title: indexName,
@@ -68,7 +72,9 @@ export const indexTypeConfig: DatasetTypeConfig = {
         const dataSources = await fetchDataSources(services.savedObjects.client);
         return {
           ...dataStructure,
-          columnHeader: 'Data Sources',
+          columnHeader: i18n.translate('data.dataset.columnHeader.dataSources', {
+            defaultMessage: 'Data Sources',
+          }),
           hasNext: true,
           children: dataSources,
         };

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -68,7 +68,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
         const dataSources = await fetchDataSources(services.savedObjects.client);
         return {
           ...dataStructure,
-          columnHeader: 'Clusters',
+          columnHeader: 'Data Sources',
           hasNext: true,
           children: dataSources,
         };


### PR DESCRIPTION
### Description

Discover data selector does not distinguish between clusters and collections, so we should call it data sources instead of just clusters.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="1353" alt="Screenshot 2025-02-06 at 12 39 06 PM" src="https://github.com/user-attachments/assets/638c2190-3ee2-4b42-bc86-df9d720438e7" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Change from cluster to data sources for dataset selector column

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
