### PR TITLE
[Discover] chore: Update query editor loading UI

### DIFF
--- a/changelogs/fragments/9344.yml
+++ b/changelogs/fragments/9344.yml
@@ -1,0 +1,2 @@
+chore:
+- Update query editor loading UI ([#9344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9344))

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -196,4 +196,5 @@
   - [RELEASING](../RELEASING.md)
   - [SECURITY](../SECURITY.md)
   - [TESTING](../TESTING.md)
+  - [TRIAGING](../TRIAGING.md)
   - [TYPESCRIPT](../TYPESCRIPT.md)

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -484,6 +484,7 @@ export {
   QueryControls,
   QueryResult,
   QueryStatus,
+  ResultStatus,
   SavedQuery,
   SavedQueryService,
   SavedQueryTimeFilter,

--- a/src/plugins/data/public/query/query_string/index.ts
+++ b/src/plugins/data/public/query/query_string/index.ts
@@ -45,5 +45,6 @@ export {
   QueryControls,
   QueryResult,
   QueryStatus,
+  ResultStatus,
   LanguageReference,
 } from './language_service';

--- a/src/plugins/data/public/query/query_string/language_service/index.ts
+++ b/src/plugins/data/public/query/query_string/language_service/index.ts
@@ -10,5 +10,6 @@ export {
   QueryControls,
   QueryResult,
   QueryStatus,
+  ResultStatus,
   LanguageReference,
 } from './lib';

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -67,5 +67,11 @@ exports[`Query Result shows loading status 1`] = `
   isLoading={true}
   onClick={[Function]}
   size="xs"
-/>
+>
+  <EuiText
+    color="subdued"
+    data-test-subj="queryResultLoadingMsg"
+    size="xs"
+  />
+</EuiButtonEmpty>
 `;

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -59,4 +59,13 @@ exports[`Query Result show error status with error message 2`] = `
 </EuiPopover>
 `;
 
-exports[`Query Result shows loading status 1`] = `""`;
+exports[`Query Result shows loading status 1`] = `
+<EuiButtonEmpty
+  className="editor__footerItem"
+  color="text"
+  data-test-subj="queryResultLoading"
+  isLoading={true}
+  onClick={[Function]}
+  size="xs"
+/>
+`;

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -76,7 +76,9 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
         data-test-subj="queryResultLoading"
         className="editor__footerItem"
       >
-        {loadingText}
+        <EuiText size="xs" color="subdued" data-test-subj="queryResultLoadingMsg">
+          {loadingText}
+        </EuiText>
       </EuiButtonEmpty>
     );
   }

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -58,8 +58,15 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     };
   }, [props.queryStatus.startTime]);
 
-  if (elapsedTime > BUFFER_TIME && props.queryStatus.status === ResultStatus.LOADING) {
+  if (props.queryStatus.status === ResultStatus.LOADING) {
     const time = Math.floor(elapsedTime / 1000);
+    const loadingText =
+      elapsedTime > BUFFER_TIME
+        ? i18n.translate('data.query.languageService.queryResults.loadTime', {
+            defaultMessage: 'Loading {time} s',
+            values: { time },
+          })
+        : '';
     return (
       <EuiButtonEmpty
         color="text"
@@ -69,10 +76,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
         data-test-subj="queryResultLoading"
         className="editor__footerItem"
       >
-        {i18n.translate('data.query.languageService.queryResults.loadTime', {
-          defaultMessage: 'Loading {time} s',
-          values: { time },
-        })}
+        {loadingText}
       </EuiButtonEmpty>
     );
   }

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -219,6 +219,10 @@
   }
 }
 
+.queryEditor__progress {
+  position: relative;
+}
+
 .queryEditor__footer {
   display: flex;
   gap: 4px;

--- a/src/plugins/data/public/ui/query_editor/editors/default_editor/_default_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/editors/default_editor/_default_editor.scss
@@ -7,6 +7,10 @@
     background-color: $euiColorLightestShade;
   }
 
+  &__progress {
+    position: relative;
+  }
+
   .monaco-editor {
     border-radius: $euiSizeXS $euiSizeXS 0 0;
 

--- a/src/plugins/data/public/ui/query_editor/editors/default_editor/index.tsx
+++ b/src/plugins/data/public/ui/query_editor/editors/default_editor/index.tsx
@@ -21,7 +21,7 @@ export interface DefaultInputProps extends React.JSX.IntrinsicAttributes {
   };
   headerRef?: React.RefObject<HTMLDivElement>;
   provideCompletionItems: monaco.languages.CompletionItemProvider['provideCompletionItems'];
-  queryStatus: QueryStatus;
+  queryStatus?: QueryStatus;
 }
 
 export const DefaultInput: React.FC<DefaultInputProps> = ({
@@ -73,7 +73,7 @@ export const DefaultInput: React.FC<DefaultInputProps> = ({
         triggerSuggestOnFocus={true}
       />
       <div className="defaultEditor__progress" data-test-subj="defaultEditorProgress">
-        {queryStatus.status === ResultStatus.LOADING && (
+        {queryStatus?.status === ResultStatus.LOADING && (
           <EuiProgress size="xs" color="accent" position="absolute" />
         )}
       </div>

--- a/src/plugins/data/public/ui/query_editor/editors/default_editor/index.tsx
+++ b/src/plugins/data/public/ui/query_editor/editors/default_editor/index.tsx
@@ -72,6 +72,11 @@ export const DefaultInput: React.FC<DefaultInputProps> = ({
         }}
         triggerSuggestOnFocus={true}
       />
+      <div className="defaultEditor__progress" data-test-subj="defaultEditorProgress">
+        {queryStatus.status === ResultStatus.LOADING && (
+          <EuiProgress size="xs" color="accent" position="absolute" />
+        )}
+      </div>
       <div className="defaultEditor__footer" data-test-subj="defaultEditorFooter">
         {footerItems && (
           <EuiFlexGroup
@@ -103,11 +108,6 @@ export const DefaultInput: React.FC<DefaultInputProps> = ({
               </EuiFlexItem>
             ))}
           </EuiFlexGroup>
-        )}
-      </div>
-      <div className="defaultEditor__progress" data-test-subj="defaultEditorProgress">
-        {queryStatus.status === ResultStatus.LOADING && (
-          <EuiProgress size="xs" color="accent" position="absolute" />
         )}
       </div>
     </div>

--- a/src/plugins/data/public/ui/query_editor/editors/default_editor/index.tsx
+++ b/src/plugins/data/public/ui/query_editor/editors/default_editor/index.tsx
@@ -4,8 +4,9 @@
  */
 
 import React from 'react';
-import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexItem, EuiFlexGroup, EuiProgress } from '@elastic/eui';
 import { monaco } from '@osd/monaco';
+import { QueryStatus, ResultStatus } from '../../../../query';
 import { CodeEditor } from '../../../../../../opensearch_dashboards_react/public';
 import { createEditor, SingleLineInput } from '../shared';
 
@@ -20,6 +21,7 @@ export interface DefaultInputProps extends React.JSX.IntrinsicAttributes {
   };
   headerRef?: React.RefObject<HTMLDivElement>;
   provideCompletionItems: monaco.languages.CompletionItemProvider['provideCompletionItems'];
+  queryStatus: QueryStatus;
 }
 
 export const DefaultInput: React.FC<DefaultInputProps> = ({
@@ -30,6 +32,7 @@ export const DefaultInput: React.FC<DefaultInputProps> = ({
   editorDidMount,
   headerRef,
   provideCompletionItems,
+  queryStatus,
 }) => {
   return (
     <div className="defaultEditor" data-test-subj="osdQueryEditor__multiLine">
@@ -100,6 +103,11 @@ export const DefaultInput: React.FC<DefaultInputProps> = ({
               </EuiFlexItem>
             ))}
           </EuiFlexGroup>
+        )}
+      </div>
+      <div className="defaultEditor__progress" data-test-subj="defaultEditorProgress">
+        {queryStatus.status === ResultStatus.LOADING && (
+          <EuiProgress size="xs" color="accent" position="absolute" />
         )}
       </div>
     </div>

--- a/src/plugins/data/public/ui/query_editor/editors/shared.tsx
+++ b/src/plugins/data/public/ui/query_editor/editors/shared.tsx
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFieldText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiProgress } from '@elastic/eui';
 import { monaco } from '@osd/monaco';
 import React, { Fragment, useCallback, useRef, useState } from 'react';
 import { CodeEditor } from '../../../../../opensearch_dashboards_react/public';
+import { QueryStatus, ResultStatus } from '../../../query';
 
 interface SingleLineInputProps extends React.JSX.IntrinsicAttributes {
   languageId: string;
@@ -16,6 +17,7 @@ interface SingleLineInputProps extends React.JSX.IntrinsicAttributes {
   provideCompletionItems: monaco.languages.CompletionItemProvider['provideCompletionItems'];
   prepend?: React.ComponentProps<typeof EuiCompressedFieldText>['prepend'];
   footerItems?: any;
+  queryStatus?: QueryStatus;
 }
 
 type CollapsedComponent<T> = React.ComponentType<T>;
@@ -63,6 +65,7 @@ export const SingleLineInput: React.FC<SingleLineInputProps> = ({
   provideCompletionItems,
   prepend,
   footerItems,
+  queryStatus,
 }) => {
   const [editorIsFocused, setEditorIsFocused] = useState(false);
   const blurTimeoutRef = useRef<NodeJS.Timeout | undefined>();
@@ -152,6 +155,11 @@ export const SingleLineInput: React.FC<SingleLineInputProps> = ({
           }}
           triggerSuggestOnFocus={true}
         />
+        <div className="queryEditor__progress" data-test-subj="queryEditorProgress">
+          {queryStatus?.status === ResultStatus.LOADING && (
+            <EuiProgress size="xs" color="accent" position="absolute" />
+          )}
+        </div>
         {editorIsFocused && (
           <div className="queryEditor__footer" data-test-subj="queryEditorFooter">
             {footerItems && (

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -341,7 +341,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
       ],
     },
     provideCompletionItems,
-    queryStatus: props.queryStatus!,
+    queryStatus: props.queryStatus,
   };
 
   const singleLineInputProps = {
@@ -402,6 +402,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
         </EuiButtonEmpty>,
       ],
     },
+    queryStatus: props.queryStatus,
   };
 
   const languageEditorFunc = languageManager.getLanguage(query.language)!.editor;

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -341,6 +341,7 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
       ],
     },
     provideCompletionItems,
+    queryStatus: props.queryStatus!,
   };
 
   const singleLineInputProps = {


### PR DESCRIPTION
### Description

Improve query editor loading UX:

1. Spinner in editor footer will show immediately when query start. (time elapsed text will show 3s later)
2. Added a progress bar in query editor
3. Update loading text font

### Issues Resolved


## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/4e85fe12-f8be-4bc9-a79f-6f9e801492e4

https://github.com/user-attachments/assets/8e489cfb-dbfa-4f3f-b0b3-97a30d33eb8c

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: Update query editor loading UI

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff

