### PR TITLE
Add retry mechanism for flaky share menu test

### DIFF
--- a/changelogs/fragments/9352.yml
+++ b/changelogs/fragments/9352.yml
@@ -1,0 +1,2 @@
+test:
+- Add retry mechanism for flaky share menu test ([#9352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9352))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/shared_links.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/shared_links.spec.js
@@ -18,7 +18,10 @@ import {
 } from '../../../../../utils/apps/query_enhancements/shared';
 import { QueryLanguages } from '../../../../../utils/apps/query_enhancements/constants';
 import { selectFieldFromSidebar } from '../../../../../utils/apps/query_enhancements/sidebar';
-import { verifyShareUrl } from '../../../../../utils/apps/query_enhancements/shared_links';
+import {
+  verifyShareUrl,
+  openShareMenuWithRetry,
+} from '../../../../../utils/apps/query_enhancements/shared_links';
 import { setSort } from '../../../../../utils/apps/query_enhancements/table';
 import { prepareTestSuite } from '../../../../../utils/helpers';
 
@@ -178,7 +181,7 @@ export const runSharedLinksTests = () => {
           });
 
           // Test snapshot url
-          cy.getElementByTestId('shareTopNavButton').click();
+          openShareMenuWithRetry();
           cy.getElementByTestId('copyShareUrlButton')
             .invoke('attr', 'data-share-url')
             .then((url) => {
@@ -207,7 +210,7 @@ export const runSharedLinksTests = () => {
           cy.getElementByTestId('exportAsSavedObject').find('input').should('be.disabled');
           cy.saveSearch(config.saveName);
           cy.waitForLoader(true);
-          cy.getElementByTestId('shareTopNavButton').click();
+          openShareMenuWithRetry();
           cy.getElementByTestId('exportAsSavedObject').find('input').should('not.be.disabled');
           cy.getElementByTestId('exportAsSavedObject').click();
           // Get saved search ID


### PR DESCRIPTION
### Description

The issue is only limit to cypress. Could be race condition or component state synchronize issues. Need further investigation. This PR adds a tmp fix (openShareMenuWithRetry helper):

* Added retry mechanism with verification
* Added explicit waits for animations
* Added better error handling and logging


### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9351


## Changelog

- test: Add retry mechanism for flaky share menu test



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
