### PR TITLE
Add support for file preview

### DIFF
--- a/src/plugins/data_importer/common/constants.ts
+++ b/src/plugins/data_importer/common/constants.ts
@@ -14,3 +14,16 @@ export const NDJSON_FILE_TYPE = 'ndjson';
 export const DEFAULT_SUPPORTED_FILE_TYPES_LIST = [CSV_FILE_TYPE, JSON_FILE_TYPE, NDJSON_FILE_TYPE];
 
 export const CSV_SUPPORTED_DELIMITERS = [',', ';', '\t', '|'];
+
+export enum DYNAMIC_MAPPING_TYPES {
+  NULL = 'null',
+  BOOLEAN = 'boolean',
+  FLOAT = 'float',
+  DOUBLE = 'double',
+  INTEGER = 'integer',
+  OBJECT = 'object',
+  ARRAY = 'array',
+  TEXT = 'text',
+  KEYWORD = 'keyword',
+  DATE = 'date',
+}

--- a/src/plugins/data_importer/config.ts
+++ b/src/plugins/data_importer/config.ts
@@ -19,6 +19,10 @@ export const configSchema = schema.object({
     defaultValue: 10000,
     min: 1,
   }),
+  filePreviewDocumentsCount: schema.number({
+    defaultValue: 10,
+    min: 1,
+  }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/data_importer/public/components/data_importer_app.tsx
+++ b/src/plugins/data_importer/public/components/data_importer_app.tsx
@@ -46,6 +46,7 @@ import {
   PLUGIN_NAME_AS_TITLE,
 } from '../../common/constants';
 import { DelimiterSelect } from './delimiter_select';
+import { previewFile } from '../lib/preview';
 
 interface DataImporterPluginAppProps {
   basename: string;
@@ -123,12 +124,54 @@ export const DataImporterPluginApp = ({
     }
   };
 
+  const previewData = async () => {
+    if (importType === IMPORT_CHOICE_FILE) {
+      if (inputFile) {
+        const fileExtension = extname(inputFile.name);
+        const response = await previewFile(
+          http,
+          inputFile,
+          // TODO This should be determined from the index name textbox/selectable
+          false,
+          // TODO This should be determined from the file type selectable
+          fileExtension,
+          indexName!,
+          delimiter,
+          dataSourceId
+        );
+        if (response) {
+          notifications.toasts.addSuccess(
+            i18n.translate('dataImporter.previewSuccess', {
+              defaultMessage: `Preview successful`,
+            })
+          );
+        } else {
+          notifications.toasts.addDanger(
+            i18n.translate('dataImporter.previewFailed', {
+              defaultMessage: `Preview failed`,
+            })
+          );
+        }
+      }
+    }
+  };
+
   const importData = async () => {
     let response: ImportResponse | undefined;
 
     try {
       if (importType === IMPORT_CHOICE_FILE) {
-        response = await importFile(http, inputFile!, indexName!, delimiter, dataSourceId);
+        response = await importFile(
+          http,
+          inputFile!,
+          indexName!,
+          // TODO This should be determined from the index name textbox/selectable
+          false,
+          // TODO This should be determined from the file type selectable
+          extname(inputFile!.name),
+          delimiter,
+          dataSourceId
+        );
       } else if (importType === IMPORT_CHOICE_TEXT) {
         response = await importText(
           http,
@@ -267,6 +310,10 @@ export const DataImporterPluginApp = ({
               {dataSourceEnabled && renderDataSourceComponent}
               <EuiButton fullWidth={true} isDisabled={disableImport} onClick={importData}>
                 Import
+              </EuiButton>
+              <EuiSpacer size="m" />
+              <EuiButton fullWidth={true} isDisabled={disableImport} onClick={previewData}>
+                Preview
               </EuiButton>
             </EuiPageSideBar>
             <EuiPageBody component="main">

--- a/src/plugins/data_importer/public/lib/preview.ts
+++ b/src/plugins/data_importer/public/lib/preview.ts
@@ -4,14 +4,14 @@
  */
 
 import { HttpStart } from '../../../../core/public';
-import { ImportResponse } from '../types';
+import { PreviewResponse } from '../types';
 
-export async function importFile(
+export async function previewFile(
   http: HttpStart,
   file: File,
-  indexName: string,
   createMode: boolean,
   fileExtension: string,
+  indexName: string,
   delimiter?: string,
   selectedDataSourceId?: string
 ) {
@@ -19,13 +19,13 @@ export async function importFile(
   formData.append('file', file);
   const query = {
     indexName,
-    createMode,
     fileExtension,
+    createMode,
     ...(selectedDataSourceId && { dataSource: selectedDataSourceId }),
     delimiter,
   };
 
-  return await http.post<ImportResponse>('/api/data_importer/_import_file', {
+  return await http.post<PreviewResponse>('/api/data_importer/_preview', {
     body: formData,
     headers: {
       'Content-Type': undefined,

--- a/src/plugins/data_importer/public/types.ts
+++ b/src/plugins/data_importer/public/types.ts
@@ -28,3 +28,9 @@ export interface ImportResponse {
   };
   success: boolean;
 }
+
+export interface PreviewResponse {
+  predictedMapping: Record<string, any>;
+  documents: Array<Record<string, any>>;
+  existingMapping?: Record<string, any>;
+}

--- a/src/plugins/data_importer/server/parsers/csv_parser.test.ts
+++ b/src/plugins/data_importer/server/parsers/csv_parser.test.ts
@@ -89,4 +89,28 @@ describe('CSVParser', () => {
       }
     );
   });
+
+  describe('parseFile()', () => {
+    const limit = 3;
+    it.each<CSVTestCaseFormat>(VALID_CSV_CASES)(
+      'should parse 3 documents from CSV file',
+      async ({ rawStringArray, delimiter, expected }) => {
+        const validCSVFileStream = Readable.from(rawStringArray);
+        const response = await parser.parseFile(validCSVFileStream, limit, { delimiter });
+
+        expect(response).toEqual(expected.slice(0, limit));
+      }
+    );
+
+    it.each<CSVTestCaseFormat>(INVALID_CSV_CASES)(
+      'should throw errors when attempting to parse documents from CSV file',
+      async ({ rawStringArray, delimiter }) => {
+        const invalidCSVFileStream = Readable.from(rawStringArray);
+        try {
+          await parser.parseFile(invalidCSVFileStream, limit, { delimiter });
+          // eslint-disable-next-line no-empty
+        } catch (_) {}
+      }
+    );
+  });
 });

--- a/src/plugins/data_importer/server/parsers/file_parser_service.test.ts
+++ b/src/plugins/data_importer/server/parsers/file_parser_service.test.ts
@@ -20,6 +20,7 @@ describe('FileParserService', () => {
         validateText: jest.fn(),
         ingestText: jest.fn(),
         ingestFile: jest.fn(),
+        parseFile: jest.fn(),
       };
       const csvParser = new CSVParser();
       fileParserService.registerFileParser('testFormat', fileParser);

--- a/src/plugins/data_importer/server/parsers/json_parser.test.ts
+++ b/src/plugins/data_importer/server/parsers/json_parser.test.ts
@@ -70,4 +70,19 @@ describe('JSONParser', () => {
       ).rejects.toThrow();
     });
   });
+
+  describe('parseFile()', () => {
+    const limit = 3;
+    it('should parse the document', async () => {
+      const validJsonFileStream = Readable.from([JSON.stringify(validJson)]);
+      const response = await parser.parseFile(validJsonFileStream, limit, {});
+
+      expect(response).toEqual([validJson]);
+    });
+
+    it('should throw an error when attempting to parse the document', async () => {
+      const invalidJsonFileStream = Readable.from([invalidJsonString]);
+      expect(parser.parseFile(invalidJsonFileStream, limit, {})).rejects.toThrow();
+    });
+  });
 });

--- a/src/plugins/data_importer/server/parsers/ndjson_parser.test.ts
+++ b/src/plugins/data_importer/server/parsers/ndjson_parser.test.ts
@@ -85,4 +85,25 @@ describe('NDJSONParser', () => {
       }
     );
   });
+
+  describe('parseFile()', () => {
+    const limit = 4;
+    it.each<NDJSONTestCaseFormat>(VALID_NDJSON_TEST_CASES)(
+      'should parse 4 documents from NDJSON',
+      async ({ rawString, expected }) => {
+        const validNDJSONFileStream = Readable.from(rawString.join('\n'));
+        const response = await parser.parseFile(validNDJSONFileStream, limit, {});
+
+        expect(response).toEqual(expected.slice(0, limit));
+      }
+    );
+
+    it.each<NDJSONTestCaseFormat>(INVALID_NDJSON_TEST_CASES)(
+      'should throw an error for invalid NDJSON',
+      async ({ rawString }) => {
+        const invalidNDJSONFileStream = Readable.from(rawString.join('\n'));
+        expect(parser.parseFile(invalidNDJSONFileStream, limit, {})).rejects.toThrow();
+      }
+    );
+  });
 });

--- a/src/plugins/data_importer/server/parsers/test_utils/csv_test_cases.ts
+++ b/src/plugins/data_importer/server/parsers/test_utils/csv_test_cases.ts
@@ -61,21 +61,21 @@ export const VALID_CSV_CASES: CSVTestCaseFormat[] = [
     rawStringArray: [
       'email,name,age,gender,occupation,phone\n',
       'john@example.com,John Smith,44,male,engineer,0\n',
-      'mary@example.com,Mary Shelby,31,VP sales,',
+      'mary@example.com,Mary Shelby,31,,VP sales,',
     ],
     expected: [
       {
         email: 'john@example.com',
         name: 'John Smith',
-        age: 44,
+        age: '44',
         gender: 'male',
         occupation: 'engineer',
-        phone: 0,
+        phone: '0',
       },
       {
         email: 'mary@example.com',
         name: 'Mary Shelby',
-        age: 31,
+        age: '31',
         gender: '',
         occupation: 'VP sales',
         phone: '',

--- a/src/plugins/data_importer/server/parsers/test_utils/ndjson_test_cases.ts
+++ b/src/plugins/data_importer/server/parsers/test_utils/ndjson_test_cases.ts
@@ -35,7 +35,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (818) 413-3869',
         address: '225 Lincoln Road, Salunga, Oregon, 1912',
         about:
-          'Consectetur incididunt do ad eu aliquip. Ipsum dolore est aute quis dolor sit sit Lorem qui duis. Aliquip amet ea ullamco exercitation velit consequat.\\r\\n',
+          'Consectetur incididunt do ad eu aliquip. Ipsum dolore est aute quis dolor sit sit Lorem qui duis. Aliquip amet ea ullamco exercitation velit consequat.\r\n',
         registered: '2022-03-14T08:16:17 +07:00',
         latitude: -14.235158,
         longitude: -126.483142,
@@ -63,7 +63,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (865) 488-3455',
         address: '550 Martense Street, Beason, New Mexico, 5488',
         about:
-          'Eiusmod ipsum cupidatat ut non ea. Excepteur dolor exercitation ipsum quis ipsum minim amet. Ad do id nostrud laboris do deserunt ea non. Adipisicing dolore elit cupidatat exercitation. Minim reprehenderit occaecat laborum sint quis quis pariatur Lorem. Sunt sunt labore labore dolore.\\r\\n',
+          'Eiusmod ipsum cupidatat ut non ea. Excepteur dolor exercitation ipsum quis ipsum minim amet. Ad do id nostrud laboris do deserunt ea non. Adipisicing dolore elit cupidatat exercitation. Minim reprehenderit occaecat laborum sint quis quis pariatur Lorem. Sunt sunt labore labore dolore.\r\n',
         registered: '2017-03-06T11:29:42 +08:00',
         latitude: -78.400609,
         longitude: -19.696437,
@@ -91,7 +91,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (859) 565-2942',
         address: '262 Anna Court, Gardners, Colorado, 2959',
         about:
-          'Labore eiusmod nostrud tempor esse culpa exercitation do est dolor elit amet Lorem ad. Officia mollit aliquip laborum exercitation est. Elit incididunt ipsum occaecat elit excepteur nulla quis. Labore voluptate sit consequat magna minim proident ad sunt velit eu culpa do esse amet. Voluptate enim exercitation non elit consequat enim. Dolor ipsum mollit qui ipsum aute dolore aute in est nostrud officia do culpa.\\r\\n',
+          'Labore eiusmod nostrud tempor esse culpa exercitation do est dolor elit amet Lorem ad. Officia mollit aliquip laborum exercitation est. Elit incididunt ipsum occaecat elit excepteur nulla quis. Labore voluptate sit consequat magna minim proident ad sunt velit eu culpa do esse amet. Voluptate enim exercitation non elit consequat enim. Dolor ipsum mollit qui ipsum aute dolore aute in est nostrud officia do culpa.\r\n',
         registered: '2018-03-28T04:23:02 +07:00',
         latitude: 84.307741,
         longitude: 147.311241,
@@ -119,7 +119,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (889) 485-3565',
         address: '861 Monitor Street, Richville, South Carolina, 4203',
         about:
-          'Minim aute nisi Lorem amet veniam. Proident ea mollit labore sint amet aliqua esse nostrud. Ea Lorem cillum minim ut dolore anim cillum ipsum in voluptate enim. Aliqua non incididunt duis culpa quis cupidatat. Sint magna minim cillum Lorem irure fugiat nulla consectetur. Cupidatat commodo Lorem nulla commodo ad consequat est proident qui eiusmod culpa amet elit.\\r\\n',
+          'Minim aute nisi Lorem amet veniam. Proident ea mollit labore sint amet aliqua esse nostrud. Ea Lorem cillum minim ut dolore anim cillum ipsum in voluptate enim. Aliqua non incididunt duis culpa quis cupidatat. Sint magna minim cillum Lorem irure fugiat nulla consectetur. Cupidatat commodo Lorem nulla commodo ad consequat est proident qui eiusmod culpa amet elit.\r\n',
         registered: '2023-04-19T04:41:24 +07:00',
         latitude: 30.87967,
         longitude: -147.679292,
@@ -147,7 +147,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (969) 504-2988',
         address: '931 Prince Street, Herald, Hawaii, 6686',
         about:
-          'Id labore eiusmod commodo pariatur incididunt velit ea sunt id et eiusmod commodo consectetur. Id id do amet minim cillum. Eiusmod duis deserunt velit id laboris culpa laboris fugiat consectetur ex. Commodo minim et labore cillum esse qui non excepteur est aliquip pariatur eiusmod.\\r\\n',
+          'Id labore eiusmod commodo pariatur incididunt velit ea sunt id et eiusmod commodo consectetur. Id id do amet minim cillum. Eiusmod duis deserunt velit id laboris culpa laboris fugiat consectetur ex. Commodo minim et labore cillum esse qui non excepteur est aliquip pariatur eiusmod.\r\n',
         registered: '2020-07-15T01:28:08 +07:00',
         latitude: 76.643551,
         longitude: 111.097854,
@@ -175,7 +175,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (891) 520-3186',
         address: '779 Highlawn Avenue, Rew, Rhode Island, 7836',
         about:
-          'Tempor labore esse officia ut consectetur nisi excepteur consectetur Lorem non. Enim sunt exercitation consequat dolore qui velit proident ex sint anim quis. Labore do nisi non minim occaecat dolore nisi velit laboris enim ad ullamco consequat. Est excepteur veniam commodo proident elit dolor. Qui mollit quis sit anim ipsum et.\\r\\n',
+          'Tempor labore esse officia ut consectetur nisi excepteur consectetur Lorem non. Enim sunt exercitation consequat dolore qui velit proident ex sint anim quis. Labore do nisi non minim occaecat dolore nisi velit laboris enim ad ullamco consequat. Est excepteur veniam commodo proident elit dolor. Qui mollit quis sit anim ipsum et.\r\n',
         registered: '2024-09-02T07:35:33 +07:00',
         latitude: 43.61443,
         longitude: -108.026998,
@@ -203,7 +203,7 @@ export const VALID_NDJSON_TEST_CASES: NDJSONTestCaseFormat[] = [
         phone: '+1 (883) 580-2660',
         address: '395 Vandervoort Avenue, Graball, North Carolina, 4702',
         about:
-          'Cupidatat exercitation sint est sunt irure cillum ullamco excepteur. Reprehenderit sit do sint Lorem amet officia consectetur cupidatat ad. Est labore duis fugiat deserunt duis eiusmod cillum do Lorem reprehenderit ea nulla deserunt velit. Officia non in velit laborum sit. Incididunt nisi reprehenderit in commodo commodo minim ea sint sunt officia officia. Est est irure mollit aute reprehenderit excepteur commodo aliquip magna nisi tempor id voluptate.\\r\\n',
+          'Cupidatat exercitation sint est sunt irure cillum ullamco excepteur. Reprehenderit sit do sint Lorem amet officia consectetur cupidatat ad. Est labore duis fugiat deserunt duis eiusmod cillum do Lorem reprehenderit ea nulla deserunt velit. Officia non in velit laborum sit. Incididunt nisi reprehenderit in commodo commodo minim ea sint sunt officia officia. Est est irure mollit aute reprehenderit excepteur commodo aliquip magna nisi tempor id voluptate.\r\n',
         registered: '2019-12-23T01:28:23 +08:00',
         latitude: -6.896081,
         longitude: -174.084986,

--- a/src/plugins/data_importer/server/plugin.ts
+++ b/src/plugins/data_importer/server/plugin.ts
@@ -17,6 +17,8 @@ import { NDJSONParser } from './parsers/ndjson_parser';
 import { JSONParser } from './parsers/json_parser';
 import { FileParserService } from './parsers/file_parser_service';
 import { validateEnabledFileTypes } from './utils/util';
+import { previewRoute } from './routes/preview';
+import { catIndicesRoute } from './routes/cat_indices';
 
 export interface DataImporterPluginSetupDeps {
   dataSource?: DataSourcePluginSetup;
@@ -48,6 +50,8 @@ export class DataImporterPlugin
     // Register server side APIs
     importFileRoute(router, this.config, this.fileParsers, !!dataSource);
     importTextRoute(router, this.config, this.fileParsers, !!dataSource);
+    previewRoute(router, this.config, this.fileParsers, !!dataSource);
+    catIndicesRoute(router, this.config, !!dataSource);
 
     return {
       registerFileParser: (fileType, fileParser) => {

--- a/src/plugins/data_importer/server/routes/cat_indices.ts
+++ b/src/plugins/data_importer/server/routes/cat_indices.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from 'src/core/server';
+import { schema, TypeOf } from '@osd/config-schema';
+import _ from 'lodash';
+import { configSchema } from '../../config';
+import { decideClient } from '../utils/util';
+
+export function catIndicesRoute(
+  router: IRouter,
+  config: TypeOf<typeof configSchema>,
+  dataSourceEnabled: boolean
+) {
+  router.post(
+    {
+      path: '/api/data_importer/_cat_indices',
+      validate: {
+        query: schema.object({
+          dataSource: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = await decideClient(dataSourceEnabled, context, request.query.dataSource);
+      if (!!!client) {
+        return response.notFound({
+          body: 'Data source is not enabled or does not exist',
+        });
+      }
+
+      try {
+        const indices = await client.cat.indices({
+          format: 'json',
+        });
+        return response.ok({
+          body: {
+            indices: indices.body.map((index: { index?: string }) => index.index || 'unknown'),
+          },
+        });
+      } catch (e) {
+        return response.internalError({
+          body: `Error when listing indices: ${e}`,
+        });
+      }
+    }
+  );
+}

--- a/src/plugins/data_importer/server/types.ts
+++ b/src/plugins/data_importer/server/types.ts
@@ -51,6 +51,7 @@ export interface ValidationOptions {
    */
   delimiter?: string;
 }
+export type ParseOptions = ValidationOptions;
 
 /**
  * Parser that handles a particular file type
@@ -63,7 +64,7 @@ export interface IFileParser {
    * @returns
    * @throws Can throw an error if text doesn't match expected format
    */
-  validateText: (text: string, options: ValidationOptions) => Promise<boolean>;
+  validateText?: (text: string, options: ValidationOptions) => Promise<boolean>;
 
   /**
    * Assuming valid text input, handle the ingestion into OpenSearch
@@ -72,7 +73,7 @@ export interface IFileParser {
    * @returns
    * @throws Can throw server errors when attempting to ingest into OpenSearch
    */
-  ingestText: (text: string, options: IngestOptions) => Promise<IngestResponse>;
+  ingestText?: (text: string, options: IngestOptions) => Promise<IngestResponse>;
 
   /**
    * Given an arbitrary file stream, handle the validation and ingestion into OpenSearch
@@ -82,4 +83,23 @@ export interface IFileParser {
    * @throws Can throw server errors when attempting to ingest into OpenSearch
    */
   ingestFile: (file: Readable, options: IngestOptions) => Promise<IngestResponse>;
+
+  /**
+   * Given an arbitrary file stream, parse the file into an object array
+   * @param file
+   * @param limit
+   * @param ingestOptions
+   * @returns
+   */
+  parseFile: (
+    file: Readable,
+    limit: number,
+    options: ParseOptions
+  ) => Promise<Array<Record<string, any>>>;
+}
+
+export interface FileStream extends Readable {
+  hapi: {
+    filename: string;
+  };
 }

--- a/src/plugins/data_importer/server/utils/util.test.ts
+++ b/src/plugins/data_importer/server/utils/util.test.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { decideClient, validateEnabledFileTypes } from './util';
+import { decideClient, determineMapping, validateEnabledFileTypes } from './util';
 import { coreMock } from '../../../../core/server/mocks';
 import { FileParserService } from '../parsers/file_parser_service';
 import { IFileParser } from '../types';
+import { MappingTypeMapping } from '@opensearch-project/opensearch/api/types';
 
 describe('util', () => {
   describe('decideClient()', () => {
@@ -15,6 +16,9 @@ describe('util', () => {
       dataSource: {
         opensearch: {
           getClient: jest.fn().mockReturnValue({}),
+          legacy: {
+            getClient: jest.fn(),
+          },
         },
       },
     };
@@ -103,6 +107,7 @@ describe('util', () => {
           validateText: jest.fn(),
           ingestText: jest.fn(),
           ingestFile: jest.fn(),
+          parseFile: jest.fn(),
         };
 
         registeredFileTypes.forEach((fileType: string) => {
@@ -120,5 +125,617 @@ describe('util', () => {
         }
       }
     );
+  });
+
+  describe('determineType()', () => {
+    const document = {
+      metadata: {
+        id: 'abc-123',
+        created_at: '2025-02-04T12:34:56Z',
+        updated_at: null,
+        tags: ['complex', 'nested', 'json'],
+        status: {
+          active: true,
+          verified: false,
+          score: 98.7,
+        },
+      },
+      user: {
+        id: 12345,
+        profile: {
+          name: 'John Doe',
+          age: 35,
+          height: 5.9,
+          contacts: {
+            email: 'john.doe@example.com',
+            phone: {
+              home: '555-1234',
+              work: '555-5678',
+              emergency: {
+                name: 'Jane Doe',
+                relation: 'sister',
+                phone: '555-9999',
+              },
+            },
+          },
+          addresses: [
+            {
+              type: 'home',
+              street: '123 Main St',
+              city: 'New York',
+              zipcode: 10001,
+            },
+            {
+              type: 'work',
+              street: '456 Office Blvd',
+              city: 'San Francisco',
+              zipcode: 94105,
+            },
+          ],
+        },
+        preferences: {
+          theme: 'dark',
+          notifications: {
+            email: true,
+            sms: false,
+            push: {
+              enabled: true,
+              sound: 'chime',
+              priority: 'high',
+            },
+          },
+          privacy: {
+            tracking: {
+              ads: false,
+              analytics: true,
+            },
+            visibility: {
+              profile: 'friends_only',
+              last_seen: 'nobody',
+            },
+          },
+        },
+      },
+      orders: [
+        {
+          order_id: 'ORD-001',
+          date: '2025-01-15T10:20:30Z',
+          total_price: 259.99,
+          items: [
+            {
+              product_id: 'P-1001',
+              name: 'Wireless Headphones',
+              quantity: 2,
+              price_per_unit: 99.99,
+            },
+            {
+              product_id: 'P-1002',
+              name: 'USB-C Charger',
+              quantity: 1,
+              price_per_unit: 59.99,
+            },
+          ],
+        },
+        {
+          order_id: 'ORD-002',
+          date: '2025-02-01T14:45:00Z',
+          total_price: 120.5,
+          items: [
+            {
+              product_id: 'P-2001',
+              name: 'Mechanical Keyboard',
+              quantity: 1,
+              price_per_unit: 120.5,
+            },
+          ],
+        },
+      ],
+      system: {
+        logs: [
+          {
+            timestamp: '2025-02-04T12:34:56Z',
+            level: 'error',
+            message: 'Database connection lost',
+            metadata: {
+              code: 500,
+              retry_attempts: 3,
+              stack_trace: ['db.connect()', 'handle_request()', 'main()'],
+            },
+          },
+          {
+            timestamp: '2025-02-04T12:35:30Z',
+            level: 'info',
+            message: 'Reconnected to database',
+          },
+        ],
+        config: {
+          version: '1.2.3',
+          features: {
+            beta: {
+              enabled: true,
+              flags: ['new_dashboard', 'ai_assist'],
+            },
+            security: {
+              firewall: {
+                enabled: true,
+                rules: [
+                  {
+                    id: 'FW-001',
+                    action: 'allow',
+                    source: '192.168.1.1/24',
+                  },
+                  {
+                    id: 'FW-002',
+                    action: 'deny',
+                    source: '0.0.0.0/0',
+                  },
+                ],
+              },
+              encryption: {
+                enabled: true,
+                key_rotation: {
+                  interval_days: 90,
+                  last_rotation: '2025-01-01T00:00:00Z',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedMapping: MappingTypeMapping = {
+      date_detection: true,
+      dynamic: true,
+      properties: {
+        metadata: {
+          properties: {
+            created_at: {
+              type: 'date',
+            },
+            id: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword',
+                  ignore_above: 256,
+                },
+              },
+            },
+            status: {
+              properties: {
+                active: {
+                  type: 'boolean',
+                },
+                score: {
+                  type: 'float',
+                },
+                verified: {
+                  type: 'boolean',
+                },
+              },
+            },
+            tags: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword',
+                  ignore_above: 256,
+                },
+              },
+            },
+            updated_at: {
+              type: 'null',
+            },
+          },
+        },
+        orders: {
+          properties: {
+            date: {
+              type: 'date',
+            },
+            items: {
+              properties: {
+                name: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+                price_per_unit: {
+                  type: 'float',
+                },
+                product_id: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+                quantity: {
+                  type: 'integer',
+                },
+              },
+            },
+            order_id: {
+              type: 'text',
+              fields: {
+                keyword: {
+                  type: 'keyword',
+                  ignore_above: 256,
+                },
+              },
+            },
+            total_price: {
+              type: 'float',
+            },
+          },
+        },
+        system: {
+          properties: {
+            config: {
+              properties: {
+                features: {
+                  properties: {
+                    beta: {
+                      properties: {
+                        enabled: {
+                          type: 'boolean',
+                        },
+                        flags: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                      },
+                    },
+                    security: {
+                      properties: {
+                        encryption: {
+                          properties: {
+                            enabled: {
+                              type: 'boolean',
+                            },
+                            key_rotation: {
+                              properties: {
+                                interval_days: {
+                                  type: 'integer',
+                                },
+                                last_rotation: {
+                                  type: 'date',
+                                },
+                              },
+                            },
+                          },
+                        },
+                        firewall: {
+                          properties: {
+                            enabled: {
+                              type: 'boolean',
+                            },
+                            rules: {
+                              properties: {
+                                action: {
+                                  type: 'text',
+                                  fields: {
+                                    keyword: {
+                                      type: 'keyword',
+                                      ignore_above: 256,
+                                    },
+                                  },
+                                },
+                                id: {
+                                  type: 'text',
+                                  fields: {
+                                    keyword: {
+                                      type: 'keyword',
+                                      ignore_above: 256,
+                                    },
+                                  },
+                                },
+                                source: {
+                                  type: 'text',
+                                  fields: {
+                                    keyword: {
+                                      type: 'keyword',
+                                      ignore_above: 256,
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                version: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+              },
+            },
+            logs: {
+              properties: {
+                level: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+                message: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+                metadata: {
+                  properties: {
+                    code: {
+                      type: 'integer',
+                    },
+                    retry_attempts: {
+                      type: 'integer',
+                    },
+                    stack_trace: {
+                      type: 'text',
+                      fields: {
+                        keyword: {
+                          type: 'keyword',
+                          ignore_above: 256,
+                        },
+                      },
+                    },
+                  },
+                },
+                timestamp: {
+                  type: 'date',
+                },
+              },
+            },
+          },
+        },
+        user: {
+          properties: {
+            id: {
+              type: 'integer',
+            },
+            preferences: {
+              properties: {
+                notifications: {
+                  properties: {
+                    email: {
+                      type: 'boolean',
+                    },
+                    push: {
+                      properties: {
+                        enabled: {
+                          type: 'boolean',
+                        },
+                        priority: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                        sound: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                      },
+                    },
+                    sms: {
+                      type: 'boolean',
+                    },
+                  },
+                },
+                privacy: {
+                  properties: {
+                    tracking: {
+                      properties: {
+                        ads: {
+                          type: 'boolean',
+                        },
+                        analytics: {
+                          type: 'boolean',
+                        },
+                      },
+                    },
+                    visibility: {
+                      properties: {
+                        last_seen: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                        profile: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                theme: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+              },
+            },
+            profile: {
+              properties: {
+                addresses: {
+                  properties: {
+                    city: {
+                      type: 'text',
+                      fields: {
+                        keyword: {
+                          type: 'keyword',
+                          ignore_above: 256,
+                        },
+                      },
+                    },
+                    street: {
+                      type: 'text',
+                      fields: {
+                        keyword: {
+                          type: 'keyword',
+                          ignore_above: 256,
+                        },
+                      },
+                    },
+                    type: {
+                      type: 'text',
+                      fields: {
+                        keyword: {
+                          type: 'keyword',
+                          ignore_above: 256,
+                        },
+                      },
+                    },
+                    zipcode: {
+                      type: 'integer',
+                    },
+                  },
+                },
+                age: {
+                  type: 'integer',
+                },
+                contacts: {
+                  properties: {
+                    email: {
+                      type: 'text',
+                      fields: {
+                        keyword: {
+                          type: 'keyword',
+                          ignore_above: 256,
+                        },
+                      },
+                    },
+                    phone: {
+                      properties: {
+                        emergency: {
+                          properties: {
+                            name: {
+                              type: 'text',
+                              fields: {
+                                keyword: {
+                                  type: 'keyword',
+                                  ignore_above: 256,
+                                },
+                              },
+                            },
+                            phone: {
+                              type: 'text',
+                              fields: {
+                                keyword: {
+                                  type: 'keyword',
+                                  ignore_above: 256,
+                                },
+                              },
+                            },
+                            relation: {
+                              type: 'text',
+                              fields: {
+                                keyword: {
+                                  type: 'keyword',
+                                  ignore_above: 256,
+                                },
+                              },
+                            },
+                          },
+                        },
+                        home: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                        work: {
+                          type: 'text',
+                          fields: {
+                            keyword: {
+                              type: 'keyword',
+                              ignore_above: 256,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                height: {
+                  type: 'float',
+                },
+                name: {
+                  type: 'text',
+                  fields: {
+                    keyword: {
+                      type: 'keyword',
+                      ignore_above: 256,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it('should correctly parse types of a deeply nested document', () => {
+      const result = determineMapping(document, 50000);
+      expect(result).toEqual(expectedMapping);
+    });
+
+    it('should error out when the object is too deeply nested', () => {
+      expect(() => determineMapping(document, 4)).toThrowError();
+    });
   });
 });

--- a/src/plugins/data_importer/server/utils/util.ts
+++ b/src/plugins/data_importer/server/utils/util.ts
@@ -3,8 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MappingProperty, MappingTypeMapping } from '@opensearch-project/opensearch/api/types';
+import _ from 'lodash';
+import moment from 'moment';
 import { FileParserService } from '../parsers/file_parser_service';
 import { OpenSearchClient, RequestHandlerContext } from '../../../../core/server';
+import { DYNAMIC_MAPPING_TYPES } from '../../common';
 
 export const decideClient = async (
   dataSourceEnabled: boolean,
@@ -25,4 +29,71 @@ export const validateEnabledFileTypes = (fileTypes: string[], fileParsers: FileP
       `The following enabledFileTypes are not registered: ${nonRegisteredFileTypes.join(', ')}`
     );
   }
+};
+
+export const determineMapping = (
+  document: Record<string, any>,
+  nestedObjectsLimit: number
+): MappingTypeMapping => {
+  return {
+    dynamic: true,
+    date_detection: true,
+    ...determineType(document, 1, nestedObjectsLimit),
+  };
+};
+
+export const determineType = (
+  value: any,
+  currentNestedCount: number,
+  nestedObjectsLimit: number
+): Record<string, MappingProperty> | MappingProperty => {
+  if (currentNestedCount >= nestedObjectsLimit) {
+    throw Error(`Current document exceeds nested object limit of ${nestedObjectsLimit}`);
+  }
+
+  switch (true) {
+    case Array.isArray(value) && value.length < 1:
+    case value == null:
+      return { type: DYNAMIC_MAPPING_TYPES.NULL };
+    case value === 'true' || value === 'false' || typeof value === 'boolean':
+      return { type: DYNAMIC_MAPPING_TYPES.BOOLEAN };
+    case !isNaN(Number(value)):
+      return { type: determineNumberType(Number(value)) };
+    case isValidDate(_.toString(value)):
+      return { type: DYNAMIC_MAPPING_TYPES.DATE };
+    case Array.isArray(value) && value.length > 0:
+      return determineType(value[0], currentNestedCount, nestedObjectsLimit);
+    case value && typeof value === 'object' && !Array.isArray(value):
+      const properties: Record<string, MappingProperty> = {};
+      Object.keys(value).forEach((key) => {
+        properties[key] = determineType(value[key], currentNestedCount + 1, nestedObjectsLimit);
+      });
+      return { properties };
+    default:
+      return {
+        type: DYNAMIC_MAPPING_TYPES.TEXT,
+        fields: {
+          keyword: {
+            type: 'keyword',
+            ignore_above: 256,
+          },
+        },
+      };
+  }
+};
+
+export const determineNumberType = (value: number) => {
+  if (Number.isSafeInteger(value)) {
+    return DYNAMIC_MAPPING_TYPES.INTEGER;
+  } else if (!Number.isInteger(value)) {
+    return DYNAMIC_MAPPING_TYPES.FLOAT;
+  } else {
+    return DYNAMIC_MAPPING_TYPES.DOUBLE;
+  }
+};
+
+export const isValidDate = (date: string) => {
+  return (
+    moment(date, moment.ISO_8601, true).isValid() || moment(date, moment.RFC_2822, true).isValid()
+  );
 };


### PR DESCRIPTION
### Description

This PR adds two new routes:
- `_preview`
- `_cat_indices`

And modifies two routes:
- `_import_file`
- `_import_text`

in order to support a file-preview like experience. Chiefly, the `_preview` route is used for parsing the file and returning the best guess index mapping that the documents will have. This PR does not cover the case where the existing index mapping and predicted index mapping differ. This is up to UI

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
