### PR TITLE
Query requests return with sample size defined in advanced setting

### DIFF
--- a/changelogs/fragments/9356.yml
+++ b/changelogs/fragments/9356.yml
@@ -1,0 +1,2 @@
+feat:
+- Remove sample size in default query string but use advanced setting ([#9356](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9356))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/01/queries.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/01/queries.spec.js
@@ -84,7 +84,7 @@ const queriesTestSuite = () => {
         // Use the more robust verifyDiscoverPageState function
         verifyDiscoverPageState({
           dataset: `${INDEX_WITH_TIME_1}*`,
-          queryString: `SELECT * FROM ${INDEX_WITH_TIME_1}* LIMIT 10`,
+          queryString: `SELECT * FROM ${INDEX_WITH_TIME_1}`,
           language: 'OpenSearch SQL',
         });
 
@@ -127,7 +127,7 @@ const queriesTestSuite = () => {
         // This handles Monaco editor's special whitespace characters better
         verifyDiscoverPageState({
           dataset: `${INDEX_WITH_TIME_1}*`,
-          queryString: `source = ${INDEX_WITH_TIME_1}*`,
+          queryString: `source = ${INDEX_WITH_TIME_1}* | head 500`,
           language: 'PPL',
           hitCount: '10,000',
         });

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/02/language_specific_display.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/02/language_specific_display.spec.js
@@ -73,9 +73,11 @@ export const runDisplayTests = () => {
           if (config.language === QueryLanguages.SQL.name) {
             cy.getElementByTestId('osdQueryEditor__multiLine').contains('SELECT');
             cy.getElementByTestId('osdQueryEditor__multiLine').contains('FROM');
-            cy.getElementByTestId('osdQueryEditor__multiLine').contains('LIMIT');
           } else if (config.language === QueryLanguages.PPL.name) {
             cy.getElementByTestId('osdQueryEditor__multiLine').contains('source');
+            //TODO: Set the query to not include head 500 because https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9421
+            cy.setQueryEditor(`source = ${INDEX_PATTERN_WITH_TIME}`);
+            cy.waitForLoader(true);
           }
 
           cy.getElementByTestId('osdQueryEditorLanguageToggle').click();

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/shared_links.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/shared_links.spec.js
@@ -153,6 +153,9 @@ export const runSharedLinksTests = () => {
           // Set query
           cy.setQueryEditor(queryString, { parseSpecialCharSequences: false });
 
+          // Set interval
+          setHistogramIntervalIfRelevant(config.language, testData.interval);
+
           // Set filter for DQL/Lucene
           if (config.hasDocLinks) {
             cy.submitFilterFromDropDown(testData.filter[0], 'is', testData.filter[1], true);

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/04/histogram_interaction.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/04/histogram_interaction.spec.js
@@ -53,6 +53,10 @@ const runHistogramInteractionTests = () => {
         cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
         cy.setQueryLanguage(config.language);
         setDatePickerDatesAndSearchIfRelevant(config.language);
+        //TODO: Set the query to not include head 500 because https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9421
+        if (language.name === QueryLanguages.PPL.name) {
+          cy.setQueryEditor(`source = ${INDEX_PATTERN_WITH_TIME}`);
+        }
         if (config.isHistogramVisible) {
           cy.getElementByTestId('dscChartChartheader').should('be.visible');
           cy.getElementByTestId('discoverChart').should('be.visible');
@@ -87,6 +91,10 @@ const runHistogramInteractionTests = () => {
         cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
         cy.setQueryLanguage(config.language);
         setDatePickerDatesAndSearchIfRelevant(config.language);
+        //TODO: Set the query to not include head 500 because https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9421
+        if (language.name === QueryLanguages.PPL.name) {
+          cy.setQueryEditor(`source = ${INDEX_PATTERN_WITH_TIME}`);
+        }
         const intervals = ['auto', 'ms', 's', 'm', 'h', 'd', 'w', 'M', 'y'];
         cy.getElementByTestId('discoverIntervalSelect').should('have.value', intervals[0]);
         intervals.forEach((interval) => {
@@ -131,6 +139,10 @@ const runHistogramInteractionTests = () => {
             .click({ force: true }); // reset state
         };
         cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
+        //TODO: Set the query to not include head 500 because https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9421
+        if (language.name === QueryLanguages.PPL.name) {
+          cy.setQueryEditor(`source = ${INDEX_PATTERN_WITH_TIME}`);
+        }
         cy.setQueryLanguage(config.language);
         if (config.isHistogramVisible) {
           // TODO: related bug
@@ -163,6 +175,10 @@ const runHistogramInteractionTests = () => {
         cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
         cy.setQueryLanguage(config.language);
         setDatePickerDatesAndSearchIfRelevant(config.language);
+        //TODO: Set the query to not include head 500 because https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9421
+        if (language.name === QueryLanguages.PPL.name) {
+          cy.setQueryEditor(`source = ${INDEX_PATTERN_WITH_TIME}`);
+        }
 
         cy.getElementByTestId('dscChartChartheader').should('be.visible');
         cy.getElementByTestId('discoverChart').should('be.visible');

--- a/cypress/utils/apps/query_enhancements/recent_queries.js
+++ b/cypress/utils/apps/query_enhancements/recent_queries.js
@@ -83,7 +83,7 @@ export const generateRecentQueriesTestConfiguration = (dataset, datasetType, lan
     PPL: 'OpenSearch SQL',
     'OpenSearch SQL': 'PPL',
   };
-  const defaultQuery = language.name === 'PPL' ? '' : ' LIMIT 10';
+  const defaultQuery = language.name === 'PPL' ? ' | head 500' : '';
   const customDatasetType = RecentQueriesDataTypes[datasetType].name;
   return {
     dataset,

--- a/cypress/utils/apps/query_enhancements/shared.js
+++ b/cypress/utils/apps/query_enhancements/shared.js
@@ -159,7 +159,7 @@ export const getDefaultQuery = (datasetName, language) => {
     case QueryLanguages.PPL.name:
       return `source = ${datasetName}`;
     case QueryLanguages.SQL.name:
-      return `SELECT * FROM ${datasetName} LIMIT 10`;
+      return `SELECT * FROM ${datasetName}`;
   }
 };
 

--- a/src/plugins/data/common/constants.ts
+++ b/src/plugins/data/common/constants.ts
@@ -113,4 +113,5 @@ export const UI_SETTINGS = {
   DATA_WITH_LONG_NUMERALS: 'data:withLongNumerals',
   DATE_FORMAT: 'dateFormat',
   DATE_FORMAT_TIMEZONE: 'dateFormat:tz',
+  DISCOVER_SAMPLE_SIZE: 'discover:sampleSize',
 } as const;

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -86,7 +86,7 @@ export const indexPatternTypeConfig: DatasetTypeConfig = {
             title: i18n.translate('data.indexPatternType.sampleQuery.basicSQLQuery', {
               defaultMessage: 'Sample query for SQL',
             }),
-            query: `SELECT * FROM ${dataset.title} LIMIT 10`,
+            query: `SELECT * FROM ${dataset.title}`,
           },
         ];
     }

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -109,7 +109,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
             title: i18n.translate('data.indexType.sampleQuery.basicSQLQuery', {
               defaultMessage: 'Sample query for SQL',
             }),
-            query: `SELECT * FROM ${dataset.title} LIMIT 10`,
+            query: `SELECT * FROM ${dataset.title}`,
           },
         ];
     }

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { EuiIconProps } from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
 import {
   Dataset,
   DatasetField,
@@ -117,5 +118,5 @@ export interface DatasetTypeConfig {
   /**
    * Returns the initial query that is added to the query editor when a dataset is selected.
    */
-  getInitialQueryString?: (query: Query) => string | void;
+  getInitialQueryString?: (query: Query, uiSettings?: CoreStart['uiSettings']) => string | void;
 }

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -86,7 +86,8 @@ export class QueryStringManager {
     }
 
     return (
-      typeConfig?.getInitialQueryString?.(query) ?? (languageConfig?.getQueryString(query) || '')
+      typeConfig?.getInitialQueryString?.(query, this.uiSettings) ??
+      (languageConfig?.getQueryString(query) || '')
     );
   }
 

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -5,7 +5,7 @@
 
 import { i18n } from '@osd/i18n';
 import { trimEnd } from 'lodash';
-import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import { CoreStart, HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import semver from 'semver';
 import {
   DATA_STRUCTURE_META_TYPES,
@@ -15,6 +15,7 @@ import {
   DataStructureCustomMeta,
   Dataset,
   DatasetField,
+  Query,
 } from '../../../data/common';
 import { DatasetTypeConfig, IDataPluginServices, OSD_FIELD_TYPES } from '../../../data/public';
 import {
@@ -131,7 +132,7 @@ export const s3TypeConfig: DatasetTypeConfig = {
             title: i18n.translate('queryEnhancements.s3Type.sampleQuery.basicPPLQuery', {
               defaultMessage: 'Sample query for PPL',
             }),
-            query: `source = ${dataset?.title}`,
+            query: `source = ${dataset.title} | head 500`,
           },
         ];
       case 'SQL':
@@ -140,9 +141,22 @@ export const s3TypeConfig: DatasetTypeConfig = {
             title: i18n.translate('queryEnhancements.s3Type.sampleQuery.basicSQLQuery', {
               defaultMessage: 'Sample query for SQL',
             }),
-            query: `SELECT * FROM ${dataset?.title} LIMIT 10`,
+            query: `SELECT * FROM ${dataset.title} LIMIT 500`,
           },
         ];
+    }
+  },
+
+  getInitialQueryString: (query: Query, uiSettings?: CoreStart['uiSettings']) => {
+    switch (query.language) {
+      case 'PPL':
+        return `source = ${query.dataset?.title} | head ${
+          uiSettings?.get('discover:sampleSize') ?? 500
+        }`;
+      case 'SQL':
+        return `SELECT * FROM ${query.dataset?.title} LIMIT ${
+          uiSettings?.get('discover:sampleSize') ?? 500
+        }`;
     }
   },
 };

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -6,7 +6,7 @@ import { i18n } from '@osd/i18n';
 import { BehaviorSubject } from 'rxjs';
 import moment from 'moment';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
-import { DataStorage, OSD_FIELD_TYPES } from '../../data/common';
+import { DataStorage, OSD_FIELD_TYPES, UI_SETTINGS } from '../../data/common';
 import {
   createEditor,
   DefaultInput,
@@ -67,7 +67,10 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
+      getQueryString: (currentQuery: Query) =>
+        `source = ${currentQuery.dataset?.title} | head ${core.uiSettings.get(
+          UI_SETTINGS.DISCOVER_SAMPLE_SIZE
+        )}`,
       fields: {
         sortable: false,
         filterable: false,
@@ -145,8 +148,7 @@ export class QueryEnhancementsPlugin
         startServices: core.getStartServices(),
         usageCollector: data.search.usageCollector,
       }),
-      getQueryString: (currentQuery: Query) =>
-        `SELECT * FROM ${currentQuery.dataset?.title} LIMIT 10`,
+      getQueryString: (currentQuery: Query) => `SELECT * FROM ${currentQuery.dataset?.title}`,
       fields: { sortable: false, filterable: false, visualizable: false },
       docLink: {
         title: i18n.translate('queryEnhancements.sqlLanguage.docLink', {

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
@@ -35,6 +35,9 @@ export const pplSearchStrategyProvider = (
   return {
     search: async (context, request: any, options) => {
       try {
+        // TODO: PPL does not support fetch_size yet due to https://github.com/opensearch-project/sql/issues/3314
+        // We can add the below back for https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9385
+        // request.body.fetch_size = await context.core.uiSettings.client.get('discover:sampleSize');
         const query: Query = request.body.query;
         const aggConfig: QueryAggConfig | undefined = request.body.aggConfig;
         const rawResponse: any = await pplFacet.describeQuery(context, request);

--- a/src/plugins/query_enhancements/server/search/sql_search_strategy.test.ts
+++ b/src/plugins/query_enhancements/server/search/sql_search_strategy.test.ts
@@ -26,7 +26,15 @@ describe('sqlSearchStrategyProvider', () => {
   let logger: Logger;
   let client: ILegacyClusterClient;
   let usage: SearchUsage;
-  const emptyRequestHandlerContext = ({} as unknown) as RequestHandlerContext;
+  const emptyRequestHandlerContext = ({
+    core: {
+      uiSettings: {
+        client: {
+          get: jest.fn(),
+        },
+      },
+    },
+  } as unknown) as RequestHandlerContext;
 
   beforeEach(() => {
     config$ = of({} as SharedGlobalConfig);
@@ -69,7 +77,6 @@ describe('sqlSearchStrategyProvider', () => {
       { name: 'field1', type: 'long' },
       { name: 'field2', type: 'text' },
     ]);
-
     const strategy = sqlSearchStrategyProvider(config$, logger, client, usage);
     const result = await strategy.search(
       emptyRequestHandlerContext,

--- a/src/plugins/query_enhancements/server/search/sql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/sql_search_strategy.ts
@@ -34,7 +34,12 @@ export const sqlSearchStrategyProvider = (
     search: async (context, request: any, options) => {
       try {
         const query: Query = request.body.query;
-        const rawResponse: any = await sqlFacet.describeQuery(context, request);
+        request.body.fetch_size = await context.core.uiSettings.client.get('discover:sampleSize');
+        const requestWithFetchSize = {
+          ...request,
+          body: { ...request.body, fetch_size: request.body.fetch_size },
+        };
+        const rawResponse: any = await sqlFacet.describeQuery(context, requestWithFetchSize);
 
         if (!rawResponse.success) throwFacetError(rawResponse);
 

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -45,6 +45,7 @@ export class Facet {
         body: {
           query: query.query,
           ...(meta?.name && { datasource: meta.name }),
+          ...(request.body?.fetch_size && { fetch_size: request.body.fetch_size }),
           ...(meta?.sessionId && {
             sessionId: meta.sessionId,
           }),


### PR DESCRIPTION
### Description
The size of the SQL and PPL responses should be determined by advanced setting `discover:sampleSize`. Default value is 500.

## SQL: 
Default
```
SELECT * FROM dataset
```
* we use fetch_size param when sending SQL request to define how many hits we should get back: 

## PPL: 
Default: 
```
source = dataset | head ${advanced setting sampleSize value, default is 500}
```
* fetch_size in sending PPL is currently broken due to https://github.com/opensearch-project/sql/issues/3314; until it get resolved, we interpolate the default PPL query to add a sample size for now
* once the bug is resolved, we should change to use fetch_size just like how SQL does it. Created an issue to track this: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9385

## async SQL/PPL:
Default: 
```
SELECT * FROM dataset LIMIT ${advanced setting sampleSize value, default is 500}
source = dataset | head ${advanced setting sampleSize value, default is 500}
```
* fetch_size currently do not support for async queries; we interpolate the default queries to add a sample size


## Screenshot


https://github.com/user-attachments/assets/492440d2-184d-459a-80af-698cf011509d






## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- feat: Remove sample size in default query string but use advanced setting

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
