### PR TITLE
Update actions/cache from v1 to v4 to address deprecation warning

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/changelogs/fragments/9366.yml
+++ b/changelogs/fragments/9366.yml
@@ -1,0 +1,2 @@
+fix:
+- Update actions/cache from v1 to v4 to address deprecation warning ([#9366](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9366))


### PR DESCRIPTION
## Description
Updates the GitHub Actions workflow to use actions/cache@v4 instead of the deprecated v1. This change prevents future workflow interruptions when v1 is discontinued.

## Related Issues
Addresses the deprecation warning:
"Error: This request has been automatically failed because it uses a deprecated version of actions/cache: v1"

<img width="1701" alt="Screenshot 2025-02-11 at 10 20 29 AM" src="https://github.com/user-attachments/assets/61afe118-535d-4a74-bff5-e5a4c2757dc1" />

## Changelog

- fix: Update actions/cache from v1 to v4 to address deprecation warning


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
