### PR TITLE
Update DEVELOPER_GUIDE.md

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -374,7 +374,7 @@ You could pass one or multiple flags. If you don't pass any flag, `yarn build-pl
 Currently, the supported flags for this script are:
 
 - `darwin` (builds Darwin x64)
-- `linux` (builds Linux x64)
+- `linux` (builds Linux x64) **Note:** This build relies on the `dart-sass-embeddable` module, which uses `glibc`. Some Linux distributions (such as Alpine Linux) use `musl` instead of `glibc` and are not compatible with this build. If you are using a musl-based distro, consider building on a glibc-based environment (for example, using a Docker image based on Debian or CentOS) to avoid compatibility issues.
 - `linux-arm` (builds Linux ARM64).
 - `windows` (builds Windows x64)
 


### PR DESCRIPTION
### Description

When building the OpenSearch Dashboards artifact for Linux, the build may fail on certain distributions. This issue stems from the recent upgrade from node-sass to dart-sass. The new process uses an embeddable module from dart-sass to process Sass files, which relies on a platform-specific compiler. On Linux, this module depends on glibc. However, some distributions—like Alpine Linux—use musl libc instead, which is incompatible with this module. I'm updating the DEVELOPER_GUIDE documentation to help other developers choose the appropriate distro for Docker images and avoid the pitfalls I encountered.

### Issues Resolved

Help developers use the correct Linux Distribution when building platform-specific artifacts.
Github Issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9329
Forum Issue: https://forum.opensearch.org/t/docker-a-error-error-worker-exitted-unexpectedly-with-code-1-last-message-bundleid-embeddable-type-running/23214

## Screenshot

![image](https://github.com/user-attachments/assets/6abd128a-e41f-48cc-9fa3-e025d3622964)

## Testing the changes

Forum of Dart-Sass-Embedded stating the issue with musl compilers: https://github.com/sass/dart-sass-embedded/issues/85
Compatibility breakage between musl and glibc: https://www.musl-libc.org/faq.html

## Changelog
- skip



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
