### PR TITLE
feat: Add MDS support for index pattern validate script

### DIFF
--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/test_script.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_help/test_script.tsx
@@ -122,6 +122,7 @@ export class TestScript extends Component<TestScriptProps, TestScriptState> {
       query,
       additionalFields: this.state.additionalFields.map((option: AdditionalField) => option.value),
       http: this.context.services.http,
+      dataSourceId: indexPattern.dataSourceRef?.id,
     });
 
     if (scriptResponse.status !== 200) {

--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
@@ -136,6 +136,7 @@ export interface FieldEditorState {
   errors?: string[];
   format: any;
   spec: IndexPatternField['spec'];
+  dataSourceId?: string;
 }
 
 export interface FieldEdiorProps {
@@ -176,6 +177,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
       isSaving: false,
       format: props.indexPattern.getFormatterForField(spec),
       spec: { ...spec },
+      dataSourceId: indexPattern.dataSourceRef?.id,
     };
     this.supportedLangs = getSupportedScriptingLanguages();
     this.deprecatedLangs = getDeprecatedScriptingLanguages();
@@ -799,6 +801,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         script: field.script as string,
         indexPatternTitle: indexPattern.title,
         http: this.context.services.http,
+        dataSourceId: this.state.dataSourceId,
       });
 
       if (!isValid) {

--- a/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/field_editor.tsx
@@ -136,7 +136,6 @@ export interface FieldEditorState {
   errors?: string[];
   format: any;
   spec: IndexPatternField['spec'];
-  dataSourceId?: string;
 }
 
 export interface FieldEdiorProps {
@@ -177,7 +176,6 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
       isSaving: false,
       format: props.indexPattern.getFormatterForField(spec),
       spec: { ...spec },
-      dataSourceId: indexPattern.dataSourceRef?.id,
     };
     this.supportedLangs = getSupportedScriptingLanguages();
     this.deprecatedLangs = getDeprecatedScriptingLanguages();
@@ -801,7 +799,7 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
         script: field.script as string,
         indexPatternTitle: indexPattern.title,
         http: this.context.services.http,
-        dataSourceId: this.state.dataSourceId,
+        dataSourceId: indexPattern.dataSourceRef?.id,
       });
 
       if (!isValid) {

--- a/src/plugins/index_pattern_management/public/components/field_editor/lib/validate_script.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/lib/validate_script.ts
@@ -38,6 +38,7 @@ export const executeScript = async ({
   query,
   additionalFields = [],
   http,
+  dataSourceId,
 }: ExecuteScriptParams): Promise<ExecuteScriptResult> => {
   return http
     .post('/internal/index-pattern-management/preview_scripted_field', {
@@ -48,6 +49,9 @@ export const executeScript = async ({
         query,
         additionalFields,
       }),
+      query: {
+        dataSourceId,
+      },
     })
     .then((res) => ({
       status: res.statusCode,
@@ -64,17 +68,20 @@ export const isScriptValid = async ({
   script,
   indexPatternTitle,
   http,
+  dataSourceId,
 }: {
   name: string;
   script: string;
   indexPatternTitle: string;
   http: HttpStart;
+  dataSourceId?: string;
 }) => {
   const scriptResponse = await executeScript({
     name,
     script,
     indexPatternTitle,
     http,
+    dataSourceId,
   });
 
   if (scriptResponse.status !== 200) {

--- a/src/plugins/index_pattern_management/public/components/field_editor/types.ts
+++ b/src/plugins/index_pattern_management/public/components/field_editor/types.ts
@@ -44,6 +44,7 @@ export interface ExecuteScriptParams {
   query?: Query['query'];
   additionalFields?: string[];
   http: HttpStart;
+  dataSourceId?: string;
 }
 
 export interface ExecuteScriptResult {

--- a/src/plugins/index_pattern_management/server/routes/preview_scripted_field.ts
+++ b/src/plugins/index_pattern_management/server/routes/preview_scripted_field.ts
@@ -51,12 +51,11 @@ export function registerPreviewScriptedFieldRoute(router: IRouter): void {
     async (context, request, res) => {
       const { index, name, script, query, additionalFields } = request.body;
       const { dataSourceId } = request.query;
-      const client =
-        dataSourceId && context.dataSource
-          ? await context.dataSource.opensearch.getClient(dataSourceId)
-          : context.core.opensearch.client.asCurrentUser;
-
       try {
+        const client =
+          dataSourceId && context.dataSource
+            ? await context.dataSource.opensearch.getClient(dataSourceId)
+            : context.core.opensearch.client.asCurrentUser;
         const response = await client.search({
           index,
           _source: additionalFields && additionalFields.length > 0 ? additionalFields : undefined,

--- a/src/plugins/index_pattern_management/server/routes/preview_scripted_field.ts
+++ b/src/plugins/index_pattern_management/server/routes/preview_scripted_field.ts
@@ -43,11 +43,18 @@ export function registerPreviewScriptedFieldRoute(router: IRouter): void {
           query: schema.maybe(schema.object({}, { unknowns: 'allow' })),
           additionalFields: schema.maybe(schema.arrayOf(schema.string())),
         }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (context, request, res) => {
-      const client = context.core.opensearch.client.asCurrentUser;
       const { index, name, script, query, additionalFields } = request.body;
+      const { dataSourceId } = request.query;
+      const client =
+        dataSourceId && context.dataSource
+          ? await context.dataSource.opensearch.getClient(dataSourceId)
+          : context.core.opensearch.client.asCurrentUser;
 
       try {
         const response = await client.search({


### PR DESCRIPTION
### Description

feat: Add MDS support for index pattern validate script

Scripted field is a feature of index pattern that used in visualizations and display in documents. Validation is an API used for validation script when creating scripts. 

![image](https://github.com/user-attachments/assets/1f02a39e-2521-48c1-a515-f19a7c88cea1)
Before this PR, this API did not support MDS, so it would throw an error when operating the index pattern on a remote data source. After this PR, this error would be fixed.

## Screenshot

No UI change

## Testing the changes

Turn on/off the MDS, and then visit index pattern script field edit page, the API won't break down any more if editing an index pattern on remote data source.

## Changelog

- feat: Add MDS support for index pattern validate script

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
