### PR TITLE
Render PPL time column using the correct time zone

### DIFF
--- a/changelogs/fragments/9379.yml
+++ b/changelogs/fragments/9379.yml
@@ -1,0 +1,2 @@
+fix:
+- Make PPL time column respect time zone and date format ([#9379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9379))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/inspect.spec.js
@@ -99,10 +99,17 @@ const inspectTestSuite = () => {
             ) {
               cy.log(`Skipped for ${key}`);
               continue;
+            } else if (config.language === QueryLanguages.PPL.name && key === 'timestamp') {
+              // PPL date field will be formatted
+              docTable
+                .getExpandedDocTableRowFieldValue(key)
+                .should('have.text', 'Dec 31, 2020 @ 16:00:00.000');
+              continue;
+            } else {
+              docTable
+                .getExpandedDocTableRowFieldValue(key)
+                .should('have.text', value === null ? ' - ' : value);
             }
-            docTable
-              .getExpandedDocTableRowFieldValue(key)
-              .should('have.text', value === null ? ' - ' : value);
           }
         });
       });

--- a/src/plugins/data/common/constants.ts
+++ b/src/plugins/data/common/constants.ts
@@ -111,4 +111,6 @@ export const UI_SETTINGS = {
   SEARCH_QUERY_LANGUAGE_BLOCKLIST: 'search:queryLanguageBlocklist',
   NEW_HOME_PAGE: 'home:useNewHomePage',
   DATA_WITH_LONG_NUMERALS: 'data:withLongNumerals',
+  DATE_FORMAT: 'dateFormat',
+  DATE_FORMAT_TIMEZONE: 'dateFormat:tz',
 } as const;

--- a/src/plugins/data/common/data_frames/utils.test.ts
+++ b/src/plugins/data/common/data_frames/utils.test.ts
@@ -4,7 +4,14 @@
  */
 
 import datemath from '@opensearch/datemath';
-import { formatTimePickerDate } from '.';
+import {
+  convertResult,
+  DATA_FRAME_TYPES,
+  formatTimePickerDate,
+  IDataFrameErrorResponse,
+  IDataFrameResponse,
+} from '.';
+import moment from 'moment';
 
 describe('formatTimePickerDate', () => {
   const mockDateFormat = 'YYYY-MM-DD HH:mm:ss';
@@ -23,5 +30,167 @@ describe('formatTimePickerDate', () => {
     expect(datemath.parse).toHaveBeenCalledTimes(2);
     expect(datemath.parse).toHaveBeenCalledWith('now/d', { roundUp: undefined });
     expect(datemath.parse).toHaveBeenCalledWith('now/d', { roundUp: true });
+  });
+});
+
+describe('convertResult', () => {
+  const mockDateString = '2025-02-13 00:51:50';
+  const expectedFormattedDate = moment.utc(mockDateString).format('YYYY-MM-DDTHH:mm:ssZ');
+
+  it('should handle empty response', () => {
+    const response: IDataFrameResponse = {
+      took: 0,
+      timed_out: false,
+      _shards: {
+        total: 1,
+        successful: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      hits: {
+        total: 0,
+        max_score: 0,
+        hits: [],
+      },
+      body: {
+        fields: [],
+        size: 0,
+        name: 'test-index',
+        values: [],
+      },
+      type: DATA_FRAME_TYPES.DEFAULT,
+    };
+
+    const result = convertResult(response);
+    expect(result.hits.hits).toEqual([]);
+    expect(result.took).toBe(0);
+  });
+
+  it('should convert simple date fields', () => {
+    const response: IDataFrameResponse = {
+      took: 100,
+      timed_out: false,
+      _shards: {
+        total: 1,
+        successful: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      hits: {
+        total: 0,
+        max_score: 0,
+        hits: [],
+      },
+      body: {
+        fields: [
+          { name: 'timestamp', type: 'date', values: [mockDateString] },
+          { name: 'message', type: 'keyword', values: ['test message'] },
+        ],
+        size: 1,
+        name: 'test-index',
+      },
+      type: DATA_FRAME_TYPES.DEFAULT,
+    };
+
+    const result = convertResult(response);
+    expect(result.hits.hits[0]._source.timestamp).toBe(expectedFormattedDate);
+    expect(result.hits.hits[0]._source.message).toBe('test message');
+  });
+
+  it('should handle nested objects with dates', () => {
+    const response: IDataFrameResponse = {
+      took: 100,
+      timed_out: false,
+      _shards: {
+        total: 1,
+        successful: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      hits: {
+        total: 0,
+        max_score: 0,
+        hits: [],
+      },
+      body: {
+        fields: [
+          {
+            name: 'metadata',
+            type: 'object',
+            values: [{ created_at: mockDateString, status: 'active' }],
+          },
+        ],
+        size: 1,
+        name: 'test-index',
+      },
+      type: DATA_FRAME_TYPES.DEFAULT,
+    };
+
+    const result = convertResult(response);
+    expect(result.hits.hits[0]._source.metadata.created_at).toBe(expectedFormattedDate);
+    expect(result.hits.hits[0]._source.metadata.status).toBe('active');
+  });
+
+  it('should handle aggregations with date histogram', () => {
+    const response: IDataFrameResponse = {
+      took: 100,
+      timed_out: false,
+      _shards: {
+        total: 1,
+        successful: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      hits: {
+        total: 0,
+        max_score: 0,
+        hits: [],
+      },
+      body: {
+        fields: [],
+        size: 0,
+        name: 'test-index',
+        aggs: {
+          timestamp_histogram: [
+            { key: mockDateString, value: 10 },
+            { key: '2025-02-13 01:51:50', value: 20 },
+          ],
+        },
+        meta: {
+          date_histogram: true,
+        },
+      },
+      type: DATA_FRAME_TYPES.DEFAULT,
+    };
+
+    const result = convertResult(response);
+    expect(result.aggregations?.timestamp_histogram.buckets).toHaveLength(2);
+    expect(result.aggregations?.timestamp_histogram.buckets[0].doc_count).toBe(10);
+  });
+
+  it('should handle error response', () => {
+    const errorResponse: IDataFrameErrorResponse = {
+      type: DATA_FRAME_TYPES.ERROR,
+      took: 0,
+      body: {
+        error: 'Some error message',
+        timed_out: false,
+        took: 0,
+        _shards: {
+          total: 1,
+          successful: 1,
+          skipped: 0,
+          failed: 0,
+        },
+        hits: {
+          total: 0,
+          max_score: 0,
+          hits: [],
+        },
+      },
+    };
+
+    const result = convertResult(errorResponse as IDataFrameResponse);
+    expect(result).toEqual(errorResponse);
   });
 });

--- a/src/plugins/data/common/data_frames/utils.test.ts
+++ b/src/plugins/data/common/data_frames/utils.test.ts
@@ -14,6 +14,7 @@ import {
 import moment from 'moment';
 import { ISearchOptions, SearchSourceFields } from '../search';
 import { IIndexPatternFieldList, IndexPattern, IndexPatternField } from '../index_patterns';
+import { OSD_FIELD_TYPES } from '../types';
 
 describe('formatTimePickerDate', () => {
   const mockDateFormat = 'YYYY-MM-DD HH:mm:ss';
@@ -95,12 +96,14 @@ describe('convertResult', () => {
     };
 
     // Custom date formatter
-    const customFormatter = (dateStr: string) => {
-      return moment.utc(dateStr).format('YYYY-MM-DDTHH:mm:ssZ');
+    const customFormatter = (dateStr: string, type: OSD_FIELD_TYPES) => {
+      if (type === OSD_FIELD_TYPES.DATE) {
+        return moment.utc(dateStr).format('YYYY-MM-DDTHH:mm:ssZ');
+      }
     };
 
     const options: ISearchOptions = {
-      dateFieldsFormatter: customFormatter,
+      formatter: customFormatter,
     };
 
     const result = convertResult({ response, options });
@@ -188,12 +191,14 @@ describe('convertResult', () => {
     };
 
     // Custom date formatter
-    const customFormatter = (dateStr: string) => {
-      return moment.utc(dateStr).format('YYYY-MM-DDTHH:mm:ssZ');
+    const customFormatter = (dateStr: string, type: OSD_FIELD_TYPES) => {
+      if (type === OSD_FIELD_TYPES.DATE) {
+        return moment.utc(dateStr).format('YYYY-MM-DDTHH:mm:ssZ');
+      }
     };
 
     const options: ISearchOptions = {
-      dateFieldsFormatter: customFormatter,
+      formatter: customFormatter,
     };
 
     const result = convertResult({ response, fields, options });

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -57,7 +57,7 @@ export const convertResult = (response: IDataFrameResponse): SearchResponse<any>
       const processField = (field: any, value: any): any => {
         // Handle date fields
         if (moment(value, ['YYYY-MM-DD HH:mm:ss'], true).isValid()) {
-          return value.replace(' ', 'T') + '+00:00';
+          return moment.utc(value).format('YYYY-MM-DDTHH:mm:ssZ');
         }
 
         // Handle nested objects with potential date fields

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -9,7 +9,6 @@ import moment from 'moment';
 import {
   DATA_FRAME_TYPES,
   DataFrameAggConfig,
-  IDataFrame,
   IDataFrameWithAggs,
   IDataFrameResponse,
   PartialDataFrame,
@@ -18,6 +17,8 @@ import {
 import { IFieldType } from './fields';
 import { IndexPatternFieldMap, IndexPatternSpec } from '../index_patterns';
 import { TimeRange } from '../types';
+import { IDataFrame } from './types';
+import { SearchSourceFields } from '../search';
 
 /**
  * Converts the data frame response to a search response.
@@ -27,7 +28,14 @@ import { TimeRange } from '../types';
  * @param response - data frame response object
  * @returns converted search response
  */
-export const convertResult = (response: IDataFrameResponse): SearchResponse<any> => {
+export const convertResult = ({
+  response,
+  fields,
+}: {
+  response: IDataFrameResponse;
+  fields: SearchSourceFields;
+}): SearchResponse<any> => {
+  console.log('fields', fields);
   const body = response.body;
   if (body.hasOwnProperty('error')) {
     return response;

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -384,6 +384,7 @@ export class IndexPattern implements IIndexPattern {
     return (this.fieldsLoading = status);
   };
 
+  // DQL and Lucene already calling this formatter, we should add ppl formatter in the language config
   /**
    * Provide a field, get its formatter
    * @param field

--- a/src/plugins/data/common/search/aggs/buckets/date_histogram.ts
+++ b/src/plugins/data/common/search/aggs/buckets/date_histogram.ts
@@ -133,7 +133,7 @@ export const getDateHistogramBucketAgg = ({
             buckets = new TimeBuckets({
               'histogram:maxBars': getConfig(UI_SETTINGS.HISTOGRAM_MAX_BARS),
               'histogram:barTarget': getConfig(UI_SETTINGS.HISTOGRAM_BAR_TARGET),
-              dateFormat: getConfig('dateFormat'),
+              dateFormat: getConfig(UI_SETTINGS.DATE_FORMAT),
               'dateFormat:scaled': getConfig('dateFormat:scaled'),
             });
             updateTimeBuckets(this, calculateBounds, buckets);

--- a/src/plugins/data/common/search/aggs/utils/calculate_auto_time_expression.ts
+++ b/src/plugins/data/common/search/aggs/utils/calculate_auto_time_expression.ts
@@ -45,7 +45,7 @@ export function getCalculateAutoTimeExpression(getConfig: (key: string) => any) 
     const buckets = new TimeBuckets({
       'histogram:maxBars': getConfig(UI_SETTINGS.HISTOGRAM_MAX_BARS),
       'histogram:barTarget': getConfig(UI_SETTINGS.HISTOGRAM_BAR_TARGET),
-      dateFormat: getConfig('dateFormat'),
+      dateFormat: getConfig(UI_SETTINGS.DATE_FORMAT),
       'dateFormat:scaled': getConfig('dateFormat:scaled'),
     });
 

--- a/src/plugins/data/common/search/opensearch_search/types.ts
+++ b/src/plugins/data/common/search/opensearch_search/types.ts
@@ -31,6 +31,7 @@
 import { SearchResponse } from 'elasticsearch';
 import { Search } from '@opensearch-project/opensearch/api/requestParams';
 import { IOpenSearchDashboardsSearchRequest, IOpenSearchDashboardsSearchResponse } from '../types';
+import { OSD_FIELD_TYPES } from '../../types';
 
 export const OPENSEARCH_SEARCH_STRATEGY = 'opensearch';
 export const OPENSEARCH_SEARCH_WITH_LONG_NUMERALS_STRATEGY = 'opensearch-with-long-numerals';
@@ -49,9 +50,9 @@ export interface ISearchOptions {
    */
   withLongNumeralsSupport?: boolean;
   /**
-   * Use this option to format the date fields in the search response.
+   * Use this option to format the fields in the search response.
    */
-  dateFieldsFormatter?: (value: string) => string;
+  formatter?: (value: any, type: OSD_FIELD_TYPES) => any;
 }
 
 export type ISearchRequestParams<T = Record<string, any>> = {

--- a/src/plugins/data/common/search/opensearch_search/types.ts
+++ b/src/plugins/data/common/search/opensearch_search/types.ts
@@ -48,6 +48,10 @@ export interface ISearchOptions {
    * Use this option to enable support for long numerals.
    */
   withLongNumeralsSupport?: boolean;
+  /**
+   * Use this option to format the date fields in the search response.
+   */
+  dateFieldsFormatter?: (value: string) => string;
 }
 
 export type ISearchRequestParams<T = Record<string, any>> = {

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -124,7 +124,7 @@ import { handleQueryResults } from '../../utils/helpers';
 
 /** @internal */
 export const searchSourceRequiredUiSettings = [
-  'dateFormat:tz',
+  UI_SETTINGS.DATE_FORMAT_TIMEZONE,
   UI_SETTINGS.COURIER_BATCH_SEARCHES,
   UI_SETTINGS.COURIER_CUSTOM_REQUEST_PREFERENCE,
   UI_SETTINGS.COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX,
@@ -444,7 +444,13 @@ export class SearchSource {
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.DEFAULT) {
           const dataFrameResponse = response as IDataFrameDefaultResponse;
           await this.setDataFrame(dataFrameResponse.body as IDataFrame);
-          return onResponse(searchRequest, convertResult(response as IDataFrameResponse));
+
+          const timeZone = getConfig(UI_SETTINGS.DATE_FORMAT_TIMEZONE);
+          const timeFormat = getConfig(UI_SETTINGS.DATE_FORMAT);
+          return onResponse(
+            searchRequest,
+            convertResult(response as IDataFrameResponse, timeZone, timeFormat)
+          );
         }
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.POLLING) {
           const startTime = Date.now();

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -121,7 +121,6 @@ import { getHighlightRequest } from '../../../common/field_formats';
 import { fetchSoon } from './legacy';
 import { extractReferences } from './extract_references';
 import { handleQueryResults } from '../../utils/helpers';
-import { query } from '../../../../console/server/lib/spec_definitions/js/query/dsl';
 
 /** @internal */
 export const searchSourceRequiredUiSettings = [
@@ -450,6 +449,7 @@ export class SearchSource {
             convertResult({
               fields: this.getFields(),
               response: response as IDataFrameResponse,
+              options,
             })
           );
         }

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -444,13 +444,7 @@ export class SearchSource {
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.DEFAULT) {
           const dataFrameResponse = response as IDataFrameDefaultResponse;
           await this.setDataFrame(dataFrameResponse.body as IDataFrame);
-
-          const timeZone = getConfig(UI_SETTINGS.DATE_FORMAT_TIMEZONE);
-          const timeFormat = getConfig(UI_SETTINGS.DATE_FORMAT);
-          return onResponse(
-            searchRequest,
-            convertResult(response as IDataFrameResponse, timeZone, timeFormat)
-          );
+          return onResponse(searchRequest, convertResult(response as IDataFrameResponse));
         }
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.POLLING) {
           const startTime = Date.now();

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -447,8 +447,8 @@ export class SearchSource {
           return onResponse(
             searchRequest,
             convertResult({
-              fields: this.getFields(),
               response: response as IDataFrameResponse,
+              fields: this.getFields(),
               options,
             })
           );
@@ -484,7 +484,14 @@ export class SearchSource {
           (results as any).took = elapsedMs;
 
           await this.setDataFrame((results as QuerySuccessStatusResponse).body as IDataFrame);
-          return onResponse(searchRequest, convertResult(results as IDataFrameResponse));
+          return onResponse(
+            searchRequest,
+            convertResult({
+              response: results as IDataFrameResponse,
+              fields: this.getFields(),
+              options,
+            })
+          );
         }
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.ERROR) {
           const dataFrameError = response as IDataFrameError;

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -121,6 +121,7 @@ import { getHighlightRequest } from '../../../common/field_formats';
 import { fetchSoon } from './legacy';
 import { extractReferences } from './extract_references';
 import { handleQueryResults } from '../../utils/helpers';
+import { query } from '../../../../console/server/lib/spec_definitions/js/query/dsl';
 
 /** @internal */
 export const searchSourceRequiredUiSettings = [
@@ -444,7 +445,13 @@ export class SearchSource {
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.DEFAULT) {
           const dataFrameResponse = response as IDataFrameDefaultResponse;
           await this.setDataFrame(dataFrameResponse.body as IDataFrame);
-          return onResponse(searchRequest, convertResult(response as IDataFrameResponse));
+          return onResponse(
+            searchRequest,
+            convertResult({
+              fields: this.getFields(),
+              response: response as IDataFrameResponse,
+            })
+          );
         }
         if ((response as IDataFrameResponse).type === DATA_FRAME_TYPES.POLLING) {
           const startTime = Date.now();

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -81,9 +81,6 @@ export const indexTypeConfig: DatasetTypeConfig = {
       pattern: dataset.title,
       dataSourceId: dataset.dataSource?.id,
     });
-    // TODO: map fields to the OSD Field type
-    // Similar to the S3 where it casteS3FieldTypeToOsdFieldType
-    // if field is object then transform
     return fields.map((field: any) => ({
       name: field.name,
       type: field.type,

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -81,6 +81,9 @@ export const indexTypeConfig: DatasetTypeConfig = {
       pattern: dataset.title,
       dataSourceId: dataset.dataSource?.id,
     });
+    // TODO: map fields to the OSD Field type
+    // Similar to the S3 where it casteS3FieldTypeToOsdFieldType
+    // if field is object then transform
     return fields.map((field: any) => ({
       name: field.name,
       type: field.type,

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -54,7 +54,7 @@ export interface LanguageConfig {
     sortable?: boolean;
     filterable?: boolean;
     visualizable?: boolean;
-    // TODO: Add more field formatter options for PPL since we need to format ppl date fields
+    dateFieldsFormatter?: (value: string) => string;
   };
   showDocLinks?: boolean;
   docLink?: {

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -5,6 +5,7 @@
 
 import { ISearchInterceptor } from '../../../search';
 import {
+  OSD_FIELD_TYPES,
   Query,
   QueryEditorExtensionConfig,
   QueryStringContract,
@@ -54,7 +55,7 @@ export interface LanguageConfig {
     sortable?: boolean;
     filterable?: boolean;
     visualizable?: boolean;
-    dateFieldsFormatter?: (value: string) => string;
+    formatter?: (value: any, type: OSD_FIELD_TYPES) => any;
   };
   showDocLinks?: boolean;
   docLink?: {

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -54,6 +54,7 @@ export interface LanguageConfig {
     sortable?: boolean;
     filterable?: boolean;
     visualizable?: boolean;
+    // TODO: Add more field formatter options for PPL since we need to format ppl date fields
   };
   showDocLinks?: boolean;
   docLink?: {

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -252,8 +252,8 @@ export const useSearch = (services: DiscoverViewServices) => {
         abortSignal: fetchStateRef.current.abortController.signal,
         withLongNumeralsSupport: await services.uiSettings.get(UI_SETTINGS.DATA_WITH_LONG_NUMERALS),
         ...(languageConfig &&
-          languageConfig.fields?.dateFieldsFormatter && {
-            dateFieldsFormatter: languageConfig.fields.dateFieldsFormatter,
+          languageConfig.fields?.formatter && {
+            formatter: languageConfig.fields.formatter,
           }),
       });
 

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -243,10 +243,18 @@ export const useSearch = (services: DiscoverViewServices) => {
         trackQueryMetric(query);
       }
 
+      const languageConfig = data.query.queryString
+        .getLanguageService()
+        .getLanguage(query!.language);
+
       // Execute the search
       const fetchResp = await searchSource.fetch({
         abortSignal: fetchStateRef.current.abortController.signal,
         withLongNumeralsSupport: await services.uiSettings.get(UI_SETTINGS.DATA_WITH_LONG_NUMERALS),
+        ...(languageConfig &&
+          languageConfig.fields?.dateFieldsFormatter && {
+            dateFieldsFormatter: languageConfig.fields.dateFieldsFormatter,
+          }),
       });
 
       inspectorRequest

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -4,6 +4,7 @@
  */
 import { i18n } from '@osd/i18n';
 import { BehaviorSubject } from 'rxjs';
+import moment from 'moment';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
 import { DataStorage } from '../../data/common';
 import {
@@ -66,7 +67,12 @@ export class QueryEnhancementsPlugin
         usageCollector: data.search.usageCollector,
       }),
       getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
-      fields: { sortable: false, filterable: false, visualizable: false },
+      fields: {
+        sortable: false,
+        filterable: false,
+        visualizable: false,
+        dateFieldsFormatter: (value: string) => moment.utc(value).format('YYYY-MM-DDTHH:mm:ssZ'), // PPL date fields need special formatting in order for discover table formatter to render in the correct time zone
+      },
       docLink: {
         title: i18n.translate('queryEnhancements.pplLanguage.docLink', {
           defaultMessage: 'PPL documentation',

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -6,7 +6,7 @@ import { i18n } from '@osd/i18n';
 import { BehaviorSubject } from 'rxjs';
 import moment from 'moment';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
-import { DataStorage } from '../../data/common';
+import { DataStorage, OSD_FIELD_TYPES } from '../../data/common';
 import {
   createEditor,
   DefaultInput,
@@ -71,7 +71,15 @@ export class QueryEnhancementsPlugin
         sortable: false,
         filterable: false,
         visualizable: false,
-        dateFieldsFormatter: (value: string) => moment.utc(value).format('YYYY-MM-DDTHH:mm:ssZ'), // PPL date fields need special formatting in order for discover table formatter to render in the correct time zone
+        formatter: (value: string, type: OSD_FIELD_TYPES) => {
+          switch (type) {
+            case OSD_FIELD_TYPES.DATE:
+              return moment.utc(value).format('YYYY-MM-DDTHH:mm:ssZ'); // PPL date fields need special formatting in order for discover table formatter to render in the correct time zone
+
+            default:
+              return value;
+          }
+        },
       },
       docLink: {
         title: i18n.translate('queryEnhancements.pplLanguage.docLink', {


### PR DESCRIPTION
### Description
When sending PPL requests, the time based fields are rendered in wrong time zone, and it looks like DQL and PPL are getting different results. We should format the PPL search response to the same format as DQL search response to indicate it is in UTC so the time fields can be formatted and rendered correctly in the discover table according to user defined time zone in advanced setting.

For example, previously 
```
// PPL search response
"order_date": "2025-02-13 00:51:50"

// DQL search response
"order_date": "2025-02-13T00:51:50+00:00”
```


### Issues Resolved

resolves #9104 

## Screenshot
Before: 
 
PPL render time field in the wrong timezone

https://github.com/user-attachments/assets/f0e24d6e-6560-4897-9d3b-5b41c780b26e

After: 

PPL and DQL return and render same results for default timezone or user defined timezone

https://github.com/user-attachments/assets/8cbc8917-3826-4c5c-81a4-0941f7af9e96




## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- fix: Make PPL time column respect time zone and date format


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
