### PR TITLE
[TEST] when creating a data source in tests, delete data source if it already exists first

### DIFF
--- a/cypress/utils/commands.osd.js
+++ b/cypress/utils/commands.osd.js
@@ -99,6 +99,9 @@ cy.osd.add('addDataSource', (options) => {
 
   const { name, url, authType = 'no_auth', credentials = {} } = options;
 
+  // in case the data source already exists, delete it first
+  cy.osd.deleteDataSourceByName(name);
+
   // Visit the create data source page
   cy.visit('app/management/opensearch-dashboards/dataSources/create');
 
@@ -148,12 +151,26 @@ cy.osd.add('deleteDataSourceByName', (dataSourceName) => {
   // Navigate to the dataSource Management page
   cy.visit('app/dataSources');
 
-  // Find the anchor text corresponding to specified dataSource
-  cy.get('a').contains(dataSourceName).click();
+  cy.get('h1').contains('Data sources').should('be.visible');
 
-  // Delete the dataSource connection
-  cy.getElementByTestId('editDatasourceDeleteIcon').click();
-  cy.getElementByTestId('confirmModalConfirmButton').click();
+  // wait to ensure page fully loaded
+  cy.wait(1000);
+
+  cy.get('body').then(($body) => {
+    const dataSourceButton = $body.find(
+      `[data-test-subj="dataSourcesManagement-dataSourceTableRowLink-${dataSourceName}"]`
+    );
+
+    if (dataSourceButton.length) {
+      cy.getElementByTestId(
+        `dataSourcesManagement-dataSourceTableRowLink-${dataSourceName}`
+      ).click();
+
+      // Delete the dataSource connection
+      cy.getElementByTestId('editDatasourceDeleteIcon').click();
+      cy.getElementByTestId('confirmModalConfirmButton').click();
+    }
+  });
 });
 
 // Deletes all data sources. This command should only be used for convenience during development

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -196,4 +196,5 @@
   - [RELEASING](../RELEASING.md)
   - [SECURITY](../SECURITY.md)
   - [TESTING](../TESTING.md)
+  - [TRIAGING](../TRIAGING.md)
   - [TYPESCRIPT](../TYPESCRIPT.md)

--- a/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_table/data_source_table.tsx
@@ -267,7 +267,12 @@ export const DataSourceTable = ({ history }: RouteComponentProps) => {
         }
       ) => (
         <>
-          <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `${index.id}`)} flush="left">
+          <EuiButtonEmpty
+            size="xs"
+            {...reactRouterNavigate(history, `${index.id}`)}
+            flush="left"
+            data-test-subj={`dataSourcesManagement-dataSourceTableRowLink-${name}`}
+          >
             {name}
           </EuiButtonEmpty>
           {index.id === defaultDataSourceId ? (


### PR DESCRIPTION


### Description

- See the errors in this cypress run: https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/13298635283/job/37135873746?pr=9358
- This happens when a data source that a test is trying to create already exists
- My change will delete the data source if it already exists before creating the new one
- This will also resolve alot of UX frustration when writing tests, where often times we would have to manually delete them

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
