### PR TITLE
Top Values and Filter Sidebar Fields By Type functionality for Discover

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/field_display_filtering.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/field_display_filtering.spec.js
@@ -7,7 +7,6 @@ import { DATASOURCE_NAME, INDEX_WITH_TIME_1 } from '../../../../../utils/apps/co
 import * as docTable from '../../../../../utils/apps/query_enhancements/doc_table.js';
 import { generateFieldDisplayFilteringTestConfiguration } from '../../../../../utils/apps/query_enhancements/field_display_filtering.js';
 import { PATHS, BASE_PATH } from '../../../../../utils/constants';
-import { NEW_SEARCH_BUTTON } from '../../../../../utils/dashboards/data_explorer/elements.js';
 import {
   generateAllTestConfigurations,
   getRandomizedWorkspaceName,
@@ -53,7 +52,7 @@ const fieldDisplayFilteringTestSuite = () => {
         page: 'discover',
         isEnhancement: true,
       });
-      cy.getElementByTestId(NEW_SEARCH_BUTTON).click();
+      cy.getElementByTestId('discoverNewButton').click();
     });
 
     afterEach(() => {

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/inspect.spec.js
@@ -11,7 +11,6 @@ import {
 } from '../../../../../utils/apps/constants.js';
 import * as docTable from '../../../../../utils/apps/query_enhancements/doc_table.js';
 import { PATHS, BASE_PATH } from '../../../../../utils/constants.js';
-import { NEW_SEARCH_BUTTON } from '../../../../../utils/dashboards/data_explorer/elements.js';
 import {
   generateAllTestConfigurations,
   getRandomizedWorkspaceName,
@@ -66,7 +65,7 @@ const inspectTestSuite = () => {
         page: 'discover',
         isEnhancement: true,
       });
-      cy.getElementByTestId(NEW_SEARCH_BUTTON).click();
+      cy.getElementByTestId('discoverNewButton').click();
     });
 
     afterEach(() => {

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/inspect.spec.js
@@ -92,7 +92,7 @@ const inspectTestSuite = () => {
           );
 
           for (const [key, value] of Object.entries(flattenedFieldsWithValues)) {
-            // For SQL and PPL, this number is not accurate. https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9305
+            // TODO: For SQL and PPL, this number is not accurate. https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9305
             if (
               key === 'event_sequence_number' &&
               (config.language === QueryLanguages.SQL.name ||

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/sidebar.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/sidebar.spec.js
@@ -22,6 +22,72 @@ import { prepareTestSuite } from '../../../../../utils/helpers';
 
 const workspaceName = getRandomizedWorkspaceName();
 
+const sidebarFields = {
+  aggregatableFields: {
+    unnested: [
+      'bytes_transferred',
+      'category',
+      'event_sequence_number',
+      'event_time',
+      'request_url',
+      'response_time',
+      'service_endpoint',
+      'status_code',
+      'timestamp',
+      'unique_category',
+    ],
+    nested: [
+      'personal.address.country',
+      'personal.address.city',
+      'personal.address.coordinates.lat',
+      'personal.address.coordinates.lon',
+      'personal.address.street',
+      'personal.age',
+      'personal.birthdate',
+      'personal.email',
+      'personal.name',
+      'personal.user_id',
+    ],
+  },
+  nonAggregatableFields: ['_score', '_type'],
+  searchableFields: [
+    'bytes_transferred',
+    'category',
+    'event_sequence_number',
+    'event_time',
+    'request_url',
+    'response_time',
+    'service_endpoint',
+    'status_code',
+    'timestamp',
+    'unique_category',
+    'personal.address.country',
+    'personal.address.city',
+    'personal.address.coordinates.lat',
+    'personal.address.coordinates.lon',
+    'personal.address.street',
+    'personal.age',
+    'personal.birthdate',
+    'personal.email',
+    'personal.name',
+    'personal.user_id',
+  ],
+  nonSearchableFields: ['_score', '_type'],
+  missingFields: ['never_present_field'],
+  stringTypeFields: [
+    'category',
+    'personal.address.country',
+    'personal.address.city',
+    'personal.address.street',
+    'personal.email',
+    'personal.name',
+    'personal.user_id',
+    'request_url',
+    'service_endpoint',
+    'unique_category',
+  ],
+};
+
 const addSidebarFieldsAndCheckDocTableColumns = (
   testFields,
   expectedValues,
@@ -251,12 +317,10 @@ export const runSideBarTests = () => {
         });
 
         it('fields should have top values', () => {
-          const testData = {
-            testAggregatableFields: ['bytes_transferred'],
-            testNestedFields: ['personal.address.country'],
-          };
+          const aggregatableFieldsToTest = [sidebarFields.aggregatableFields.unnested[0]];
+          const nestedFieldsToTest = [sidebarFields.aggregatableFields.nested[0]];
 
-          testData.testAggregatableFields.forEach((aggregatableField) => {
+          aggregatableFieldsToTest.forEach((aggregatableField) => {
             verifyFieldShowDetailsShowsTopValuesAndViewVisualization(
               config,
               aggregatableField,
@@ -275,8 +339,47 @@ export const runSideBarTests = () => {
           cy.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
           cy.setQueryLanguage(config.language);
 
-          testData.testNestedFields.forEach((nestedField) => {
+          nestedFieldsToTest.forEach((nestedField) => {
             verifyFieldShowDetailsShowsTopValuesAndViewVisualization(config, nestedField, false);
+          });
+        });
+
+        it('fields should be filtered by type', () => {
+          cy.getElementByTestId('toggleFieldFilterButton').click();
+
+          sideBar.selectFilterVerifySidebarFieldsVisibleAndActiveFiltersNumber(
+            'aggregatable',
+            sidebarFields.aggregatableFields.unnested.concat(
+              sidebarFields.aggregatableFields.nested
+            )
+          );
+
+          // TODO: Index dataset type does not support searchable fields.
+          // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9381
+          if (config.datasetType !== 'INDEXES') {
+            sideBar.selectFilterVerifySidebarFieldsVisibleAndActiveFiltersNumber(
+              'searchable',
+              sidebarFields.searchableFields
+            );
+          }
+
+          cy.getElementByTestId('missingSwitch').click();
+          sidebarFields.missingFields.forEach((fieldName) => {
+            cy.getElementByTestId(`field-${fieldName}`).should('be.visible');
+          });
+          cy.getElementByTestId('missingSwitch').click();
+
+          sideBar.verifyNumberOfActiveFilters(0);
+          cy.getElementByTestId('aggregatable-true').parent().click();
+          sideBar.verifyNumberOfActiveFilters(1);
+          cy.getElementByTestId('typeSelect').select('string');
+          sideBar.verifyNumberOfActiveFilters(2);
+
+          const intersectionAggregatableStringTypeSidebarFields = sidebarFields.aggregatableFields.unnested
+            .concat(sidebarFields.aggregatableFields.nested)
+            .filter((field) => sidebarFields.stringTypeFields.includes(field));
+          intersectionAggregatableStringTypeSidebarFields.forEach((fieldName) => {
+            cy.getElementByTestId(`field-${fieldName}`).should('be.visible');
           });
         });
       });

--- a/cypress/utils/apps/query_enhancements/constants.js
+++ b/cypress/utils/apps/query_enhancements/constants.js
@@ -83,6 +83,7 @@ export const QueryLanguages = {
       datepicker: true,
       multilineQuery: false,
       expandedDocument: true,
+      visualizeButton: true,
     },
   },
   Lucene: {
@@ -96,6 +97,7 @@ export const QueryLanguages = {
       datepicker: true,
       multilineQuery: false,
       expandedDocument: true,
+      visualizeButton: true,
     },
   },
   SQL: {
@@ -109,6 +111,7 @@ export const QueryLanguages = {
       datepicker: false,
       multilineQuery: true,
       expandedDocument: false,
+      visualizeButton: false,
     },
   },
   PPL: {
@@ -123,6 +126,7 @@ export const QueryLanguages = {
       datepicker: true,
       multilineQuery: true,
       expandedDocument: false,
+      visualizeButton: false,
     },
   },
 };

--- a/cypress/utils/apps/query_enhancements/sidebar.js
+++ b/cypress/utils/apps/query_enhancements/sidebar.js
@@ -99,3 +99,31 @@ export const generateSideBarTestConfiguration = (dataset, datasetType, language)
     visualizeButton: language.supports.visualizeButton,
   };
 };
+
+/**
+ * Verify that the sidebar filters shows the number of sidebar filters active.
+ * @param {number} numActiveFilters - Number of sidebar filters that are active
+ */
+export const verifyNumberOfActiveFilters = (numActiveFilters) => {
+  cy.getElementByTestId('toggleFieldFilterButton')
+    .find(`[aria-label="${numActiveFilters} active filters"]`)
+    .should('be.visible');
+};
+
+/**
+ * Select the filter in the sidebar, verify sidebar fields are filtered correctly, and the number of sidebar filters is displayed correctly.
+ * @param {string} filterType - Filters in the sidebar : 'aggregatable' xor 'searchable' only.
+ * @param {[string]} sidebarFields - Fields that should exist in the sidebar after applying the filter.
+ */
+export const selectFilterVerifySidebarFieldsVisibleAndActiveFiltersNumber = (
+  filterType,
+  sidebarFields
+) => {
+  cy.getElementByTestId(`${filterType}-true`).parent().click();
+  sidebarFields.forEach((fieldName) => {
+    cy.getElementByTestId(`field-${fieldName}`).should('be.visible');
+  });
+  verifyNumberOfActiveFilters(1);
+  cy.getElementByTestId(`${filterType}-any`).parent().click();
+  verifyNumberOfActiveFilters(0);
+};

--- a/cypress/utils/apps/query_enhancements/sidebar.js
+++ b/cypress/utils/apps/query_enhancements/sidebar.js
@@ -64,6 +64,17 @@ export const selectFieldFromSidebar = (field) => {
 };
 
 /**
+ * Shows Top Values of the field in a popover by clicking field show details button.
+ * @param {string} field Field name to show top values
+ * @example
+ * // View Top Values of the timestamp field.
+ * selectFieldFromSidebar('timestamp')
+ */
+export const showSidebarFieldDetails = (field) => {
+  cy.getElementByTestId(`field-${field}-showDetails`).click();
+};
+
+/**
  * The configurations needed for side bar tests
  * @typedef {Object} SideBarTestConfig
  * @property {string} dataset - the dataset name to use
@@ -85,5 +96,6 @@ export const generateSideBarTestConfiguration = (dataset, datasetType, language)
     datasetType,
     language: language.name,
     testName: `dataset: ${datasetType} and language: ${language.name}`,
+    visualizeButton: language.supports.visualizeButton,
   };
 };


### PR DESCRIPTION
### Description

Adds a Cypress test spec for the Top Values and Filter Sidebar Fields by Type functionality for the Discover page.

### Issues Resolved

closes #8946 

## Screenshot


https://github.com/user-attachments/assets/d21b0847-8862-45d0-97d6-1aaa7b480fa4


https://github.com/user-attachments/assets/1e58a9c9-d932-4a43-b9c2-2fd0b642c90c


https://github.com/user-attachments/assets/ae826978-95bd-4234-8523-93a27b323b93


https://github.com/user-attachments/assets/12195050-f22f-4a6c-b1e7-172a26ec26a0


https://github.com/user-attachments/assets/1248eaf9-27c2-47a0-8c81-9ee811713163


https://github.com/user-attachments/assets/4605ff7f-1408-48b5-b257-dd840f24d4a6


https://github.com/user-attachments/assets/2da52ce3-0373-46c0-b199-e1558c39bca3


https://github.com/user-attachments/assets/91277bed-a2c8-4d39-8961-94d1a64d416a


https://github.com/user-attachments/assets/5e23eebb-50c2-43e0-99ce-15d07f230e32


https://github.com/user-attachments/assets/22cce073-16fd-4f15-a5a7-86e6f06d8ad2


https://github.com/user-attachments/assets/d1d37511-759a-4ac8-b9fe-a9dbfe7db795


https://github.com/user-attachments/assets/bf1b2787-84de-458c-ac4a-e5fb6999603c



## Testing the changes

With OSD running, run `yarn run cypress open`. In E2E specs, you will see sidebar.spec.js. Run the test spec.

## Changelog
- test: Add Top Values and Filter Sidebar Fields by Type testing for the Discover Page.
