### PR TITLE
Remove reload in saved_search spec as bug has been resolved

### DIFF
--- a/changelogs/fragments/9396.yml
+++ b/changelogs/fragments/9396.yml
@@ -1,0 +1,2 @@
+test:
+- Remove unnecessary reload in saved_search test. ([#9396](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9396))

--- a/cypress/utils/apps/query_enhancements/saved.js
+++ b/cypress/utils/apps/query_enhancements/saved.js
@@ -250,9 +250,6 @@ export const setSearchConfigurations = ({
 
     cy.getElementByTestId(`docTableHeaderFieldSort_${APPLIED_SORT}`).click();
 
-    // TODO: This reload shouldn't need to be here, but currently the sort doesn't always happen right away
-    // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9131
-    cy.reload();
     cy.getElementByTestId('querySubmitButton').should('be.visible');
   }
 };


### PR DESCRIPTION
### Description

To workaround [a bug](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9131), a reload was added. Now that the bug has been resolved, the reload no longer needs to be there.

### Issues Resolved

closes #9131

## Screenshot

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/a2b72dc1-116c-4d82-b33f-becfec22fecb" />


## Testing the changes

With OSD running, run yarn run cypress open. In E2E specs, you will see saved_search.spec.js. Run the test spec.

## Changelog
- test: remove unnecessary reload in saved_search test.
