### PR TITLE
[Discover]: Make colour of discover histogram match theme

### DIFF
--- a/changelogs/fragments/9405.yml
+++ b/changelogs/fragments/9405.yml
@@ -1,0 +1,2 @@
+chore:
+- Make colour of discover histogram match theme ([#9405](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9405))

--- a/src/plugins/discover/public/application/components/chart/histogram/histogram.tsx
+++ b/src/plugins/discover/public/application/components/chart/histogram/histogram.tsx
@@ -316,6 +316,8 @@ export class DiscoverHistogram extends Component<DiscoverHistogramProps, Discove
     chartsTheme.axes!.axisTitle = {
       fill: euiThemeVars.euiTextColor,
     };
+    chartsTheme.colors = chartsTheme.colors ?? {};
+    chartsTheme.colors.vizColors = [euiThemeVars.euiColorVis1_behindText];
 
     return (
       <Chart size="100%">


### PR DESCRIPTION
### Description

Make colour of discover histogram match theme

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

Before
<img width="1920" alt="2172" src="https://github.com/user-attachments/assets/4d2f1778-f83a-47b9-8c3a-ed1ddc61644b" />


After
<img width="1919" alt="2171" src="https://github.com/user-attachments/assets/2493efbe-4f85-4ddd-bfd0-099cdd040a90" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: Make colour of discover histogram match theme

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
