### PR TITLE
[workspace]remove * when calling find in data source association modal and in workspace list page

### DIFF
--- a/changelogs/fragments/9409.yml
+++ b/changelogs/fragments/9409.yml
@@ -1,0 +1,2 @@
+fix:
+- Remove * when calling find in data source association modal and in workspace list page ([#9409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9409))

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -386,7 +386,7 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.070Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "prependOptions": undefined,
               "query": Object {
@@ -405,7 +405,7 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.070Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "prependOptions": undefined,
               "query": Object {
@@ -426,7 +426,7 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.070Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "prependOptions": undefined,
               "query": Object {
@@ -587,7 +587,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": Object {},
+              "prependOptions": undefined,
               "query": Object {
                 "workspaces": Array [
                   "foo",
@@ -699,7 +699,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.096Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "prependOptions": undefined,
               "query": Object {
@@ -721,7 +721,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.096Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "prependOptions": undefined,
               "query": Object {
@@ -745,7 +745,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.096Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "prependOptions": undefined,
               "query": Object {
@@ -818,7 +818,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": Object {},
+              "prependOptions": undefined,
               "query": Object {
                 "default_search_operator": "OR",
                 "fields": Array [
@@ -859,7 +859,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": Object {},
+              "prependOptions": undefined,
               "query": Object {
                 "workspaces": Array [
                   "bar",

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -521,9 +521,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": Object {
-                "withoutClientBasePath": true,
-              },
+              "prependOptions": undefined,
               "query": Object {
                 "default_search_operator": "OR",
                 "fields": Array [
@@ -562,9 +560,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": Object {
-                "withoutClientBasePath": true,
-              },
+              "prependOptions": undefined,
               "query": Object {},
             },
           ],

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -82,6 +82,7 @@ describe('SavedObjectsClient', () => {
           Object {
             "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\"}]",
             "method": "POST",
+            "prependOptions": undefined,
             "query": undefined,
           },
         ]
@@ -103,6 +104,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"type1\\"},{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"type0\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -126,6 +128,7 @@ describe('SavedObjectsClient', () => {
           Object {
             "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\"},{\\"id\\":\\"some-id\\",\\"type\\":\\"some-type\\"}]",
             "method": "POST",
+            "prependOptions": undefined,
             "query": undefined,
           },
         ]
@@ -196,6 +199,7 @@ describe('SavedObjectsClient', () => {
           Object {
             "body": undefined,
             "method": "DELETE",
+            "prependOptions": undefined,
             "query": Object {
               "force": false,
             },
@@ -240,6 +244,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"version\\":\\"1\\"}",
               "method": "PUT",
+              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -302,6 +307,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"}}",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -320,6 +326,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"}}",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -340,6 +347,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -378,8 +386,9 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.070Z\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": false,
               },
@@ -396,8 +405,9 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.070Z\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": true,
               },
@@ -416,8 +426,9 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.070Z\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
                 "workspaces": Array [
@@ -460,6 +471,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\"}]",
               "method": "PUT",
+              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -509,6 +521,9 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
+              "prependOptions": Object {
+                "withoutClientBasePath": true,
+              },
               "query": Object {
                 "default_search_operator": "OR",
                 "fields": Array [
@@ -547,6 +562,9 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
+              "prependOptions": Object {
+                "withoutClientBasePath": true,
+              },
               "query": Object {},
             },
           ],
@@ -569,6 +587,7 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
+              "prependOptions": Object {},
               "query": Object {
                 "workspaces": Array [
                   "foo",
@@ -617,6 +636,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -635,6 +655,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -655,6 +676,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -677,8 +699,9 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.096Z\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": false,
                 "workspaces": Array [
@@ -698,8 +721,9 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.096Z\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": true,
                 "workspaces": Array [
@@ -721,8 +745,9 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-02-18T07:16:42.096Z\\"}]",
               "method": "POST",
+              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
                 "workspaces": Array [
@@ -756,6 +781,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\"}]",
               "method": "PUT",
+              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -792,6 +818,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": undefined,
               "method": "GET",
+              "prependOptions": Object {},
               "query": Object {
                 "default_search_operator": "OR",
                 "fields": Array [
@@ -832,6 +859,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": undefined,
               "method": "GET",
+              "prependOptions": Object {},
               "query": Object {
                 "workspaces": Array [
                   "bar",

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -82,7 +82,6 @@ describe('SavedObjectsClient', () => {
           Object {
             "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\"}]",
             "method": "POST",
-            "prependOptions": undefined,
             "query": undefined,
           },
         ]
@@ -104,7 +103,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"type1\\"},{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"type0\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -128,7 +126,6 @@ describe('SavedObjectsClient', () => {
           Object {
             "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\"},{\\"id\\":\\"some-id\\",\\"type\\":\\"some-type\\"}]",
             "method": "POST",
-            "prependOptions": undefined,
             "query": undefined,
           },
         ]
@@ -199,7 +196,6 @@ describe('SavedObjectsClient', () => {
           Object {
             "body": undefined,
             "method": "DELETE",
-            "prependOptions": undefined,
             "query": Object {
               "force": false,
             },
@@ -244,7 +240,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"version\\":\\"1\\"}",
               "method": "PUT",
-              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -307,7 +302,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"}}",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -326,7 +320,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"}}",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -347,7 +340,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -386,9 +378,8 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.478Z\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": false,
               },
@@ -405,9 +396,8 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.478Z\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": true,
               },
@@ -426,9 +416,8 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.478Z\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
                 "workspaces": Array [
@@ -471,7 +460,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\"}]",
               "method": "PUT",
-              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -521,7 +509,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": undefined,
               "query": Object {
                 "default_search_operator": "OR",
                 "fields": Array [
@@ -560,7 +547,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": undefined,
               "query": Object {},
             },
           ],
@@ -583,7 +569,6 @@ describe('SavedObjectsClient', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": undefined,
               "query": Object {
                 "workspaces": Array [
                   "foo",
@@ -632,7 +617,6 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -651,7 +635,6 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -672,7 +655,6 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "{\\"attributes\\":{\\"foo\\":\\"Foo\\",\\"bar\\":\\"Bar\\"},\\"workspaces\\":[\\"foo\\"]}",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
               },
@@ -695,9 +677,8 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.513Z\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": false,
                 "workspaces": Array [
@@ -717,9 +698,8 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.513Z\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": true,
                 "workspaces": Array [
@@ -741,9 +721,8 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.513Z\\"}]",
               "method": "POST",
-              "prependOptions": undefined,
               "query": Object {
                 "overwrite": undefined,
                 "workspaces": Array [
@@ -777,7 +756,6 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\"}]",
               "method": "PUT",
-              "prependOptions": undefined,
               "query": undefined,
             },
           ],
@@ -814,7 +792,6 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": undefined,
               "query": Object {
                 "default_search_operator": "OR",
                 "fields": Array [
@@ -855,7 +832,6 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
             Object {
               "body": undefined,
               "method": "GET",
-              "prependOptions": undefined,
               "query": Object {
                 "workspaces": Array [
                   "bar",

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -378,7 +378,7 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.478Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "query": Object {
                 "overwrite": false,
@@ -396,7 +396,7 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.478Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "query": Object {
                 "overwrite": true,
@@ -416,7 +416,7 @@ describe('SavedObjectsClient', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.478Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "query": Object {
                 "overwrite": undefined,
@@ -677,7 +677,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.513Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "query": Object {
                 "overwrite": false,
@@ -698,7 +698,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.513Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "query": Object {
                 "overwrite": true,
@@ -721,7 +721,7 @@ describe('SavedObjectsClientWithWorkspaceSet', () => {
           Array [
             "/api/saved_objects/_bulk_create",
             Object {
-              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"2025-03-18T02:12:38.513Z\\"}]",
+              "body": "[{\\"id\\":\\"AVwSwFxtcMV38qjDZoQg\\",\\"type\\":\\"config\\",\\"attributes\\":{\\"title\\":\\"Example title\\"},\\"version\\":\\"foo\\",\\"updated_at\\":\\"${updatedAt}\\"}]",
               "method": "POST",
               "query": Object {
                 "overwrite": undefined,

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -42,7 +42,7 @@ import {
 } from '../../server';
 
 import { SimpleSavedObject } from './simple_saved_object';
-import { HttpFetchOptions, HttpSetup } from '../http';
+import { HttpFetchOptions, HttpSetup, PrependOptions } from '../http';
 
 type SavedObjectsFindOptions = Omit<
   SavedObjectFindOptionsServer,
@@ -373,7 +373,8 @@ export class SavedObjectsClient {
    * @returns A find result with objects matching the specified search.
    */
   public find = <T = unknown>(
-    options: SavedObjectsFindOptions
+    options: SavedObjectsFindOptions,
+    prependOptions?: PrependOptions
   ): Promise<SavedObjectsFindResponsePublic<T>> => {
     const path = this.getPath(['_find']);
     const renameMap = {
@@ -404,9 +405,6 @@ export class SavedObjectsClient {
     // a query param
     if (query.has_reference) query.has_reference = JSON.stringify(query.has_reference);
 
-    // if no workspaces are provided, we need to remove the client base path
-    const prependOptions =
-      query.workspaces === undefined ? { withoutClientBasePath: true } : undefined;
     const request: ReturnType<SavedObjectsApi['find']> = this.savedObjectsFetch(path, {
       method: 'GET',
       query,

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -405,7 +405,8 @@ export class SavedObjectsClient {
     if (query.has_reference) query.has_reference = JSON.stringify(query.has_reference);
 
     // if no workspaces are provided, we need to remove the client base path
-    const prependOptions = query.workspaces === undefined ? { withoutClientBasePath: true } : {};
+    const prependOptions =
+      query.workspaces === undefined ? { withoutClientBasePath: true } : undefined;
     const request: ReturnType<SavedObjectsApi['find']> = this.savedObjectsFetch(path, {
       method: 'GET',
       query,

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -404,9 +404,12 @@ export class SavedObjectsClient {
     // a query param
     if (query.has_reference) query.has_reference = JSON.stringify(query.has_reference);
 
+    // if no workspaces are provided, we need to remove the client base path
+    const prependOptions = query.workspaces === undefined ? { withoutClientBasePath: true } : {};
     const request: ReturnType<SavedObjectsApi['find']> = this.savedObjectsFetch(path, {
       method: 'GET',
       query,
+      prependOptions,
     });
     return request.then((resp) => {
       return renameKeys<
@@ -548,8 +551,11 @@ export class SavedObjectsClient {
    * the old kfetch error format of `{res: {status: number}}` whereas `http.fetch`
    * uses `{response: {status: number}}`.
    */
-  private savedObjectsFetch(path: string, { method, query, body }: HttpFetchOptions) {
-    return this.http.fetch(path, { method, query, body });
+  private savedObjectsFetch(
+    path: string,
+    { method, query, body, prependOptions }: HttpFetchOptions
+  ) {
+    return this.http.fetch(path, { method, query, body, prependOptions });
   }
 }
 

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -554,7 +554,12 @@ export class SavedObjectsClient {
     path: string,
     { method, query, body, prependOptions }: HttpFetchOptions
   ) {
-    return this.http.fetch(path, { method, query, body, prependOptions });
+    return this.http.fetch(path, {
+      method,
+      query,
+      body,
+      ...(prependOptions && { prependOptions }),
+    });
   }
 }
 

--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
@@ -230,7 +230,7 @@ export const AssociationDataSourceModalContent = ({
 
   useEffect(() => {
     setIsLoading(true);
-    getDataSourcesList(savedObjects.client, ['*'])
+    getDataSourcesList(savedObjects.client)
       .then((dataSourcesList) =>
         fetchDataSourceConnections(dataSourcesList, http, notifications, mode)
       )

--- a/src/plugins/workspace/public/components/workspace_list/index.tsx
+++ b/src/plugins/workspace/public/components/workspace_list/index.tsx
@@ -127,7 +127,7 @@ export const WorkspaceListInner = ({
   useEffect(() => {
     setDefaultWorkspaceId(uiSettings?.get(DEFAULT_WORKSPACE));
     if (savedObjects) {
-      getDataSourcesList(savedObjects.client, ['*']).then((data) => {
+      getDataSourcesList(savedObjects.client).then((data) => {
         setAllDataSources(data);
       });
     }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -418,6 +418,32 @@ describe('workspace utils: getDataSourcesList', () => {
     ]);
   });
 
+  it('should call client.find with { withoutClientBasePath: true }', async () => {
+    mockedSavedObjectClient.find = jest.fn().mockResolvedValue({
+      savedObjects: [],
+    });
+
+    await getDataSourcesList(mockedSavedObjectClient, ['workspace-1']);
+
+    expect(mockedSavedObjectClient.find).toHaveBeenCalledWith(
+      {
+        type: [DATA_SOURCE_SAVED_OBJECT_TYPE, DATA_CONNECTION_SAVED_OBJECT_TYPE],
+        fields: [
+          'id',
+          'title',
+          'auth',
+          'description',
+          'dataSourceEngineType',
+          'type',
+          'connectionId',
+        ],
+        perPage: 10000,
+        workspaces: ['workspace-1'],
+      },
+      { withoutClientBasePath: true }
+    );
+  });
+
   it('should return title for data source object and connectionId as title for data connection object', async () => {
     mockedSavedObjectClient.find = jest.fn().mockResolvedValue({
       savedObjects: [

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -364,7 +364,7 @@ export const mergeDataSourcesWithConnections = (
 
 // If all connected data sources are serverless, will only allow to select essential use case.
 export const getIsOnlyAllowEssentialUseCase = async (client: SavedObjectsStart['client']) => {
-  const allDataSources = await getDataSourcesList(client, ['*']);
+  const allDataSources = await getDataSourcesList(client);
   if (allDataSources.length > 0) {
     return allDataSources.every(
       (ds) => ds?.auth?.credentials?.service === SigV4ServiceName.OpenSearchServerless

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -223,7 +223,7 @@ export const filterWorkspaceConfigurableApps = (applications: PublicAppInfo[]) =
 
 export const getDataSourcesList = (
   client: SavedObjectsStart['client'],
-  targetWorkspaces: string[]
+  targetWorkspaces?: string[]
 ) => {
   return client
     .find({

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -226,20 +226,23 @@ export const getDataSourcesList = (
   targetWorkspaces?: string[]
 ) => {
   return client
-    .find({
-      type: WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
-      fields: [
-        'id',
-        'title',
-        'auth',
-        'description',
-        'dataSourceEngineType',
-        'type',
-        'connectionId',
-      ],
-      perPage: 10000,
-      workspaces: targetWorkspaces,
-    })
+    .find(
+      {
+        type: WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
+        fields: [
+          'id',
+          'title',
+          'auth',
+          'description',
+          'dataSourceEngineType',
+          'type',
+          'connectionId',
+        ],
+        perPage: 10000,
+        workspaces: targetWorkspaces,
+      },
+      { withoutClientBasePath: true }
+    )
     .then((response) => {
       const objects = response?.savedObjects;
       if (objects) {

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
@@ -243,24 +243,6 @@ describe('WorkspaceIdConsumerWrapper', () => {
       expect(mockedWorkspaceClient.get).toBeCalledTimes(0);
       expect(mockedWorkspaceClient.list).toBeCalledTimes(1);
     });
-
-    it(`Should not throw error when passing in '*'`, async () => {
-      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(mockedWorkspaceClient);
-      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
-      updateWorkspaceState(mockRequest, {});
-      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
-        client: mockedClient,
-        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
-        request: mockRequest,
-      });
-      await mockedWrapperClient.find({
-        type: ['dashboard', 'visualization'],
-        workspaces: ['*'],
-      });
-      expect(mockedClient.find).toBeCalledWith({
-        type: ['dashboard', 'visualization'],
-      });
-    });
   });
 
   describe('get', () => {

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -47,7 +47,7 @@ export class WorkspaceIdConsumerWrapper {
     let finalWorkspaces: string[] = [];
     if (options?.hasOwnProperty('workspaces')) {
       // In order to get all data sources in workspace, use * to skip appending workspace id automatically
-      finalWorkspaces = (workspaceIdsInUserOptions || []).filter((id) => id !== '*');
+      finalWorkspaces = workspaceIdsInUserOptions || [];
     } else if (workspaceIdParsedFromRequest) {
       finalWorkspaces = [workspaceIdParsedFromRequest];
     }

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -46,7 +46,7 @@ export class WorkspaceIdConsumerWrapper {
     const workspaceIdsInUserOptions = options?.workspaces;
     let finalWorkspaces: string[] = [];
     if (options?.hasOwnProperty('workspaces')) {
-      // In order to get all data sources in workspace, use * to skip appending workspace id automatically
+      // In order to get all data sources in workspace
       finalWorkspaces = workspaceIdsInUserOptions || [];
     } else if (workspaceIdParsedFromRequest) {
       finalWorkspaces = [workspaceIdParsedFromRequest];


### PR DESCRIPTION
### Description
This pr remove * when calling getDataSourcesList in data source association modal and in workspace list page.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

Inside a workspace and open data source association modal, we want to find all the data sources, here we remove the client base path
![截屏2025-02-18 14 54 09](https://github.com/user-attachments/assets/ccafe35c-4e3a-4395-9780-328285ad6774)

in workspace list page, we also remove the client base path
![截屏2025-02-18 14 57 59](https://github.com/user-attachments/assets/8fccc469-6de1-46c4-9a54-0435e37636f9)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: remove * when calling find in data source association modal and in workspace list page
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
