### PR TITLE
Bump markdown-it from 12.3.2 to 13.0.2

### DIFF
--- a/changelogs/fragments/9412.yml
+++ b/changelogs/fragments/9412.yml
@@ -1,0 +1,2 @@
+security:
+- Bump markdown-it from 12.3.2 to 13.0.2 ([#9412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9412))

--- a/package.json
+++ b/package.json
@@ -452,7 +452,7 @@
     "load-grunt-config": "^4.0.1",
     "load-json-file": "^6.2.0",
     "luxon": "^3.2.1",
-    "markdown-it": "^12.3.2",
+    "markdown-it": "^13.0.2",
     "mocha": "^10.1.0",
     "mock-fs": "^4.12.0",
     "monaco-editor": "~0.17.0",

--- a/packages/osd-dev-utils/package.json
+++ b/packages/osd-dev-utils/package.json
@@ -24,7 +24,7 @@
     "getopts": "^2.2.5",
     "globby": "^11.1.0",
     "load-json-file": "^6.2.0",
-    "markdown-it": "^12.3.2",
+    "markdown-it": "^13.0.2",
     "moment": "^2.24.0",
     "normalize-path": "^3.0.0",
     "rxjs": "^6.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7563,15 +7563,10 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^3.0.1:
+entities@^3.0.1, entities@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
-
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
-  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 envinfo@^7.7.3:
   version "7.8.1"
@@ -11722,10 +11717,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -12189,14 +12184,14 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-markdown-it@^12.3.2:
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
-  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+markdown-it@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.2.tgz#1bc22e23379a6952e5d56217fbed881e0c94d536"
+  integrity sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==
   dependencies:
     argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 


### PR DESCRIPTION
### Description

Bump markdown-it from 12.3.2 to 13.0.2
```
yarn why markdown-it
yarn why v1.22.21
[1/4] 🤔  Why do we have the module "markdown-it"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@~4.5.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Lockfile has incorrect entry for "typescript@4.0.2". Ignoring it.
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
warning Resolution field "typescript@4.6.4" is incompatible with requested version "typescript@4.0.2"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "markdown-it@13.0.2"
info Has been hoisted to "markdown-it"
info Reasons this module exists
   - "workspace-aggregator-b3b81190-140d-44fa-9437-3a525a0e2d1e" depends on it
   - Specified in "devDependencies"
   - Hoisted from "_project_#@osd#dev-utils#markdown-it"
   - Hoisted from "_project_#markdown-it"
info Disk size without dependencies: "1MB"
info Disk size with unique dependencies: "1.57MB"
info Disk size with transitive dependencies: "1.64MB"
info Number of shared dependencies: 6
✨  Done in 1.66s.
```


## Changelog

- security: Bump markdown-it from 12.3.2 to 13.0.2


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
