### PR TITLE
[Enhancement] Extended caching mechanism used for async operations

### DIFF
--- a/src/plugins/data_source_management/framework/catalog_cache/cache_loader.tsx
+++ b/src/plugins/data_source_management/framework/catalog_cache/cache_loader.tsx
@@ -133,13 +133,15 @@ export const updateAccelerationsToCache = (
   const currentTime = new Date().toUTCString();
 
   if (!pollingResult) {
-    CatalogCacheManager.addOrUpdateAccelerationsByDataSource({
-      name: dataSourceName,
-      accelerations: [],
-      lastUpdated: currentTime,
-      status: CachedDataSourceStatus.Failed,
-      ...(dataSourceMDSId && { dataSourceMDSId }),
-    });
+    CatalogCacheManager.addOrUpdateAccelerationsByDataSource(
+      {
+        name: dataSourceName,
+        accelerations: [],
+        lastUpdated: currentTime,
+        status: CachedDataSourceStatus.Failed,
+      },
+      dataSourceMDSId
+    );
     return;
   }
 
@@ -155,13 +157,15 @@ export const updateAccelerationsToCache = (
     status: row.status,
   }));
 
-  CatalogCacheManager.addOrUpdateAccelerationsByDataSource({
-    name: dataSourceName,
-    accelerations: newAccelerations,
-    lastUpdated: currentTime,
-    status: CachedDataSourceStatus.Updated,
-    ...(dataSourceMDSId && { dataSourceMDSId }),
-  });
+  CatalogCacheManager.addOrUpdateAccelerationsByDataSource(
+    {
+      name: dataSourceName,
+      accelerations: newAccelerations,
+      lastUpdated: currentTime,
+      status: CachedDataSourceStatus.Updated,
+    },
+    dataSourceMDSId
+  );
 };
 
 export const updateTableColumnsToCache = (

--- a/src/plugins/data_source_management/framework/catalog_cache/cache_manager.ts
+++ b/src/plugins/data_source_management/framework/catalog_cache/cache_manager.ts
@@ -101,7 +101,7 @@ export class CatalogCacheManager {
       );
     }
     if (index !== -1) {
-      accCacheData.dataSources[index] = dataSource;
+      accCacheData.dataSources[index] = { ...dataSource, dataSourceMDSId };
     } else {
       accCacheData.dataSources.push(dataSource);
     }
@@ -157,7 +157,11 @@ export class CatalogCacheManager {
           ds.name === dataSource.name && ds.dataSourceMDSId === dataSourceMDSId
       );
     }
-    index = cacheData.dataSources.findIndex((ds: CachedDataSource) => ds.name === dataSource.name);
+    else {
+      index = cacheData.dataSources.findIndex(
+        (ds: CachedDataSource) => ds.name === dataSource.name
+      );
+    }
     if (index !== -1) {
       cacheData.dataSources[index] = dataSource;
     } else {

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -52,6 +52,8 @@ import { AccelerationDetailsFlyout } from './components/direct_query_data_source
 import { CreateAcceleration } from './components/direct_query_data_sources_components/acceleration_creation/create/create_acceleration';
 import { AssociatedObjectsDetailsFlyout } from './components/direct_query_data_sources_components/associated_object_management/associated_objects_details_flyout';
 import { getScopedBreadcrumbs } from '../../opensearch_dashboards_react/public';
+import { CatalogCacheManager } from '../framework/catalog_cache/cache_manager';
+import { useLoadAccelerationsToCache, useLoadDatabasesToCache, useLoadTableColumnsToCache, useLoadTablesToCache } from '../framework/catalog_cache/cache_loader';
 
 export const [
   getRenderAccelerationDetailsFlyout,
@@ -104,7 +106,8 @@ export class DataSourceManagementPlugin
     Plugin<
       DataSourceManagementPluginSetup,
       DataSourceManagementPluginStart,
-      DataSourceManagementSetupDependencies
+      DataSourceManagementSetupDependencies,
+      CacheStart
     > {
   private started = false;
   private authMethodsRegistry = new AuthenticationMethodRegistry();
@@ -302,9 +305,22 @@ export class DataSourceManagementPlugin
       );
     };
     setRenderAssociatedObjectsDetailsFlyout(renderAssociatedObjectsDetailsFlyout);
+    const CatalogCacheManagerInstance = CatalogCacheManager;
+    const useLoadDatabasesToCacheHook = useLoadDatabasesToCache;
+    const useLoadTablesToCacheHook = useLoadTablesToCache;
+    const useLoadTableColumnsToCacheHook = useLoadTableColumnsToCache;
+    const useLoadAccelerationsToCacheHook = useLoadAccelerationsToCache;
 
     return {
       getAuthenticationMethodRegistry: () => this.authMethodsRegistry,
+      renderAccelerationDetailsFlyout,
+      renderAssociatedObjectsDetailsFlyout,
+      renderCreateAccelerationFlyout,
+      CatalogCacheManagerInstance,
+      useLoadDatabasesToCacheHook,
+      useLoadTablesToCacheHook,
+      useLoadTableColumnsToCacheHook,
+      useLoadAccelerationsToCacheHook,
     };
   }
 

--- a/src/plugins/data_source_management/public/types.ts
+++ b/src/plugins/data_source_management/public/types.ts
@@ -22,6 +22,8 @@ import { AuthType } from '../../data_source/common/data_sources';
 import { SigV4ServiceName } from '../../data_source/common/data_sources';
 import { OpenSearchDashboardsReactContextValue } from '../../opensearch_dashboards_react/public';
 import { AuthenticationMethodRegistry } from './auth_registry';
+import { LoadCachehookOutput, RenderAccelerationDetailsFlyoutParams, RenderAccelerationFlyoutParams, RenderAssociatedObjectsDetailsFlyoutParams } from '../framework/types';
+import { CatalogCacheManager } from '../framework/catalog_cache/cache_manager';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DataSourceManagementPluginStart {}
@@ -200,3 +202,31 @@ export interface PermissionsConfigurationProps {
   layout: 'horizontal' | 'vertical';
   hasSecurityAccess: boolean;
 }
+
+export interface CacheStart {
+  renderAccelerationDetailsFlyout: ({
+    acceleration,
+    dataSourceName,
+    handleRefresh,
+    dataSourceMDSId,
+  }: RenderAccelerationDetailsFlyoutParams) => void;
+  renderAssociatedObjectsDetailsFlyout: ({
+    tableDetail,
+    dataSourceName,
+    handleRefresh,
+  }: RenderAssociatedObjectsDetailsFlyoutParams) => void;
+  renderCreateAccelerationFlyout: ({
+    dataSourceName,
+    dataSourceMDSId,
+    databaseName,
+    tableName,
+    handleRefresh,
+  }: RenderAccelerationFlyoutParams) => void;
+  CatalogCacheManagerInstance: typeof CatalogCacheManager;
+  useLoadDatabasesToCacheHook: () => LoadCachehookOutput;
+  useLoadTablesToCacheHook: () => LoadCachehookOutput;
+  useLoadTableColumnsToCacheHook: () => LoadCachehookOutput;
+  useLoadAccelerationsToCacheHook: () => LoadCachehookOutput;
+}
+export type CatalogCacheManagerType = typeof CatalogCacheManager;
+export type LoadCachehookOutputType = LoadCachehookOutput;


### PR DESCRIPTION
### Description

This PR updates the Query Workbench side-tree to use the caching mechanism from Dashboards Core instead of Observability.

Previously, a caching mechanism was implemented in Observability to improve performance when fetching indexes for async operations. During the Data Sources page migration to Core, this cache was also moved to support OpenSearch connections more efficiently. However, the Query Workbench side-tree was still dependent on the old caching mechanism in Observability.

With this update, the side-tree now utilizes the centralized cache in Dashboards Core, ensuring better consistency and performance across the platform.

https://github.com/user-attachments/assets/064a64b5-4007-46a4-9e82-52413e1d9f8b



## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
