### PR TITLE
[Workspace] Fix find saved object within a workspace without queryparams return all the saved objects

### DIFF
--- a/changelogs/fragments/9420.yml
+++ b/changelogs/fragments/9420.yml
@@ -1,0 +1,2 @@
+fix:
+- Fixing when find saved objects within a workspace returns saved objects in all the workspaces ([#9420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9420))

--- a/src/plugins/saved_objects_management/server/routes/find.test.ts
+++ b/src/plugins/saved_objects_management/server/routes/find.test.ts
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { registerFindRoute } from './find';
+import { ISavedObjectsManagement } from '../services';
+import { managementMock } from '../services/management.mock';
+import { IRouter } from 'src/core/server';
+import { httpServiceMock } from '../../../../core/server/mocks';
+
+describe('Find route', () => {
+  let router: jest.Mocked<IRouter>;
+  let managementService: jest.Mocked<ISavedObjectsManagement>;
+  let context: any;
+  let req: any;
+  let res: any;
+
+  beforeAll(() => {
+    router = httpServiceMock.createRouter();
+
+    // Mock management service
+    managementService = managementMock.create();
+
+    // Mock context with savedObjects client
+    const savedObjectsClient = {
+      find: jest.fn(),
+      get: jest.fn(),
+    };
+
+    context = {
+      core: {
+        savedObjects: {
+          client: savedObjectsClient,
+        },
+      },
+    };
+
+    // Mock request
+    req = {
+      query: {
+        perPage: 20,
+        page: 1,
+        type: 'test-type',
+        fields: ['field1', 'field2'],
+      },
+    };
+
+    // Mock response
+    res = {
+      ok: jest.fn(),
+    };
+  });
+
+  it('should register GET route with correct path', () => {
+    registerFindRoute(router, Promise.resolve(managementService));
+
+    expect(router.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/opensearch-dashboards/management/saved_objects/_find',
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('should handle basic find request', async () => {
+    registerFindRoute(router, Promise.resolve(managementService));
+
+    const findResponse = {
+      saved_objects: [
+        {
+          type: 'test-type',
+          id: '1',
+          attributes: {
+            field1: 'value1',
+            field2: 'value2',
+          },
+        },
+      ],
+      total: 1,
+      per_page: 20,
+      page: 1,
+    };
+
+    context.core.savedObjects.client.find.mockResolvedValue(findResponse);
+
+    const handler = router.get.mock.calls[0][1];
+    await handler(context, req, res);
+
+    expect(context.core.savedObjects.client.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        perPage: 20,
+        page: 1,
+        type: 'test-type',
+      })
+    );
+    expect(res.ok).toHaveBeenCalled();
+  });
+
+  it('should handle index-pattern type correctly', async () => {
+    registerFindRoute(router, Promise.resolve(managementService));
+
+    const findResponse = {
+      saved_objects: [
+        {
+          type: 'index-pattern',
+          id: '1',
+          attributes: {
+            title: 'test-pattern',
+          },
+          references: [],
+        },
+      ],
+      total: 1,
+      per_page: 20,
+      page: 1,
+    };
+
+    context.core.savedObjects.client.find.mockResolvedValue(findResponse);
+    context.core.savedObjects.client.get.mockResolvedValue({ attributes: {} });
+
+    const handler = router.get.mock.calls[0][1];
+    await handler(context, req, res);
+
+    expect(context.core.savedObjects.client.find).toHaveBeenCalled();
+    expect(res.ok).toHaveBeenCalled();
+  });
+
+  it('should handle workspace filtering', async () => {
+    registerFindRoute(router, Promise.resolve(managementService));
+
+    req.query.workspaces = ['workspace1'];
+
+    const findResponse = {
+      saved_objects: [],
+      total: 0,
+      per_page: 20,
+      page: 1,
+    };
+
+    context.core.savedObjects.client.find.mockResolvedValue(findResponse);
+
+    const handler = router.get.mock.calls[0][1];
+    await handler(context, req, res);
+
+    expect(context.core.savedObjects.client.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaces: ['workspace1'],
+      })
+    );
+  });
+});

--- a/src/plugins/saved_objects_management/server/routes/find.ts
+++ b/src/plugins/saved_objects_management/server/routes/find.ts
@@ -98,7 +98,11 @@ export const registerFindRoute = (
         ...req.query,
         fields: undefined,
         searchFields: [...searchFields],
-        workspaces: req.query.workspaces ? Array<string>().concat(req.query.workspaces) : undefined,
+        ...(req.query.workspaces
+          ? {
+              workspaces: Array<string>().concat(req.query.workspaces),
+            }
+          : {}),
       } as SavedObjectsFindOptions;
 
       const findResponse = await client.find<any>(findOptions);

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -19,7 +19,7 @@ const testWorkspace: WorkspaceAttribute = {
   features: ['use-case-all'],
 };
 
-const cleanWorkspaces = async (
+const clearWorkspaces = async (
   root: ReturnType<typeof osdTestServer.createRoot>,
   osd: osdTestServer.TestOpenSearchDashboardsUtils
 ) => {
@@ -70,7 +70,7 @@ describe('workspace service api integration test', () => {
     await opensearchServer.stop();
   });
   describe('Workspace CRUD APIs', () => {
-    afterEach(async () => cleanWorkspaces(root, osd));
+    afterEach(async () => clearWorkspaces(root, osd));
 
     it('create', async () => {
       await osdTestServer.request
@@ -458,7 +458,7 @@ describe('workspace service api integration test', () => {
       references: [],
     };
 
-    afterAll(async () => cleanWorkspaces(root, osd));
+    afterAll(async () => clearWorkspaces(root, osd));
 
     it('requires objects', async () => {
       const result = await osdTestServer.request
@@ -605,7 +605,7 @@ describe('workspace service api integration test when savedObjects.permission.en
     await opensearchServer.stop();
   });
   describe('Workspace CRUD APIs', () => {
-    afterEach(async () => cleanWorkspaces(root, osd));
+    afterEach(async () => clearWorkspaces(root, osd));
 
     it('create', async () => {
       await osdTestServer.request
@@ -673,7 +673,7 @@ describe('workspace service api integration test when savedObjects.permission.en
   });
 
   describe('Saved Object Management APIs', () => {
-    afterEach(async () => cleanWorkspaces(root, osd));
+    afterEach(async () => clearWorkspaces(root, osd));
 
     const findUrl = '/api/opensearch-dashboards/management/saved_objects/_find?type=index-pattern';
 

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -19,6 +19,27 @@ const testWorkspace: WorkspaceAttribute = {
   features: ['use-case-all'],
 };
 
+const cleanWorkspaces = async (
+  root: ReturnType<typeof osdTestServer.createRoot>,
+  osd: osdTestServer.TestOpenSearchDashboardsUtils
+) => {
+  const listResult = await osdTestServer.request
+    .post(root, `/api/workspaces/_list`)
+    .send({
+      page: 1,
+    })
+    .expect(200);
+  const savedObjectsRepository = osd.coreStart.savedObjects.createInternalRepository([
+    WORKSPACE_TYPE,
+  ]);
+  await Promise.all(
+    listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
+      // this will delete reserved workspace
+      savedObjectsRepository.delete(WORKSPACE_TYPE, item.id)
+    )
+  );
+};
+
 describe('workspace service api integration test', () => {
   let root: ReturnType<typeof osdTestServer.createRoot>;
   let opensearchServer: osdTestServer.TestOpenSearchUtils;
@@ -49,23 +70,8 @@ describe('workspace service api integration test', () => {
     await opensearchServer.stop();
   });
   describe('Workspace CRUD APIs', () => {
-    afterEach(async () => {
-      const listResult = await osdTestServer.request
-        .post(root, `/api/workspaces/_list`)
-        .send({
-          page: 1,
-        })
-        .expect(200);
-      const savedObjectsRepository = osd.coreStart.savedObjects.createInternalRepository([
-        WORKSPACE_TYPE,
-      ]);
-      await Promise.all(
-        listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
-          // this will delete reserved workspace
-          savedObjectsRepository.delete(WORKSPACE_TYPE, item.id)
-        )
-      );
-    });
+    afterEach(async () => cleanWorkspaces(root, osd));
+
     it('create', async () => {
       await osdTestServer.request
         .post(root, `/api/workspaces`)
@@ -452,23 +458,7 @@ describe('workspace service api integration test', () => {
       references: [],
     };
 
-    afterAll(async () => {
-      const listResult = await osdTestServer.request
-        .post(root, `/api/workspaces/_list`)
-        .send({
-          page: 1,
-        })
-        .expect(200);
-      const savedObjectsRepository = osd.coreStart.savedObjects.createInternalRepository([
-        WORKSPACE_TYPE,
-      ]);
-      await Promise.all(
-        listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
-          // this will delete reserved workspace
-          savedObjectsRepository.delete(WORKSPACE_TYPE, item.id)
-        )
-      );
-    });
+    afterAll(async () => cleanWorkspaces(root, osd));
 
     it('requires objects', async () => {
       const result = await osdTestServer.request
@@ -615,23 +605,8 @@ describe('workspace service api integration test when savedObjects.permission.en
     await opensearchServer.stop();
   });
   describe('Workspace CRUD APIs', () => {
-    afterEach(async () => {
-      const listResult = await osdTestServer.request
-        .post(root, `/api/workspaces/_list`)
-        .send({
-          page: 1,
-        })
-        .expect(200);
-      const savedObjectsRepository = osd.coreStart.savedObjects.createInternalRepository([
-        WORKSPACE_TYPE,
-      ]);
-      await Promise.all(
-        listResult.body.result.workspaces.map((item: WorkspaceAttribute) =>
-          // this will delete reserved workspace
-          savedObjectsRepository.delete(WORKSPACE_TYPE, item.id)
-        )
-      );
-    });
+    afterEach(async () => cleanWorkspaces(root, osd));
+
     it('create', async () => {
       await osdTestServer.request
         .post(root, `/api/workspaces`)
@@ -694,6 +669,72 @@ describe('workspace service api integration test when savedObjects.permission.en
             .get<{ permissions: Permissions }>(WORKSPACE_TYPE, result.body.result.id)
         ).permissions
       ).toEqual({ write: { users: ['foo'] } });
+    });
+  });
+
+  describe('Saved Object Management APIs', () => {
+    afterEach(async () => cleanWorkspaces(root, osd));
+
+    const findUrl = '/api/opensearch-dashboards/management/saved_objects/_find?type=index-pattern';
+
+    it('find should return 400 using invalid workspace id', async () => {
+      const invalidWorkspaceId = 'non-exist workspace id';
+      const findResult: any = await osdTestServer.request.get(
+        root,
+        `/w/${invalidWorkspaceId}${findUrl}`
+      );
+      expect(findResult.body).toEqual({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Exist invalid workspaces',
+      });
+    });
+
+    it('find should only return saved objects within current workspace', async () => {
+      // Create two workspaces
+      const firstCreateResult: any = await osdTestServer.request
+        .post(root, '/api/workspaces')
+        .send({
+          attributes: { ...omitId(testWorkspace), name: 'test_workspace_1' },
+        })
+        .expect(200);
+      const firstWorkspaceId = firstCreateResult.body.result.id;
+      const secondCreateResult: any = await osdTestServer.request
+        .post(root, '/api/workspaces')
+        .send({
+          attributes: { ...omitId(testWorkspace), name: 'test_workspace_2' },
+        })
+        .expect(200);
+      const secondWorkspaceId = secondCreateResult.body.result.id;
+
+      // Only add a saved object for the first workspace
+      await osdTestServer.request
+        .post(root, `/api/saved_objects/index-pattern/logstash-*`)
+        .send({
+          attributes: {
+            title: 'logstash-*',
+          },
+          workspaces: [firstWorkspaceId],
+        })
+        .expect(200);
+
+      // get all saved objects should return one result
+      const withoutWorkspaceResult: any = await osdTestServer.request
+        .get(root, findUrl)
+        .expect(200);
+      expect(withoutWorkspaceResult.body.saved_objects.length).toBe(1);
+
+      // get saved objects for the first workspace should return one result
+      const firstWorkspaceResult: any = await osdTestServer.request
+        .get(root, `/w/${firstWorkspaceId}${findUrl}`)
+        .expect(200);
+      expect(firstWorkspaceResult.body.saved_objects.length).toBe(1);
+
+      // get saved objects for the second workspace should return no result
+      const secondWorkspaceResult: any = await osdTestServer.request
+        .get(root, `/w/${secondWorkspaceId}${findUrl}`)
+        .expect(200);
+      expect(secondWorkspaceResult.body.saved_objects.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
### Description

Given we have two workspaces (namely `first` and `second`), and each has a saved object.

We retrieve the saved objects using the following URL (using workspace prefix but no query parameters):
`/w/first/api/opensearch-dashboards/management/saved_objects/_find?type=index-pattern`

Previously, this request would return both saved objects because when no `workspace` query parameter was provided, our endpoint would pass `workspace: undefined` to the actual query, bypassing the workspace check. As a result, the backend would return all saved objects even when the original request was made under the `first` workspace context.

This PR removes the logic of passing `workspace: undefined `when there is no `workspace` query parameter. Now, the wrapper for the `_find` endpoint automatically retrieves the current workspace context, ensuring the backend only returns saved objects associated with the current workspace.

### Issues Resolved

NA

## Screenshot

NA

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: fixing when find saved objects within a workspace returns saved objects in all the workspaces

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
