### PR TITLE
Version bump to 2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dashboarding"
   ],
   "private": true,
-  "version": "2.19.1",
+  "version": "2.20.0",
   "branch": "2.x",
   "types": "./opensearch_dashboards.d.ts",
   "tsdocMetadata": "./build/tsdoc-metadata.json",


### PR DESCRIPTION
### Description
Correction on the version bump of OSD core. This PR points 2.x to 2.20.0 instead of 2.19.1

### Issues Resolved

This backport https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9410 created an issue with the 2.x branch version. Ideally 2.x should point to next minor version which is 2.20.0. 



## Changelog
- chore: Version Bump to 2.x 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
