### PR TITLE
Allow v8/v9 as default setting

### DIFF
--- a/packages/osd-ui-shared-deps/theme_config.d.ts
+++ b/packages/osd-ui-shared-deps/theme_config.d.ts
@@ -29,6 +29,16 @@ export const themeVersionLabelMap: Record<string, string>;
 export const themeVersionValueMap: Record<string, string>;
 
 /**
+ * List of theme schema values
+ */
+export const themeSchemaValues: string[];
+
+/**
+ * List of theme options
+ */
+export const themeOptions: string[];
+
+/**
  * Theme CSS distributable filenames by themeVersion and themeMode
  * Note: used by bootstrap template
  */

--- a/packages/osd-ui-shared-deps/theme_config.js
+++ b/packages/osd-ui-shared-deps/theme_config.js
@@ -25,11 +25,20 @@ const THEME_VERSION_VALUE_MAP = {
 const THEME_VERSIONS = Object.keys(THEME_VERSION_LABEL_MAP);
 const THEME_TAGS = THEME_VERSIONS.flatMap((v) => THEME_MODES.map((m) => `${v}${m}`));
 
+// Setup theme options to be backwards compatible with the fact that v8 was persisted with its
+// label rather than with the correct themeVersion value
+const THEME_SCHEMA_VALUES = THEME_VERSIONS.concat(THEME_VERSION_LABEL_MAP.v8);
+const THEME_OPTIONS = THEME_VERSIONS.map((v) => (v !== 'v8' ? v : THEME_VERSION_LABEL_MAP.v8));
+
 exports.themeVersionLabelMap = THEME_VERSION_LABEL_MAP;
 
 exports.themeVersionValueMap = THEME_VERSION_VALUE_MAP;
 
 exports.themeTags = THEME_TAGS;
+
+exports.themeSchemaValues = THEME_SCHEMA_VALUES;
+
+exports.themeOptions = THEME_OPTIONS;
 
 exports.themeCssDistFilenames = THEME_VERSIONS.reduce((map, v) => {
   map[v] = THEME_MODES.reduce((acc, m) => {

--- a/src/core/server/ui_settings/settings/theme.test.ts
+++ b/src/core/server/ui_settings/settings/theme.test.ts
@@ -57,6 +57,8 @@ describe('theme settings', () => {
 
     it('should only accept valid values', () => {
       expect(() => validate('v7')).not.toThrow();
+      expect(() => validate('v8')).not.toThrow();
+      expect(() => validate('v9')).not.toThrow();
       expect(() => validate('Next (preview)')).not.toThrow();
       expect(() => validate('v12')).toThrowErrorMatchingInlineSnapshot(`
         "types that failed validation:

--- a/src/core/server/ui_settings/settings/theme.ts
+++ b/src/core/server/ui_settings/settings/theme.ts
@@ -30,16 +30,10 @@
 
 import { schema } from '@osd/config-schema';
 import { i18n } from '@osd/i18n';
-import { themeVersionLabelMap } from '@osd/ui-shared-deps';
+import { themeVersionLabelMap, themeSchemaValues, themeOptions } from '@osd/ui-shared-deps';
 import type { Type } from '@osd/config-schema';
 import { UiSettingsParams } from '../../../types';
 import { DEFAULT_THEME_VERSION } from '../ui_settings_config';
-
-// Setup theme options to be backwards compatible with the fact that v8 was persisted with its
-// label rather than with the correct themeVersion value
-const THEME_VERSIONS = Object.keys(themeVersionLabelMap);
-const THEME_SCHEMA_VALUES = THEME_VERSIONS.concat(themeVersionLabelMap.v8);
-const THEME_OPTIONS = THEME_VERSIONS.map((v) => (v !== 'v8' ? v : themeVersionLabelMap.v8));
 
 export const getThemeSettings = (): Record<string, UiSettingsParams> => {
   return {
@@ -79,7 +73,7 @@ export const getThemeSettings = (): Record<string, UiSettingsParams> => {
           ? themeVersionLabelMap[DEFAULT_THEME_VERSION]
           : DEFAULT_THEME_VERSION,
       type: 'select',
-      options: THEME_OPTIONS,
+      options: themeOptions,
       optionLabels: themeVersionLabelMap,
       description: i18n.translate('core.ui_settings.params.themeVersionText', {
         defaultMessage: `<p>Switch between the themes used for the current and next versions of OpenSearch Dashboards. A page refresh is required for the setting to be applied.</p><p><a href="{href}">{linkText}</a></p>`,
@@ -91,7 +85,7 @@ export const getThemeSettings = (): Record<string, UiSettingsParams> => {
       requiresPageReload: true,
       preferBrowserSetting: true,
       category: ['appearance'],
-      schema: schema.oneOf(THEME_SCHEMA_VALUES.map((v) => schema.literal(v)) as [Type<string>]),
+      schema: schema.oneOf(themeSchemaValues.map((v) => schema.literal(v)) as [Type<string>]),
     },
   };
 };

--- a/src/core/server/ui_settings/ui_settings_config.ts
+++ b/src/core/server/ui_settings/ui_settings_config.ts
@@ -28,7 +28,8 @@
  * under the License.
  */
 
-import { schema, TypeOf } from '@osd/config-schema';
+import { schema, TypeOf, Type } from '@osd/config-schema';
+import { themeOptions } from '@osd/ui-shared-deps';
 import { ConfigDeprecationProvider } from 'src/core/server';
 import { ServiceConfigDescriptor } from '../internal_types';
 
@@ -59,7 +60,7 @@ const configSchema = schema.object({
   defaults: schema.object({
     'theme:darkMode': schema.maybe(schema.boolean({ defaultValue: false })),
     'theme:version': schema.maybe(
-      schema.oneOf([schema.literal('v7'), schema.literal('Next (preview)')], {
+      schema.oneOf(themeOptions.map((option) => schema.literal(option)) as [Type<string>], {
         defaultValue: 'Next (preview)',
       })
     ),


### PR DESCRIPTION
### Description

Allow v8/v9 as default setting

### Issues Resolved

Previously setting default theme version as `v8` or `v9` in `opensearch_dashboards.yml` will fail validation.

```
FATAL  ValidationError: [config validation of [uiSettings].defaults.theme:version]: types that failed validation:
- [config validation of [uiSettings].defaults.theme:version.0]: expected value to equal [v7]
- [config validation of [uiSettings].defaults.theme:version.3]: expected value to equal [Next (preview)]
```

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
