### PR TITLE
[Discover] Add New Mappings for S3 Type

### DIFF
--- a/changelogs/fragments/9430.yml
+++ b/changelogs/fragments/9430.yml
@@ -1,0 +1,2 @@
+fix:
+- Add mappings for tinyint, smallint, and bigint in S3 dataset type ([#9430](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9430))

--- a/src/plugins/query_enhancements/common/types.ts
+++ b/src/plugins/query_enhancements/common/types.ts
@@ -57,6 +57,9 @@ export enum S3_FIELD_TYPES {
   LONG = 'long',
   FLOAT = 'float',
   DOUBLE = 'double',
+  TINYINT = 'tinyint',
+  SMALLINT = 'smallint',
+  BIGINT = 'bigint',
   KEYWORD = 'keyword',
   TEXT = 'text',
   STRING = 'string',
@@ -70,8 +73,5 @@ export enum S3_FIELD_TYPES {
   BINARY = 'binary',
   STRUCT = 'struct',
   ARRAY = 'array',
-  TINYINT = 'tinyint',
-  SMALLINT = 'smallint',
-  BIGINT = 'bigint',
   UNKNOWN = 'unknown', // For unmapped or unsupported types
 }

--- a/src/plugins/query_enhancements/common/types.ts
+++ b/src/plugins/query_enhancements/common/types.ts
@@ -70,5 +70,8 @@ export enum S3_FIELD_TYPES {
   BINARY = 'binary',
   STRUCT = 'struct',
   ARRAY = 'array',
+  TINYINT = 'tinyint',
+  SMALLINT = 'smallint',
+  BIGINT = 'bigint',
   UNKNOWN = 'unknown', // For unmapped or unsupported types
 }

--- a/src/plugins/query_enhancements/public/datasets/s3_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/s3_type.ts
@@ -311,6 +311,9 @@ export function castS3FieldTypeToOSDFieldType(sqlType: S3_FIELD_TYPES): OSD_FIEL
     case S3_FIELD_TYPES.LONG:
     case S3_FIELD_TYPES.FLOAT:
     case S3_FIELD_TYPES.DOUBLE:
+    case S3_FIELD_TYPES.TINYINT:
+    case S3_FIELD_TYPES.SMALLINT:
+    case S3_FIELD_TYPES.BIGINT:
       return OSD_FIELD_TYPES.NUMBER;
     case S3_FIELD_TYPES.KEYWORD:
     case S3_FIELD_TYPES.STRING:


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
For PPL in OpenSearch / OpenSearch Spark, the typings for `byte`, `short`, `int`, `integer`, `long`, `float`, `double`, `tinyint`, `smallint`, and `bigint` need to be mapped to numeric. This PR adds the numeric mapping for `tinyint`, `smallint`, and `bigint` in the S3 dataset type.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Add mappings for tinyint, smallint, and bigint in S3 dataset type

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
