### PR TITLE
Format PPL date fields to `YYYY-MM-DDTHH:mm:ss.SSSZ`

### DIFF
--- a/changelogs/fragments/9436.yml
+++ b/changelogs/fragments/9436.yml
@@ -1,0 +1,2 @@
+fix:
+- Make PPL handle miliseconds in date fields ([#9436](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9436))

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -74,7 +74,7 @@ export class QueryEnhancementsPlugin
         formatter: (value: string, type: OSD_FIELD_TYPES) => {
           switch (type) {
             case OSD_FIELD_TYPES.DATE:
-              return moment.utc(value).format('YYYY-MM-DDTHH:mm:ssZ'); // PPL date fields need special formatting in order for discover table formatter to render in the correct time zone
+              return moment.utc(value).format('YYYY-MM-DDTHH:mm:ss.SSSZ'); // PPL date fields need special formatting in order for discover table formatter to render in the correct time zone
 
             default:
               return value;


### PR DESCRIPTION
### Description

Format PPL to include mili-seconds in date fields. 

Actual data: 2022-06-15T10:12:52.382Z

Previously: 
Jun 15, 2022 @ 03:12:52.000 (current browser timezone)

After PR: 
Jun 15, 2022 @ 03:12:52.382 (current browser timezone)


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Make PPL handle miliseconds in date fields

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
