### PR TITLE
[TEST] add setting sort for PPL and SQL for inspect.spec

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/inspect.spec.js
@@ -80,6 +80,10 @@ const inspectTestSuite = () => {
         cy.setQueryLanguage(config.language);
         setDatePickerDatesAndSearchIfRelevant(config.language);
 
+        if (config.queryString) {
+          cy.setQueryEditor(config.queryString, { submit: false });
+        }
+
         cy.intercept('POST', '**/search/*').as('docTablePostRequest');
         cy.getElementByTestId('querySubmitButton').click();
 

--- a/cypress/utils/apps/query_enhancements/inspect.js
+++ b/cypress/utils/apps/query_enhancements/inspect.js
@@ -20,6 +20,27 @@ export const visualizationTitlesWithInspectOptions = [
 ];
 
 /**
+ * Returns the query string to use for a given dataset+language
+ * @param {string} dataset - the dataset name to use
+ * @param {QueryEnhancementLanguage} language - the name of query language
+ * @returns {string}
+ */
+export const getQueryString = (dataset, language) => {
+  switch (language) {
+    case QueryLanguages.DQL.name:
+      return '';
+    case QueryLanguages.Lucene.name:
+      return '';
+    case QueryLanguages.SQL.name:
+      return `SELECT * FROM ${dataset} ORDER BY timestamp`;
+    case QueryLanguages.PPL.name:
+      return `source = ${dataset} | sort timestamp`;
+    default:
+      throw new Error(`getQueryString encountered unsupported language: ${language}`);
+  }
+};
+
+/**
  * Returns the SavedSearchTestConfig for the provided dataset, datasetType, and language
  * @param {string} dataset - the dataset name
  * @param {QueryEnhancementDataset} datasetType - the type of the dataset
@@ -31,6 +52,7 @@ export const generateInspectTestConfiguration = (dataset, datasetType, language)
     dataset,
     datasetType,
     language: language.name,
+    queryString: getQueryString(dataset, language.name),
     testName: `dataset: ${datasetType} and language: ${language.name}`,
   };
 };


### PR DESCRIPTION
### Description

in differing environments, the way PPL is sorted comes through differently, causing our tests to fail. This enforces that we specify the sort for both PPL and SQL

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
