### PR TITLE
remove deprecated CssDistFilename for 3.0

### DIFF
--- a/changelogs/fragments/9446.yml
+++ b/changelogs/fragments/9446.yml
@@ -1,0 +1,2 @@
+breaking:
+- Remove `CssDistFilename` ([#9446](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9446))

--- a/packages/osd-ui-shared-deps/index.d.ts
+++ b/packages/osd-ui-shared-deps/index.d.ts
@@ -54,29 +54,6 @@ export * from './theme_config';
 export const baseCssDistFilename: string;
 
 /**
- * Filename of the dark-theme css file in the distributable directory
- * @deprecated
- */
-export const darkCssDistFilename: string;
-
-/**
- * Filename of the dark-theme css file in the distributable directory
- * @deprecated
- */
-export const darkV8CssDistFilename: string;
-
-/**
- * Filename of the light-theme css file in the distributable directory
- * @deprecated
- */
-export const lightCssDistFilename: string;
-
-/**
- * Filename of the light-theme css file in the distributable directory
- * @deprecated
- */
-export const lightV8CssDistFilename: string;
-/**
  * Externals mapping inteded to be used in a webpack config
  */
 export const externals: {

--- a/packages/osd-ui-shared-deps/index.js
+++ b/packages/osd-ui-shared-deps/index.js
@@ -35,14 +35,6 @@ exports.distDir = Path.resolve(__dirname, 'target');
 exports.jsDepFilenames = ['osd-ui-shared-deps.@elastic.js'];
 exports.jsFilename = 'osd-ui-shared-deps.js';
 exports.baseCssDistFilename = 'osd-ui-shared-deps.css';
-/** @deprecated */
-exports.lightCssDistFilename = 'osd-ui-shared-deps.v7.light.css';
-/** @deprecated */
-exports.lightV8CssDistFilename = 'osd-ui-shared-deps.v8.light.css';
-/** @deprecated */
-exports.darkCssDistFilename = 'osd-ui-shared-deps.v7.dark.css';
-/** @deprecated */
-exports.darkV8CssDistFilename = 'osd-ui-shared-deps.v8.dark.css';
 exports.externals = {
   // stateful deps
   '@osd/i18n': '__osdSharedDeps__.OsdI18n',


### PR DESCRIPTION
### Description

#7625 has deprecated various `CssDistFilename` from `osd-ui-shared-deps`. For 3.0 release, we are removing them from the codebase.

### Issues Resolved

Part of #9253.

## Changelog
- breaking: remove `CssDistFilename`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
