### PR TITLE
Bump dompurify from 3.1.6 to 3.2.4

### DIFF
--- a/changelogs/fragments/9447.yml
+++ b/changelogs/fragments/9447.yml
@@ -1,0 +1,2 @@
+fix:
+- Bump dompurify from 3.1.6 to 3.2.4 ([#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447))

--- a/changelogs/fragments/9447.yml
+++ b/changelogs/fragments/9447.yml
@@ -1,2 +1,2 @@
-fix:
+security:
 - Bump dompurify from 3.1.6 to 3.2.4 ([#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447))

--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
     "d3-cloud": "1.2.5",
     "dedent": "^0.7.0",
     "delete-empty": "^2.0.0",
-    "dompurify": "^3.0.11",
+    "dompurify": "^3.2.4",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "enzyme-to-json": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3883,6 +3883,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/type-detect@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/type-detect/-/type-detect-4.0.1.tgz#3b0f5ac82ea630090cbf57c57a1bf5a63a29b9b6"
@@ -7307,10 +7312,12 @@ domhandler@^4.0, domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.2.2, domhan
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@^3.0.11:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.6.tgz#43c714a94c6a7b8801850f82e756685300a027e2"
-  integrity sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==
+dompurify@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
+  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
### Description

Bump dompurify from 3.1.6 to 3.2.4
```
=> Found "dompurify@3.2.4"
info Has been hoisted to "dompurify"
info Reasons this module exists
   - "workspace-aggregator-4999c2e0-ed64-49ee-b921-36c0e97d5740" depends on it
   - Specified in "devDependencies"
   - Hoisted from "_project_#dompurify"
info Disk size without dependencies: "372KB"
info Disk size with unique dependencies: "372KB"
info Disk size with transitive dependencies: "372KB"
info Number of shared dependencies: 0
✨  Done in 1.57s.
```

### Issues Resolved
CVE-2025-26791

## Changelog
- security: Bump dompurify from 3.1.6 to 3.2.4

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
