### PR TITLE
remove withLongNumerals in HttpFetchOptions as it is deprecated in 3.0

### DIFF
--- a/changelogs/fragments/9448.yml
+++ b/changelogs/fragments/9448.yml
@@ -1,0 +1,2 @@
+breaking:
+- Remove `withLongNumerals` in `HttpFetchOptions`. ([#9448](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9448))

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -192,20 +192,14 @@ export class Fetch {
       if (NDJSON_CONTENT.test(contentType)) {
         body = await response.blob();
       } else if (JSON_CONTENT.test(contentType)) {
-        // ToDo: [3.x] Remove withLongNumerals
-        body =
-          fetchOptions.withLongNumeralsSupport || fetchOptions.withLongNumerals
-            ? parse(await response.text())
-            : await response.json();
+        body = fetchOptions.withLongNumeralsSupport
+          ? parse(await response.text())
+          : await response.json();
       } else {
         const text = await response.text();
 
         try {
-          // ToDo: [3.x] Remove withLongNumerals
-          body =
-            fetchOptions.withLongNumeralsSupport || fetchOptions.withLongNumerals
-              ? parse(text)
-              : JSON.parse(text);
+          body = fetchOptions.withLongNumeralsSupport ? parse(text) : JSON.parse(text);
         } catch (err) {
           body = text;
         }

--- a/src/core/public/http/types.ts
+++ b/src/core/public/http/types.ts
@@ -282,9 +282,6 @@ export interface HttpFetchOptions extends HttpRequestInit {
    */
   withLongNumeralsSupport?: boolean;
 
-  /** @deprecated use {@link withLongNumeralsSupport} instead */
-  withLongNumerals?: boolean;
-
   prependOptions?: PrependOptions;
 }
 


### PR DESCRIPTION
### Description

#5592 renamed `withLongNumerals` to `withLongNumeralsSupport` in `HttpFetchOptions`. Now we are removing the deprecated `withLongNumerals` for 3.0

### Issues Resolved

Part of #9253 

## Changelog

- breaking: remove `withLongNumerals` in `HttpFetchOptions`.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
