### PR TITLE
[workspace] Prevent user from visiting discover when out of a workspace 

### DIFF
--- a/changelogs/fragments/9465.yml
+++ b/changelogs/fragments/9465.yml
@@ -1,0 +1,2 @@
+fix:
+- Prevent user from visiting discover when out of a workspace ([#9465](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9465))

--- a/src/plugins/data_explorer/public/plugin.ts
+++ b/src/plugins/data_explorer/public/plugin.ts
@@ -33,6 +33,7 @@ import { getPreloadedStore } from './utils/state_management';
 import { opensearchFilters } from '../../data/public';
 import { setUsageCollector } from './services';
 import { WorkspaceAvailability } from '../../../../src/core/public';
+
 export class DataExplorerPlugin
   implements
     Plugin<
@@ -87,7 +88,6 @@ export class DataExplorerPlugin
       title: PLUGIN_NAME,
       navLinkStatus: AppNavLinkStatus.hidden,
       workspaceAvailability: WorkspaceAvailability.insideWorkspace,
-      defaultPath: '#/',
       mount: async (params: AppMountParameters) => {
         // Load application bundle
         const { renderApp } = await import('./application');

--- a/src/plugins/data_explorer/public/plugin.ts
+++ b/src/plugins/data_explorer/public/plugin.ts
@@ -32,7 +32,7 @@ import {
 import { getPreloadedStore } from './utils/state_management';
 import { opensearchFilters } from '../../data/public';
 import { setUsageCollector } from './services';
-
+import { WorkspaceAvailability } from '../../../../src/core/public';
 export class DataExplorerPlugin
   implements
     Plugin<
@@ -86,6 +86,8 @@ export class DataExplorerPlugin
       id: PLUGIN_ID,
       title: PLUGIN_NAME,
       navLinkStatus: AppNavLinkStatus.hidden,
+      workspaceAvailability: WorkspaceAvailability.insideWorkspace,
+      defaultPath: '#/',
       mount: async (params: AppMountParameters) => {
         // Load application bundle
         const { renderApp } = await import('./application');

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -34,6 +34,7 @@ import { DataPublicPluginStart, DataPublicPluginSetup, opensearchFilters } from 
 import { SavedObjectLoader } from '../../saved_objects/public';
 import { url } from '../../opensearch_dashboards_utils/public';
 import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../core/public';
+import { WorkspaceAvailability } from '../../../../src/core/public';
 import { UrlGeneratorState } from '../../share/public';
 import { DocViewInput, DocViewInputFn } from './application/doc_views/doc_views_types';
 import { generateDocViewsUrl } from './application/components/doc_views/generate_doc_views_url';
@@ -265,6 +266,7 @@ export class DiscoverPlugin
       title: 'Discover',
       updater$: this.appStateUpdater.asObservable(),
       order: 1000,
+      workspaceAvailability: WorkspaceAvailability.insideWorkspace,
       euiIconType: 'inputOutput',
       defaultPath: '#/',
       category: DEFAULT_APP_CATEGORIES.opensearchDashboards,


### PR DESCRIPTION
### Description

This pr prevents user from visiting discover when out of a workspace  

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

when removing workspace in url
<img width="1715" alt="截屏2025-02-28 10 28 02" src="https://github.com/user-attachments/assets/0df1720b-ab0b-4ae8-aa66-b1628a678249" />



## Changelog
- fix: Prevent user from visiting discover when out of a workspace 
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
