### PR TITLE
Add Joey Liu (`@Maosaic`) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi @mengweieric @LDrago27 @virajsanghvi @sejli @joshuali925 @huyaboo @angle943
+*   @ananzh @kavilla @AMoo-Miki @ashwin-pc @joshuarrrr @abbyhu2000 @zengyan-amazon @zhongnansu @manasvinibs @ZilongX @Flyingliuhub @curq @bandinib-amzn @SuZhou-Joe @ruanyl @BionIT @xinruiba @zhyuanqi @mengweieric @LDrago27 @virajsanghvi @sejli @joshuali925 @huyaboo @angle943 @Maosaic

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,6 +32,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Huy Nguyen                | [huyaboo](https://github.com/huyaboo)               | Amazon      |
 | Hailong Cui               | [Hailong-am](https://github.com/Hailong-am)         | Amazon      |
 | Justin Kim                | [angle943](https://github.com/angle943)             | Amazon      |
+| Joey Liu                  | [Maosaic](jiyili@amazon.com)                        | Amazon      |
 
 ## Emeritus
 

--- a/changelogs/fragments/9467.yml
+++ b/changelogs/fragments/9467.yml
@@ -1,0 +1,2 @@
+doc:
+- Add Joey Liu (`@Maosaic`) as maintainer ([#9467](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9467))


### PR DESCRIPTION
### Description

Add Joey Liu (@Maosaic) as a maintainer for the opensearch-project/OpenSearch-Dashboards repository.

Joey has demonstrated strong technical capabilities and has been making valuable contributions to our codebase.

Here are some examples of his recent contributions:

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9383
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9379
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9316
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9314
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9298

Joey has shown exceptional understanding of web development, React, and engineering principles that are crucial for developing a data analytics tool. His ability to quickly grasp complex concepts and provide meaningful insights during code reviews has been impressive. He's also demonstrated a great attitude towards receiving feedback and incorporating it into his work.

You can see his full contribution history here:
https://github.com/opensearch-project/OpenSearch-Dashboards/commits?author=Maosaic
https://github.com/opensearch-project/OpenSearch-Dashboards/pulls?q=is%3Apr+maosaic+is%3Aclosed

https://github.com/opensearch-project/.github/issues/295

## Changelog
- doc: add Joey Liu (`@Maosaic`) as maintainer

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
