### PR TITLE
Prevent `_cat/indices` when there is no datasource available

### DIFF
--- a/src/plugins/data_importer/public/application.tsx
+++ b/src/plugins/data_importer/public/application.tsx
@@ -27,6 +27,7 @@ export const renderApp = (
       config={config}
       savedObjects={savedObjects}
       dataSourceEnabled={!!dataSource}
+      hideLocalCluster={dataSource?.hideLocalCluster || false}
       dataSourceManagement={dataSourceManagement}
     />,
     element

--- a/src/plugins/data_importer/public/components/data_importer_app.tsx
+++ b/src/plugins/data_importer/public/components/data_importer_app.tsx
@@ -55,6 +55,7 @@ interface DataImporterPluginAppProps {
   savedObjects: CoreStart['savedObjects'];
   navigation: NavigationPublicPluginStart;
   config: PublicConfigSchema;
+  hideLocalCluster: boolean;
   dataSourceEnabled: boolean;
   dataSourceManagement?: DataSourceManagementPluginSetup;
 }
@@ -69,6 +70,7 @@ export const DataImporterPluginApp = ({
   config,
   savedObjects,
   dataSourceEnabled,
+  hideLocalCluster,
   dataSourceManagement,
 }: DataImporterPluginAppProps) => {
   const DataSourceMenuComponent = dataSourceManagement?.ui.getDataSourceMenu<
@@ -271,8 +273,10 @@ export const DataImporterPluginApp = ({
       }
     }
 
-    fetchIndices();
-  }, [http, dataSourceId, notifications.toasts, filePreviewData]);
+    if (!hideLocalCluster || dataSourceId) {
+      fetchIndices();
+    }
+  }, [http, dataSourceId, notifications.toasts, filePreviewData, hideLocalCluster]);
 
   useEffect(() => {
     setDisableImport(shouldDisableImportButton());


### PR DESCRIPTION
### Description

This PR fixes the `Server error` that may occur if the `dataSource.hideLocalCluster` option is set to `true`. Essentially, this PR prevents a network call if there are no available data sources on startup.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

Without MDS: makes the network call to `_cat/indices` as expected
With MDS, with local cluster: makes the network call to `_cat/indices` as expected
With MDS, with local cluster and a data source connected: makes the network call to `_cat/indices` as expected
With MDS, without local cluster, no datasource: no network call to `_cat/indices` as expected (with toast from the `DataSourceSelectable` component
With MDS, without local cluster, with datasource: makes the network call to `_cat/indices` as expected

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
