### PR TITLE
Update formatHit to accept type as param

### DIFF
--- a/src/plugins/data/common/index_patterns/index_patterns/format_hit.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/format_hit.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { IndexPattern } from './index_pattern';
+import { formatHitProvider } from './format_hit';
+
+const mockFlattenHit = {
+  fieldA: 'valueA',
+  fieldB: 'valueB',
+};
+const indexPatternGetFormatterForFieldConvertMock = jest.fn((val) => val);
+const getByNameMock = (name: string) => {
+  if (name === 'fieldA' || name === 'fieldB') {
+    return name;
+  }
+  return undefined;
+};
+const defaultFormatConvertMock = jest.fn((val) => val);
+const defaultFormatMock = {
+  convert: defaultFormatConvertMock,
+};
+
+// this is a mock of index pattern that has just the things needed for this test
+const indexPatternMock = ({
+  fields: {
+    getByName: getByNameMock,
+  },
+  flattenHit: () => mockFlattenHit,
+  getFormatterForField: () => ({ convert: indexPatternGetFormatterForFieldConvertMock }),
+} as unknown) as IndexPattern;
+
+describe('formatHit', () => {
+  let formatHit: any;
+
+  beforeEach(() => {
+    formatHit = formatHitProvider(indexPatternMock, defaultFormatMock);
+  });
+
+  afterEach(() => {
+    indexPatternGetFormatterForFieldConvertMock.mockClear();
+    defaultFormatConvertMock.mockClear();
+  });
+
+  test('formats hit in html as default correctly', () => {
+    formatHit({});
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(2);
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenNthCalledWith(
+      1,
+      'valueA',
+      'html',
+      expect.objectContaining({ field: 'fieldA' })
+    );
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenNthCalledWith(
+      2,
+      'valueB',
+      'html',
+      expect.objectContaining({ field: 'fieldB' })
+    );
+  });
+
+  test('formats hit in html called multiple times leverages the cache', () => {
+    const mockHit = {};
+    formatHit(mockHit);
+    formatHit(mockHit);
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('formats hit in text correctly', () => {
+    formatHit({}, 'text');
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(2);
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenNthCalledWith(
+      1,
+      'valueA',
+      'text',
+      expect.objectContaining({ field: 'fieldA' })
+    );
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenNthCalledWith(
+      2,
+      'valueB',
+      'text',
+      expect.objectContaining({ field: 'fieldB' })
+    );
+  });
+
+  test('formats hit in text called multiple times does not leverage cache', () => {
+    const mockHit = {};
+    formatHit(mockHit, 'text');
+    formatHit(mockHit, 'text');
+    expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(4);
+  });
+
+  describe('formatHit.formatField', () => {
+    test('formats field in html as default correctly for field in index pattern', () => {
+      const mockHit = {};
+      formatHit.formatField(mockHit, 'fieldA');
+      expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(1);
+      expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledWith(
+        'valueA',
+        'html',
+        expect.objectContaining({ field: 'fieldA' })
+      );
+    });
+
+    test('formats field in html as default correctly for field in index pattern, using the cache when called after formatField()', () => {
+      const mockHit = {};
+      // should call indexPatternGetFormatterForFieldConvertMock twice
+      formatHit(mockHit);
+      // should not call indexPatternGetFormatterForFieldConvertMock
+      formatHit.formatField(mockHit, 'fieldA');
+      expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(2);
+    });
+
+    test('formats field in html as default correctly for field not in index pattern', () => {
+      formatHit.formatField({}, 'fieldC');
+      expect(indexPatternGetFormatterForFieldConvertMock).not.toHaveBeenCalled();
+      expect(defaultFormatConvertMock).toHaveBeenCalledTimes(1);
+      expect(defaultFormatConvertMock).toHaveBeenCalledWith(undefined, 'html', expect.anything());
+    });
+
+    test('formats field in html as default correctly for _source', () => {
+      formatHit.formatField({ _source: 'source value' }, '_source');
+      expect(defaultFormatConvertMock).toHaveBeenCalledTimes(1);
+      expect(defaultFormatConvertMock).toHaveBeenCalledWith(
+        'source value',
+        'html',
+        expect.anything()
+      );
+    });
+
+    test('formats field in text correctly for field in index pattern', () => {
+      const mockHit = {};
+      formatHit.formatField(mockHit, 'fieldA', 'text');
+      expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(1);
+      expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledWith(
+        'valueA',
+        'text',
+        expect.objectContaining({ field: 'fieldA' })
+      );
+    });
+
+    test('formats field in text correctly for field in index pattern, skipping the cache when called after formatField()', () => {
+      const mockHit = {};
+      // should call indexPatternGetFormatterForFieldConvertMock twice
+      formatHit(mockHit);
+      // should call indexPatternGetFormatterForFieldConvertMock once
+      formatHit.formatField(mockHit, 'fieldA', 'text');
+      expect(indexPatternGetFormatterForFieldConvertMock).toHaveBeenCalledTimes(3);
+    });
+
+    test('formats field in text correctly for field not in index pattern', () => {
+      formatHit.formatField({}, 'fieldC', 'text');
+      expect(indexPatternGetFormatterForFieldConvertMock).not.toHaveBeenCalled();
+      expect(defaultFormatConvertMock).toHaveBeenCalledTimes(1);
+      expect(defaultFormatConvertMock).toHaveBeenCalledWith(undefined, 'text', expect.anything());
+    });
+
+    test('formats field in text correctly for _source', () => {
+      formatHit.formatField({ _source: 'source value' }, '_source', 'text');
+      expect(defaultFormatConvertMock).toHaveBeenCalledTimes(1);
+      expect(defaultFormatConvertMock).toHaveBeenCalledWith(
+        'source value',
+        'text',
+        expect.anything()
+      );
+    });
+  });
+});

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -29,7 +29,7 @@
  */
 
 import _, { each, reject } from 'lodash';
-import { SavedObjectsClientCommon } from '../..';
+import { FieldFormatsContentType, SavedObjectsClientCommon } from '../..';
 import { DuplicateField } from '../../../../opensearch_dashboards_utils/common';
 
 import { SerializedFieldFormat } from '../../../../expressions/common';
@@ -71,7 +71,11 @@ interface SavedObjectBody {
   type?: string;
 }
 
-type FormatFieldFn = (hit: Record<string, any>, fieldName: string) => any;
+type FormatFieldFn = (
+  hit: Record<string, any>,
+  fieldName: string,
+  type?: FieldFormatsContentType
+) => any;
 
 const DATA_SOURCE_REFERNECE_NAME = 'dataSource';
 export class IndexPattern implements IIndexPattern {
@@ -84,7 +88,7 @@ export class IndexPattern implements IIndexPattern {
   public intervalName: string | undefined;
   public type: string | undefined;
   public formatHit: {
-    (hit: Record<string, any>, type?: string): any;
+    (hit: Record<string, any>, type?: FieldFormatsContentType): any;
     formatField: FormatFieldFn;
   };
   public formatField: FormatFieldFn;
@@ -251,7 +255,6 @@ export class IndexPattern implements IIndexPattern {
    * @param name field name
    * @param script script code
    * @param fieldType
-   * @param lang
    */
   async addScriptedField(name: string, script: string, fieldType: string = 'string') {
     const scriptedFields = this.getScriptedFields();


### PR DESCRIPTION
### Description

- Update `formatHit.formatField()` to accept `type` as an argument.
- This is needed because when working on the "export to CSV" functionality, we want to export it as type "text", not type "html", which was the default (and unconfigurable)
- `formatHit.formatField()` calls `convert()`, which already accepts `type`, so my code is just leveraging that
- But since `formatHit.formatField()` assumed that it was only for HTML type, the code was written to always leverage cache. But we should only be leveraging cache when its for HTML type, so I added an `if` condition.
- I also added unit tests for the entire `format_hit.ts` file
- This is part of a larger work on export to CSV functionality. You can see the draft PR here: #9333 . 


## Changelog
- feat: update formatHit.formatField() to accept `type` as an argument

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
