### PR TITLE
fix: Do not call data2summary api when summary toggle is collapsed

### DIFF
--- a/changelogs/fragments/9479.yml
+++ b/changelogs/fragments/9479.yml
@@ -1,0 +1,2 @@
+fix:
+- Do not call data2summary api when summary toggle is collapsed ([#9479](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9479))

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
@@ -121,6 +121,7 @@ export const QueryAssistSummary: React.FC<QueryAssistSummaryProps> = (props) => 
   const fetchSummary = useCallback(
     async (queryContext: QueryContext) => {
       if (isEmpty(queryContext?.queryResults)) return;
+      if (isQuerySummaryCollapsed) return setSummary('');
       setLoading(true);
       setSummary('');
       setFeedback(FeedbackStatus.NONE);
@@ -150,7 +151,7 @@ export const QueryAssistSummary: React.FC<QueryAssistSummaryProps> = (props) => 
         setLoading(false);
       }
     },
-    [props.http, reportCountMetric, errorPrompt]
+    [props.http, reportCountMetric, errorPrompt, isQuerySummaryCollapsed]
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Description

If user toggles the query summary off, the summary API will not be called and the summary will be reset when the user sends a query.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/dedc4e3e-d602-4922-96fd-886866129cff



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Do not call data2summary api when summary toggle is collapsed

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
