### PR TITLE
[workspace] Fix : should not show summary if there is no response

### DIFF
--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.test.tsx
@@ -269,6 +269,7 @@ describe('query assist summary', () => {
     query$.next({ query: PPL, language: 'PPL' });
     data$.next(emptyDataFrame);
     expect(httpMock.post).toBeCalledTimes(0);
+    expect(screen.queryAllByTestId('queryAssist_summary_empty_text')).toHaveLength(1);
   });
 
   it('should fetch summary with expected payload and response', async () => {

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
@@ -120,9 +120,9 @@ export const QueryAssistSummary: React.FC<QueryAssistSummaryProps> = (props) => 
 
   const fetchSummary = useCallback(
     async (queryContext: QueryContext) => {
+      setSummary('');
       if (isEmpty(queryContext?.queryResults)) return;
       setLoading(true);
-      setSummary('');
       setFeedback(FeedbackStatus.NONE);
       const SUCCESS_METRIC = 'fetch_summary_success';
       try {


### PR DESCRIPTION
### Description
This PR fixes a bug where the summary is displayed even when there is no response. 
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

## Changelog
- fix: should not show summary if there is no response
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
