### PR TITLE
Skeleton of prometheus data selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "start:docker": "scripts/use_node scripts/opensearch_dashboards --dev --opensearch.hosts=$OPENSEARCH_HOSTS --opensearch.ignoreVersionMismatch=true --server.host=$SERVER_HOST",
     "start:security": "scripts/use_node scripts/opensearch_dashboards --dev --security",
     "start:enhancements": "scripts/use_node scripts/opensearch_dashboards --dev --uiSettings.overrides['query:enhancements:enabled']=true --uiSettings.overrides['home:useNewHomePage']=true",
-    "debug": "scripts/use_node --nolazy --inspect scripts/opensearch_dashboards --dev",
+    "debug": "scripts/use_node --nolazy --inspect scripts/opensearch_dashboards --dev --uiSettings.overrides['query:enhancements:enabled']=true --uiSettings.overrides['home:useNewHomePage']=true --workspace.enabled=true --no-base-path --opensearch.ignoreVersionMismatch=true",
     "debug-break": "scripts/use_node --nolazy --inspect-brk scripts/opensearch_dashboards --dev",
     "lint": "yarn run lint:es && yarn run lint:style",
     "lint:es": "scripts/use_node scripts/eslint",

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -91,6 +91,8 @@ export interface DatasetTypeConfig {
     dataset: Dataset,
     services?: Partial<IDataPluginServices>
   ) => Promise<DatasetField[]>;
+
+  fetchMetrics: (dataset: Dataset, services?: Partial<IDataPluginServices>) => Promise<string[]>;
   /**
    * Retrieves the supported query languages for this dataset type.
    * @returns {Promise<string[]>} A promise that resolves to an array of supported language ids.

--- a/src/plugins/data_source/common/data_connections/data_connection_saved_object_attributes.ts
+++ b/src/plugins/data_source/common/data_connections/data_connection_saved_object_attributes.ts
@@ -21,6 +21,7 @@ export interface DataConnectionSavedObjectAttributes extends SavedObjectAttribut
 
 export enum DataConnectionType {
   CloudWatch = 'AWS CloudWatch',
+  Prometheus = 'Prometheus',
   SecurityLake = 'AWS Security Lake',
   NA = 'None',
 }

--- a/src/plugins/data_source/common/data_sources/types.ts
+++ b/src/plugins/data_source/common/data_sources/types.ts
@@ -59,5 +59,6 @@ export enum DataSourceEngineType {
   OpenSearch = 'OpenSearch',
   OpenSearchServerless = 'OpenSearch Serverless',
   Elasticsearch = 'Elasticsearch',
+  Prometheus = 'Prometheus',
   NA = 'No Engine Type Available',
 }

--- a/src/plugins/discover/public/application/components/sidebar/metrics_sidebar.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/metrics_sidebar.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiText,
+  EuiDragDropContext,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSplitPanel,
+  EuiIcon,
+  EuiPopover,
+  EuiSelectable,
+  EuiToolTip,
+  EuiSmallButton,
+  EuiDroppable,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { I18nProvider } from '@osd/i18n/react';
+import React, { useState, useCallback } from 'react';
+import { usePrometheus, PrometheusContext } from '../../view_components/utils/use_prometheus';
+import { FieldIcon } from '../../../../../opensearch_dashboards_react/public';
+import './discover_sidebar.scss';
+
+export const MetricsSidebar = () => {
+  const prometheusContext = usePrometheus();
+
+  return (
+    <I18nProvider>
+      <EuiDragDropContext onDragEnd={() => {}}>
+        <EuiSplitPanel.Outer
+          className="sidebar-list eui-yScroll"
+          aria-label={i18n.translate(
+            'discover.fieldChooser.filter.indexAndFieldsSectionAriaLabel',
+            {
+              defaultMessage: 'Index and fields',
+            }
+          )}
+          borderRadius="none"
+          color="transparent"
+          hasBorder={false}
+        >
+          <EuiSplitPanel.Inner grow={false} paddingSize="s" className="dscSideBar_searchContainer">
+            <MetricsSelector prometheusContext={prometheusContext} />
+          </EuiSplitPanel.Inner>
+          <EuiSplitPanel.Inner
+            className="eui-yScroll dscSideBar_fieldListContainer"
+            paddingSize="none"
+          >
+            <EuiDroppable droppableId="PROMETHEUS_LABELS" spacing="l">
+              <>
+                {prometheusContext.metadata.labelNames.length > 0 && (
+                  <>
+                    {prometheusContext.metadata.labelNames.map((label) => (
+                      <EuiFlexGroup
+                        gutterSize="s"
+                        alignItems="center"
+                        responsive={false}
+                        className="dscSidebarField"
+                        data-test-subj="dscSidebarField"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <FieldIcon type="string" />
+                        </EuiFlexItem>
+                        <EuiFlexItem grow>
+                          <EuiText size="xs">{label}</EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    ))}
+                  </>
+                )}
+              </>
+            </EuiDroppable>
+          </EuiSplitPanel.Inner>
+        </EuiSplitPanel.Outer>
+      </EuiDragDropContext>
+    </I18nProvider>
+  );
+};
+
+interface MetricsSelectorProps {
+  prometheusContext: PrometheusContext;
+}
+
+interface MetricOption {
+  label: string;
+  checked?: 'on' | 'off';
+}
+
+const MetricsSelector = ({ prometheusContext }: MetricsSelectorProps) => {
+  const {
+    metadata: { selectedMetricName, metricNames },
+  } = prometheusContext;
+
+  const selectedMetricLabel = selectedMetricName ?? 'Select Metric';
+  const metricOptions = metricNames.map((metricName): MetricOption => ({ label: metricName }));
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const togglePopover = useCallback(() => {
+    setIsOpen(!isOpen);
+  }, [isOpen]);
+
+  const closePopover = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleOptionChange = (options: MetricOption[]) => {
+    const selectedOption = options.find((option) => option.checked === 'on');
+    if (selectedOption) {
+      prometheusContext.actions.setSelectedMetricName(selectedOption.label);
+    }
+    closePopover();
+  };
+
+  return (
+    <EuiPopover
+      button={
+        <EuiToolTip display="block" content={selectedMetricLabel}>
+          <EuiSmallButton
+            className="datasetSelector__button"
+            data-test-subj="datasetSelectorButton"
+            iconType="arrowDown"
+            iconSide="right"
+            fullWidth
+            onClick={togglePopover}
+          >
+            <EuiIcon
+              type={'text'}
+              className="datasetSelector__icon"
+              data-test-subj="datasetSelectorIcon"
+            />
+            {selectedMetricLabel}
+          </EuiSmallButton>
+        </EuiToolTip>
+      }
+      isOpen={isOpen}
+      closePopover={closePopover}
+      anchorPosition="downLeft"
+      display="block"
+      panelPaddingSize="none"
+    >
+      <EuiSelectable
+        className="datasetSelector__selectable"
+        data-test-subj="datasetSelectorSelectable"
+        options={metricOptions}
+        singleSelection="always"
+        searchable={true}
+        onChange={handleOptionChange}
+        listProps={{
+          showIcons: false,
+        }}
+        searchProps={{
+          compressed: true,
+        }}
+      >
+        {(list, search) => (
+          <>
+            {search}
+            {list}
+          </>
+        )}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};

--- a/src/plugins/discover/public/application/view_components/panel/index.tsx
+++ b/src/plugins/discover/public/application/view_components/panel/index.tsx
@@ -21,6 +21,7 @@ import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_re
 import { DiscoverViewServices } from '../../../build_services';
 import { popularizeField } from '../../helpers/popularize_field';
 import { buildColumns } from '../../utils/columns';
+import { MetricsSidebar } from '../../components/sidebar/metrics_sidebar';
 
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverPanel(props: ViewProps) {
@@ -103,6 +104,10 @@ export default function DiscoverPanel(props: ViewProps) {
   const isEnhancementsEnabledOverride = services.uiSettings.get(
     UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED
   );
+
+  if (indexPattern?.id === 'promql1') {
+    return <MetricsSidebar />;
+  }
 
   return (
     <DiscoverSidebar

--- a/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+const PROMETHEUS_ENDPOINT = 'http://127.0.0.1:9090';
+
+interface PrometheusDataSourceMetadata {
+  selectedMetricName: string | null;
+  metricNames: string[];
+  labelNames: string[];
+}
+
+export interface PrometheusContext {
+  metadata: PrometheusDataSourceMetadata;
+  actions: {
+    setSelectedMetricName: (selectedMetricName: string) => void;
+  };
+}
+
+export const usePrometheus = (): PrometheusContext => {
+  const [selectedMetricName, setSelectedMetricName] = useState<string | null>(null);
+  const [metricNames, setMetricNames] = useState<string[]>([]);
+  const [labelNames, setLabelNames] = useState<string[]>([]);
+
+  const updateLabels = useCallback(async () => {
+    const query = selectedMetricName ? `?match[]=${selectedMetricName}` : '';
+    const response = await fetch(`${PROMETHEUS_ENDPOINT}/api/v1/labels${query}`).then((r) =>
+      r.json()
+    );
+    setLabelNames(response.data.slice(1));
+  }, [selectedMetricName]);
+
+  const updateMetrics = useCallback(async () => {
+    const response = await fetch(`${PROMETHEUS_ENDPOINT}/api/v1/label/__name__/values`).then((r) =>
+      r.json()
+    );
+    setMetricNames(response.data);
+  }, []);
+
+  useEffect(() => {
+    updateMetrics();
+  }, [updateMetrics]);
+
+  useEffect(() => {
+    updateLabels();
+  }, [selectedMetricName, updateLabels]);
+
+  return {
+    metadata: {
+      selectedMetricName,
+      metricNames,
+      labelNames,
+    },
+    actions: {
+      setSelectedMetricName,
+    },
+  };
+};

--- a/src/plugins/query_enhancements/common/constants.ts
+++ b/src/plugins/query_enhancements/common/constants.ts
@@ -11,11 +11,13 @@ export const BASE_API_ASSISTANT = '/api/assistant';
 
 export const DATASET = {
   S3: 'S3',
+  PROMETHEUS: 'PROMETHEUS',
 };
 
 export const SEARCH_STRATEGY = {
   PPL: 'ppl',
   PPL_RAW: 'pplraw',
+  PROMQL: 'promql',
   SQL: 'sql',
   SQL_ASYNC: 'sqlasync',
   PPL_ASYNC: 'pplasync',

--- a/src/plugins/query_enhancements/common/constants.ts
+++ b/src/plugins/query_enhancements/common/constants.ts
@@ -26,6 +26,7 @@ export const SEARCH_STRATEGY = {
 export const API = {
   SEARCH: `${BASE_API}/search`,
   PPL_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.PPL}`,
+  PROMQL_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.PROMQL}`,
   SQL_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.SQL}`,
   SQL_ASYNC_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.SQL_ASYNC}`,
   PPL_ASYNC_SEARCH: `${BASE_API}/search/${SEARCH_STRATEGY.PPL_ASYNC}`,
@@ -44,6 +45,7 @@ export const API = {
 
 export const URI = {
   PPL: '/_plugins/_ppl',
+  PROMQL: '/_plugins/_promql',
   SQL: '/_plugins/_sql',
   ASYNC_QUERY: '/_plugins/_async_query',
   ML: '/_plugins/_ml',
@@ -54,6 +56,7 @@ export const URI = {
 export const OPENSEARCH_API = {
   PANELS: `${URI.OBSERVABILITY}/object`,
   DATA_CONNECTIONS: URI.DATA_CONNECTIONS,
+  METRICS: URI.PROMQL,
 };
 
 export const UI_SETTINGS = {

--- a/src/plugins/query_enhancements/public/assets/prometheus_mark.svg
+++ b/src/plugins/query_enhancements/public/assets/prometheus_mark.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="115.333px"
+   height="114px"
+   viewBox="0 0 115.333 114"
+   enable-background="new 0 0 115.333 114"
+   xml:space="preserve"
+   sodipodi:docname="prometheus_logo_orange.svg"
+   inkscape:version="0.92.1 r15371"><metadata
+     id="metadata4495"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs4493" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1484"
+     inkscape:window-height="886"
+     id="namedview4491"
+     showgrid="false"
+     inkscape:zoom="5.2784901"
+     inkscape:cx="60.603667"
+     inkscape:cy="60.329656"
+     inkscape:window-x="54"
+     inkscape:window-y="7"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><g
+     id="Layer_2" /><path
+     style="fill:#e6522c;fill-opacity:1"
+     inkscape:connector-curvature="0"
+     id="path4486"
+     d="M 56.667,0.667 C 25.372,0.667 0,26.036 0,57.332 c 0,31.295 25.372,56.666 56.667,56.666 31.295,0 56.666,-25.371 56.666,-56.666 0,-31.296 -25.372,-56.665 -56.666,-56.665 z m 0,106.055 c -8.904,0 -16.123,-5.948 -16.123,-13.283 H 72.79 c 0,7.334 -7.219,13.283 -16.123,13.283 z M 83.297,89.04 H 30.034 V 79.382 H 83.298 V 89.04 Z M 83.106,74.411 H 30.186 C 30.01,74.208 29.83,74.008 29.66,73.802 24.208,67.182 22.924,63.726 21.677,60.204 c -0.021,-0.116 6.611,1.355 11.314,2.413 0,0 2.42,0.56 5.958,1.205 -3.397,-3.982 -5.414,-9.044 -5.414,-14.218 0,-11.359 8.712,-21.285 5.569,-29.308 3.059,0.249 6.331,6.456 6.552,16.161 3.252,-4.494 4.613,-12.701 4.613,-17.733 0,-5.21 3.433,-11.262 6.867,-11.469 -3.061,5.045 0.793,9.37 4.219,20.099 1.285,4.03 1.121,10.812 2.113,15.113 C 63.797,33.534 65.333,20.5 71,16 c -2.5,5.667 0.37,12.758 2.333,16.167 3.167,5.5 5.087,9.667 5.087,17.548 0,5.284 -1.951,10.259 -5.242,14.148 3.742,-0.702 6.326,-1.335 6.326,-1.335 l 12.152,-2.371 c 10e-4,-10e-4 -1.765,7.261 -8.55,14.254 z" /></svg>

--- a/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsClientContract } from 'opensearch-dashboards/public';
+import {
+  DATA_STRUCTURE_META_TYPES,
+  DataStructure,
+  DataStructureCustomMeta,
+  Dataset,
+} from '../../../data/common';
+import { DatasetTypeConfig } from '../../../data/public';
+import { DATASET } from '../../common';
+import PROMETHEUS_ICON from '../assets/prometheus_mark.svg';
+
+export const prometheusTypeConfig: DatasetTypeConfig = {
+  id: DATASET.PROMETHEUS,
+  title: 'Prometheus',
+  meta: {
+    icon: { type: PROMETHEUS_ICON },
+    tooltip: 'Prometheus',
+    searchOnLoad: true,
+  },
+
+  toDataset: (path) => {
+    const connection = path[path.length - 1];
+    const patternMeta = connection.meta as DataStructureCustomMeta;
+    return {
+      id: connection.id,
+      title: connection.title,
+      type: DATASET.PROMETHEUS,
+      timeFieldName: patternMeta?.timeFieldName,
+      dataSource: connection.parent
+        ? {
+            id: connection.parent.id,
+            title: connection.parent.title,
+            type: connection.parent.type,
+          }
+        : undefined,
+    } as Dataset;
+  },
+
+  fetch: async (services, path) => {
+    const dataStructure = path[path.length - 1];
+    const indexPatterns = await fetchConnections(services.savedObjects.client);
+    return {
+      ...dataStructure,
+      columnHeader: 'Connections',
+      children: indexPatterns,
+      hasNext: false,
+    };
+  },
+
+  fetchFields: async (dataset: Dataset) => {
+    return [];
+  },
+
+  supportedLanguages: (dataset): string[] => {
+    return ['promql'];
+  },
+};
+
+const fetchConnections = async (client: SavedObjectsClientContract): Promise<DataStructure[]> => {
+  // TODO: fetch from saved objects (type data-connection)
+  return [
+    {
+      id: 'promql1',
+      title: 'Prometheus connection 1',
+      type: DATASET.PROMETHEUS,
+      meta: {
+        type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+        language: 'promql',
+        timeFieldName: 'Time',
+      },
+    },
+  ];
+};

--- a/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
@@ -10,7 +10,7 @@ import {
   DataStructureCustomMeta,
   Dataset,
 } from '../../../data/common';
-import { DatasetTypeConfig } from '../../../data/public';
+import { DatasetTypeConfig, IDataPluginServices } from '../../../data/public';
 import { DATASET } from '../../common';
 import PROMETHEUS_ICON from '../assets/prometheus_mark.svg';
 
@@ -20,7 +20,7 @@ export const prometheusTypeConfig: DatasetTypeConfig = {
   meta: {
     icon: { type: PROMETHEUS_ICON },
     tooltip: 'Prometheus',
-    searchOnLoad: true,
+    searchOnLoad: false,
   },
 
   toDataset: (path) => {
@@ -43,7 +43,7 @@ export const prometheusTypeConfig: DatasetTypeConfig = {
 
   fetch: async (services, path) => {
     const dataStructure = path[path.length - 1];
-    const indexPatterns = await fetchConnections(services.savedObjects.client);
+    const indexPatterns = await fetchConnections();
     return {
       ...dataStructure,
       columnHeader: 'Connections',
@@ -52,16 +52,21 @@ export const prometheusTypeConfig: DatasetTypeConfig = {
     };
   },
 
-  fetchFields: async (dataset: Dataset) => {
-    return [];
+  fetchFields: async () => {
+    return [
+      {
+        name: 'Time',
+        type: 'date',
+      },
+    ];
   },
 
   supportedLanguages: (dataset): string[] => {
-    return ['promql'];
+    return ['PROMQL'];
   },
 };
 
-const fetchConnections = async (client: SavedObjectsClientContract): Promise<DataStructure[]> => {
+const fetchConnections = async (): Promise<DataStructure[]> => {
   // TODO: fetch from saved objects (type data-connection)
   return [
     {

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -221,7 +221,7 @@ export class QueryEnhancementsPlugin
     // TODO: This will need to get updated when we're closer to dispatching queries
     const promqlLanguageConfig: LanguageConfig = {
       id: 'PROMQL',
-      title: 'PROMQL',
+      title: 'PromQL',
       search: new PPLSearchInterceptor({
         toasts: core.notifications.toasts,
         http: core.http,

--- a/src/plugins/query_enhancements/server/plugin.ts
+++ b/src/plugins/query_enhancements/server/plugin.ts
@@ -20,6 +20,7 @@ import {
   pplAsyncSearchStrategyProvider,
   pplRawSearchStrategyProvider,
   pplSearchStrategyProvider,
+  promqlSearchStrategyProvider,
   sqlAsyncSearchStrategyProvider,
   sqlSearchStrategyProvider,
 } from './search';
@@ -53,6 +54,7 @@ export class QueryEnhancementsPlugin
 
     const pplSearchStrategy = pplSearchStrategyProvider(this.config$, this.logger, client);
     const pplRawSearchStrategy = pplRawSearchStrategyProvider(this.config$, this.logger, client);
+    const promqlSearchStrategy = promqlSearchStrategyProvider(this.config$, this.logger, client);
     const sqlSearchStrategy = sqlSearchStrategyProvider(this.config$, this.logger, client);
     const sqlAsyncSearchStrategy = sqlAsyncSearchStrategyProvider(
       this.config$,
@@ -67,6 +69,7 @@ export class QueryEnhancementsPlugin
 
     data.search.registerSearchStrategy(SEARCH_STRATEGY.PPL, pplSearchStrategy);
     data.search.registerSearchStrategy(SEARCH_STRATEGY.PPL_RAW, pplRawSearchStrategy);
+    data.search.registerSearchStrategy(SEARCH_STRATEGY.PROMQL, promqlSearchStrategy);
     data.search.registerSearchStrategy(SEARCH_STRATEGY.SQL, sqlSearchStrategy);
     data.search.registerSearchStrategy(SEARCH_STRATEGY.SQL_ASYNC, sqlAsyncSearchStrategy);
     data.search.registerSearchStrategy(SEARCH_STRATEGY.PPL_ASYNC, pplAsyncSearchStrategy);
@@ -92,6 +95,7 @@ export class QueryEnhancementsPlugin
     defineRoutes(this.logger, router, client, {
       ppl: pplSearchStrategy,
       sql: sqlSearchStrategy,
+      promql: promqlSearchStrategy,
       sqlasync: sqlAsyncSearchStrategy,
       pplasync: pplAsyncSearchStrategy,
     });

--- a/src/plugins/query_enhancements/server/routes/metrics/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/metrics/routes.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function getMetricNames(): Promise<string[]> {}
+
+function getLabels(metricName: string) {}

--- a/src/plugins/query_enhancements/server/search/index.ts
+++ b/src/plugins/query_enhancements/server/search/index.ts
@@ -6,5 +6,6 @@
 export { pplAsyncSearchStrategyProvider } from './ppl_async_search_strategy';
 export { pplRawSearchStrategyProvider } from './ppl_raw_search_strategy';
 export { pplSearchStrategyProvider } from './ppl_search_strategy';
+export { promqlSearchStrategyProvider } from './promql_search_strategy';
 export { sqlAsyncSearchStrategyProvider } from './sql_async_search_strategy';
 export { sqlSearchStrategyProvider } from './sql_search_strategy';

--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SharedGlobalConfig, Logger, ILegacyClusterClient } from 'opensearch-dashboards/server';
+import { Observable } from 'rxjs';
+import { ISearchStrategy, SearchUsage } from '../../../data/server';
+import {
+  DATA_FRAME_TYPES,
+  IDataFrameResponse,
+  IDataFrameWithAggs,
+  IOpenSearchDashboardsSearchRequest,
+  Query,
+  createDataFrame,
+} from '../../../data/common';
+import { getFields, throwFacetError } from '../../common/utils';
+import { Facet } from '../utils';
+import { QueryAggConfig } from '../../common';
+
+export const promqlSearchStrategyProvider = (
+  config$: Observable<SharedGlobalConfig>,
+  logger: Logger,
+  client: ILegacyClusterClient,
+  usage?: SearchUsage
+): ISearchStrategy<IOpenSearchDashboardsSearchRequest, IDataFrameResponse> => {
+  const promqlFacet = new Facet({
+    client,
+    logger,
+    endpoint: 'enhancements.promqlQuery',
+    useJobs: false,
+    shimResponse: true, // TODO: is this needed?
+  });
+
+  return {
+    search: async (context, request: any, options) => {
+      try {
+        const query: Query = request.body.query;
+        const aggConfig: QueryAggConfig | undefined = request.body.aggConfig;
+        const rawResponse: any = await promqlFacet.describeQuery(context, request);
+
+        if (!rawResponse.success) throwFacetError(rawResponse);
+
+        const dataFrame = createDataFrame({
+          name: query.dataset?.id,
+          schema: rawResponse.data.schema,
+          meta: aggConfig,
+          fields: getFields(rawResponse),
+        });
+
+        dataFrame.size = rawResponse.data.datarows.length;
+
+        if (usage) usage.trackSuccess(rawResponse.took);
+
+        if (aggConfig) {
+          for (const [key, aggQueryString] of Object.entries(aggConfig.qs)) {
+            request.body.query.query = aggQueryString;
+            const rawAggs: any = await promqlFacet.describeQuery(context, request);
+            if (!rawAggs.success) continue;
+            (dataFrame as IDataFrameWithAggs).aggs = {};
+            (dataFrame as IDataFrameWithAggs).aggs[key] = rawAggs.data.datarows?.map((hit: any) => {
+              return {
+                key: hit[1],
+                value: hit[0],
+              };
+            });
+          }
+        }
+
+        return {
+          type: DATA_FRAME_TYPES.DEFAULT,
+          body: dataFrame,
+          took: rawResponse.took,
+        } as IDataFrameResponse;
+      } catch (e) {
+        logger.error(`promqlSearchStrategy: ${e.message}`);
+        if (usage) usage.trackError();
+        throw e;
+      }
+    },
+  };
+};

--- a/src/plugins/query_enhancements/server/utils/plugins.ts
+++ b/src/plugins/query_enhancements/server/utils/plugins.ts
@@ -59,6 +59,11 @@ export const OpenSearchEnhancements = (client: any, config: any, components: any
     method: 'POST',
     needBody: true,
   });
+  enhancements.promqlQuery = createAction(client, components, {
+    endpoint: URI.PROMQL,
+    method: 'POST',
+    needBody: true,
+  });
   enhancements.getDataConnectionById = createAction(client, components, {
     endpoint: OPENSEARCH_API.DATA_CONNECTIONS,
     method: 'GET',
@@ -82,6 +87,11 @@ export const OpenSearchEnhancements = (client: any, config: any, components: any
   enhancements.getDataConnections = createAction(client, components, {
     endpoint: OPENSEARCH_API.DATA_CONNECTIONS,
     method: 'GET',
+  });
+  enhancements.getMetrics = createAction(client, components, {
+    endpoint: OPENSEARCH_API.METRICS,
+    method: 'GET',
+    needBody: true,
   });
 
   enhancements.getObject = createAction(client, components, {


### PR DESCRIPTION
### Description
This is to allow for basic prometheus data selection in Discover in our wip prometheus feature branch

What this doesn't do
- Connect to persistence for datasources/connections. I've left a TODO in the `fetchConnections` method to address in the near future 

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
