### PR TITLE
[Workspace] fix: text size in generated summary should be s

### DIFF
--- a/changelogs/fragments/9492.yml
+++ b/changelogs/fragments/9492.yml
@@ -1,0 +1,2 @@
+fix:
+- Text size in generated summary should be s ([#9492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9492))

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_summary.tsx
@@ -335,9 +335,9 @@ export const QueryAssistSummary: React.FC<QueryAssistSummaryProps> = (props) => 
           </EuiText>
         )}
         {summary && !loading && (
-          <div data-test-subj="queryAssist_summary_result">
+          <EuiText size="s" data-test-subj="queryAssist_summary_result">
             <EuiMarkdownFormat>{summary}</EuiMarkdownFormat>
-          </div>
+          </EuiText>
         )}
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>


### PR DESCRIPTION
### Description
This pr set the text size in generated summary S

## Screenshot
![截屏2025-03-05 12 08 52](https://github.com/user-attachments/assets/26bc22e3-d13b-4c26-a7d1-0ddd1cf3c27c)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: text size in generated summary should be s
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
