### PR TITLE
[workspace] feat: changes the position of the query summary and query editor

### DIFF
--- a/changelogs/fragments/9494.yml
+++ b/changelogs/fragments/9494.yml
@@ -1,0 +1,2 @@
+feat:
+- Update position of summary ([#9494](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9494))

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
@@ -215,7 +215,7 @@ describe('CreateExtension', () => {
     expect(summaryPanels).toHaveLength(0);
   });
 
-  it('should render the query assist panel if it is enabled', async () => {
+  it('should render the summary panel if it is enabled', async () => {
     httpMock.get.mockResolvedValueOnce({ configuredLanguages: ['PPL'] });
     const modifiedConfig: ConfigSchema['queryAssist'] = {
       supportedLanguages: [{ language: 'PPL', agentConfig: 'os_query_assist_ppl' }],

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.test.tsx
@@ -215,7 +215,7 @@ describe('CreateExtension', () => {
     expect(summaryPanels).toHaveLength(0);
   });
 
-  it('should render the summary panel if it is enabled', async () => {
+  it('should render the query assist panel if it is enabled', async () => {
     httpMock.get.mockResolvedValueOnce({ configuredLanguages: ['PPL'] });
     const modifiedConfig: ConfigSchema['queryAssist'] = {
       supportedLanguages: [{ language: 'PPL', agentConfig: 'os_query_assist_ppl' }],
@@ -229,7 +229,7 @@ describe('CreateExtension', () => {
       mockIsSummaryAgentAvailable$,
       mockresultSummaryEnabled$
     );
-    const component = extension.getComponent?.(dependencies);
+    const component = extension.getBottomPanel?.(dependencies);
 
     if (!component) throw new Error('QueryEditorExtensions Component is undefined');
 

--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -126,22 +126,9 @@ export const createQueryAssistExtension = (
           dependencies={dependencies}
           http={http}
           data={data}
-          isQuerySummaryCollapsed$={isQuerySummaryCollapsed$}
-          isSummaryAgentAvailable$={isSummaryAgentAvailable$}
-          {...(config.summary.enabled && { resultSummaryEnabled$ })}
           question$={question$}
         >
           <QueryAssistBar dependencies={dependencies} />
-          {config.summary.enabled && (
-            <QueryAssistSummary
-              data={data}
-              http={http}
-              usageCollection={usageCollection}
-              dependencies={dependencies}
-              core={core}
-              brandingLabel={config.summary.branding.label}
-            />
-          )}
         </QueryAssistWrapper>
       );
     },
@@ -153,6 +140,30 @@ export const createQueryAssistExtension = (
             dependencies={dependencies}
             languages={config.supportedLanguages.map((conf) => conf.language)}
           />
+        </QueryAssistWrapper>
+      );
+    },
+    getBottomPanel: (dependencies) => {
+      return (
+        <QueryAssistWrapper
+          dependencies={dependencies}
+          http={http}
+          data={data}
+          isQuerySummaryCollapsed$={isQuerySummaryCollapsed$}
+          isSummaryAgentAvailable$={isSummaryAgentAvailable$}
+          {...(config.summary.enabled && { resultSummaryEnabled$ })}
+          question$={question$}
+        >
+          {config.summary.enabled && (
+            <QueryAssistSummary
+              data={data}
+              http={http}
+              usageCollection={usageCollection}
+              dependencies={dependencies}
+              core={core}
+              brandingLabel={config.summary.branding.label}
+            />
+          )}
         </QueryAssistWrapper>
       );
     },


### PR DESCRIPTION
### Description
This PR changes the position of the query summary and query editor.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<img width="1728" alt="截屏2025-03-05 15 26 04" src="https://github.com/user-attachments/assets/ff7d9f52-f6ad-49d3-bc38-5ed2ba4fe11e" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: update position of summary
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
