### PR TITLE
rearranged search overview page cards

### DIFF
--- a/src/plugins/home/public/application/components/usecase_overview/search_use_case_setup.tsx
+++ b/src/plugins/home/public/application/components/usecase_overview/search_use_case_setup.tsx
@@ -35,7 +35,7 @@ export const setupSearchUseCase = (contentManagement: ContentManagementPluginSet
       getStartedSection,
       {
         id: SECTIONS.DIFFERENT_SEARCH_TYPES,
-        order: 2000,
+        order: 3000,
         title: i18n.translate('home.searchOverview.differentSearchTypes.title', {
           defaultMessage: 'Try out different search techniques',
         }),
@@ -45,7 +45,7 @@ export const setupSearchUseCase = (contentManagement: ContentManagementPluginSet
       },
       {
         id: SECTIONS.CONFIG_EVALUATE_SEARCH,
-        order: 3000,
+        order: 2000,
         title: i18n.translate('home.searchOverview.configEvaluate.title', {
           defaultMessage: 'Configure and evaluate search',
         }),


### PR DESCRIPTION
### Description

- rearranged search overview page cards as shown in below screenshot. 
- This change is done to make "Try AI Search Flows" card visible to users. (Dylan Tong Suggested the following changes)







## Screenshot

<img width="1141" alt="Screenshot 2025-03-06 at 5 56 40 AM" src="https://github.com/user-attachments/assets/25afd53e-1abc-4199-ad57-1543d00ad3e8" />





## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
