### PR TITLE
Minor UX fixes for discover summary

### DIFF
--- a/changelogs/fragments/9509.yml
+++ b/changelogs/fragments/9509.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix minor UX style issues on discover summary section ([#9509](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9509))

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -137,7 +137,7 @@
 .osdQueryEditor__header {
   display: flex;
   align-items: center;
-  padding: $euiSizeS $euiSizeXS 0;
+  padding: 0 $euiSizeXS;
 }
 
 .osdQueryEditor__topBar {
@@ -182,7 +182,7 @@
   margin-top: $euiSizeS;
 
   .globalFilterGroup__wrapper {
-    margin-top: -$euiSizeS * 2;
+    margin-top: -$euiSizeS;
   }
 }
 

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -137,7 +137,7 @@
 .osdQueryEditor__header {
   display: flex;
   align-items: center;
-  padding: 0 $euiSizeXS $euiSizeS;
+  padding: $euiSizeS $euiSizeXS 0;
 }
 
 .osdQueryEditor__topBar {

--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -178,8 +178,12 @@
 }
 
 // TODO: improve how this is styled. Styling just for the DQL editor.
-.osdQueryEditor__body .globalFilterGroup__wrapper {
-  margin-top: -$euiSizeS;
+.osdQueryEditor__body {
+  margin-top: $euiSizeS;
+
+  .globalFilterGroup__wrapper {
+    margin-top: -$euiSizeS * 2;
+  }
 }
 
 .osdQuerEditor__singleLine {

--- a/src/plugins/data/public/ui/query_editor/editors/default_editor/_default_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/editors/default_editor/_default_editor.scss
@@ -1,7 +1,6 @@
 .defaultEditor {
   border: $euiBorderThin;
   border-radius: $euiSizeXS;
-  margin-top: $euiSizeS;
 
   &__footer {
     padding-left: $euiSizeXS;

--- a/src/plugins/data/public/ui/query_editor/editors/default_editor/_default_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/editors/default_editor/_default_editor.scss
@@ -1,6 +1,7 @@
 .defaultEditor {
   border: $euiBorderThin;
   border-radius: $euiSizeXS;
+  margin-top: $euiSizeS;
 
   &__footer {
     padding-left: $euiSizeXS;

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -22,6 +22,10 @@
     margin-bottom: $euiSizeS;
   }
 
+  &.queryAssist__form {
+    margin-top: $euiSizeS;
+  }
+
   .queryAssist__popoverWrapper {
     display: flex;
     align-items: center;

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -5,13 +5,13 @@
 
 .queryAssist {
   &.queryAssist__summary {
-    margin: $euiSizeS $euiSizeXS 0;
+    margin-top: $euiSizeS;
   }
 
   &.queryAssist__summary_banner {
     /* stylelint-disable  @osd/stylelint/no_restricted_values */
     background: lightOrDarkTheme(linear-gradient(to left, #edf7ff, #f9f4ff), $euiColorEmptyShade);
-    padding: $euiSizeXS;
+    padding: $euiSizeXS $euiSizeXS $euiSizeXS $euiSizeS;
   }
 
   &.queryAssist__callout {

--- a/src/plugins/query_enhancements/public/query_assist/_index.scss
+++ b/src/plugins/query_enhancements/public/query_assist/_index.scss
@@ -5,7 +5,7 @@
 
 .queryAssist {
   &.queryAssist__summary {
-    margin-top: $euiSizeXS;
+    margin: $euiSizeS $euiSizeXS 0;
   }
 
   &.queryAssist__summary_banner {
@@ -15,7 +15,11 @@
   }
 
   &.queryAssist__callout {
-    margin-top: $euiSizeXS;
+    margin-top: $euiSizeS;
+  }
+
+  &.queryAssist__banner {
+    margin-bottom: $euiSizeS;
   }
 
   .queryAssist__popoverWrapper {

--- a/src/plugins/query_enhancements/public/query_assist/components/__snapshots__/call_outs.test.tsx.snap
+++ b/src/plugins/query_enhancements/public/query_assist/components/__snapshots__/call_outs.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`CallOuts spec should display empty_index call out 1`] = `
         aria-hidden="true"
         class="euiCallOutHeader__icon"
         color="inherit"
-        data-euiicon-type="iInCircle"
+        data-euiicon-type="help"
       />
       <span
         class="euiCallOutHeader__title"
@@ -40,7 +40,7 @@ exports[`CallOuts spec should display empty_query call out 1`] = `
         aria-hidden="true"
         class="euiCallOutHeader__icon"
         color="inherit"
-        data-euiicon-type="iInCircle"
+        data-euiicon-type="help"
       />
       <span
         class="euiCallOutHeader__title"

--- a/src/plugins/query_enhancements/public/query_assist/components/call_outs.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/call_outs.tsx
@@ -32,7 +32,7 @@ const EmptyIndexCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
     }
     size="s"
     color="warning"
-    iconType="iInCircle"
+    iconType="help"
     dismissible
     onDismiss={props.onDismiss}
   />
@@ -68,7 +68,7 @@ const EmptyQueryCallOut: React.FC<QueryAssistCallOutProps> = (props) => (
     }
     size="s"
     color="warning"
-    iconType="iInCircle"
+    iconType="help"
     dismissible
     onDismiss={props.onDismiss}
   />

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_banner.tsx
@@ -40,7 +40,7 @@ export const QueryAssistBanner: React.FC<QueryAssistBannerProps> = (props) => {
 
   return (
     <EuiCallOut
-      className="queryAssist"
+      className="queryAssist queryAssist__banner"
       size="s"
       title={
         <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_input.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_input.tsx
@@ -90,6 +90,7 @@ export const QueryAssistInput: React.FC<QueryAssistInputProps> = (props) => {
           prepend={<EuiIcon type={assistantMark} />}
           append={<WarningBadge error={props.error} />}
           fullWidth
+          compressed
         />
         <EuiPortal>
           <SuggestionsComponent


### PR DESCRIPTION
### Description

1. Compress the natural language input field (i.e., reduce height to align with the button)
2. Change the icon in the caution banner
3. Add margin to the top of the natural language input field
4. Adjust overall padding between elements within the discover summary (i.e., below header and above editor) to be more consistent

### Issues Resolved

NA

## Screenshot

Before:
<img width="1155" alt="Screenshot 2025-03-10 at 17 06 29" src="https://github.com/user-attachments/assets/06151244-00d9-4789-8f98-ddf0e9f1c6c2" />
<img width="1160" alt="Screenshot 2025-03-10 at 17 06 42" src="https://github.com/user-attachments/assets/b838185d-4b24-4d8a-b7e5-6dff080ef94d" />
After:
<img width="1158" alt="Screenshot 2025-03-10 at 17 05 08" src="https://github.com/user-attachments/assets/c7331fb8-87b1-49fb-9c9f-affa8c742431" />
<img width="1126" alt="Screenshot 2025-03-17 at 14 18 32" src="https://github.com/user-attachments/assets/69bb6c23-b0a4-4e86-b691-a2c3c7873de2" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Fix minor UX style issues on discover summary section
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
