### PR TITLE
deprecate the discover:newExpereince

### DIFF
--- a/changelogs/fragments/9511.yml
+++ b/changelogs/fragments/9511.yml
@@ -1,0 +1,2 @@
+deprecate:
+- Discover:newExpereince and DataGridTable ([#9511](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9511))

--- a/src/plugins/discover/public/application/components/data_grid/data_grid.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid.tsx
@@ -30,6 +30,9 @@ export interface DataGridProps {
   isContextView?: boolean;
 }
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 const DataGridUI = ({
   columns,
   indexPattern,
@@ -150,4 +153,7 @@ const DataGridUI = ({
   );
 };
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const DataGrid = React.memo(DataGridUI);

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { i18n } from '@osd/i18n';
 import React, { useState } from 'react';
 import { EuiPanel } from '@elastic/eui';
 import { QUERY_ENHANCEMENT_ENABLED_SETTING } from '../../../../common';
@@ -71,6 +70,9 @@ export const DataGridTable = ({
     adjustedColumns = [...adjustedColumns, '_source'];
   }
 
+  /**
+   * deprecated - we will no longer support newDiscoveredEnabled
+   */
   const newDiscoverEnabled = getNewDiscoverSetting(services.storage);
   const isQueryEnhancementEnabled = services.uiSettings.get(QUERY_ENHANCEMENT_ENABLED_SETTING);
 

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_actions.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_actions.tsx
@@ -9,6 +9,9 @@ import { i18n } from '@osd/i18n';
 import { IndexPatternField } from '../../../../../data/common';
 import { useDataGridContext } from './data_grid_table_context';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export function getCellActions(field: IndexPatternField) {
   const cellActions = field.filterable
     ? [

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_cell_value.tsx
@@ -18,6 +18,9 @@ import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { shortenDottedString } from '../../helpers';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export function fetchSourceTypeDataCell(
   idxPattern: IndexPattern,
   row: Record<string, unknown>,
@@ -52,6 +55,9 @@ export function fetchSourceTypeDataCell(
   );
 }
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const fetchTableDataCell = (
   idxPattern: IndexPattern,
   dataRows: OpenSearchSearchHit[] | undefined,

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_columns.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_columns.tsx
@@ -8,6 +8,9 @@ import { i18n } from '@osd/i18n';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { getCellActions } from './data_grid_table_cell_actions';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export function buildDataGridColumns(
   columnNames: string[],
   idxPattern: IndexPattern,
@@ -27,6 +30,9 @@ export function buildDataGridColumns(
   );
 }
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export function generateDataGridTableColumn(
   colName: string,
   idxPattern: IndexPattern,
@@ -72,6 +78,9 @@ export function generateDataGridTableColumn(
   return dataGridCol;
 }
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export function computeVisibleColumns(
   columnNames: string[],
   idxPattern: IndexPattern,

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_context.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_context.tsx
@@ -7,6 +7,9 @@ import React from 'react';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export interface DataGridContextProps {
   inspectedHit?: OpenSearchSearchHit;
   onFilter: DocViewFilterFn;
@@ -15,9 +18,19 @@ export interface DataGridContextProps {
   indexPattern: IndexPattern;
 }
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const DataGridContext = React.createContext<DataGridContextProps>(
   {} as DataGridContextProps
 );
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const DiscoverGridContextProvider = DataGridContext.Provider;
+
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const useDataGridContext = () => React.useContext(DataGridContext);

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_docview_inspect_button.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_docview_inspect_button.tsx
@@ -8,6 +8,9 @@ import { i18n } from '@osd/i18n';
 import { EuiToolTip, EuiSmallButtonIcon, EuiDataGridCellValueElementProps } from '@elastic/eui';
 import { useDataGridContext } from './data_grid_table_context';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const DocViewInspectButton = ({ rowIndex }: EuiDataGridCellValueElementProps) => {
   const { inspectedHit, setInspectedHit, rows } = useDataGridContext();
   const currentInspected = rows[rowIndex];

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table_flyout.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table_flyout.tsx
@@ -19,6 +19,9 @@ import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { DocViewFilterFn, OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { DocViewerLinks } from '../doc_viewer_links/doc_viewer_links';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 interface Props {
   columns: string[];
   hit: OpenSearchSearchHit;
@@ -29,6 +32,9 @@ interface Props {
   onRemoveColumn: (column: string) => void;
 }
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export function DataGridFlyout({
   hit,
   columns,

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_toolbar.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_toolbar.tsx
@@ -13,6 +13,9 @@ import {
 import React, { useState } from 'react';
 import { useLocalStorage } from 'react-use';
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 const AddtitionalControls = ({
   setLineCount,
   lineCount,
@@ -58,6 +61,9 @@ const AddtitionalControls = ({
   );
 };
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const useToolbarOptions = (): {
   toolbarOptions: EuiDataGridToolBarVisibilityOptions | boolean;
   lineCount: number;

--- a/src/plugins/discover/public/application/components/utils/local_storage.ts
+++ b/src/plugins/discover/public/application/components/utils/local_storage.ts
@@ -5,13 +5,22 @@
 
 import { Storage } from '../../../../../opensearch_dashboards_utils/public';
 
+/**
+ * @deprecated - We will only support legacy discover
+ */
 export const NEW_DISCOVER_KEY = 'discover:newExpereince';
 
+/**
+ * @deprecated - We will only support legacy discover
+ */
 export const getNewDiscoverSetting = (storage: Storage): boolean => {
   const storedValue = storage.get(NEW_DISCOVER_KEY);
   return storedValue !== null ? storedValue : false;
 };
 
+/**
+ * @deprecated - We will only support legacy discover
+ */
 export const setNewDiscoverSetting = (value: boolean, storage: Storage) => {
   storage.set(NEW_DISCOVER_KEY, value);
 };

--- a/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_chart_container.tsx
@@ -36,6 +36,9 @@ export const DiscoverChartContainer = ({ hits, bucketInterval, chartData }: Sear
 
   if (!hits) return null;
 
+  /**
+   * deprecated - we will no longer support this option. Only legacyDiscoverTable will be supported
+   */
   const discoverOptions = (
     <EuiPopover
       button={

--- a/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable_component.tsx
@@ -21,6 +21,9 @@ interface SearchEmbeddableProps {
 }
 export type DiscoverEmbeddableProps = DataGridTableProps;
 
+/**
+ * @deprecated - use DefaultDiscoverTable
+ */
 export const DataGridTableMemoized = React.memo((props: DataGridTableProps) => (
   <DataGridTable {...props} />
 ));


### PR DESCRIPTION
### Description

- We are deprecating the `discover:newExperience` setting and DataGrid table for 3.0.
- Note that this newExperience does not exist in the `queryEnhanced` view.



## Screenshot

These are the things going away for 3.0:

- We are first deprecating the option to toggle the legacy discover experience:

<img width="1331" alt="Screenshot 2025-03-10 at 10 17 05 AM" src="https://github.com/user-attachments/assets/ffb282fc-0798-44ef-bf18-ec45666c002b" />


- And we are deprecating the "new" discover table:

<img width="1321" alt="Screenshot 2025-03-10 at 10 17 48 AM" src="https://github.com/user-attachments/assets/d9639055-39d4-411f-9627-ece3936b1a4a" />


## Changelog

- deprecate: discover:newExpereince and DataGridTable
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
