### PR TITLE
[Navigation] fix: make nav icon style compatible with sidecar

### DIFF
--- a/changelogs/fragments/9514.yml
+++ b/changelogs/fragments/9514.yml
@@ -1,0 +1,2 @@
+fix:
+- Make nav icon style compatible with sidecar ([#9514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9514))

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -10086,6 +10086,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
               className="newAppTopNavExpander navToggleInLargeScreen eui-hideFor--xs eui-hideFor--s eui-hideFor--m"
               data-test-subj="toggleNavButton"
               onClick={[Function]}
+              style={Object {}}
             >
               <EuiButtonEmpty
                 aria-controls="mockId"
@@ -10126,6 +10127,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                 color="text"
                 data-test-subj="toggleNavButton"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <button
                   aria-controls="mockId"
@@ -10136,6 +10138,7 @@ exports[`Header renders application header without title and breadcrumbs 1`] = `
                   data-test-subj="toggleNavButton"
                   disabled={false}
                   onClick={[Function]}
+                  style={Object {}}
                   type="button"
                 >
                   <EuiButtonContent
@@ -19548,6 +19551,7 @@ exports[`Header renders page header with application title 1`] = `
               className="newPageTopNavExpander navToggleInLargeScreen eui-hideFor--xs eui-hideFor--s eui-hideFor--m"
               data-test-subj="toggleNavButton"
               onClick={[Function]}
+              style={Object {}}
             >
               <EuiButtonEmpty
                 aria-controls="mockId"
@@ -19588,6 +19592,7 @@ exports[`Header renders page header with application title 1`] = `
                 color="text"
                 data-test-subj="toggleNavButton"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <button
                   aria-controls="mockId"
@@ -19598,6 +19603,7 @@ exports[`Header renders page header with application title 1`] = `
                   data-test-subj="toggleNavButton"
                   disabled={false}
                   onClick={[Function]}
+                  style={Object {}}
                   type="button"
                 >
                   <EuiButtonContent

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.scss
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.scss
@@ -135,7 +135,7 @@
   }
 
   .searchBarIcon {
-    position: fixed;
+    position: relative;
     top: $ouiHeaderChildSize;
     left: 0;
   }

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -61,7 +61,11 @@ import { WorkspaceObject, WorkspacesStart } from '../../../../public/workspace';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
 import { useObservableValue } from '../../../utils';
-import { getOsdSidecarPaddingStyle, ISidecarConfig } from '../../../overlays';
+import {
+  getOsdSidecarPaddingStyle,
+  ISidecarConfig,
+  getSidecarLeftNavStyle,
+} from '../../../overlays';
 import {
   ChromeBranding,
   ChromeBreadcrumbEnricher,
@@ -178,6 +182,10 @@ export function Header({
 
   const sidecarPaddingStyle = useMemo(() => {
     return getOsdSidecarPaddingStyle(sidecarConfig);
+  }, [sidecarConfig]);
+
+  const sidecarLeftNavStyle = useMemo(() => {
+    return getSidecarLeftNavStyle(sidecarConfig);
   }, [sidecarConfig]);
 
   const isNavOpen = useUpdatedHeader ? isLocked : isNavOpenState;
@@ -321,6 +329,8 @@ export function Header({
           ? null
           : renderNavToggleWithExtraProps({
               className: 'navToggleInLargeScreen eui-hideFor--xs eui-hideFor--s eui-hideFor--m',
+              // Nav toggle button has a fixed position and its left size is 0 be default, it should have a left size if sidecar is docked to left.
+              style: sidecarLeftNavStyle,
             })}
         {renderNavToggleWithExtraProps({
           flush: 'both',

--- a/src/core/public/overlays/index.ts
+++ b/src/core/public/overlays/index.ts
@@ -39,4 +39,5 @@ export {
   ISidecarConfig,
   getOsdSidecarPaddingStyle,
   SIDECAR_DOCKED_MODE,
+  getSidecarLeftNavStyle,
 } from './sidecar';

--- a/src/core/public/overlays/sidecar/helper.test.ts
+++ b/src/core/public/overlays/sidecar/helper.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getPosition, getOsdSidecarPaddingStyle } from './helper';
+import { getPosition, getOsdSidecarPaddingStyle, getSidecarLeftNavStyle } from './helper';
 import { ISidecarConfig, SIDECAR_DOCKED_MODE } from './sidecar_service';
 
 describe('sidecar helper', () => {
@@ -57,6 +57,40 @@ describe('sidecar helper', () => {
       expect(
         getOsdSidecarPaddingStyle({ ...props, dockedMode: SIDECAR_DOCKED_MODE.TAKEOVER })
       ).toEqual({});
+    });
+  });
+
+  describe('getSidecarLeftNavStyle', () => {
+    const props: ISidecarConfig = {
+      paddingSize: 460,
+      dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+      isHidden: false,
+    };
+
+    test('return left style object when dockedMode is left and not hidden', () => {
+      expect(getSidecarLeftNavStyle({ ...props, dockedMode: SIDECAR_DOCKED_MODE.LEFT })).toEqual({
+        left: 460,
+      });
+    });
+
+    test('return empty object when dockedMode is right', () => {
+      expect(getSidecarLeftNavStyle({ ...props, dockedMode: SIDECAR_DOCKED_MODE.RIGHT })).toEqual(
+        {}
+      );
+    });
+
+    test('return empty object when dockedMode is takeover', () => {
+      expect(
+        getSidecarLeftNavStyle({ ...props, dockedMode: SIDECAR_DOCKED_MODE.TAKEOVER })
+      ).toEqual({});
+    });
+
+    test('return empty object when isHidden is true', () => {
+      expect(getSidecarLeftNavStyle({ ...props, isHidden: true })).toEqual({});
+    });
+
+    test('return empty object when config is undefined', () => {
+      expect(getSidecarLeftNavStyle(undefined)).toEqual({});
     });
   });
 });

--- a/src/core/public/overlays/sidecar/helper.ts
+++ b/src/core/public/overlays/sidecar/helper.ts
@@ -33,3 +33,14 @@ export const getOsdSidecarPaddingStyle = (config: ISidecarConfig | undefined) =>
   }
   return {};
 };
+
+export const getSidecarLeftNavStyle = (config: ISidecarConfig | undefined) => {
+  // Only left style is required for left nav
+  if (!config?.isHidden && config?.dockedMode === SIDECAR_DOCKED_MODE.LEFT) {
+    const { paddingSize } = config;
+    return {
+      left: paddingSize,
+    };
+  }
+  return {};
+};

--- a/src/core/public/overlays/sidecar/index.ts
+++ b/src/core/public/overlays/sidecar/index.ts
@@ -10,4 +10,4 @@ export {
   ISidecarConfig,
   SIDECAR_DOCKED_MODE,
 } from './sidecar_service';
-export { getOsdSidecarPaddingStyle } from './helper';
+export { getOsdSidecarPaddingStyle, getSidecarLeftNavStyle } from './helper';


### PR DESCRIPTION
### Description

make nav icon style compatible with sidecar

## Screenshot

![image](https://github.com/user-attachments/assets/d84fed0a-d5ca-4771-842d-93621b2212ce)
Before

![image](https://github.com/user-attachments/assets/5ae036b4-a18e-4f7e-bd8a-a59a5e55c472)
After
## Testing the changes

Open chatbot and dock to left to test the changes.

## Changelog

- fix: Make nav icon style compatible with sidecar

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
