### PR TITLE
Fix data frame null or undefined object conversion error 

### DIFF
--- a/changelogs/fragments/9516.yml
+++ b/changelogs/fragments/9516.yml
@@ -1,2 +1,2 @@
 fix:
-- Fix null or undefined object conversion error ([#9516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9516))
+- Fix data frame null or undefined object conversion error ([#9516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9516))

--- a/changelogs/fragments/9516.yml
+++ b/changelogs/fragments/9516.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix null or undefined object conversion error ([#9516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9516))

--- a/src/plugins/data/common/data_frames/utils.test.ts
+++ b/src/plugins/data/common/data_frames/utils.test.ts
@@ -319,7 +319,18 @@ describe('convertResult', () => {
       type: DATA_FRAME_TYPES.DEFAULT,
     };
 
-    const result = convertResult({ response });
+    // Custom date formatter
+    const customFormatter = (dateStr: string, type: OSD_FIELD_TYPES) => {
+      if (type === OSD_FIELD_TYPES.DATE) {
+        return moment.utc(dateStr).format('YYYY-MM-DDTHH:mm:ssZ');
+      }
+    };
+
+    const options: ISearchOptions = {
+      formatter: customFormatter,
+    };
+
+    const result = convertResult({ response, options });
     expect(result.hits.hits[0]._source.foo).toBe(null);
     expect(result.hits.hits[1]._source.foo).toBe(undefined);
   });

--- a/src/plugins/data/common/data_frames/utils.test.ts
+++ b/src/plugins/data/common/data_frames/utils.test.ts
@@ -295,4 +295,32 @@ describe('convertResult', () => {
     const result = convertResult({ response });
     expect(result.hits.hits[0]._source.timestamp).toBe(mockDateString);
   });
+
+  it('should handle null or undefined objects', () => {
+    const response: IDataFrameResponse = {
+      took: 100,
+      timed_out: false,
+      _shards: {
+        total: 2,
+        successful: 2,
+        skipped: 0,
+        failed: 0,
+      },
+      hits: {
+        total: 0,
+        max_score: 0,
+        hits: [],
+      },
+      body: {
+        fields: [{ name: 'foo', type: 'object', values: [null, undefined] }],
+        size: 2,
+        name: 'test-index',
+      },
+      type: DATA_FRAME_TYPES.DEFAULT,
+    };
+
+    const result = convertResult({ response });
+    expect(result.hits.hits[0]._source.foo).toBe(null);
+    expect(result.hits.hits[1]._source.foo).toBe(undefined);
+  });
 });

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -63,6 +63,9 @@ export const convertResult = ({
       const hit: { [key: string]: any } = {};
 
       const processNestedFieldEntry = (field: any, value: any, formatter: any): any => {
+        if (!value) {
+          return value;
+        }
         Object.entries(value).forEach(([nestedField, nestedValue]) => {
           // Need to get the flattened field name for nested fields ex.products.created_on
           const flattenedFieldName = `${field.name}.${nestedField}`;


### PR DESCRIPTION
### Description

Fix data frame conversion error for null/undefined objects

Problem:
- `processNestedFieldEntry` function uses `Object.entries()`
- `Object.entries()` throws "Uncaught TypeError: Cannot convert undefined or null to object" when given null/undefined values

Solution:
- Added a `!value` check before calling `Object.entries()`
- Returns the value directly when `!value` is true, avoiding the error

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->


- Clone branch code and run `yarn osd bootstrap --single-version loose`
- Add below configs in `config/opensearch_dashboards.yml`
```
data_source.enabled: true
workspace.enabled: true
savedObjects.permission.enabled: true
uiSettings:
  overrides:
    'home:useNewHomePage': true
    'query:enhancements:enabled': true
```
- Run `yarn start --no-base-path`
- Login with admin user
- Visit data source page
- Create an open search data source with PPL plugin
- Create a workspace
- Visit created workspace's data sources page
- Assign created data source to workspace
- Visit "Sample data" page of created workspace
- Import otel sample data to specific data source
- Visit "Discover" page of created workspace
- Select "ss4o_logs-otel-sample" with "PPL" language
- Should not error after query execute completed


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Fix data frame null or undefined object conversion error

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
