### PR TITLE
[Discover] fix: Correctly load saved search from snapshot URL

### DIFF
--- a/changelogs/fragments/9529.yml
+++ b/changelogs/fragments/9529.yml
@@ -1,0 +1,2 @@
+fix:
+- Correctly load saved search from snapshot URL ([#9529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529))

--- a/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_search_panel.tsx
@@ -58,6 +58,7 @@ export function OpenSearchPanel({ onClose, makeUrl }: Props) {
       core: { uiSettings, savedObjects, application },
       addBasePath,
       data,
+      filterManager,
     },
   } = useOpenSearchDashboards<DiscoverViewServices>();
 
@@ -92,6 +93,9 @@ export function OpenSearchPanel({ onClose, makeUrl }: Props) {
             },
           ]}
           onChoose={(id) => {
+            // Reset query app filters before loading saved search
+            filterManager.setAppFilters([]);
+            data.query.queryString.clearQuery();
             application.navigateToApp('discover', { path: `#/view/${id}` });
             onClose();
           }}

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -400,12 +400,13 @@ export const useSearch = (services: DiscoverViewServices) => {
   useEffect(() => {
     const loadSavedSearch = async () => {
       const savedSearchInstance = await getSavedSearchById(savedSearchId);
-
-      const savedSearchQuery = savedSearchInstance.searchSource.getField('query');
       const dataQuery = data.query.queryString.getQuery();
+      const defaultQuery = data.query.queryString.getDefaultQuery();
+      const isDataQueryDefault = dataQuery.query === defaultQuery.query;
+      const savedSearchQuery = savedSearchInstance.searchSource.getField('query');
 
-      // Use eixisting query, if not, use query from saved search
-      const query = dataQuery.query ? dataQuery : savedSearchQuery ?? dataQuery;
+      // Use eixisting query, if eixisting query match default, use query from saved search
+      const query = isDataQueryDefault ? savedSearchQuery ?? dataQuery : dataQuery;
 
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       if (isEnhancementsEnabled && query.dataset) {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Previously, when loading a snapshot URL that contains a saved search with temporary editing, the temporary editing content will not be loaded. This is because when the app getting initialize, status store in URL snapshot will be loaded first, later the async fetch result from saved search will override those temporary editing.

Ideally when loading a saved search, if it’s loaded by user click on saved search panel UI, we want to wipe current state and use the saved query states, if the saved search is loaded from user directly paste a url in browser, we want use the url snapshot state instead.

To build the ideal experience, this PR contains changes below:

1. When user click a saved search from UI panel, clean filter and query
2. When loading saved search, saved filters will apply on top of existing filters 
3. When loading saved search, only apply query from saved search if there is no existing query

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

Before

https://github.com/user-attachments/assets/4b826da5-78a8-4741-b78d-9edce1c951c6

After


https://github.com/user-attachments/assets/b12092e4-7f70-49f3-a6a9-52e827d0b36a


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Correctly load saved search from snapshot URL

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
