### PR TITLE
[Discover] fix: correctly load saved search query in query editor

### DIFF
--- a/changelogs/fragments/9541.yml
+++ b/changelogs/fragments/9541.yml
@@ -1,0 +1,2 @@
+fix:
+- Correctly load saved search query in query editor ([#9541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9541))

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -131,7 +131,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     }
 
     let nextQuery = null;
-    if (nextProps.query && nextProps.query.query !== get(prevState, 'currentProps.query.query')) {
+    if (nextProps.query && nextProps.query.query !== prevState.query?.query) {
       nextQuery = {
         query: nextProps.query.query,
         language: nextProps.query.language,


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Query information that stores in `QueryStringManager` get pass to `SearchBarUI`, and `SearchBarUI` manipulates the `query` props and pass it to `QueryEditor`.

When loading a saved search, `Query` in `QueryStringManager` get updated three times, follow by the order `query => language => dataset`(fields of `Query`). However, the `getDerivedStateFromProps` in `SearchBarUI` will wipe query text if the saved search get loaded has different language and same dataset compare to the current query.

This PR change the comparison between "incoming" prop to "previous" prop to comparing "incoming" prop with "previous" state. In this case, loading saved search will correctly show on query editor, while switching languages will still wipe the query.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

Before

https://github.com/user-attachments/assets/c75ef859-a18a-4b66-8704-5a901e80ec6f

After

https://github.com/user-attachments/assets/2afd871a-c187-46ad-a70d-4ebb5cb7b3bd

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: correctly load saved search query in query editor

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
