### PR TITLE
feat: display vega error and warning messages in the toast

### DIFF
--- a/changelogs/fragments/9543.yml
+++ b/changelogs/fragments/9543.yml
@@ -1,0 +1,3 @@
+feat:
+- Display vega error and warning messages in the toast ([#9543](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9543))
+- Changed the behavior of hideWarnings to default to be true ([#9543](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9543))

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -166,7 +166,7 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
     this.useHover = !this.isVegaLite;
 
     this._config = this._parseConfig();
-    this.hideWarnings = !!this._config.hideWarnings;
+    this.hideWarnings = this._config.hideWarnings !== false;
     this.visibleVisLayers = this._config.visibleVisLayers;
     this.visAugmenterConfig = this._config.visAugmenterConfig;
     this.useMap = this._config.type === 'map';

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -38,7 +38,7 @@ import { i18n } from '@osd/i18n';
 import { TooltipHandler } from './vega_tooltip';
 import { opensearchFilters } from '../../../data/public';
 
-import { getEnableExternalUrls, getData } from '../services';
+import { getEnableExternalUrls, getData, getNotifications } from '../services';
 import { extractIndexPatternsFromSpec } from '../lib/extract_index_pattern';
 
 vega.scheme('euiPaletteColorBlind', euiPaletteColorBlind());
@@ -86,6 +86,7 @@ export class VegaBaseView {
     this._destroyHandlers = [];
     this._initialized = false;
     this._enableExternalUrls = getEnableExternalUrls();
+    this._notifications = getNotifications();
   }
 
   async init() {
@@ -97,11 +98,11 @@ export class VegaBaseView {
 
       // bypass the onWarn warning checks - in some cases warnings may still need to be shown despite being disabled
       for (const warn of this._parser.warnings) {
-        this._addMessage('warn', warn);
+        this._addMessage('warn', warn.toString());
       }
 
       if (this._parser.error) {
-        this._addMessage('err', this._parser.error);
+        this._addMessage('err', this._parser.error.toString());
         return;
       }
 
@@ -230,14 +231,12 @@ export class VegaBaseView {
   }
 
   _addMessage(type, text) {
-    if (!this._$messages) {
-      this._$messages = $(`<ul class="vgaVis__messages">`).appendTo(this._$parentEl);
+    if (type === 'warn') {
+      this._notifications.toasts.addWarning(text);
     }
-    this._$messages.append(
-      $(`<li class="vgaVis__message vgaVis__message--${type}">`).append(
-        $(`<pre class="vgaVis__messageCode">`).text(text)
-      )
-    );
+    if (type === 'err') {
+      this._notifications.toasts.addDanger(text);
+    }
   }
 
   resize() {


### PR DESCRIPTION
### Description
1. display vega error and warning messages in the toast
2. changed the default behavior of vega warnings so it will by default not show warnings unless `hideWarnings` is set specifically to false

<!-- Describe what this change achieves-->

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6165

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: display vega error and warning messages in the toast
- feat: changed the behavior of hideWarnings to default to be true

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
