### PR TITLE
[TEST] fix delete all old workspaces

### DIFF
--- a/cypress/utils/commands.osd.js
+++ b/cypress/utils/commands.osd.js
@@ -301,6 +301,11 @@ cy.osd.add('deleteAllOldWorkspaces', () => {
         const link = $links[i];
         const wsName = link.textContent;
 
+        // If we have multiple pages of ws, then we do not want to select the links for the paginated results
+        if (!wsName.includes('-')) {
+          continue;
+        }
+
         // the first portion of the ws name is the epoch time it was created in seconds,
         // see: getRandomizedWorkspaceName() util
         const epochTimeCreated = Number(wsName.split('-')[0]);


### PR DESCRIPTION
### Description

- when we have multiple workspaces in our test to the point where we have a paginated result of the workspaces, the tests begin failing due to the custom command `deleteAllOldWorkspaces` not knowing how to deal with the paginated links. This change fixes it so that we don't click those

## Testing the changes

- verified that it works by manually creating a lot of workspaces and having the tests still passing

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
