### PR TITLE
[TESTS] make download_csv tests smaller to reduce the num of crashes

### DIFF
--- a/cypress/utils/apps/query_enhancements/shared.js
+++ b/cypress/utils/apps/query_enhancements/shared.js
@@ -117,7 +117,7 @@ export const generateIndexPatternTestConfigurations = (
 };
 
 /**
- * Sets the top nav date if it is relevant for the passed language
+ * Sets the top nav date if it is relevant for the passed language and searches
  * @param {QueryEnhancementLanguage} language - query language
  * @param {string=} start - start datetime string
  * @param {string=} end - end datetime string
@@ -129,6 +129,18 @@ export const setDatePickerDatesAndSearchIfRelevant = (
 ) => {
   if (language !== QueryLanguages.SQL.name) {
     cy.osd.setTopNavDate(start, end);
+  }
+};
+
+/**
+ * Sets the top nav date if it is relevant for the passed language
+ * @param {QueryEnhancementLanguage} language - query language
+ * @param {string=} start - start datetime string
+ * @param {string=} end - end datetime string
+ */
+export const setDatePickerDatesIfRelevant = (language, start = START_TIME, end = END_TIME) => {
+  if (language !== QueryLanguages.SQL.name) {
+    cy.osd.setTopNavDate(start, end, false);
   }
 };
 

--- a/cypress/utils/index.d.ts
+++ b/cypress/utils/index.d.ts
@@ -202,7 +202,7 @@ declare namespace Cypress {
        * @example
        * cy.setTopNavDate('Oct 5, 2022 @ 00:57:06.429', 'Oct 6, 2022 @ 00:57:06.429')
        */
-      setTopNavDate(start: string, end: string): Chainable<any>;
+      setTopNavDate(start: string, end: string, submit?: boolean): Chainable<any>;
 
       /**
        * Sets the top nav date to relative time


### PR DESCRIPTION
### Description

- I've been noticing that the `download_csv.spec.js` is crashing in some of the CI runs, here is an example: https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/13910917046/job/38924790602?pr=9531
- This PR breaks apart the csv tests into smaller `it` statements to reduce the num of crashes

## Screenshot

<img width="567" alt="Screenshot 2025-03-17 at 7 14 59 PM" src="https://github.com/user-attachments/assets/d21a3a85-db05-4277-b5c0-c587b8d38df1" />


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
