### PR TITLE
update prometheus response interface, plot series on same y scale

### DIFF
--- a/src/plugins/discover/public/application/components/visualizations/vislib/line/to_expression.ts
+++ b/src/plugins/discover/public/application/components/visualizations/vislib/line/to_expression.ts
@@ -142,11 +142,6 @@ const createVegaSpec = (rows: OpenSearchSearchHit[], indexPattern: IndexPattern)
     data: { values: data },
     transform: [{ calculate: `datum['${columns[0].field}']`, as: 'timestamp_ms' }],
     layer,
-    resolve: {
-      scale: {
-        y: 'independent', // This is critical for multiple y-axes
-      },
-    },
     config: {
       axis: {
         labelFont: 'sans-serif',

--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
@@ -28,10 +28,8 @@ interface PrometheusResponse {
   sessionId: string;
   results: {
     [connectionId: string]: {
-      data: {
-        resultType: string;
-        result: MetricResult[];
-      };
+      resultType: string;
+      result: MetricResult[];
     };
   };
 }
@@ -97,7 +95,7 @@ export const promqlSearchStrategyProvider = (
 
 function createDataFrame(rawResponse: PrometheusResponse, datasetId: string) {
   try {
-    const series = rawResponse.results[datasetId].data.result;
+    const series = rawResponse.results[datasetId].result;
     const initDataFrame: IDataFrame = {
       type: DATA_FRAME_TYPES.DEFAULT,
       name: datasetId,


### PR DESCRIPTION
### Description
This is to update the prometheus query response interface to reflect a recent sql plugin change and plot all series on the same y axis/scale.

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
