### PR TITLE
Add showVisualization setting in language config

### DIFF
--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -58,6 +58,7 @@ export interface LanguageConfig {
     formatter?: (value: any, type: OSD_FIELD_TYPES) => any;
   };
   showDocLinks?: boolean;
+  showVisualization?: boolean;
   docLink?: {
     title: string;
     url: string;

--- a/src/plugins/discover/public/application/view_components/canvas/discover_visualization.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/discover_visualization.tsx
@@ -34,6 +34,10 @@ export const DiscoverVisualization = ({ hits, bucketInterval, chartData, rows }:
     filters: filterManager.getFilters(),
     timeRange: timefilter.timefilter.getTime(),
   });
+  const [enableViz, setEnableViz] = useState(
+    queryString.getLanguageService().getLanguage(queryString.getQuery()!.language)!
+      .showVisualization
+  );
 
   useEffect(() => {
     async function loadExpression() {
@@ -47,36 +51,33 @@ export const DiscoverVisualization = ({ hits, bucketInterval, chartData, rows }:
     loadExpression();
   }, [toExpression, searchContext, rows, indexPattern, services]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const subscription = services.data.query.state$.subscribe(({ state }) => {
       setSearchContext({
         query: state.query,
         timeRange: state.time,
         filters: state.filters,
       });
+      setEnableViz(
+        queryString.getLanguageService().getLanguage(state.query!.language)!.showVisualization ??
+          false
+      );
     });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [services.data.query.state$]);
+  }, [queryString, services.data.query.state$]);
 
-  return (
+  return enableViz && expression ? (
     <EuiPanel className="discoverVisualization" data-test-subj="visualizationLoader">
-      {expression ? (
-        <ReactExpressionRenderer
-          key={JSON.stringify(searchContext) + expression}
-          expression={expression}
-          searchContext={searchContext}
-        />
-      ) : (
-        <EuiFlexItem
-          className="discoverVisualization__empty"
-          data-test-subj="emptyDiscoverVisualization"
-        >
-          <>No data to display</>
-        </EuiFlexItem>
-      )}
+      <ReactExpressionRenderer
+        key={JSON.stringify(searchContext) + expression}
+        expression={expression}
+        searchContext={searchContext}
+      />
     </EuiPanel>
+  ) : (
+    <></>
   );
 };

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -252,6 +252,7 @@ export class QueryEnhancementsPlugin
         url: 'https://opensearch.org/docs/latest/search-plugins/sql/ppl/syntax/',
       },
       showDocLinks: false,
+      showVisualization: true,
       editor: createEditor(SingleLineInput, null, pplControls, DefaultInput),
       editorSupportedAppNames: ['discover'],
       supportedAppNames: ['discover', 'data-explorer'],


### PR DESCRIPTION
### Description

Add `showVisualization` setting in the language config, so currently discover will only render visualization for promQl based queries. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
