### PR TITLE
create and integrate the clientside resource client factory

### DIFF
--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -95,6 +95,7 @@ import { getSuggestions as getSQLSuggestions } from './antlr/opensearch_sql/code
 import { getSuggestions as getDQLSuggestions } from './antlr/dql/code_completion';
 import { getSuggestions as getPPLSuggestions } from './antlr/opensearch_ppl/code_completion';
 import { createStorage, DataStorage, UI_SETTINGS } from '../common';
+import { ResourceClientFactory } from './resources/resource_client_factory';
 
 declare module '../../ui_actions/public' {
   export interface ActionContextMapping {
@@ -287,6 +288,7 @@ export class DataPublicPlugin
         dataSourceService,
         dataSourceFactory,
       },
+      resourceClientFactory: new ResourceClientFactory(core.http),
     };
 
     registerDefaultDataSource(dataServices);

--- a/src/plugins/data/public/resources/base_resource_client.ts
+++ b/src/plugins/data/public/resources/base_resource_client.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpSetup } from 'opensearch-dashboards/public';
+
+const BASE_API = 'api/enhancements';
+
+export class BaseResourceClient {
+  private http: HttpSetup;
+  private dataConnectionType: string;
+
+  constructor(http: HttpSetup, dataConnectionType: string) {
+    this.http = http;
+    this.dataConnectionType = dataConnectionType;
+  }
+
+  protected async get<T>(
+    dataConnectionId: string,
+    resourceType: string,
+    resourceName?: string
+  ): Promise<T> {
+    const resourceNameSuffix = resourceName ? `/${resourceName}` : '';
+    const path = `/${BASE_API}/${this.dataConnectionType}/${dataConnectionId}/resources/${resourceType}${resourceNameSuffix}`;
+    const response = await this.http.get(path);
+    return response.data;
+  }
+}

--- a/src/plugins/data/public/resources/prometheus_resource_client.ts
+++ b/src/plugins/data/public/resources/prometheus_resource_client.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpSetup } from 'opensearch-dashboards/public';
+import { BaseResourceClient } from './base_resource_client';
+
+const RESOURCE_TYPES = {
+  LABELS: 'labels',
+  LABEL_VALUES: 'label_values',
+  METRIC_METADATA: 'metric_metadata',
+} as const;
+
+interface MetricMetadata {
+  [metric: string]: Array<{
+    type: string;
+    unit: string;
+    help: string;
+  }>;
+}
+
+export class PrometheusResourceClient extends BaseResourceClient {
+  constructor(http: HttpSetup) {
+    super(http, 'prometheus');
+  }
+
+  getLabels(dataConnectionId: string, metric?: string) {
+    return this.get<string[]>(dataConnectionId, RESOURCE_TYPES.LABELS, metric);
+  }
+
+  getLabelValues(dataConnectionId: string, label: string) {
+    return this.get<string[]>(dataConnectionId, RESOURCE_TYPES.LABEL_VALUES, label);
+  }
+
+  getMetricMetadata(dataConnectionId: string, metric?: string) {
+    return this.get<MetricMetadata>(dataConnectionId, 'metric_metadata', metric);
+  }
+}

--- a/src/plugins/data/public/resources/resource_client_factory.ts
+++ b/src/plugins/data/public/resources/resource_client_factory.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpSetup } from 'opensearch-dashboards/public';
+import { PrometheusResourceClient } from './prometheus_resource_client';
+
+type DataConnectionType = 'prometheus';
+
+export class ResourceClientFactory {
+  private http: HttpSetup;
+
+  constructor(http: HttpSetup) {
+    this.http = http;
+  }
+
+  create(dataConnectionType: DataConnectionType) {
+    switch (dataConnectionType) {
+      case 'prometheus':
+        return new PrometheusResourceClient(this.http);
+      default:
+        throw new Error(`Connection type unsupported: ${dataConnectionType}`);
+    }
+  }
+}

--- a/src/plugins/data/public/types.ts
+++ b/src/plugins/data/public/types.ts
@@ -41,6 +41,7 @@ import { UsageCollectionSetup } from '../../usage_collection/public';
 import { DataSourceStart } from './data_sources/datasource_services/types';
 import { IUiStart } from './ui';
 import { DataStorage } from '../common';
+import { ResourceClientFactory } from './resources/resource_client_factory';
 
 export interface DataPublicPluginEnhancements {
   search?: SearchEnhancements;
@@ -123,6 +124,8 @@ export interface DataPublicPluginStart {
    * {@link DataSourceStart}
    */
   dataSources: DataSourceStart;
+
+  resourceClientFactory: ResourceClientFactory;
 }
 
 export interface IDataPluginServices extends Partial<CoreStart> {

--- a/src/plugins/discover/public/application/components/visualizations/vislib/line/to_expression.ts
+++ b/src/plugins/discover/public/application/components/visualizations/vislib/line/to_expression.ts
@@ -80,14 +80,11 @@ const createVegaSpec = (rows: OpenSearchSearchHit[], indexPattern: IndexPattern)
   ];
 
   for (let i = 1; i < columns.length; i++) {
-    const colorIndex = (i - 1) % colorPalette.length;
-    const color = colorPalette[colorIndex];
-
     const yAxisParam = {
       field: columns[i].name,
       type: 'quantitative',
       scale: { zero: false },
-      axis: { titleColor: color, title: columns[i].name },
+      axis: { title: '' },
     };
 
     const tooltipParam = [
@@ -119,8 +116,10 @@ const createVegaSpec = (rows: OpenSearchSearchHit[], indexPattern: IndexPattern)
           range: colorPalette.slice(0, columns.length - 1),
         },
         legend: {
-          title: 'Series',
-          labelExpr: "datum.label + ': ' + '" + columns[i].field + "'",
+          title: '',
+          labelExpr: "'" + columns[i].field + "'",
+          orient: 'bottom',
+          labelLimit: 999,
         },
       },
     };

--- a/src/plugins/discover/public/application/components/visualizations/vislib/line/to_expression.ts
+++ b/src/plugins/discover/public/application/components/visualizations/vislib/line/to_expression.ts
@@ -13,10 +13,13 @@ import { OpenSearchSearchHit } from '../../../../doc_views/doc_views_types';
 import { IndexPattern } from '../../../../../../../data/public';
 import { DiscoverViewServices } from '../../../../../build_services';
 
+type Source = Record<string, number | string>;
+type Row = OpenSearchSearchHit<Source>;
+
 export const toExpression = async (
   services: DiscoverViewServices,
   searchContext: IExpressionLoaderParams['searchContext'],
-  rows: OpenSearchSearchHit[],
+  rows: Row[],
   indexPattern: IndexPattern
 ) => {
   const opensearchDashboards = buildExpressionFunction<ExpressionFunctionOpenSearchDashboards>(
@@ -29,7 +32,7 @@ export const toExpression = async (
     query: JSON.stringify(searchContext!.query || []),
   });
 
-  const vegaSpec = createVegaSpec(rows, indexPattern);
+  const vegaSpec = createVegaSpec(rows);
 
   const vega = buildExpressionFunction<any>('vega', {
     spec: JSON.stringify(vegaSpec),
@@ -38,7 +41,7 @@ export const toExpression = async (
   return buildExpression([opensearchDashboards, opensearchDashboardsContext, vega]).toString();
 };
 
-const createVegaSpec = (rows: OpenSearchSearchHit[], indexPattern: IndexPattern) => {
+const createVegaSpec = (rows: Row[]) => {
   const columns = Object.keys(rows[0]._source).map((column, index) => {
     return {
       field: column,
@@ -47,8 +50,8 @@ const createVegaSpec = (rows: OpenSearchSearchHit[], indexPattern: IndexPattern)
     };
   });
 
-  const data = rows.map((row: OpenSearchSearchHit) => {
-    const transformedRow: Record<string, any> = {};
+  const data = rows.map((row: Row) => {
+    const transformedRow: Source = {};
     for (const column of columns) {
       transformedRow[column.name] = row._source[column.field];
     }

--- a/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DiscoverViewServices } from '../../../build_services';
 
@@ -33,16 +33,14 @@ export const usePrometheus = (): PrometheusContext => {
   const [labelNames, setLabelNames] = useState<string[]>([]);
 
   const updateLabels = useCallback(async () => {
-    const labels = await prometheusResourceClient.getLabels('my_prometheus', selectedMetricName);
+    const labels = await prometheusResourceClient.getLabels('my_prometheus');
     setLabelNames(labels.sort());
-  }, [prometheusResourceClient, selectedMetricName]);
+  }, [prometheusResourceClient]);
 
   const updateMetrics = useCallback(async () => {
     const metricMetadata = await prometheusResourceClient.getMetricMetadata('my_prometheus');
     const metrics = Object.keys(metricMetadata).sort();
-    const defaultMetric = metrics[0];
     setMetricNames(metrics);
-    setSelectedMetricName(defaultMetric);
   }, [prometheusResourceClient]);
 
   useEffect(() => {
@@ -54,9 +52,11 @@ export const usePrometheus = (): PrometheusContext => {
   }, [selectedMetricName, updateLabels]);
 
   useEffect(() => {
-    data.query.queryString.setQuery({
-      query: selectedMetricName,
-    });
+    if (selectedMetricName) {
+      data.query.queryString.setQuery({
+        query: selectedMetricName,
+      });
+    }
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [selectedMetricName]);
 

--- a/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DiscoverViewServices } from '../../../build_services';
 
@@ -41,6 +41,11 @@ export const usePrometheus = (): PrometheusContext => {
     const metricMetadata = await prometheusResourceClient.getMetricMetadata('my_prometheus');
     const metrics = Object.keys(metricMetadata).sort();
     setMetricNames(metrics);
+
+    if (!data.query.queryString.getQuery().query) {
+      setSelectedMetricName(metrics[0]);
+    }
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [prometheusResourceClient]);
 
   useEffect(() => {

--- a/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_prometheus.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback } from 'react';
-
-const PROMETHEUS_ENDPOINT = 'http://127.0.0.1:9090';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { DiscoverViewServices } from '../../../build_services';
 
 interface PrometheusDataSourceMetadata {
-  selectedMetricName: string | null;
+  selectedMetricName?: string;
   metricNames: string[];
   labelNames: string[];
 }
@@ -21,24 +21,29 @@ export interface PrometheusContext {
 }
 
 export const usePrometheus = (): PrometheusContext => {
-  const [selectedMetricName, setSelectedMetricName] = useState<string | null>(null);
+  const {
+    services: { data },
+  } = useOpenSearchDashboards<DiscoverViewServices>();
+  const prometheusResourceClient = useMemo(() => {
+    return data.resourceClientFactory.create('prometheus');
+  }, [data.resourceClientFactory]);
+
+  const [selectedMetricName, setSelectedMetricName] = useState<string | undefined>();
   const [metricNames, setMetricNames] = useState<string[]>([]);
   const [labelNames, setLabelNames] = useState<string[]>([]);
 
   const updateLabels = useCallback(async () => {
-    const query = selectedMetricName ? `?match[]=${selectedMetricName}` : '';
-    const response = await fetch(`${PROMETHEUS_ENDPOINT}/api/v1/labels${query}`).then((r) =>
-      r.json()
-    );
-    setLabelNames(response.data.slice(1));
-  }, [selectedMetricName]);
+    const labels = await prometheusResourceClient.getLabels('my_prometheus', selectedMetricName);
+    setLabelNames(labels.sort());
+  }, [prometheusResourceClient, selectedMetricName]);
 
   const updateMetrics = useCallback(async () => {
-    const response = await fetch(`${PROMETHEUS_ENDPOINT}/api/v1/label/__name__/values`).then((r) =>
-      r.json()
-    );
-    setMetricNames(response.data);
-  }, []);
+    const metricMetadata = await prometheusResourceClient.getMetricMetadata('my_prometheus');
+    const metrics = Object.keys(metricMetadata).sort();
+    const defaultMetric = metrics[0];
+    setMetricNames(metrics);
+    setSelectedMetricName(defaultMetric);
+  }, [prometheusResourceClient]);
 
   useEffect(() => {
     updateMetrics();
@@ -47,6 +52,13 @@ export const usePrometheus = (): PrometheusContext => {
   useEffect(() => {
     updateLabels();
   }, [selectedMetricName, updateLabels]);
+
+  useEffect(() => {
+    data.query.queryString.setQuery({
+      query: selectedMetricName,
+    });
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [selectedMetricName]);
 
   return {
     metadata: {

--- a/src/plugins/query_enhancements/server/connections/clients/base_connection_client.ts
+++ b/src/plugins/query_enhancements/server/connections/clients/base_connection_client.ts
@@ -20,7 +20,7 @@ export interface ClientRequest {
 
 export interface GetResourcesResponse<R> {
   nextToken?: string;
-  status: string;
+  status: 'success' | 'failed';
   data: R;
   type: string;
 }

--- a/src/plugins/query_enhancements/server/connections/managers/prometheus_manager.ts
+++ b/src/plugins/query_enhancements/server/connections/managers/prometheus_manager.ts
@@ -43,7 +43,7 @@ interface CommonQuery {
 }
 interface LabelsQuery {
   resourceType: typeof PROMETHEUS_RESOURCE_TYPES.LABELS;
-  resourceName: undefined;
+  resourceName?: string;
 }
 interface LabelValuesQuery {
   resourceType: typeof PROMETHEUS_RESOURCE_TYPES.LABEL_VALUES;
@@ -73,14 +73,15 @@ class PrometheusManager extends BaseConnectionManager<OpenSearchClient> {
     const { resourceType, resourceName } = query;
     switch (resourceType) {
       case PROMETHEUS_RESOURCE_TYPES.LABELS:
-        return `${BASE_RESOURCE_API}/labels`;
+        const labelsQueryString = resourceName ? `?match[]=${resourceName}` : '';
+        return `${BASE_RESOURCE_API}/labels${labelsQueryString}`;
       case PROMETHEUS_RESOURCE_TYPES.ALERTS:
         return `${BASE_RESOURCE_API}/alerts`;
       case PROMETHEUS_RESOURCE_TYPES.LABEL_VALUES:
         return `${BASE_RESOURCE_API}/label/${resourceName}/values`;
       case PROMETHEUS_RESOURCE_TYPES.METRIC_METADATA:
-        const queryString = resourceName ? `?metric=${resourceName}` : '';
-        return `${BASE_RESOURCE_API}/metadata${queryString}`;
+        const metricMetadataQueryString = resourceName ? `?metric=${resourceName}` : '';
+        return `${BASE_RESOURCE_API}/metadata${metricMetadataQueryString}`;
 
       default:
         throw Error(`unknown resource type: ${resourceType}`);

--- a/src/plugins/query_enhancements/server/routes/resources/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/resources/routes.ts
@@ -36,13 +36,18 @@ export function registerResourceRoutes(router: IRouter, defaultClient: ILegacyCl
     async (context, request, response) => {
       const { dataConnectionId, dataConnectionType, resourceType, resourceName } = request.params;
       if (dataConnectionType === 'prometheus') {
-        const resources = await prometheusManager.getResources(context, request, {
+        const resourcesResponse = await prometheusManager.getResources(context, request, {
           dataSourceName: dataConnectionId,
           resourceType,
           resourceName,
           query: request.query,
         } as PrometheusResourceQuery);
-        return response.ok({ body: resources }) as any;
+
+        if (resourcesResponse.status === 'failed') {
+          return response.internalError();
+        }
+
+        return response.ok({ body: resourcesResponse }) as any;
       }
     }
   );


### PR DESCRIPTION
### Description
This is to create a clientside API to surface data connection resources. With this PR I've implemented the prometheus resource API which will be used for dynamic query suggestions. 

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
