### PR TITLE
Fix: fix potential memory leak in getDirectQueryConnections with node 20

### DIFF
--- a/changelogs/fragments/9575.yml
+++ b/changelogs/fragments/9575.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix potential memory leak in getDirectQueryConnections ([#9575](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9575))

--- a/src/plugins/data_source/config.ts
+++ b/src/plugins/data_source/config.ts
@@ -41,7 +41,7 @@ export const configSchema = schema.object({
     ),
   }),
   clientPool: schema.object({
-    size: schema.number({ defaultValue: 5 }),
+    size: schema.number({ defaultValue: 10 }),
   }),
   audit: schema.object({
     enabled: schema.boolean({ defaultValue: false }),

--- a/src/plugins/data_source_management/server/routes/data_connections_router.ts
+++ b/src/plugins/data_source_management/server/routes/data_connections_router.ts
@@ -222,7 +222,9 @@ export function registerDataConnectionsRoute(router: IRouter, dataSourceEnabled:
         let dataConnectionsresponse;
         if (dataSourceEnabled && dataSourceMDSId) {
           const client = await context.dataSource.opensearch.legacy.getClient(dataSourceMDSId);
-          dataConnectionsresponse = await client.callAPI('ppl.getDataConnections');
+          dataConnectionsresponse = await client.callAPI('ppl.getDataConnections', {
+            requestTimeout: 5000, // Enforce timeout to avoid hanging requests
+          });
         } else {
           dataConnectionsresponse = await context.opensearch_data_source_management.dataSourceManagementClient
             .asScoped(request)


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
fix potential memory leak in getDirectQueryConnections with node 20


1. enforce timeout to `2s` for the legacy client call on `ppl.dataSource`
2. use larger default client pool size `10`. Note that if single page is loading with 10+ datasources, this could still lead to server crash due to a deprecated `parseUrl` function in `url` is used in elasticsearch legacy library. However, to address this, we will need to deprecate usage of elasticsearch client, which is not currently in scope of 3.0 release.
    - related issue #2220 
![image](https://github.com/user-attachments/assets/2e6a7e76-57f2-4eeb-9733-78206dd8fe99)

```
(node:504350) [DEP0170] DeprecationWarning: The URL search-data-logs-2-xrnwkouy6zb62xpw5vaarfndm4.aos.us-west-2.on.aws:443::::::::true::::::::::::: is invalid. Future versions of Node.js will throw an error.
(Use node --trace-deprecation ... to show where the warning was created)
Node.js process-warning detected:

DeprecationWarning: The URL search-data-logs-2-xrnwkouy6zb62xpw5vaarfndm4.aos.us-west-2.on.aws:443::::::::true::::::::::::: is invalid. Future versions of Node.js will throw an error.
    at getHostname (node:url:517:17)
    at Url.parse (node:url:385:14)
    at urlParse (node:url:142:13)
    at /home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/connectors/http.js:78:34
    at arrayEach (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/lodash/lodash.js:530:11)
    at Function.forEach (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/lodash/lodash.js:9410:14)
    at HttpConnector.onStatusSet (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/connectors/http.js:75:7)
    at HttpConnector.wrapper (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/lodash/lodash.js:4991:19)
    at HttpConnector.emit (node:events:530:35)
    at HttpConnector.emit (node:domain:489:12)
    at HttpConnector.ConnectionAbstract.setStatus (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/connection.js:102:8)
    at ConnectionPool.removeConnection (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/connection_pool.js:325:16)
    at ConnectionPool.setHosts (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/connection_pool.js:357:10)
    at ConnectionPool.close (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/connection_pool.js:371:8)
    at Transport.close (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/transport.js:521:23)
    at EsApiClient.close (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/elasticsearch/src/lib/client.js:57:22)
    at LRUCache.dispose (/home/ubuntu/Projects/OpenSearch-Dashboards/src/plugins/data_source/server/client/client_pool.ts:48:24)
    at del (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/lru-cache/index.js:453:20)
    at trim (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/lru-cache/index.js:443:7)
    at LRUCache.set (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/lru-cache/index.js:343:3)
    at addClientToPool (/home/ubuntu/Projects/OpenSearch-Dashboards/src/plugins/data_source/server/client/client_pool.ts:85:31)
    at getQueryClient (/home/ubuntu/Projects/OpenSearch-Dashboards/src/plugins/data_source/server/legacy/configure_legacy_client.ts:158:7)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at configureLegacyClient (/home/ubuntu/Projects/OpenSearch-Dashboards/src/plugins/data_source/server/legacy/configure_legacy_client.ts:75:12)
    at /home/ubuntu/Projects/OpenSearch-Dashboards/src/plugins/data_source_management/server/routes/data_connections_router.ts:225:37
    at Router.handle (/home/ubuntu/Projects/OpenSearch-Dashboards/src/core/server/http/router/router.ts:286:44)
    at handler (/home/ubuntu/Projects/OpenSearch-Dashboards/src/core/server/http/router/router.ts:241:11)
    at exports.Manager.execute (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at Object.internals.handler (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at exports.execute (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at Request._lifecycle (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/@hapi/hapi/lib/request.js:371:32)
    at Request._execute (/home/ubuntu/Projects/OpenSearch-Dashboards/node_modules/@hapi/hapi/lib/request.js:281:9)

Terminating process...
 server crashed  with status code 1
```

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9459

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

![image](https://github.com/user-attachments/assets/e13187ad-3280-415c-8c5d-294b9efed108)


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: fix potential memory leak in getDirectQueryConnections

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
