### PR TITLE
fix issue in discover grid table on resize when filtering out

### DIFF
--- a/changelogs/fragments/9582.yml
+++ b/changelogs/fragments/9582.yml
@@ -1,0 +1,2 @@
+fix:
+- Discover table not updating with row size when filtering out ([#9582](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9582))

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { EuiDataGrid, EuiDataGridSorting, EuiPanel } from '@elastic/eui';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { fetchTableDataCell } from './data_grid_table_cell_value';
@@ -131,9 +131,12 @@ export const DataGridTable = ({
     ];
   }, []);
 
-  const table = useMemo(
-    () => (
+  const tableKey = useMemo(() => `${columns.join(',')}-${rows.length}`, [columns, rows.length]);
+
+  const table = useMemo(() => {
+    return (
       <EuiDataGrid
+        key={tableKey}
         aria-labelledby="aria-labelledby"
         columns={dataGridTableColumns}
         columnVisibility={dataGridTableColumnsVisibility}
@@ -146,19 +149,19 @@ export const DataGridTable = ({
         toolbarVisibility={isToolbarVisible ? toolbarVisibility : false}
         rowHeightsOptions={rowHeightsOptions}
       />
-    ),
-    [
-      dataGridTableColumns,
-      dataGridTableColumnsVisibility,
-      leadingControlColumns,
-      pagination,
-      renderCellValue,
-      rowCount,
-      sorting,
-      isToolbarVisible,
-      rowHeightsOptions,
-    ]
-  );
+    );
+  }, [
+    tableKey,
+    dataGridTableColumns,
+    dataGridTableColumnsVisibility,
+    leadingControlColumns,
+    pagination,
+    renderCellValue,
+    rowCount,
+    sorting,
+    isToolbarVisible,
+    rowHeightsOptions,
+  ]);
 
   return (
     <DiscoverGridContextProvider

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { EuiDataGrid, EuiDataGridSorting, EuiPanel } from '@elastic/eui';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { fetchTableDataCell } from './data_grid_table_cell_value';


### PR DESCRIPTION
### Description

In the Discover Page, sometimes if we filter the contents such that only one item is present, if we then add a field, when we then remove/disable the filter, the table doesn't resize to accommodate the original contents, i.e., it we can only see one row at a time or so.


### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9401

## Screenshot

https://drive.google.com/file/d/1zw3iitCa9jL0kmx_UOHk5WZvS-xjkRjC/view?usp=sharing

## Changelog
- fix: Discover table not updating with row size when filtering out 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
