### PR TITLE
Fix: Correctly show error message in DQL and PPL query editor

### DIFF
--- a/changelogs/fragments/9586.yml
+++ b/changelogs/fragments/9586.yml
@@ -1,0 +1,2 @@
+fix:
+- Correctly show error message in DQL and PPL query editor ([#9586](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9586))

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`Query Result show error status with error message 2`] = `
           Message:
         </strong>
          
+        {"reason":"error reason","details":"error details"}
       </p>
     </EuiText>
   </div>

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { mountWithIntl, shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { QueryResult } from './query_result';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 enum ResultStatus {
   UNINITIALIZED = 'uninitialized',
@@ -116,5 +117,80 @@ describe('Query Result', () => {
     };
     const component = shallowWithIntl(<QueryResult {...props} />);
     expect(component).toEqual({});
+  });
+
+  it('should render error message correctly with normal search strategy', async () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.ERROR,
+        body: {
+          error: {
+            error: 'error',
+            statusCode: 400,
+            message: {
+              error: {
+                reason: 'error reason',
+                details: 'error details',
+                type: 'error type',
+              },
+              status: 400,
+            },
+          },
+        },
+      },
+    };
+
+    render(<QueryResult {...props} />);
+
+    await fireEvent.click(screen.getByText('Error'));
+
+    await waitFor(() => {
+      expect(screen.getByText('error details')).toBeInTheDocument();
+    });
+  });
+
+  it('should render error message correctly with async search strategy', async () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.ERROR,
+        body: {
+          error: {
+            error: 'error',
+            statusCode: 400,
+            message: {
+              error: 'error message',
+              status: 400,
+            },
+          },
+        },
+      },
+    };
+
+    render(<QueryResult {...props} />);
+
+    await fireEvent.click(screen.getByText('Error'));
+
+    await waitFor(() => {
+      expect(screen.getByText('error message')).toBeInTheDocument();
+    });
+  });
+
+  it('should render error message with flexible error format', async () => {
+    const props = {
+      queryStatus: {
+        status: ResultStatus.ERROR,
+        body: {
+          error: 'error message',
+        },
+      },
+    };
+
+    render(<QueryResult {...props} />);
+
+    await fireEvent.click(screen.getByText('Error'));
+
+    await waitFor(() => {
+      expect(screen.getByText('error message')).toBeInTheDocument();
+    });
   });
 });

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -8,7 +8,7 @@ import { i18n } from '@osd/i18n';
 import './_recent_query.scss';
 import { EuiButtonEmpty, EuiPopover, EuiText, EuiPopoverTitle } from '@elastic/eui';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 export enum ResultStatus {
   UNINITIALIZED = 'uninitialized',
@@ -22,8 +22,16 @@ export interface QueryStatus {
   status: ResultStatus;
   body?: {
     error?: {
+      error?: string;
+      message?: {
+        error?: {
+          reason?: string;
+          details: string;
+          type?: string;
+        };
+        status?: number;
+      };
       statusCode?: number;
-      message?: string;
     };
   };
   elapsedMs?: number;
@@ -57,6 +65,25 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       setElapsedTime(0);
     };
   }, [props.queryStatus.startTime]);
+
+  const displayErrorMessage = useMemo(() => {
+    const error = props.queryStatus.body?.error;
+    const reason = error?.message?.error?.reason;
+
+    if (reason) {
+      return reason;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      return JSON.stringify(error);
+    }
+
+    return 'Unkown Error';
+  }, [props.queryStatus.body?.error]);
 
   if (props.queryStatus.status === ResultStatus.LOADING) {
     const time = Math.floor(elapsedTime / 1000);
@@ -166,7 +193,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
                 defaultMessage: `Message:`,
               })}
             </strong>{' '}
-            {props.queryStatus.body.error.message}
+            {displayErrorMessage}
           </p>
         </EuiText>
       </div>

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -93,6 +93,10 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
       };
       setQueryStatus(result);
     });
+
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [data$]);
 
   useEffect(() => {

--- a/src/plugins/discover/public/application/view_components/utils/use_search.test.tsx
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.test.tsx
@@ -12,7 +12,7 @@ import { Subject } from 'rxjs';
 import { createDataExplorerServicesMock } from '../../../../../data_explorer/public/utils/mocks';
 import { DiscoverViewServices } from '../../../build_services';
 import { discoverPluginMock } from '../../../mocks';
-import { ResultStatus, useSearch } from './use_search';
+import { ResultStatus, safeJSONParse, useSearch } from './use_search';
 import { Filter, ISearchSource, UI_SETTINGS } from '../../../../../data/common';
 import { opensearchFilters } from 'src/plugins/data/public';
 
@@ -416,5 +416,14 @@ describe('useSearch', () => {
       abortSignal: expect.anything(),
       withLongNumeralsSupport: undefined,
     });
+  });
+});
+
+describe('safeJSONParse', () => {
+  it('should covert string to JSON if possible', () => {
+    const validJSONString = '{"result":true, "count":42}';
+    const invalidJSONString = 'invalidJSON';
+    expect(safeJSONParse(validJSONString)).toEqual(JSON.parse(validJSONString));
+    expect(safeJSONParse(invalidJSONString)).toEqual(invalidJSONString);
   });
 });

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -34,7 +34,7 @@ import { useSelector } from '../../utils/state_management';
 import { SEARCH_ON_PAGE_LOAD_SETTING } from '../../../../common';
 import { trackQueryMetric } from '../../../ui_metric';
 
-function safeJSONParse(text: any) {
+export function safeJSONParse(text: any) {
   try {
     return JSON.parse(text);
   } catch (error) {

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -83,8 +83,8 @@ export const fetch = (context: EnhancedFetchContext, query: Query, aggConfig?: Q
             // eslint-disable-next-line no-console
             console.error('Failed to cancel query:', cancelError);
           }
-          throw error;
         }
+        throw error;
       })
   );
 };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

This PR fix a bug that causing error message in query editor to show `Cannot read properties of undefined (reading 'hasOwnProperty')` instead of the correct error message.

There are 2 major changes in this PR:
1. Correctly throw error from `fetch` result
2. Properly handle error message base on current error structure

Example error
```
{
    "statusCode": 404,
    "error": "Not Found",
    "message": "{\n  \"error\": {\n    \"reason\": \"Error occurred in OpenSearch engine: no such index [data_logs_small_time_12]\",\n    \"details\": \"[data_logs_small_time_12] IndexNotFoundException[no such index [data_logs_small_time_12]]\\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.\",\n    \"type\": \"IndexNotFoundException\"\n  },\n  \"status\": 404\n}"
}
``` 



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

Fix a issue that cause error message in query editor to show `Cannot read properties of undefined (reading 'hasOwnProperty')`

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

Before

![Screenshot 2025-03-20 at 7 28 03 PM](https://github.com/user-attachments/assets/4ffc454c-ddbf-4480-9de7-4d5fc67ce3b6)


After

![Screenshot 2025-03-20 at 7 21 05 PM](https://github.com/user-attachments/assets/a0c68a5d-bb2b-4f10-873e-fd32aea59841)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Correctly show error message in DQL and PPL query editor

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
