### PR TITLE
 Fix: Correctly show error message in DQL and PPL query editor

### DIFF
--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Query Result show error status with error message 2`] = `
           Message:
         </strong>
          
-        {"error":"error reason: error details"}
+        {"reason":"error reason","details":"error details","status":400}
       </p>
     </EuiText>
   </div>

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Query Result show error status with error message 2`] = `
           Message:
         </strong>
          
-        {"reason":"error reason","details":"error details"}
+        {"error":"error reason: error details"}
       </p>
     </EuiText>
   </div>

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -95,7 +95,11 @@ describe('Query Result', () => {
         status: ResultStatus.ERROR,
         body: {
           error: {
-            error: 'error reason: error details',
+            message: {
+              reason: 'error reason',
+              details: 'error details',
+              status: 400,
+            },
           },
           statusCode: 400,
         },

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { mountWithIntl, shallowWithIntl } from 'test_utils/enzyme_helpers';
 import { QueryResult } from './query_result';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MessageChannel } from 'node:worker_threads';
 
 enum ResultStatus {
   UNINITIALIZED = 'uninitialized',
@@ -94,8 +95,7 @@ describe('Query Result', () => {
         status: ResultStatus.ERROR,
         body: {
           error: {
-            reason: 'error reason',
-            details: 'error details',
+            error: 'error reason: error details',
           },
           statusCode: 400,
         },
@@ -145,7 +145,7 @@ describe('Query Result', () => {
     await fireEvent.click(screen.getByText('Error'));
 
     await waitFor(() => {
-      expect(screen.getByText('error details')).toBeInTheDocument();
+      expect(screen.getByText('error reason')).toBeInTheDocument();
     });
   });
 
@@ -180,7 +180,14 @@ describe('Query Result', () => {
       queryStatus: {
         status: ResultStatus.ERROR,
         body: {
-          error: 'error message',
+          error: {
+            error: 'error',
+            statusCode: 400,
+            message: {
+              reason: 'error message',
+              status: 400,
+            },
+          },
         },
       },
     };
@@ -190,7 +197,7 @@ describe('Query Result', () => {
     await fireEvent.click(screen.getByText('Error'));
 
     await waitFor(() => {
-      expect(screen.getByText('error message')).toBeInTheDocument();
+      expect(screen.getByText('{"reason":"error message","status":400}')).toBeInTheDocument();
     });
   });
 });

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -24,13 +24,11 @@ export interface QueryStatus {
     error?: {
       error?: string;
       message?: {
-        error?:
-          | string
-          | {
-              reason?: string;
-              details: string;
-              type?: string;
-            };
+        error?: {
+          reason?: string;
+          details: string;
+          type?: string;
+        };
         status?: number;
       };
       statusCode?: number;
@@ -102,7 +100,21 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       return JSON.stringify(message);
     }
 
-    return `Unknown Error: ${String(message)}`;
+    const reason = error?.message?.error?.reason;
+
+    if (reason) {
+      return reason;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      return JSON.stringify(error);
+    }
+
+    return 'Unkown Error';
   }, [props.queryStatus.body?.error]);
 
   if (props.queryStatus.status === ResultStatus.LOADING) {

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -24,11 +24,13 @@ export interface QueryStatus {
     error?: {
       error?: string;
       message?: {
-        error?: {
-          reason?: string;
-          details: string;
-          type?: string;
-        };
+        error?:
+          | string
+          | {
+              reason?: string;
+              details: string;
+              type?: string;
+            };
         status?: number;
       };
       statusCode?: number;
@@ -68,7 +70,8 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
 
   const displayErrorMessage = useMemo(() => {
     const error = props.queryStatus.body?.error;
-    const reason = error?.message?.error?.reason;
+    const reason =
+      typeof error?.message?.error === 'object' ? error.message.error.reason : undefined;
 
     if (reason) {
       return reason;
@@ -107,7 +110,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       return JSON.stringify(message);
     }
 
-    return `Unknown Error`;
+    return `Unknown Error: ${String(message)}`;
   }, [props.queryStatus.body?.error]);
 
   if (props.queryStatus.status === ResultStatus.LOADING) {

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -68,6 +68,12 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
 
   const displayErrorMessage = useMemo(() => {
     const error = props.queryStatus.body?.error;
+    const reason = error?.message?.error?.reason;
+
+    if (reason) {
+      return reason;
+    }
+
     const message = error?.message;
 
     if (message == null) {
@@ -92,6 +98,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       return message.error.details;
     }
 
+    // For normal search strategy, expecting message.error to be object
     if (typeof message === 'string') {
       return message;
     }
@@ -100,21 +107,7 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
       return JSON.stringify(message);
     }
 
-    const reason = error?.message?.error?.reason;
-
-    if (reason) {
-      return reason;
-    }
-
-    if (typeof error === 'string') {
-      return error;
-    }
-
-    if (typeof error === 'object') {
-      return JSON.stringify(error);
-    }
-
-    return 'Unkown Error';
+    return `Unknown Error`;
   }, [props.queryStatus.body?.error]);
 
   if (props.queryStatus.status === ResultStatus.LOADING) {

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -34,16 +34,11 @@ import { useSelector } from '../../utils/state_management';
 import { SEARCH_ON_PAGE_LOAD_SETTING } from '../../../../common';
 import { trackQueryMetric } from '../../../ui_metric';
 
-function isJSONString(text: any) {
-  if (typeof text !== 'string') {
-    return false;
-  }
-
+export function safeJSONParse(text: any) {
   try {
-    JSON.parse(text);
-    return true;
+    return JSON.parse(text);
   } catch (error) {
-    return false;
+    return text;
   }
 }
 
@@ -372,9 +367,7 @@ export const useSearch = (services: DiscoverViewServices) => {
 
       // Currently error message is sent as encoded JSON string, which requires extra parsing
       // TODO: Confirm error contract
-      if (isJSONString(errorBody.message)) {
-        errorBody.message = JSON.parse(errorBody.message);
-      }
+      errorBody.message = safeJSONParse(errorBody.message);
 
       data$.next({
         status: ResultStatus.ERROR,

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -367,8 +367,21 @@ export const useSearch = (services: DiscoverViewServices) => {
         }
       }
 
-      // Currently error message is sent as encoded JSON string, which requires extra parsing
-      // TODO: Confirm error contract
+      // Error message can be sent as encoded JSON string, which requires extra parsing
+      /*
+        errorBody: {
+          error: string,
+          statusCode: number,
+          message: {
+            error: {
+              reason: string;
+              details: string;
+              type: string;
+            };
+            status: number;
+          }
+        }
+      */
       errorBody.message = safeJSONParse(errorBody.message);
 
       data$.next({

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -64,11 +64,13 @@ export interface SearchData {
       error?: {
         error?: string;
         message?: {
-          error?: {
-            reason?: string;
-            details: string;
-            type?: string;
-          };
+          error?:
+            | string
+            | {
+                reason?: string;
+                details: string;
+                type?: string;
+              };
           status?: number;
         };
         statusCode?: number;

--- a/src/plugins/query_enhancements/common/utils.test.ts
+++ b/src/plugins/query_enhancements/common/utils.test.ts
@@ -6,15 +6,15 @@
 import { isPPLSearchQuery, throwFacetError } from './utils';
 import { Query } from 'src/plugins/data/common';
 
-describe('handleFacetError', () => {
-  const error = new Error('mock-error');
-  (error as any).body = {
-    message: 'test error message',
-  };
-  (error as any).status = '400';
+describe('throwFacetError', () => {
   it('should throw an error with message from response.data.body.message', () => {
     const response = {
-      data: error,
+      data: {
+        body: {
+          message: 'test error message',
+        },
+        status: '400',
+      },
     };
 
     expect(() => throwFacetError(response)).toThrowError();
@@ -24,6 +24,91 @@ describe('handleFacetError', () => {
       expect(err.message).toBe('test error message');
       expect(err.name).toBe('400');
       expect(err.status).toBe('400');
+    }
+  });
+
+  it('should throw an error with message from response.data.body if it is a string', () => {
+    const response = {
+      data: {
+        body: 'string error message',
+        status: '500',
+      },
+    };
+
+    expect(() => throwFacetError(response)).toThrowError();
+    try {
+      throwFacetError(response);
+    } catch (err: any) {
+      expect(err.message).toBe('string error message');
+      expect(err.name).toBe('500');
+      expect(err.status).toBe('500');
+    }
+  });
+
+  it('should throw an error with message from response.data if body is undefined', () => {
+    const response = {
+      data: {
+        message: 'fallback error message',
+        status: '404',
+      },
+    };
+
+    expect(() => throwFacetError(response)).toThrowError();
+    try {
+      throwFacetError(response);
+    } catch (err: any) {
+      expect(err.message).toBe('"fallback error message"');
+      expect(err.name).toBe('404');
+      expect(err.status).toBe('404');
+    }
+  });
+
+  it('should throw an error with message from Error object', () => {
+    const error = new Error('error object message');
+    const response = {
+      data: error,
+    };
+
+    expect(() => throwFacetError(response)).toThrowError();
+    try {
+      throwFacetError(response);
+    } catch (err: any) {
+      expect(err.message).toBe('error object message');
+      expect(err.name).toBeUndefined();
+      expect(err.status).toBeUndefined();
+    }
+  });
+
+  it('should throw an error with stringified message if response.data.body is a plain object', () => {
+    const response = {
+      data: {
+        body: { key: 'value' },
+        status: '400',
+      },
+    };
+
+    expect(() => throwFacetError(response)).toThrowError();
+    try {
+      throwFacetError(response);
+    } catch (err: any) {
+      expect(err.message).toBe('{"key":"value"}');
+      expect(err.name).toBe('400');
+      expect(err.status).toBe('400');
+    }
+  });
+
+  it('should throw an error with default message if no valid message is found', () => {
+    const response = {
+      data: {},
+    };
+
+    expect(() => throwFacetError(response)).toThrowError();
+    try {
+      throwFacetError(response);
+    } catch (err: any) {
+      expect(err.message).toBe('{}');
+      expect(err.name).toBeUndefined();
+      expect(err.status).toBeUndefined();
     }
   });
 });

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -44,7 +44,23 @@ export const removeKeyword = (queryString: string | undefined) => {
 };
 
 export const throwFacetError = (response: any) => {
-  const error = new Error(response.data.body?.message ?? response.data.body ?? response.data);
+  let errorMessage = response.data.body?.message ?? response.data.body ?? response.data;
+
+  // Check if errorMessage is an object and handle Error objects
+  if (typeof errorMessage === 'object') {
+    if (errorMessage instanceof Error) {
+      // If errorMessage is an instance of Error, extract its message
+      errorMessage = errorMessage.message;
+    } else if (errorMessage.message) {
+      // If errorMessage has a message property, extract that message
+      errorMessage = JSON.stringify(errorMessage.message);
+    } else {
+      // If errorMessage is a plain object, stringify it
+      errorMessage = JSON.stringify(errorMessage);
+    }
+  }
+
+  const error = new Error(errorMessage);
   error.name = response.data.status ?? response.status ?? response.data.statusCode;
   (error as any).status = error.name;
   throw error;


### PR DESCRIPTION
### Description

This PR fix a bug that causing error message in query editor as message[object object] instead of the correct error message .

There are 2 major changes in this PR:

Correctly throw error from fetch result
Properly handle error message base on current error structure


### Issues Resolved

Fix message [object object] issue in ppl editor

## Screenshot
Before

<img width="593" alt="Screenshot 2025-03-21 at 1 45 22 PM" src="https://github.com/user-attachments/assets/80ab230f-fe4c-443f-afb0-d017b7afd05e" />


After

<img width="1068" alt="Screenshot 2025-03-21 at 3 45 00 PM" src="https://github.com/user-attachments/assets/56b7e21d-978c-4814-a22a-bab362238aa7" />


## Changelog
- fix: Correctly show error message in DQL and PPL query editor

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
