### PR TITLE
Moving SQL and PPL Provider Registration to Query Enhancements Plugin

### DIFF
--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
@@ -9,19 +9,15 @@
  * GitHub history for details.
  */
 
-import { monaco } from '@osd/monaco';
 import { CursorPosition, OpenSearchPplAutocompleteResult } from '../shared/types';
-import {
-  fetchColumnValues,
-  formatFieldsToSuggestions,
-  formatValuesToSuggestions,
-  parseQuery,
-} from '../shared/utils';
+import { parseQuery } from '../shared/utils';
 import { openSearchPplAutocompleteData } from './opensearch_ppl_autocomplete';
 import { QuerySuggestion, QuerySuggestionGetFnArgs } from '../../autocomplete';
-import { SuggestionItemDetailsTags } from '../shared/constants';
-import { PPL_AGGREGATE_FUNCTIONS, PPL_SUGGESTION_IMPORTANCE } from './constants';
 
+/**
+ * @deprecated PPL suggestion provider has been moved to the query_enhancements plugin.
+ * This function is kept for backward compatibility and will be removed in a future release.
+ */
 export const getSuggestions = async ({
   selectionStart,
   selectionEnd,
@@ -30,85 +26,15 @@ export const getSuggestions = async ({
   position,
   query,
   services,
-}: QuerySuggestionGetFnArgs) => {
-  if (!services || !services.appName || !indexPattern) return [];
-  try {
-    const { lineNumber, column } = position || {};
-    const suggestions = getOpenSearchPplAutoCompleteSuggestions(query, {
-      line: lineNumber || selectionStart,
-      column: column || selectionEnd,
-    });
-
-    const finalSuggestions: QuerySuggestion[] = [];
-
-    if (suggestions.suggestColumns) {
-      finalSuggestions.push(...formatFieldsToSuggestions(indexPattern, (f: any) => `${f} `, '3'));
-    }
-
-    if (suggestions.suggestValuesForColumn) {
-      finalSuggestions.push(
-        ...formatValuesToSuggestions(
-          await fetchColumnValues(
-            indexPattern.title,
-            suggestions.suggestValuesForColumn,
-            services,
-            indexPattern.fields.find((field) => field.name === suggestions.suggestValuesForColumn),
-            datasetType
-          ).catch(() => []),
-          (val: any) => (typeof val === 'string' ? `"${val}" ` : `${val} `)
-        )
-      );
-    }
-
-    if (suggestions.suggestAggregateFunctions) {
-      finalSuggestions.push(
-        ...PPL_AGGREGATE_FUNCTIONS.map((af) => ({
-          text: `${af}()`,
-          type: monaco.languages.CompletionItemKind.Function,
-          insertText: af + ' ',
-          detail: SuggestionItemDetailsTags.AggregateFunction,
-        }))
-      );
-    }
-
-    if (suggestions.suggestSourcesOrTables) {
-      finalSuggestions.push({
-        text: indexPattern.title,
-        type: monaco.languages.CompletionItemKind.Struct,
-        insertText: `${indexPattern.title} `,
-        detail: SuggestionItemDetailsTags.Table,
-      });
-    }
-
-    if (suggestions.suggestRenameAs) {
-      finalSuggestions.push({
-        text: 'as',
-        insertText: 'as ',
-        type: monaco.languages.CompletionItemKind.Keyword,
-        detail: SuggestionItemDetailsTags.Keyword,
-      });
-    }
-
-    // Fill in PPL keywords
-    if (suggestions.suggestKeywords?.length) {
-      finalSuggestions.push(
-        ...suggestions.suggestKeywords.map((sk) => ({
-          text: sk.value.toLowerCase(),
-          insertText: `${sk.value.toLowerCase()} `,
-          type: monaco.languages.CompletionItemKind.Keyword,
-          detail: SuggestionItemDetailsTags.Keyword,
-          // sortText is the only option to sort suggestions, compares strings
-          sortText: PPL_SUGGESTION_IMPORTANCE.get(sk.id) ?? '9' + sk.value.toLowerCase(), // '9' used to devalue every other suggestion
-        }))
-      );
-    }
-
-    return finalSuggestions;
-  } catch (e) {
-    return [];
-  }
+}: QuerySuggestionGetFnArgs): Promise<QuerySuggestion[]> => {
+  // Return empty array - the actual implementation has been moved to query_enhancements plugin
+  return [];
 };
 
+/**
+ * Helper function to get PPL autocomplete suggestions
+ * This is still exported for use by the query_enhancements plugin
+ */
 export const getOpenSearchPplAutoCompleteSuggestions = (
   query: string,
   cursor: CursorPosition

--- a/src/plugins/data/public/antlr/opensearch_sql/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_sql/code_completion.ts
@@ -3,34 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { monaco } from '@osd/monaco';
-import {
-  ColumnValuePredicate,
-  CursorPosition,
-  OpenSearchSqlAutocompleteResult,
-} from '../shared/types';
+import { CursorPosition, OpenSearchSqlAutocompleteResult } from '../shared/types';
 import { openSearchSqlAutocompleteData } from './opensearch_sql_autocomplete';
-import { SQL_SUGGESTION_IMPORTANCE, SQL_SYMBOLS } from './constants';
 import { QuerySuggestion, QuerySuggestionGetFnArgs } from '../../autocomplete';
-import {
-  fetchColumnValues,
-  formatFieldsToSuggestions,
-  formatValuesToSuggestions,
-  parseQuery,
-} from '../shared/utils';
-import { SuggestionItemDetailsTags } from '../shared/constants';
+import { parseQuery } from '../shared/utils';
 
-export interface SuggestionParams {
-  position: monaco.Position;
-  query: string;
-}
-
-export interface ISuggestionItem {
-  text: string;
-  type: string;
-  fieldType?: string;
-}
-
+/**
+ * @deprecated SQL suggestion provider has been moved to the query_enhancements plugin.
+ * This function is kept for backward compatibility and will be removed in a future release.
+ */
 export const getSuggestions = async ({
   selectionStart,
   selectionEnd,
@@ -40,129 +21,14 @@ export const getSuggestions = async ({
   query,
   services,
 }: QuerySuggestionGetFnArgs): Promise<QuerySuggestion[]> => {
-  if (!services || !services.appName || !indexPattern) return [];
-  try {
-    const { lineNumber, column } = position || {};
-    const suggestions = getOpenSearchSqlAutoCompleteSuggestions(query, {
-      line: lineNumber || selectionStart,
-      column: column || selectionEnd,
-    });
-
-    const finalSuggestions: QuerySuggestion[] = [];
-
-    // Fetch columns and values
-    if (suggestions.suggestColumns?.tables?.length) {
-      finalSuggestions.push(...formatFieldsToSuggestions(indexPattern, (f: any) => `${f} `, '2'));
-    }
-
-    if (suggestions.suggestColumnValuePredicate) {
-      switch (suggestions.suggestColumnValuePredicate) {
-        case ColumnValuePredicate.COLUMN: {
-          finalSuggestions.push(
-            ...formatFieldsToSuggestions(indexPattern, (f: any) => `${f} `, '2')
-          );
-          break;
-        }
-        case ColumnValuePredicate.OPERATOR: {
-          finalSuggestions.push({
-            text: '=',
-            insertText: '= ',
-            type: monaco.languages.CompletionItemKind.Operator,
-            detail: SuggestionItemDetailsTags.Operator,
-            sortText: '0',
-          });
-          break;
-        }
-        case ColumnValuePredicate.LPAREN: {
-          finalSuggestions.push({
-            text: '(',
-            insertText: '( ',
-            type: monaco.languages.CompletionItemKind.Keyword,
-            detail: SuggestionItemDetailsTags.Keyword,
-            sortText: '0',
-          });
-          break;
-        }
-        case ColumnValuePredicate.END_IN_TERM: {
-          finalSuggestions.push({
-            text: ',',
-            insertText: ', ',
-            type: monaco.languages.CompletionItemKind.Keyword,
-            detail: SuggestionItemDetailsTags.Keyword,
-            sortText: '0',
-          });
-          finalSuggestions.push({
-            text: ')',
-            insertText: ') ',
-            type: monaco.languages.CompletionItemKind.Keyword,
-            detail: SuggestionItemDetailsTags.Keyword,
-            sortText: '08',
-          });
-          break;
-        }
-        case ColumnValuePredicate.VALUE: {
-          if (suggestions.suggestValuesForColumn) {
-            finalSuggestions.push(
-              ...formatValuesToSuggestions(
-                await fetchColumnValues(
-                  indexPattern.title,
-                  suggestions.suggestValuesForColumn,
-                  services,
-                  indexPattern.fields.find(
-                    (field) => field.name === suggestions.suggestValuesForColumn
-                  ),
-                  datasetType
-                ).catch(() => []),
-                (val: any) => (typeof val === 'string' ? `'${val}' ` : `${val} `)
-              )
-            );
-          }
-          break;
-        }
-      }
-    }
-
-    // Fill in aggregate functions
-    if (suggestions.suggestAggregateFunctions) {
-      finalSuggestions.push(
-        ...SQL_SYMBOLS.AGREGATE_FUNCTIONS.map((af) => ({
-          text: af,
-          type: monaco.languages.CompletionItemKind.Function,
-          insertText: `${af} `,
-          detail: SuggestionItemDetailsTags.AggregateFunction,
-        }))
-      );
-    }
-
-    if (suggestions.suggestViewsOrTables) {
-      finalSuggestions.push({
-        text: indexPattern.title,
-        type: monaco.languages.CompletionItemKind.Struct,
-        insertText: `${indexPattern.title} `,
-        detail: SuggestionItemDetailsTags.Table,
-      });
-    }
-
-    // Fill in SQL keywords
-    if (suggestions.suggestKeywords?.length) {
-      finalSuggestions.push(
-        ...suggestions.suggestKeywords.map((sk) => ({
-          text: sk.value,
-          type: monaco.languages.CompletionItemKind.Keyword,
-          insertText: `${sk.value} `,
-          detail: SuggestionItemDetailsTags.Keyword,
-          sortText: SQL_SUGGESTION_IMPORTANCE.get(sk.id) ?? '9' + sk.value.toLowerCase(),
-        }))
-      );
-    }
-
-    return finalSuggestions;
-  } catch (error) {
-    // TODO: Handle errors appropriately, possibly logging or displaying a message to the user
-    return [];
-  }
+  // Return empty array - the actual implementation has been moved to query_enhancements plugin
+  return [];
 };
 
+/**
+ * Helper function to get SQL autocomplete suggestions
+ * This is still exported for use by the query_enhancements plugin
+ */
 export const getOpenSearchSqlAutoCompleteSuggestions = (
   query: string,
   cursor: CursorPosition

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -306,6 +306,28 @@ export {
   AutocompleteStart,
 } from './autocomplete';
 
+// Export shared utilities for query suggestions
+export {
+  fetchColumnValues,
+  formatFieldsToSuggestions,
+  formatValuesToSuggestions,
+  parseQuery,
+} from './antlr/shared/utils';
+export { SuggestionItemDetailsTags } from './antlr/shared/constants';
+
+// Export ANTLR-related types and constants for SQL
+export { SQL_SUGGESTION_IMPORTANCE, SQL_SYMBOLS } from './antlr/opensearch_sql/constants';
+export { openSearchSqlAutocompleteData } from './antlr/opensearch_sql/opensearch_sql_autocomplete';
+export { getOpenSearchSqlAutoCompleteSuggestions } from './antlr/opensearch_sql/code_completion';
+
+// Export ANTLR-related types and constants for PPL
+export {
+  PPL_AGGREGATE_FUNCTIONS,
+  PPL_SUGGESTION_IMPORTANCE,
+} from './antlr/opensearch_ppl/constants';
+export { openSearchPplAutocompleteData } from './antlr/opensearch_ppl/opensearch_ppl_autocomplete';
+export { getOpenSearchPplAutoCompleteSuggestions } from './antlr/opensearch_ppl/code_completion';
+
 /*
  * Search:
  */

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -91,9 +91,7 @@ import { DataSourceFactory } from './data_sources/datasource';
 import { registerDefaultDataSource } from './data_sources/register_default_datasource';
 import { DefaultDslDataSource } from './data_sources/default_datasource';
 import { DEFAULT_DATA_SOURCE_TYPE } from './data_sources/constants';
-import { getSuggestions as getSQLSuggestions } from './antlr/opensearch_sql/code_completion';
 import { getSuggestions as getDQLSuggestions } from './antlr/dql/code_completion';
-import { getSuggestions as getPPLSuggestions } from './antlr/opensearch_ppl/code_completion';
 import { createStorage, DataStorage, UI_SETTINGS } from '../common';
 
 declare module '../../ui_actions/public' {
@@ -177,9 +175,7 @@ export class DataPublicPlugin
     );
 
     const autoComplete = this.autocomplete.setup(core);
-    autoComplete.addQuerySuggestionProvider('SQL', getSQLSuggestions);
     autoComplete.addQuerySuggestionProvider('kuery', getDQLSuggestions);
-    autoComplete.addQuerySuggestionProvider('PPL', getPPLSuggestions);
 
     const useNewSavedQueriesUI =
       core.uiSettings.get(UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED) &&

--- a/src/plugins/query_enhancements/public/autocomplete/index.ts
+++ b/src/plugins/query_enhancements/public/autocomplete/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { getSQLSuggestions } from './sql_suggestions';
+export { getPPLSuggestions } from './ppl_suggestions';

--- a/src/plugins/query_enhancements/public/autocomplete/ppl_suggestions.ts
+++ b/src/plugins/query_enhancements/public/autocomplete/ppl_suggestions.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { monaco } from '@osd/monaco';
+import {
+  QuerySuggestion,
+  QuerySuggestionGetFn,
+  QuerySuggestionGetFnArgs,
+  formatFieldsToSuggestions,
+  formatValuesToSuggestions,
+  fetchColumnValues,
+  SuggestionItemDetailsTags,
+  PPL_AGGREGATE_FUNCTIONS,
+  PPL_SUGGESTION_IMPORTANCE,
+  getOpenSearchPplAutoCompleteSuggestions,
+} from '../../../data/public';
+
+/**
+ * PPL query suggestion provider
+ *
+ * This implementation uses the sophisticated ANTLR-based parser from the data plugin
+ * to provide context-aware suggestions based on the cursor position in the query.
+ */
+export const getPPLSuggestions: QuerySuggestionGetFn = async ({
+  selectionStart,
+  selectionEnd,
+  indexPattern,
+  datasetType,
+  position,
+  query,
+  services,
+}: QuerySuggestionGetFnArgs): Promise<QuerySuggestion[]> => {
+  if (!services || !services.appName || !indexPattern) return [];
+
+  try {
+    const { lineNumber, column } = position || {};
+    const suggestions = getOpenSearchPplAutoCompleteSuggestions(query, {
+      line: lineNumber || selectionStart,
+      column: column || selectionEnd,
+    });
+
+    const finalSuggestions: QuerySuggestion[] = [];
+
+    if (suggestions.suggestColumns) {
+      finalSuggestions.push(...formatFieldsToSuggestions(indexPattern, (f: any) => `${f} `, '3'));
+    }
+
+    if (suggestions.suggestValuesForColumn) {
+      finalSuggestions.push(
+        ...formatValuesToSuggestions(
+          await fetchColumnValues(
+            indexPattern.title,
+            suggestions.suggestValuesForColumn,
+            services,
+            indexPattern.fields.find((field) => field.name === suggestions.suggestValuesForColumn),
+            datasetType
+          ).catch(() => []),
+          (val: any) => (typeof val === 'string' ? `"${val}" ` : `${val} `)
+        )
+      );
+    }
+
+    if (suggestions.suggestAggregateFunctions) {
+      finalSuggestions.push(
+        ...PPL_AGGREGATE_FUNCTIONS.map((af) => ({
+          text: `${af}()`,
+          type: monaco.languages.CompletionItemKind.Function,
+          insertText: af + ' ',
+          detail: SuggestionItemDetailsTags.AggregateFunction,
+        }))
+      );
+    }
+
+    if (suggestions.suggestSourcesOrTables) {
+      finalSuggestions.push({
+        text: indexPattern.title,
+        type: monaco.languages.CompletionItemKind.Struct,
+        insertText: `${indexPattern.title} `,
+        detail: SuggestionItemDetailsTags.Table,
+      });
+    }
+
+    if (suggestions.suggestRenameAs) {
+      finalSuggestions.push({
+        text: 'as',
+        insertText: 'as ',
+        type: monaco.languages.CompletionItemKind.Keyword,
+        detail: SuggestionItemDetailsTags.Keyword,
+      });
+    }
+
+    // Fill in PPL keywords
+    if (suggestions.suggestKeywords?.length) {
+      finalSuggestions.push(
+        ...suggestions.suggestKeywords.map((sk) => ({
+          text: sk.value.toLowerCase(),
+          insertText: `${sk.value.toLowerCase()} `,
+          type: monaco.languages.CompletionItemKind.Keyword,
+          detail: SuggestionItemDetailsTags.Keyword,
+          // sortText is the only option to sort suggestions, compares strings
+          sortText: PPL_SUGGESTION_IMPORTANCE.get(sk.id) ?? '9' + sk.value.toLowerCase(), // '9' used to devalue every other suggestion
+        }))
+      );
+    }
+
+    return finalSuggestions;
+  } catch (error) {
+    // Handle error silently
+    return [];
+  }
+};

--- a/src/plugins/query_enhancements/public/autocomplete/sql_suggestions.ts
+++ b/src/plugins/query_enhancements/public/autocomplete/sql_suggestions.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { monaco } from '@osd/monaco';
+import {
+  QuerySuggestion,
+  QuerySuggestionGetFn,
+  QuerySuggestionGetFnArgs,
+  formatFieldsToSuggestions,
+  formatValuesToSuggestions,
+  fetchColumnValues,
+  SuggestionItemDetailsTags,
+  SQL_SUGGESTION_IMPORTANCE,
+  SQL_SYMBOLS,
+  getOpenSearchSqlAutoCompleteSuggestions,
+} from '../../../data/public';
+
+/**
+ * SQL query suggestion provider
+ *
+ * This implementation uses the sophisticated ANTLR-based parser from the data plugin
+ * to provide context-aware suggestions based on the cursor position in the query.
+ */
+export const getSQLSuggestions: QuerySuggestionGetFn = async ({
+  selectionStart,
+  selectionEnd,
+  indexPattern,
+  datasetType,
+  position,
+  query,
+  services,
+}: QuerySuggestionGetFnArgs): Promise<QuerySuggestion[]> => {
+  if (!services || !services.appName || !indexPattern) return [];
+
+  try {
+    const { lineNumber, column } = position || {};
+    const suggestions = getOpenSearchSqlAutoCompleteSuggestions(query, {
+      line: lineNumber || selectionStart,
+      column: column || selectionEnd,
+    });
+
+    const finalSuggestions: QuerySuggestion[] = [];
+
+    // Fetch columns and values
+    if (suggestions.suggestColumns?.tables?.length) {
+      finalSuggestions.push(...formatFieldsToSuggestions(indexPattern, (f: any) => `${f} `, '2'));
+    }
+
+    if (suggestions.suggestColumnValuePredicate) {
+      switch (suggestions.suggestColumnValuePredicate) {
+        case 'COLUMN': {
+          finalSuggestions.push(
+            ...formatFieldsToSuggestions(indexPattern, (f: any) => `${f} `, '2')
+          );
+          break;
+        }
+        case 'OPERATOR': {
+          finalSuggestions.push({
+            text: '=',
+            insertText: '= ',
+            type: monaco.languages.CompletionItemKind.Operator,
+            detail: SuggestionItemDetailsTags.Operator,
+            sortText: '0',
+          });
+          break;
+        }
+        case 'LPAREN': {
+          finalSuggestions.push({
+            text: '(',
+            insertText: '( ',
+            type: monaco.languages.CompletionItemKind.Keyword,
+            detail: SuggestionItemDetailsTags.Keyword,
+            sortText: '0',
+          });
+          break;
+        }
+        case 'END_IN_TERM': {
+          finalSuggestions.push({
+            text: ',',
+            insertText: ', ',
+            type: monaco.languages.CompletionItemKind.Keyword,
+            detail: SuggestionItemDetailsTags.Keyword,
+            sortText: '0',
+          });
+          finalSuggestions.push({
+            text: ')',
+            insertText: ') ',
+            type: monaco.languages.CompletionItemKind.Keyword,
+            detail: SuggestionItemDetailsTags.Keyword,
+            sortText: '08',
+          });
+          break;
+        }
+        case 'VALUE': {
+          if (suggestions.suggestValuesForColumn) {
+            finalSuggestions.push(
+              ...formatValuesToSuggestions(
+                await fetchColumnValues(
+                  indexPattern.title,
+                  suggestions.suggestValuesForColumn,
+                  services,
+                  indexPattern.fields.find(
+                    (field) => field.name === suggestions.suggestValuesForColumn
+                  ),
+                  datasetType
+                ).catch(() => []),
+                (val: any) => (typeof val === 'string' ? `'${val}' ` : `${val} `)
+              )
+            );
+          }
+          break;
+        }
+      }
+    }
+
+    // Fill in aggregate functions
+    if (suggestions.suggestAggregateFunctions) {
+      finalSuggestions.push(
+        ...SQL_SYMBOLS.AGREGATE_FUNCTIONS.map((af) => ({
+          text: af,
+          type: monaco.languages.CompletionItemKind.Function,
+          insertText: `${af} `,
+          detail: SuggestionItemDetailsTags.AggregateFunction,
+        }))
+      );
+    }
+
+    if (suggestions.suggestViewsOrTables) {
+      finalSuggestions.push({
+        text: indexPattern.title,
+        type: monaco.languages.CompletionItemKind.Struct,
+        insertText: `${indexPattern.title} `,
+        detail: SuggestionItemDetailsTags.Table,
+      });
+    }
+
+    // Fill in SQL keywords
+    if (suggestions.suggestKeywords?.length) {
+      finalSuggestions.push(
+        ...suggestions.suggestKeywords.map((sk) => ({
+          text: sk.value,
+          type: monaco.languages.CompletionItemKind.Keyword,
+          insertText: `${sk.value} `,
+          detail: SuggestionItemDetailsTags.Keyword,
+          sortText: SQL_SUGGESTION_IMPORTANCE.get(sk.id) ?? '9' + sk.value.toLowerCase(),
+        }))
+      );
+    }
+
+    return finalSuggestions;
+  } catch (error) {
+    // Handle error silently
+    return [];
+  }
+};

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -20,6 +20,7 @@ import { createQueryAssistExtension } from './query_assist';
 import { pplLanguageReference, sqlLanguageReference } from './query_editor_extensions';
 import { PPLSearchInterceptor, SQLSearchInterceptor } from './search';
 import { setData, setStorage } from './services';
+import { getSQLSuggestions, getPPLSuggestions } from './autocomplete';
 import {
   QueryEnhancementsPluginSetup,
   QueryEnhancementsPluginSetupDependencies,
@@ -200,6 +201,11 @@ export class QueryEnhancementsPlugin
       ],
     };
     queryString.getLanguageService().registerLanguage(sqlLanguageConfig);
+
+    // Register SQL and PPL autocomplete providers
+    data.autocomplete.addQuerySuggestionProvider('SQL', getSQLSuggestions);
+    data.autocomplete.addQuerySuggestionProvider('PPL', getPPLSuggestions);
+
     data.__enhance({
       editor: {
         queryEditorExtension: createQueryAssistExtension(


### PR DESCRIPTION
### Description

#### Autocomplete Service
* Located in `src/plugins/data/public/autocomplete/autocomplete_service.ts`
* Provides methods to register query suggestion providers for different languages
* Exposes `addQuerySuggestionProvider` in its setup contract
* Remains in the data plugin as a central registry for all autocomplete providers

#### Language Registration
* The data plugin now only registers the DQL language provider in its setup method:
```typescript
// In src/plugins/data/public/plugin.ts
autoComplete.addQuerySuggestionProvider('kuery', getDQLSuggestions);
```
* The query_enhancements plugin registers SQL and PPL providers in its setup method:
```typescript
// In src/plugins/query_enhancements/public/plugin.tsx
data.autocomplete.addQuerySuggestionProvider('SQL', getSQLSuggestions);
data.autocomplete.addQuerySuggestionProvider('PPL', getPPLSuggestions);
```

#### Language Implementations/Providers
* **DQL suggestions**: `src/plugins/data/public/antlr/dql/code_completion.ts` (unchanged)
* **SQL suggestions**: 
  * Original implementation in `src/plugins/data/public/antlr/opensearch_sql/code_completion.ts` (now deprecated)
  * New implementation in `src/plugins/query_enhancements/public/autocomplete/sql_suggestions.ts`
* **PPL suggestions**: 
  * Original implementation in `src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts` (now deprecated)
  * New implementation in `src/plugins/query_enhancements/public/autocomplete/ppl_suggestions.ts`

#### Shared Utilities and Components
* The data plugin exports shared utilities and ANTLR-related components through its public API:
```typescript
// In src/plugins/data/public/index.ts
export {
  fetchColumnValues,
  formatFieldsToSuggestions,
  formatValuesToSuggestions,
  parseQuery,
} from './antlr/shared/utils';
export { SuggestionItemDetailsTags } from './antlr/shared/constants';
export { SQL_SUGGESTION_IMPORTANCE, SQL_SYMBOLS } from './antlr/opensearch_sql/constants';
export { openSearchSqlAutocompleteData } from './antlr/opensearch_sql/opensearch_sql_autocomplete';
export { getOpenSearchSqlAutoCompleteSuggestions } from './antlr/opensearch_sql/code_completion';
export { PPL_AGGREGATE_FUNCTIONS, PPL_SUGGESTION_IMPORTANCE } from './antlr/opensearch_ppl/constants';
export { openSearchPplAutocompleteData } from './antlr/opensearch_ppl/opensearch_ppl_autocomplete';
export { getOpenSearchPplAutoCompleteSuggestions } from './antlr/opensearch_ppl/code_completion';
```

#### Query Enhancements Plugin
* Registers language configurations for SQL and PPL in `src/plugins/query_enhancements/public/plugin.tsx`
* Now also registers autocomplete providers for SQL and PPL
* Implements sophisticated SQL and PPL suggestion providers that use the shared utilities and ANTLR-related components from the data plugin

#### Current Implementation of Syntax/Error Highlighting
* There doesn't appear to be a dedicated service for syntax highlighting or error highlighting
* Monaco editor likely handles basic syntax highlighting based on language configuration
* Error highlighting might be handled by Monaco's validation capabilities, but there are no explicit error highlighting providers


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9584

## Screenshot


https://github.com/user-attachments/assets/f655000a-2f0d-4086-8345-ce99ed52f2de


## Changelog

- refactor: Moving SQL and PPL Provider Registration to Query Enhancements Plugin


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
