### PR TITLE
Fix: Skip appending time range to ppl when not querying with source

### DIFF
--- a/changelogs/fragments/9603.yml
+++ b/changelogs/fragments/9603.yml
@@ -1,0 +1,2 @@
+fix:
+- Skip appending time range to ppl when not querying with source ([#9603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9603))

--- a/src/plugins/query_enhancements/common/utils.test.ts
+++ b/src/plugins/query_enhancements/common/utils.test.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { throwFacetError } from './utils';
+import { isPPLSearchQuery, throwFacetError } from './utils';
+import { Query } from 'src/plugins/data/common';
 
 describe('handleFacetError', () => {
   const error = new Error('mock-error');
@@ -24,5 +25,48 @@ describe('handleFacetError', () => {
       expect(err.name).toBe('400');
       expect(err.status).toBe('400');
     }
+  });
+});
+
+describe('isPPLSearchQuery', () => {
+  it('should return false if query language is not PPL', () => {
+    const query: Query = {
+      language: 'lucene',
+      query: 'test',
+    };
+
+    expect(isPPLSearchQuery(query)).toBe(false);
+  });
+
+  it('should return false if query is not string', () => {
+    const query: Query = {
+      language: 'PPL',
+      query: {
+        field: 'something',
+      },
+    };
+
+    expect(isPPLSearchQuery(query)).toBe(false);
+  });
+
+  it('should return false if query is not using search command', () => {
+    const query: Query = {
+      language: 'PPL',
+      query: 'test',
+    };
+
+    expect(isPPLSearchQuery(query)).toBe(false);
+  });
+
+  it('should return true if query is using search command', () => {
+    const query: Query = {
+      language: 'PPL',
+      query: 'source = test | stats count',
+    };
+
+    expect(isPPLSearchQuery(query)).toBe(true);
+
+    query.query = 'search source = test | stats count';
+    expect(isPPLSearchQuery(query)).toBe(true);
   });
 });

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -121,3 +121,21 @@ export const buildQueryStatusConfig = (response: any) => {
     sessionId: response.data.sessionId,
   } as QueryStatusConfig;
 };
+
+/**
+ * Test if a PPL query is using search command
+ * https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/cmd/search.rst
+ */
+export const isPPLSearchQuery = (query: Query) => {
+  if (query.language !== 'PPL') {
+    return false;
+  }
+
+  if (typeof query.query !== 'string') {
+    return false;
+  }
+
+  const string = query.query.toLowerCase().replace(/\s/g, '');
+
+  return string.startsWith('source=') || string.startsWith('searchsource=');
+};

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -20,6 +20,7 @@ import {
   EnhancedFetchContext,
   fetch,
   formatDate,
+  isPPLSearchQuery,
   QueryAggConfig,
   SEARCH_STRATEGY,
 } from '../../common';
@@ -95,11 +96,8 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     const datasetService = queryString.getDatasetService();
     if (datasetService.getType(dataset.type)?.languageOverrides?.PPL?.hideDatePicker === false)
       return query;
-    if (
-      typeof query.query === 'string' &&
-      !query.query.toLowerCase().replace(/\s/g, '').startsWith('source=')
-    )
-      return query;
+    // Only append time range if query is running search command
+    if (!isPPLSearchQuery(query)) return query;
 
     const [baseQuery, ...afterPipeParts] = query.query.split('|');
     const afterPipe = afterPipeParts.length > 0 ? ` | ${afterPipeParts.join('|').trim()}` : '';

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -95,6 +95,11 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     const datasetService = queryString.getDatasetService();
     if (datasetService.getType(dataset.type)?.languageOverrides?.PPL?.hideDatePicker === false)
       return query;
+    if (
+      typeof query.query === 'string' &&
+      !query.query.toLowerCase().replace(/\s/g, '').startsWith('source=')
+    )
+      return query;
 
     const [baseQuery, ...afterPipeParts] = query.query.split('|');
     const afterPipe = afterPipeParts.length > 0 ? ` | ${afterPipeParts.join('|').trim()}` : '';


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Update PPL query builder to skip appending time range to ppl when not querying with source.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

Resolve a issue that cause PPL query to failed unexpectedly


## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

Before

<img width="1919" alt="Screenshot 2025-03-25 at 1 34 54 PM" src="https://github.com/user-attachments/assets/c274bf2f-1321-4bc8-8f14-fbda43557503" />

After

<img width="1919" alt="Screenshot 2025-03-25 at 1 34 31 PM" src="https://github.com/user-attachments/assets/09166a25-c342-46eb-9c2f-21eda837a6c5" />



## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

-fix: Skip appending time range to ppl when not querying with source

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
