### PR TITLE
[Discover]fix: should clear previous query if input invalid questions

### DIFF
--- a/changelogs/fragments/9605.yml
+++ b/changelogs/fragments/9605.yml
@@ -1,0 +1,2 @@
+fix:
+- Should clear previous query if input invalid questions ([#9605](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9605))

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
@@ -136,6 +136,26 @@ describe('QueryAssistBar', () => {
     });
   });
 
+  it('display callout for AgentError', async () => {
+    const generateQueryMock = jest.fn().mockResolvedValue({
+      error: new AgentError({
+        error: { type: 'mock-type', reason: 'mock-reason', details: 'mock-details' },
+        status: 404,
+      }),
+    });
+    (useGenerateQuery as jest.Mock).mockReturnValue({
+      generateQuery: generateQueryMock,
+      loading: false,
+    });
+    renderQueryAssistBar();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'test query' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('query-assist-guard-callout')).toBeInTheDocument();
+    });
+  });
+
   it('passes agent errors to input', async () => {
     const generateQueryMock = jest.fn().mockResolvedValue({
       error: new AgentError({

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
@@ -156,43 +156,6 @@ describe('QueryAssistBar', () => {
     });
   });
 
-  it('should set query to initial query for AgentError', async () => {
-    queryStringMock.getInitialQuery.mockReturnValueOnce({ query: 'initial', language: 'PPL' });
-    const generateQueryMock = jest.fn().mockResolvedValue({
-      error: new AgentError({
-        error: { type: 'mock-type', reason: 'mock-reason', details: 'mock-details' },
-        status: 404,
-      }),
-    });
-    (useGenerateQuery as jest.Mock).mockReturnValue({
-      generateQuery: generateQueryMock,
-      loading: false,
-    });
-    renderQueryAssistBar();
-
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'false query' } });
-    fireEvent.click(screen.getByRole('button'));
-
-    await waitFor(() => {
-      expect(queryStringMock.getInitialQuery).toBeCalledTimes(1);
-      expect(queryStringMock.setQuery).toHaveBeenCalledWith({
-        dataset: {
-          dataSource: {
-            id: 'mock-data-source-id',
-            title: 'Default Data Source',
-            type: 'OpenSearch',
-          },
-          id: 'default-index-pattern',
-          timeFieldName: '@timestamp',
-          title: 'Default Index Pattern',
-          type: 'INDEX_PATTERN',
-        },
-        language: 'PPL',
-        query: 'initial',
-      });
-    });
-  });
-
   it('passes agent errors to input', async () => {
     const generateQueryMock = jest.fn().mockResolvedValue({
       error: new AgentError({

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.test.tsx
@@ -148,11 +148,48 @@ describe('QueryAssistBar', () => {
       loading: false,
     });
     renderQueryAssistBar();
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'test query' } });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'false query' } });
     fireEvent.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(screen.getByTestId('query-assist-guard-callout')).toBeInTheDocument();
+    });
+  });
+
+  it('should set query to initial query for AgentError', async () => {
+    queryStringMock.getInitialQuery.mockReturnValueOnce({ query: 'initial', language: 'PPL' });
+    const generateQueryMock = jest.fn().mockResolvedValue({
+      error: new AgentError({
+        error: { type: 'mock-type', reason: 'mock-reason', details: 'mock-details' },
+        status: 404,
+      }),
+    });
+    (useGenerateQuery as jest.Mock).mockReturnValue({
+      generateQuery: generateQueryMock,
+      loading: false,
+    });
+    renderQueryAssistBar();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'false query' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(queryStringMock.getInitialQuery).toBeCalledTimes(1);
+      expect(queryStringMock.setQuery).toHaveBeenCalledWith({
+        dataset: {
+          dataSource: {
+            id: 'mock-data-source-id',
+            title: 'Default Data Source',
+            type: 'OpenSearch',
+          },
+          id: 'default-index-pattern',
+          timeFieldName: '@timestamp',
+          title: 'Default Index Pattern',
+          type: 'INDEX_PATTERN',
+        },
+        language: 'PPL',
+        query: 'initial',
+      });
     });
   });
 

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -78,6 +78,7 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
       if (error instanceof ProhibitedQueryError) {
         setCallOutType('invalid_query');
       } else if (error instanceof AgentError) {
+        setCallOutType('invalid_query');
         setAgentError(error);
       } else {
         services.notifications.toasts.addError(error, { title: 'Failed to generate results' });
@@ -85,6 +86,14 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
       updateQueryState({
         question: previousQuestionRef.current,
         generatedQuery: '', // query generate failed, set it to empty
+      });
+
+      // if the return error, then we will replace the previous query with the initial query
+      const initialQuery = services.data.query.queryString.getInitialQuery().query;
+      services.data.query.queryString.setQuery({
+        query: initialQuery,
+        language: params.language,
+        dataset: selectedDataset,
       });
     } else if (response) {
       services.data.query.queryString.setQuery({

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -87,14 +87,6 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
         question: previousQuestionRef.current,
         generatedQuery: '', // query generate failed, set it to empty
       });
-
-      // if the return error, then we will replace the previous query with the initial query
-      const initialQuery = services.data.query.queryString.getInitialQuery().query;
-      services.data.query.queryString.setQuery({
-        query: initialQuery,
-        language: params.language,
-        dataset: selectedDataset,
-      });
     } else if (response) {
       services.data.query.queryString.setQuery({
         query: response.query,


### PR DESCRIPTION
### Description
This pr retains previous query if input invalid questions and adds callout

## Screenshot
https://github.com/user-attachments/assets/58b44355-3bed-45af-acd8-caad863dc906

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: should clear previous query if input invalid questions
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
