### PR TITLE
fixed an issue that the initial result summary generated with the wrong data

### DIFF
--- a/changelogs/fragments/9611.yml
+++ b/changelogs/fragments/9611.yml
@@ -1,0 +1,2 @@
+fix:
+- Initial result summary generated with the wrong data ([#9611](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9611))


### PR DESCRIPTION
### Description
#### Steps to reproduce:
1. Open discover and let the default query(1st) to run
2. After the results returned, use query assistant to generate a new ppl query(2nd)
3. The result summary is **immediately** triggered automatically without waiting for the 2nd query to return
4. The generated summary is incorrect because it uses the results of 1st query

#### Expected:
It should wait for the 2nd query to complete, then trigger the result summary.

This is a quick fix that stop loading discover results to summary component when natural language query is not provided(the initial case). Only when the query is generated with NLQ, the results will be loaded, and the summarization then will be triggered.

For the long term, the result summary component should not rely on the UI state of discover results. There will be a follow up PR to refactor the result summary component.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: initial result summary generated with the wrong data

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
