### PR TITLE
Fix a issue that can cause incorrect query to fire when switch plugin

### DIFF
--- a/changelogs/fragments/9625.yml
+++ b/changelogs/fragments/9625.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix a issue that can cause incorrect query to fire when switch plugin ([#9625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9625))

--- a/src/plugins/data/public/query/query_string/query_string_manager.test.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.test.ts
@@ -123,7 +123,15 @@ describe('QueryStringManager', () => {
   });
 
   test('clearQuery resets to default query', () => {
-    const newQuery = { query: 'test query', language: 'sql' };
+    const newQuery: Query = {
+      query: 'test query',
+      language: 'SQL',
+      dataset: {
+        id: 'test-dataset',
+        title: 'Test Dataset',
+        type: DEFAULT_DATA.SET_TYPES.INDEX,
+      },
+    };
     service.setQuery(newQuery);
     expect(service.getQuery()).toEqual(newQuery);
 
@@ -131,6 +139,7 @@ describe('QueryStringManager', () => {
     const defaultQuery = service.getQuery();
     expect(defaultQuery).not.toEqual(newQuery);
     expect(defaultQuery.query).toBe('');
+    expect(defaultQuery.dataset).toBe(undefined);
   });
 
   test('formatQuery handles different input types', () => {

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -177,9 +177,13 @@ export class QueryStringManager {
    * Updates the query.
    * @param {Query} query
    */
-  public setQuery = (query: Partial<Query>, force: boolean = false) => {
+  public setQuery = (
+    query: Partial<Query>,
+    force: boolean = false,
+    mergeCurrentQuery: boolean = true
+  ) => {
     const curQuery = this.query$.getValue();
-    let newQuery = { ...curQuery, ...query };
+    let newQuery = mergeCurrentQuery ? { ...curQuery, ...query } : (query as Query);
     // If the current query is different from the new query, or the user explicitly set force to true,
     // then proceed with updating the query.
     if (!isEqual(curQuery, newQuery) || force) {
@@ -225,28 +229,9 @@ export class QueryStringManager {
    * Resets the query to the default one.
    */
   public clearQuery = () => {
-    const curQuery = this.query$.getValue();
-    let newQuery = this.getDefaultQuery();
-    // Check if dataset changed and if new dataset has language restrictions
-    if (newQuery.dataset && !isEqual(curQuery.dataset, newQuery.dataset)) {
-      // Get supported languages for the dataset
-      const supportedLanguages = this.datasetService
-        .getType(newQuery.dataset.type)
-        ?.supportedLanguages(newQuery.dataset);
-
-      // If we have supported languages and current language isn't supported
-      if (supportedLanguages && !supportedLanguages.includes(newQuery.language)) {
-        // Get initial query with first supported language and new dataset
-        newQuery = this.getInitialQuery({
-          language: supportedLanguages[0],
-          dataset: newQuery.dataset,
-        });
-      }
-
-      // Add to recent datasets
-      this.datasetService.addRecentDataset(newQuery.dataset);
-    }
-    this.query$.next(newQuery);
+    const force = false;
+    const mergeCurrentQuery = false;
+    this.setQuery(this.getDefaultQuery(), force, mergeCurrentQuery);
   };
 
   // Todo: update this function to use the Query object when it is udpated, Query object should include time range and dataset

--- a/src/plugins/data/public/query/state_sync/connect_to_query_state.ts
+++ b/src/plugins/data/public/query/state_sync/connect_to_query_state.ts
@@ -77,11 +77,13 @@ export const connectStorageToQueryState = (
       filters: filterManager.getAppFilters(),
     };
 
-    // set up initial '_q' flag in the URL to sync query and filter changes
     if (!osdUrlStateStorage.get('_q')) {
+      // set up initial '_q' flag in the URL to sync query and filter changes
       osdUrlStateStorage.set('_q', initialStateFromURL, {
         replace: true,
       });
+      // clear existing query and apply default query
+      queryString.clearQuery();
     }
 
     if (syncConfig.query && !_.isEqual(initialStateFromURL.query, queryString.getQuery())) {

--- a/src/plugins/data/public/ui/dataset_selector/index.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/index.test.tsx
@@ -21,6 +21,7 @@ jest.mock('./dataset_selector', () => ({
 describe('ConnectedDatasetSelector', () => {
   const mockSubscribe = jest.fn();
   const mockUnsubscribe = jest.fn();
+  const mockSetUserQueryLanguage = jest.fn();
   const mockQueryString = {
     getQuery: jest.fn().mockReturnValue({}),
     getDefaultQuery: jest.fn().mockReturnValue({}),
@@ -32,6 +33,10 @@ describe('ConnectedDatasetSelector', () => {
     getUpdates$: jest.fn().mockReturnValue({
       subscribe: mockSubscribe.mockReturnValue({ unsubscribe: mockUnsubscribe }),
     }),
+    getLanguageService: jest.fn().mockReturnValue({
+      setUserQueryLanguage: mockSetUserQueryLanguage,
+    }),
+    getInitialQueryByLanguage: jest.fn(),
   };
   const mockOnSubmit = jest.fn();
   const mockServices = {
@@ -75,6 +80,9 @@ describe('ConnectedDatasetSelector', () => {
 
     expect(mockQueryString.getInitialQuery).toHaveBeenCalledTimes(1);
     expect(mockQueryString.setQuery).toHaveBeenCalledTimes(1);
+    expect(mockQueryString.getLanguageService).toHaveBeenCalledTimes(1);
+    expect(mockQueryString.getInitialQueryByLanguage).toHaveBeenCalledTimes(1);
+    expect(mockSetUserQueryLanguage).toHaveBeenCalledTimes(1);
     expect(mockOnSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/data/public/ui/dataset_selector/index.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/index.tsx
@@ -43,8 +43,11 @@ const ConnectedDatasetSelector = ({
   const onSelect = useCallback(
     (partialQuery: Partial<Query>) => {
       const query = queryString.getInitialQuery(partialQuery);
+      const languageService = queryString.getLanguageService();
       setSelectedDataset(query.dataset);
       queryString.setQuery(query);
+      languageService.setUserQueryLanguage(query.language);
+      queryString.getInitialQueryByLanguage(query.language);
       onSubmit!(query);
     },
     [onSubmit, queryString]

--- a/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_string_input.tsx
@@ -469,7 +469,9 @@ export default class QueryStringInputUI extends Component<Props, State> {
       body: JSON.stringify({ opt_in: language === 'kuery' }),
     });
 
+    // Update local storage
     this.services.storage.set('userQueryLanguage', language);
+    this.services.data.query.queryString.getInitialQueryByLanguage(language);
 
     const newQuery = { query: '', language };
     this.onChange(newQuery);

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -589,6 +589,9 @@ export const useSearch = (services: DiscoverViewServices) => {
 
       filterManager.setAppFilters(actualFilters);
       data.query.queryString.setQuery(query);
+      // Update local storage after loading saved search
+      data.query.queryString.getLanguageService().setUserQueryLanguage(query.language);
+      data.query.queryString.getInitialQueryByLanguage(query.language);
       setSavedSearch(savedSearchInstance);
 
       if (savedSearchInstance?.id) {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Fix a issue that can cause `Discover` fire incorrect query when switch from other plugin. There are a few problems add up to this unexpected user experience:

1. When user navigate to `Discover` using the left side navigation panel, it will always try to do a "fresh start" by loading a empty dataset with the query and language store in local storage. But because `setQuery` always try to merge the next query state into the current query state, if there is a existing dataset, it will never be replace by the empty dataset.
2. Currently, dataset is store in `queryStringManager` as part of the `query` state, and because `queryStringManager` is global, dataset state persist when user navigate to other plugin after visiting Discover.
3. Whenever the selected language changed, we need to update the query and language store in local storage, this update was missing when:

    - Switching language between "DQL" and "Lucene" using the legacy language switcher
    - Loading a saved search
    - Selecting dataset

To addrees these problems, this PR introduces the changes below:

1. Update `clearQuery` to allow empty dataset replace existing dataset
2. Call `clearQuery` if url does not contain `_q` state("fresh start")
3. Add missing local storage updates

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9264

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

Before

https://github.com/user-attachments/assets/ab8a77fa-eb98-48b8-8755-a80e8620a4ab

After

https://github.com/user-attachments/assets/9d973688-52c5-448f-97be-07a6e57590d7


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: fix a issue that can cause incorrect query to fire when switch plugin

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
