### PR TITLE
feat: support streaming when content type is event stream

### DIFF
--- a/changelogs/fragments/9647.yml
+++ b/changelogs/fragments/9647.yml
@@ -1,0 +1,2 @@
+feat:
+- Support streaming when content type is event stream ([#9647](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9647))

--- a/src/core/public/http/fetch.test.ts
+++ b/src/core/public/http/fetch.test.ts
@@ -481,6 +481,21 @@ describe('Fetch', () => {
 
       expect(ndjson).toEqual(content);
     });
+
+    it('should make requests for text/event-stream content', async () => {
+      const body = 'data: ';
+      fetchMock.post('*', () => ({
+        body,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }));
+
+      const data = await fetchInstance.post('/my/path', {
+        body,
+        asResponse: true,
+      });
+
+      expect(await data.response?.text()).toEqual(body);
+    });
   });
 
   describe('interception', () => {

--- a/src/core/public/http/fetch.test.ts
+++ b/src/core/public/http/fetch.test.ts
@@ -495,6 +495,22 @@ describe('Fetch', () => {
       });
 
       expect(await data.response?.text()).toEqual(body);
+      expect(data.body === data.response?.body).toEqual(true);
+    });
+
+    it('should return pure body for text/event-stream;charset=UTF-8 content', async () => {
+      const body = 'data: ';
+      fetchMock.post('*', () => ({
+        body,
+        headers: { 'Content-Type': 'text/event-stream;charset=UTF-8' },
+      }));
+
+      const data = await fetchInstance.post('/my/path', {
+        body,
+        asResponse: true,
+      });
+
+      expect(data.body === data.response?.body).toEqual(true);
     });
   });
 

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -53,7 +53,7 @@ interface Params {
 
 const JSON_CONTENT = /^(application\/(json|x-javascript)|text\/(x-)?javascript|x-json)(;.*)?$/;
 const NDJSON_CONTENT = /^(application\/ndjson)(;.*)?$/;
-const EVENT_STREAM_CONTENT = /text\/event-stream/;
+const EVENT_STREAM_CONTENT = /^(text\/event-stream)(;.*)?$/;
 
 const removedUndefined = (obj: Record<string, any> | undefined) => {
   return omitBy(obj, (v) => v === undefined);

--- a/src/core/public/http/fetch.ts
+++ b/src/core/public/http/fetch.ts
@@ -53,6 +53,7 @@ interface Params {
 
 const JSON_CONTENT = /^(application\/(json|x-javascript)|text\/(x-)?javascript|x-json)(;.*)?$/;
 const NDJSON_CONTENT = /^(application\/ndjson)(;.*)?$/;
+const EVENT_STREAM_CONTENT = /text\/event-stream/;
 
 const removedUndefined = (obj: Record<string, any> | undefined) => {
   return omitBy(obj, (v) => v === undefined);
@@ -195,6 +196,11 @@ export class Fetch {
         body = fetchOptions.withLongNumeralsSupport
           ? parse(await response.text())
           : await response.json();
+      } else if (EVENT_STREAM_CONTENT.test(contentType)) {
+        // Browsers often need to buffer the entire response before decompressing, which defeats the purpose of streaming.
+        // So for plugins who want to use streaming experience,
+        // please remember to set 'Content-Encoding' as 'identity' or ''
+        body = response.body;
       } else {
         const text = await response.text();
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR supports returning pure fetch response when content-type in response header is `text/event-stream`. And I searched for the whole project that no API is using `text/event-stream` as its response content type. https://github.com/search?q=org%3Aopensearch-project%20text%2Fevent-stream&type=code

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
closes #9604 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
https://github.com/opensearch-project/dashboards-assistant/pull/493

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->
Unit test has been added, and you can find the consumer in: https://github.com/opensearch-project/dashboards-assistant/pull/493

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: support streaming when content type is event stream

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
