### PR TITLE
remove numTestsKeptInMemory duplicate in cypress config

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -17,7 +17,6 @@ module.exports = defineConfig({
     runMode: 2,
     openMode: 0,
   },
-  numTestsKeptInMemory: 5,
   viewportWidth: 1920,
   viewportHeight: 1080,
   env: {


### PR DESCRIPTION
### Description

`numOfTestsKepInMemory` was set to 0 in this change #9497 . Now we had a duplicate of this. So removing the duplicate


## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
