### PR TITLE
Discover Grid filter fix

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/changelogs/fragments/9659.yml
+++ b/changelogs/fragments/9659.yml
@@ -1,2 +1,3 @@
 fix:
 - Discover table not updating with row size when filtering out ([#9659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9659))
+- Update actions/cache from v1 to v4 to address deprecation warning ([#9659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9659))

--- a/changelogs/fragments/9659.yml
+++ b/changelogs/fragments/9659.yml
@@ -1,0 +1,2 @@
+fix:
+- Discover table not updating with row size when filtering out ([#9659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9659))

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -379,6 +379,3 @@
 
 # Set the value to true to enable the new UI for savedQueries in Discover
 # data.savedQueriesNewUI.enabled: true
-opensearch.ignoreVersionMismatch: true
-data_source.enabled: true
-data.savedQueriesNewUI.enabled: true

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -372,10 +372,13 @@
 
 # Set the backend roles in groups or users, whoever has the backend roles or exactly match the user ids defined in this config will be regard as dashboard admin.
 # Dashboard admin will have the access to all the workspaces(workspace.enabled: true) and objects inside OpenSearch Dashboards.
-# The default config is [], and no one will be dashboard admin. 
+# The default config is [], and no one will be dashboard admin.
 # If the user config is set to wildcard ["*"], anyone will be dashboard admin.
 # opensearchDashboards.dashboardAdmin.groups: ["dashboard_admin"]
 # opensearchDashboards.dashboardAdmin.users: ["dashboard_admin"]
 
 # Set the value to true to enable the new UI for savedQueries in Discover
 # data.savedQueriesNewUI.enabled: true
+opensearch.ignoreVersionMismatch: true
+data_source.enabled: true
+data.savedQueriesNewUI.enabled: true

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -372,7 +372,7 @@
 
 # Set the backend roles in groups or users, whoever has the backend roles or exactly match the user ids defined in this config will be regard as dashboard admin.
 # Dashboard admin will have the access to all the workspaces(workspace.enabled: true) and objects inside OpenSearch Dashboards.
-# The default config is [], and no one will be dashboard admin.
+# The default config is [], and no one will be dashboard admin. 
 # If the user config is set to wildcard ["*"], anyone will be dashboard admin.
 # opensearchDashboards.dashboardAdmin.groups: ["dashboard_admin"]
 # opensearchDashboards.dashboardAdmin.users: ["dashboard_admin"]

--- a/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
+++ b/src/plugins/discover/public/application/components/data_grid/data_grid_table.tsx
@@ -4,7 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { EuiPanel } from '@elastic/eui';
 import { QUERY_ENHANCEMENT_ENABLED_SETTING } from '../../../../common';
 import { IndexPattern, getServices } from '../../../opensearch_dashboards_services';
@@ -74,6 +74,8 @@ export const DataGridTable = ({
   const newDiscoverEnabled = getNewDiscoverSetting(services.storage);
   const isQueryEnhancementEnabled = services.uiSettings.get(QUERY_ENHANCEMENT_ENABLED_SETTING);
 
+  const tableKey = useMemo(() => `${columns.join(',')}-${rows.length}`, [columns, rows.length]);
+
   const panelContent =
     isQueryEnhancementEnabled || !newDiscoverEnabled ? (
       <DefaultDiscoverTable
@@ -93,6 +95,7 @@ export const DataGridTable = ({
       />
     ) : (
       <DataGrid
+        key={tableKey}
         columns={columns}
         indexPattern={indexPattern}
         sort={sort}


### PR DESCRIPTION
### Description

1. In the Discover Page, sometimes if we filter the contents such that only one item is present, if we then add a field, when we then remove/disable the filter, the table doesn't resize to accommodate the original contents, i.e., it we can only see one row at a time or so.
2.  Addresses the deprecation warning in cypress:
"Error: This request has been automatically failed because it uses a deprecated version of actions/cache: v1"

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9401

## Screenshot
(https://drive.google.com/file/d/1zw3iitCa9jL0kmx_UOHk5WZvS-xjkRjC/view?usp=sharing)

## Changelog

- fix: Discover table not updating with row size when filtering out
- fix: Update actions/cache from v1 to v4 to address deprecation warning

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
