### PR TITLE
Fix issue connecting to data source with SigV4 auth after upgrading aws sdk from v2 to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Replace `@elastic/filesaver` in favor of `file-saver`. ([#9484](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9484))
  - Replace `formatNumWithCommas` with `toLocaleString` ([#9488](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9488))
  - Upgrade @aws-crypto/client-node to ^4.2.0 and aws-sdk from v2 to v3 ([#9641](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9641))
+ - Use AbortController from aws-sdk v3 to abort request ([#9663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9663))
 
 ### 🪛 Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Replace `@elastic/filesaver` in favor of `file-saver`. ([#9484](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9484))
  - Replace `formatNumWithCommas` with `toLocaleString` ([#9488](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9488))
  - Upgrade @aws-crypto/client-node to ^4.2.0 and aws-sdk from v2 to v3 ([#9641](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9641))
- - Use AbortController from aws-sdk v3 to abort request ([#9663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9663))
 
 ### 🪛 Refactoring
 

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
   "dependencies": {
     "@aws-crypto/client-node": "^4.2.0",
     "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-sdk/abort-controller": "^3.374.0",
     "@aws-sdk/client-sts": "^3.777.0",
     "@aws-sdk/credential-provider-node": "^3.777.0",
     "@aws-sdk/node-http-handler": "^3.374.0",

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.ts
@@ -240,6 +240,9 @@ const getAWSClient = (credential: SigV4Content, clientOptions: ConfigOptions): L
   const { region } = credential;
   const client = new LegacyClient({
     connectionClass: HttpAmazonESConnector,
+    awsConfig: {
+      region,
+    },
     ...clientOptions,
   });
   return client;

--- a/src/plugins/data_source/server/legacy/http_aws_es/connector.js
+++ b/src/plugins/data_source/server/legacy/http_aws_es/connector.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Credentials } from '@aws-sdk/client-sts';
 import { SignatureV4 } from '@aws-sdk/signature-v4';
 import { HttpRequest } from '@aws-sdk/protocol-http';
 import { Sha256 } from '@aws-crypto/sha256-js';
@@ -88,11 +87,11 @@ class HttpAmazonESConnector extends HttpConnector {
       this.service = awssigv4Cred.service;
       delete reqParams.headers.auth;
 
-      return new Credentials({
+      return {
         accessKeyId,
         secretAccessKey,
         sessionToken,
-      });
+      };
     }
 
     // Use default credential provider chain

--- a/src/plugins/data_source/server/legacy/http_aws_es/connector.test.js
+++ b/src/plugins/data_source/server/legacy/http_aws_es/connector.test.js
@@ -48,33 +48,6 @@ describe('request', function () {
     this.signRequest = sinon.stub(connector, 'signRequest');
   });
 
-  it('returns a cancel function that aborts the request', function (done) {
-    const fakeReq = new EventEmitter();
-
-    fakeReq.setNoDelay = sinon.stub();
-    fakeReq.setSocketKeepAlive = sinon.stub();
-    fakeReq.abort = sinon.stub();
-
-    sinon.stub(connector, 'createRequest').returns(fakeReq);
-
-    const cancel = connector.request({}, () => {});
-
-    // since getCredentials is async, we have to let the event loop tick
-    setTimeout(() => {
-      try {
-        expect(cancel).to.be.a('function');
-
-        cancel();
-
-        expect(fakeReq.abort.called).to.be.true;
-
-        done();
-      } catch (e) {
-        done(e);
-      }
-    });
-  });
-
   it('calls callback with error', function (done) {
     const error = new Error();
     const fakeReq = new EventEmitter();

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,6 +237,14 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
+"@aws-sdk/abort-controller@^3.374.0":
+  version "3.374.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.374.0.tgz#f57ec7e02cdd7f66432e4e71af9e0ac224d6e9b3"
+  integrity sha512-pO1pqFBdIF28ZvnJmg58Erj35RLzXsTrjvHghdc/xgtSvodFFCNrUsPg6AP3On8eiw9elpHoS4P8jMx1pHDXEw==
+  dependencies:
+    "@smithy/abort-controller" "^1.0.1"
+    tslib "^2.5.0"
+
 "@aws-sdk/client-dynamodb@^3.616.0", "@aws-sdk/client-dynamodb@^3.621.0":
   version "3.777.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.777.0.tgz#ed6b70e5500ad24218123d6de39ec2bb5cd76cb1"
@@ -3961,7 +3969,7 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@smithy/abort-controller@^1.1.0":
+"@smithy/abort-controller@^1.0.1", "@smithy/abort-controller@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-1.1.0.tgz#2da0d73c504b93ca8bb83bdc8d6b8208d73f418b"
   integrity sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==


### PR DESCRIPTION
### Description

This PR fixes an error when configuring a data source with SigV4 auth that was a regression from upgrading the aws sdk from v2 to v3 in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9641. While https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9641 fixed an issue when configuring a data source with basic auth credentials after upgrading OSD Core from node18 -> node20, it broke sigv4 auth.

This PR contains the following changes.

1. Use AbortController from aws-sdk v3 to abort request
2. Remove `import { Credentials } from '@aws-sdk/client-sts';` and pass creds directly

This error was discovered on future playground with the following message:

`TypeError: request.abort is not a function`

### Testing

I verified that SigV4 auth works by connecting to an AOS domain from my localhost when configuring a datasource.

## Changelog
- fix: Fix issue connecting to data source with SigV4 auth after upgrading aws sdk from v2 to v3

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
