### PR TITLE
[Chore] Bump caniuse-lite to fix CI Group 1

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -312,6 +312,7 @@ jobs:
           path: |
             test/*/failure_debug/
             test/*/screenshots/
+          overwrite: true
 
   plugin-functional-tests:
     name: Run plugin functional tests on ${{ matrix.name }}
@@ -423,6 +424,7 @@ jobs:
           path: |
             test/*/failure_debug/
             test/*/screenshots/
+          overwrite: true
 
   build-min-artifact-tests:
     name: Build min release artifacts on ${{ matrix.name }}
@@ -535,6 +537,7 @@ jobs:
           name: ${{ matrix.suffix }}-${{ env.VERSION }}
           path: ./artifacts/target/${{ env.ARTIFACT_BUILD_NAME }}
           retention-days: 1
+          overwrite: true
 
   bwc-tests:
     needs: [build-min-artifact-tests]
@@ -615,3 +618,4 @@ jobs:
             ./artifacts/bwc_tmp/test/cypress/screenshots/*
             ./artifacts/bwc_tmp/test/cypress/results/*
           retention-days: 1
+          overwrite: true

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -92,7 +92,7 @@ jobs:
           # Dashboard tests with query enhanced - group 3
           - group: 13
             config: query_enhanced
-            test_location: source  
+            test_location: source
           # Dashboard tests with query enhanced - group 4
           - group: 14
             config: query_enhanced
@@ -100,7 +100,7 @@ jobs:
           # Dashboard tests with query enhanced - group 5
           - group: 15
             config: query_enhanced
-            test_location: source    
+            test_location: source
     container:
       image: docker://opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
       options: --user 1001
@@ -281,14 +281,16 @@ jobs:
           name: ftr-cypress-screenshots-${{ matrix.group }}
           path: ${{ env.FTR_PATH }}/cypress/screenshots
           retention-days: 1
+          overwrite: true
 
       - name: Upload FT repo videos
         uses: actions/upload-artifact@v4
-        if: always() && matrix.test_location == 'ftr'
+        if: failure() && matrix.test_location == 'ftr'
         with:
           name: ftr-cypress-videos-${{ matrix.group }}
           path: ${{ env.FTR_PATH }}/cypress/videos
           retention-days: 1
+          overwrite: true
 
       - name: Upload FT repo results
         uses: actions/upload-artifact@v4
@@ -297,6 +299,7 @@ jobs:
           name: ftr-cypress-results-${{ matrix.group }}
           path: ${{ env.FTR_PATH }}/cypress/results
           retention-days: 1
+          overwrite: true
 
       - name: Upload Dashboards screenshots
         if: failure() && matrix.test_location == 'source'
@@ -305,14 +308,16 @@ jobs:
           name: dashboards-cypress-screenshots
           path: cypress/screenshots
           retention-days: 1
+          overwrite: true
 
       - name: Upload Dashboards repo videos
         uses: actions/upload-artifact@v4
-        if: always() && matrix.test_location == 'source'
+        if: failure() && matrix.test_location == 'source'
         with:
           name: dashboards-cypress-videos
           path: cypress/videos
           retention-days: 1
+          overwrite: true
 
       - name: Upload Dashboards repo results
         uses: actions/upload-artifact@v4
@@ -321,6 +326,7 @@ jobs:
           name: dashboards-cypress-results
           path: cypress/results
           retention-days: 1
+          overwrite: true
 
   add-comment:
     needs: [cypress-tests]

--- a/.github/workflows/cypress_workflow_with_s3.yml
+++ b/.github/workflows/cypress_workflow_with_s3.yml
@@ -130,14 +130,16 @@ jobs:
           name: dashboards-cypress-screenshots-10
           path: cypress/screenshots
           retention-days: 1
+          overwrite: true
 
       - name: Upload Dashboards repo videos
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: dashboards-cypress-videos-10
           path: cypress/videos
           retention-days: 1
+          overwrite: true
 
       - name: Upload Dashboards repo results
         uses: actions/upload-artifact@v4
@@ -146,3 +148,4 @@ jobs:
           name: dashboards-cypress-results-10
           path: cypress/results
           retention-days: 1
+          overwrite: true

--- a/changelogs/fragments/9672.yml
+++ b/changelogs/fragments/9672.yml
@@ -1,0 +1,2 @@
+chore:
+- Bump caniuse-lite to fix CI group 1 ([#9672](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9672))

--- a/yarn.lock
+++ b/yarn.lock
@@ -5670,9 +5670,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001640:
-  version "1.0.30001659"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001659.tgz"
-  integrity sha512-Qxxyfv3RdHAfJcXelgf0hU4DFUVXBGTjqrBUZLUh8AtlGnsDo+CnncYtTd95+ZKfnANUOzxyIQCuU/UeBZBYoA==
+  version "1.0.30001713"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz#6b33a8857e6c7dcb41a0caa2dd0f0489c823a52d"
+  integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

CI group 1 is failing on `2.x` due to `cainuse-lite` being outdated. This was bumped in `main` in the Node 20 upgrade, but won't be backported. This PR manually bumps `caniuse-lite` to resolve the failure in `packages/osd-plugin-helpers/src/integration_tests/build.test.ts`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- chore: Bump caniuse-lite to fix CI group 1

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
