### PR TITLE
Fix issue with adding sample data to data source

### DIFF
--- a/changelogs/fragments/9676.yml
+++ b/changelogs/fragments/9676.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix issue with adding sample data to data source ([#9676](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9676))

--- a/src/plugins/data_source/server/legacy/http_aws_es/connector.js
+++ b/src/plugins/data_source/server/legacy/http_aws_es/connector.js
@@ -104,7 +104,7 @@ class HttpAmazonESConnector extends HttpConnector {
     const body = params.body;
     if (body) {
       const contentLength = Buffer.isBuffer(body) ? body.length : Buffer.byteLength(body);
-      request.headers['Content-Length'] = contentLength;
+      request.headers['Content-Length'] = contentLength.toString();
       request.body = body;
     }
 

--- a/src/plugins/data_source/server/legacy/http_aws_es/connector.test.js
+++ b/src/plugins/data_source/server/legacy/http_aws_es/connector.test.js
@@ -95,4 +95,66 @@ describe('createRequest', () => {
 
     expect(request.path).to.equal(reqParams.path);
   });
+
+  it('should set Content-Length as a string for a string body', () => {
+    const host = new Host();
+    const connector = new Connector(host, {
+      awsConfig: {
+        region: 'us-east-1',
+        credentials: defaultProvider(),
+      },
+    });
+
+    const bodyString = '{"name": "test"}';
+
+    // Pass the body in the first parameter (params) so that createRequest picks it up.
+    const params = {
+      method: 'POST',
+      body: bodyString,
+    };
+    const reqParams = {
+      method: 'POST',
+      path: '/test',
+      headers: {},
+    };
+
+    const request = connector.createRequest(params, reqParams);
+
+    // Calculate the expected content length and convert it to string.
+    const expectedLength = Buffer.byteLength(bodyString).toString();
+    expect(request.headers).to.have.property('Content-Length');
+    expect(request.headers['Content-Length']).to.be.a('string');
+    expect(request.headers['Content-Length']).to.equal(expectedLength);
+  });
+
+  it('should set Content-Length as a string for a Buffer body', () => {
+    const host = new Host();
+    const connector = new Connector(host, {
+      awsConfig: {
+        region: 'us-east-1',
+        credentials: defaultProvider(),
+      },
+    });
+
+    const bodyBuffer = Buffer.from('This is a test');
+
+    // Again, place the body in the first parameter.
+    const params = {
+      method: 'POST',
+      body: bodyBuffer,
+    };
+    const reqParams = {
+      method: 'POST',
+      path: '/test',
+      headers: {},
+    };
+
+    const request = connector.createRequest(params, reqParams);
+
+    // Calculate the expected content length for the Buffer and convert to string.
+    const expectedLength = bodyBuffer.length.toString();
+    expect(request.headers).to.have.property('Content-Length');
+    expect(request.headers['Content-Length']).to.be.a('string');
+    expect(request.headers['Content-Length']).to.equal(expectedLength);
+  });
 });


### PR DESCRIPTION
### Description

Summary
This PR fixes the error:


```
Elasticsearch ERROR: 2025-04-11T21:10:24Z
  Error: Request error, retrying
  PUT https://search-aos-215-xxxq6sjh2os6mbvxnizn5mr5yy.us-west-2.es.amazonaws.com/opensearch_dashboards_sample_data_ecommerce => headers[headerName].trim is not a function
```


Root Cause
The error occurred because the Content-Length header was set as a numeric value instead of a string. When the HTTP library calls .trim() on header values, it fails if the value isn’t a string.

```
TypeError: headers[headerName].trim is not a function
    at getCanonicalHeaders (/Volumes/workplace/NeoDevStack-szhongna/src/OpenSearch-Dashboards/node_modules/@smithy/signature-v4/dist-cjs/getCanonicalHeaders.js:20:62)
    at SignatureV4.signRequest (/Volumes/workplace/NeoDevStack-szhongna/src/OpenSearch-Dashboards/node_modules/@smithy/signature-v4/dist-cjs/SignatureV4.js:120:80)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at HttpAmazonESConnector.request (/Volumes/workplace/NeoDevStack-szhongna/src/OpenSearch-Dashboards/src/plugins/data_source/server/legacy/http_aws_es/connector.js:49:17)
```

Solution
This change converts the numeric value to a string:

```
request.headers['Content-Length'] = (Buffer.isBuffer(body) ? body.length : Buffer.byteLength(body)).toString();
```
Testing
Added new unit tests to ensure that the Content-Length header is:

Set as a string for both string and Buffer bodies.

Correctly computed based on the actual content length.



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Fix issue with adding sample data to data source

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
