### PR TITLE
Update default index pattern logic

### DIFF
--- a/changelogs/fragments/9692.yml
+++ b/changelogs/fragments/9692.yml
@@ -1,0 +1,2 @@
+fix:
+- Update default index pattern logic ([#9692](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9692))

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -71,7 +71,7 @@ export const createEnsureDefaultIndexPattern = (
               });
             }
           } catch (e) {
-            // console.error(e);
+            console.error(e);
           }
         } else {
           return;
@@ -82,7 +82,6 @@ export const createEnsureDefaultIndexPattern = (
     }
 
     if (patterns.length >= 1) {
-      // await this.setDefault(patterns[0]);
       await uiSettings.set('defaultIndex', patterns[0]);
     } else {
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -71,7 +71,7 @@ export const createEnsureDefaultIndexPattern = (
               });
             }
           } catch (e) {
-            console.error(e);
+            //  if it fails, jump directly to the execution of Redirect
           }
         } else {
           return;

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -44,6 +44,19 @@ export const createEnsureDefaultIndexPattern = (
    * one otherwise.
    */
   return async function ensureDefaultIndexPattern(this: IndexPatternsContract) {
+    const datasources = await savedObjectsClient.find({ type: 'data-source' });
+    const indexPatterns = await savedObjectsClient.find({ type: 'index-pattern' });
+    const existDataSources = datasources.map((item) => item.id);
+    const availablePatterns: string[] = [];
+
+    indexPatterns.forEach((item) => {
+      const refId = item.references[0]?.id;
+      const refIdBool = !!refId;
+      if (!refIdBool || existDataSources.includes(refId)) {
+        availablePatterns.push(item.id);
+      }
+    });
+
     if (canUpdateUiSetting === false) {
       return;
     }

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -107,10 +107,10 @@ export class IndexPatternsService {
     this.onError = onError;
     this.onUnsupportedTimePattern = onUnsupportedTimePattern;
     this.ensureDefaultIndexPattern = createEnsureDefaultIndexPattern(
-      savedObjectsClient,
       uiSettings,
       onRedirectNoIndexPattern,
-      canUpdateUiSetting
+      canUpdateUiSetting,
+      savedObjectsClient
     );
   }
 

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -107,6 +107,7 @@ export class IndexPatternsService {
     this.onError = onError;
     this.onUnsupportedTimePattern = onUnsupportedTimePattern;
     this.ensureDefaultIndexPattern = createEnsureDefaultIndexPattern(
+      savedObjectsClient,
       uiSettings,
       onRedirectNoIndexPattern,
       canUpdateUiSetting


### PR DESCRIPTION
### Description

Currently, when a default index pattern is associated with a deleted data source, the system continues to use it as the default pattern. This PR enhances the existing logic that handles non-existent default index patterns to also check for non-existing data sources.

### Issues Resolved

fixes: Remove default index pattern when associated data source is deleted.

## Changelog

- fix: Update default index pattern logic
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
