### PR TITLE
[Fix] filter out Opensearch Data sources in Associate Direct Query Sources Modal

### DIFF
--- a/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
+++ b/src/plugins/workspace/public/components/data_source_association/association_data_source_modal.tsx
@@ -203,28 +203,14 @@ const convertConnectionsToOptions = ({
         return [];
       }
 
-      if (showDirectQueryConnections) {
-        // For direct Query connections filtering out the opensearch connections
-        if (!connection.relatedConnections || connection.relatedConnections.length === 0) {
-          return [];
-        }
-        // Show the relatedConnections
-        return [
-          connection,
-          ...(selectedConnectionIds.includes(connection.id) ? connection.relatedConnections : []),
-        ];
-      } else {
-        // Display OpenSearch connections
-        if (!connection.relatedConnections || connection.relatedConnections.length === 0) {
-          return [connection];
-        }
-
-        // Show the relatedConnections
-        return [
-          connection,
-          ...(selectedConnectionIds.includes(connection.id) ? connection.relatedConnections : []),
-        ];
+      if (!connection.relatedConnections || connection.relatedConnections.length === 0) {
+        return showDirectQueryConnections ? [] : [connection];
       }
+
+      return [
+        connection,
+        ...(selectedConnectionIds.includes(connection.id) ? connection.relatedConnections : []),
+      ];
     })
     .map((connection) =>
       convertConnectionToOption({ connection, selectedConnectionIds, logos, mode })


### PR DESCRIPTION
### Description

OpenSearch connections were being shown when user clicked on the Associate  Direct query data sources button. This behaviour was contrary to the expectation of modal only showcasing the DQS and DQC objects. The PR is to fix this behaviour. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9706

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

Before fix 

https://github.com/user-attachments/assets/b140b43d-69d1-416b-8f2f-171ea59182db

After fix

https://github.com/user-attachments/assets/3f9f0c4f-4466-495b-9897-2427a1272b24



## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
 - fix: filter out Opensearch Data sources in Associate Direct Query Sources Modal

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
