### PR TITLE
Fix SigV4 signing mismatch issue with `?v` query parameter

### DIFF
--- a/changelogs/fragments/9730.yml
+++ b/changelogs/fragments/9730.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix SigV4 signing mismatch issue with ?v query parameter ([#9730](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9730))

--- a/src/plugins/data_source/server/legacy/http_aws_es/connector.js
+++ b/src/plugins/data_source/server/legacy/http_aws_es/connector.js
@@ -9,7 +9,7 @@ import { Sha256 } from '@aws-crypto/sha256-js';
 import { AbortController } from '@aws-sdk/abort-controller';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { NodeHttpHandler } from '@aws-sdk/node-http-handler';
-import queryString from 'query-string';
+
 const HttpConnector = require('elasticsearch/src/lib/connectors/http');
 
 class HttpAmazonESConnector extends HttpConnector {
@@ -94,7 +94,12 @@ class HttpAmazonESConnector extends HttpConnector {
   createRequest(params, reqParams) {
     const [pathname = '/', queryStr = ''] = (reqParams.path || '').split('?', 2);
 
-    const queryParams = queryStr ? queryString.parse(queryStr) : undefined;
+    const queryParams = {};
+    if (queryStr) {
+      for (const [key, value] of new URLSearchParams(queryStr)) {
+        queryParams[key] = value ?? '';
+      }
+    }
 
     const request = new HttpRequest({
       ...this.endpoint,

--- a/src/plugins/data_source/server/legacy/http_aws_es/connector.test.js
+++ b/src/plugins/data_source/server/legacy/http_aws_es/connector.test.js
@@ -233,4 +233,58 @@ describe('createRequest', () => {
     expect(request.path).to.equal('/test');
     expect(request.query).to.be.empty;
   });
+
+  it('should treat query parameter without value as empty string', () => {
+    const host = new Host();
+    const connector = new Connector(host, {
+      awsConfig: {
+        region: 'us-east-1',
+        credentials: defaultProvider(),
+      },
+    });
+
+    const params = { method: 'GET' };
+    const reqParams = { method: 'GET', path: '/test?v', headers: {} };
+
+    const request = connector.createRequest(params, reqParams);
+
+    expect(request.path).to.equal('/test');
+    expect(request.query).to.have.property('v', '');
+  });
+
+  it('should treat query parameter with explicit empty value as empty string', () => {
+    const host = new Host();
+    const connector = new Connector(host, {
+      awsConfig: {
+        region: 'us-east-1',
+        credentials: defaultProvider(),
+      },
+    });
+
+    const params = { method: 'GET' };
+    const reqParams = { method: 'GET', path: '/test?v=', headers: {} };
+
+    const request = connector.createRequest(params, reqParams);
+
+    expect(request.path).to.equal('/test');
+    expect(request.query).to.have.property('v', '');
+  });
+
+  it('should correctly parse standard key-value query parameters', () => {
+    const host = new Host();
+    const connector = new Connector(host, {
+      awsConfig: {
+        region: 'us-east-1',
+        credentials: defaultProvider(),
+      },
+    });
+
+    const params = { method: 'GET' };
+    const reqParams = { method: 'GET', path: '/test?foo=bar&baz=qux', headers: {} };
+
+    const request = connector.createRequest(params, reqParams);
+
+    expect(request.path).to.equal('/test');
+    expect(request.query).to.deep.equal({ foo: 'bar', baz: 'qux' });
+  });
 });


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Fix SigV4 signing mismatch issue with `?v` query parameter

When you call APIs like `/_cat/indices/_hot?v`, without `=`, Node.js `querystring.parse()` sets `v: null`, not `v: ''`

But AWS expects it to be `v=`, that is, an empty string value, not null.

In this PR, we ensure when parsing query string, empty values are properly preserved. Instead of using Node `querystring.parse()`, use `URLSearchParams` which behaves properly

## Issue
```
message": "Error from esClient call: {\"statusCode\":403,\"body\":{\"message\":\"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.\\n\\nThe Canonical String for this request should have been\\n'GET\\n/_cat/indices/_hot\\nv=\\nhost:search-dashboard-test-yw65ghylhbqrxo2feuimftagxe.us-west-2.es.amazonaws.com\\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\\nx-amz-date:20250425T161408Z\\nx-amz-security-token:FwoGZXIvYXdzEKr//////////wEaDBQ2trk+RC4gXEJT6yKdA3AhypiYnUb2thlV7nECa30J94Zyt1+A+eyWgrBzXf8V8IR5+UO1tKSF/Ggtpmcz4b/Gg8I9sxTfRPkBt5j7jM2SS6YegnOkiXF4HeDKBZtqZdVQaIkLP8l+lOxF6ZcskdflZb4bEPIjubVQp4/Iyuga+tM+KYPHMU0PaA7m9SaJ7ZaSBH+VXl77/DZgDAJ/oohi90EwH/nGH61ZWx4qoczLROYoSGDi3CC2sUyGjxOsWJaAhOt4EuIwDgXvyOf4LCNw8BZSw0jB6Uq9+KNbjV5x0s8xeQLvkauQ5x6DCPsIvPw9lLxmGNsJedUGHPEe4+swFbSWnj60IwOjzeW+H5n9xdm9jC4bSLr7F+SiezSzFn7nJAdssHmGzrawll/WO7R0SlEuFQoxfkGTLNZrB0dCcAkGVDA0EA4YW8cjpivGvrVfEJ9MOJAhlc8DDyvriV/ryvbSKjckas+x49GVAXBAmjcJe7NT7S0jPfTn1L+aLZjbY7T4v7L/pnC5BQJh8RaY7AAyFhM5EgFSNK8+XRR1eAVJd5sAjSKoQt5wKMHprsAGMpcBlzTGqczoIwHEQkOdqvQhCKnkaHFptmKxWev6LcuapwkJRy9mpeaqM8rbjSBwVrw6MqUOqg8QBQs6efBimx5YZmhNYa+oNiJjRINs03OZkafL2RTVKfF7ZH1oSIxYQKv5MMow0A+9McjLGnsx0fSqIkmoFVQWHhCmjP2dZqUZ8jx8Ce8qng6Kd1U1qsTIgtJwd4FK9nU1TQ==|MjA1LjI1MS4yMzMuMTc4\\n\\nhost;x-amz-content-sha256;x-amz-date;x-amz-security-token\\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'\\n\\nThe String-to-Sign should have been\\n'AWS4-HMAC-SHA256\\n20250425T161408Z\\n20250425/us-west-2/es/aws4_request\\n7c3a1a4880214fe677663922c125b0e18038470299ef3868bf2a5a74c702ca13'\\n\"}}"
```

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/125441b7-a65c-423a-b815-762197abe4c8)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Fix SigV4 signing mismatch issue with ?v query parameter

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
