### PR TITLE
Fix collaborators displays under custom tab on left navigation when saved object permission is disabled

### DIFF
--- a/changelogs/fragments/9734.yml
+++ b/changelogs/fragments/9734.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix collaborators displays under custom tab on navigation when saved object permission is disabled ([#9734](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9734))

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -593,7 +593,6 @@ describe('Workspace plugin', () => {
 
     expect(result).toStrictEqual({
       status: AppStatus.accessible,
-      chromeless: false,
       navLinkStatus: AppNavLinkStatus.visible,
     });
   });
@@ -635,7 +634,6 @@ describe('Workspace plugin', () => {
 
     expect(result).toStrictEqual({
       status: AppStatus.inaccessible,
-      chromeless: true,
       navLinkStatus: AppNavLinkStatus.hidden,
     });
   });

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -570,6 +570,7 @@ export class WorkspacePlugin
     this.collaboratorsAppUpdater$.next(() => {
       return {
         status: isPermissionEnabled ? AppStatus.accessible : AppStatus.inaccessible,
+        chromeless: !isPermissionEnabled,
         navLinkStatus: core.chrome.navGroup.getNavGroupEnabled()
           ? AppNavLinkStatus.visible
           : AppNavLinkStatus.hidden,

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -570,10 +570,10 @@ export class WorkspacePlugin
     this.collaboratorsAppUpdater$.next(() => {
       return {
         status: isPermissionEnabled ? AppStatus.accessible : AppStatus.inaccessible,
-        chromeless: !isPermissionEnabled,
-        navLinkStatus: core.chrome.navGroup.getNavGroupEnabled()
-          ? AppNavLinkStatus.visible
-          : AppNavLinkStatus.hidden,
+        navLinkStatus:
+          core.chrome.navGroup.getNavGroupEnabled() && isPermissionEnabled
+            ? AppNavLinkStatus.visible
+            : AppNavLinkStatus.hidden,
       };
     });
 


### PR DESCRIPTION
### Description

Before:
```
savedObjects.permission.enabled: false
```
<img width="1715" alt="Screenshot 2025-04-28 at 10 26 38" src="https://github.com/user-attachments/assets/4d925773-9802-40a5-a31a-17902ae4b8a0" />

After:
<img width="1716" alt="Screenshot 2025-04-28 at 10 29 23" src="https://github.com/user-attachments/assets/a06c399b-bc58-4de0-a40e-47f6b0243cb7" />



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Fix collaborators displays under custom tab on navigation when saved object permission is disabled
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
