### PR TITLE
Fix chatbot flyout cannot be resized beyond the window size

### DIFF
--- a/changelogs/fragments/9735.yml
+++ b/changelogs/fragments/9735.yml
@@ -1,0 +1,2 @@
+fix:
+- Chatbot flyout cannot be resized beyond the window size ([#9735](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9735))

--- a/src/core/public/overlays/sidecar/components/resizable_button.test.tsx
+++ b/src/core/public/overlays/sidecar/components/resizable_button.test.tsx
@@ -6,8 +6,15 @@
 import React from 'react';
 
 import { ResizableButton, MIN_SIDECAR_SIZE } from './resizable_button';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { SIDECAR_DOCKED_MODE } from '../sidecar_service';
+import { act } from 'react-dom/test-utils';
+
+const originalAddEventListener = window.addEventListener;
+
+const restoreWindowEvents = () => {
+  window.addEventListener = originalAddEventListener;
+};
 
 const storeWindowEvents = () => {
   const map: Record<string, Function> = {};
@@ -47,6 +54,17 @@ test('it should be vertical when docked mode is takeover', () => {
 test('it should emit onResize with new flyout size when docked right and drag and horizontal', () => {
   const windowEvents = storeWindowEvents();
 
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: 2000,
+  });
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 2000,
+  });
+
   const onResize = jest.fn();
   const newProps = { ...props, onResize };
   const component = shallow(<ResizableButton {...newProps} />);
@@ -62,6 +80,17 @@ test('it should emit onResize with new flyout size when docked right and drag an
 
 test('it should emit onResize with new flyout size when docked left and drag and horizontal', () => {
   const windowEvents = storeWindowEvents();
+
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: 2000,
+  });
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 2000,
+  });
 
   const onResize = jest.fn();
   const newProps = { ...props, onResize, dockedMode: SIDECAR_DOCKED_MODE.LEFT };
@@ -79,6 +108,17 @@ test('it should emit onResize with new flyout size when docked left and drag and
 test('it should emit onResize with new flyout size when drag and vertical', () => {
   const windowEvents = storeWindowEvents();
 
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: 2000,
+  });
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 2000,
+  });
+
   const onResize = jest.fn();
   const newProps = { ...props, onResize, dockedMode: SIDECAR_DOCKED_MODE.TAKEOVER };
   const component = shallow(<ResizableButton {...newProps} />);
@@ -94,6 +134,7 @@ test('it should emit onResize with new flyout size when drag and vertical', () =
 
 test('it should emit onResize with min size when drag if new size is below the minimum', () => {
   const windowEvents = storeWindowEvents();
+
   const onResize = jest.fn();
   const newProps = { ...props, onResize };
   const component = shallow(<ResizableButton {...newProps} />);
@@ -105,4 +146,107 @@ test('it should emit onResize with min size when drag if new size is below the m
   const newSize = MIN_SIDECAR_SIZE;
   expect(onResize).toHaveBeenCalledWith(newSize);
   expect(component).toMatchSnapshot();
+});
+
+test('it should not call onResize when new size exceeds window bounds', () => {
+  const windowEvents = storeWindowEvents();
+  const onResize = jest.fn();
+
+  // Mock window dimensions
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: 1000,
+  });
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 1200,
+  });
+
+  // Test takeover mode with size exceeding window height
+  const takeoverProps = {
+    ...props,
+    onResize,
+    dockedMode: SIDECAR_DOCKED_MODE.TAKEOVER,
+  };
+  const takeoverComponent = shallow(<ResizableButton {...takeoverProps} />);
+  const takeoverResizer = takeoverComponent.find(`[data-test-subj~="resizableButton"]`).first();
+
+  takeoverResizer.simulate('mousedown', { clientY: 0, pageX: 0, pageY: 0 });
+  let mouseMoveEvent = new MouseEvent('mousemove', {
+    clientY: -2000,
+    pageX: 0,
+    pageY: 0,
+  } as any);
+  windowEvents?.mousemove(mouseMoveEvent); // Exceeds window.innerHeight
+  windowEvents?.mouseup();
+
+  expect(onResize).not.toHaveBeenCalled();
+
+  // Test right mode with size exceeding window width
+  const rightProps = {
+    ...props,
+    onResize,
+    dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
+  };
+  const rightComponent = shallow(<ResizableButton {...rightProps} />);
+  const rightResizer = rightComponent.find(`[data-test-subj~="resizableButton"]`).first();
+
+  rightResizer.simulate('mousedown', { clientX: 0, pageX: 0, pageY: 0 });
+  mouseMoveEvent = new MouseEvent('mousemove', { clientX: -2000, pageX: 0, pageY: 0 } as any);
+  windowEvents?.mousemove(mouseMoveEvent); // Exceeds window.innerWidth
+  windowEvents?.mouseup();
+
+  expect(onResize).not.toHaveBeenCalled();
+});
+
+test('it should handle window resize events correctly for different docked modes', async () => {
+  restoreWindowEvents();
+  const onResize = jest.fn();
+
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: 1000,
+  });
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: 1200,
+  });
+
+  const takeoverProps = {
+    ...props,
+    onResize,
+    dockedMode: SIDECAR_DOCKED_MODE.TAKEOVER,
+    flyoutSize: 800,
+  };
+  let component = mount(<ResizableButton {...takeoverProps} />);
+
+  await act(async () => {
+    Object.defineProperty(window, 'innerHeight', { value: 600 });
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  expect(onResize).toHaveBeenCalledWith(600);
+
+  onResize.mockClear();
+
+  const rightProps = {
+    ...props,
+    onResize,
+    dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
+    flyoutSize: 1000,
+  };
+  component = mount(<ResizableButton {...rightProps} />);
+
+  await act(async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 800 });
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  expect(onResize).toHaveBeenCalledWith(800);
+
+  component.unmount();
 });

--- a/src/core/public/overlays/sidecar/components/resizable_button.test.tsx
+++ b/src/core/public/overlays/sidecar/components/resizable_button.test.tsx
@@ -5,10 +5,12 @@
 
 import React from 'react';
 
-import { ResizableButton, MIN_SIDECAR_SIZE } from './resizable_button';
+import { ResizableButton } from './resizable_button';
 import { mount, shallow } from 'enzyme';
 import { SIDECAR_DOCKED_MODE } from '../sidecar_service';
 import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/dom';
+import { MIN_SIDECAR_SIZE } from '../helper';
 
 const originalAddEventListener = window.addEventListener;
 
@@ -229,8 +231,10 @@ test('it should handle window resize events correctly for different docked modes
     window.dispatchEvent(new Event('resize'));
   });
 
-  expect(onResize).toHaveBeenCalledWith(600);
-
+  await waitFor(() => {
+    // wait for debounce
+    expect(onResize).toHaveBeenCalledWith(600);
+  });
   onResize.mockClear();
 
   const rightProps = {
@@ -246,7 +250,10 @@ test('it should handle window resize events correctly for different docked modes
     window.dispatchEvent(new Event('resize'));
   });
 
-  expect(onResize).toHaveBeenCalledWith(800);
+  await waitFor(() => {
+    // wait for debounce
+    expect(onResize).toHaveBeenCalledWith(800);
+  });
 
   component.unmount();
 });

--- a/src/core/public/overlays/sidecar/helper.ts
+++ b/src/core/public/overlays/sidecar/helper.ts
@@ -11,6 +11,8 @@ function isMouseEvent(
   return typeof event === 'object' && 'pageX' in event && 'pageY' in event;
 }
 
+export const MIN_SIDECAR_SIZE = 350;
+
 export const getPosition = (
   event: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent,
   isHorizontal: boolean
@@ -43,4 +45,24 @@ export const getSidecarLeftNavStyle = (config: ISidecarConfig | undefined) => {
     };
   }
   return {};
+};
+
+export const calculateNewPaddingSize = (
+  dockedMode: SIDECAR_DOCKED_MODE | undefined,
+  currentSize: number
+): number => {
+  let paddingSize = currentSize;
+  // Make sure flyout never below min size even if the window goes below the size
+  if (dockedMode === SIDECAR_DOCKED_MODE.TAKEOVER && currentSize > window.innerHeight) {
+    // Automatically reduce the height in full screen mode when resize the window
+    paddingSize = window.innerHeight;
+  } else if (
+    (dockedMode === SIDECAR_DOCKED_MODE.LEFT || dockedMode === SIDECAR_DOCKED_MODE.RIGHT) &&
+    currentSize > window.innerWidth
+  ) {
+    // Automatically reduce the width in left or right docked mode when resize the window
+    paddingSize = window.innerWidth;
+  }
+  // Make sure the padding size never goes below minimum size
+  return Math.max(paddingSize, MIN_SIDECAR_SIZE);
 };

--- a/src/core/public/overlays/sidecar/sidecar_service.tsx
+++ b/src/core/public/overlays/sidecar/sidecar_service.tsx
@@ -12,6 +12,7 @@ import { I18nStart } from '../../i18n';
 import { MountPoint } from '../../types';
 import { OverlayRef } from '../types';
 import { Sidecar } from './components/sidecar';
+import { calculateNewPaddingSize } from './helper';
 /**
  * A SidecarRef is a reference to an opened sidecar panel. It offers methods to
  * close the sidecar panel again. If you open a sidecar panel you should make
@@ -133,7 +134,13 @@ export class SidecarService {
         // init
         (!sidecarConfig$.value && config.dockedMode && config.paddingSize)
       ) {
-        sidecarConfig$.next({ ...sidecarConfig$.value, ...config } as ISidecarConfig);
+        sidecarConfig$.next({
+          ...sidecarConfig$.value,
+          ...config,
+          ...(config.paddingSize
+            ? { paddingSize: calculateNewPaddingSize(config.dockedMode, config.paddingSize) }
+            : {}),
+        } as ISidecarConfig);
       }
     };
 


### PR DESCRIPTION
### Description


Previously, the implementation of the resize button allowed users to drag it and resize the chatbot window outside of the browser window. This meant that if users dragged the button outside of the browser window and released the mouse press, they could never resize the window back to its original size since the button was now outside of the window and could not be reached.

This PR consists of the following changes:

1. When resizing the chatbot window, prevent users from resizing the chatbot window beyond the browser window size
2. When resizing the window, if the chatbot window exceeds the window size, automatically shrink the chatbot window accordingly


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

Before:

https://github.com/user-attachments/assets/423fb273-7541-4835-94f1-a80de25e5d7b

After:

https://github.com/user-attachments/assets/2b77d6dd-ab2d-4eb8-8c5f-8e1ae0e117f0



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Chatbot flyout cannot be resized beyond the window size
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.

- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
