### PR TITLE
optimize plugin build bundle size

### DIFF
--- a/packages/osd-optimizer/src/common/bundle_refs.ts
+++ b/packages/osd-optimizer/src/common/bundle_refs.ts
@@ -143,6 +143,11 @@ export class BundleRefs {
     return this.refs;
   }
 
+  public addRefs(refs: BundleRef[]) {
+    this.refs.push(...refs);
+    return this;
+  }
+
   public toSpecJson() {
     return JSON.stringify(this.refs);
   }

--- a/packages/osd-optimizer/src/index.ts
+++ b/packages/osd-optimizer/src/index.ts
@@ -28,9 +28,10 @@
  * under the License.
  */
 
-export { OptimizerConfig } from './optimizer';
+export { OptimizerConfig, findOpenSearchDashboardsPlatformPlugins } from './optimizer';
 export * from './run_optimizer';
 export * from './log_optimizer_state';
 export * from './report_optimizer_stats';
 export * from './node';
 export * from './limits';
+export { BundleRef } from './common';

--- a/packages/osd-optimizer/src/integration_tests/__snapshots__/basic_optimization.test.ts.snap
+++ b/packages/osd-optimizer/src/integration_tests/__snapshots__/basic_optimization.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`builds expected bundles, saves bundle counts to metadata: OptimizerConfig 1`] = `
 OptimizerConfig {
+  "bundleRefs": Array [],
   "bundles": Array [
     Bundle {
       "banner": undefined,

--- a/packages/osd-optimizer/src/optimizer/index.ts
+++ b/packages/osd-optimizer/src/optimizer/index.ts
@@ -37,3 +37,4 @@ export * from './run_workers';
 export * from './bundle_cache';
 export * from './handle_optimizer_completion';
 export * from './get_output_stats';
+export * from './opensearch_dashboards_platform_plugins';

--- a/packages/osd-optimizer/src/optimizer/observe_worker.ts
+++ b/packages/osd-optimizer/src/optimizer/observe_worker.ts
@@ -148,7 +148,7 @@ function initWorker(
         args: [
           JSON.stringify(workerConfig),
           JSON.stringify(bundles.map((b) => b.toSpec())),
-          BundleRefs.fromBundles(config.bundles).toSpecJson(),
+          BundleRefs.fromBundles(config.bundles).addRefs(config.bundleRefs).toSpecJson(),
         ],
       });
       return [];

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.test.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.test.ts
@@ -139,6 +139,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -166,6 +167,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -193,6 +195,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -220,6 +223,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -247,6 +251,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -274,6 +279,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -298,6 +304,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -322,6 +329,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -347,6 +355,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -372,6 +381,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -397,6 +407,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -424,6 +435,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -451,6 +463,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -478,6 +491,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -505,6 +519,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -532,6 +547,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -556,6 +572,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -580,6 +597,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -605,6 +623,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": false,
         "dist": false,
         "filters": Array [],
@@ -630,6 +649,7 @@ describe('OptimizerConfig::parseOptions()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
+        "bundleRefs": Array [],
         "cache": true,
         "dist": false,
         "filters": Array [],
@@ -693,6 +713,7 @@ describe('OptimizerConfig::create()', () => {
       profileWebpack: Symbol('parsed profile webpack'),
       filters: [],
       includeCoreBundle: false,
+      bundleRefs: Symbol('bundle refs'),
     }));
   });
 
@@ -703,6 +724,7 @@ describe('OptimizerConfig::create()', () => {
 
     expect(config).toMatchInlineSnapshot(`
       OptimizerConfig {
+        "bundleRefs": Symbol(bundle refs),
         "bundles": Symbol(filtered bundles),
         "cache": Symbol(parsed cache),
         "dist": Symbol(parsed dist),

--- a/packages/osd-optimizer/src/optimizer/optimizer_config.ts
+++ b/packages/osd-optimizer/src/optimizer/optimizer_config.ts
@@ -38,6 +38,7 @@ import {
   ThemeTag,
   ThemeTags,
   parseThemeTags,
+  BundleRef,
 } from '../common';
 
 import {
@@ -131,6 +132,8 @@ interface Options {
    *  - "k7light"
    */
   themes?: ThemeTag | '*' | ThemeTag[];
+
+  bundleRefs?: BundleRef[];
 }
 
 export interface ParsedOptions {
@@ -147,6 +150,7 @@ export interface ParsedOptions {
   inspectWorkers: boolean;
   includeCoreBundle: boolean;
   themeTags: ThemeTags;
+  bundleRefs: BundleRef[];
 }
 
 export class OptimizerConfig {
@@ -159,6 +163,7 @@ export class OptimizerConfig {
     const cache = options.cache !== false && !process.env.OSD_OPTIMIZER_NO_CACHE;
     const includeCoreBundle = !!options.includeCoreBundle;
     const filters = options.filter || [];
+    const bundleRefs = options.bundleRefs ?? [];
 
     const repoRoot = options.repoRoot;
     if (!Path.isAbsolute(repoRoot)) {
@@ -223,6 +228,7 @@ export class OptimizerConfig {
       inspectWorkers,
       includeCoreBundle,
       themeTags,
+      bundleRefs,
     };
   }
 
@@ -259,7 +265,8 @@ export class OptimizerConfig {
       options.dist,
       options.profileWebpack,
       options.themeTags,
-      readLimits()
+      readLimits(),
+      options.bundleRefs
     );
   }
 
@@ -274,7 +281,8 @@ export class OptimizerConfig {
     public readonly dist: boolean,
     public readonly profileWebpack: boolean,
     public readonly themeTags: ThemeTags,
-    public readonly limits: Limits
+    public readonly limits: Limits,
+    public readonly bundleRefs: BundleRef[]
   ) {}
 
   getWorkerConfig(optimizerCacheKey: unknown): WorkerConfig {


### PR DESCRIPTION
### Description
This PR introduces bundle references optimization when building and packaging OpenSearch Dashboards (OSD) plugins.

Previously, when building OSD plugins that imported modules from the OSD core or other core plugins, these imported modules were re-bundled into the plugin's output, even though they were already present in the core bundle.

After this change, imported modules from the core are no longer duplicated into plugin bundles. Instead, the plugin references the existing core modules directly, reducing plugin bundle sizes.

Here is a comparison of building OSD `3.6.0` before and after the optimization, we can see significant size reduction for the plugins' main entry.

# Plugin Build Artifact Comparison: Before vs Optimized

> Excludes `.br`, `.gz` compressed variants files.

## Summary

| Metric     | Before       | Optimized | Savings            |
| ---------- | --------- | --------- | ------------------ |
| Total Size | 101.73 MB | 47.48 MB  | -54.24 MB (-53.3%) |

## Per-Plugin Breakdown

| Plugin                      | Before Total | Opt Total | Savings | Before entry plugin.js | Opt entry plugin.js | Before Chunks (count / size) | Opt Chunks (count / size) | Before Static           | Opt Static           |
| --------------------------- | --------- | --------- | ------- | ------------- | ------------- | ------------------------- | ------------------------- | -------------------- | -------------------- |
| alertingDashboards          | 11.23 MB  | 2.53 MB   | -77.4%  | 9.19 MB       | 2.14 MB       | 24 / 1.61 MB              | 2 / 401 KB                | 2 SVGs (437 KB)      | —                    |
| anomalyDetectionDashboards  | 15.87 MB  | 7.27 MB   | -54.1%  | 7.75 MB       | 794 KB        | 28 / 7.69 MB              | 5 / 6.49 MB               | 2 SVGs (437 KB)      | —                    |
| assistantDashboards         | 11.39 MB  | 479 KB    | -95.8%  | 8.49 MB       | 425 KB        | 27 / 1.56 MB              | 1 / 54 KB                 | 7 files (1.33 MB)¹   | —                    |
| customImportMapDashboards   | 9.85 MB   | 2.23 MB   | -77.3%  | 8.38 MB       | 2.22 MB       | 20 / 1.03 MB              | 1 / 6.8 KB                | 2 SVGs (437 KB)      | —                    |
| flowFrameworkDashboards     | 2.96 MB   | 1.95 MB   | -34.2%  | 1.28 MB       | 206 KB        | 3 / 1.62 MB               | 2 / 1.69 MB               | 1 SVG (55 KB)        | 1 SVG (55 KB)        |
| indexManagementDashboards   | 3.31 MB   | 2.07 MB   | -37.6%  | 3.06 MB       | 1.99 MB       | 5 / 263 KB                | 4 / 75 KB                 | —                    | —                    |
| mlCommonsDashboards         | 1.74 MB   | 161 KB    | -90.9%  | 1.03 MB       | 16 KB         | 8 / 722 KB                | 2 / 145 KB                | —                    | —                    |
| notificationsDashboards     | 1.47 MB   | 284 KB    | -81.1%  | 1.06 MB       | 39 KB         | 3 / 422 KB                | 2 / 244 KB                | —                    | —                    |
| observabilityDashboards     | 26.15 MB  | 19.98 MB  | -23.5%  | 15.36 MB      | 9.76 MB       | 20 / 9.15 MB              | 2 / 8.59 MB               | 10 assets (1.62 MB)² | 10 assets (1.62 MB)² |
| queryInsightsDashboards     | 4.37 MB   | 3.15 MB   | -27.9%  | 1.04 MB       | 34 KB         | 3 / 3.32 MB               | 2 / 3.12 MB               | —                    | —                    |
| queryWorkbenchDashboards    | 1.12 MB   | 308 KB    | -73.3%  | 302 KB        | 26 KB         | 8 / 852 KB                | 2 / 282 KB                | —                    | —                    |
| reportsDashboards           | 2.94 MB   | 1.83 MB   | -37.8%  | 2.28 MB       | 1.35 MB       | 4 / 677 KB                | 3 / 491 KB                | —                    | —                    |
| searchRelevanceDashboards   | 2.72 MB   | 1.09 MB   | -59.9%  | 1.07 MB       | 60 KB         | 8 / 1.65 MB               | 2 / 1.03 MB               | —                    | —                    |
| securityAnalyticsDashboards | 3.96 MB   | 2.77 MB   | -30.1%  | 1.98 MB       | 993 KB        | 3 / 1.98 MB               | 2 / 1.80 MB               | —                    | —                    |
| securityDashboards          | 2.56 MB   | 1.38 MB   | -46.2%  | 2.28 MB       | 1.28 MB       | 5 / 291 KB                | 4 / 103 KB                | —                    | —                    |

## Per-Plugin Details

### alertingDashboards

| Category                     | Before                 | Optimized         |
| ---------------------------- | ------------------- | ----------------- |
| Total                        | 11.23 MB            | 2.53 MB (-77.4%)  |
| alertingDashboards.plugin.js | 9.19 MB             | 2.14 MB           |
| Chunks                       | 24 chunks (1.61 MB) | 2 chunks (401 KB) |
| Static assets                | 2 SVGs (437 KB)     | —                 |

<details><summary>Chunk details</summary>

**Before (24 chunks):**

- alertingDashboards.chunk.0.js — 21.93 KB
- alertingDashboards.chunk.1.js — 9.42 KB
- alertingDashboards.chunk.2.js — 10.87 KB
- alertingDashboards.chunk.3.js — 25.88 KB
- alertingDashboards.chunk.4.js — 1.15 KB
- alertingDashboards.chunk.5.js — 71.62 KB
- alertingDashboards.chunk.6.js — 41.03 KB
- alertingDashboards.chunk.7.js — 168.76 KB
- alertingDashboards.chunk.8.js — 186.54 KB
- alertingDashboards.chunk.9.js — 13.40 KB
- alertingDashboards.chunk.10.js — 171.70 KB
- alertingDashboards.chunk.11.js — 6.45 KB
- alertingDashboards.chunk.12.js — 24.52 KB
- alertingDashboards.chunk.13.js — 14.49 KB
- alertingDashboards.chunk.14.js — 24.73 KB
- alertingDashboards.chunk.15.js — 49.09 KB
- alertingDashboards.chunk.16.js — 375.40 KB
- alertingDashboards.chunk.17.js — 58.49 KB
- alertingDashboards.chunk.18.js — 336.28 KB
- alertingDashboards.chunk.19.js — 2.95 KB
- alertingDashboards.chunk.20.js — 6.74 KB
- alertingDashboards.chunk.21.js — 4.73 KB
- alertingDashboards.chunk.22.js — 22.87 KB
- alertingDashboards.chunk.23.js — 5.87 KB

**Optimized (2 chunks):**

- alertingDashboards.chunk.0.js — 25.94 KB
- alertingDashboards.chunk.1.js — 375.34 KB

</details>

---

### anomalyDetectionDashboards

| Category                             | Before                 | Optimized          |
| ------------------------------------ | ------------------- | ------------------ |
| Total                                | 15.87 MB            | 7.27 MB (-54.1%)   |
| anomalyDetectionDashboards.plugin.js | 7.75 MB             | 794 KB             |
| Chunks                               | 28 chunks (7.69 MB) | 5 chunks (6.49 MB) |
| Static assets                        | 2 SVGs (437 KB)     | —                  |

<details><summary>Chunk details</summary>

**Before (28 chunks):**

- anomalyDetectionDashboards.chunk.0.js — 21.95 KB
- anomalyDetectionDashboards.chunk.1.js — 9.44 KB
- anomalyDetectionDashboards.chunk.2.js — 10.89 KB
- anomalyDetectionDashboards.chunk.3.js — 10.99 KB
- anomalyDetectionDashboards.chunk.4.js — 25.89 KB
- anomalyDetectionDashboards.chunk.5.js — 1.16 KB
- anomalyDetectionDashboards.chunk.6.js — 71.63 KB
- anomalyDetectionDashboards.chunk.7.js — 41.04 KB
- anomalyDetectionDashboards.chunk.8.js — 459.32 KB
- anomalyDetectionDashboards.chunk.9.js — 168.78 KB
- anomalyDetectionDashboards.chunk.10.js — 186.55 KB
- anomalyDetectionDashboards.chunk.11.js — 13.41 KB
- anomalyDetectionDashboards.chunk.12.js — 170.18 KB
- anomalyDetectionDashboards.chunk.13.js — 6.47 KB
- anomalyDetectionDashboards.chunk.14.js — 369.63 KB
- anomalyDetectionDashboards.chunk.15.js — 22.97 KB
- anomalyDetectionDashboards.chunk.16.js — 14.51 KB
- anomalyDetectionDashboards.chunk.17.js — 24.74 KB
- anomalyDetectionDashboards.chunk.18.js — 49.11 KB
- anomalyDetectionDashboards.chunk.19.js — 58.51 KB
- anomalyDetectionDashboards.chunk.20.js — 336.29 KB
- anomalyDetectionDashboards.chunk.21.js — 2.97 KB
- anomalyDetectionDashboards.chunk.22.js — 6.76 KB
- anomalyDetectionDashboards.chunk.23.js — 78.57 KB
- anomalyDetectionDashboards.chunk.24.js — 4.75 KB
- anomalyDetectionDashboards.chunk.25.js — 22.89 KB
- anomalyDetectionDashboards.chunk.26.js — 5.88 KB
- anomalyDetectionDashboards.chunk.27.js — 5.54 MB ⚠️

**Optimized (5 chunks):**

- anomalyDetectionDashboards.chunk.0.js — 23.18 KB
- anomalyDetectionDashboards.chunk.1.js — 459.49 KB
- anomalyDetectionDashboards.chunk.2.js — 78.51 KB
- anomalyDetectionDashboards.chunk.3.js — 5.58 MB ⚠️
- anomalyDetectionDashboards.chunk.4.js — 369.48 KB

</details>

---

### assistantDashboards

| Category                      | Before                 | Optimized       |
| ----------------------------- | ------------------- | --------------- |
| Total                         | 11.39 MB            | 479 KB (-95.8%) |
| assistantDashboards.plugin.js | 8.49 MB             | 425 KB          |
| Chunks                        | 27 chunks (1.56 MB) | 1 chunk (54 KB) |
| Static assets                 | 7 files (1.33 MB)¹  | —               |

<details><summary>Chunk details</summary>

**Before (27 chunks):**

- assistantDashboards.chunk.0.js — 21.94 KB
- assistantDashboards.chunk.1.js — 9.43 KB
- assistantDashboards.chunk.2.js — 10.88 KB
- assistantDashboards.chunk.3.js — 25.88 KB
- assistantDashboards.chunk.4.js — 1.15 KB
- assistantDashboards.chunk.5.js — 71.62 KB
- assistantDashboards.chunk.6.js — 41.03 KB
- assistantDashboards.chunk.7.js — 45.15 KB
- assistantDashboards.chunk.8.js — 3.59 KB
- assistantDashboards.chunk.9.js — 168.76 KB
- assistantDashboards.chunk.10.js — 186.54 KB
- assistantDashboards.chunk.11.js — 13.40 KB
- assistantDashboards.chunk.12.js — 179.50 KB
- assistantDashboards.chunk.13.js — 6.46 KB
- assistantDashboards.chunk.14.js — 35.98 KB
- assistantDashboards.chunk.15.js — 14.49 KB
- assistantDashboards.chunk.16.js — 24.73 KB
- assistantDashboards.chunk.17.js — 49.10 KB
- assistantDashboards.chunk.18.js — 181.88 KB
- assistantDashboards.chunk.19.js — 58.50 KB
- assistantDashboards.chunk.20.js — 54.02 KB
- assistantDashboards.chunk.21.js — 335.13 KB
- assistantDashboards.chunk.22.js — 2.95 KB
- assistantDashboards.chunk.23.js — 24.80 KB
- assistantDashboards.chunk.24.js — 6.75 KB
- assistantDashboards.chunk.25.js — 22.88 KB
- assistantDashboards.chunk.26.js — 5.87 KB

**Optimized (1 chunk):**

- assistantDashboards.chunk.0.js — 54.08 KB

</details>

---

### customImportMapDashboards

| Category                            | Before                 | Optimized        |
| ----------------------------------- | ------------------- | ---------------- |
| Total                               | 9.85 MB             | 2.23 MB (-77.3%) |
| customImportMapDashboards.plugin.js | 8.38 MB             | 2.22 MB          |
| Chunks                              | 20 chunks (1.03 MB) | 1 chunk (6.8 KB) |
| Static assets                       | 2 SVGs (437 KB)     | —                |

---

### flowFrameworkDashboards

| Category                          | Before                | Optimized          |
| --------------------------------- | ------------------ | ------------------ |
| Total                             | 2.96 MB            | 1.95 MB (-34.2%)   |
| flowFrameworkDashboards.plugin.js | 1.28 MB            | 206 KB             |
| Chunks                            | 3 chunks (1.62 MB) | 2 chunks (1.69 MB) |
| Static assets                     | 1 SVG (55 KB)      | 1 SVG (55 KB)      |

---

### indexManagementDashboards

| Category                            | Before               | Optimized        |
| ----------------------------------- | ----------------- | ---------------- |
| Total                               | 3.31 MB           | 2.07 MB (-37.6%) |
| indexManagementDashboards.plugin.js | 3.06 MB           | 1.99 MB          |
| Chunks                              | 5 chunks (263 KB) | 4 chunks (75 KB) |
| Static assets                       | —                 | —                |

---

### mlCommonsDashboards

| Category                      | Before               | Optimized         |
| ----------------------------- | ----------------- | ----------------- |
| Total                         | 1.74 MB           | 161 KB (-90.9%)   |
| mlCommonsDashboards.plugin.js | 1.03 MB           | 16 KB             |
| Chunks                        | 8 chunks (722 KB) | 2 chunks (145 KB) |
| Static assets                 | —                 | —                 |

---

### notificationsDashboards

| Category                          | Before               | Optimized         |
| --------------------------------- | ----------------- | ----------------- |
| Total                             | 1.47 MB           | 284 KB (-81.1%)   |
| notificationsDashboards.plugin.js | 1.06 MB           | 39 KB             |
| Chunks                            | 3 chunks (422 KB) | 2 chunks (244 KB) |
| Static assets                     | —                 | —                 |

---

### observabilityDashboards

| Category                          | Before                  | Optimized            |
| --------------------------------- | -------------------- | -------------------- |
| Total                             | 26.15 MB             | 19.98 MB (-23.5%)    |
| observabilityDashboards.plugin.js | 15.36 MB             | 9.76 MB              |
| Chunks                            | 20 chunks (9.15 MB)  | 2 chunks (8.59 MB)   |
| Static assets                     | 10 assets (1.62 MB)² | 10 assets (1.62 MB)² |

<details><summary>Chunk details</summary>

**Before (20 chunks):**

- observabilityDashboards.chunk.0.js — 9.43 KB
- observabilityDashboards.chunk.1.js — 10.89 KB
- observabilityDashboards.chunk.2.js — 25.89 KB
- observabilityDashboards.chunk.3.js — 1.16 KB
- observabilityDashboards.chunk.4.js — 71.63 KB
- observabilityDashboards.chunk.5.js — 41.04 KB
- observabilityDashboards.chunk.6.js — 168.77 KB
- observabilityDashboards.chunk.7.js — 186.55 KB
- observabilityDashboards.chunk.8.js — 13.41 KB
- observabilityDashboards.chunk.9.js — 6.46 KB
- observabilityDashboards.chunk.10.js — 14.50 KB
- observabilityDashboards.chunk.11.js — 24.74 KB
- observabilityDashboards.chunk.12.js — 49.10 KB
- observabilityDashboards.chunk.13.js — 58.50 KB
- observabilityDashboards.chunk.14.js — 2.96 KB
- observabilityDashboards.chunk.15.js — 6.75 KB
- observabilityDashboards.chunk.16.js — 22.88 KB
- observabilityDashboards.chunk.17.js — 5.88 KB
- observabilityDashboards.chunk.18.js — 5.60 MB ⚠️
- observabilityDashboards.chunk.19.js — 2.84 MB ⚠️

**Optimized (2 chunks):**

- observabilityDashboards.chunk.0.js — 2.84 MB ⚠️
- observabilityDashboards.chunk.1.js — 5.74 MB ⚠️

</details>

<details><summary>Static assets</summary>

- 06f7da2ea0b5be56.svg — 240 KB
- 35b2b4076accd9d7.svg — 72 KB
- 67f75f6af17dcac5.png — 365 KB
- 6e96656dd2ffdd38.jpg — 91 KB
- 6f08ff4fb54977b2.png — 286 KB
- 7ecca3210772fd22.svg — 197 KB
- 93aaa9172c1ed1f0.jpg — 156 KB
- 9f6049f15c39a012.jpg — 138 KB
- b7bb123246971909.svg — 96 KB
- e5d70ca90b76b817.png — 22 KB

</details>

---

### queryInsightsDashboards

| Category                          | Before                | Optimized          |
| --------------------------------- | ------------------ | ------------------ |
| Total                             | 4.37 MB            | 3.15 MB (-27.9%)   |
| queryInsightsDashboards.plugin.js | 1.04 MB            | 34 KB              |
| Chunks                            | 3 chunks (3.32 MB) | 2 chunks (3.12 MB) |
| Static assets                     | —                  | —                  |

---

### queryWorkbenchDashboards

| Category                           | Before               | Optimized         |
| ---------------------------------- | ----------------- | ----------------- |
| Total                              | 1.12 MB           | 308 KB (-73.3%)   |
| queryWorkbenchDashboards.plugin.js | 302 KB            | 26 KB             |
| Chunks                             | 8 chunks (852 KB) | 2 chunks (282 KB) |
| Static assets                      | —                 | —                 |

---

### reportsDashboards

| Category                    | Before               | Optimized         |
| --------------------------- | ----------------- | ----------------- |
| Total                       | 2.94 MB           | 1.83 MB (-37.8%)  |
| reportsDashboards.plugin.js | 2.28 MB           | 1.35 MB           |
| Chunks                      | 4 chunks (677 KB) | 3 chunks (491 KB) |
| Static assets               | —                 | —                 |

---

### searchRelevanceDashboards

| Category                            | Before                | Optimized          |
| ----------------------------------- | ------------------ | ------------------ |
| Total                               | 2.72 MB            | 1.09 MB (-59.9%)   |
| searchRelevanceDashboards.plugin.js | 1.07 MB            | 60 KB              |
| Chunks                              | 8 chunks (1.65 MB) | 2 chunks (1.03 MB) |
| Static assets                       | —                  | —                  |

---

### securityAnalyticsDashboards

| Category                              | Before                | Optimized          |
| ------------------------------------- | ------------------ | ------------------ |
| Total                                 | 3.96 MB            | 2.77 MB (-30.1%)   |
| securityAnalyticsDashboards.plugin.js | 1.98 MB            | 993 KB             |
| Chunks                                | 3 chunks (1.98 MB) | 2 chunks (1.80 MB) |
| Static assets                         | —                  | —                  |

---

### securityDashboards

| Category                     | Before               | Optimized         |
| ---------------------------- | ----------------- | ----------------- |
| Total                        | 2.56 MB           | 1.38 MB (-46.2%)  |
| securityDashboards.plugin.js | 2.28 MB           | 1.28 MB           |
| Chunks                       | 5 chunks (291 KB) | 4 chunks (103 KB) |
| Static assets                | —                 | —                 |

---


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- infra: introduce bundle refs settings and add core plugins and core entry as refs to plugin build config

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
