### PR TITLE
fix path alias not working for distribution builds

### DIFF
--- a/changelogs/fragments/9784.yml
+++ b/changelogs/fragments/9784.yml
@@ -1,0 +1,2 @@
+fix:
+- Path alias not properly resolved if the source code was copied and built from another directory ([#9784](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9784))

--- a/packages/osd-babel-preset/node_preset.js
+++ b/packages/osd-babel-preset/node_preset.js
@@ -66,8 +66,8 @@ module.exports = (_, options = {}) => {
       [
         require.resolve('babel-plugin-module-resolver'),
         {
-          root: [path.resolve(__dirname, '../..')],
-          cwd: path.resolve(__dirname, '../..'),
+          root: options['babel-plugin-module-resolver']?.root ?? [path.resolve(__dirname, '../..')],
+          cwd: options['babel-plugin-module-resolver']?.cwd ?? path.resolve(__dirname, '../..'),
           alias: {
             'opensearch-dashboards/server': './src/core/server',
             'opensearch-dashboards/public': './src/core/public',

--- a/src/dev/build/tasks/transpile_babel_task.ts
+++ b/src/dev/build/tasks/transpile_babel_task.ts
@@ -39,7 +39,9 @@ import { Task, Build } from '../lib';
 
 const asyncPipeline = promisify(pipeline);
 
-const transpileWithBabel = async (srcGlobs: string[], build: Build, presets: string[]) => {
+type Preset = string | [string, Record<string, any>];
+
+const transpileWithBabel = async (srcGlobs: string[], build: Build, presets: Preset[]) => {
   const buildRoot = build.resolvePath();
 
   await asyncPipeline(
@@ -71,7 +73,12 @@ export const TranspileBabel: Task = {
   async run(config, log, build) {
     // Transpile server code
     await transpileWithBabel(['**/*.{js,ts,tsx}', '!**/public/**'], build, [
-      require.resolve('@osd/babel-preset/node_preset'),
+      [
+        require.resolve('@osd/babel-preset/node_preset'),
+        {
+          'babel-plugin-module-resolver': { root: [build.resolvePath()], cwd: build.resolvePath() },
+        },
+      ],
     ]);
 
     // Transpile client code


### PR DESCRIPTION
### Description

When run `opensearch-build` to build OSD distributions, the source codes are copied to `build/opensearch-dashboards`, so the build dir is NOT the project root, the current babel path alias plugin config `babel-plugin-module-resolver` assume OSD is build from project root dir, so the resolved path for alias are incorrect at the moment if it's build from `build/opensearch-dashboards`.

To fix the issue, we will pass the build dir to `babel-plugin-module-resolver` when building OSD distributions.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: path alias not properly resolved if the source code was copied and built from another directory

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
