### PR TITLE
fix: fail to delete multiple workspaces with the same data source

### DIFF
--- a/changelogs/fragments/9785.yml
+++ b/changelogs/fragments/9785.yml
@@ -1,0 +1,2 @@
+fix:
+- Change workspace deletion from parallel to serial ([#9785](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9785))

--- a/changelogs/fragments/9785.yml
+++ b/changelogs/fragments/9785.yml
@@ -1,2 +1,2 @@
 fix:
-- Change workspace deletion from parallel to serial ([#9785](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9785))
+- Fail to delete multiple workspaces with the same data source ([#9785](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9785))

--- a/src/plugins/workspace/public/components/delete_workspace_modal/delete_workspace_modal.tsx
+++ b/src/plugins/workspace/public/components/delete_workspace_modal/delete_workspace_modal.tsx
@@ -38,7 +38,7 @@ export function DeleteWorkspaceModal(props: DeleteWorkspaceModalProps) {
 
   const deleteWorkspaces = async () => {
     if (selectedWorkspaces && selectedWorkspaces.length > 0) {
-      selectedWorkspaces.forEach(async (selectedWorkspace) => {
+      for (const selectedWorkspace of selectedWorkspaces) {
         if (selectedWorkspace?.id) {
           let result;
           try {
@@ -71,7 +71,7 @@ export function DeleteWorkspaceModal(props: DeleteWorkspaceModalProps) {
             });
           }
         }
-      });
+      }
     }
   };
 


### PR DESCRIPTION
### Description

Change workspace deletion from parallel to serial to avoid operation conflicts on the same data source, which could lead to deletion failures.

### Issues Resolved

## Screenshot

## Testing the changes

Delete multiple workspaces with the same data source.

## Changelog

- fix: fail to delete multiple workspaces with the same data source

### Check List

- [ ] All tests pass
- [ ] `yarn test:jest`
- [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
