### PR TITLE
Fix the bug of open field link in a new tab

### DIFF
--- a/src/plugins/vis_type_table/public/components/table_vis_cell.test.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_cell.test.tsx
@@ -62,4 +62,23 @@ describe('getTableVisCellValue', () => {
     const { container } = render(<TableCell rowIndex={0} columnId="nonexistent" />);
     expect(container.firstChild).toBeNull();
   });
+
+  test('should sanitize HTML content using dompurify', () => {
+    mockFormatter.convert.mockReturnValueOnce(
+      '<a href="http://example.com" target="_blank">Link</a>'
+    );
+    const { container } = render(<TableCell rowIndex={0} columnId="testId" />);
+    const anchorElement = container.querySelector('a');
+    expect(anchorElement).toHaveAttribute('href', 'http://example.com');
+    expect(anchorElement).toHaveAttribute('target', '_blank');
+    expect(anchorElement).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('should handle unsafe HTML content gracefully', () => {
+    mockFormatter.convert.mockReturnValueOnce('<img src="x" onerror="alert(1)">');
+    const { container } = render(<TableCell rowIndex={0} columnId="testId" />);
+    const imgElement = container.querySelector('img');
+    expect(imgElement).toHaveAttribute('src', 'x');
+    expect(imgElement).not.toHaveAttribute('onerror');
+  });
 });

--- a/src/plugins/vis_type_table/public/components/table_vis_cell.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_cell.tsx
@@ -23,6 +23,17 @@ export const getTableVisCellValue = (
   const rawContent = row[columnId];
   const colIndex = columns.findIndex((col) => col.id === columnId);
   const htmlContent = columns[colIndex].formatter.convert(rawContent, 'html');
+  dompurify.addHook('uponSanitizeAttribute', (node, event) => {
+    if (event.attrName === 'target') {
+      event.forceKeepAttr = true;
+    }
+  });
+
+  dompurify.addHook('afterSanitizeElements', (node) => {
+    if (node instanceof Element && node.tagName?.toUpperCase() === 'A') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
   const formattedContent = (
     /*
      * Justification for dangerouslySetInnerHTML:


### PR DESCRIPTION
### Description
In table vis, a url field with the setting of open in a new tab did not open itself in a new tab. More detailed can be found in the below issue.

### Issues Resolved

#3500 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Open field link in a new tab

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
