### PR TITLE
Default data:withLongNumerals to Off

### DIFF
--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -539,7 +539,7 @@ export function getUiSettings(
       name: i18n.translate('data.advancedSettings.data.withLongNumeralsTitle', {
         defaultMessage: 'Extend Numeric Precision',
       }),
-      value: true,
+      value: false,
       description: i18n.translate('data.advancedSettings.data.withLongNumeralsText', {
         defaultMessage:
           "Turn on for precise handling of extremely large numbers. Turn off to optimize performance when high precision for large values isn't required.",


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

In #8837, the option to extend numeric precision was added. This PR updates the default to be off.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

#9562 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Default extending numeric precision to off

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
