### PR TITLE
[Discover] Fix scroll bar not showing up for dataset table

### DIFF
--- a/src/plugins/data/public/ui/dataset_selector/_dataset_explorer.scss
+++ b/src/plugins/data/public/ui/dataset_selector/_dataset_explorer.scss
@@ -16,6 +16,7 @@
     display: grid;
     grid-template-rows: auto 1fr;
     border-right: $euiBorderThin;
+    overflow-y: hidden;
 
     &--empty,
     &--leaf {
@@ -34,6 +35,8 @@
   }
 
   .datasetTable {
+    overflow-y: auto;
+
     &__loadMore {
       text-align: center;
       padding: $euiSizeS;


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9668 sets overflow-y of the top container to hidden, this breaks the dataset table with multi-selectable datasets. The scrollbar is gone and user cannot scroll the table. Additionally, 

This PR fixes it, tested both table and list, scrollbar is present and not observing flickering.

The scrollbar in "Connections" looks different in the screenshots because before this PR, the height of `.datasetExplorer` is the height of the table, and the entire `.datasetExplorer` was scrollable before #9668. After this PR, the table/list scrolling is constrained in "Test items", and scrolling table will not scroll the entire `.datasetExplorer`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

### Before

![image](https://github.com/user-attachments/assets/d678b04c-6767-4b13-8495-2c15e6e674ab)

### After

#### multi-select dataset table
![image](https://github.com/user-attachments/assets/4cb805b7-f8cd-4c62-a968-aed1829a5d23)
#### default single select list
![image](https://github.com/user-attachments/assets/5356f894-b037-45bd-90e5-86e649a14722)


## Testing the changes

only manual testing.

Currently all scss/css are mocked in jest, and since core does not contain any dataset type that supports multi-select tables and uses this component, integration tests require additional setup (maybe a plugin that registers a dummy dataset during test run)

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
