### PR TITLE
[Explore] rename Explore nav item to Discover

### DIFF
--- a/src/core/public/chrome/ui/header/nav_link.test.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.test.tsx
@@ -20,6 +20,10 @@ describe('isActiveNavLink', () => {
     expect(isActiveNavLink('data-explorer', 'discover')).toBe(true);
   });
 
+  it('should return true if the appId is "data-explorer" and linkId is "explore"', () => {
+    expect(isActiveNavLink('data-explorer', 'explore')).toBe(true);
+  });
+
   it('should return false if the appId and linkId do not match', () => {
     expect(isActiveNavLink('dashboard', 'discover')).toBe(false);
   });

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -43,6 +43,7 @@ export const isModifiedOrPrevented = (event: React.MouseEvent<HTMLButtonElement,
 // TODO: replace hard-coded values with a registration function, so that apps can control active nav links similar to breadcrumbs
 const aliasedApps: { [key: string]: string[] } = {
   discover: ['data-explorer'],
+  explore: ['data-explorer'],
 };
 
 export const isActiveNavLink = (appId: string | undefined, linkId: string): boolean =>

--- a/src/plugins/discover/opensearch_dashboards.json
+++ b/src/plugins/discover/opensearch_dashboards.json
@@ -16,7 +16,7 @@
     "visualizations",
     "usageCollection"
   ],
-  "optionalPlugins": ["home", "share"],
+  "optionalPlugins": ["home", "share", "explore"],
   "requiredBundles": [
     "home",
     "opensearchDashboardsUtils",

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -78,6 +78,7 @@ declare module '../../share/public' {
   }
 }
 import { UsageCollectionSetup } from '../../usage_collection/public';
+import { ExplorePluginSetup } from '../../explore/public';
 
 /**
  * @public
@@ -132,6 +133,7 @@ export interface DiscoverSetupPlugins {
   data: DataPublicPluginSetup;
   dataExplorer: DataExplorerPluginSetup;
   usageCollection: UsageCollectionSetup;
+  explore?: ExplorePluginSetup;
 }
 
 /**
@@ -303,13 +305,17 @@ export class DiscoverPlugin
       },
     });
 
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-      {
-        id: PLUGIN_ID,
-        category: undefined,
-        order: 300,
-      },
-    ]);
+    // If Explore plugin is enabled, it will register a Discover menu to the
+    // side nav in observability workspaces, we should skip registration here.
+    if (!plugins.explore) {
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+        {
+          id: PLUGIN_ID,
+          category: undefined,
+          order: 300,
+        },
+      ]);
+    }
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
       {

--- a/src/plugins/explore/common/index.ts
+++ b/src/plugins/explore/common/index.ts
@@ -4,6 +4,6 @@
  */
 
 export const PLUGIN_ID = 'explore';
-export const PLUGIN_NAME = 'Explore';
+export const PLUGIN_NAME = 'Discover';
 
 export const LOGS_VIEW_ID = 'logs';

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -208,6 +208,7 @@ export class ExplorePlugin
     core.application.register({
       id: PLUGIN_ID,
       title: PLUGIN_NAME,
+      updater$: this.appStateUpdater.asObservable(),
       order: 1000,
       workspaceAvailability: WorkspaceAvailability.insideWorkspace,
       euiIconType: 'inputOutput',
@@ -227,6 +228,7 @@ export class ExplorePlugin
           !isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.observability.id, features)
         ) {
           coreStart.application.navigateToApp('discover', { replace: true });
+          return () => {};
         }
 
         const { renderApp } = await import('./application/legacy/data_explorer/application');
@@ -270,6 +272,7 @@ export class ExplorePlugin
         id: PLUGIN_ID,
         category: undefined,
         order: 300,
+        showInAllNavGroup: false,
       },
     ]);
 


### PR DESCRIPTION
### Description

This PR makes explore plugin to show as Discover and removes discover plugin's "Discover" link under Observability workspaces. In other workspaces, the "Discover" link is still from discover plugin.

Note that in Analytics workspaces, there will be two Discover links. This is due to issue described in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9812, and will be fixed when that merges in.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: [Explore] rename Explore nav item to Discover

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
