### PR TITLE
fix(content_management): do not show content and bar in create new dropdown

### DIFF
--- a/src/plugins/content_management/public/components/card_container/card_container_factory.test.ts
+++ b/src/plugins/content_management/public/components/card_container/card_container_factory.test.ts
@@ -15,6 +15,7 @@ test('CardContainerFactoryDefinition', async () => {
   expect(factory.type).toBe(CARD_CONTAINER);
   expect(factory.isContainerType).toBe(true);
   expect(await factory.isEditable()).toBe(false);
+  expect(factory.canCreateNew()).toBe(false);
   expect(factory.getDisplayName()).toBe('Card container');
   expect(await factory.create({ id: 'card-id', panels: {} })).toBeInstanceOf(CardContainer);
 });

--- a/src/plugins/content_management/public/components/card_container/card_container_factory.ts
+++ b/src/plugins/content_management/public/components/card_container/card_container_factory.ts
@@ -11,7 +11,8 @@ import {
   EmbeddableFactory,
   ContainerOutput,
 } from '../../../../embeddable/public';
-import { CARD_CONTAINER, CardContainer, CardContainerInput } from './card_container';
+import { CARD_CONTAINER, CardContainer } from './card_container';
+import { CardContainerInput } from './types';
 
 interface StartServices {
   embeddableServices: EmbeddableStart;
@@ -26,6 +27,10 @@ export class CardContainerFactoryDefinition
   constructor(private getStartServices: () => Promise<StartServices>) {}
 
   public async isEditable() {
+    return false;
+  }
+
+  public canCreateNew() {
     return false;
   }
 

--- a/src/plugins/content_management/public/components/card_container/card_embeddable_factory.test.ts
+++ b/src/plugins/content_management/public/components/card_container/card_embeddable_factory.test.ts
@@ -11,6 +11,7 @@ test('create CardEmbeddableFactoryDefinition', async () => {
   expect(factory.type).toBe(CARD_EMBEDDABLE);
   expect(factory.getDisplayName()).toBe('Card');
   expect(await factory.isEditable()).toBe(false);
+  expect(factory.canCreateNew()).toBe(false);
   expect(await factory.create({ id: 'card-id', title: 'title', description: '' })).toBeInstanceOf(
     CardEmbeddable
   );

--- a/src/plugins/content_management/public/components/card_container/card_embeddable_factory.ts
+++ b/src/plugins/content_management/public/components/card_container/card_embeddable_factory.ts
@@ -14,6 +14,10 @@ export class CardEmbeddableFactoryDefinition implements EmbeddableFactoryDefinit
     return false;
   }
 
+  public canCreateNew() {
+    return false;
+  }
+
   public async create(initialInput: CardEmbeddableInput, parent?: IContainer) {
     return new CardEmbeddable(initialInput, parent);
   }

--- a/src/plugins/content_management/public/components/custom_content_embeddable_factory.test.ts
+++ b/src/plugins/content_management/public/components/custom_content_embeddable_factory.test.ts
@@ -10,6 +10,7 @@ test('create CustomContentEmbeddableFactory', async () => {
   const factory = new CustomContentEmbeddableFactoryDefinition();
   expect(factory.type).toBe(CUSTOM_CONTENT_EMBEDDABLE);
   expect(await factory.isEditable()).toBe(false);
+  expect(factory.canCreateNew()).toBe(false);
   expect(factory.getDisplayName()).toBe('Content');
   expect(await factory.create({ id: 'id', render: jest.fn() })).toBeInstanceOf(
     CustomContentEmbeddable

--- a/src/plugins/content_management/public/components/custom_content_embeddable_factory.ts
+++ b/src/plugins/content_management/public/components/custom_content_embeddable_factory.ts
@@ -19,6 +19,10 @@ export class CustomContentEmbeddableFactoryDefinition implements EmbeddableFacto
     return false;
   }
 
+  public canCreateNew() {
+    return false;
+  }
+
   public async create(initialInput: CustomContentEmbeddableInput, parent?: IContainer) {
     return new CustomContentEmbeddable(initialInput, parent);
   }


### PR DESCRIPTION
### Description
<img width="862" alt="Screenshot 2025-05-23 at 10 41 19" src="https://github.com/user-attachments/assets/0defd103-06fe-4b6f-8049-6d6ffecb407d" />

"Content" and "Card" are mistakenly placed under the create visualization dropdown menu, this PR fixed the issue.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Content and Card are mistakenly placed under the create visualization dropdown menu

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
