### PR TITLE
Feature: deprecate showInAllNavGroup property

### DIFF
--- a/changelogs/fragments/9818.yml
+++ b/changelogs/fragments/9818.yml
@@ -1,0 +1,3 @@
+feat:
+- Deprecate showInAllNavGroup property ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))
+- Register search overview page to all use case by using addNavLinksToGroup ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))

--- a/src/core/public/chrome/nav_group/nav_group_service.test.ts
+++ b/src/core/public/chrome/nav_group/nav_group_service.test.ts
@@ -231,7 +231,7 @@ describe('ChromeNavGroupService#start()', () => {
     expect(groupsMap[mockedGroupBar.id].navLinks.length).toEqual(1);
   });
 
-  it('should populate links with custom category if the nav link does not belong to any use case', async () => {
+  it('should populate links with custom category in all use case if the nav link does not belong to any use case', async () => {
     const chromeNavGroupService = new ChromeNavGroupService();
     const uiSettings = uiSettingsServiceMock.createSetupContract();
     const chromeNavGroupServiceSetup = chromeNavGroupService.setup({ uiSettings });

--- a/src/core/public/chrome/nav_group/nav_group_service.test.ts
+++ b/src/core/public/chrome/nav_group/nav_group_service.test.ts
@@ -231,7 +231,7 @@ describe('ChromeNavGroupService#start()', () => {
     expect(groupsMap[mockedGroupBar.id].navLinks.length).toEqual(1);
   });
 
-  it('should populate links with custom category if the nav link is inside second level but no entry in all use case', async () => {
+  it('should populate links with custom category if the nav link does not belong to any use case', async () => {
     const chromeNavGroupService = new ChromeNavGroupService();
     const uiSettings = uiSettingsServiceMock.createSetupContract();
     const chromeNavGroupServiceSetup = chromeNavGroupService.setup({ uiSettings });
@@ -278,11 +278,6 @@ describe('ChromeNavGroupService#start()', () => {
     expect(groupsMap[ALL_USE_CASE_ID].navLinks).toEqual([
       {
         id: 'foo',
-      },
-      {
-        id: 'bar',
-        title: 'bar',
-        category: { id: 'custom', label: 'Custom', order: 8500 },
       },
       {
         id: 'customized_app',

--- a/src/plugins/home/public/plugin.test.ts
+++ b/src/plugins/home/public/plugin.test.ts
@@ -110,5 +110,15 @@ describe('HomePublicPlugin', () => {
       });
       expect(coreMocks.application.register).toBeCalledTimes(2);
     });
+
+    test('wires up and call addNavLinksToGroup if new navigation is enabled and workspace not enabled', async () => {
+      const coreMocks = coreMock.createSetup();
+      coreMocks.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+      await new HomePublicPlugin(mockInitializerContext).setup(coreMocks, {
+        urlForwarding: urlForwardingPluginMock.createSetupContract(),
+        contentManagement: contentManagementPluginMocks.createSetupContract(),
+      });
+      expect(coreMocks.chrome.navGroup.addNavLinksToGroup).toBeCalledTimes(3);
+    });
   });
 });

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -219,7 +219,7 @@ export class HomePublicPlugin
         },
       ]);
 
-      // add search to all nav group
+      // add search overview to all nav group
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
         {
           id: SEARCH_OVERVIEW_PAGE_ID,

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -216,7 +216,18 @@ export class HomePublicPlugin
         {
           id: SEARCH_OVERVIEW_PAGE_ID,
           order: -1,
-          showInAllNavGroup: true,
+        },
+      ]);
+
+      // add search to all nav group
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
+        {
+          id: SEARCH_OVERVIEW_PAGE_ID,
+          order: -1,
+          category: {
+            id: DEFAULT_NAV_GROUPS.search.id,
+            label: DEFAULT_NAV_GROUPS.search.title,
+          },
         },
       ]);
     }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
The `showInAllNavGroup` was used for nested structure of multi-levels of left navigation. Since we've flattened menus for analytics(all) use case, the property should be deprecated to reduce confusion.

For more context, please refer to #9812 .

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
Register `Discover` to Observability use case

### Before the change:
![image](https://github.com/user-attachments/assets/238caeaa-d2b7-4e29-ba7e-363b2f17ae2f)


### After the change:
![image](https://github.com/user-attachments/assets/70df88e0-efcd-4daf-aaea-ebd9f9139366)

![image](https://github.com/user-attachments/assets/fa33f151-3bf2-4f3c-8e81-608b2421f4c0)



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: deprecate showInAllNavGroup property
- feat: register search overview page to all use case by using addNavLinksToGroup

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
