### PR TITLE
[Explore] fix download_csv for explore

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/03/download_csv.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/03/download_csv.spec.js
@@ -22,11 +22,13 @@ import {
   getHeadersForSourceDownload,
   getMaxCount,
   getVisibleCountForLanguage,
-  prepareDiscoverPageForDownload,
   toggleFieldsForCsvDownload,
 } from '../../../../../../utils/apps/query_enhancements/download_csv';
 import { prepareTestSuite } from '../../../../../../utils/helpers';
-import { generateDownloadCsvTestConfigurations } from '../../../../../../utils/apps/explore/download_csv';
+import {
+  generateDownloadCsvTestConfigurations,
+  prepareDiscoverPageForDownload,
+} from '../../../../../../utils/apps/explore/download_csv';
 
 const workspaceName = getRandomizedWorkspaceName();
 

--- a/cypress/utils/apps/explore/download_csv.js
+++ b/cypress/utils/apps/explore/download_csv.js
@@ -3,8 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DatasetTypesExplore } from './constants';
-import { INDEX_WITH_TIME_1, INDEX_WITHOUT_TIME_1 } from '../query_enhancements/constants';
+import { DatasetTypesExplore, QueryLanguagesExplore } from './constants';
+import {
+  DATASOURCE_NAME,
+  INDEX_WITH_TIME_1,
+  INDEX_WITHOUT_TIME_1,
+} from '../query_enhancements/constants';
+import { setDatePickerDatesIfRelevant } from '../query_enhancements/shared';
 
 /**
  * The configurations needed for saved search/queries tests
@@ -49,4 +54,59 @@ export const generateDownloadCsvTestConfigurations = () => {
       ];
     });
   });
+};
+
+/**
+ * Returns the query string to use for a given dataset+language
+ * @param {string} dataset - the dataset name to use
+ * @param {QueryEnhancementLanguage} language - the name of query language
+ * @param {boolean} hasTime - whether the dataset has time or not
+ * @returns {string}
+ */
+export const getQueryString = (dataset, language, hasTime) => {
+  switch (language) {
+    case QueryLanguagesExplore.PPL.name:
+      return `source = ${dataset} | where bytes_transferred > 8900${
+        hasTime ? ' | sort timestamp' : ''
+      }`;
+    default:
+      throw new Error(`getQueryString encountered unsupported language: ${language}`);
+  }
+};
+
+/**
+ * Prepares the discover page for CSV download
+ * @param {DownloadCsvTestConfig} config - config data related to the test
+ * @param {string} workspaceName - workspace name
+ */
+export const prepareDiscoverPageForDownload = (config, workspaceName) => {
+  cy.osd.navigateToWorkSpaceSpecificPage({
+    workspaceName,
+    page: 'explore',
+    isEnhancement: true,
+  });
+
+  if (config.datasetType === DatasetTypesExplore.INDEX_PATTERN.name) {
+    cy.setIndexPatternAsDataset(config.dataset, DATASOURCE_NAME);
+  } else {
+    cy.setIndexAsDataset(
+      config.dataset,
+      DATASOURCE_NAME,
+      'PPL',
+      config.hasTime ? 'timestamp' : "I don't want to use the time filter",
+      'submit'
+    );
+  }
+
+  cy.setQueryLanguage(config.language.name);
+  if (config.hasTime) {
+    setDatePickerDatesIfRelevant(config.language.name);
+  }
+
+  cy.setQueryEditor(getQueryString(config.dataset, config.language.name, config.hasTime), {
+    parseSpecialCharSequences: false,
+  });
+
+  // waiting as there is no good way to verify that the query has loaded
+  cy.wait(2000);
 };


### PR DESCRIPTION
### Description

- Explore test for `download_csv` was accidently going to discover page. This was discovered when debugging the failed test in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9813


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
