### PR TITLE
[Explore] fix ciGroup15 for explore

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -134,7 +134,7 @@ jobs:
             config: explore
             test_location: source
           # Explore tests - group 5
-          - group: 15
+          - group: 15Explore
             config: explore
             test_location: source
     container:


### PR DESCRIPTION
### Description

ciGroup15 was accidently running the `explore` script on CI/CD. This was discovered due to failure on this PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9813

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
