### PR TITLE
[UI setting] feat: keep backward compatibility for UI setting client.

### DIFF
--- a/changelogs/fragments/9854.yml
+++ b/changelogs/fragments/9854.yml
@@ -1,0 +1,2 @@
+feat:
+- Keep backward compatibility for UI setting client ([#9854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9854))

--- a/src/core/server/ui_settings/ui_settings_client.test.ts
+++ b/src/core/server/ui_settings/ui_settings_client.test.ts
@@ -145,11 +145,13 @@ describe('ui settings', () => {
       };
       const { uiSettings } = setup({ defaults });
 
-      try {
-        await uiSettings.setMany({ one: 'value', user: 'val', workspace: 'value' });
-      } catch (error) {
-        expect(error.message).toBe('Unable to update "workspace", because it has multiple scopes');
-      }
+      await expect(
+        async () => await uiSettings.setMany({ one: 'value', user: 'val', workspace: 'value' })
+      ).not.toThrow();
+
+      expect(logger.warn).toBeCalledWith(
+        'Deprecation warning: Setting "workspace" with multiple scopes is deprecated. Please specify a single scope instead.'
+      );
     });
 
     it('automatically creates the savedConfig if it is missing', async () => {

--- a/src/core/server/ui_settings/ui_settings_client.test.ts
+++ b/src/core/server/ui_settings/ui_settings_client.test.ts
@@ -150,7 +150,7 @@ describe('ui settings', () => {
       ).not.toThrow();
 
       expect(logger.warn).toBeCalledWith(
-        'Deprecation warning: Setting "workspace" with multiple scopes is deprecated. Please specify a single scope instead.'
+        'Deprecation warning: The setting "workspace" has multiple scopes. Please specify a scope when updating it.'
       );
     });
 

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -335,13 +335,14 @@ export class UiSettingsClient implements IUiSettingsClient {
 
     Object.entries(changes).forEach(([key, val]) => {
       if (Array.isArray(this.defaults[key]?.scope) && (this.defaults[key].scope?.length ?? 0) > 1) {
+        const keyScope: UiSettingScope[] = this.defaults[key].scope;
         // If this setting applies to multiple scopes including global
         // categorize it as global to maintain backward compatibility.
-        if (this.defaults[key].scope?.includes(UiSettingScope.GLOBAL)) {
+        if (keyScope.includes(UiSettingScope.GLOBAL)) {
           groupedChanges[UiSettingScope.GLOBAL][key] = val;
         } else {
           // else we use first scope as fallback
-          groupedChanges[this.defaults[key].scope?.[0]][key] = val;
+          groupedChanges[keyScope[0]][key] = val;
         }
 
         this.log.warn(

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -337,11 +337,11 @@ export class UiSettingsClient implements IUiSettingsClient {
       if (Array.isArray(this.defaults[key]?.scope) && (this.defaults[key].scope?.length ?? 0) > 1) {
         // If this setting applies to multiple scopes including global
         // categorize it as global to maintain backward compatibility.
-        if (this.defaults[key].scope.includes(UiSettingScope.GLOBAL)) {
+        if (this.defaults[key].scope?.includes(UiSettingScope.GLOBAL)) {
           groupedChanges[UiSettingScope.GLOBAL][key] = val;
         } else {
           // else we use first scope as fallback
-          groupedChanges[this.defaults[key].scope[0]][key] = val;
+          groupedChanges[this.defaults[key].scope?.[0]][key] = val;
         }
 
         this.log.warn(

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -333,8 +333,12 @@ export class UiSettingsClient implements IUiSettingsClient {
 
     Object.entries(changes).forEach(([key, val]) => {
       if (Array.isArray(this.defaults[key]?.scope) && (this.defaults[key].scope?.length ?? 0) > 1) {
-        // if this setting has more than one scope, we should not update this setting without specifying scope
-        throw new Error(`Unable to update "${key}", because it has multiple scopes`);
+        // If this setting applies to multiple scopes, categorize it as global to maintain backward compatibility.
+        globalChanges[key] = val;
+
+        this.log.warn(
+          `Deprecation warning: Setting "${key}" with multiple scopes is deprecated. Please specify a single scope instead.`
+        );
       } else if (this.userLevelSettingsKeys.includes(key)) {
         userChanges[key] = val;
       } else if (this.adminUiSettingsKeys.includes(key)) {

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -335,14 +335,14 @@ export class UiSettingsClient implements IUiSettingsClient {
 
     Object.entries(changes).forEach(([key, val]) => {
       if (Array.isArray(this.defaults[key]?.scope) && (this.defaults[key].scope?.length ?? 0) > 1) {
-        const keyScope: UiSettingScope[] = this.defaults[key].scope;
+        const keyScopes = Array<UiSettingScope>().concat(this.defaults[key].scope || []);
         // If this setting applies to multiple scopes including global
         // categorize it as global to maintain backward compatibility.
-        if (keyScope.includes(UiSettingScope.GLOBAL)) {
+        if (keyScopes.includes(UiSettingScope.GLOBAL)) {
           groupedChanges[UiSettingScope.GLOBAL][key] = val;
         } else {
           // else we use first scope as fallback
-          groupedChanges[keyScope[0]][key] = val;
+          groupedChanges[keyScopes[0]][key] = val;
         }
 
         this.log.warn(

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -337,7 +337,7 @@ export class UiSettingsClient implements IUiSettingsClient {
         globalChanges[key] = val;
 
         this.log.warn(
-          `Deprecation warning: Setting "${key}" with multiple scopes is deprecated. Please specify a single scope instead.`
+          `Deprecation warning: The setting "${key}" has multiple scopes. Please specify a scope when updating it.`
         );
       } else if (this.userLevelSettingsKeys.includes(key)) {
         userChanges[key] = val;

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -70,6 +70,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
   private workspaceSavedObjectsClientWrapper?: WorkspaceSavedObjectsClientWrapper;
   private workspaceUiSettingsClientWrapper?: WorkspaceUiSettingsClientWrapper;
   private workspaceConfig$: Observable<ConfigSchema>;
+  private env: PluginInitializerContext['env'];
 
   private proxyWorkspaceTrafficToRealHandler(setupDeps: CoreSetup) {
     /**
@@ -218,6 +219,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     this.logger = initializerContext.logger.get();
     this.globalConfig$ = initializerContext.config.legacy.globalConfig$;
     this.workspaceConfig$ = initializerContext.config.create();
+    this.env = initializerContext.env;
   }
 
   public async setup(core: CoreSetup, deps: WorkspacePluginDependencies) {
@@ -245,7 +247,10 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     );
     this.proxyWorkspaceTrafficToRealHandler(core);
 
-    const workspaceUiSettingsClientWrapper = new WorkspaceUiSettingsClientWrapper(this.logger);
+    const workspaceUiSettingsClientWrapper = new WorkspaceUiSettingsClientWrapper(
+      this.logger,
+      this.env
+    );
     this.workspaceUiSettingsClientWrapper = workspaceUiSettingsClientWrapper;
     core.savedObjects.addClientWrapper(
       PRIORITY_FOR_WORKSPACE_UI_SETTINGS_WRAPPER,
@@ -303,6 +308,9 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     this.workspaceConflictControl?.setSerializer(core.savedObjects.createSerializer());
     this.workspaceSavedObjectsClientWrapper?.setScopedClient(core.savedObjects.getScopedClient);
     this.workspaceUiSettingsClientWrapper?.setScopedClient(core.savedObjects.getScopedClient);
+    this.workspaceUiSettingsClientWrapper?.setAsScopedUISettingsClient(
+      core.uiSettings.asScopedToClient
+    );
 
     return {
       client: this.client as IWorkspaceClientImpl,

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.test.ts
@@ -4,12 +4,19 @@
  */
 
 import { loggerMock } from '@osd/logging/target/mocks';
-import { httpServerMock, savedObjectsClientMock, coreMock } from '../../../../core/server/mocks';
+import {
+  httpServerMock,
+  savedObjectsClientMock,
+  coreMock,
+  uiSettingsServiceMock,
+} from '../../../../core/server/mocks';
 import { WorkspaceUiSettingsClientWrapper } from './workspace_ui_settings_client_wrapper';
 import {
   WORKSPACE_TYPE,
   CURRENT_WORKSPACE_PLACEHOLDER,
   SavedObjectsErrorHelpers,
+  PackageInfo,
+  UiSettingScope,
 } from '../../../../core/server';
 import {
   DEFAULT_DATA_SOURCE_UI_SETTINGS_ID,
@@ -19,6 +26,9 @@ import * as utils from '../../../../core/server/utils';
 
 jest.mock('../../../../core/server/utils');
 
+const WORKSPACE_SCOPE_SETTING_WITHOUT_VALUE_ID = 'workspace_scope_setting_without_value';
+const GLOBAL_SCOPE_SETTING_ID = 'global_scope_setting';
+
 describe('WorkspaceUiSettingsClientWrapper', () => {
   const createWrappedClient = () => {
     const clientMock = savedObjectsClientMock.create();
@@ -26,6 +36,24 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
     const requestHandlerContext = coreMock.createRequestHandlerContext();
     const requestMock = httpServerMock.createOpenSearchDashboardsRequest();
     const logger = loggerMock.create();
+    const uiSettingsMock = coreMock.createStart().uiSettings;
+    const uiSettingsClientMock = uiSettingsServiceMock.createClient();
+    uiSettingsMock.asScopedToClient.mockReturnValue(uiSettingsClientMock);
+    const pluginInitializerContext = coreMock.createPluginInitializerContext();
+    (pluginInitializerContext.env.packageInfo as PackageInfo).version = '3.0.0';
+
+    uiSettingsClientMock.getRegistered.mockReturnValue({
+      [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: {
+        scope: [UiSettingScope.GLOBAL, UiSettingScope.WORKSPACE],
+      },
+      [DEFAULT_INDEX_PATTERN_UI_SETTINGS_ID]: {
+        scope: UiSettingScope.WORKSPACE,
+      },
+      [WORKSPACE_SCOPE_SETTING_WITHOUT_VALUE_ID]: {
+        scope: UiSettingScope.WORKSPACE,
+      },
+      [GLOBAL_SCOPE_SETTING_ID]: {},
+    });
 
     clientMock.get.mockImplementation(async (type, id) => {
       if (type === 'config') {
@@ -55,8 +83,20 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
       return Promise.reject();
     });
 
-    const wrapper = new WorkspaceUiSettingsClientWrapper(logger);
+    clientMock.update.mockResolvedValue({
+      id: '3.0.0',
+      references: [],
+      type: 'config',
+      attributes: {
+        defaultDashboard: 'default-dashboard-global',
+        [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: 'default-ds-global',
+        [DEFAULT_INDEX_PATTERN_UI_SETTINGS_ID]: 'default-index-global',
+      },
+    });
+
+    const wrapper = new WorkspaceUiSettingsClientWrapper(logger, pluginInitializerContext.env);
     wrapper.setScopedClient(getClientMock);
+    wrapper.setAsScopedUISettingsClient(uiSettingsMock.asScopedToClient);
 
     return {
       wrappedClient: wrapper.wrapperFactory({
@@ -94,14 +134,18 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
 
     const { wrappedClient } = createWrappedClient();
 
-    const result = await wrappedClient.get(`config`, `${CURRENT_WORKSPACE_PLACEHOLDER}_3.0.0`);
-    expect(result).toEqual({
+    const result = await wrappedClient.get<{
+      [key: string]: unknown;
+    }>(`config`, `${CURRENT_WORKSPACE_PLACEHOLDER}_3.0.0`);
+    expect(result).toStrictEqual({
       id: '3.0.0',
       references: [],
       type: 'config',
       attributes: {
         defaultDashboard: 'default-dashboard-workspace',
         [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: 'default-ds-workspace',
+        [DEFAULT_INDEX_PATTERN_UI_SETTINGS_ID]: undefined,
+        [WORKSPACE_SCOPE_SETTING_WITHOUT_VALUE_ID]: undefined,
       },
     });
   });
@@ -182,7 +226,7 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
     expect(error.message).toEqual('Bad Request');
   });
 
-  it('should update global ui settings', async () => {
+  it('should update global ui settings when out of workspace', async () => {
     // Currently NOT in a workspace
     jest.spyOn(utils, 'getWorkspaceState').mockReturnValue({});
 
@@ -197,6 +241,30 @@ describe('WorkspaceUiSettingsClientWrapper', () => {
         defaultDashboard: 'new-dashboard-id',
       },
       {}
+    );
+  });
+
+  it('should update workspace settings when inside workspace and config id equals global setting', async () => {
+    jest.spyOn(utils, 'getWorkspaceState').mockReturnValue({ requestWorkspaceId: 'workspace-id' });
+
+    const { wrappedClient, clientMock, logger } = createWrappedClient();
+
+    await wrappedClient.update('config', '3.0.0', {
+      [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: 'data_source_id',
+    });
+
+    expect(clientMock.update).toHaveBeenCalledWith(
+      WORKSPACE_TYPE,
+      'workspace-id',
+      {
+        uiSettings: expect.objectContaining({
+          [DEFAULT_DATA_SOURCE_UI_SETTINGS_ID]: 'data_source_id',
+        }),
+      },
+      {}
+    );
+    expect(logger.warn).toBeCalledWith(
+      'Deprecation warning: updating workspace settings through global scope will no longer be supported.'
     );
   });
 });

--- a/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts
@@ -17,6 +17,10 @@ import {
   SavedObjectsClientContract,
   SavedObjectsErrorHelpers,
   CURRENT_WORKSPACE_PLACEHOLDER,
+  PluginInitializerContext,
+  UiSettingsServiceStart,
+  IUiSettingsClient,
+  UiSettingScope,
 } from '../../../../core/server';
 import { WORKSPACE_UI_SETTINGS_CLIENT_WRAPPER_ID } from '../../common/constants';
 import { Logger } from '../../../../core/server';
@@ -26,8 +30,12 @@ import { Logger } from '../../../../core/server';
  * the context of the current workspace.
  */
 export class WorkspaceUiSettingsClientWrapper {
-  constructor(private readonly logger: Logger) {}
+  constructor(
+    private readonly logger: Logger,
+    private readonly env: PluginInitializerContext['env']
+  ) {}
   private getScopedClient?: SavedObjectsServiceStart['getScopedClient'];
+  private asScopedUISettingsClient?: UiSettingsServiceStart['asScopedToClient'];
 
   /**
    * WORKSPACE_TYPE is a hidden type, regular saved object client won't return hidden types.
@@ -41,8 +49,16 @@ export class WorkspaceUiSettingsClientWrapper {
     }) as SavedObjectsClientContract;
   }
 
+  private getUISettingsClient(savedObjectClient: SavedObjectsClientContract) {
+    return this.asScopedUISettingsClient?.(savedObjectClient) as IUiSettingsClient;
+  }
+
   public setScopedClient(getScopedClient: SavedObjectsServiceStart['getScopedClient']) {
     this.getScopedClient = getScopedClient;
+  }
+
+  public setAsScopedUISettingsClient(asScopedToClient: UiSettingsServiceStart['asScopedToClient']) {
+    this.asScopedUISettingsClient = asScopedToClient;
   }
 
   public wrapperFactory: SavedObjectsClientWrapperFactory = (wrapperOptions) => {
@@ -73,16 +89,35 @@ export class WorkspaceUiSettingsClientWrapper {
         );
 
         let workspaceObject: SavedObject<WorkspaceAttribute> | null = null;
+        const workspaceTypeEnabledClient = this.getWorkspaceTypeEnabledClient(
+          wrapperOptions.request
+        );
 
         try {
-          workspaceObject = await this.getWorkspaceTypeEnabledClient(wrapperOptions.request).get<
-            WorkspaceAttribute
-          >(WORKSPACE_TYPE, requestWorkspaceId);
+          workspaceObject = await workspaceTypeEnabledClient.get<WorkspaceAttribute>(
+            WORKSPACE_TYPE,
+            requestWorkspaceId
+          );
         } catch (e) {
           this.logger.error(`Unable to get workspaceObject with id: ${requestWorkspaceId}`);
         }
 
-        configObject.attributes = workspaceObject?.attributes?.uiSettings || {};
+        const UISettingsClient = this.getUISettingsClient(workspaceTypeEnabledClient);
+        const registeredConfigs = UISettingsClient.getRegistered();
+        const workspaceScopeKeys = Object.entries(registeredConfigs)
+          .filter(([, config]) =>
+            Array<UiSettingScope>()
+              .concat(config.scope || [])
+              .includes(UiSettingScope.WORKSPACE)
+          )
+          .map(([key]) => key);
+
+        const workspaceSettings = workspaceObject?.attributes?.uiSettings || {};
+        workspaceScopeKeys.forEach((key) => {
+          workspaceSettings[key] = workspaceSettings[key];
+        });
+
+        configObject.attributes = workspaceSettings;
 
         return configObject as SavedObject<T>;
       }
@@ -97,38 +132,29 @@ export class WorkspaceUiSettingsClientWrapper {
       options: SavedObjectsUpdateOptions = {}
     ): Promise<SavedObjectsUpdateResponse<T>> => {
       const { requestWorkspaceId } = getWorkspaceState(wrapperOptions.request);
-
-      /**
-       * When updating ui settings within a workspace, it will update the workspace ui settings,
-       * the global ui settings will remain unchanged.
-       * Skip updating workspace level setting if the request is updating user level setting specifically or global workspace level setting.
-       */
-      if (type === 'config' && id.startsWith(CURRENT_WORKSPACE_PLACEHOLDER)) {
-        // if not in a workspace and try to update workspace level settings
-        // it should return 400 BadRequestError
-        if (!requestWorkspaceId) {
-          throw SavedObjectsErrorHelpers.createBadRequestError();
-        }
-
+      const updateWorkspaceSettings = async (
+        configDocId: string,
+        workspaceId: string,
+        workspaceAttributes: Partial<T>
+      ) => {
         const savedObjectsClient = this.getWorkspaceTypeEnabledClient(wrapperOptions.request);
-        const normalizeDocId = id.replace(`${CURRENT_WORKSPACE_PLACEHOLDER}_`, '');
         const configObject = await wrapperOptions.client.get<Record<string, any>>(
           'config',
-          normalizeDocId,
+          configDocId,
           options
         );
 
         const workspaceObject = await savedObjectsClient.get<WorkspaceAttribute>(
           WORKSPACE_TYPE,
-          requestWorkspaceId
+          workspaceId
         );
 
         const workspaceUpdateResult = await savedObjectsClient.update<WorkspaceAttribute>(
           WORKSPACE_TYPE,
-          requestWorkspaceId,
+          workspaceId,
           {
             ...workspaceObject.attributes,
-            uiSettings: { ...workspaceObject.attributes.uiSettings, ...attributes },
+            uiSettings: { ...workspaceObject.attributes.uiSettings, ...workspaceAttributes },
           },
           options
         );
@@ -136,6 +162,32 @@ export class WorkspaceUiSettingsClientWrapper {
         configObject.attributes = workspaceUpdateResult.attributes.uiSettings || {};
 
         return configObject as SavedObjectsUpdateResponse<T>;
+      };
+
+      /**
+       * When updating ui settings within a workspace, it will update the workspace ui settings,
+       * the global ui settings will remain unchanged.
+       * Skip updating workspace level setting if the request is updating user level setting specifically or global workspace level setting.
+       */
+      if (type === 'config') {
+        if (id.startsWith(CURRENT_WORKSPACE_PLACEHOLDER)) {
+          // if not in a workspace and try to update workspace level settings
+          // it should return 400 BadRequestError
+          if (!requestWorkspaceId) {
+            throw SavedObjectsErrorHelpers.createBadRequestError();
+          }
+
+          const normalizeDocId = id.replace(`${CURRENT_WORKSPACE_PLACEHOLDER}_`, '');
+
+          return updateWorkspaceSettings(normalizeDocId, requestWorkspaceId, attributes);
+        } else if (requestWorkspaceId && id === this.env.packageInfo.version) {
+          // The code below maintains backward compatibility for UI setting updates in version 3.0.0.
+          // Remove if no external code is modifying these settings through the global scope.
+          this.logger.warn(
+            'Deprecation warning: updating workspace settings through global scope will no longer be supported.'
+          );
+          return updateWorkspaceSettings(id, requestWorkspaceId, attributes);
+        }
       }
       return wrapperOptions.client.update(type, id, attributes, options);
     };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Previously we merged https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726 but actually the PR introduced a breaking change for uiSettingClient, as well as the router: `/api/opensearch-dashboards/settings`.

This PR is trying to make the change backward compatible but also add a deprecation warning log to tell developers the incorrect call will be deprecated in next major release.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
Only backend changes introduced.

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Update yml file
```yml
data_source.enabled: true
workspace.enabled: true
```
in opensearch_dashboards.yml file as for now only defaultDataSource is the config that has multiple scopes.
- `yarn start --no-base-path` to start OSD server
- Try to update defaultDataSource through curl
```bash
curl 'http://localhost:5601/api/opensearch-dashboards/settings' \
  -H 'Accept-Language: en,zh-CN;q=0.9,zh;q=0.8' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:5601' \
  -H 'Pragma: no-cache' \
  -H 'Referer: http://localhost:5601/app/dataSources/e6b1fc40-cc0d-11ef-93d3-994d1302c8c5' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36' \
  -H 'accept: application/json' \
  -H 'osd-version: 3.1.0' \
  -H 'osd-xsrf: osd-fetch' \
  -H 'sec-ch-ua: "Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw '{"changes":{"defaultDataSource":"foo"}}'
```
- The global default data source should be updated with the value, and you will find a deprecation warning in your server log.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: keep backward compatibility for UI setting client

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
