### PR TITLE
[Improvement] Add two integration tests for workspace=*

### DIFF
--- a/src/plugins/workspace/server/saved_objects/integration_tests/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/integration_tests/workspace_id_consumer_wrapper.test.ts
@@ -54,6 +54,7 @@ describe('workspace_id_consumer integration test', () => {
           migrations: {
             skip: false,
           },
+          data_source: { enabled: true },
         },
       },
     });
@@ -108,6 +109,22 @@ describe('workspace_id_consumer integration test', () => {
     await deleteItem({
       type: dashboard.type,
       id: 'bar',
+    });
+  };
+
+  const createDataSource = async (dataSourceTitle: string) => {
+    return await osdTestServer.request.post(root, `/api/saved_objects/data-source`).send({
+      attributes: {
+        title: dataSourceTitle,
+        description: '',
+        endpoint: 'http://localhost:9201',
+        auth: {
+          type: 'no_auth',
+        },
+        dataSourceVersion: '',
+        dataSourceEngineType: 'opensearch',
+        installedPlugins: [],
+      },
     });
   };
 
@@ -363,6 +380,55 @@ describe('workspace_id_consumer integration test', () => {
       await deleteItem({
         type: dashboard.type,
         id: 'foo',
+      });
+    });
+
+    it('should return all data source when find with * within a workspace', async () => {
+      // Create a data source with workspace context
+      const createResult1 = await createDataSource('ds1');
+      const createResult2 = await createDataSource('ds2');
+      const withOutWorkspaceDSId = createResult1.body.id;
+      const withWorkspaceDSId = createResult2.body.id;
+
+      await osdTestServer.request
+        .post(root, `/w/${createdFooWorkspace.id}/api/workspaces/_associate`)
+        .send({
+          savedObjects: [
+            {
+              id: withWorkspaceDSId,
+              type: 'data-source',
+            },
+          ],
+          workspaceId: createdFooWorkspace.id,
+        })
+        .expect(200);
+
+      // Find all data sources with wildcard workspace
+      const findResult = await osdTestServer.request
+        .get(
+          root,
+          `/w/${createdFooWorkspace.id}/api/saved_objects/_find?type=data-source&workspaces=*`
+        )
+        .expect(200);
+
+      // Verify the data source is returned
+      expect(findResult.body.total).toEqual(2);
+
+      const datasourceIdSet = new Set(
+        findResult.body.saved_objects.map((obj: SavedObject) => obj.id)
+      );
+
+      expect(datasourceIdSet.has(withOutWorkspaceDSId)).toBe(true);
+      expect(datasourceIdSet.has(withWorkspaceDSId)).toBe(true);
+
+      // Clean up
+      await deleteItem({
+        type: 'data-source',
+        id: withOutWorkspaceDSId,
+      });
+      await deleteItem({
+        type: 'data-source',
+        id: withWorkspaceDSId,
       });
     });
 


### PR DESCRIPTION
### Description
Add two integration tests for workspace=*
 - should return all data source when find with * within a workspace
 - should return all data source when find with * out a workspace

```
 PASS  src/plugins/workspace/server/saved_objects/integration_tests/workspace_id_consumer_wrapper.test.ts (74.028 s)
  workspace_id_consumer integration test
    saved objects client related CRUD
      ✓ create (2102 ms)
      ✓ create should not append requestWorkspaceId automatically when the type is config (2096 ms)
      ✓ should return error when create with a not existing workspace (2104 ms)
      ✓ bulk create (4191 ms)
      ✓ should return error when bulk create with a not existing workspace (2076 ms)
      ✓ checkConflicts when importing ndjson (5202 ms)
      ✓ find by workspaces (3172 ms)
      ✓ should not return 400 error when find with * (2074 ms)
      ✓ should return all data source when find with * within a workspace (5255 ms)
      ✓ should return all data source when find with * out a workspace (4179 ms)
      ✓ should return error when find with a not existing workspace (6 ms)
      ✓ import within workspace (3132 ms)
      ✓ get (8414 ms)
      ✓ bulk get (5325 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   1 passed, 1 total
Time:        74.781 s
```

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
