### PR TITLE
docs: Update maintainer responsibilies on merging

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 ## Overview
 
-This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+This document contains a list of maintainers in this repo. See [Responsibilities](#responsibilities) for more information about the maintainer role. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Maintainers
 
@@ -47,3 +47,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sean Neumann  | [seanneumann](https://github.com/seanneumann) | Contributor |
 | Kristen Tian  | [kristenTian](https://github.com/kristenTian) | Amazon      |
 | Matt Provost  | [BSFishy](https://github.com/BSFishy)         | Amazon      |
+
+## Responsibilities
+
+See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it.
+
+In addition to the standard responsibilities above, this respository also requires:
+- PRs should not be merged unless all CI passes. If a CI failure must be overridden, please add a comment articulating why with the logins of two supporting maintainers (who are not the PR author).

--- a/changelogs/fragments/9863.yml
+++ b/changelogs/fragments/9863.yml
@@ -1,0 +1,2 @@
+doc:
+- Update maintainer merging responsibilities ([#9863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9863))


### PR DESCRIPTION
### Description

Updates documentation to call out that maintainers should ensure CI passes for merging and to validate with other maintainers if they need to override.

Please let me know if there's a better place to add this to docs.

### Issues Resolved

N/A

## Screenshot

N/A

## Testing the changes

N/A

## Changelog
- doc: Update maintainer merging responsibilities 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
