### PR TITLE
Add dependabot workflow to monitor and upgrade outdated dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: /
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependabot"
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description

Taken from https://github.com/opensearch-project/opensearch-js/pull/905, this PR adds a dependabot workflow that runs weekly to automatically update any outdated dependencies in the package.json file

**Note**: This only monitors the root package.json file. This should be extended in another PR to monitor all of the packages in the `packages` folder.

### Issues Resolved

Related to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3008

## Changelog

chore: Add dependabot workflow to automatically monitor and upgrade outdated dependencies

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
