### PR TITLE
feat: make default index pattern method more robust

### DIFF
--- a/changelogs/fragments/9867.yml
+++ b/changelogs/fragments/9867.yml
@@ -1,0 +1,2 @@
+feat:
+- Make default index pattern method more robust ([#9867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9867))

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
@@ -5,32 +5,38 @@
 
 import { createEnsureDefaultIndexPattern } from './ensure_default_index_pattern';
 import { IndexPatternsContract } from './index_patterns';
-import { UiSettingsCommon, SavedObjectsClientCommon } from '../types';
+import { UiSettingsCommon, SavedObjectsClientCommon, SavedObject } from '../types';
+import { IndexPattern } from './index_pattern';
 
 describe('ensureDefaultIndexPattern', () => {
-  let uiSettings: UiSettingsCommon;
+  let uiSettings: jest.Mocked<UiSettingsCommon>;
   let onRedirectNoIndexPattern: jest.Mock;
-  let savedObjectsClient: SavedObjectsClientCommon;
-  let indexPatterns: IndexPatternsContract;
+  let savedObjectsClient: jest.Mocked<SavedObjectsClientCommon>;
+  let indexPatterns: jest.Mocked<IndexPatternsContract>;
   let ensureDefaultIndexPattern: () => Promise<unknown | void> | undefined;
 
   beforeEach(() => {
-    uiSettings = ({
+    uiSettings = {
       get: jest.fn(),
       set: jest.fn(),
+      getAll: jest.fn(),
       remove: jest.fn(),
-    } as unknown) as UiSettingsCommon;
+    };
 
     onRedirectNoIndexPattern = jest.fn();
-    savedObjectsClient = ({
+    savedObjectsClient = {
       find: jest.fn(),
-    } as unknown) as SavedObjectsClientCommon;
+      get: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
 
     indexPatterns = ({
       getIds: jest.fn(),
       get: jest.fn(),
       getDataSource: jest.fn(),
-    } as unknown) as IndexPatternsContract;
+    } as unknown) as jest.Mocked<IndexPatternsContract>;
   });
 
   test('should return early if canUpdateUiSetting is false', async () => {
@@ -54,8 +60,8 @@ describe('ensureDefaultIndexPattern', () => {
       savedObjectsClient
     );
 
-    (indexPatterns.getIds as jest.Mock).mockResolvedValue(['pattern1']);
-    (uiSettings.get as jest.Mock).mockImplementation((key) => {
+    indexPatterns.getIds.mockResolvedValue(['pattern1']);
+    uiSettings.get.mockImplementation(async (key) => {
       if (key === 'defaultIndex') return 'invalid-pattern';
       return false;
     });
@@ -255,5 +261,83 @@ describe('ensureDefaultIndexPattern', () => {
 
     await ensureDefaultIndexPattern.call(indexPatterns);
     expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+  });
+
+  test("should handle index patterns without throwing error when data sources reference's id is empty", async () => {
+    ensureDefaultIndexPattern = createEnsureDefaultIndexPattern(
+      uiSettings,
+      onRedirectNoIndexPattern,
+      true,
+      savedObjectsClient
+    );
+
+    const defaultId = 'pattern1';
+    indexPatterns.getIds.mockResolvedValue([defaultId]);
+    uiSettings.get.mockResolvedValue(defaultId);
+    indexPatterns.get.mockResolvedValue({
+      dataSourceRef: { id: '', type: 'data-source' },
+    } as IndexPattern);
+    indexPatterns.getDataSource.mockResolvedValue({
+      id: '',
+      type: '',
+      attributes: {
+        title: '',
+        endpoint: '',
+        dataSourceVersion: '',
+        auth: {
+          type: '',
+          credentials: undefined,
+        },
+      },
+      references: [],
+      error: { statusCode: 403, error: '', message: '' },
+    });
+
+    savedObjectsClient.find.mockImplementation(async (params) => {
+      if (params.type === 'data-source') {
+        return Promise.resolve([{ id: 'ds2' }] as Array<SavedObject<unknown>>);
+      }
+      if (params.type === 'index-pattern') {
+        return Promise.resolve([
+          {
+            id: 'pattern1',
+            references: [],
+          },
+          {
+            id: 'pattern2',
+            references: [{ id: 'ds3' }],
+          },
+        ] as Array<SavedObject<unknown>>);
+      }
+
+      return [] as Array<SavedObject<unknown>>;
+    });
+
+    await ensureDefaultIndexPattern.call(indexPatterns);
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
+    uiSettings.set.mockClear();
+
+    savedObjectsClient.find.mockImplementation(async (params) => {
+      if (params.type === 'data-source') {
+        return Promise.resolve([{ id: 'ds2' }] as Array<SavedObject<unknown>>);
+      }
+      if (params.type === 'index-pattern') {
+        return Promise.resolve([
+          {
+            id: 'pattern1',
+            references: [{ id: '', type: 'data-source' }],
+          },
+          {
+            id: 'pattern2',
+            references: [{ id: 'ds3' }],
+          },
+        ] as Array<SavedObject<unknown>>);
+      }
+
+      return [] as Array<SavedObject<unknown>>;
+    });
+
+    await ensureDefaultIndexPattern.call(indexPatterns);
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
   });
 });

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
@@ -340,4 +340,20 @@ describe('ensureDefaultIndexPattern', () => {
     await ensureDefaultIndexPattern.call(indexPatterns);
     expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
   });
+
+  test('should not throw error when getDataSource throws error', async () => {
+    ensureDefaultIndexPattern = createEnsureDefaultIndexPattern(
+      uiSettings,
+      onRedirectNoIndexPattern,
+      true,
+      savedObjectsClient
+    );
+
+    indexPatterns.getIds.mockResolvedValue(['pattern1']);
+    indexPatterns.get.mockRejectedValue(new Error('Failed to get index pattern'));
+
+    await expect(
+      async () => await ensureDefaultIndexPattern.call(indexPatterns)
+    ).not.toThrowError();
+  });
 });

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
@@ -349,8 +349,12 @@ describe('ensureDefaultIndexPattern', () => {
       savedObjectsClient
     );
 
+    uiSettings.get.mockResolvedValue('pattern1');
+    indexPatterns.get.mockResolvedValue({
+      dataSourceRef: { id: 'datasource1', type: 'data-source' },
+    } as IndexPattern);
     indexPatterns.getIds.mockResolvedValue(['pattern1']);
-    indexPatterns.get.mockRejectedValue(new Error('Failed to get index pattern'));
+    indexPatterns.getDataSource.mockRejectedValue(new Error('Failed to get data source'));
 
     await expect(
       async () => await ensureDefaultIndexPattern.call(indexPatterns)

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.test.ts
@@ -339,6 +339,26 @@ describe('ensureDefaultIndexPattern', () => {
 
     await ensureDefaultIndexPattern.call(indexPatterns);
     expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern2');
+    uiSettings.set.mockClear();
+
+    savedObjectsClient.find.mockImplementation(async (params) => {
+      if (params.type === 'data-source') {
+        return Promise.resolve([{ id: 'ds2' }] as Array<SavedObject<unknown>>);
+      }
+      if (params.type === 'index-pattern') {
+        return Promise.resolve([
+          {
+            id: 'pattern1',
+            references: [{ id: 'ds2', type: 'data-source' }],
+          },
+        ] as Array<SavedObject<unknown>>);
+      }
+
+      return [] as Array<SavedObject<unknown>>;
+    });
+
+    await ensureDefaultIndexPattern.call(indexPatterns);
+    expect(uiSettings.set).toHaveBeenCalledWith('defaultIndex', 'pattern1');
   });
 
   test('should not throw error when getDataSource throws error', async () => {

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -92,9 +92,9 @@ export const createEnsureDefaultIndexPattern = (
               const sourceRef = item.references?.find((ref) => ref.type === 'data-source');
               let isDataSourceReferenceValid = false;
               /**
-               * the reference will be valid only when:
-               * 1. no data source reference(local cluster)
-               * 2. data source reference exists with a valid data source id
+               * The reference is valid when either:
+               * 1. No data source is referenced (using local cluster, which must be available for OpenSearch Dashboards to function)
+               * 2. A data source is referenced with a valid ID
                */
               if (!sourceRef) {
                 isDataSourceReferenceValid = true;

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -75,6 +75,8 @@ export const createEnsureDefaultIndexPattern = (
             result.error?.statusCode === 403 || result.error?.statusCode === 404
           );
         } catch (e) {
+          // The logic below for updating the default index pattern only handles cases where the data source is not found or the user lacks access permissions
+          // For other unexpected errors, we simply return to prevent infinite loops when updating the default index pattern.
           return;
         }
       }

--- a/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/ensure_default_index_pattern.ts
@@ -93,8 +93,8 @@ export const createEnsureDefaultIndexPattern = (
               let isDataSourceReferenceValid = false;
               /**
                * the reference will be valid only when:
-               * 1. no data source reference
-               * 2. data source reference exists and with a valid data source id
+               * 1. no data source reference(local cluster)
+               * 2. data source reference exists with a valid data source id
                */
               if (!sourceRef) {
                 isDataSourceReferenceValid = true;


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
The ensureDefaultIndexPattern will throw error when data source reference id is '', this PR is to enhance the method so that:
- It can correctly solve the edge case and won't throw error.
- It should update default index pattern if the reference data source's id is empty.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

### Before the fix
<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
![image](https://github.com/user-attachments/assets/940a9a09-0b6b-4c24-82c7-d6eb33df527d)

### After the fix

![image](https://github.com/user-attachments/assets/345f15ee-365a-4ab7-aae0-724350af3b75)

Able to render dashboard page, and the error will be gone once user has a valid index pattern.

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: make default index pattern method more robust

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
