### PR TITLE
[Explore] Banner in query explore

### DIFF
--- a/src/plugins/explore/public/application/app.scss
+++ b/src/plugins/explore/public/application/app.scss
@@ -85,6 +85,11 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
     top: 0;
     right: 0;
   }
+
+  &__experienceBannerWrapper {
+    margin-bottom: $euiSizeS;
+    margin-top: $euiSizeS;
+  }
 }
 
 // TopNav styles for the Discover

--- a/src/plugins/explore/public/application/app.tsx
+++ b/src/plugins/explore/public/application/app.tsx
@@ -36,6 +36,7 @@ import { useTimefilterSubscription } from './utils/hooks/use_timefilter_subscrip
 import { ExploreDataTable } from '../components/data_table/explore_data_table';
 import { ExploreTabs } from '../components/tabs/tabs';
 import { useHeaderVariants } from './utils/hooks/use_header_variants';
+import { NewExperienceBanner } from '../components/experience_banners/new_experience_banner';
 
 /**
  * Main application component for the Explore plugin
@@ -148,6 +149,10 @@ export const ExploreApp: React.FC<{ setHeaderActionMenu?: (menuMount: any) => vo
 
             {/* HeaderDatasetSelector component - renders dataset selector in portal */}
             <HeaderDatasetSelector datasetSelectorRef={datasetSelectorRef} />
+
+            <div className="dscCanvas__experienceBannerWrapper">
+              <NewExperienceBanner />
+            </div>
 
             {/* QueryPanel component */}
             <div className="dscCanvas__queryPanel">

--- a/src/plugins/explore/public/components/experience_banners/experience_banner_wrapper/experience_banner_wrapper.test.tsx
+++ b/src/plugins/explore/public/components/experience_banners/experience_banner_wrapper/experience_banner_wrapper.test.tsx
@@ -32,11 +32,12 @@ describe('ExperienceBannerWrapper', () => {
     expect(screen.queryByTestId('exploreNewExperienceBanner')).not.toBeInTheDocument();
   });
 
-  it('should render new banner if !showClassicExperienceBanner', async () => {
+  it('should render nothing if !showClassicExperienceBanner', async () => {
     render(
       <ExperienceBannerWrapper initializeBannerWrapper={mockInitializeBannerWrapperToFalse} />
     );
-    expect(await screen.findByTestId('exploreNewExperienceBanner')).toBeInTheDocument();
+    expect(screen.queryByTestId('exploreClassicExperienceBanner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('exploreNewExperienceBanner')).not.toBeInTheDocument();
   });
 
   it('should render classic banner if showClassicExperienceBanner', async () => {

--- a/src/plugins/explore/public/components/experience_banners/experience_banner_wrapper/experience_banner_wrapper.tsx
+++ b/src/plugins/explore/public/components/experience_banners/experience_banner_wrapper/experience_banner_wrapper.tsx
@@ -5,7 +5,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { ClassicExperienceBanner } from '../classic_experience_banner';
-import { NewExperienceBanner } from '../new_experience_banner';
 
 export const ExperienceBannerWrapper = ({
   initializeBannerWrapper,
@@ -15,30 +14,26 @@ export const ExperienceBannerWrapper = ({
     navigateToExplore: () => void;
   }>;
 }) => {
-  const [isMounted, setIsMounted] = useState<boolean>(false);
-  const [handleSwitchToExplore, setHandleSwitchToExplore] = useState<(() => void) | null>(null);
-  const [showClassic, setShowClassic] = useState<boolean>(false);
+  const [state, setState] = useState<{
+    showBanner: boolean;
+    handleSwitchToExplore: () => void;
+  } | null>(null);
 
   useEffect(() => {
     const callInitializeBannerWrapper = async () => {
       const { showClassicExperienceBanner, navigateToExplore } = await initializeBannerWrapper();
-      setHandleSwitchToExplore(() => navigateToExplore);
-      setShowClassic(showClassicExperienceBanner);
-      setIsMounted(true);
+      setState({
+        showBanner: showClassicExperienceBanner,
+        handleSwitchToExplore: navigateToExplore,
+      });
     };
 
     callInitializeBannerWrapper();
   }, [initializeBannerWrapper]);
 
-  if (!isMounted) {
+  if (!state || !state.showBanner) {
     return null;
   }
 
-  // there is no reason for !!handleSwitchToExplore to be false here, but in case it is, then
-  // we will not show the banner
-  return !!handleSwitchToExplore && showClassic ? (
-    <ClassicExperienceBanner navigateToExplore={handleSwitchToExplore} />
-  ) : (
-    <NewExperienceBanner />
-  );
+  return <ClassicExperienceBanner navigateToExplore={state.handleSwitchToExplore} />;
 };


### PR DESCRIPTION
### Description

- This change adds the banner into the new architecture in explore
- Previously, we leveraged the Data Plugin's Query Editor to inject the banner there. Since the new explore does not use that editor, that is no longer applicable in the new experience.
- So i manually add the banner in the new experience while refactoring the previous code to only show banner within data plugin's query editor for the classic experience

## Screenshot


<img width="1483" alt="Screenshot 2025-06-11 at 2 07 37 PM" src="https://github.com/user-attachments/assets/92207043-8771-43da-ba2b-800933ba4d2f" />

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
