### PR TITLE
ignore iso.org for linkchecker due to its flakiness

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -101,3 +101,4 @@ http://dev.w3.org/
 https://qntm.org/cmd
 http://fakenews.co/
 http://blond-winner.biz/
+https://www.iso.org/*


### PR DESCRIPTION
### Description

- LinkChecker CI has been failing pretty sporadically for ISO websites. Ex: https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/15573200573/job/43853185494?pr=9830

- You can manually go to those ISO websites usually, but it is very slow and sometimes it fails. I think that is the reason

- To not block CI for these links, this PR adds them to lycheeignore

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
