### PR TITLE
Skip failing selenium test "should show Percentiles"

### DIFF
--- a/test/functional/apps/visualize/_metric_chart.js
+++ b/test/functional/apps/visualize/_metric_chart.js
@@ -145,7 +145,8 @@ export default function ({ getService, getPageObjects }) {
       });
     });
 
-    it('should show Percentiles', async function () {
+    // TODO: Investigate why this is failing: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9878
+    it.skip('should show Percentiles', async function () {
       const percentileMachineRam = [
         '2,147,483,648',
         '1st percentile of machine.ram',


### PR DESCRIPTION
### Description

- skips the failing test and created an issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9878

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
