### PR TITLE
feat(docs): ensure `.md` files are git tracked when generating sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ snapshots.js
 # Ignore the lighthousereport generatated
 .lighthouserc.js
 .lhci_output.json
+/.lighthouseci/


### PR DESCRIPTION
### Description

This PR makes the sidebar docs generation to ignore markdown files that are not git tracked. Additionally it ignores lighthouse reports in `/.lighthouseci/` directory.

### Issues Resolved

I might have local markdown files that are not tracked by git, it won't make sense to put those in [docs/_sidebar](https://github.com/opensearch-project/opensearch-dashboards/blob/main/docs/_sidebar.md).

The sidebar generation only includes `.md` and it does not pick up `.MD`, `.markdown`, `.MARKDOWN`, etc. This is existing behavior.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
