### PR TITLE
making 3.1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [3.1.0-2025-06-13](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.1.0)
+
+### 💥 Breaking Changes
+
+### Deprecations
+
+### 🛡 Security
+
+ - [CVE-2024-47764] Remove `cookie@0.4.1` as a nested dependency ([#9838](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9838))
+
+### 📈 Features/Enhancements
+
+ - Add a new Data Importer Plugin to OSD Core ([#9602](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9602))
+ - Ui action supports `isDisabled` and `getTooltip` ([#9696](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9696))
+ - Adding back storybook ([#9697](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9697))
+ - Update default index pattern logic ([#9703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9703))
+ - Support new OpenSearch type match_only_text ([#9707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9707))
+ - Add new Explore plugin ([#9724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9724))
+ - Support multiple-scopes ui settings ([#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726))
+ - Add resource API pattern in query_enhancements ([#9770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9770))
+ - Support explore only in the observability workspace type ([#9773](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9773))
+ - Remove theme update modal ([#9776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9776))
+ - Add new state management base implementations and hooks ([#9777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9777))
+ - Add permission control for admin UI settings ([#9795](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9795))
+ - Duplicate discover and data-explorer into explore plugin ([#9798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9798))
+ - Saved explore type in explore plugin ([#9809](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9809))
+ - [Feature][Integration] Vended Dashboards Synchronization #9816 ([#9816](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9816))
+ - Deprecate showInAllNavGroup property ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))
+ - Register search overview page to all use case by using addNavLinksToGroup ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))
+ - Add a permission controlled admin UI setting for enable/disable AI features in OSD ([#9824](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9824))
+ - Auto visualization for explore ([#9834](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9834))
+ - Add new experience banners for explore for both new and classic ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
+ - Update data plugin's __enhance type to include promises ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
+ - Add tabs in explore, introduce logs tab ([#9849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9849))
+ - Make default index pattern method more robust ([#9867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9867))
+
+### 🐛 Bug Fixes
+
+ - Remove * when calling find in data source association modal and in workspace list page ([#9409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9409))
+ - Should clear previous query if input invalid questions ([#9605](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9605))
+ - Initial result summary generated with the wrong data ([#9611](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9611))
+ - Fix a issue that can cause incorrect query to fire when switch plugin ([#9625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9625))
+ - Data source opensearch client honors the timeout settings in yaml file ([#9651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9651))
+ - Support left navigation search for OSD with workspace plugin disabled ([#9662](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9662))
+ - Fix Branding test urls ([#9694](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9694))
+ - Fix user appearance not working ([#9700](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9700))
+ - Cancel existing query when new natural language prompt is being generated-new ([#9701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9701))
+ - Fix SigV4 signing mismatch issue with ?v query parameter ([#9730](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9730))
+ - Fix collaborators displays under custom tab on navigation when saved object permission is disabled ([#9734](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9734))
+ - Chatbot flyout cannot be resized beyond the window size ([#9735](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9735))
+ - Performance script ([#9738](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9738))
+ - Path alias not properly resolved if the source code was copied and built from another directory ([#9784](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9784))
+ - [Explore] rename Explore nav item to Discover ([#9813](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9813))
+ - Content and Card are mistakenly placed under the create visualization dropdown menu ([#9815](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9815))
+ - UI setting will give error if a specific setting is not defined. ([#9820](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9820))
+ - Revert workspaces=* and add warning log ([#9848](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9848))
+ - Adds the displaying of unknown fields back to Discover ([#9856](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9856))
+ - Update @testing-library/user-event version ([#9857](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9857))
+ - Fix update button issue in DateTimeRange picker ([#9875](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9875))
+
+### 🚞 Infrastructure
+
+### 📝 Documentation
+
+ - Update maintainer merging responsibilities ([#9863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9863))
+
+### 🛠 Maintenance
+
+ - Bump version to 3.1.0 ([#9789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9789))
+ - Add package resolutions to fix braces CVE-2024-4068 ([#9846](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9846))
+
+### 🪛 Refactoring
+
+ - Extract path alias babel config to a reusable function ([#9831](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9831))
+
+### 🔩 Tests
+
 ## [3.0.0-2025-05-05](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.0.0)
 
 ### 💥 Breaking Changes

--- a/changelogs/fragments/9409.yml
+++ b/changelogs/fragments/9409.yml
@@ -1,2 +1,0 @@
-fix:
-- Remove * when calling find in data source association modal and in workspace list page ([#9409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9409))

--- a/changelogs/fragments/9602.yml
+++ b/changelogs/fragments/9602.yml
@@ -1,2 +1,0 @@
-feat:
-- Add a new Data Importer Plugin to OSD Core ([#9602](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9602))

--- a/changelogs/fragments/9605.yml
+++ b/changelogs/fragments/9605.yml
@@ -1,2 +1,0 @@
-fix:
-- Should clear previous query if input invalid questions ([#9605](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9605))

--- a/changelogs/fragments/9611.yml
+++ b/changelogs/fragments/9611.yml
@@ -1,2 +1,0 @@
-fix:
-- Initial result summary generated with the wrong data ([#9611](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9611))

--- a/changelogs/fragments/9625.yml
+++ b/changelogs/fragments/9625.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix a issue that can cause incorrect query to fire when switch plugin ([#9625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9625))

--- a/changelogs/fragments/9651.yml
+++ b/changelogs/fragments/9651.yml
@@ -1,2 +1,0 @@
-fix:
-- Data source opensearch client honors the timeout settings in yaml file ([#9651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9651))

--- a/changelogs/fragments/9662.yml
+++ b/changelogs/fragments/9662.yml
@@ -1,2 +1,0 @@
-fix:
-- Support left navigation search for OSD with workspace plugin disabled ([#9662](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9662))

--- a/changelogs/fragments/9694.yml
+++ b/changelogs/fragments/9694.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix Branding test urls ([#9694](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9694))

--- a/changelogs/fragments/9696.yml
+++ b/changelogs/fragments/9696.yml
@@ -1,2 +1,0 @@
-feat:
-- Ui action supports `isDisabled` and `getTooltip` ([#9696](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9696))

--- a/changelogs/fragments/9697.yml
+++ b/changelogs/fragments/9697.yml
@@ -1,2 +1,0 @@
-feat:
-- Adding back storybook ([#9697](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9697))

--- a/changelogs/fragments/9700.yml
+++ b/changelogs/fragments/9700.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix user appearance not working ([#9700](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9700))

--- a/changelogs/fragments/9701.yml
+++ b/changelogs/fragments/9701.yml
@@ -1,2 +1,0 @@
-fix:
-- Cancel existing query when new natural language prompt is being generated-new ([#9701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9701))

--- a/changelogs/fragments/9703.yml
+++ b/changelogs/fragments/9703.yml
@@ -1,2 +1,0 @@
-feat:
-- Update default index pattern logic ([#9703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9703))

--- a/changelogs/fragments/9707.yml
+++ b/changelogs/fragments/9707.yml
@@ -1,2 +1,0 @@
-feat:
-- Support new OpenSearch type match_only_text ([#9707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9707))

--- a/changelogs/fragments/9724.yml
+++ b/changelogs/fragments/9724.yml
@@ -1,2 +1,0 @@
-feat:
-- Add new Explore plugin ([#9724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9724))

--- a/changelogs/fragments/9726.yml
+++ b/changelogs/fragments/9726.yml
@@ -1,2 +1,0 @@
-feat:
-- Support multiple-scopes ui settings ([#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726))

--- a/changelogs/fragments/9730.yml
+++ b/changelogs/fragments/9730.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix SigV4 signing mismatch issue with ?v query parameter ([#9730](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9730))

--- a/changelogs/fragments/9734.yml
+++ b/changelogs/fragments/9734.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix collaborators displays under custom tab on navigation when saved object permission is disabled ([#9734](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9734))

--- a/changelogs/fragments/9735.yml
+++ b/changelogs/fragments/9735.yml
@@ -1,2 +1,0 @@
-fix:
-- Chatbot flyout cannot be resized beyond the window size ([#9735](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9735))

--- a/changelogs/fragments/9738.yml
+++ b/changelogs/fragments/9738.yml
@@ -1,2 +1,0 @@
-fix:
-- Performance script ([#9738](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9738))

--- a/changelogs/fragments/9770.yml
+++ b/changelogs/fragments/9770.yml
@@ -1,2 +1,0 @@
-feat:
-- Add resource API pattern in query_enhancements ([#9770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9770))

--- a/changelogs/fragments/9773.yml
+++ b/changelogs/fragments/9773.yml
@@ -1,2 +1,0 @@
-feat:
-- Support explore only in the observability workspace type ([#9773](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9773))

--- a/changelogs/fragments/9776.yml
+++ b/changelogs/fragments/9776.yml
@@ -1,2 +1,0 @@
-feat:
-- Remove theme update modal ([#9776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9776))

--- a/changelogs/fragments/9777.yml
+++ b/changelogs/fragments/9777.yml
@@ -1,2 +1,0 @@
-feat:
-- Add new state management base implementations and hooks ([#9777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9777))

--- a/changelogs/fragments/9784.yml
+++ b/changelogs/fragments/9784.yml
@@ -1,2 +1,0 @@
-fix:
-- Path alias not properly resolved if the source code was copied and built from another directory ([#9784](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9784))

--- a/changelogs/fragments/9789.yml
+++ b/changelogs/fragments/9789.yml
@@ -1,2 +1,0 @@
-chore:
-- Bump version to 3.1.0 ([#9789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9789))

--- a/changelogs/fragments/9795.yml
+++ b/changelogs/fragments/9795.yml
@@ -1,2 +1,0 @@
-feat:
-- Add permission control for admin UI settings ([#9795](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9795))

--- a/changelogs/fragments/9798.yml
+++ b/changelogs/fragments/9798.yml
@@ -1,2 +1,0 @@
-feat:
-- Duplicate discover and data-explorer into explore plugin ([#9798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9798))

--- a/changelogs/fragments/9809.yml
+++ b/changelogs/fragments/9809.yml
@@ -1,2 +1,0 @@
-feat:
-- Saved explore type in explore plugin ([#9809](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9809))

--- a/changelogs/fragments/9813.yml
+++ b/changelogs/fragments/9813.yml
@@ -1,2 +1,0 @@
-fix:
-- [Explore] rename Explore nav item to Discover ([#9813](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9813))

--- a/changelogs/fragments/9815.yml
+++ b/changelogs/fragments/9815.yml
@@ -1,2 +1,0 @@
-fix:
-- Content and Card are mistakenly placed under the create visualization dropdown menu ([#9815](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9815))

--- a/changelogs/fragments/9816.yml
+++ b/changelogs/fragments/9816.yml
@@ -1,2 +1,0 @@
-feat:
-- [Feature][Integration] Vended Dashboards Synchronization #9816 ([#9816](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9816))

--- a/changelogs/fragments/9818.yml
+++ b/changelogs/fragments/9818.yml
@@ -1,3 +1,0 @@
-feat:
-- Deprecate showInAllNavGroup property ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))
-- Register search overview page to all use case by using addNavLinksToGroup ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))

--- a/changelogs/fragments/9820.yml
+++ b/changelogs/fragments/9820.yml
@@ -1,2 +1,0 @@
-fix:
-- UI setting will give error if a specific setting is not defined. ([#9820](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9820))

--- a/changelogs/fragments/9824.yml
+++ b/changelogs/fragments/9824.yml
@@ -1,2 +1,0 @@
-feat:
-- Add a permission controlled admin UI setting for enable/disable AI features in OSD ([#9824](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9824))

--- a/changelogs/fragments/9831.yml
+++ b/changelogs/fragments/9831.yml
@@ -1,2 +1,0 @@
-refactor:
-- Extract path alias babel config to a reusable function ([#9831](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9831))

--- a/changelogs/fragments/9834.yml
+++ b/changelogs/fragments/9834.yml
@@ -1,2 +1,0 @@
-feat:
-- Auto visualization for explore ([#9834](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9834))

--- a/changelogs/fragments/9838.yml
+++ b/changelogs/fragments/9838.yml
@@ -1,2 +1,0 @@
-security:
-- [CVE-2024-47764] Remove `cookie@0.4.1` as a nested dependency ([#9838](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9838))

--- a/changelogs/fragments/9842.yml
+++ b/changelogs/fragments/9842.yml
@@ -1,3 +1,0 @@
-feat:
-- Add new experience banners for explore for both new and classic ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
-- Update data plugin's __enhance type to include promises ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))

--- a/changelogs/fragments/9846.yml
+++ b/changelogs/fragments/9846.yml
@@ -1,2 +1,0 @@
-chore:
-- Add package resolutions to fix braces CVE-2024-4068 ([#9846](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9846))

--- a/changelogs/fragments/9848.yml
+++ b/changelogs/fragments/9848.yml
@@ -1,2 +1,0 @@
-fix:
-- Revert workspaces=* and add warning log ([#9848](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9848))

--- a/changelogs/fragments/9849.yml
+++ b/changelogs/fragments/9849.yml
@@ -1,2 +1,0 @@
-feat:
-- Add tabs in explore, introduce logs tab ([#9849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9849))

--- a/changelogs/fragments/9856.yml
+++ b/changelogs/fragments/9856.yml
@@ -1,2 +1,0 @@
-fix:
-- Adds the displaying of unknown fields back to Discover ([#9856](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9856))

--- a/changelogs/fragments/9857.yml
+++ b/changelogs/fragments/9857.yml
@@ -1,2 +1,0 @@
-fix:
-- Update @testing-library/user-event version ([#9857](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9857))

--- a/changelogs/fragments/9863.yml
+++ b/changelogs/fragments/9863.yml
@@ -1,2 +1,0 @@
-doc:
-- Update maintainer merging responsibilities ([#9863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9863))

--- a/changelogs/fragments/9867.yml
+++ b/changelogs/fragments/9867.yml
@@ -1,2 +1,0 @@
-feat:
-- Make default index pattern method more robust ([#9867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9867))

--- a/changelogs/fragments/9875.yml
+++ b/changelogs/fragments/9875.yml
@@ -1,2 +1,0 @@
-fix:
-- Fix update button issue in DateTimeRange picker ([#9875](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9875))

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -194,6 +194,7 @@
     - [Opensearch dashboards.release notes 3.0.0 alpha1](../release-notes/opensearch-dashboards.release-notes-3.0.0-alpha1.md)
     - [Opensearch dashboards.release notes 3.0.0 beta1](../release-notes/opensearch-dashboards.release-notes-3.0.0-beta1.md)
     - [Opensearch dashboards.release notes 3.0.0](../release-notes/opensearch-dashboards.release-notes-3.0.0.md)
+    - [Opensearch dashboards.release notes 3.1.0](../release-notes/opensearch-dashboards.release-notes-3.1.0.md)
   - scripts
     - [README](../scripts/README.md)
   - [DOCS_README](DOCS_README.md)

--- a/release-notes/opensearch-dashboards.release-notes-3.1.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-3.1.0.md
@@ -32,7 +32,6 @@
  - Add new experience banners for explore for both new and classic ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
  - Update data plugin's __enhance type to include promises ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
  - Add tabs in explore, introduce logs tab ([#9849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9849))
- - Implement polling for index state in Vended Dashboard progress ([#9862](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9862))
  - Make default index pattern method more robust ([#9867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9867))
 
 ### 🐛 Bug Fixes

--- a/release-notes/opensearch-dashboards.release-notes-3.1.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-3.1.0.md
@@ -1,0 +1,77 @@
+# VERSION 3.1.0 Release Note
+
+### 💥 Breaking Changes
+
+### Deprecations
+
+### 🛡 Security
+
+ - [CVE-2024-47764] Remove `cookie@0.4.1` as a nested dependency ([#9838](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9838))
+
+### 📈 Features/Enhancements
+
+ - Add a new Data Importer Plugin to OSD Core ([#9602](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9602))
+ - Ui action supports `isDisabled` and `getTooltip` ([#9696](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9696))
+ - Adding back storybook ([#9697](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9697))
+ - Update default index pattern logic ([#9703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9703))
+ - Support new OpenSearch type match_only_text ([#9707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9707))
+ - Add new Explore plugin ([#9724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9724))
+ - Support multiple-scopes ui settings ([#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726))
+ - Add resource API pattern in query_enhancements ([#9770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9770))
+ - Support explore only in the observability workspace type ([#9773](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9773))
+ - Remove theme update modal ([#9776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9776))
+ - Add new state management base implementations and hooks ([#9777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9777))
+ - Add permission control for admin UI settings ([#9795](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9795))
+ - Duplicate discover and data-explorer into explore plugin ([#9798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9798))
+ - Saved explore type in explore plugin ([#9809](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9809))
+ - [Feature][Integration] Vended Dashboards Synchronization #9816 ([#9816](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9816))
+ - Deprecate showInAllNavGroup property ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))
+ - Register search overview page to all use case by using addNavLinksToGroup ([#9818](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9818))
+ - Add a permission controlled admin UI setting for enable/disable AI features in OSD ([#9824](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9824))
+ - Auto visualization for explore ([#9834](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9834))
+ - Add new experience banners for explore for both new and classic ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
+ - Update data plugin's __enhance type to include promises ([#9842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9842))
+ - Add tabs in explore, introduce logs tab ([#9849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9849))
+ - Implement polling for index state in Vended Dashboard progress ([#9862](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9862))
+ - Make default index pattern method more robust ([#9867](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9867))
+
+### 🐛 Bug Fixes
+
+ - Remove * when calling find in data source association modal and in workspace list page ([#9409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9409))
+ - Should clear previous query if input invalid questions ([#9605](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9605))
+ - Initial result summary generated with the wrong data ([#9611](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9611))
+ - Fix a issue that can cause incorrect query to fire when switch plugin ([#9625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9625))
+ - Data source opensearch client honors the timeout settings in yaml file ([#9651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9651))
+ - Support left navigation search for OSD with workspace plugin disabled ([#9662](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9662))
+ - Fix Branding test urls ([#9694](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9694))
+ - Fix user appearance not working ([#9700](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9700))
+ - Cancel existing query when new natural language prompt is being generated-new ([#9701](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9701))
+ - Fix SigV4 signing mismatch issue with ?v query parameter ([#9730](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9730))
+ - Fix collaborators displays under custom tab on navigation when saved object permission is disabled ([#9734](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9734))
+ - Chatbot flyout cannot be resized beyond the window size ([#9735](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9735))
+ - Performance script ([#9738](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9738))
+ - Path alias not properly resolved if the source code was copied and built from another directory ([#9784](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9784))
+ - [Explore] rename Explore nav item to Discover ([#9813](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9813))
+ - Content and Card are mistakenly placed under the create visualization dropdown menu ([#9815](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9815))
+ - UI setting will give error if a specific setting is not defined. ([#9820](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9820))
+ - Revert workspaces=* and add warning log ([#9848](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9848))
+ - Adds the displaying of unknown fields back to Discover ([#9856](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9856))
+ - Update @testing-library/user-event version ([#9857](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9857))
+ - Fix update button issue in DateTimeRange picker ([#9875](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9875))
+
+### 🚞 Infrastructure
+
+### 📝 Documentation
+
+ - Update maintainer merging responsibilities ([#9863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9863))
+
+### 🛠 Maintenance
+
+ - Bump version to 3.1.0 ([#9789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9789))
+ - Add package resolutions to fix braces CVE-2024-4068 ([#9846](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9846))
+
+### 🪛 Refactoring
+
+ - Extract path alias babel config to a reusable function ([#9831](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9831))
+
+### 🔩 Tests


### PR DESCRIPTION
### Description

3.1.0 release notes.

Two changes in main currently are not going into the 3.1.0 release:

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9830 - This one accidently did not have an associated changelog entry. @LDrago27 will make a new PR with the changelog

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9862 - I omitted the changelog for this one.

### Issues Resolved

#9793


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
