### PR TITLE
ignore release_notes directory for casing check

### DIFF
--- a/src/dev/precommit_hook/casing_check_config.js
+++ b/src/dev/precommit_hook/casing_check_config.js
@@ -55,6 +55,7 @@ export const IGNORE_FILE_GLOBS = [
   'Dockerfile*',
   'vars/*',
   '.ci/pipeline-library/**/*',
+  'release-notes/*',
 
   // filename must match language code which requires capital letters
   '**/translations/*.json',


### PR DESCRIPTION
### Description

- when i generated the release notes for https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9892 via the script `yarn release_note:generate`, i could not commit as the generated release note did not follow the casing convention:

<img width="901" alt="Screenshot 2025-06-13 at 2 48 16 PM" src="https://github.com/user-attachments/assets/b4c60aa0-56dc-45c5-b3c0-8605dd269518" />

- i had to `git force` it to commit it, which is annoying. So i am adding the release_note folder to casing ignore path


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
