### PR TITLE
[Explore] Fix autocomplete service and update temp query_panel

### DIFF
--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -455,6 +455,7 @@ export {
   // for BWC, keeping the old name
   IUiStart as DataPublicPluginStartUi,
   useQueryStringManager,
+  getEffectiveLanguageForAutoComplete,
 } from './ui';
 
 /**

--- a/src/plugins/data/public/ui/index.ts
+++ b/src/plugins/data/public/ui/index.ts
@@ -44,6 +44,7 @@ export {
   DefaultInput,
   DQLBody,
   SingleLineInput,
+  getEffectiveLanguageForAutoComplete,
 } from './query_editor';
 export {
   SearchBar,

--- a/src/plugins/data/public/ui/query_editor/index.tsx
+++ b/src/plugins/data/public/ui/query_editor/index.tsx
@@ -33,3 +33,4 @@ export {
 } from './query_editor_extensions';
 
 export { createEditor, DefaultInput, DQLBody, SingleLineInput } from './editors';
+export { getEffectiveLanguageForAutoComplete } from './utils';

--- a/src/plugins/explore/public/application/app.tsx
+++ b/src/plugins/explore/public/application/app.tsx
@@ -21,6 +21,7 @@ import {
 import { HeaderVariant } from 'opensearch-dashboards/public';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../types';
+import { useIndexPatternContext } from './components/index_pattern_context';
 import { RootState } from './utils/state_management/store';
 import { ResultStatus } from './utils/state_management/types';
 import { TopNav } from './legacy/discover/application/view_components/canvas/top_nav';
@@ -46,6 +47,11 @@ export const ExploreApp: React.FC<{ setHeaderActionMenu?: (menuMount: any) => vo
   setHeaderActionMenu,
 }) => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
+  const {
+    indexPattern,
+    isLoading: indexPatternLoading,
+    error: indexPatternError,
+  } = useIndexPatternContext();
   const showActionsInGroup = services.uiSettings.get('home:useNewHomePage', false);
 
   // Get status and rows for histogram and tab content
@@ -177,9 +183,21 @@ export const ExploreApp: React.FC<{ setHeaderActionMenu?: (menuMount: any) => vo
               <NewExperienceBanner />
             </div>
 
-            {/* QueryPanel component */}
+            {/* QueryPanel component - only render when IndexPattern is loaded */}
             <div className="dscCanvas__queryPanel">
-              <QueryPanel datePickerRef={datePickerRef} />
+              {indexPatternLoading ? (
+                <div>Loading IndexPattern...</div>
+              ) : indexPatternError ? (
+                <div>Error loading IndexPattern: {indexPatternError}</div>
+              ) : indexPattern ? (
+                <QueryPanel
+                  datePickerRef={datePickerRef}
+                  services={services}
+                  indexPattern={indexPattern}
+                />
+              ) : (
+                <div>No IndexPattern available</div>
+              )}
             </div>
 
             {/* Main content area with resizable panels under QueryPanel */}

--- a/src/plugins/explore/public/build_services.ts
+++ b/src/plugins/explore/public/build_services.ts
@@ -34,6 +34,7 @@ export function buildServices(
 
   return {
     addBasePath: core.http.basePath.prepend,
+    appName: 'explore',
     capabilities: core.application.capabilities,
     chrome: core.chrome,
     core,

--- a/src/plugins/explore/public/components/query_panel/components/footer/index.scss
+++ b/src/plugins/explore/public/components/query_panel/components/footer/index.scss
@@ -6,7 +6,7 @@
 .queryPanel__footer {
 
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-  .euiFlexGroup--gutterExtraSmall>.euiFlexItem {
+  .euiFlexGroup--gutterExtraSmall > .euiFlexItem {
     margin: 0;
   }
 

--- a/src/plugins/explore/public/types.ts
+++ b/src/plugins/explore/public/types.ts
@@ -142,6 +142,7 @@ export interface ExploreServices {
   visualizations: VisualizationsStart;
   storage: Storage;
   uiActions: UiActionsStart;
+  appName: string; // Required by autocomplete service
 
   // Additional CoreStart properties that are accessed directly
   savedObjects: CoreStart['savedObjects'];


### PR DESCRIPTION
### Description

https://github.com/user-attachments/assets/4e462e55-f9d8-408d-91bd-8533d7a09455

PPL autocomplete was not working in the explore plugin. When users typed in the query editor, no autocomplete suggestions appeared, unlike in the discover plugin where autocomplete worked correctly.

The PPL_Simplified autocomplete provider requires services.appName parameter now due to added `PPL_Simplified` for explore, but the explore plugin was not updated and passing this required parameter, causing the provider to return early with empty suggestions.

In this PR, I fixed the following:
* Added missing appName parameter:  Added 'explore' to the ExploreServices interface and services object creation
* Improved Type Safety: Exported getEffectiveLanguageForAutoComplete function properly to eliminate as any type casts
* Enhanced Architecture: Moved IndexPattern loading to app level and simplified QueryPanel component. We need it ready for autocomplete service


## Testing the changes

NA

## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
