### PR TITLE
[Explore] clean up top nav

### DIFF
--- a/src/plugins/explore/public/application/legacy/discover/application/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/top_nav/get_top_nav_links.tsx
@@ -25,7 +25,6 @@ import {
   LegacyState,
   setSavedSearch,
 } from '../../../../../utils/state_management/slices/legacy_slice';
-import { RootState } from '../../../../../utils/state_management/store';
 import {
   DOC_HIDE_TIME_COLUMN_SETTING,
   SORT_DEFAULT_ORDER_SETTING,
@@ -34,268 +33,11 @@ import { getSortForSearchSource } from '../../view_components/utils/get_sort_for
 import { getRootBreadcrumbs } from '../../helpers/breadcrumbs';
 import { OpenSearchPanel } from './open_search_panel';
 
-const getLegacyTopNavLinks = (
-  services: ExploreServices,
-  inspectorAdapters: Adapters,
-  savedSearch: SavedExplore,
-  startSyncingQueryStateWithUrl: () => void,
-  isEnhancementEnabled: boolean = false
-) => {
-  const {
-    history,
-    inspector,
-    core,
-    capabilities,
-    share,
-    toastNotifications,
-    chrome,
-    store,
-  } = services;
-
-  const newSearch: TopNavMenuData = {
-    id: 'new',
-    label: i18n.translate('explore.explore.discover.localMenu.localMenu.newSearchTitle', {
-      defaultMessage: 'New',
-    }),
-    description: i18n.translate('explore.discover.localMenu.newSearchDescription', {
-      defaultMessage: 'New Search',
-    }),
-    run() {
-      core.application.navigateToApp('explore', {
-        path: `${LOGS_VIEW_ID}#/`,
-      });
-    },
-    testId: 'discoverNewButton',
-    ariaLabel: i18n.translate('explore.explore.discover.topNav.discoverNewButtonLabel', {
-      defaultMessage: `New Search`,
-    }),
-    iconType: 'plusInCircle',
-  };
-
-  const saveSearch: TopNavMenuData = {
-    id: 'save',
-    label: i18n.translate('explore.explore.discover.localMenu.saveTitle', {
-      defaultMessage: 'Save',
-    }),
-    description: i18n.translate('explore.discover.localMenu.saveSearchDescription', {
-      defaultMessage: 'Save Search',
-    }),
-    testId: 'discoverSaveButton',
-    ariaLabel: i18n.translate('explore.explore.discover.topNav.discoverSaveButtonLabel', {
-      defaultMessage: `Save search`,
-    }),
-    run: async () => {
-      const onSave = async ({
-        newTitle,
-        newCopyOnSave,
-        isTitleDuplicateConfirmed,
-        onTitleDuplicate,
-      }: OnSaveProps): Promise<SaveResult | undefined> => {
-        const currentTitle = savedSearch.title;
-        savedSearch.title = newTitle;
-        savedSearch.copyOnSave = newCopyOnSave;
-        const saveOptions = {
-          confirmOverwrite: false,
-          isTitleDuplicateConfirmed,
-          onTitleDuplicate,
-        };
-
-        const state: LegacyState = store!.getState().legacy; // store is defined before the view is loaded
-
-        // Use transform approach similar to vis_builder - serialize state into saved object
-        const { updateLegacyPropertiesInSavedObject } = await import(
-          '../../../../../../saved_explore/transforms'
-        );
-        updateLegacyPropertiesInSavedObject(savedSearch, {
-          columns: state.columns,
-          sort: state.sort,
-        });
-
-        try {
-          const id = await savedSearch.save(saveOptions);
-
-          // If the title is a duplicate, the id will be an empty string. Checking for this condition here
-          if (id) {
-            toastNotifications.addSuccess({
-              title: i18n.translate('explore.explore.discover.notifications.savedSearchTitle', {
-                defaultMessage: `Search '{savedSearchTitle}' was saved`,
-                values: {
-                  savedSearchTitle: savedSearch.title,
-                },
-              }),
-              'data-test-subj': 'saveSearchSuccess',
-            });
-
-            if (id !== state.savedSearch) {
-              history().push(`/view/${encodeURIComponent(id)}`);
-            } else {
-              chrome.docTitle.change(savedSearch.lastSavedTitle);
-              chrome.setBreadcrumbs([...getRootBreadcrumbs(), { text: savedSearch.title }]);
-            }
-
-            // set App state to clean
-            store!.dispatch(setSavedSearch(id));
-
-            // starts syncing `_g` portion of url with query services
-            startSyncingQueryStateWithUrl();
-
-            return { id };
-          }
-        } catch (error) {
-          toastNotifications.addDanger({
-            title: i18n.translate('explore.explore.discover.notifications.notSavedSearchTitle', {
-              defaultMessage: `Search '{savedSearchTitle}' was not saved.`,
-              values: {
-                savedSearchTitle: savedSearch.title,
-              },
-            }),
-            text: (error as Error).message,
-          });
-
-          // Reset the original title
-          savedSearch.title = currentTitle;
-
-          return { error };
-        }
-      };
-
-      const saveModal = (
-        <SavedObjectSaveModal
-          onSave={onSave}
-          onClose={() => {}}
-          title={savedSearch.title}
-          showCopyOnSave={!!savedSearch.id}
-          objectType="search"
-          description={i18n.translate(
-            'explore.explore.discover.localMenu.saveSaveSearchDescription',
-            {
-              defaultMessage:
-                'Save your Discover search so you can use it in visualizations and dashboards',
-            }
-          )}
-          showDescription={false}
-        />
-      );
-      showSaveModal(saveModal, core.i18n.Context);
-    },
-    iconType: 'save',
-  };
-
-  const openSearch: TopNavMenuData = {
-    id: 'open',
-    label: i18n.translate('explore.explore.discover.localMenu.openTitle', {
-      defaultMessage: 'Open',
-    }),
-    description: i18n.translate('explore.discover.localMenu.openSavedSearchDescription', {
-      defaultMessage: 'Open Saved Search',
-    }),
-    testId: 'discoverOpenButton',
-    ariaLabel: i18n.translate('explore.explore.discover.topNav.discoverOpenButtonLabel', {
-      defaultMessage: `Open Saved Search`,
-    }),
-    run: () => {
-      const flyoutSession = services.overlays.openFlyout(
-        toMountPoint(
-          <OpenSearchDashboardsContextProvider services={services}>
-            <OpenSearchPanel
-              onClose={() => {
-                if (flyoutSession) {
-                  flyoutSession.close();
-                }
-              }}
-              makeUrl={(searchId) => `#/view/${encodeURIComponent(searchId)}`}
-            />
-          </OpenSearchDashboardsContextProvider>
-        )
-      );
-    },
-    iconType: 'folderOpen',
-  };
-
-  const shareSearch: TopNavMenuData = {
-    id: 'share',
-    label: i18n.translate('explore.discover.localMenu.shareTitle', {
-      defaultMessage: 'Share',
-    }),
-    description: i18n.translate('explore.discover.localMenu.shareSearchDescription', {
-      defaultMessage: 'Share Search',
-    }),
-    testId: 'shareTopNavButton',
-    ariaLabel: i18n.translate('explore.discover.topNav.discoverShareButtonLabel', {
-      defaultMessage: `Share search`,
-    }),
-    run: async (anchorElement: HTMLElement) => {
-      const state: LegacyState = store!.getState().legacy; // store is defined before the view is loaded
-      const sharingData = await getSharingData({
-        searchSource: savedSearch.searchSource,
-        state,
-        services,
-      });
-      share?.toggleShareContextMenu({
-        anchorElement,
-        allowEmbed: false,
-        allowShortUrl: capabilities.discover?.createShortUrl as boolean,
-        shareableUrl: unhashUrl(window.location.href),
-        objectId: savedSearch.id,
-        objectType: 'search',
-        sharingData: {
-          ...sharingData,
-          title: savedSearch.title,
-        },
-        isDirty: !savedSearch.id || state.isDirty || false,
-      });
-    },
-    iconType: 'share',
-  };
-
-  const inspectSearch: TopNavMenuData = {
-    id: 'inspect',
-    label: i18n.translate('explore.discover.localMenu.inspectTitle', {
-      defaultMessage: 'Inspect',
-    }),
-    description: i18n.translate('explore.discover.localMenu.openInspectorForSearchDescription', {
-      defaultMessage: 'Open Inspector for search',
-    }),
-    testId: 'openInspectorButton',
-    ariaLabel: i18n.translate('explore.discover.topNav.discoverInspectorButtonLabel', {
-      defaultMessage: `Open Inspector for search`,
-    }),
-    run() {
-      inspector.open(inspectorAdapters, {
-        title: savedSearch?.title || undefined,
-      });
-    },
-    iconType: 'inspect',
-  };
-
-  const topNavLinksArray = [
-    newSearch,
-    ...(capabilities.discover?.save ? [saveSearch] : []),
-    openSearch,
-    ...(share ? [shareSearch] : []), // Show share option only if share plugin is available
-    inspectSearch,
-  ];
-
-  if (!isEnhancementEnabled) {
-    return topNavLinksArray.map((topNavLink) => {
-      if (topNavLink) {
-        const { iconType, ...rest } = topNavLink; // Removing the Icon Type property to maintain consistency with older Nav Bar
-        return rest;
-      }
-      return topNavLink;
-    });
-  }
-
-  return topNavLinksArray;
-};
-
 export const getTopNavLinks = (
   services: ExploreServices,
   inspectorAdapters: Adapters,
   savedExplore: SavedExplore,
-  startSyncingQueryStateWithUrl: () => void,
-  isEnhancementEnabled: boolean = false,
-  useNoIndexPatternsTopNav: boolean = false
+  startSyncingQueryStateWithUrl: () => void
 ) => {
   const {
     history,
@@ -306,18 +48,7 @@ export const getTopNavLinks = (
     toastNotifications,
     chrome,
     store,
-    uiSettings,
   } = services;
-
-  const showActionsInGroup = uiSettings.get('home:useNewHomePage', false);
-  if (!showActionsInGroup)
-    return getLegacyTopNavLinks(
-      services,
-      inspectorAdapters,
-      savedExplore,
-      startSyncingQueryStateWithUrl,
-      isEnhancementEnabled
-    );
 
   const topNavLinksMap = new Map<string, TopNavMenuData>();
 
@@ -395,6 +126,7 @@ export const getTopNavLinks = (
             onTitleDuplicate,
           };
 
+          // @ts-expect-error TODO: Fix me
           const state: LegacyState = store!.getState().legacy; // store is defined before the view is loaded
 
           // Use transform approach similar to vis_builder - serialize state into saved object
@@ -490,6 +222,7 @@ export const getTopNavLinks = (
         defaultMessage: `Share search`,
       }),
       run: async (anchorElement) => {
+        // @ts-expect-error TODO: Fix me
         const state: LegacyState = store!.getState().legacy; // store is defined before the view is loaded
         const sharingData = await getSharingData({
           searchSource: savedExplore.searchSource,
@@ -538,16 +271,7 @@ export const getTopNavLinks = (
   return ['save', 'open', 'new', 'inspect', 'share'].reduce((acc, item) => {
     const itemDef = topNavLinksMap.get(item);
     if (itemDef) {
-      if (useNoIndexPatternsTopNav && item !== 'open') {
-        // Disable all buttons except 'open' when in no index patterns mode
-        acc.push({
-          ...itemDef,
-          disabled: true,
-          run: () => {}, // Empty function for disabled buttons
-        });
-      } else {
-        acc.push(itemDef);
-      }
+      acc.push(itemDef);
     }
     return acc;
   }, [] as TopNavMenuData[]);

--- a/src/plugins/explore/public/application/legacy/discover/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/view_components/canvas/top_nav.tsx
@@ -4,8 +4,6 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { Query, TimeRange } from '../../../../../../../../data/common';
@@ -14,8 +12,6 @@ import {
   opensearchFilters,
   QueryStatus,
   useSyncQueryStateWithUrl,
-  DatasetSelector,
-  DatasetSelectorAppearance,
 } from '../../../../../../../../data/public';
 import { createOsdUrlStateStorage } from '../../../../../../../../opensearch_dashboards_utils/public';
 import { useOpenSearchDashboards } from '../../../../../../../../opensearch_dashboards_react/public';
@@ -24,7 +20,6 @@ import { PLUGIN_ID } from '../../../../../../../common';
 import { ExploreServices } from '../../../../../../types';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
 import { getTopNavLinks } from '../../components/top_nav/get_top_nav_links';
-import { getRootBreadcrumbs } from '../../helpers/breadcrumbs';
 import { useDispatch, useSelector } from '../../utils/state_management';
 import { setSavedQuery } from '../../../../../utils/state_management/slices/legacy_slice';
 import { useIndexPatternContext } from '../../../../../components/index_pattern_context';
@@ -68,12 +63,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     navigation: {
       ui: { TopNavMenu },
     },
-    core: {
-      application: { getUrlForApp },
-    },
     data,
-    chrome,
-    storage,
     uiSettings,
     history,
   } = services;
@@ -97,8 +87,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     services,
     inspectorAdapters,
     savedSearch || ({} as any), // Provide empty object if savedSearch is null
-    startSyncingQueryStateWithUrl,
-    isEnhancementsEnabled
+    startSyncingQueryStateWithUrl
   );
 
   const syncConfig = useMemo(() => {
@@ -150,55 +139,26 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     dispatch(setSavedQuery(newSavedQueryId));
   };
 
-  const displayToNavLinkInPortal =
-    isEnhancementsEnabled && !!opts?.optionalRef?.topLinkRef?.current && !showActionsInGroup;
-
   return (
-    <>
-      {displayToNavLinkInPortal &&
-        createPortal(
-          <EuiFlexGroup gutterSize="xs" alignItems="center">
-            {topNavLinks.map((topNavLink) => (
-              <EuiFlexItem grow={false} key={(topNavLink as any).id}>
-                <EuiToolTip position="bottom" content={(topNavLink as any).label}>
-                  <EuiButtonIcon
-                    onClick={(event: any) => {
-                      if (topNavLink.run) {
-                        (topNavLink.run as any)(event.currentTarget);
-                      }
-                    }}
-                    iconType={(topNavLink as any).iconType}
-                    aria-label={(topNavLink as any).ariaLabel}
-                    size="s"
-                    color="text"
-                    data-test-subj={`${(topNavLink as any).id}Button`}
-                  />
-                </EuiToolTip>
-              </EuiFlexItem>
-            ))}
-          </EuiFlexGroup>,
-          opts.optionalRef!.topLinkRef.current!
-        )}
-      <TopNavMenu
-        appName={PLUGIN_ID}
-        config={displayToNavLinkInPortal ? [] : topNavLinks}
-        data={data}
-        showSearchBar={false}
-        showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
-        showSaveQuery={showSaveQuery}
-        useDefaultBehaviors
-        setMenuMountPoint={opts.setHeaderActionMenu}
-        indexPatterns={indexPattern ? [indexPattern] : indexPatterns}
-        onQuerySubmit={opts.onQuerySubmit}
-        savedQueryId={legacyState.savedQuery}
-        onSavedQueryIdChange={updateSavedQueryId}
-        datasetSelectorRef={opts?.optionalRef?.datasetSelectorRef}
-        datePickerRef={opts?.optionalRef?.datePickerRef}
-        groupActions={showActionsInGroup}
-        screenTitle={screenTitle}
-        queryStatus={queryStatus}
-        showQueryBar={false}
-      />
-    </>
+    <TopNavMenu
+      appName={PLUGIN_ID}
+      config={topNavLinks}
+      data={data}
+      showSearchBar={false}
+      showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
+      showSaveQuery={showSaveQuery}
+      useDefaultBehaviors
+      setMenuMountPoint={opts.setHeaderActionMenu}
+      indexPatterns={indexPattern ? [indexPattern] : indexPatterns}
+      onQuerySubmit={opts.onQuerySubmit}
+      savedQueryId={legacyState.savedQuery}
+      onSavedQueryIdChange={updateSavedQueryId}
+      datasetSelectorRef={opts?.optionalRef?.datasetSelectorRef}
+      datePickerRef={opts?.optionalRef?.datePickerRef}
+      groupActions={showActionsInGroup}
+      screenTitle={screenTitle}
+      queryStatus={queryStatus}
+      showQueryBar={false}
+    />
   );
 };


### PR DESCRIPTION
Clean up top nav:

- `getLegacyTopNavLinks` only renders if `!home:useNewHomePage`, but for explore we will always have `home:useNewHomePage`
- Along the same logic, `displayToNavLinkInPortal` would only display if `!home:useNewHomePage`. So delete that crap too
- `useNoIndexPatternsTopNav` argument for `getTopNavLinks` is never called. i think its dead code. so removing it