### PR TITLE
update 3.1 release-notes to include #9903

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
  - Bump version to 3.1.0 ([#9789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9789))
  - Add package resolutions to fix braces CVE-2024-4068 ([#9846](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9846))
+ - Fix CVE 2025-5889 braces-expansion ([#9903](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9903))
 
 ### 🪛 Refactoring
 

--- a/changelogs/fragments/9903.yml
+++ b/changelogs/fragments/9903.yml
@@ -1,2 +1,0 @@
-chore:
-- Fix CVE 2025-5889 braces-expansion ([#9903](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9903))

--- a/release-notes/opensearch-dashboards.release-notes-3.1.0.md
+++ b/release-notes/opensearch-dashboards.release-notes-3.1.0.md
@@ -68,6 +68,7 @@
 
  - Bump version to 3.1.0 ([#9789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9789))
  - Add package resolutions to fix braces CVE-2024-4068 ([#9846](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9846))
+ - Fix CVE 2025-5889 braces-expansion ([#9903](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9903))
 
 ### 🪛 Refactoring
 


### PR DESCRIPTION
### Description

- update release notes to include #9903 as that is a CVE fix.

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
