### PR TITLE
[Explore] disable legend for line chart when it is 1 metric and 1 date

### DIFF
--- a/src/plugins/explore/public/components/visualizations/line/__snapshots__/line_vis_options.test.tsx.snap
+++ b/src/plugins/explore/public/components/visualizations/line/__snapshots__/line_vis_options.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`LineVisStyleControls handles empty column arrays gracefully 1`] = `
         onAddLegendChange={[Function]}
         onAddTooltipChange={[Function]}
         onLegendPositionChange={[Function]}
+        shouldShowLegend={true}
       />,
       "id": "basic",
       "name": "Basic",
@@ -29,6 +30,7 @@ exports[`LineVisStyleControls handles empty column arrays gracefully 1`] = `
           onAddLegendChange={[Function]}
           onAddTooltipChange={[Function]}
           onLegendPositionChange={[Function]}
+          shouldShowLegend={true}
         />,
         "id": "basic",
         "name": "Basic",
@@ -146,6 +148,7 @@ exports[`LineVisStyleControls renders without crashing 1`] = `
         onAddLegendChange={[Function]}
         onAddTooltipChange={[Function]}
         onLegendPositionChange={[Function]}
+        shouldShowLegend={true}
       />,
       "id": "basic",
       "name": "Basic",
@@ -162,6 +165,7 @@ exports[`LineVisStyleControls renders without crashing 1`] = `
           onAddLegendChange={[Function]}
           onAddTooltipChange={[Function]}
           onLegendPositionChange={[Function]}
+          shouldShowLegend={true}
         />,
         "id": "basic",
         "name": "Basic",

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
@@ -38,7 +38,7 @@ export const LineVisStyleControls: React.FC<LineVisStyleControlsProps> = ({
 
   // if it is 1 metric and 1 date, then it should not show legend
   const notShowLegend =
-    numericalColumns.length === 1 && categoricalColumns.length === 0 && dateColumns.length === 0;
+    numericalColumns.length === 1 && categoricalColumns.length === 0 && dateColumns.length === 1;
   const tabs: EuiTabbedContentTab[] = [
     {
       id: 'basic',


### PR DESCRIPTION
### Description
This pr disables legend for line chart when it is 1 metric and 1 date

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<img width="1708" alt="截屏2025-06-17 14 49 57" src="https://github.com/user-attachments/assets/da11fa5f-7103-4851-945b-3c5fe00ea86a" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: disable legend for line chart when it is 1 metric and 1 date
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
