### PR TITLE
[Explore] Fix refresh by removing duplicate sync

### DIFF
--- a/src/plugins/explore/public/application/legacy/discover/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/view_components/canvas/top_nav.tsx
@@ -7,12 +7,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { Query, TimeRange } from '../../../../../../../../data/common';
-import {
-  useConnectStorageToQueryState,
-  opensearchFilters,
-  QueryStatus,
-  useSyncQueryStateWithUrl,
-} from '../../../../../../../../data/public';
+import { QueryStatus, useSyncQueryStateWithUrl } from '../../../../../../../../data/public';
 import { createOsdUrlStateStorage } from '../../../../../../../../opensearch_dashboards_utils/public';
 import { useOpenSearchDashboards } from '../../../../../../../../opensearch_dashboards_react/public';
 import { RequestAdapter } from '../../../../../../../../inspector/public';
@@ -89,15 +84,6 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
     savedSearch || ({} as any), // Provide empty object if savedSearch is null
     startSyncingQueryStateWithUrl
   );
-
-  const syncConfig = useMemo(() => {
-    return {
-      filters: opensearchFilters.FilterStateStore.APP_STATE,
-      query: true,
-    };
-  }, []);
-
-  useConnectStorageToQueryState(services.data.query, osdUrlStateStorage, syncConfig);
 
   // Replace data$ subscription with Redux state-based queryStatus
   useEffect(() => {

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
@@ -49,11 +49,10 @@ export const persistReduxState = (state: RootState, services: any) => {
 
 /**
  * Loads Redux state from URL or returns default state
- * OPTIMIZED: Avoids duplicate dataset caching by smart state handling
  */
 export const loadReduxState = async (services: any): Promise<any> => {
   try {
-    // Use the osdUrlStateStorage from services (now properly initialized in plugin.ts)
+    // Use the osdUrlStateStorage from services
     if (!services.osdUrlStateStorage) {
       return await getPreloadedState(services);
     }
@@ -62,24 +61,16 @@ export const loadReduxState = async (services: any): Promise<any> => {
     const queryState = services.osdUrlStateStorage.get('_q');
     const appState = services.osdUrlStateStorage.get('_a');
 
-    // Smart query state handling
+    // Query state handling
     let finalQueryState;
     if (queryState && queryState.dataset) {
-      // We have a complete query state with dataset from URL - use it directly
-      // No need to run dataset caching since it's already been processed
-
       finalQueryState = queryState;
     } else {
-      // No query state or missing dataset - run full initialization
-
-      const defaultQuery = {
-        language: 'PPL', // Default language for explore
-      };
       finalQueryState = await getPreloadedQueryState(services);
     }
+    services.data.query.queryString.setQuery(finalQueryState);
 
-    // Smart app state handling - only run preload functions for missing sections
-
+    // Only run preload functions for missing sections
     const finalUIState = appState?.ui || (await getPreloadedUIState(services));
     const finalResultsState = appState?.results || (await getPreloadedResultsState(services));
     const finalTabState = appState?.tab || (await getPreloadedTabState(services));
@@ -155,17 +146,11 @@ const getPreloadedQueryState = async (services: any) => {
 
   // If we have a dataset, generate query with PPL language
   if (selectedDataset) {
-    // Set language to PPL for explore
-    const exploreLanguage = 'PPL';
-    const datasetWithPPL = { ...selectedDataset, language: exploreLanguage };
-
-    // Generate query using the same method as HeaderDatasetSelector
+    // Currently set default language to PPL for explore
+    const datasetWithPPL = { ...selectedDataset, language: 'PPL' };
     const queryWithDefaults = services.data.query.queryString.getInitialQueryByDataset(
       datasetWithPPL
     );
-
-    // Update global QueryStringManager to keep it in sync
-    services.data.query.queryString.setQuery(queryWithDefaults);
 
     return queryWithDefaults;
   } else {


### PR DESCRIPTION
### Description

https://github.com/user-attachments/assets/7e9f6cc6-629f-4448-9ba4-ad366fbfb748

The Explore plugin was experiencing query state synchronization conflicts due to dual state management systems
* Standard URL State Sync: Using useConnectStorageToQueryState from the data plugin in top_nav
* Redux State Management: Custom persistence logic in redux_persistence.ts

connectStorageToQueryState expects QueryState from src/plugins/data/public/query/state_sync/types.ts, but Explore uses query types from src/plugins/data/common/query/types.ts.

#### Solution Options Considered
Option 1: Smart Language Detection
Modify connectStorageToQueryState to use context-appropriate language defaults instead of hard-coding kuery.

Option 2: Type Alignment
Update Explore's query slice to use the same QueryState type as other plugins.

Option 3: Complete Removal (IMPLEMENTED)
Remove useConnectStorageToQueryState entirely from Explore since Redux already handles all state synchronization.

### Issues Resolved

NA

## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
