### PR TITLE
[Bugfix]: make UI setting client more robust when the setting key not exists

### DIFF
--- a/src/core/public/ui_settings/ui_settings_client.test.ts
+++ b/src/core/public/ui_settings/ui_settings_client.test.ts
@@ -261,6 +261,12 @@ describe('#set', () => {
     await client.set('defaultIndex', 'index', UiSettingScope.USER);
     expect(getAll).toHaveBeenCalled();
   });
+
+  it('should not throw error if the key does not exist', async () => {
+    const { client } = setup();
+
+    await expect(client.set('not_exist', UiSettingScope.GLOBAL)).resolves.not.toThrowError();
+  });
 });
 
 describe('#getUserProvidedWithScope', () => {
@@ -286,6 +292,13 @@ describe('#getUserProvidedWithScope', () => {
     await expect(
       client.getUserProvidedWithScope('defaultDatasource', UiSettingScope.WORKSPACE)
     ).resolves.toBe('ds');
+  });
+
+  it('should not throw error if the key does not exist', async () => {
+    const { client } = setup();
+    const notExistSettingKey = 'not_exist';
+
+    await client.getUserProvidedWithScope(notExistSettingKey, UiSettingScope.GLOBAL);
   });
 });
 
@@ -321,6 +334,11 @@ describe('#remove', () => {
     expect(() =>
       client.remove('defaultDatasource', UiSettingScope.USER)
     ).rejects.toThrowErrorMatchingSnapshot();
+  });
+  it('should not throw error if the key does not exist', () => {
+    const { client } = setup();
+
+    expect(() => client.remove('not_exist')).not.toThrowError();
   });
 });
 

--- a/src/core/public/ui_settings/ui_settings_client.ts
+++ b/src/core/public/ui_settings/ui_settings_client.ts
@@ -141,7 +141,7 @@ You can use \`IUiSettingsClient.get("${key}", defaultValue)\`, which will just r
   }
 
   private validateScope(key: string, scope: UiSettingScope) {
-    const definition = this.cache[key];
+    const definition = this.cache[key] || {};
     const validScopes = Array.isArray(definition.scope)
       ? definition.scope
       : [definition.scope || UiSettingScope.GLOBAL];
@@ -157,7 +157,7 @@ You can use \`IUiSettingsClient.get("${key}", defaultValue)\`, which will just r
       .getAll()
       .then((response: any) => {
         const value = response.settings[key]?.userValue;
-        const type = this.cache[key].type;
+        const type = this.cache[key]?.type;
         return this.resolveValue(value, type);
       });
   }
@@ -277,8 +277,7 @@ You can use \`IUiSettingsClient.get("${key}", defaultValue)\`, which will just r
     key: string,
     defaults: Record<string, any>,
     enableUserControl: boolean,
-    settings: Record<string, any> = {},
-    scope: UiSettingScope | undefined
+    settings: Record<string, any> = {}
   ) {
     const hasMultipleScopes =
       Array.isArray(this.cache[key]?.scope) && (this.cache[key].scope?.length ?? 0) > 1;


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: make UI setting client more robust when the setting key not exists

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
