### PR TITLE
[Explore] Fix: PPL queries requiring two clicks to work correctly

### DIFF
--- a/src/plugins/explore/public/application/components/header_dataset_selector.tsx
+++ b/src/plugins/explore/public/application/components/header_dataset_selector.tsx
@@ -14,7 +14,7 @@ import {
   beginTransaction,
   finishTransaction,
 } from '../utils/state_management/actions/transaction_actions';
-import { setDataset, setQuery } from '../utils/state_management/slices/query_slice';
+import { setQuery } from '../utils/state_management/slices/query_slice';
 
 export interface HeaderDatasetSelectorProps {
   datasetSelectorRef: React.RefObject<HTMLDivElement>;
@@ -46,13 +46,8 @@ export const HeaderDatasetSelector: React.FC<HeaderDatasetSelectorProps> = ({
 
       dispatch(beginTransaction());
       try {
-        // EXPLICIT cache clear - separate cache logic
         dispatch(clearResults());
-
-        // Update dataset
         dispatch(setQuery(queryStringState));
-
-        // Execute queries - cache already cleared
         dispatch(executeQueries({ services }) as any);
       } finally {
         dispatch(finishTransaction());

--- a/src/plugins/explore/public/application/legacy/discover/application/utils/state_management/index.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/utils/state_management/index.ts
@@ -9,11 +9,6 @@ import {
   useSelector as useReduxSelector,
 } from 'react-redux';
 import { RootState } from '../../../../../utils/state_management/store';
-import { setDataset } from '../../../../../utils/state_management/slices/query_slice';
-
-// Legacy state management has been migrated to main Redux store
-// This file now just re-exports the main store functionality for compatibility
 
 export const useSelector: TypedUseSelectorHook<RootState> = useReduxSelector;
 export const useDispatch = useReduxDispatch;
-export const updateIndexPattern = setDataset;

--- a/src/plugins/explore/public/application/legacy/discover/application/view_components/utils/use_index_pattern.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/view_components/utils/use_index_pattern.ts
@@ -4,7 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { IndexPattern, useQueryStringManager } from '../../../../../../../../data/public';
 import { ExploreServices } from '../../../../../../types';
 import { getIndexPatternId } from '../../helpers/get_index_pattern_id';

--- a/src/plugins/explore/public/application/utils/state_management/actions/export_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/export_actions.ts
@@ -125,6 +125,7 @@ export const exportMaxSizeCsv = (
         .setField('query', {
           query: preparedQuery.query,
           language: preparedQuery.language,
+          dataset: preparedQuery.dataset,
         })
         .setField('filter', timeRangeFilter ? [timeRangeFilter] : [])
         .setField('size', options.maxSize || 500);

--- a/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Middleware } from '@reduxjs/toolkit';
+import { isEqual } from 'lodash';
+import { RootState } from '../store';
+import { ExploreServices } from '../../../../types';
+
+/**
+ * Middleware to sync Redux query state with global queryStringManager
+ * This ensures that whenever query state changes, the global state is updated
+ * before any search operations occur.
+ */
+export const createQuerySyncMiddleware = (services: ExploreServices): Middleware<{}, RootState> => {
+  return (store) => (next) => (action) => {
+    // Let the action go through first
+    const result = next(action);
+
+    // Check if this action affects query state
+    if (action.type === 'query/setQuery') {
+      const state = store.getState();
+      const query = state.query;
+
+      if (query.dataset && services.data?.query?.queryString) {
+        const queryStringQuery = services.data.query.queryString.getQuery();
+
+        if (!isEqual(queryStringQuery, query)) {
+          services.data.query.queryString.setQuery(query);
+        }
+      }
+    }
+
+    return result;
+  };
+};

--- a/src/plugins/explore/public/application/utils/state_management/slices/query_slice.ts
+++ b/src/plugins/explore/public/application/utils/state_management/slices/query_slice.ts
@@ -26,20 +26,8 @@ const querySlice = createSlice({
         ...action.payload,
       };
     },
-    setQueryString: (state, action: PayloadAction<string>) => {
-      // Update just the query string
-      state.query = action.payload;
-    },
-    setLanguage: (state, action: PayloadAction<string>) => {
-      // Update just the language
-      state.language = action.payload;
-    },
-    setDataset: (state, action: PayloadAction<Dataset | undefined>) => {
-      // Update just the dataset
-      state.dataset = action.payload;
-    },
   },
 });
 
-export const { setQuery, setQueryString, setLanguage, setDataset } = querySlice.actions;
+export const { setQuery } = querySlice.actions;
 export const queryReducer = querySlice.reducer;

--- a/src/plugins/explore/public/application/utils/state_management/store.ts
+++ b/src/plugins/explore/public/application/utils/state_management/store.ts
@@ -11,6 +11,8 @@ import { resultsReducer } from './slices/results_slice';
 import { tabReducer } from './slices/tab_slice';
 import { legacyReducer } from './slices/legacy_slice';
 import { persistReduxState, loadReduxState } from './utils/redux_persistence';
+import { createQuerySyncMiddleware } from './middleware/query_sync_middleware';
+import { ExploreServices } from '../../../types';
 // Note: Query execution is handled by Redux Thunk actions, not store subscriptions
 // This follows the design requirement for "Middleware-Driven: Query execution via Redux middleware"
 
@@ -27,16 +29,23 @@ export type RootState = ReturnType<typeof rootReducer>;
 // Timefilter subscriptions are handled in components, not in store
 // This follows the design requirement for component-driven timefilter handling
 
-export const configurePreloadedStore = (preloadedState: PreloadedState<RootState>) => {
+export const configurePreloadedStore = (
+  preloadedState: PreloadedState<RootState>,
+  services?: ExploreServices
+) => {
   return configureStore({
     reducer: rootReducer,
     preloadedState,
+    middleware: (getDefaultMiddleware) =>
+      services
+        ? getDefaultMiddleware().concat(createQuerySyncMiddleware(services))
+        : getDefaultMiddleware(),
   });
 };
 
-export const getPreloadedStore = async (services: import('../../../types').ExploreServices) => {
+export const getPreloadedStore = async (services: ExploreServices) => {
   const preloadedState = await loadReduxState(services);
-  const store = configurePreloadedStore(preloadedState);
+  const store = configurePreloadedStore(preloadedState, services);
 
   let previousState = store.getState();
 

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
@@ -13,27 +13,10 @@ import { ResultStatus } from '../types';
 export const persistReduxState = (state: RootState, services: any) => {
   if (state.ui.transaction?.inProgress) return;
   try {
-    // Update QueryStringManager to match Redux state
-    if (state.query.dataset && services.data?.query?.queryString) {
-      const queryStringQuery = services.data.query.queryString.getQuery();
-      const isEqual = (a: any, b: any) => JSON.stringify(a) === JSON.stringify(b);
-
-      if (!isEqual(queryStringQuery, state.query)) {
-        services.data.query.queryString.setQuery(state.query);
-
-        // Set language if it changed
-        if (state.query.language !== queryStringQuery.language) {
-          services.data.query.queryString
-            .getLanguageService()
-            .setUserQueryLanguage(state.query.language);
-        }
-      }
-    }
-
-    // Persist _q (Query state)
+    // Sync up _q (Query state) to URL state
     services.osdUrlStateStorage.set('_q', state.query, { replace: true });
 
-    // Persist _a (Application state)
+    // Sync up _a (Application state) to URL state
     services.osdUrlStateStorage.set(
       '_a',
       {

--- a/src/plugins/explore/public/components/data_table/explore_data_table.tsx
+++ b/src/plugins/explore/public/components/data_table/explore_data_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, memo } from 'react';
 import {
   DEFAULT_COLUMNS_SETTING,
   DOC_HIDE_TIME_COLUMN_SETTING,
@@ -35,7 +35,7 @@ import {
   removeColumn,
 } from '../../application/utils/state_management/slices/legacy_slice';
 
-export const ExploreDataTable = () => {
+const ExploreDataTableComponent = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const {
     uiSettings,
@@ -81,29 +81,36 @@ export const ExploreDataTable = () => {
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const scrollToTop = () => {
+  const scrollToTop = useCallback(() => {
     if (containerRef.current) {
       containerRef.current.scrollTop = 0;
     }
-  };
+  }, []);
 
-  const docViewsRegistry = getDocViewsRegistry();
+  const docViewsRegistry = useMemo(() => getDocViewsRegistry(), []);
 
   const dispatch = useDispatch();
-  const onAddColumn = (col: string) => {
-    if (indexPattern && capabilities.discover?.save) {
-      popularizeField(indexPattern, col, indexPatterns);
-    }
+  const onAddColumn = useCallback(
+    (col: string) => {
+      if (indexPattern && capabilities.discover?.save) {
+        popularizeField(indexPattern, col, indexPatterns);
+      }
 
-    dispatch(addColumn({ column: col }));
-  };
-  const onRemoveColumn = (col: string) => {
-    if (indexPattern && capabilities.discover?.save) {
-      popularizeField(indexPattern, col, indexPatterns);
-    }
+      dispatch(addColumn({ column: col }));
+    },
+    [indexPattern, capabilities.discover?.save, indexPatterns, dispatch]
+  );
 
-    dispatch(removeColumn(col));
-  };
+  const onRemoveColumn = useCallback(
+    (col: string) => {
+      if (indexPattern && capabilities.discover?.save) {
+        popularizeField(indexPattern, col, indexPatterns);
+      }
+
+      dispatch(removeColumn(col));
+    },
+    [indexPattern, capabilities.discover?.save, indexPatterns, dispatch]
+  );
 
   const onAddFilter = useCallback(
     (field: string | IndexPatternField, values: string, operation: '+' | '-') => {
@@ -120,16 +127,6 @@ export const ExploreDataTable = () => {
     },
     [filterManager, indexPattern]
   );
-
-  if (indexPattern === undefined) {
-    // TODO: handle better
-    return null;
-  }
-
-  if (!rows || rows.length === 0) {
-    // TODO: handle better
-    return <div>{'loading...'}</div>;
-  }
 
   return (
     <div
@@ -157,3 +154,5 @@ export const ExploreDataTable = () => {
     </div>
   );
 };
+
+export const ExploreDataTable = memo(ExploreDataTableComponent);

--- a/src/plugins/explore/public/components/tabs/action_bar/action_bar.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/action_bar.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import React from 'react';
+import React, { memo } from 'react';
 import { DiscoverResultsActionBar } from '../../../application/legacy/discover/application/components/results_action_bar/results_action_bar';
 import { ExploreServices } from '../../../types';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
@@ -19,7 +19,7 @@ import { LOGS_VIEW_ID } from '../../../../common';
  * Logs tab component for displaying log entries
  * Uses legacy components from discover and handles all content states
  */
-export const ActionBar = () => {
+const ActionBarComponent = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const { indexPattern } = useIndexPatternContext();
   const { core } = services;
@@ -42,3 +42,5 @@ export const ActionBar = () => {
     />
   );
 };
+
+export const ActionBar = memo(ActionBarComponent);

--- a/src/plugins/explore/public/components/tabs/logs_tab.tsx
+++ b/src/plugins/explore/public/components/tabs/logs_tab.tsx
@@ -2,14 +2,14 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import React from 'react';
+import React, { memo } from 'react';
 import { ExploreDataTable } from '../data_table/explore_data_table';
 import { ActionBar } from './action_bar/action_bar';
 
 /**
  * Logs tab component for displaying log entries
  */
-export const LogsTab = () => {
+const LogsTabComponent = () => {
   return (
     <div className="explore-logs-tab tab-container">
       <ActionBar />
@@ -17,3 +17,5 @@ export const LogsTab = () => {
     </div>
   );
 };
+
+export const LogsTab = memo(LogsTabComponent);

--- a/src/plugins/explore/public/components/tabs/tabs.tsx
+++ b/src/plugins/explore/public/components/tabs/tabs.tsx
@@ -4,7 +4,7 @@
  */
 
 import './tabs.scss';
-import React, { useCallback } from 'react';
+import React, { useCallback, memo } from 'react';
 import { EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -28,7 +28,7 @@ import { RootState } from '../../application/utils/state_management/store';
  * A view can contain a React `component`, or any JS framework by using
  * a `render` function.
  */
-export const ExploreTabs = () => {
+export const ExploreTabsComponent = () => {
   const dispatch = useDispatch();
   // Get services from context
   const { services } = useOpenSearchDashboards<ExploreServices>();
@@ -88,3 +88,5 @@ export const ExploreTabs = () => {
     />
   );
 };
+
+export const ExploreTabs = memo(ExploreTabsComponent);


### PR DESCRIPTION
### Description

Problem: PPL queries with limitations (e.g., | head 50) required clicking "Run" twice to get correct results due to timing issues between Redux state updates and global query service synchronization.

Root Cause: The executeQueries thunk was called before queryStringManager was synchronized with the new query, causing the search service to use stale query data on first execution.

Solution: Implemented Redux middleware (createQuerySyncMiddleware) that automatically syncs Redux query state with the global queryStringManager whenever query actions are dispatched.


https://github.com/user-attachments/assets/08484072-7ec7-4422-a52f-248e1e16d0cb



### Issues Resolved

NA


## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
