### PR TITLE
[Explore] Fix: Align Explore Plugin Date Picker Behavior with Discover

### DIFF
--- a/src/plugins/explore/public/application/utils/hooks/use_timefilter_subscription.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_timefilter_subscription.ts
@@ -11,25 +11,20 @@ import { executeQueries } from '../state_management/actions/query_actions';
 import { clearResults } from '../state_management/slices/results_slice';
 
 /**
- * Hook to handle timefilter subscription and re-execute queries on time range changes
- * Follows discover pattern for time range change handling
+ * Hook to handle auto-refresh subscription only
  */
 export const useTimefilterSubscription = (services: ExploreServices) => {
   const dispatch = useDispatch();
-  const queryState = useSelector((state: RootState) => state.query);
+  const query = useSelector((state: RootState) => state.query);
 
-  // TimeFilter Changes: Manual subscription to trigger Redux actions
   useEffect(() => {
     if (!services?.data?.query?.timefilter?.timefilter) return;
 
     const subscription = services.data.query.timefilter.timefilter
-      .getTimeUpdate$()
+      .getAutoRefreshFetch$()
       .subscribe(() => {
-        // Only execute if we have a query and dataset
-        if (queryState.query && queryState.dataset) {
-          // EXPLICIT cache clear - separate cache logic
+        if (query.query && query.dataset) {
           dispatch(clearResults());
-          // Execute queries - cache already cleared
           dispatch(executeQueries({ services }) as unknown);
         }
       });
@@ -37,5 +32,5 @@ export const useTimefilterSubscription = (services: ExploreServices) => {
     return () => {
       subscription.unsubscribe();
     };
-  }, [services, dispatch, queryState.query, queryState.dataset]);
+  }, [services, dispatch, query]);
 };


### PR DESCRIPTION
### Description

The Explore plugin had inconsistent behavior compared to Discover when the date picker was changed:

Explore: Automatically executed queries when date picker changed (e.g., from 15 minutes to 15 days)
Discover: Required manual "Run" button click after date picker changes

The Explore plugin was subscribing to timefilter.getTimeUpdate$() which fires on all time range changes, including date picker modifications.

In this PR, simply replaced `getTimeUpdate$()` with `getAutoRefreshFetch$()` to only subscribes to auto-refresh events, not date picker changes.

### Issues Resolved

NA


## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
