### PR TITLE
update new experience banner to persist the dismissed banner via localStorage

### DIFF
--- a/src/plugins/explore/public/components/experience_banners/constants.ts
+++ b/src/plugins/explore/public/components/experience_banners/constants.ts
@@ -9,3 +9,4 @@ export const NEW_DISCOVER_INFO_URL =
   'https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9826';
 
 export const SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY = 'openSearchDashboards.showClassicDiscover';
+export const HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY = 'openSearchDashboards.hideNewDiscoverBanner';

--- a/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.test.tsx
+++ b/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.test.tsx
@@ -6,17 +6,37 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { NewExperienceBanner } from './new_experience_banner';
-import { NEW_DISCOVER_INFO_URL, SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY } from '../constants';
+import {
+  HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY,
+  NEW_DISCOVER_INFO_URL,
+  SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY,
+} from '../constants';
 
 describe('NewExperienceBanner', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('renders the banner correctly', () => {
     render(<NewExperienceBanner />);
     expect(screen.getByTestId('exploreNewExperienceBanner')).toBeInTheDocument();
   });
 
   it('hides the banner if clicking on dismiss button', () => {
+    jest.spyOn(Storage.prototype, 'setItem');
+    Storage.prototype.setItem = jest.fn();
     render(<NewExperienceBanner />);
     fireEvent.click(screen.getByTestId('closeCallOutButton'));
+    expect(screen.queryByTestId('exploreNewExperienceBanner')).not.toBeInTheDocument();
+    expect(localStorage.setItem).toHaveBeenCalledWith(HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY, 'true');
+  });
+
+  it('does not render the banner if local storage has previously been set', () => {
+    jest.spyOn(Storage.prototype, 'getItem');
+    Storage.prototype.getItem = jest.fn((key) =>
+      key === HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY ? 'true' : null
+    );
+    render(<NewExperienceBanner />);
     expect(screen.queryByTestId('exploreNewExperienceBanner')).not.toBeInTheDocument();
   });
 

--- a/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.tsx
+++ b/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.tsx
@@ -6,15 +6,29 @@
 import React, { useState } from 'react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import './new_experience_banner.scss';
-import { NEW_DISCOVER_INFO_URL, SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY } from '../constants';
+import {
+  HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY,
+  NEW_DISCOVER_INFO_URL,
+  SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY,
+} from '../constants';
 
 export const NewExperienceBanner = () => {
   const [isVisible, setIsVisible] = useState<boolean>(true);
+
+  // short circuit if the user has already dismissed the banner
+  if (!!localStorage.getItem(HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY)) {
+    return null;
+  }
 
   // TODO: This should open a modal to add more friction
   const handleSwitch = () => {
     localStorage.setItem(SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY, 'true');
     window.location.reload();
+  };
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    localStorage.setItem(HIDE_NEW_DISCOVER_LOCAL_STORAGE_KEY, 'true');
   };
 
   return isVisible ? (
@@ -23,7 +37,7 @@ export const NewExperienceBanner = () => {
       data-test-subj="exploreNewExperienceBanner"
       size="s"
       dismissible={true}
-      onDismiss={() => setIsVisible(false)}
+      onDismiss={handleDismiss}
     >
       <span
         className="exploreNewExperienceBanner__img"


### PR DESCRIPTION
persist the removing of new experience banner