### PR TITLE
[Explore] Fix: Preserve selected tab when query run, correctly update cacheKeys when query run

### DIFF
--- a/changelogs/fragments/9946.yml
+++ b/changelogs/fragments/9946.yml
@@ -1,0 +1,2 @@
+fix:
+- Preserve selected tab when query run, correctly update cacheKeys when query run ([#9946](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9946))

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -66,14 +66,12 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
       return [];
     }
 
-    // Try all available cache keys to find one with results (same logic as TabContent)
-    for (const cacheKey of executionCacheKeys) {
-      // TODO: why return first hit?
-      const results = state.results[cacheKey];
-      if (results) {
-        const hits = results.hits?.hits || [];
-        return hits;
-      }
+    // Use default query cacheKey
+    const cacheKey = executionCacheKeys[0];
+    const results = state.results[cacheKey];
+    if (results) {
+      const hits = results.hits?.hits || [];
+      return hits;
     }
 
     return [];

--- a/src/plugins/explore/public/application/pages/metrics/metrics_page.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_page.tsx
@@ -66,14 +66,12 @@ export const MetricsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAc
       return [];
     }
 
-    // Try all available cache keys to find one with results (same logic as TabContent)
-    for (const cacheKey of executionCacheKeys) {
-      // why return first hit?
-      const results = state.results[cacheKey];
-      if (results) {
-        const hits = results.hits?.hits || [];
-        return hits;
-      }
+    // Use default query cacheKey
+    const cacheKey = executionCacheKeys[0];
+    const results = state.results[cacheKey];
+    if (results) {
+      const hits = results.hits?.hits || [];
+      return hits;
     }
 
     return [];

--- a/src/plugins/explore/public/application/pages/traces/traces_page.tsx
+++ b/src/plugins/explore/public/application/pages/traces/traces_page.tsx
@@ -66,14 +66,12 @@ export const TracesPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAct
       return [];
     }
 
-    // Try all available cache keys to find one with results (same logic as TabContent)
-    for (const cacheKey of executionCacheKeys) {
-      // why return first hit?
-      const results = state.results[cacheKey];
-      if (results) {
-        const hits = results.hits?.hits || [];
-        return hits;
-      }
+    // Use default query cacheKey
+    const cacheKey = executionCacheKeys[0];
+    const results = state.results[cacheKey];
+    if (results) {
+      const hits = results.hits?.hits || [];
+      return hits;
     }
 
     return [];

--- a/src/plugins/explore/public/components/tabs/tabs.tsx
+++ b/src/plugins/explore/public/components/tabs/tabs.tsx
@@ -16,7 +16,7 @@ import {
   defaultPrepareQuery,
   executeQueries,
 } from '../../application/utils/state_management/actions/query_actions';
-import { selectQuery } from '../../application/utils/state_management/selectors';
+import { selectActiveTab, selectQuery } from '../../application/utils/state_management/selectors';
 import { createCacheKey } from '../../application/utils/state_management/utils/query_utils';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../types';
@@ -35,6 +35,7 @@ export const ExploreTabsComponent = () => {
   const registryTabs = services.tabRegistry.getAllTabs();
 
   const query = useSelector(selectQuery);
+  const activeTabId = useSelector(selectActiveTab);
   const results = useSelector((state: RootState) => state.results);
 
   const onTabsClick = useCallback(
@@ -78,6 +79,10 @@ export const ExploreTabsComponent = () => {
     };
   });
 
+  const activeTab = tabs.find((tab) => {
+    return tab.id === activeTabId;
+  });
+
   return (
     <EuiTabbedContent
       className="exploreTabs"
@@ -85,6 +90,7 @@ export const ExploreTabsComponent = () => {
       tabs={tabs}
       size="s"
       onTabClick={onTabsClick}
+      selectedTab={activeTab}
     />
   );
 };

--- a/src/plugins/explore/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.tsx
@@ -43,12 +43,11 @@ export const VisualizationContainer = () => {
       return [];
     }
 
-    // Try all available cache keys to find one with field schema
-    for (const cacheKey of executionCacheKeys) {
-      const results = state.results[cacheKey];
-      if (results && results.fieldSchema) {
-        return results.fieldSchema;
-      }
+    // Use tab specific cacheKey
+    const cacheKey = executionCacheKeys[1];
+    const results = state.results[cacheKey];
+    if (results && results.fieldSchema) {
+      return results.fieldSchema;
     }
 
     return [];


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

This PR fix 2 issues:

1. Use tab id in redux state to control rendering active tab content
2. Update `executeQueries` action to properly update `executionCacheKeys`
3. Update components read `executionCacheKeys`

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

1. Selected tab reset to logs tab when query run
4. Switch to visualization tab does not show visualization content, unless clicking "run query" button when visualization tab is selected

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Preserve selected tab when query run, correctly update cacheKeys when query run

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
