### PR TITLE
Fix the Autocomplete for the New Query Panel

### DIFF
--- a/src/plugins/explore/public/components/query_panel/components/editor_stack/resuable_editor.tsx
+++ b/src/plugins/explore/public/components/query_panel/components/editor_stack/resuable_editor.tsx
@@ -149,6 +149,37 @@ export const ReusableEditor: React.FC<ReusableEditorProps> = ({
         },
       });
 
+      // Add Tab key handling to trigger next autosuggestions after selection
+      editor.addCommand(monaco.KeyCode.Tab, () => {
+        // First accept the selected suggestion
+        editor.trigger('keyboard', 'acceptSelectedSuggestion', {});
+
+        // Then retrigger suggestions after a short delay
+        setTimeout(() => {
+          editor.trigger('keyboard', 'editor.action.triggerSuggest', {});
+        }, 100);
+      });
+
+      // Add Enter key handling for suggestions
+      editor.addCommand(monaco.KeyCode.Enter, () => {
+        // Check if suggestion widget is visible by checking for any suggestion context
+        const contextKeyService = (editor as any)._contextKeyService;
+        const suggestWidgetVisible = contextKeyService?.getContextKeyValue('suggestWidgetVisible');
+
+        if (suggestWidgetVisible) {
+          // Accept the selected suggestion and trigger next suggestions
+          editor.trigger('keyboard', 'acceptSelectedSuggestion', {});
+          setTimeout(() => {
+            editor.trigger('keyboard', 'editor.action.triggerSuggest', {});
+          }, 100);
+        } else {
+          // Run the query if no suggestions are visible
+          const val = editor.getValue();
+          onRun(val);
+          onEdit();
+        }
+      });
+
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
         const maxHeight = 100;

--- a/src/plugins/explore/public/components/query_panel/components/editor_stack/shared.tsx
+++ b/src/plugins/explore/public/components/query_panel/components/editor_stack/shared.tsx
@@ -36,6 +36,7 @@ export const getEditorConfig = (languageType: LanguageType) => {
           overviewRulerLanes: 0,
           hideCursorInOverviewRuler: true,
           cursorStyle: 'line',
+          tabCompletion: 'on',
           suggest: {
             snippetsPreventQuickSuggestions: false, // Ensure all suggestions are shown
             filterGraceful: false, // Don't filter suggestions

--- a/src/plugins/explore/public/components/query_panel/query_panel.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel.tsx
@@ -127,7 +127,7 @@ const QueryPanel: React.FC<QueryPanelProps> = ({ datePickerRef, services, indexP
 
         // Use centralized IndexPattern from context
         const suggestions = await services?.data?.autocomplete?.getQuerySuggestions({
-          query: typeof localQuery === 'string' ? localQuery : '',
+          query: model.getValue(), // Use the current editor content, using the local query results in a race condition where we can get stale query data
           selectionStart: model.getOffsetAt(position),
           selectionEnd: model.getOffsetAt(position),
           language: effectiveLanguage,
@@ -169,7 +169,7 @@ const QueryPanel: React.FC<QueryPanelProps> = ({ datePickerRef, services, indexP
         return { suggestions: [], incomplete: false };
       }
     },
-    [query, services, localQuery, indexPattern, dataset]
+    [query, services, indexPattern, dataset]
   );
 
   // TODO: Create query status overlay for progress indicator


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
- Fix stale query being passed to autocomplete service.
- Selecting an autosuggestion by tab was not triggering next autocomplete 
- Pressing enter within the suggestion widget insert the suggestion and triggers the next autocomplete. Outside of the suggestion widget it runs the query. 


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Fix autocomplete for ne query panel

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
