### PR TITLE
Fix PPL/SQL interceptors to respect queries from request instead of queryStringManager

### DIFF
--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -55,7 +55,10 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       },
     };
 
-    const query = this.buildQuery();
+    // Use query from request if available, otherwise fall back to queryStringManager
+    const requestQuery =
+      request.params?.body?.query?.queries?.[0] || this.queryService.queryString.getQuery();
+    const query = this.buildQuery(requestQuery);
 
     return fetch(context, query, this.getAggConfig(searchRequest, query));
   }
@@ -88,9 +91,8 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     return this.runSearch(request, options.abortSignal, strategy);
   }
 
-  private buildQuery() {
+  private buildQuery(query: Query) {
     const { queryString } = this.queryService;
-    const query: Query = queryString.getQuery();
     const dataset = query.dataset;
     if (!dataset || !dataset.timeFieldName) return query;
     const datasetService = queryString.getDatasetService();

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -46,7 +46,11 @@ export class SQLSearchInterceptor extends SearchInterceptor {
       },
     };
 
-    return fetch(context, this.queryService.queryString.getQuery()).pipe(
+    // Use query from request if available, otherwise fall back to queryStringManager
+    const query =
+      request.params?.body?.query?.queries?.[0] || this.queryService.queryString.getQuery();
+
+    return fetch(context, query).pipe(
       catchError((error) => {
         return throwError(error);
       })


### PR DESCRIPTION
## Description

PPL and SQL search interceptors were incorrectly using `queryStringManager.getQuery()` instead of the query from the request object. This caused a mismatch between the intended query (processed by Explore plugin tab definitions) and the executed query.

This PR updated both PPL and SQL interceptors to:
1. Extract the actual Query object from `request.params.body.query.queries[0]`
2. Fall back to `queryStringManager.getQuery()` for backward compatibility
3. Only modify the `runSearch` methods where query execution occurs

Before: Logs Tab will remove `stats count()` in the query input and send the request. The recording shows that current interseptor does not respect the prepared actual query 


https://github.com/user-attachments/assets/3bde132b-8f4d-4b3b-bcf8-779089fd0c26


After: Use actual request which already remove `stats count()`

https://github.com/user-attachments/assets/bfcbbf9a-d685-45cd-a7af-b3e3df068c66



### Issues Resolved

NA


## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
