### PR TITLE
add margin between the banners

### DIFF
--- a/src/plugins/data/public/ui/query_editor/_query_editor.scss
+++ b/src/plugins/data/public/ui/query_editor/_query_editor.scss
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+.osdQueryEditor__banner {
+  & > * {
+    margin-bottom: $ouiSizeXS;
+  }
+}
+
 .osdQueryEditor__wrapper {
   display: flex;
 }


### PR DESCRIPTION
### Description

- note this only affects classic experience.
- when there were multiple banners, the bganners were scrunched on top of each other:
<img width="1134" alt="Screenshot 2025-06-25 at 2 55 51 PM" src="https://github.com/user-attachments/assets/97c1b9d5-6e3d-4337-b75d-0c74228638e3" />
- after this change, there is some padding between each banner (as well as padding to the query editor, it looked weird to be so adjacent to it):
<img width="1124" alt="Screenshot 2025-06-25 at 2 57 50 PM" src="https://github.com/user-attachments/assets/4c53c84b-befd-49d3-a780-88f40271da0e" />
