### PR TITLE
more top nav refactor

### DIFF
--- a/src/plugins/explore/public/application/legacy/discover/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/view_components/canvas/top_nav.tsx
@@ -7,7 +7,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { useSelector as useNewStateSelector } from 'react-redux';
-import { Query, TimeRange } from '../../../../../../../../data/common';
 import { QueryStatus, useSyncQueryStateWithUrl } from '../../../../../../../../data/public';
 import { createOsdUrlStateStorage } from '../../../../../../../../opensearch_dashboards_utils/public';
 import { useOpenSearchDashboards } from '../../../../../../../../opensearch_dashboards_react/public';
@@ -29,16 +28,13 @@ import { selectUIState } from '../../../../../utils/state_management/selectors';
 import { useFlavorId } from '../../../../../../helpers/use_flavor_id';
 import { useSavedExplore } from '../../../../../utils/hooks/use_saved_explore';
 import { getSavedExploreIdFromUrl } from '../../../../../utils/state_management/utils/url';
+import { RootState } from '../../../../../utils/state_management/store';
 
 export interface TopNavProps {
-  opts: {
-    setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
-    onQuerySubmit: (payload: { dateRange: TimeRange; query?: Query }, isUpdate?: boolean) => void;
-  };
-  showSaveQuery: boolean;
+  setHeaderActionMenu?: AppMountParameters['setHeaderActionMenu'];
 }
 
-export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
+export const TopNav = ({ setHeaderActionMenu = () => {} }: TopNavProps) => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const flavorId = useFlavorId();
   const {
@@ -58,7 +54,7 @@ export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
   const uiState = useNewStateSelector(selectUIState);
 
   const savedQueryId = useSelector(selectSavedQuery);
-  const isLoading = useSelector((state: any) => state.ui.status === ResultStatus.LOADING);
+  const isLoading = useSelector((state: RootState) => state.ui.status === ResultStatus.LOADING);
   const { savedExplore } = useSavedExplore(savedExploreIdFromUrl);
   const [searchContext, setSearchContext] = useState<ExecutionContextSearch>({
     query: queryString.getQuery(),
@@ -103,8 +99,6 @@ export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
     data.query,
     osdUrlStateStorage
   );
-  const showActionsInGroup = uiSettings.get('home:useNewHomePage');
-  // const showActionsInGroup = false; // Use portal approach to display actions in nav bar
 
   const topNavLinks = useMemo(() => {
     return getTopNavLinks(
@@ -164,14 +158,13 @@ export const TopNav = ({ opts, showSaveQuery }: TopNavProps) => {
       data={data}
       showSearchBar={false}
       showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
-      showSaveQuery={showSaveQuery}
+      showSaveQuery={true}
       useDefaultBehaviors
-      setMenuMountPoint={opts.setHeaderActionMenu}
+      setMenuMountPoint={setHeaderActionMenu}
       indexPatterns={indexPattern ? [indexPattern] : indexPatterns}
-      onQuerySubmit={opts.onQuerySubmit}
       savedQueryId={savedQueryId}
       onSavedQueryIdChange={updateSavedQueryId}
-      groupActions={showActionsInGroup}
+      groupActions={true}
       screenTitle={screenTitle}
       queryStatus={queryStatus}
       showQueryBar={false}

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -20,10 +20,7 @@ import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_re
 import { ExploreServices } from '../../../types';
 import { RootState } from '../../utils/state_management/store';
 import { ResultStatus } from '../../utils/state_management/types';
-import {
-  TopNav,
-  TopNavProps,
-} from '../../legacy/discover/application/view_components/canvas/top_nav';
+import { TopNav } from '../../legacy/discover/application/view_components/canvas/top_nav';
 import { DiscoverChartContainer } from '../../legacy/discover/application/view_components/canvas/discover_chart_container';
 import { QueryPanel } from '../../../components/query_panel';
 import { DiscoverPanel } from '../../legacy/discover/application/view_components/panel';
@@ -89,20 +86,6 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
   useUrlStateSync(services);
   useTimefilterSubscription(services);
   useHeaderVariants(services, HeaderVariant.APPLICATION);
-
-  // Create TopNav props - use portal approach for precise positioning
-  const topNavProps: TopNavProps = {
-    opts: {
-      setHeaderActionMenu: setHeaderActionMenu || (() => {}), // Use real global header mount point
-      onQuerySubmit: ({ dateRange, query }: any) => {
-        // Update time range
-        if (dateRange && services?.data?.query?.timefilter?.timefilter) {
-          services.data.query.timefilter.timefilter.setTime(dateRange);
-        }
-      },
-    },
-    showSaveQuery: true,
-  };
 
   // Function to refresh data (for uninitialized state)
   const onRefresh = () => {
@@ -208,7 +191,7 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
             paddingSize="none"
           >
             <EuiPageBody className="explore-layout__canvas">
-              <TopNav {...topNavProps} />
+              <TopNav setHeaderActionMenu={setHeaderActionMenu} />
               {renderBottomRightPanel()}
             </EuiPageBody>
           </EuiResizablePanel>

--- a/src/plugins/explore/public/application/pages/metrics/metrics_page.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_page.tsx
@@ -20,10 +20,7 @@ import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_re
 import { ExploreServices } from '../../../types';
 import { RootState } from '../../utils/state_management/store';
 import { ResultStatus } from '../../utils/state_management/types';
-import {
-  TopNav,
-  TopNavProps,
-} from '../../legacy/discover/application/view_components/canvas/top_nav';
+import { TopNav } from '../../legacy/discover/application/view_components/canvas/top_nav';
 import { DiscoverChartContainer } from '../../legacy/discover/application/view_components/canvas/discover_chart_container';
 import { QueryPanel } from '../../../components/query_panel';
 import { DiscoverPanel } from '../../legacy/discover/application/view_components/panel';
@@ -89,20 +86,6 @@ export const MetricsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAc
   useUrlStateSync(services);
   useTimefilterSubscription(services);
   useHeaderVariants(services, HeaderVariant.APPLICATION);
-
-  // Create TopNav props - use portal approach for precise positioning
-  const topNavProps: TopNavProps = {
-    opts: {
-      setHeaderActionMenu: setHeaderActionMenu || (() => {}), // Use real global header mount point
-      onQuerySubmit: ({ dateRange, query }: any) => {
-        // Update time range
-        if (dateRange && services?.data?.query?.timefilter?.timefilter) {
-          services.data.query.timefilter.timefilter.setTime(dateRange);
-        }
-      },
-    },
-    showSaveQuery: true,
-  };
 
   // Function to refresh data (for uninitialized state)
   const onRefresh = () => {
@@ -208,7 +191,7 @@ export const MetricsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAc
             paddingSize="none"
           >
             <EuiPageBody className="explore-layout__canvas">
-              <TopNav {...topNavProps} />
+              <TopNav setHeaderActionMenu={setHeaderActionMenu} />
               {renderBottomRightPanel()}
             </EuiPageBody>
           </EuiResizablePanel>

--- a/src/plugins/explore/public/application/pages/traces/traces_page.tsx
+++ b/src/plugins/explore/public/application/pages/traces/traces_page.tsx
@@ -20,10 +20,7 @@ import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_re
 import { ExploreServices } from '../../../types';
 import { RootState } from '../../utils/state_management/store';
 import { ResultStatus } from '../../utils/state_management/types';
-import {
-  TopNav,
-  TopNavProps,
-} from '../../legacy/discover/application/view_components/canvas/top_nav';
+import { TopNav } from '../../legacy/discover/application/view_components/canvas/top_nav';
 import { DiscoverChartContainer } from '../../legacy/discover/application/view_components/canvas/discover_chart_container';
 import { QueryPanel } from '../../../components/query_panel/query_panel';
 import { DiscoverPanel } from '../../legacy/discover/application/view_components/panel';
@@ -59,7 +56,6 @@ export const TracesPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAct
     isLoading: indexPatternLoading,
     error: indexPatternError,
   } = useIndexPatternContext();
-  const showActionsInGroup = services.uiSettings.get('home:useNewHomePage', false);
 
   // Get status for conditional rendering
   const status = useSelector((state: RootState) => {
@@ -90,20 +86,6 @@ export const TracesPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAct
   useUrlStateSync(services);
   useTimefilterSubscription(services);
   useHeaderVariants(services, HeaderVariant.APPLICATION);
-
-  // Create TopNav props - use portal approach for precise positioning
-  const topNavProps: TopNavProps = {
-    opts: {
-      setHeaderActionMenu: setHeaderActionMenu || (() => {}), // Use real global header mount point
-      onQuerySubmit: ({ dateRange, query }: any) => {
-        // Update time range
-        if (dateRange && services?.data?.query?.timefilter?.timefilter) {
-          services.data.query.timefilter.timefilter.setTime(dateRange);
-        }
-      },
-    },
-    showSaveQuery: true,
-  };
 
   // Function to refresh data (for uninitialized state)
   const onRefresh = () => {
@@ -209,7 +191,7 @@ export const TracesPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAct
             paddingSize="none"
           >
             <EuiPageBody className="explore-layout__canvas">
-              <TopNav {...topNavProps} />
+              <TopNav setHeaderActionMenu={setHeaderActionMenu} />
               {renderBottomRightPanel()}
             </EuiPageBody>
           </EuiResizablePanel>


### PR DESCRIPTION
- more prop refactor for TopNav
- we don't need `onQuerySubmit` as that is props that TopNav uses for SearchBar, which we don't use.
- `showSaveQuery` is always true
- `uiSettings.get('home:useNewHomePage')` is always true for new app