### PR TITLE
Fix Autocomplete Bugs 

### DIFF
--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
@@ -150,7 +150,7 @@ export const getSimplifiedPPLSuggestions = async ({
           availableFields,
           (f: string) => `${f} `,
           (f: string) => {
-            return f.startsWith('_') ? `9` : `3`;
+            return f.startsWith('_') ? `9` : `3`; // This devalues all the Field Names that start _ so that appear further down the autosuggest wizard
           }
         )
       );

--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
@@ -146,7 +146,13 @@ export const getSimplifiedPPLSuggestions = async ({
       );
 
       finalSuggestions.push(
-        ...formatAvailableFieldsToSuggestions(availableFields, (f: string) => `${f} `, '3')
+        ...formatAvailableFieldsToSuggestions(
+          availableFields,
+          (f: string) => `${f} `,
+          (f: string) => {
+            return f.startsWith('_') ? `9` : `3`;
+          }
+        )
       );
     }
 

--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion_simplified.test.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion_simplified.test.ts
@@ -15,6 +15,7 @@ describe('ppl code_completion', () => {
   const mockIndexPattern = {
     title: 'test-index',
     fields: [
+      { name: '_field5', type: 'string' },
       { name: 'field1', type: 'string' },
       { name: 'field2', type: 'number' },
       { name: 'field3', type: 'boolean' },
@@ -322,6 +323,13 @@ describe('ppl code_completion', () => {
         text: 'counter',
         type: monaco.languages.CompletionItemKind.Field,
       });
+    });
+
+    it('should devalue the fieldNames starting _', async () => {
+      const results = await getSimpleSuggestions('source = test-index | where ');
+
+      const resultField = results.find((result) => result.text === '_field5');
+      expect(resultField?.sortText).toBe('9');
     });
   });
 });

--- a/src/plugins/data/public/antlr/shared/utils.test.ts
+++ b/src/plugins/data/public/antlr/shared/utils.test.ts
@@ -7,6 +7,7 @@ import { of } from 'rxjs';
 import {
   fetchColumnValues,
   fetchData,
+  formatAvailableFieldsToSuggestions,
   formatFieldsToSuggestions,
   formatValuesToSuggestions,
 } from './utils';
@@ -167,6 +168,50 @@ describe('formatFieldsToSuggestions', () => {
         sortText: '01',
       },
     ]);
+  });
+});
+
+describe('formatAvailableFields', () => {
+  it('should format the availableFields as per the format functions', () => {
+    const availableFields = [
+      { name: 'field1', type: 'text' },
+      { name: '_field2', type: 'text' },
+      { name: 'field3', type: 'boolean' },
+    ];
+
+    const result = formatAvailableFieldsToSuggestions(
+      availableFields,
+      (f: string) => `${f} `,
+      (f: string) => {
+        return f.startsWith('_') ? `9` : `3`;
+      }
+    );
+
+    const expectedResult = [
+      {
+        text: 'field1',
+        type: monaco.languages.CompletionItemKind.Field,
+        detail: 'Field: text',
+        insertText: 'field1 ',
+        sortText: '3',
+      },
+      {
+        text: '_field2',
+        type: monaco.languages.CompletionItemKind.Field,
+        detail: 'Field: text',
+        insertText: '_field2 ',
+        sortText: '9',
+      },
+      {
+        text: 'field3',
+        type: monaco.languages.CompletionItemKind.Field,
+        detail: 'Field: boolean',
+        insertText: 'field3 ',
+        sortText: '3',
+      },
+    ];
+
+    expect(result).toStrictEqual(expectedResult);
   });
 });
 

--- a/src/plugins/data/public/antlr/shared/utils.ts
+++ b/src/plugins/data/public/antlr/shared/utils.ts
@@ -190,7 +190,7 @@ export const formatFieldsToSuggestions = (
 export const formatAvailableFieldsToSuggestions = (
   availableFields: IFieldType[],
   modifyInsertText?: (input: string) => string,
-  sortTextImportance?: string
+  sortTextImportanceFunction?: (input: string) => string
 ) => {
   return availableFields.map((field) => {
     return {
@@ -198,7 +198,7 @@ export const formatAvailableFieldsToSuggestions = (
       type: monaco.languages.CompletionItemKind.Field,
       detail: `Field: ${field.esTypes?.[0] ?? field.type}`,
       ...(modifyInsertText && { insertText: modifyInsertText(field.name) }), // optionally include insert text if fn exists
-      ...(sortTextImportance && { sortText: sortTextImportance }),
+      ...(sortTextImportanceFunction && { sortText: sortTextImportanceFunction(field.name) }),
     };
   });
 };

--- a/src/plugins/explore/public/components/query_panel/components/editor_stack/resuable_editor.tsx
+++ b/src/plugins/explore/public/components/query_panel/components/editor_stack/resuable_editor.tsx
@@ -123,6 +123,8 @@ export const ReusableEditor: React.FC<ReusableEditorProps> = ({
         contextMenuGroupId: 'navigation',
         contextMenuOrder: 1.5,
         run: () => {
+          // Close autocomplete if open
+          editor.trigger('keyboard', 'hideSuggestWidget', {});
           const val = editor.getValue();
           onRun(val);
           onEdit();

--- a/src/plugins/explore/public/components/query_panel/query_panel.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel.tsx
@@ -19,7 +19,6 @@ import { Query, TimeRange, LanguageType } from './types';
 
 import {
   selectIsLoading,
-  selectDataset,
   selectShowDataSetFields,
 } from '../../application/utils/state_management/selectors';
 import './index.scss';
@@ -61,7 +60,6 @@ const QueryPanel: React.FC<QueryPanelProps> = ({ datePickerRef, services, indexP
 
   // Use selectors to get state from Redux
   const isLoading = useSelector(selectIsLoading);
-  const dataset = useSelector(selectDataset);
   const showDatasetFields = useSelector(selectShowDataSetFields);
 
   // Determine if DatePicker should be shown
@@ -131,14 +129,31 @@ const QueryPanel: React.FC<QueryPanelProps> = ({ datePickerRef, services, indexP
         // Get the effective language for autocomplete (PPL -> PPL_Simplified for explore app)
         const effectiveLanguage = getEffectiveLanguageForAutoComplete(query.language, 'explore');
 
-        // Use centralized IndexPattern from context
+        // Get the current dataset from Query Service to avoid stale closure values
+        const currentDataset = services?.data?.query?.queryString?.getQuery().dataset;
+
+        // Get the current indexPattern from services to avoid stale closure values
+        let currentIndexPattern = indexPattern;
+        if (currentDataset) {
+          try {
+            currentIndexPattern = await services?.indexPatterns?.get(
+              currentDataset.id,
+              currentDataset.type !== 'INDEX_PATTERN'
+            );
+          } catch (error) {
+            // Fallback to the prop indexPattern if fetching fails
+            currentIndexPattern = indexPattern;
+          }
+        }
+
+        // Use the current IndexPattern to avoid stale data
         const suggestions = await services?.data?.autocomplete?.getQuerySuggestions({
           query: model.getValue(), // Use the current editor content, using the local query results in a race condition where we can get stale query data
           selectionStart: model.getOffsetAt(position),
           selectionEnd: model.getOffsetAt(position),
           language: effectiveLanguage,
-          indexPattern: indexPattern as any,
-          datasetType: dataset?.type,
+          indexPattern: currentIndexPattern as any,
+          datasetType: currentDataset?.type,
           position,
           services: services as any, // ExploreServices storage type incompatible with IDataPluginServices.DataStorage
         });
@@ -175,7 +190,7 @@ const QueryPanel: React.FC<QueryPanelProps> = ({ datePickerRef, services, indexP
         return { suggestions: [], incomplete: false };
       }
     },
-    [query, services, indexPattern, dataset]
+    [query, services, indexPattern]
   );
 
   // TODO: Create query status overlay for progress indicator


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

- Devalue fields in the Autosuggestion Wizard that begin with _ (Mostly are meta fields)
- Close the Autocomplete Suggestion Wizard when using CMD + Enter to run the query 
- Switching Datasets using the Dataset picker was still showing the fields from the previous dataset
( Although the React Component was being updated the provideCompletionItem Method was using the older reference for indexPattern and dataset that was causing data from previous dataset to show up. Currently Modified the method to fetch the current dataset and indexPattern from queryString manager before firing the actual autocomplete query. This ensures that we are always getting the latest updates)
- Minor Cleanups

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix : Resolve Autocomplete bugs 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
