### PR TITLE
Increase timeout waiting for the exiting of an optimizer worker

### DIFF
--- a/packages/osd-optimizer/src/worker/run_worker.ts
+++ b/packages/osd-optimizer/src/worker/run_worker.ts
@@ -79,12 +79,12 @@ const exit = (code: number) => {
     send(
       workerMsgs.error(
         new Error(
-          `process did not automatically exit within 15 seconds (previous code: ${code}); forcing exit...`
+          `process did not automatically exit within 30 seconds (previous code: ${code}); forcing exit...`
         )
       )
     );
     process.exit(1);
-  }, 15000).unref();
+  }, 30000).unref();
 };
 
 // check for connected parent on an unref'd timer rather than listening


### PR DESCRIPTION
### Description

Notice it was showing the failed to timeout again so bumping it up like: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3193

### Issues Resolved

PR with commits that ran into this issue

## Changelog
- fix: Increase timeout waiting for the exiting of an optimizer worker

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
