### PR TITLE
make old saved search findable in open top nav panel

### DIFF
--- a/src/plugins/saved_objects/public/finder/saved_object_finder.tsx
+++ b/src/plugins/saved_objects/public/finder/saved_object_finder.tsx
@@ -167,7 +167,7 @@ class SavedObjectFinderUi extends React.Component<
     // If the current app id is explore, although explore app might not support
     // a language, it still supports all saved searches that are supported by
     // discover by redirecting to discover for backward compatibility.
-    if (currentAppId === 'explore') {
+    if (currentAppId.includes('explore/')) {
       return (
         (supportedInApp ||
           languageService?.getLanguage(languageId)?.supportedAppNames?.includes('discover')) ??


### PR DESCRIPTION
- our appId for the explore changed to things like `explore/logs`, `explore/traces`, etc. so we had a regression in opening old saved searches