### PR TITLE
remove flavor from UI Slice

### DIFF
--- a/src/plugins/explore/public/application/utils/state_management/README.md
+++ b/src/plugins/explore/public/application/utils/state_management/README.md
@@ -34,7 +34,6 @@ interface QueryState {
 ```typescript
 interface UIState {
   activeTabId: string;           // Currently active tab
-  flavor: string;                // Current flavor setting
   status: ResultStatus;          // Loading/ready/error status
   transaction: {                 // Transaction management
     inProgress: boolean;

--- a/src/plugins/explore/public/application/utils/state_management/selectors/index.ts
+++ b/src/plugins/explore/public/application/utils/state_management/selectors/index.ts
@@ -60,8 +60,6 @@ export const selectIsLoading = createSelector(
 
 // Error handling moved to toast notifications and search service
 
-export const selectFlavor = createSelector([selectUIState], (uiState) => uiState.flavor);
-
 // TODO: Fix this selector - queryPanel doesn't exist in UIState
 // export const selectPromptQuery = createSelector(
 //   [selectUIState],

--- a/src/plugins/explore/public/application/utils/state_management/slices/tab/tab_slice.ts
+++ b/src/plugins/explore/public/application/utils/state_management/slices/tab/tab_slice.ts
@@ -21,7 +21,7 @@ export interface TabState {
 const initialState: TabState = {
   logs: {},
   visualizations: {
-    styleOptions: defaultMetricChartStyles as ChartStyleControlMap[ChartType],
+    styleOptions: defaultMetricChartStyles,
     chartType: 'metric',
   },
 };

--- a/src/plugins/explore/public/application/utils/state_management/slices/ui/ui_slice.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/slices/ui/ui_slice.test.ts
@@ -6,7 +6,6 @@
 import {
   uiReducer,
   setActiveTab,
-  setFlavor,
   setStatus,
   startTransaction,
   commitTransaction,
@@ -20,7 +19,6 @@ describe('UI Slice', () => {
   const initialState: UIState = {
     activeTabId: 'logs',
     chartType: 'line',
-    flavor: 'log',
     status: ResultStatus.UNINITIALIZED,
     transaction: {
       inProgress: false,
@@ -48,25 +46,6 @@ describe('UI Slice', () => {
       expect(newState.activeTabId).toBe(newTabId);
 
       // Other state properties should remain unchanged
-      expect(newState.flavor).toBe(initialState.flavor);
-      expect(newState.status).toBe(initialState.status);
-      expect(newState.transaction).toEqual(initialState.transaction);
-    });
-  });
-
-  describe('setFlavor', () => {
-    it('should handle setFlavor action', () => {
-      const newFlavor = 'metric';
-      const action = setFlavor(newFlavor);
-
-      expect(action.type).toBe('ui/setFlavor');
-      expect(action.payload).toBe(newFlavor);
-
-      const newState = uiReducer(initialState, action);
-      expect(newState.flavor).toBe(newFlavor);
-
-      // Other state properties should remain unchanged
-      expect(newState.activeTabId).toBe(initialState.activeTabId);
       expect(newState.status).toBe(initialState.status);
       expect(newState.transaction).toEqual(initialState.transaction);
     });
@@ -85,7 +64,6 @@ describe('UI Slice', () => {
 
       // Other state properties should remain unchanged
       expect(newState.activeTabId).toBe(initialState.activeTabId);
-      expect(newState.flavor).toBe(initialState.flavor);
       expect(newState.transaction).toEqual(initialState.transaction);
     });
   });
@@ -104,7 +82,6 @@ describe('UI Slice', () => {
 
       // Other state properties should remain unchanged
       expect(newState.activeTabId).toBe(initialState.activeTabId);
-      expect(newState.flavor).toBe(initialState.flavor);
       expect(newState.status).toBe(initialState.status);
     });
 
@@ -127,7 +104,6 @@ describe('UI Slice', () => {
 
       // Other state properties should remain unchanged
       expect(newState.activeTabId).toBe(initialState.activeTabId);
-      expect(newState.flavor).toBe(initialState.flavor);
       expect(newState.status).toBe(initialState.status);
     });
 
@@ -152,7 +128,6 @@ describe('UI Slice', () => {
 
       // Other state properties should remain unchanged
       expect(newState.activeTabId).toBe(initialState.activeTabId);
-      expect(newState.flavor).toBe(initialState.flavor);
       expect(newState.status).toBe(initialState.status);
     });
   });
@@ -169,15 +144,10 @@ describe('UI Slice', () => {
       state = uiReducer(state, setStatus(ResultStatus.LOADING));
       expect(state.status).toBe(ResultStatus.LOADING);
 
-      // Third action: set flavor
-      state = uiReducer(state, setFlavor('metric'));
-      expect(state.flavor).toBe('metric');
-
       // Final state should have all changes
       expect(state).toEqual({
         ...initialState,
         activeTabId: 'visualizations',
-        flavor: 'metric',
         status: ResultStatus.LOADING,
         prompt: '',
         transaction: {

--- a/src/plugins/explore/public/application/utils/state_management/slices/ui/ui_slice.ts
+++ b/src/plugins/explore/public/application/utils/state_management/slices/ui/ui_slice.ts
@@ -12,7 +12,6 @@ import {
 
 export interface UIState {
   activeTabId: string;
-  flavor: string;
   status: ResultStatus;
   showDatasetFields: boolean;
   transaction: {
@@ -26,7 +25,6 @@ export interface UIState {
 
 const initialState: UIState = {
   activeTabId: 'logs',
-  flavor: 'log',
   status: ResultStatus.UNINITIALIZED,
   showDatasetFields: true,
   transaction: {
@@ -47,9 +45,6 @@ const uiSlice = createSlice({
     },
     setActiveTab: (state, action: PayloadAction<string>) => {
       state.activeTabId = action.payload;
-    },
-    setFlavor: (state, action: PayloadAction<string>) => {
-      state.flavor = action.payload;
     },
     setStatus: (state, action: PayloadAction<ResultStatus>) => {
       state.status = action.payload;
@@ -87,7 +82,6 @@ const uiSlice = createSlice({
 
 export const {
   setActiveTab,
-  setFlavor,
   setStatus,
   setShowDatasetFields,
   setQueryPrompt,


### PR DESCRIPTION
- remove flavor from UI Slice
- We have this hook that retrieves the correct flavor from the app ID: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/query_explore/src/plugins/explore/public/helpers/use_flavor_id/use_flavor_id.ts
- added expliit types on redux_persistence as i missed a flavor there but it was not typed