### PR TITLE
fix datepicker locaiton in classic experience

### DIFF
--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -242,7 +242,7 @@ export function TopNavMenu(props: TopNavMenuProps): ReactElement | null {
                     <EuiFlexItem grow={false} className="osdTopNavMenu">
                       {renderMenu(menuClassName)}
                     </EuiFlexItem>
-                    <EuiFlexItem grow={false} className="globalDatePicker">
+                    <EuiFlexItem className="globalDatePicker">
                       <div ref={datePickerRef} />
                     </EuiFlexItem>
                   </EuiFlexGroup>


### PR DESCRIPTION
Before:

<img width="1505" alt="Screenshot 2025-06-30 at 6 38 00 PM" src="https://github.com/user-attachments/assets/2043f1e3-cf15-4a0d-ada9-a792a6558cdd" />

After:

<img width="1541" alt="Screenshot 2025-06-30 at 6 37 49 PM" src="https://github.com/user-attachments/assets/528edf50-b384-42d9-bb33-bee00980a74a" />

offending change: https://github.com/opensearch-project/OpenSearch-Dashboards/commit/627955dfe4ac8831a9ecc255431a264bb4eda253#diff-b293cb9367af92bb97c71d71cae66dcc2b12c26168fc4e4c5cf472334bcb4453R246