### PR TITLE
[Explore] add style persistence across refresh

### DIFF
--- a/src/plugins/explore/public/components/visualizations/visualization.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization.tsx
@@ -87,18 +87,6 @@ export const Visualization = <T extends ChartType>({
             })}
         </EuiFlexItem>
       </EuiFlexItem>
-      {/* <div data-test-subj="exploreStylePanel" className="exploreVisStylePanel">
-          {visualizationData.visualizationType?.ui.style.render({
-            styleOptions,
-            onStyleChange,
-            numericalColumns: visualizationData.numericalColumns,
-            categoricalColumns: visualizationData.categoricalColumns,
-            dateColumns: visualizationData.dateColumns,
-            availableChartTypes,
-            selectedChartType,
-            onChartTypeChange,
-          })}
-        </div> */}
     </EuiFlexGroup>
   );
 };

--- a/src/plugins/explore/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.tsx
@@ -72,13 +72,25 @@ export const VisualizationContainer = () => {
 
   const visualizationRegistry = useVisualizationRegistry();
 
-  // Initialize selectedChartType and its default styles when visualizationData changes
   useEffect(() => {
     if (visualizationData && visualizationData.visualizationType) {
-      dispatch(setSelectedChartType(visualizationData.visualizationType.type));
-      dispatch(setStyleOptions(visualizationData.visualizationType.ui.style.defaults));
+      if (!selectedChartType) {
+        // default initialization on load
+        dispatch(setSelectedChartType(visualizationData.visualizationType.type));
+        dispatch(setStyleOptions(visualizationData.visualizationType.ui.style.defaults));
+        return;
+      }
+      // if URL stores a different chart type than the visualizationData; we should persist the chart type from URL
+      if (selectedChartType !== visualizationData.visualizationType.type) {
+        const chartConfig = visualizationRegistry.getVisualizationConfig(selectedChartType);
+        setVisualizationData({
+          ...visualizationData,
+          visualizationType: chartConfig as VisualizationType<ChartType>,
+        });
+        return;
+      }
     }
-  }, [visualizationData, dispatch]);
+  }, [visualizationData, dispatch, selectedChartType, visualizationRegistry]);
 
   // Hook to generate the expression based on the visualization type and data
   const expression = useMemo(() => {
@@ -199,7 +211,7 @@ export const VisualizationContainer = () => {
   };
 
   // Don't render if visualization is not enabled or data is not ready
-  if (!visualizationData) {
+  if (!visualizationData || !expression) {
     return null;
   }
 

--- a/src/plugins/explore/public/components/visualizations/visualization_empty_state.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_empty_state.tsx
@@ -83,6 +83,12 @@ export const VisualizationEmptyState: React.FC<VisualizationEmptyStateProps> = (
     visualizationData.visualizationType ? visualizationData.visualizationType.name : undefined
   );
 
+  useEffect(() => {
+    if (visualizationData.visualizationType) {
+      setCurrChartTypeId(visualizationData.visualizationType.name);
+    }
+  }, [visualizationData.visualizationType]);
+
   // Selected fields by user, categorized by field types
   const [fieldsSelection, setFieldsSelection] = useState<{
     numerical: VisColumn[];


### PR DESCRIPTION
### Description

This PR does two persistence: 

1. Persist the chart type and its styling configurations across refresh

https://github.com/user-attachments/assets/816ebd38-ad58-4dd5-b948-6686ed57355c



2. Persist the chart type and its styling configurations across different query execution if the new query can still be mapped to the previous chart type

https://github.com/user-attachments/assets/bbf96bda-3b98-4e5f-bd10-aa73bfae2b02



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
