### PR TITLE
[Explore] change name of add to dashboard modal

### DIFF
--- a/changelogs/fragments/10055.yml
+++ b/changelogs/fragments/10055.yml
@@ -1,0 +1,2 @@
+fix:
+- Change name of add to dashboard modal ([#10055](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10055))

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.tsx
@@ -219,13 +219,13 @@ export const AddToDashboardModal: React.FC<AddToDashboardModalProps> = ({
             <EuiFlexItem grow={true} style={{ width: '100%' }}>
               <DebouncedText
                 value={title}
-                placeholder="Save Explore name"
+                placeholder="Save discover title"
                 onChange={(text) => {
                   setIsTitleOrDashboardTitleDupilcate(false);
                   setTitle(text);
                 }}
                 label={i18n.translate('explore.addtoDashboardModal.saveExploreName', {
-                  defaultMessage: 'Save Explore name',
+                  defaultMessage: 'Save discover title',
                 })}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.tsx
@@ -224,7 +224,7 @@ export const AddToDashboardModal: React.FC<AddToDashboardModalProps> = ({
                   setIsTitleOrDashboardTitleDupilcate(false);
                   setTitle(text);
                 }}
-                label={i18n.translate('explore.addtoDashboardModal.saveExploreName', {
+                label={i18n.translate('explore.addtoDashboardModal.saveDiscoverTitle', {
                   defaultMessage: 'Save discover title',
                 })}
               />


### PR DESCRIPTION
### Description
This pr changes name of add to dashboard modal, new name is save discover title

## Screenshot
<img width="590" alt="截屏2025-07-02 17 10 51" src="https://github.com/user-attachments/assets/22ecb910-ac96-42ab-9979-91e8c1b4afe6" />

aligns with

<img width="590" alt="截屏2025-07-02 17 11 45" src="https://github.com/user-attachments/assets/ca691ca7-a74c-4fa4-a842-27a629de3643" />

## Testing the changes


<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix:  change name of add to dashboard modal
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
