### PR TITLE
[Explore] Allow switch dataset to update recent query

### DIFF
--- a/src/plugins/explore/public/application/components/header_dataset_selector.tsx
+++ b/src/plugins/explore/public/application/components/header_dataset_selector.tsx
@@ -9,7 +9,7 @@ import { DatasetSelector, DatasetSelectorAppearance, Query } from '../../../../d
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../types';
 import { executeQueries } from '../utils/state_management/actions/query_actions';
-import { clearResults, setQueryState } from '../utils/state_management/slices';
+import { clearResults, setQueryWithHistory } from '../utils/state_management/slices';
 
 /**
  * Header dataset selector component for Explore
@@ -34,7 +34,7 @@ export const HeaderDatasetSelector: React.FC = () => {
       const queryStringState = services.data.query.queryString.getQuery();
 
       dispatch(clearResults());
-      dispatch(setQueryState(queryStringState));
+      dispatch(setQueryWithHistory(queryStringState));
       dispatch(executeQueries({ services }));
     },
     [dispatch, services]

--- a/src/plugins/explore/public/application/utils/state_management/__mocks__/chart_utils.ts
+++ b/src/plugins/explore/public/application/utils/state_management/__mocks__/chart_utils.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Consolidated chart utility mocks
+ */
+export const mockChartUtilsMocks = {
+  createHistogramConfigs: jest.fn(),
+  getDimensions: jest.fn(),
+  buildPointSeriesData: jest.fn(),
+};
+
+/**
+ * Data plugin mocks
+ */
+export const mockDataPluginMocks = {
+  search: {
+    tabifyAggResponse: jest.fn(),
+  },
+};
+
+// Mock the modules using the mock objects
+jest.mock('../../../legacy/discover/application/components/chart/utils', () => mockChartUtilsMocks);
+jest.mock('../../../../../../data/public', () => mockDataPluginMocks);
+
+// Export individual mock functions for convenience
+export const mockCreateHistogramConfigs = mockChartUtilsMocks.createHistogramConfigs;
+export const mockGetDimensions = mockChartUtilsMocks.getDimensions;
+export const mockBuildPointSeriesData = mockChartUtilsMocks.buildPointSeriesData;
+export const mockTabifyAggResponse = mockDataPluginMocks.search.tabifyAggResponse;
+
+/**
+ * Creates mock histogram configurations for testing
+ */
+export const createMockHistogramConfigs = () => ({
+  aggs: [
+    {},
+    {
+      buckets: {
+        getInterval: jest.fn(() => ({ interval: '1h', scale: 1 })),
+      },
+    },
+  ],
+});

--- a/src/plugins/explore/public/application/utils/state_management/__mocks__/data_factories.ts
+++ b/src/plugins/explore/public/application/utils/state_management/__mocks__/data_factories.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ISearchResult } from '../slices/results/results_slice';
+import { IndexPattern } from '../../../legacy/discover/opensearch_dashboards_services';
+
+/**
+ * Creates a mock search result for testing
+ */
+export const createMockSearchResult = (overrides: Partial<ISearchResult> = {}): ISearchResult => ({
+  hits: {
+    hits: [
+      {
+        _index: 'test-index',
+        _type: '_doc',
+        _id: '1',
+        _score: 1.0,
+        _source: { field1: 'value1', field2: 'value2' },
+      },
+      {
+        _index: 'test-index',
+        _type: '_doc',
+        _id: '2',
+        _score: 0.8,
+        _source: { field1: 'value3', field3: 'value4' },
+      },
+    ],
+    total: 2,
+    max_score: 1.0,
+  },
+  took: 5,
+  timed_out: false,
+  _shards: {
+    total: 1,
+    successful: 1,
+    skipped: 0,
+    failed: 0,
+  },
+  elapsedMs: 100,
+  ...overrides,
+});
+
+/**
+ * Creates a mock search result with aggregations for histogram testing
+ */
+export const createMockSearchResultWithAggregations = (): ISearchResult =>
+  createMockSearchResult({
+    aggregations: {
+      histogram: {
+        buckets: [
+          { key: 1609459200000, doc_count: 5 },
+          { key: 1609462800000, doc_count: 3 },
+        ],
+      },
+    },
+  });
+
+/**
+ * Creates a mock IndexPattern for testing
+ */
+export const createMockIndexPattern = (overrides: any = {}): IndexPattern =>
+  ({
+    flattenHit: jest.fn((hit) => {
+      const flattened: any = {};
+      if (hit._source.field1) flattened.field1 = hit._source.field1;
+      if (hit._source.field2) flattened.field2 = hit._source.field2;
+      if (hit._source.field3) flattened.field3 = hit._source.field3;
+      return flattened;
+    }),
+    timeFieldName: '@timestamp',
+    isTimeBased: jest.fn().mockReturnValue(true),
+    ...overrides,
+  } as IndexPattern);
+
+/**
+ * Creates a mock DataPublicPluginStart for testing
+ */
+export const createMockDataPublicPluginStart = () =>
+  ({
+    // Mock DataPublicPluginStart properties as needed
+  } as any);

--- a/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts
+++ b/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './services';
+export * from './store';
+export * from './chart_utils';
+export * from './data_factories';
+
+export const setupTestMocks = () => {
+  jest.clearAllMocks();
+};
+
+export const resetTestMocks = () => {
+  jest.resetAllMocks();
+};

--- a/src/plugins/explore/public/application/utils/state_management/__mocks__/services.ts
+++ b/src/plugins/explore/public/application/utils/state_management/__mocks__/services.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ExploreServices } from '../../../../types';
+
+/**
+ * Creates a mock ExploreServices object for testing
+ */
+export const createMockExploreServices = (
+  overrides: Partial<ExploreServices> = {}
+): ExploreServices =>
+  ({
+    data: {
+      query: {
+        queryString: {
+          getQuery: jest.fn().mockReturnValue({ query: '', language: 'sql' }),
+          setQuery: jest.fn(),
+          addToQueryHistory: jest.fn(),
+        },
+        timefilter: {
+          timefilter: {
+            getTime: jest.fn().mockReturnValue({ from: 'now-15m', to: 'now' }),
+          },
+        },
+      },
+      search: {
+        tabifyAggResponse: jest.fn(),
+      },
+    },
+    ...overrides,
+  } as ExploreServices);

--- a/src/plugins/explore/public/application/utils/state_management/__mocks__/store.ts
+++ b/src/plugins/explore/public/application/utils/state_management/__mocks__/store.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RootState } from '../store';
+
+/**
+ * Mock store interface for testing middleware and components
+ */
+export interface MockStore {
+  getState: jest.MockedFunction<() => RootState>;
+  dispatch: jest.MockedFunction<(action: any) => any>;
+}
+
+/**
+ * Creates a mock Redux store for testing
+ */
+export const createMockStore = (initialState?: Partial<RootState>): MockStore => ({
+  getState: jest.fn().mockReturnValue({
+    query: {
+      query: 'SELECT * FROM logs',
+      language: 'sql',
+      dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
+    },
+    ui: {
+      showDatasetFields: false,
+      prompt: '',
+    },
+    results: {},
+    tab: {},
+    legacy: {
+      interval: 'auto',
+      columns: [],
+      sort: [],
+    },
+    system: {
+      status: 'UNINITIALIZED',
+    },
+    ...initialState,
+  }),
+  dispatch: jest.fn(),
+});
+
+/**
+ * Creates a mock state with common test scenarios
+ */
+export const createMockRootState = (overrides?: Partial<RootState>): RootState =>
+  ({
+    query: {
+      query: 'SELECT * FROM logs',
+      language: 'sql',
+      dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
+    },
+    ui: {
+      showDatasetFields: false,
+      prompt: '',
+    },
+    results: {},
+    tab: {},
+    legacy: {
+      interval: 'auto',
+      columns: [],
+      sort: [],
+    },
+    system: {
+      status: 'UNINITIALIZED',
+    },
+    ...overrides,
+  } as RootState);

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -12,7 +12,7 @@ import {
   mockGetDimensions,
   mockBuildPointSeriesData,
   mockTabifyAggResponse,
-} from './test_utils';
+} from '../__mocks__';
 
 import {
   defaultPrepareQuery,
@@ -87,7 +87,7 @@ describe('Query Actions', () => {
   });
 
   describe('histogramResultsProcessor', () => {
-    const mockData = {} as any; // Simple mock object for DataPublicPluginStart
+    const mockData = {} as any;
     const mockHistogramConfigs = createMockHistogramConfigs();
 
     beforeEach(() => {

--- a/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
@@ -27,14 +27,14 @@ export const createQuerySyncMiddleware = (services: ExploreServices): Middleware
 
         if (!isEqual(queryStringQuery, query)) {
           services.data.query.queryString.setQuery(query);
+        }
 
-          // Add to query history only for user-initiated query executions
-          // This prevents programmatic updates (loading saved queries, clearing, etc.) from polluting history
-          if (action.meta?.addToHistory && query.query?.trim()) {
-            const timefilter = services?.data?.query?.timefilter?.timefilter;
-            if (timefilter) {
-              services.data.query.queryString.addToQueryHistory(query, timefilter.getTime());
-            }
+        // Add to query history only for user-initiated query executions
+        // This prevents programmatic updates (loading saved queries, clearing, etc.) from polluting history
+        if (action.meta?.addToHistory && query.query?.trim()) {
+          const timefilter = services?.data?.query?.timefilter?.timefilter;
+          if (timefilter) {
+            services.data.query.queryString.addToQueryHistory(query, timefilter.getTime());
           }
         }
       }


### PR DESCRIPTION
### Description

This PR allows recent query to update when dataset is changed:

https://github.com/user-attachments/assets/ca541006-45dc-491e-9401-b436ba5f3a09




## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
