### PR TITLE
[Explore] Fix recent query bug to allow run query update query history via middleware

### DIFF
--- a/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
@@ -18,7 +18,11 @@ export const createQuerySyncMiddleware = (services: ExploreServices): Middleware
   return (store) => (next) => (action) => {
     const result = next(action);
 
-    if (action.type === 'query/setQueryState' || action.type === 'query/setQueryWithHistory') {
+    if (
+      action.type === 'query/setQueryState' ||
+      action.type === 'query/setQueryWithHistory' ||
+      action.type === 'query/setQueryStringWithHistory'
+    ) {
       const state = store.getState();
       const query = state.query;
 

--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -25,7 +25,6 @@ import { useFlavorId } from '../../helpers/use_flavor_id';
 import { getTopNavLinks } from './top_nav_links';
 import { SavedExplore } from '../../saved_explore';
 
-// import './discover_canvas.scss';
 export interface TopNavProps {
   savedExplore?: SavedExplore;
   setHeaderActionMenu?: AppMountParameters['setHeaderActionMenu'];


### PR DESCRIPTION
### Description

Fix a regression bug by updating middleware



## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
