### PR TITLE
[Explore] fix monaco reference to old `suggestionProvider`

### DIFF
--- a/src/plugins/explore/public/components/query_panel/utils/use_shared_editor/use_shared_editor.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/utils/use_shared_editor/use_shared_editor.test.tsx
@@ -240,6 +240,18 @@ describe('useSharedEditor', () => {
       expect(result.current.suggestionProvider.triggerCharacters).toEqual([' ']);
       expect(result.current.suggestionProvider.provideCompletionItems).toBeInstanceOf(Function);
     });
+
+    it('should register completion provider', () => {
+      // Mock monaco.languages.registerCompletionItemProvider
+      const registerCompletionItemProviderMock = jest.fn();
+      (monaco.languages as any).registerCompletionItemProvider = registerCompletionItemProviderMock;
+
+      // Render hook which should trigger useEffect
+      renderUseSharedEditor();
+
+      // Provider registration should be called
+      expect(registerCompletionItemProviderMock).toHaveBeenCalled();
+    });
   });
 
   describe('onChange', () => {

--- a/src/plugins/explore/public/components/query_panel/utils/use_shared_editor/use_shared_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/utils/use_shared_editor/use_shared_editor.ts
@@ -162,6 +162,17 @@ export const useSharedEditor = ({
     };
   }, [provideCompletionItems]);
 
+  // We need to manually register suggestionProvider if it gets re-created,
+  // because monaco.languages.onLanguage will not trigger registration
+  // callbacks if language is the same.
+  useEffect(() => {
+    const disposable = monaco.languages.registerCompletionItemProvider(
+      queryLanguage,
+      suggestionProvider
+    );
+    return () => disposable.dispose();
+  }, [suggestionProvider, queryLanguage]);
+
   const handleRun = useCallback(() => {
     dispatch(onEditorRunActionCreator(services, editorContextRef.current));
   }, [dispatch, services]);


### PR DESCRIPTION
### Description

The problem is that `monaco.languages.registerCompletionItemProvider` uses a global registry, and monaco editor will use the old provider if the new one is not registered, even after monaco component unmount.

Currently, `monaco.languages.registerCompletionItemProvider` is called in the render function of `CodeEditor`. This can be moved to `editorWillMount`, but it creates a closure on `languageId` and does not register other completion providers when language switches. Calling this in `editorDidMount` will not have any effect.
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/89ed4f10e9b1aae9679d19783830ceda0b02bd19/src/plugins/opensearch_dashboards_react/public/code_editor/code_editor.tsx#L171-L190

This PR overrides the completion provider when suggestion provider changes in `useSharedEditor` hook. This is needed when switching flavors and components are remounted, otherwise the old suggestion provider closure will use the old `editorModeRef`, resulting incorrect behavior.

I have tried to refactor `CodeEditor` to re-register provider when language or suggestion provider object changes, but it would involve larger refactor that might lead to regressions.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
