### PR TITLE
[Explore] Make log table columns to be controlled by query result

### DIFF
--- a/src/plugins/explore/public/application/legacy/discover/application/view_components/utils/filter_columns.test.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/view_components/utils/filter_columns.test.ts
@@ -5,6 +5,16 @@
 
 import { filterColumns } from './filter_columns';
 import { IndexPattern } from '../../../opensearch_dashboards_services';
+import { getIndexPatternFieldList } from '../../components/sidebar/lib/get_index_pattern_field_list';
+import { buildColumns } from '../../utils/columns';
+
+jest.mock('../../components/sidebar/lib/get_index_pattern_field_list');
+jest.mock('../../utils/columns');
+
+const mockGetIndexPatternFieldList = getIndexPatternFieldList as jest.MockedFunction<
+  typeof getIndexPatternFieldList
+>;
+const mockBuildColumns = buildColumns as jest.MockedFunction<typeof buildColumns>;
 
 describe('filterColumns', () => {
   const indexPatternMock = {
@@ -13,32 +23,94 @@ describe('filterColumns', () => {
     },
   } as IndexPattern;
 
-  it('should return columns that exist in the index pattern fields when MODIFY_COLUMN_ON_SWITCH is true', () => {
-    const columns = ['a', 'b'];
-    const result = filterColumns(columns, indexPatternMock, ['a'], true);
-    expect(result).toEqual(['a']);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuildColumns.mockImplementation((cols) => cols);
   });
 
-  it('should return all of the columns when MODIFY_COLUMN_ON_SWITCH is false', () => {
-    const columns = ['a', 'b'];
-    const result = filterColumns(columns, indexPatternMock, ['a'], false);
+  it('should return built columns when modifyColumn is false and fieldCounts exist', () => {
+    const fieldCounts = { a: 5, b: 3 };
+    const defaultColumns = ['a'];
+    mockBuildColumns.mockReturnValue(['a', 'b']);
+
+    const result = filterColumns(indexPatternMock, defaultColumns, false, fieldCounts);
+
+    expect(mockBuildColumns).toHaveBeenCalledWith(['a', 'b']);
     expect(result).toEqual(['a', 'b']);
   });
 
-  it('should return defualt columns if columns are empty', () => {
-    const result = filterColumns([], indexPatternMock, ['a'], false);
+  it('should return ["_source"] when modifyColumn is false and no fieldCounts', () => {
+    const defaultColumns = ['a'];
+
+    const result = filterColumns(indexPatternMock, defaultColumns, false);
+
     expect(result).toEqual(['_source']);
   });
 
-  it('should return defaultColumns if no columns exist in the index pattern fields when MODIFY_COLUMN_ON_SWITCH is true', () => {
-    const columns = ['b', 'e'];
-    const result = filterColumns(columns, indexPatternMock, ['e'], true);
+  it('should filter columns based on index pattern fields when modifyColumn is true and no fieldCounts', () => {
+    const defaultColumns = ['a', 'e'];
+    mockBuildColumns.mockReturnValue(['a']);
+
+    const result = filterColumns(indexPatternMock, defaultColumns, true);
+
+    expect(mockBuildColumns).toHaveBeenCalledWith(['a']);
+    expect(result).toEqual(['a']);
+  });
+
+  it('should use getIndexPatternFieldList when fieldCounts is provided and modifyColumn is true', () => {
+    const fieldCounts = { a: 5, b: 3 };
+    const defaultColumns = ['a'];
+    mockGetIndexPatternFieldList.mockReturnValue([{ name: 'a' } as any, { name: 'b' } as any]);
+    mockBuildColumns.mockReturnValue(['a', 'b']);
+
+    const result = filterColumns(indexPatternMock, defaultColumns, true, fieldCounts);
+
+    expect(mockGetIndexPatternFieldList).toHaveBeenCalledWith(indexPatternMock, fieldCounts);
+    expect(mockBuildColumns).toHaveBeenCalledWith(['a', 'b']);
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('should combine columns and defaultColumns without duplicates', () => {
+    const fieldCounts = { a: 5, b: 3 };
+    const defaultColumns = ['a', 'c'];
+    mockGetIndexPatternFieldList.mockReturnValue([{ name: 'a' } as any, { name: 'c' } as any]);
+    mockBuildColumns.mockReturnValue(['a', 'c']);
+
+    const result = filterColumns(indexPatternMock, defaultColumns, true, fieldCounts);
+
+    expect(mockBuildColumns).toHaveBeenCalledWith(['a', 'c']);
+    expect(result).toEqual(['a', 'c']);
+  });
+
+  it('should return ["_source"] when adjustedColumns has 8 or more items', () => {
+    const fieldCounts = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 };
+    const defaultColumns = ['a'];
+    mockGetIndexPatternFieldList.mockReturnValue([
+      { name: 'a' } as any,
+      { name: 'b' } as any,
+      { name: 'c' } as any,
+      { name: 'd' } as any,
+      { name: 'e' } as any,
+      { name: 'f' } as any,
+      { name: 'g' } as any,
+      { name: 'h' } as any,
+    ]);
+    mockBuildColumns.mockReturnValue(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+
+    const result = filterColumns(indexPatternMock, defaultColumns, true, fieldCounts);
+
     expect(result).toEqual(['_source']);
   });
 
-  it('should return defaultColumns if no columns and indexPattern is undefined', () => {
-    const columns = ['b', 'e'];
-    const result = filterColumns(columns, undefined, ['a'], true);
-    expect(result).toEqual(['_source']);
+  it('should handle undefined indexPattern when modifyColumn is true', () => {
+    const fieldCounts = { a: 5, b: 3 };
+    const defaultColumns = ['a'];
+    mockGetIndexPatternFieldList.mockReturnValue([]);
+    mockBuildColumns.mockReturnValue([]);
+
+    const result = filterColumns(undefined, defaultColumns, true, fieldCounts);
+
+    expect(mockGetIndexPatternFieldList).toHaveBeenCalledWith(undefined, fieldCounts);
+    expect(result).toEqual([]);
   });
 });

--- a/src/plugins/explore/public/application/legacy/discover/application/view_components/utils/filter_columns.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/view_components/utils/filter_columns.ts
@@ -18,15 +18,15 @@ import { buildColumns } from '../../utils/columns';
  * @param modifyColumn Booelan of 'discover:modifyColumnsOnSwitch'
  */
 export function filterColumns(
-  columns: string[],
   indexPattern: IndexPattern | undefined,
   defaultColumns: string[],
   modifyColumn: boolean,
   fieldCounts?: Record<string, number>
 ) {
+  const columns = fieldCounts ? Object.keys(fieldCounts) : [];
   // if false, we keep all the chosen columns
   if (!modifyColumn) {
-    return columns.length > 0 ? columns : ['_source'];
+    return columns.length > 0 ? buildColumns(columns) : ['_source'];
   }
   // if true, we keep columns that exist in the new index pattern
   // const fieldsName = indexPattern?.fields?.getAll?.()?.map((fld) => fld.name) || [];
@@ -38,5 +38,6 @@ export function filterColumns(
   const combinedColumns = [...new Set([...columns, ...defaultColumns])];
   const filteredColumns = combinedColumns.filter((column) => fieldsName.includes(column));
   const adjustedColumns = buildColumns(filteredColumns);
-  return adjustedColumns.length > 0 ? adjustedColumns : ['_source'];
+  // show all columns if query fields are less than 8
+  return adjustedColumns.length < 8 ? adjustedColumns : ['_source'];
 }

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -83,7 +83,7 @@ export const defaultResultsProcessor: DefaultDataProcessor = (
   const fieldCounts: Record<string, number> = {};
   if (rawResults.hits && rawResults.hits.hits && indexPattern) {
     for (const hit of rawResults.hits.hits) {
-      const fields = Object.keys(indexPattern.flattenHit(hit));
+      const fields = Object.keys(hit._source);
       for (const fieldName of fields) {
         fieldCounts[fieldName] = (fieldCounts[fieldName] || 0) + 1;
       }

--- a/src/plugins/explore/public/components/data_table/data_table.tsx
+++ b/src/plugins/explore/public/components/data_table/data_table.tsx
@@ -28,8 +28,8 @@ export interface DataTableProps {
   isShortDots: boolean;
   showPagination?: boolean;
   docViewsRegistry: DocViewsRegistry;
-  onRemoveColumn: (column: string) => void;
-  onAddColumn: (column: string) => void;
+  onRemoveColumn?: (column: string) => void;
+  onAddColumn?: (column: string) => void;
   onFilter: DocViewFilterFn;
   onClose?: () => void;
   scrollToTop?: () => void;
@@ -197,7 +197,7 @@ const DataTableUI = ({
            * First cell is skipped because it has a fixed dimension set already.
            */
           tableElement.querySelectorAll('thead > tr > th:not(:first-child)').forEach((th) => {
-            (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 'px';
+            (th as HTMLTableCellElement).style.width = th.getBoundingClientRect().width + 20 + 'px';
           });
 
           tableElement.style.tableLayout = 'fixed';

--- a/src/plugins/explore/public/components/data_table/table_row/table_row.tsx
+++ b/src/plugins/explore/public/components/data_table/table_row/table_row.tsx
@@ -114,7 +114,7 @@ export const TableRowUI = ({
 
         const sanitizedCellValue = dompurify.sanitize(formattedValue);
 
-        if (!fieldInfo?.filterable === false) {
+        if (fieldInfo?.filterable === false) {
           return (
             <td
               key={colName}
@@ -179,18 +179,24 @@ export const TableRowUI = ({
                 hit: row,
                 columns,
                 indexPattern,
-                filter: (mapping, value, mode) => {
-                  onFilter?.(mapping, value, mode);
-                  onClose?.();
-                },
-                onAddColumn: (columnName: string) => {
-                  onAddColumn?.(columnName);
-                  onClose?.();
-                },
-                onRemoveColumn: (columnName: string) => {
-                  onRemoveColumn?.(columnName);
-                  onClose?.();
-                },
+                filter: onFilter
+                  ? (mapping, value, mode) => {
+                      onFilter(mapping, value, mode);
+                      onClose?.();
+                    }
+                  : undefined,
+                onAddColumn: onAddColumn
+                  ? (columnName: string) => {
+                      onAddColumn(columnName);
+                      onClose?.();
+                    }
+                  : undefined,
+                onRemoveColumn: onRemoveColumn
+                  ? (columnName: string) => {
+                      onRemoveColumn(columnName);
+                      onClose?.();
+                    }
+                  : undefined,
               }}
               docViewsRegistry={docViewsRegistry}
             />

--- a/src/plugins/explore/public/helpers/data_table_helper.test.tsx
+++ b/src/plugins/explore/public/helpers/data_table_helper.test.tsx
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { getTimeColumn, getLegacyDisplayedColumns } from './data_table_helper';
+import { IndexPattern } from '../../../../plugins/data/public';
+
+import { getOsdFieldOverrides } from '../../../../plugins/data/public';
+import { shortenDottedString } from './shorten_dotted_string';
+
+jest.mock('../../../../plugins/data/public', () => ({
+  getOsdFieldOverrides: jest.fn(),
+}));
+
+jest.mock('./shorten_dotted_string', () => ({
+  shortenDottedString: jest.fn((str) => str),
+}));
+
+const mockGetOsdFieldOverrides = getOsdFieldOverrides as jest.MockedFunction<
+  typeof getOsdFieldOverrides
+>;
+const mockShortenDottedString = shortenDottedString as jest.MockedFunction<
+  typeof shortenDottedString
+>;
+
+describe('data_table_helper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetOsdFieldOverrides.mockReturnValue({ sortable: true });
+  });
+
+  describe('getTimeColumn', () => {
+    it('should return time column properties with default values', () => {
+      const timeFieldName = '@timestamp';
+      const osdFieldOverrides = { sortable: true };
+
+      const result = getTimeColumn(timeFieldName, osdFieldOverrides);
+
+      expect(result).toEqual({
+        name: '@timestamp',
+        displayName: 'Time',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      });
+    });
+
+    it('should use sortable from osdFieldOverrides when provided', () => {
+      const timeFieldName = '@timestamp';
+      const osdFieldOverrides = { sortable: false };
+
+      const result = getTimeColumn(timeFieldName, osdFieldOverrides);
+
+      expect(result.isSortable).toBe(false);
+    });
+
+    it('should default to true when sortable is not provided', () => {
+      const timeFieldName = '@timestamp';
+      const osdFieldOverrides = {};
+
+      const result = getTimeColumn(timeFieldName, osdFieldOverrides);
+
+      expect(result.isSortable).toBe(true);
+    });
+  });
+
+  describe('getLegacyDisplayedColumns', () => {
+    const mockIndexPattern = ({
+      getFieldByName: jest.fn(),
+      timeFieldName: '@timestamp',
+    } as unknown) as IndexPattern;
+
+    beforeEach(() => {
+      (mockIndexPattern.getFieldByName as jest.Mock).mockReturnValue({
+        sortable: true,
+      });
+    });
+
+    it('should return empty array when columns is not an array', () => {
+      const result = getLegacyDisplayedColumns(null as any, mockIndexPattern, false, false);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when indexPattern is invalid', () => {
+      const result = getLegacyDisplayedColumns(['field1'], null as any, false, false);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return column properties without time field when hideTimeField is true', () => {
+      const columns = ['field1', 'field2'];
+
+      const result = getLegacyDisplayedColumns(columns, mockIndexPattern, true, false);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        name: 'field1',
+        displayName: 'field1',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: -1,
+        colRightIdx: 1,
+      });
+      expect(result[1]).toEqual({
+        name: 'field2',
+        displayName: 'field2',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: 0,
+        colRightIdx: -1,
+      });
+    });
+
+    it('should include time field when hideTimeField is false and timeFieldName exists', () => {
+      const columns = ['field1'];
+
+      const result = getLegacyDisplayedColumns(columns, mockIndexPattern, false, false);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        name: '@timestamp',
+        displayName: 'Time',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      });
+      expect(result[1]).toEqual({
+        name: 'field1',
+        displayName: 'field1',
+        isSortable: true,
+        isRemoveable: false,
+        colLeftIdx: -1,
+        colRightIdx: -1,
+      });
+    });
+
+    it('should not include time field when it is already in columns', () => {
+      const columns = ['@timestamp', 'field1'];
+
+      const result = getLegacyDisplayedColumns(columns, mockIndexPattern, false, false);
+
+      expect(result).toHaveLength(2);
+      expect(
+        result.find((col) => col.name === '@timestamp' && col.displayName === 'Time')
+      ).toBeUndefined();
+    });
+
+    it('should use shortenDottedString when isShortDots is true', () => {
+      const columns = ['field.with.dots'];
+      mockShortenDottedString.mockReturnValue('field...dots');
+
+      const result = getLegacyDisplayedColumns(columns, mockIndexPattern, true, true);
+
+      expect(mockShortenDottedString).toHaveBeenCalledWith('field.with.dots');
+      expect(result[0].displayName).toBe('field...dots');
+    });
+
+    it('should handle field sortability from indexPattern', () => {
+      const columns = ['field1'];
+      (mockIndexPattern.getFieldByName as jest.Mock).mockReturnValue({
+        sortable: false,
+      });
+
+      const result = getLegacyDisplayedColumns(columns, mockIndexPattern, true, false);
+
+      expect(result[0].isSortable).toBe(true); // Should use osdFieldOverrides.sortable
+    });
+  });
+});

--- a/src/plugins/explore/public/helpers/data_table_helper.tsx
+++ b/src/plugins/explore/public/helpers/data_table_helper.tsx
@@ -86,7 +86,7 @@ export function getLegacyDisplayedColumns(
   hideTimeField: boolean,
   isShortDots: boolean
 ): LegacyDisplayedColumn[] {
-  if (!Array.isArray(columns) || typeof indexPattern !== 'object' || !indexPattern.getFieldByName) {
+  if (!Array.isArray(columns) || !indexPattern || !indexPattern.getFieldByName) {
     return [];
   }
   // TODO: Remove overrides once we support PPL/SQL sorting
@@ -97,7 +97,8 @@ export function getLegacyDisplayedColumns(
       name: column,
       displayName: isShortDots ? shortenDottedString(column) : column,
       isSortable: osdFieldOverrides.sortable ?? !!field?.sortable,
-      isRemoveable: column !== '_source' || columns.length > 1,
+      // Explore will not support remove columns from UI
+      isRemoveable: false,
       colLeftIdx: idx - 1 < 0 ? -1 : idx - 1,
       colRightIdx: idx + 1 >= columns.length ? -1 : idx + 1,
     };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

This PR contains changes below:
1. Make log table columns to be controlled by query result(using `fields` keyword).
2. Remove toggle table column button in expanded table row.
3. If there are less than 8 fields in the query result show all the fields as individual columns, otherwise show `source`.
4. Remove meta field from field selector and log table, if the field was not included in query result.
5. Increas column width to fix a issue that filter overlay button can block expand table row button.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

<img width="961" height="485" alt="Screenshot 2025-07-10 at 11 54 43 AM" src="https://github.com/user-attachments/assets/4e71b6c2-84d0-495a-8ed6-2196e278fbc2" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
