### PR TITLE
[Explore] support single-empty mode for filters

### DIFF
--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.test.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.test.ts
@@ -185,6 +185,23 @@ describe('useChangeQueryEditor', () => {
     expect(mockSetEditorText).toHaveBeenCalledWith("Show me logs, field is 'value'");
   });
 
+  it('should add filters to query in SingleEmpty mode', () => {
+    (useSelector as jest.Mock).mockImplementation((selector) => {
+      if (selector === selectEditorMode) return EditorMode.SingleEmpty;
+      if (selector === selectQuery) return { language: 'ppl' };
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useChangeQueryEditor());
+
+    result.current.onAddFilter('field', 'value', '+');
+
+    expect(mockLanguageConfig.addFiltersToQuery).toHaveBeenCalledWith(mockEditorQuery, [
+      { meta: { key: 'field', value: 'value' } },
+    ]);
+    expect(mockSetEditorText).toHaveBeenCalledWith("source=logs | where `field` = 'value'");
+  });
+
   it('should not update editor text if language config does not provide filter methods', () => {
     // @ts-expect-error
     mockLanguageConfig.addFiltersToQuery = undefined;

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.ts
@@ -44,9 +44,9 @@ export const useChangeQueryEditor = () => {
       );
       const languageConfig = queryString.getLanguageService().getLanguage(query.language);
       const newText =
-        editorMode === EditorMode.SingleQuery || editorMode === EditorMode.DualQuery
-          ? languageConfig?.addFiltersToQuery?.(editorQuery, newFilters)
-          : languageConfig?.addFiltersToPrompt?.(editorPrompt, newFilters);
+        editorMode === EditorMode.SinglePrompt || editorMode === EditorMode.DualPrompt
+          ? languageConfig?.addFiltersToPrompt?.(editorPrompt, newFilters)
+          : languageConfig?.addFiltersToQuery?.(editorQuery, newFilters);
       if (newText) setEditorText(newText);
     },
     [

--- a/src/plugins/query_enhancements/public/search/filters/ppl_filter_utils.test.ts
+++ b/src/plugins/query_enhancements/public/search/filters/ppl_filter_utils.test.ts
@@ -86,7 +86,7 @@ describe('PPLFilterUtils', () => {
     });
   });
 
-  describe('insertFiltersToQuery', () => {
+  describe('addFiltersToQuery', () => {
     it('should return original query when filters array is empty', () => {
       const query = 'source=test_index | fields *';
       const result = PPLFilterUtils.addFiltersToQuery(query, []);
@@ -123,6 +123,13 @@ describe('PPLFilterUtils', () => {
       const filters = [createFilter('field1', 'value1', false)]; // Non-negated version
       const result = PPLFilterUtils.addFiltersToQuery(query, filters);
       expect(result).toBe("source=test_index | WHERE `field1` = 'value1' | fields *");
+    });
+
+    it('should handle empty query', () => {
+      const query = '';
+      const filters = [createFilter('field1', 'value1')];
+      const result = PPLFilterUtils.addFiltersToQuery(query, filters);
+      expect(result).toBe("| WHERE `field1` = 'value1'");
     });
   });
 });

--- a/src/plugins/query_enhancements/public/search/filters/ppl_filter_utils.ts
+++ b/src/plugins/query_enhancements/public/search/filters/ppl_filter_utils.ts
@@ -54,7 +54,7 @@ export class PPLFilterUtils extends FilterUtils {
       commands.splice(1, 0, whereCommand);
     }
 
-    return commands.join(' | ');
+    return commands.join(' | ').trim();
   }
 
   /**


### PR DESCRIPTION
### Description
- trim filter PPL command for empty query
   - If user did not type query, adding a filter will result in `| WHERE field = 'value'`. We are using `WHERE` with pipe because it supports parentheses which might be needed
- add as PPL filter in single-empty mode
   - If user didn't type anything, we'll add a PPL filter. Only if user is explicitly in prompt mode, then it adds as prompt

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
