### PR TITLE
[Banner Plugin] UI Implementation Refactor

### DIFF
--- a/src/core/public/_variables.scss
+++ b/src/core/public/_variables.scss
@@ -1,3 +1,7 @@
 @import "@elastic/eui/src/global_styling/variables/header";
 
-$osdHeaderOffset: $euiHeaderHeightCompensation;
+// Base header offset including the banner height
+$osdHeaderOffset: calc(#{$euiHeaderHeightCompensation} + var(--global-banner-height, 0px));
+
+// Double header offset for expanded state
+$osdHeaderOffsetExpanded: calc((#{$euiHeaderHeightCompensation} * 2) + var(--global-banner-height, 0px));

--- a/src/core/public/chrome/ui/header/_index.scss
+++ b/src/core/public/chrome/ui/header/_index.scss
@@ -3,7 +3,7 @@
 }
 
 .headerIsExpanded {
-  @include euiHeaderAffordForFixed($osdHeaderOffset * 2);
+  @include euiHeaderAffordForFixed($osdHeaderOffsetExpanded);
 }
 
 .headerGlobalNav .euiHeaderSectionItem:empty {

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -213,7 +213,16 @@ export function Header({
 
   const toggleCollapsibleNavRef = createRef<HTMLButtonElement & { euiAnimate: () => void }>();
   const navId = htmlIdGenerator()();
-  const className = classnames('hide-for-sharing', 'headerGlobalNav');
+
+  // Get the banner plugin configuration
+  const bannerPluginConfig = injectedMetadata
+    ?.getPlugins()
+    ?.find((plugin: { id: string }) => plugin.id === 'banner')?.config;
+  const isBannerEnabled = bannerPluginConfig?.enabled === true;
+
+  const className = classnames('hide-for-sharing', 'headerGlobalNav', {
+    'headerGlobalNav--withBanner': isBannerEnabled,
+  });
   const { useExpandedHeader = true } = branding;
   const useApplicationHeader = headerVariant === HeaderVariant.APPLICATION;
 
@@ -657,12 +666,6 @@ export function Header({
   const renderHeader = () => {
     return useApplicationHeader ? renderApplicationHeader() : renderPageHeader();
   };
-
-  // Get the banner plugin configuration
-  const bannerPluginConfig = injectedMetadata
-    ?.getPlugins()
-    ?.find((plugin: { id: string }) => plugin.id === 'banner')?.config;
-  const isBannerEnabled = bannerPluginConfig?.enabled === true;
 
   return (
     <>

--- a/src/core/public/rendering/_base.scss
+++ b/src/core/public/rendering/_base.scss
@@ -15,7 +15,7 @@
   min-height: calc(100vh - #{$osdHeaderOffset});
 
   .headerIsExpanded & {
-    min-height: calc(100vh - #{$osdHeaderOffset * 2});
+    min-height: calc(100vh - #{$osdHeaderOffsetExpanded});
   }
 
   &.hidden-chrome {

--- a/src/plugins/banner/public/index.scss
+++ b/src/plugins/banner/public/index.scss
@@ -3,6 +3,12 @@
    ================================================================= */
 
 /**
+ * Header spacing variables
+ */
+$headerWidth: $ouiSizeL * 2 + 1px;
+$expandedHeaderWidth: $headerWidth * 2;
+
+/**
  * 1. CSS Variable - Defines the space needed for the global banner
  *    Default value is 0px when no banner is present
  *    Will be dynamically set to the actual banner height when visible
@@ -19,47 +25,22 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1100; /* Higher than header z-index (1000) */
+  z-index: 1100;
   width: 100%;
   min-height: var(--global-banner-height);
 }
 
 /**
- * 3. Smooth transitions - Prevents jarring layout shifts when banner height changes
- */
-/* stylelint-disable @osd/stylelint/no_modifying_global_selectors */
-.euiHeader {
-  transition: top 0.3s ease;
-}
-
-/**
- * 4. Header positioning - Places headers below the banner
+ * 3. Header positioning - Places headers below the banner
  *    expandedHeader: directly below the banner
  *    primaryHeader: below the expanded header
  */
-.expandedHeader {
-  top: var(--global-banner-height) !important;
+.headerGlobalNav--withBanner .expandedHeader {
+  top: var(--global-banner-height);
 }
 
-.primaryHeader:not(.newTopNavHeader) {
-  top: calc(var(--global-banner-height) + $euiSizeXL + $euiSizeM) !important;
+.headerGlobalNav--withBanner .primaryHeader:not(.newTopNavHeader) {
+  top: calc(var(--global-banner-height) + $headerWidth);
 }
-
-/**
- * 5. Fix for body padding when header is expanded and fixed
- *    Ensures content doesn't overlap with headers
- */
-.headerIsExpanded.euiBody--headerIsFixed {
-  padding-top: calc(var(--global-banner-height) + $euiSizeXL + $euiSizeM + $euiSizeXL + $euiSizeM) !important;
-}
-
-/**
- * 6. Fix for flayout position when header is expanded and fixed
- *    Ensures content doesn't overlap with headers
- */
-.euiOverlayMask {
-  top: calc(var(--global-banner-height) + $euiSizeXL + $euiSizeM + $euiSizeXL + $euiSizeM) !important;
-}
-/* stylelint-enable @osd/stylelint/no_modifying_global_selectors */
 
 /* End of Global Banner Positioning */

--- a/src/plugins/home/public/application/components/_home.scss
+++ b/src/plugins/home/public/application/components/_home.scss
@@ -28,14 +28,16 @@
  * under the License.
  */
 
+@import "src/core/public/variables";
+
 .homWrapper {
   background-color: $euiColorEmptyShade;
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - #{$euiHeaderHeightCompensation});
+  min-height: calc(100vh - #{$osdHeaderOffset});
 
   .headerIsExpanded & {
-    min-height: calc(100vh - #{$euiHeaderHeightCompensation * 2});
+    min-height: calc(100vh - #{$osdHeaderOffsetExpanded});
   }
 }
 


### PR DESCRIPTION
### Description

Adds a lightweight **header wrapper** and shared `--global-banner-height` / `$osdHeaderOffset` variables so all headers, body content, flyouts and masks automatically shift downward whenever the Global Banner is mounted. Removes all `!important` overrides and hard-coded pixel offsets.

### Issues Resolved

The concerns raised in discussion of #9989.

## Screenshot

<img width="790" height="636" alt="design drawio" src="https://github.com/user-attachments/assets/4faeb0bc-73f2-4d9a-a052-14e20f6b74c8" />
<img width="840" height="709" alt="design 2 drawio" src="https://github.com/user-attachments/assets/e6b3eab1-efb5-410e-bb21-68770e2a36ce" />

### Implementation Details

This change avoids hardcoded CSS overrides by dynamically offsetting headers and page content using a shared layout strategy:

#### **Banner Mounting**

* The banner is rendered as a fixed element: `#pluginGlobalBanner`
* On mount, it sets a CSS variable:

```css
--global-banner-height
```

---

#### **Header Wrapping**

* A new class `.headerGlobalNav--withBanner` is conditionally applied when the banner is enabled.
* This class modifies header positioning:

```scss
.headerGlobalNav--withBanner .expandedHeader {
  top: var(--global-banner-height);
}

.headerGlobalNav--withBanner .primaryHeader:not(.newTopNavHeader) {
  top: calc(var(--global-banner-height) + $headerWidth);
}
```

---

#### **Shared Offsets**

* Body content, flyouts, and overlay masks use shared SCSS variables:

```scss
$osdHeaderOffset: calc(#{$euiHeaderHeightCompensation} + var(--global-banner-height, 0px));
$osdHeaderOffsetExpanded: calc((#{$euiHeaderHeightCompensation} * 2) + var(--global-banner-height, 0px));
```

* These values are injected into `min-height`, `padding`, and `top` styles to ensure content shifts automatically when the banner appears.

---

#### **Fallback Safety**

* If the banner is not rendered, `--global-banner-height` defaults to `0px`, preserving the existing layout when the banner is disabled.

## Testing the changes

1. **Start Dashboards** with banner disabled – verify no layout change.
2. Enable banner plugin (`opensearch_dashboards.yml`).
3. Refresh any app page:

   * Banner appears at top.
   * Expanded Header & Primary Header reposition correctly.
   * Flyouts / overlay masks open without overlap.
4. Resize window, and switch to dark mode – confirm offsets remain correct.

## Changelog

- feat: add wrapper & CSS-variable offsets to support Global Banner without `!important` hacks

### Check List

* [ ] All tests pass

  * [ ] `yarn test:jest`
  * [ ] `yarn test:jest_integration`
* [ ] New functionality includes testing.
* [ ] New functionality has been documented.
* [ ] Update [[CHANGELOG.md](https://chatgpt.com/CHANGELOG.md)](./../CHANGELOG.md)
* [ ] Commits are signed per the DCO using `--signoff`