### PR TITLE
fix datasets to not call fetchDatasets on every re-render

### DIFF
--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { useSelector as useNewStateSelector, useDispatch } from 'react-redux';
@@ -150,30 +150,33 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
 
   const dispatch = useDispatch();
 
-  const handleDatasetSelect = (newDataset: any) => {
-    if (!newDataset) return;
-    const currentQuery = queryString.getQuery();
-    const serializableDataset =
-      'toDataset' in newDataset && typeof (newDataset as any).toDataset === 'function'
-        ? (newDataset as any).toDataset()
-        : {
-            id: newDataset.id,
-            title: newDataset.title,
-            type: newDataset.type || '',
-            timeFieldName: newDataset.timeFieldName,
-            dataSource: newDataset.dataSource,
-          };
+  const handleDatasetSelect = useCallback(
+    (newDataset: any) => {
+      if (!newDataset) return;
+      const currentQuery = queryString.getQuery();
+      const serializableDataset =
+        'toDataset' in newDataset && typeof (newDataset as any).toDataset === 'function'
+          ? (newDataset as any).toDataset()
+          : {
+              id: newDataset.id,
+              title: newDataset.title,
+              type: newDataset.type || '',
+              timeFieldName: newDataset.timeFieldName,
+              dataSource: newDataset.dataSource,
+            };
 
-    dispatch(
-      setQueryState({
-        ...currentQuery,
-        query: queryString.getInitialQueryByDataset(newDataset).query,
-        dataset: serializableDataset,
-      })
-    );
+      dispatch(
+        setQueryState({
+          ...currentQuery,
+          query: queryString.getInitialQueryByDataset(newDataset).query,
+          dataset: serializableDataset,
+        })
+      );
 
-    dispatch(setDatasetActionCreator(services, clearEditors));
-  };
+      dispatch(setDatasetActionCreator(services, clearEditors));
+    },
+    [clearEditors, dispatch, queryString, services]
+  );
 
   return (
     <TopNavMenu

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -92,6 +92,8 @@ export type TopNavMenuProps = Omit<StatefulSearchBarProps, 'showDatePicker'> &
     queryStatus?: QueryStatus;
   };
 
+const defaultOnSelect = () => {};
+
 /*
  * Top Nav Menu is a convenience wrapper component for:
  * - Top navigation menu - configured by an array of `TopNavMenuData` objects
@@ -177,7 +179,7 @@ export function TopNavMenu(props: TopNavMenuProps): ReactElement | null {
 
     return (
       <DatasetSelect
-        onSelect={props.datasetSelectProps?.onSelect || (() => {})}
+        onSelect={props.datasetSelectProps?.onSelect || defaultOnSelect}
         appName={props.datasetSelectProps?.appName || props.appName || ''}
       />
     );


### PR DESCRIPTION
### Description

Follow up fix for #10117. Currently every re-render triggers a call to `GET /api/saved_objects/_find?fields=title&per_page=10000&type=index-pattern&workspaces=xxx`. It makes debugging other issues difficult

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
