### PR TITLE
[explore] reset store when unmounting app

### DIFF
--- a/src/plugins/explore/public/application/utils/state_management/store.ts
+++ b/src/plugins/explore/public/application/utils/state_management/store.ts
@@ -16,6 +16,7 @@ import { loadReduxState } from './utils/redux_persistence';
 import { createQuerySyncMiddleware } from './middleware/query_sync_middleware';
 import { createPersistenceMiddleware } from './middleware/persistence_middleware';
 import { createOverallStatusMiddleware } from './middleware/overall_status_middleware';
+import { resetExploreStateActionCreator } from './actions/reset_explore_state/reset_explore_state';
 import { ExploreServices } from '../../../types';
 
 export const rootReducer = combineReducers({
@@ -51,5 +52,8 @@ export const configurePreloadedStore = (
 export const getPreloadedStore = async (services: ExploreServices) => {
   const preloadedState = await loadReduxState(services);
   const store = configurePreloadedStore(preloadedState, services);
-  return { store, unsubscribe: () => {} };
+  const reset = () => {
+    store.dispatch(resetExploreStateActionCreator(services));
+  };
+  return { store, unsubscribe: () => {}, reset };
 };

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -305,7 +305,9 @@ export class ExplorePlugin
         registerTabs(services);
 
         // Instantiate the store
-        const { store, unsubscribe: unsubscribeStore } = await getPreloadedStore(services);
+        const { store, unsubscribe: unsubscribeStore, reset: resetStore } = await getPreloadedStore(
+          services
+        );
         services.store = store;
 
         appMounted();
@@ -317,6 +319,7 @@ export class ExplorePlugin
           appUnMounted();
           unmount();
           unsubscribeStore();
+          resetStore();
         };
       },
       ...options,


### PR DESCRIPTION
### Description

When switching flavors or opening the explore app, the redux store will be re-created as part of the component mount/unmount lifecycle. The store should get garbage collected, but it might take time. We can reset states in the store to reduce memory usage, since it stores query results that will not be used after unmount.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
