### PR TITLE
[Explore] remove traces and metrics page in nav menu

### DIFF
--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -355,7 +355,8 @@ export class ExplorePlugin
         order: 300,
         parentNavLinkId: PLUGIN_ID,
       },
-      {
+      // uncomment when traces and metrics are ready for launch
+      /* {
         id: `${PLUGIN_ID}/${ExploreFlavor.Traces}`,
         category: undefined,
         order: 300,
@@ -366,7 +367,7 @@ export class ExplorePlugin
         category: undefined,
         order: 300,
         parentNavLinkId: PLUGIN_ID,
-      },
+      }, */
     ]);
     this.registerEmbeddable(core, setupDeps);
 


### PR DESCRIPTION
### Description

Since traces and metrics are not going to be in the initial launch, we are removing them from nav bar items for now. Note that developers can still go to traces using URL like `http://localhost:5601/w/p8HkJt/app/explore/traces#/`. FYI @TackAdam 

Before release, we'll remove registering them as applications, 

https://github.com/opensearch-project/OpenSearch-Dashboards/blob/b132dfe1287582a6e61217337cd4dd6da6788ec2/src/plugins/explore/public/plugin.ts#L332-L343
so that users won't see traces if they go to that URL.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="1644" height="498" alt="image" src="https://github.com/user-attachments/assets/2c13210d-3435-4830-be71-1a5c1ca54d30" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
