### PR TITLE
support inline script invoked from `node -e`

### DIFF
--- a/packages/osd-dev-utils/src/run/help.ts
+++ b/packages/osd-dev-utils/src/run/help.ts
@@ -35,7 +35,9 @@ import dedent from 'dedent';
 
 import { Command } from './run_with_commands';
 
-const DEFAULT_GLOBAL_USAGE = `node ${Path.relative(process.cwd(), process.argv[1])}`;
+const DEFAULT_GLOBAL_USAGE = `node ${
+  process.argv[1] ? Path.relative(process.cwd(), process.argv[1]) : '<script>'
+}`;
 export const GLOBAL_FLAGS = dedent`
   --verbose, -v      Log verbosely
   --debug            Log debug messages (less than verbose)


### PR DESCRIPTION
### Description

Currently if I run a one line command, it fails
```bash
❯ scripts/use_node -e "require('./src/setup_node_env'); require('./src/cli/cluster/run_osd_optimizer') .runOsdOptimizer({}, require('./src/legacy/server/config').Config.withDefaultSchema()) .subscribe({ next: ({ state }) => { if (state.phase === 'success') process.exit(0); else if (state.phase === 'issue') process.exit(1); }, error: (err) => process.exit(1) });"
node:internal/validators:162
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError: The "to" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.relative (node:path:1191:5)
    at Object.<anonymous> (/local/home/lijshu/projects/os-reviews/opensearch-dashboards/packages/osd-dev-utils/target/run/help.js:36:53)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1019:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at Module.Hook._require.Module.require (/local/home/lijshu/projects/os-reviews/opensearch-dashboards/node_modules/require-in-the-middle/index.js:80:39)
```

This is because there's no `process.argv[1]`. This PR fixes it, so that it runs properly

```sh
❯ scripts/use_node -e "require('./src/setup_node_env'); require('./src/cli/cluster/run_osd_optimizer') .runOsdOptimizer({}, require('./src/legacy/server/config').Config.withDefaultSchema()) .subscribe({ next: ({ state }) => { if (state.phase === 'success') process.exit(0); else if (state.phase === 'issue') process.exit(1); }, error: (err) => process.exit(1) });"
np bld    log   [23:58:25.520] [info][@osd/optimizer] initialized, 0 bundles cached
np bld    log   [23:58:25.922] [info][@osd/optimizer] starting worker [9 bundles]
np bld    log   [23:58:25.923] [info][@osd/optimizer] starting worker [10 bundles]
np bld    log   [23:58:25.924] [info][@osd/optimizer] starting worker [9 bundles]
np bld    log   [23:58:25.927] [info][@osd/optimizer] starting worker [9 bundles]
np bld    log   [23:58:25.928] [info][@osd/optimizer] starting worker [10 bundles]
np bld    log   [23:58:25.938] [info][@osd/optimizer] starting worker [9 bundles]
```

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
