### PR TITLE
[Explore] fix type errors on legacy folder

### DIFF
--- a/src/plugins/explore/public/application/legacy/discover/application/components/default_discover_table/default_discover_table.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/default_discover_table/default_discover_table.tsx
@@ -195,6 +195,7 @@ const DefaultDiscoverTableUI = ({
   const indexOfRenderedData = rows?.[0]?._index;
   const timeFromFirstRow =
     typeof indexPattern?.timeFieldName === 'string' &&
+    // @ts-expect-error This is from legacy code, which appears to be working
     rows?.[0]?._source?.[indexPattern.timeFieldName];
 
   useEffect(() => {

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer.test.tsx
@@ -33,7 +33,7 @@ import { mount, shallow } from 'enzyme';
 import { DocViewer } from './doc_viewer';
 import { findTestSubject } from 'test_utils/helpers';
 import { getDocViewsRegistry } from '../../../opensearch_dashboards_services';
-import { DocViewRenderProps } from '../../../doc_views/doc_views_types';
+import { DocViewRenderProps } from '../../doc_views/doc_views_types';
 
 jest.mock('../../../opensearch_dashboards_services', () => {
   let registry: any[] = [];

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer_render_tab.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer_render_tab.test.tsx
@@ -31,7 +31,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { DocViewRenderTab } from './doc_viewer_render_tab';
-import { DocViewRenderProps } from '../../../doc_views/doc_views_types';
+import { DocViewRenderProps } from '../../doc_views/doc_views_types';
 
 test('Mounting and unmounting DocViewerRenderTab', () => {
   const unmountFn = jest.fn();

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer_tab.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer_tab.test.tsx
@@ -16,11 +16,11 @@ test('DocViewerTab updated when getting new renderProps', () => {
   const mockProps: DocViewerTabProps = {
     id: 1,
     title: 'Test1',
-    component: MockComp,
+    component: MockComp as any,
     renderProps: {
       hit: { _id: '1' },
       columns: ['test1'],
-    },
+    } as DocViewRenderProps,
   };
 
   const wrapper = mount(<DocViewerTab {...mockProps} />);
@@ -28,7 +28,7 @@ test('DocViewerTab updated when getting new renderProps', () => {
   const div = wrapper.find({ 'data-test-subj': 'test-div' });
   expect(div.text()).toEqual('test1');
 
-  mockProps.renderProps = { hit: { _id: '1' }, columns: ['test2'] };
-  wrapper.setProps(mockProps);
+  mockProps.renderProps = { hit: { _id: '1' }, columns: ['test2'] } as DocViewRenderProps;
+  wrapper.setProps(mockProps as any);
   expect(div.text()).toEqual('test2');
 });

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer_tab.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer/doc_viewer_tab.tsx
@@ -34,7 +34,7 @@ import { DocViewRenderTab } from './doc_viewer_render_tab';
 import { DocViewerError } from './doc_viewer_render_error';
 import { DocViewRenderFn, DocViewRenderProps } from '../../../../../../types/doc_views_types';
 
-interface Props {
+export interface DocViewerTabProps {
   component?: React.ComponentType<DocViewRenderProps>;
   id: number;
   render?: DocViewRenderFn;
@@ -51,7 +51,7 @@ interface State {
  * Displays an error message when it encounters exceptions, thanks to
  * Error Boundaries.
  */
-export class DocViewerTab extends React.Component<Props, State> {
+export class DocViewerTab extends React.Component<DocViewerTabProps, State> {
   state = {
     hasError: false,
     error: '',
@@ -62,7 +62,7 @@ export class DocViewerTab extends React.Component<Props, State> {
     return { hasError: true, error };
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: DocViewerTabProps, nextState: State) {
     return (
       nextProps.renderProps.hit._id !== this.props.renderProps.hit._id ||
       nextProps.renderProps.columns !== this.props.renderProps.columns ||

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer_links/doc_viewer_links.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer_links/doc_viewer_links.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { DocViewerLinks } from './doc_viewer_links';
 import { getDocViewsLinksRegistry } from '../../../opensearch_dashboards_services';
-import { DocViewLinkRenderProps } from '../doc_views/doc_views_links/doc_views_links_types';
+import { DocViewLinkRenderProps } from '../../doc_views_links/doc_views_links_types';
 
 jest.mock('../../../opensearch_dashboards_services', () => {
   let registry: any[] = [];

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer_links/doc_viewer_links.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_viewer_links/doc_viewer_links.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { i18n } from '@osd/i18n';
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiListGroupItemProps, EuiLink } from '@elastic/eui';
 import { getDocViewsLinksRegistry } from '../../../opensearch_dashboards_services';

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/_stubs.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/_stubs.ts
@@ -68,7 +68,7 @@ export function createSearchSourceStub(hits: OpenSearchHitRecordList, timeField?
     _stubHits: hits,
     _stubTimeField: timeField,
     _createStubHit: (timestamp: number, tiebreaker = 0) => ({
-      [searchSourceStub._stubTimeField]: timestamp,
+      [searchSourceStub._stubTimeField as any]: timestamp,
       sort: [timestamp, tiebreaker],
     }),
   };
@@ -85,7 +85,7 @@ export function createSearchSourceStub(hits: OpenSearchHitRecordList, timeField?
     Promise.resolve({
       hits: {
         hits: searchSourceStub._stubHits,
-        total: searchSourceStub._stubHits.length,
+        total: (searchSourceStub._stubHits as any).length,
       },
     })
   );

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/anchor.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/anchor.ts
@@ -56,10 +56,10 @@ export async function fetchAnchor(
     );
   }
 
-  return {
+  return ({
     ...doc,
     isAnchor: true,
-  } as OpenSearchHitRecord;
+  } as unknown) as OpenSearchHitRecord;
 }
 
 export function updateSearchSource(

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/context.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/context.ts
@@ -28,11 +28,7 @@
  * under the License.
  */
 
-import {
-  Filter,
-  IndexPatternsContract,
-  IndexPattern,
-} from '../../../../../../../../../../data/public';
+import { Filter, IndexPattern } from '../../../../../../../../../../data/public';
 import { reverseSortDir, SortDirection } from './utils/sorting';
 import { extractNanos, convertIsoToMillis } from './utils/date_conversion';
 import { fetchHitsInInterval } from './utils/fetch_hits_in_interval';

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/utils/use_context_state.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/utils/use_context_state.ts
@@ -29,13 +29,14 @@ export const useContextState = ({ services, indexPattern }: Props) => {
   } = useMemo(() => {
     return getState({
       defaultStepSize: uiSettings.get(CONTEXT_DEFAULT_SIZE_SETTING),
-      timeFieldName: indexPattern.timeFieldName,
+      timeFieldName: indexPattern.timeFieldName || '',
       storeInSessionStorage: uiSettings.get('state:storeInSessionStorage'),
       history: history(),
       toasts: core.notifications.toasts,
     });
   }, [uiSettings, history, core.notifications.toasts, indexPattern.timeFieldName]);
 
+  // @ts-expect-error This error existed in Discover plugin
   const [contextAppState, setContextState] = useState<AppState>(appStateContainer.getState());
 
   useEffect(() => {
@@ -43,6 +44,7 @@ export const useContextState = ({ services, indexPattern }: Props) => {
 
     startSync();
 
+    // @ts-expect-error This error existed in Discover plugin
     const unsubscribeFromAppStateChanges = appStateContainer.subscribe((newState) => {
       setContextState((currentState) => ({ ...currentState, ...newState }));
     });

--- a/src/plugins/explore/public/application/legacy/discover/application/components/sidebar/discover_field_search.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/sidebar/discover_field_search.test.tsx
@@ -32,7 +32,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mountWithIntl } from 'test_utils/enzyme_helpers';
 import { findTestSubject } from 'test_utils/helpers';
-import { DiscoverFieldSearch, NUM_FILTERS, Props } from './discover_field_search';
+import { DiscoverFieldSearch, Props } from './discover_field_search';
 import { EuiButtonGroupProps, EuiPopover } from '@elastic/eui';
 import { ReactWrapper } from 'enzyme';
 
@@ -41,6 +41,7 @@ describe('DiscoverFieldSearch', () => {
     onChange: jest.fn(),
     value: 'test',
     types: ['any', 'string', '_source'],
+    isEnhancementsEnabledOverride: true,
   };
 
   function mountComponent(props?: Props) {

--- a/src/plugins/explore/public/application/legacy/discover/application/components/table/table_row.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/table/table_row.tsx
@@ -28,7 +28,6 @@
  * under the License.
  */
 
-import { i18n } from '@osd/i18n';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import { FieldMapping, DocViewFilterFn } from '../../doc_views/doc_views_types';

--- a/src/plugins/explore/public/application/legacy/discover/mocks.ts
+++ b/src/plugins/explore/public/application/legacy/discover/mocks.ts
@@ -29,6 +29,7 @@
  */
 
 import { coreMock } from 'opensearch-dashboards/public/mocks';
+import { BehaviorSubject } from 'rxjs';
 import { ExplorePluginSetup, ExplorePluginStart } from '../../../types';
 import { chartPluginMock } from '../../../../../charts/public/mocks';
 import { dataPluginMock } from '../../../../../data/public/mocks';
@@ -41,18 +42,23 @@ import { urlForwardingPluginMock } from '../../../../../url_forwarding/public/mo
 import { visualizationsPluginMock } from '../../../../../visualizations/public/mocks';
 import { ExploreServices } from '../../../types';
 import { buildServices } from '../../../build_services';
+import { VisualizationRegistry } from '../../../components/visualizations/visualization_registry';
+import { expressionsPluginMock } from '../../../../../expressions/public/mocks';
+import { dashboardPluginMock } from '../../../../../dashboard/public/mocks';
 
 export type Setup = jest.Mocked<ExplorePluginSetup>;
 export type Start = jest.Mocked<ExplorePluginStart>;
 
 const createSetupContract = (): Setup => {
   const setupContract: Setup = {
+    visualizationRegistry: (jest.fn() as unknown) as VisualizationRegistry,
     docViews: {
       addDocView: jest.fn(),
     },
     docViewsLinks: {
       addDocViewLink: jest.fn(),
     },
+    isSummaryAgentAvailable$: new BehaviorSubject(true as boolean),
   };
   return setupContract;
 };
@@ -61,6 +67,7 @@ const createStartContract = (): Start => {
   const startContract: Start = {
     savedExploreLoader: {} as any,
     savedSearchLoader: {} as any,
+    visualizationRegistry: {} as VisualizationRegistry,
     urlGenerator: {
       createUrl: jest.fn(),
     } as any,
@@ -81,9 +88,13 @@ const createExploreServicesMock = (): ExploreServices =>
       urlForwarding: urlForwardingPluginMock.createStartContract(),
       visualizations: visualizationsPluginMock.createStartContract(),
       opensearchDashboardsLegacy: opensearchDashboardsLegacyPluginMock.createStartContract(),
+      expressions: expressionsPluginMock.createStartContract(),
+      dashboard: dashboardPluginMock.createStartContract(),
     },
     coreMock.createPluginInitializerContext(),
-    {} as any // Mock tabRegistry
+    {} as any, // Mock tabRegistry
+    {} as any, // Mock visualizationRegistry
+    new BehaviorSubject(true as boolean)
   );
 
 export const discoverPluginMock = {

--- a/src/plugins/explore/public/build_services.ts
+++ b/src/plugins/explore/public/build_services.ts
@@ -14,6 +14,7 @@ import { createSavedExploreLoader } from './saved_explore';
 import { getHistory } from './application/legacy/discover/opensearch_dashboards_services';
 import { TabRegistryService } from './services/tab_registry/tab_registry_service';
 import { VisualizationRegistryService } from './services/visualization_registry_service';
+import { AppStore } from './application/utils/state_management/store';
 
 export function buildServices(
   core: CoreStart,
@@ -75,7 +76,7 @@ export function buildServices(
     overlays: core.overlays,
 
     // From DataExplorerServices (since Explore incorporates DataExplorer functionality)
-    store: undefined, // Will be set by the store
+    store: (undefined as unknown) as AppStore, // Will be set by the store
     viewRegistry: undefined, // Will be replaced with tabRegistry
     embeddable: plugins.embeddable,
     scopedHistory: undefined, // Will be set by the app

--- a/src/plugins/explore/public/components/chart/discover_chart_container.tsx
+++ b/src/plugins/explore/public/components/chart/discover_chart_container.tsx
@@ -17,6 +17,7 @@ import {
 import { RootState } from '../../application/utils/state_management/store';
 import { selectShowHistogram } from '../../application/utils/state_management/selectors';
 import { CanvasPanel } from '../../application/legacy/discover/application/components/panel/canvas_panel';
+import { Chart } from './utils';
 
 export const DiscoverChartContainer = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
@@ -66,7 +67,7 @@ export const DiscoverChartContainer = () => {
       <div className="dscCanvas__chart">
         <DiscoverChart
           bucketInterval={processedResults.bucketInterval}
-          chartData={processedResults.chartData}
+          chartData={processedResults.chartData as Chart}
           config={uiSettings}
           data={data}
           services={services}

--- a/src/plugins/explore/public/components/tabs/logs_tab.tsx
+++ b/src/plugins/explore/public/components/tabs/logs_tab.tsx
@@ -2,14 +2,14 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import React, { memo } from 'react';
+import React from 'react';
 import { ExploreDataTable } from '../data_table/explore_data_table';
 import { ActionBar } from './action_bar/action_bar';
 
 /**
  * Logs tab component for displaying log entries
  */
-const LogsTabComponent = () => {
+export const LogsTab = () => {
   return (
     <div className="explore-logs-tab tab-container">
       <ActionBar />
@@ -17,5 +17,3 @@ const LogsTabComponent = () => {
     </div>
   );
 };
-
-export const LogsTab = memo(LogsTabComponent);


### PR DESCRIPTION
- only ones remaining are `abort_data_query_action.test.ts` and few errors related to index patterns