### PR TITLE
Add Bar Size Control Switch

### DIFF
--- a/changelogs/fragments/10152.yml
+++ b/changelogs/fragments/10152.yml
@@ -1,0 +1,2 @@
+feat:
+- Add Bar Size Control Switch for auto/manual bar sizing in bar charts ([#10152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10152))

--- a/src/plugins/explore/public/components/visualizations/bar/bar_exclusive_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_exclusive_vis_options.tsx
@@ -13,16 +13,19 @@ import {
   EuiSpacer,
   EuiColorPicker,
   EuiSwitch,
+  EuiButtonGroup,
 } from '@elastic/eui';
 import { useDebouncedNumericValue } from '../utils/use_debounced_value';
 import { StyleAccordion } from '../style_panel/style_accordion';
 
 interface BarExclusiveVisOptionsProps {
+  barSizeMode: 'auto' | 'manual';
   barWidth: number;
   barPadding: number;
   showBarBorder: boolean;
   barBorderWidth: number;
   barBorderColor: string;
+  onBarSizeModeChange: (barSizeMode: 'auto' | 'manual') => void;
   onBarWidthChange: (barWidth: number) => void;
   onBarPaddingChange: (barPadding: number) => void;
   onShowBarBorderChange: (showBarBorder: boolean) => void;
@@ -31,11 +34,13 @@ interface BarExclusiveVisOptionsProps {
 }
 
 export const BarExclusiveVisOptions = ({
+  barSizeMode,
   barWidth,
   barPadding,
   showBarBorder,
   barBorderWidth,
   barBorderColor,
+  onBarSizeModeChange,
   onBarWidthChange,
   onBarPaddingChange,
   onShowBarBorderChange,
@@ -61,6 +66,21 @@ export const BarExclusiveVisOptions = ({
     { min: 1, max: 10, defaultValue: 1 }
   );
 
+  const sizeModeOptions = [
+    {
+      id: 'auto',
+      label: i18n.translate('explore.stylePanel.bar.sizeModeAuto', {
+        defaultMessage: 'Auto',
+      }),
+    },
+    {
+      id: 'manual',
+      label: i18n.translate('explore.stylePanel.bar.sizeModeManual', {
+        defaultMessage: 'Manual',
+      }),
+    },
+  ];
+
   return (
     <StyleAccordion
       id="barSection"
@@ -69,48 +89,71 @@ export const BarExclusiveVisOptions = ({
       })}
       initialIsOpen={true}
     >
-      <EuiFlexGroup>
-        <EuiFlexItem>
-          <EuiFormRow
-            label={i18n.translate('explore.stylePanel.bar.barWidth', {
-              defaultMessage: 'Width',
-            })}
-            helpText={i18n.translate('explore.stylePanel.bar.barWidthHelp', {
-              defaultMessage: 'Value between 0.1 and 1',
-            })}
-          >
-            <EuiFieldNumber
-              compressed
-              value={localBarWidth}
-              onChange={(e) => handleBarWidthChange(e.target.value)}
-              min={0.1}
-              max={1}
-              step={0.1}
-              data-test-subj="barWidthInput"
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiFormRow
-            label={i18n.translate('explore.stylePanel.bar.barPadding', {
-              defaultMessage: 'Padding',
-            })}
-            helpText={i18n.translate('explore.stylePanel.bar.barPaddingHelp', {
-              defaultMessage: 'Value between 0 and 0.5',
-            })}
-          >
-            <EuiFieldNumber
-              compressed
-              value={localBarPadding}
-              onChange={(e) => handleBarPaddingChange(e.target.value)}
-              min={0}
-              max={0.5}
-              step={0.05}
-              data-test-subj="barPaddingInput"
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFormRow
+        label={i18n.translate('explore.stylePanel.bar.sizeMode', {
+          defaultMessage: 'Bar size',
+        })}
+      >
+        <EuiButtonGroup
+          legend={i18n.translate('explore.stylePanel.bar.sizeMode', {
+            defaultMessage: 'Bar size',
+          })}
+          options={sizeModeOptions}
+          idSelected={barSizeMode}
+          onChange={(id) => onBarSizeModeChange(id as 'auto' | 'manual')}
+          buttonSize="compressed"
+          isFullWidth
+          data-test-subj="barSizeModeButtonGroup"
+        />
+      </EuiFormRow>
+
+      {barSizeMode === 'manual' && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiFormRow
+                label={i18n.translate('explore.stylePanel.bar.barWidth', {
+                  defaultMessage: 'Bar width',
+                })}
+                helpText={i18n.translate('explore.stylePanel.bar.barWidthHelp', {
+                  defaultMessage: 'Value between 0.1 and 1',
+                })}
+              >
+                <EuiFieldNumber
+                  compressed
+                  value={localBarWidth}
+                  onChange={(e) => handleBarWidthChange(e.target.value)}
+                  min={0.1}
+                  max={1}
+                  step={0.1}
+                  data-test-subj="barWidthInput"
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label={i18n.translate('explore.stylePanel.bar.barPadding', {
+                  defaultMessage: 'Bar padding',
+                })}
+                helpText={i18n.translate('explore.stylePanel.bar.barPaddingHelp', {
+                  defaultMessage: 'Value between 0 and 0.5',
+                })}
+              >
+                <EuiFieldNumber
+                  compressed
+                  value={localBarPadding}
+                  onChange={(e) => handleBarPaddingChange(e.target.value)}
+                  min={0}
+                  max={0.5}
+                  step={0.05}
+                  data-test-subj="barPaddingInput"
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
 
       <EuiSpacer size="s" />
 

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
@@ -26,6 +26,7 @@ export interface BarChartStyleControls {
   tooltipOptions: TooltipOptions;
 
   // Bar specific controls
+  barSizeMode: 'auto' | 'manual';
   barWidth: number;
   barPadding: number;
   showBarBorder: boolean;
@@ -50,6 +51,7 @@ export const defaultBarChartStyles: BarChartStyleControls = {
   },
 
   // Bar specific controls
+  barSizeMode: 'auto',
   barWidth: 0.7,
   barPadding: 0.1,
   showBarBorder: false,

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -77,11 +77,13 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
 
           <EuiFlexItem grow={false}>
             <BarExclusiveVisOptions
+              barSizeMode={styleOptions.barSizeMode}
               barWidth={styleOptions.barWidth}
               barPadding={styleOptions.barPadding}
               showBarBorder={styleOptions.showBarBorder}
               barBorderWidth={styleOptions.barBorderWidth}
               barBorderColor={styleOptions.barBorderColor}
+              onBarSizeModeChange={(barSizeMode) => updateStyleOption('barSizeMode', barSizeMode)}
               onBarWidthChange={(barWidth) => updateStyleOption('barWidth', barWidth)}
               onBarPaddingChange={(barPadding) => updateStyleOption('barPadding', barPadding)}
               onShowBarBorderChange={(showBarBorder) =>

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -8,6 +8,14 @@ import { BarChartStyleControls } from './bar_vis_config';
 import { applyAxisStyling } from '../line/line_chart_utils';
 import { getStrokeDash, createThresholdLayer } from '../style_panel/threshold/utils';
 
+// Only set size and binSpacing in manual mode
+const configureBarSizeAndSpacing = (barMark: any, styles: Partial<BarChartStyleControls>) => {
+  if (styles.barSizeMode === 'manual') {
+    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
+    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
+  }
+};
+
 export const createBarSpec = (
   transformedData: Array<Record<string, any>>,
   numericalColumns: VisColumn[],
@@ -40,12 +48,7 @@ export const createBarSpec = (
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
   };
-
-  // Only set size and binSpacing in manual mode
-  if (styles.barSizeMode === 'manual') {
-    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14; // Scale the bar width
-    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1; // Scale the bar padding
-  }
+  configureBarSizeAndSpacing(barMark, styles);
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -144,12 +147,7 @@ export const createTimeBarChart = (
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
   };
-
-  // Only set size and binSpacing in manual mode
-  if (styles.barSizeMode === 'manual') {
-    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
-    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
-  }
+  configureBarSizeAndSpacing(barMark, styles);
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -256,12 +254,7 @@ export const createGroupedTimeBarChart = (
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
   };
-
-  // Only set size and binSpacing in manual mode
-  if (styles.barSizeMode === 'manual') {
-    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
-    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
-  }
+  configureBarSizeAndSpacing(barMark, styles);
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -375,12 +368,7 @@ export const createFacetedTimeBarChart = (
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
   };
-
-  // Only set size and binSpacing in manual mode
-  if (styles.barSizeMode === 'manual') {
-    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
-    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
-  }
+  configureBarSizeAndSpacing(barMark, styles);
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -514,12 +502,7 @@ export const createStackedBarSpec = (
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
   };
-
-  // Only set size and binSpacing in manual mode
-  if (styles.barSizeMode === 'manual') {
-    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
-    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
-  }
+  configureBarSizeAndSpacing(barMark, styles);
 
   // Add border if enabled
   if (styles.showBarBorder) {

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -39,9 +39,13 @@ export const createBarSpec = (
   const barMark: any = {
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
-    size: styles.barWidth ? styles.barWidth * 20 : 14, // Scale the bar width
-    binSpacing: styles.barPadding ? styles.barPadding * 10 : 1, // Scale the bar padding
   };
+
+  // Only set size and binSpacing in manual mode
+  if (styles.barSizeMode === 'manual') {
+    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14; // Scale the bar width
+    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1; // Scale the bar padding
+  }
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -139,9 +143,13 @@ export const createTimeBarChart = (
   const barMark: any = {
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
-    size: styles.barWidth ? styles.barWidth * 20 : 14, // Scale the bar width
-    binSpacing: styles.barPadding ? styles.barPadding * 10 : 1, // Scale the bar padding
   };
+
+  // Only set size and binSpacing in manual mode
+  if (styles.barSizeMode === 'manual') {
+    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
+    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
+  }
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -247,9 +255,13 @@ export const createGroupedTimeBarChart = (
   const barMark: any = {
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
-    size: styles.barWidth ? styles.barWidth * 20 : 14, // Scale the bar width
-    binSpacing: styles.barPadding ? styles.barPadding * 10 : 1, // Scale the bar padding
   };
+
+  // Only set size and binSpacing in manual mode
+  if (styles.barSizeMode === 'manual') {
+    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
+    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
+  }
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -362,9 +374,13 @@ export const createFacetedTimeBarChart = (
   const barMark: any = {
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
-    size: styles.barWidth ? styles.barWidth * 20 : 14, // Scale the bar width
-    binSpacing: styles.barPadding ? styles.barPadding * 10 : 1, // Scale the bar padding
   };
+
+  // Only set size and binSpacing in manual mode
+  if (styles.barSizeMode === 'manual') {
+    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
+    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
+  }
 
   // Add border if enabled
   if (styles.showBarBorder) {
@@ -497,9 +513,13 @@ export const createStackedBarSpec = (
   const barMark: any = {
     type: 'bar',
     tooltip: styles.tooltipOptions?.mode !== 'hidden',
-    size: styles.barWidth ? styles.barWidth * 20 : 14, // Scale the bar width
-    binSpacing: styles.barPadding ? styles.barPadding * 10 : 1, // Scale the bar padding
   };
+
+  // Only set size and binSpacing in manual mode
+  if (styles.barSizeMode === 'manual') {
+    barMark.size = styles.barWidth ? styles.barWidth * 20 : 14;
+    barMark.binSpacing = styles.barPadding ? styles.barPadding * 10 : 1;
+  }
 
   // Add border if enabled
   if (styles.showBarBorder) {


### PR DESCRIPTION
### Description

This feature introduces a "Bar Size Control Switch" to the bar chart visualization in OpenSearch Dashboards. It allows users to toggle between "Auto" and "Manual" modes for bar sizing. In "Auto" mode, Vega automatically determines the bar width and padding, optimizing the chart's appearance based on the data. In "Manual" mode, users can specify custom values for barWidth and barPadding through input fields, providing fine-grained control over the bar chart's appearance. This enhances flexibility and usability for customizing bar chart visualizations.

## Screenshot

https://github.com/user-attachments/assets/5c64fa68-ad32-49bf-b4cf-37e9c8798701



## Testing the changes

1. Navigate to the OpenSearch Dashboards Discover Page.
2. Run a PPL query.
3. Open the "Bar Settings" accordion in the style options panel.
4. Verify that a "Bar Size Mode" toggle is present with options "Auto" and "Manual". The default value is "Auto".
5. Select "Auto" and confirm that the barWidth and barPadding input fields are hidden.
6. Switch to "Manual" and verify that the barWidth and barPadding input fields appear.
7. Check the rendered bar chart to ensure that bars reflect the custom width and padding in "Manual" mode.
8. Switch back to "Auto" mode, save, and verify that the bar chart uses Vega's default sizing (bars adjust automatically to fit the data).

## Changelog
- feat: Add Bar Size Control Switch for auto/manual bar sizing in bar charts

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
