### PR TITLE
[Explore] make save query button always show up

### DIFF
--- a/src/plugins/data/public/ui/saved_query_management/saved_query_management_component.tsx
+++ b/src/plugins/data/public/ui/saved_query_management/saved_query_management_component.tsx
@@ -39,7 +39,6 @@ import {
   EuiPagination,
   EuiText,
   EuiSpacer,
-  EuiListGroupItem,
 } from '@elastic/eui';
 
 import { i18n } from '@osd/i18n';
@@ -70,6 +69,7 @@ interface Props {
   onClearSavedQuery: () => void;
   closeMenuPopover: () => void;
   saveQuery: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
+  saveQueryIsDisabled?: boolean;
 }
 
 export function SavedQueryManagementComponent({
@@ -83,6 +83,7 @@ export function SavedQueryManagementComponent({
   closeMenuPopover,
   useNewSavedQueryUI,
   saveQuery,
+  saveQueryIsDisabled,
 }: Props) {
   const [savedQueries, setSavedQueries] = useState([] as SavedQuery[]);
   const [count, setTotalCount] = useState(0);
@@ -221,49 +222,56 @@ export function SavedQueryManagementComponent({
       data-test-subj="saved-query-management-popover"
     >
       <EuiListGroup>
-        <EuiListGroupItem
-          label={i18n.translate('data.saved_query_management.save_query_item_label', {
-            defaultMessage: 'Save query',
-          })}
-          data-test-subj="saved-query-management-save-button"
-          iconType="save"
-          onClick={() => {
-            closeMenuPopover();
-            const saveQueryFlyout = overlays?.openFlyout(
-              toMountPoint(
-                <SaveQueryFlyout
-                  savedQueryService={savedQueryService}
-                  onClose={() => saveQueryFlyout?.close().then()}
-                  onSave={saveQuery}
-                  showFilterOption={true}
-                  showTimeFilterOption={true}
-                  savedQuery={loadedSavedQuery?.attributes}
-                />
-              )
-            );
-          }}
-        />
-        <EuiListGroupItem
-          label={i18n.translate('data.saved_query_management.open_query_item_label', {
-            defaultMessage: 'Open query',
-          })}
-          data-test-subj="saved-query-management-open-button"
-          iconType="folderOpen"
-          onClick={() => {
-            closeMenuPopover();
-            const openSavedQueryFlyout = overlays?.openFlyout(
-              toMountPoint(
-                <OpenSavedQueryFlyout
-                  savedQueryService={savedQueryService}
-                  notifications={notifications}
-                  onClose={() => openSavedQueryFlyout?.close().then()}
-                  onQueryOpen={onLoad}
-                  handleQueryDelete={handleDelete}
-                />
-              )
-            );
-          }}
-        />
+        <div>
+          <EuiButtonEmpty
+            data-test-subj="saved-query-management-save-button"
+            disabled={saveQueryIsDisabled}
+            iconType="save"
+            onClick={() => {
+              closeMenuPopover();
+              const saveQueryFlyout = overlays?.openFlyout(
+                toMountPoint(
+                  <SaveQueryFlyout
+                    savedQueryService={savedQueryService}
+                    onClose={() => saveQueryFlyout?.close().then()}
+                    onSave={saveQuery}
+                    showFilterOption={true}
+                    showTimeFilterOption={true}
+                    savedQuery={loadedSavedQuery?.attributes}
+                  />
+                )
+              );
+            }}
+          >
+            {i18n.translate('data.saved_query_management.save_query_item_label', {
+              defaultMessage: 'Save query',
+            })}
+          </EuiButtonEmpty>
+        </div>
+        <div>
+          <EuiButtonEmpty
+            data-test-subj="saved-query-management-open-button"
+            iconType="folderOpen"
+            onClick={() => {
+              closeMenuPopover();
+              const openSavedQueryFlyout = overlays?.openFlyout(
+                toMountPoint(
+                  <OpenSavedQueryFlyout
+                    savedQueryService={savedQueryService}
+                    notifications={notifications}
+                    onClose={() => openSavedQueryFlyout?.close().then()}
+                    onQueryOpen={onLoad}
+                    handleQueryDelete={handleDelete}
+                  />
+                )
+              );
+            }}
+          >
+            {i18n.translate('data.saved_query_management.open_query_item_label', {
+              defaultMessage: 'Open query',
+            })}
+          </EuiButtonEmpty>
+        </div>
       </EuiListGroup>
     </div>
   ) : (

--- a/src/plugins/explore/public/components/query_panel/footer/query_panel_footer.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/footer/query_panel_footer.test.tsx
@@ -75,23 +75,11 @@ describe('QueryPanelFooter', () => {
     body: undefined,
   };
 
-  const mockEditorMode = 'single-query';
-
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Mock useSelector to return different values based on call order
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return mockQueryStatus; // First call is selectQueryStatus
-      }
-      if (callCount === 2) {
-        return mockEditorMode; // Second call is selectEditorMode
-      }
-      return mockQueryStatus; // fallback
-    });
+    // Mock useSelector to return queryStatus since that's the only selector used now
+    mockUseSelector.mockReturnValue(mockQueryStatus);
   });
 
   it('renders all footer components with correct layout', () => {
@@ -190,17 +178,7 @@ describe('QueryPanelFooter', () => {
       },
     };
 
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return errorQueryStatus; // First call is selectQueryStatus
-      }
-      if (callCount === 2) {
-        return mockEditorMode; // Second call is selectEditorMode
-      }
-      return errorQueryStatus; // fallback
-    });
+    mockUseSelector.mockReturnValue(errorQueryStatus);
 
     mockUseDatasetContext.mockReturnValue({
       dataset: { timeFieldName: '@timestamp' } as any,
@@ -213,19 +191,7 @@ describe('QueryPanelFooter', () => {
     expect(screen.getByTestId('query-result')).toHaveTextContent('Query Result: error - 500ms');
   });
 
-  it('shows save button for SingleQuery editor mode', () => {
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return mockQueryStatus; // First call is selectQueryStatus
-      }
-      if (callCount === 2) {
-        return 'single-query'; // Second call is selectEditorMode (EditorMode.SingleQuery)
-      }
-      return mockQueryStatus; // fallback
-    });
-
+  it('calls selectQueryStatus selector', () => {
     mockUseDatasetContext.mockReturnValue({
       dataset: { timeFieldName: '@timestamp' } as any,
       isLoading: false,
@@ -234,90 +200,6 @@ describe('QueryPanelFooter', () => {
 
     render(<QueryPanelFooter />);
 
-    expect(screen.getByTestId('save-query-button')).toBeInTheDocument();
-  });
-
-  it('shows save button for DualQuery editor mode', () => {
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return mockQueryStatus; // First call is selectQueryStatus
-      }
-      if (callCount === 2) {
-        return 'dual-query'; // Second call is selectEditorMode (EditorMode.DualQuery)
-      }
-      return mockQueryStatus; // fallback
-    });
-
-    mockUseDatasetContext.mockReturnValue({
-      dataset: { timeFieldName: '@timestamp' } as any,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<QueryPanelFooter />);
-
-    expect(screen.getByTestId('save-query-button')).toBeInTheDocument();
-  });
-
-  it('hides save button for SingleEmpty editor mode', () => {
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return mockQueryStatus; // First call is selectQueryStatus
-      }
-      if (callCount === 2) {
-        return 'single-empty'; // Second call is selectEditorMode (EditorMode.SingleEmpty)
-      }
-      return mockQueryStatus; // fallback
-    });
-
-    mockUseDatasetContext.mockReturnValue({
-      dataset: { timeFieldName: '@timestamp' } as any,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<QueryPanelFooter />);
-
-    expect(screen.queryByTestId('save-query-button')).not.toBeInTheDocument();
-  });
-
-  it('hides save button for SinglePrompt editor mode', () => {
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return mockQueryStatus; // First call is selectQueryStatus
-      }
-      if (callCount === 2) {
-        return 'single-prompt'; // Second call is selectEditorMode (EditorMode.SinglePrompt)
-      }
-      return mockQueryStatus; // fallback
-    });
-
-    mockUseDatasetContext.mockReturnValue({
-      dataset: { timeFieldName: '@timestamp' } as any,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<QueryPanelFooter />);
-
-    expect(screen.queryByTestId('save-query-button')).not.toBeInTheDocument();
-  });
-
-  it('calls selectQueryStatus and selectEditorMode selectors', () => {
-    mockUseDatasetContext.mockReturnValue({
-      dataset: { timeFieldName: '@timestamp' } as any,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<QueryPanelFooter />);
-
-    expect(mockUseSelector).toHaveBeenCalledTimes(2); // Once for each selector
+    expect(mockUseSelector).toHaveBeenCalledTimes(1); // Once for selectQueryStatus
   });
 });

--- a/src/plugins/explore/public/components/query_panel/footer/query_panel_footer.tsx
+++ b/src/plugins/explore/public/components/query_panel/footer/query_panel_footer.tsx
@@ -13,19 +13,13 @@ import { RecentQueriesButton } from './recent_queries_button';
 import { useDatasetContext } from '../../../application/context';
 import { DetectedLanguage } from './detected_language';
 import { QueryResult, ResultStatus } from '../../../../../data/public';
-import {
-  selectQueryStatus,
-  selectEditorMode,
-} from '../../../application/utils/state_management/selectors';
-import { EditorMode } from '../../../application/utils/state_management/types';
+import { selectQueryStatus } from '../../../application/utils/state_management/selectors';
 import './query_panel_footer.scss';
 
 export const QueryPanelFooter = () => {
   const { dataset } = useDatasetContext();
   const showDatePicker = Boolean(dataset?.timeFieldName);
   const queryStatus = useSelector(selectQueryStatus);
-  const editorMode = useSelector(selectEditorMode);
-  const shouldShowSaveButton = [EditorMode.SingleQuery, EditorMode.DualQuery].includes(editorMode);
 
   return (
     <div className="exploreQueryPanelFooter">
@@ -34,12 +28,8 @@ export const QueryPanelFooter = () => {
         <FilterPanelToggle />
         <div className="exploreQueryPanelFooter__verticalSeparator" />
         <RecentQueriesButton />
-        {shouldShowSaveButton && (
-          <>
-            <div className="exploreQueryPanelFooter__verticalSeparator" />
-            <SaveQueryButton />
-          </>
-        )}
+        <div className="exploreQueryPanelFooter__verticalSeparator" />
+        <SaveQueryButton />
         <div className="exploreQueryPanelFooter__verticalSeparator" />
         <DetectedLanguage />
         {queryStatus.status === ResultStatus.ERROR && <QueryResult queryStatus={queryStatus} />}

--- a/src/plugins/explore/public/components/query_panel/footer/save_query/save_query.tsx
+++ b/src/plugins/explore/public/components/query_panel/footer/save_query/save_query.tsx
@@ -13,7 +13,10 @@ import {
   SavedQueryMeta,
   SavedQuery,
 } from '../../../../../../data/public';
-import { selectQuery } from '../../../../application/utils/state_management/selectors';
+import {
+  selectEditorMode,
+  selectQuery,
+} from '../../../../application/utils/state_management/selectors';
 import { clearResults, setSavedQuery } from '../../../../application/utils/state_management/slices';
 import { ExploreServices } from '../../../../types';
 import { setQueryState } from '../../../../application/utils/state_management/slices';
@@ -24,10 +27,12 @@ import { RootState } from '../../../../application/utils/state_management/store'
 import { executeQueries } from '../../../../application/utils/state_management/actions/query_actions';
 import { useClearEditorsAndSetText, useEditorText } from '../../../../application/hooks';
 import './save_query.scss';
+import { EditorMode } from '../../../../application/utils/state_management/types';
 
 export const SaveQueryButton = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const { timeFilter } = useTimeFilter();
+  const editorMode = useSelector(selectEditorMode);
   const query = useSelector(selectQuery);
   const userInputText = useEditorText();
   const savedQueryService = services.data.query.savedQueries;
@@ -40,6 +45,7 @@ export const SaveQueryButton = () => {
 
   // Get the actual saved query object if we have an ID
   const [currentSavedQuery, setCurrentSavedQuery] = useState<SavedQuery | undefined>();
+  const saveButtonIsDisabled = ![EditorMode.SingleQuery, EditorMode.DualQuery].includes(editorMode);
 
   // Load saved query when ID changes
   useEffect(() => {
@@ -185,6 +191,7 @@ export const SaveQueryButton = () => {
         showSaveQuery={!!services.capabilities?.explore?.saveQuery}
         saveQuery={handleSaveQuery}
         useNewSavedQueryUI={true}
+        saveQueryIsDisabled={saveButtonIsDisabled}
       />
     </EuiPopover>
   );

--- a/src/plugins/explore/public/components/query_panel/utils/editor_options/shared.ts
+++ b/src/plugins/explore/public/components/query_panel/utils/editor_options/shared.ts
@@ -15,6 +15,7 @@ export const sharedEditorOptions: IEditorConstructionOptions = {
   cursorStyle: 'line-thin',
   wordWrap: 'on',
   lineDecorationsWidth: 0,
+  renderLineHighlight: 'none',
   scrollbar: {
     vertical: 'visible',
     horizontalScrollbarSize: 1,


### PR DESCRIPTION
- save query button should always be there, as hiding save query button is jarring
- under the popover, the `save query` is disabled when you are not in query mode. Loading however is always present
- I had to update the component in data plugin as putting disabled state made no visual change, but i think this is fine

<img width="1116" height="459" alt="Screenshot 2025-07-15 at 3 39 48 PM" src="https://github.com/user-attachments/assets/199497e1-4662-45e5-a00b-0d475556a58a" />
