### PR TITLE
[datasets] style improvements for dataset select

### DIFF
--- a/src/plugins/data/public/ui/dataset_select/_dataset_details.scss
+++ b/src/plugins/data/public/ui/dataset_select/_dataset_details.scss
@@ -8,7 +8,8 @@
     margin-left: $euiSizeXS;
     white-space: nowrap;
     flex-shrink: 0;
-    width: 32px;
+    width: $euiSizeXL;
+    height: $euiSizeXL;
   }
 
   &__panel {

--- a/src/plugins/data/public/ui/dataset_select/_dataset_details.scss
+++ b/src/plugins/data/public/ui/dataset_select/_dataset_details.scss
@@ -35,12 +35,6 @@
     min-width: 0;
   }
 
-  &__defaultBadge {
-    span:is([class*="euiBadge__text"]) {
-      cursor: pointer;
-    }
-  }
-
   &__footer {
     padding: 0;
   }

--- a/src/plugins/data/public/ui/dataset_select/_dataset_select.scss
+++ b/src/plugins/data/public/ui/dataset_select/_dataset_select.scss
@@ -6,9 +6,11 @@
 .datasetSelect {
   margin: 0;
   border: $euiBorderThin;
-  background-color: $euiColorLightestShade;
+  border-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   width: 400px;
   max-width: 400px;
+  height: $euiSizeXL - 1px;
 
   &__container {
     width: 100%;
@@ -16,18 +18,22 @@
   }
 
   &__detailsContainer {
-    width: 32px;
-    max-width: 32px;
+    width: $euiSizeXL;
+    max-width: $euiSizeXL;
   }
 
   div:is([class$="labelWrapper"]) {
-    width: fit-content;
+    width: $euiSizeXL;
+    height: $euiSizeXL - 1px;
     padding: 0 $euiSizeXS;
     margin-right: $euiSizeXS;
 
     :first-child {
       word-wrap: normal;
       word-break: normal;
+      height: $euiSizeXL - 1px;
+      display: block;
+      line-height: $euiSizeXL - 1px;
     }
   }
 
@@ -47,7 +53,7 @@
   &__button {
     background-color: $euiColorEmptyShade;
     width: 100%;
-    height: 32px;
+    height: $euiSizeXL;
     min-width: 0;
     display: flex;
     align-items: center;
@@ -62,6 +68,7 @@
 
   &__text {
     text-align: left;
+    align-items: center;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -69,7 +76,9 @@
     flex: 1;
     width: 250px;
     min-width: 0;
-    max-width: calc(100% - 32px);
+    max-width: calc(100% - $euiSizeXL);
+    height: $euiSizeXL - 1px;
+    line-height: $euiSizeXL - 1px;
   }
 
   &__checkbox {
@@ -92,6 +101,7 @@
   &__searchContainer {
     padding: $euiSizeXS;
     border-bottom: $euiBorderThin;
+    font-size: $euiFontSizeS;
   }
 
   &__list {
@@ -109,7 +119,7 @@
   }
 
   &__footer {
-    padding: 0;
+    padding: $euiSizeXS;
   }
 
   &__footerItem {

--- a/src/plugins/data/public/ui/dataset_select/dataset_details.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_details.tsx
@@ -10,7 +10,6 @@ import {
   EuiPopoverTitle,
   EuiTitle,
   EuiText,
-  EuiIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiDescriptionList,
@@ -31,12 +30,21 @@ export const DatasetDetails: React.FC<DatasetDetailsProps> = ({ dataset, isDefau
   const { services } = useOpenSearchDashboards<IDataPluginServices>();
   const [isOpen, setIsOpen] = useState(false);
   const {
+    dataViews,
     query: { queryString },
   } = services.data;
   const datasetService = queryString.getDatasetService();
 
   const togglePopover = useCallback(() => setIsOpen(!isOpen), [isOpen]);
   const closePopover = useCallback(() => setIsOpen(false), []);
+
+  const handleDataDefinitionClicked = useCallback(async () => {
+    if (!dataset || !dataset.dataSourceRef) {
+      return;
+    }
+
+    services.application!.navigateToApp('dataSources', { path: `/${dataset.dataSourceRef.id}` });
+  }, [dataset, services.application]);
 
   const getTypeFromUri = useCallback((uri?: string): string | undefined => {
     if (!uri) return undefined;
@@ -56,11 +64,7 @@ export const DatasetDetails: React.FC<DatasetDetailsProps> = ({ dataset, isDefau
   }
 
   const datasetType =
-    getTypeFromUri(dataset.dataSourceRef?.name) ||
-    dataset.type ||
-    DEFAULT_DATA.SET_TYPES.INDEX_PATTERN;
-  const datasetIcon = datasetService.getType(datasetType)?.meta.icon.type || 'database';
-
+    getTypeFromUri(dataset.dataSourceRef?.name) || dataViews.convertToDataset(dataset).type;
   const dataSourceName = dataset.dataSourceRef?.name || `default`;
   const datasetTitle = dataset.displayName || dataset.title;
   const datasetDescription = dataset.description || '';
@@ -147,16 +151,28 @@ export const DatasetDetails: React.FC<DatasetDetailsProps> = ({ dataset, isDefau
               </EuiText>
             ),
             description: (
-              <EuiFlexGroup gutterSize="xs" alignItems="center" wrap={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiIcon type={datasetIcon} size="s" />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs" color="subdued" className="datasetDetails__textTruncate">
-                    {dataSourceName}
-                  </EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+              <EuiBadge
+                color="hollow"
+                iconType={
+                  (datasetType === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN
+                    ? 'logoOpenSearch'
+                    : datasetService.getType(datasetType)?.meta.icon.type)!
+                }
+                onClick={handleDataDefinitionClicked}
+                onClickAriaLabel={i18n.translate('data.datasetDetails.dataDefinitionAriaLabel', {
+                  defaultMessage: 'View data definition',
+                })}
+                className="datasetDetails__dataDefinition"
+                data-test-subj="datasetDetailsDataDefinition"
+              >
+                <EuiFlexGroup gutterSize="xs" alignItems="center" wrap={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="xs" className="datasetDetails__textTruncate">
+                      {dataSourceName}
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiBadge>
             ),
           },
           {

--- a/src/plugins/data/public/ui/dataset_select/dataset_details.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_details.tsx
@@ -161,7 +161,7 @@ export const DatasetDetails: React.FC<DatasetDetailsProps> = ({ dataset, isDefau
             title: (
               <EuiText size="xs">
                 {i18n.translate('data.datasetDetails.dataDefinitionTitle', {
-                  defaultMessage: 'Data Definition',
+                  defaultMessage: 'Data definition',
                 })}
               </EuiText>
             ),

--- a/src/plugins/data/public/ui/dataset_select/dataset_details.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_details.tsx
@@ -30,26 +30,13 @@ export interface DatasetDetailsProps {
 export const DatasetDetails: React.FC<DatasetDetailsProps> = ({ dataset, isDefault }) => {
   const { services } = useOpenSearchDashboards<IDataPluginServices>();
   const [isOpen, setIsOpen] = useState(false);
-  const [isDefaultDataset, setIsDefaultDataset] = useState(isDefault);
   const {
     query: { queryString },
-    dataViews,
   } = services.data;
   const datasetService = queryString.getDatasetService();
 
   const togglePopover = useCallback(() => setIsOpen(!isOpen), [isOpen]);
   const closePopover = useCallback(() => setIsOpen(false), []);
-
-  const handleDefaultDatasetClicked = useCallback(async () => {
-    if (!dataset) return;
-
-    if (isDefaultDataset) {
-      return;
-    } else {
-      await dataViews.setDefault(dataset.id as string, true);
-      setIsDefaultDataset(true);
-    }
-  }, [dataset, isDefaultDataset, dataViews]);
 
   const getTypeFromUri = useCallback((uri?: string): string | undefined => {
     if (!uri) return undefined;
@@ -113,21 +100,15 @@ export const DatasetDetails: React.FC<DatasetDetailsProps> = ({ dataset, isDefau
             }
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <div
-              onClick={handleDefaultDatasetClicked}
-              data-test-subj="datasetDetailsDefaultButton"
-              tabIndex={0}
-              onKeyDown={() => {}}
+            <EuiBadge
+              color={isDefault ? 'default' : 'hollow'}
+              className="datasetDetails__defaultBadge"
+              data-test-subj="datasetDetailsDefault"
             >
-              <EuiBadge
-                color={isDefault ? 'default' : 'hollow'}
-                className="datasetDetails__defaultBadge"
-              >
-                {i18n.translate('data.datasetDetails.defaultLabel', {
-                  defaultMessage: 'Default',
-                })}
-              </EuiBadge>
-            </div>
+              {i18n.translate('data.datasetDetails.defaultLabel', {
+                defaultMessage: 'Default',
+              })}
+            </EuiBadge>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPopoverTitle>

--- a/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
@@ -290,11 +290,12 @@ const DatasetSelect: React.FC<DatasetSelectProps> = ({ onSelect, appName }) => {
                 </>
               )}
             </EuiSelectable>
-            <EuiPopoverFooter paddingSize="s">
+            <EuiPopoverFooter paddingSize="none">
               <EuiFlexGroup
                 justifyContent="spaceBetween"
                 alignItems="center"
                 responsive={false}
+                gutterSize="none"
                 className="datasetSelect__footer"
               >
                 <EuiFlexItem grow={false} className="datasetSelect__footerItem">


### PR DESCRIPTION
### Description

Style updates for visual regressions. Should address the icon being not centered in the select component and then the scroll bar being present always in the explore plugin

Also includes some clean ups and add the click to data source feature in the dataset select details component (the `...`)

### Issues Resolved

n/a

## Screenshot

<img width="432" height="223" alt="Screenshot 2025-07-15 at 4 57 20 PM" src="https://github.com/user-attachments/assets/218675e8-c5b2-42ee-8100-5bef57afd168" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
