### PR TITLE
Fix Tooltip Display Names for Multiple Chart Types

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -28,8 +28,8 @@ export const createSimpleAreaChart = (
 
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
 
   const layers: any[] = [];
 
@@ -68,6 +68,12 @@ export const createSimpleAreaChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 
@@ -123,8 +129,8 @@ export const createMultiAreaChart = (
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
   const categoryField = colorColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
@@ -232,8 +238,8 @@ export const createFacetedMultiAreaChart = (
   const dateField = xAxisMapping?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -395,8 +401,8 @@ export const createCategoryAreaChart = (
 
   const metricField = yAxisColumn?.column;
   const categoryField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const categoryName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const categoryName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   const mainLayer = {
@@ -488,9 +494,8 @@ export const createStackedAreaChart = (
   const metricField = yAxisMapping?.column;
   const categoryField1 = xAxisMapping?.column; // X-axis (categories)
   const categoryField2 = colorMapping?.column; // Color (stacking)
-
-  const metricName = yAxisMapping?.name;
-  const categoryName1 = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const categoryName1 = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const categoryName2 = colorMapping?.name;
 
   const spec: any = {

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -34,8 +34,8 @@ export const createBarSpec = (
 
   const metricField = yAxisColumn?.column;
   const categoryField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const categoryName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const categoryName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
 
   const layers: any[] = [];
 
@@ -88,6 +88,12 @@ export const createBarSpec = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: categoryField, type: 'nominal', title: categoryName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 
@@ -138,8 +144,8 @@ export const createTimeBarChart = (
 
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   // Configure bar mark
@@ -185,6 +191,12 @@ export const createTimeBarChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 
@@ -244,8 +256,8 @@ export const createGroupedTimeBarChart = (
 
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryField = colorColumn?.column;
   const categoryName = colorColumn?.name;
 
@@ -358,8 +370,8 @@ export const createFacetedTimeBarChart = (
   const dateField = xAxisMapping?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -436,6 +448,13 @@ export const createFacetedTimeBarChart = (
                   }
                 : null,
             },
+            ...(styles.tooltipOptions?.mode !== 'hidden' && {
+              tooltip: [
+                { field: dateField, type: 'temporal', title: dateName },
+                { field: metricField, type: 'quantitative', title: metricName },
+                { field: category1Field, type: 'nominal', title: category1Name },
+              ],
+            }),
           },
         },
         // Add threshold layer to each facet if enabled
@@ -489,8 +508,8 @@ export const createStackedBarSpec = (
   const metricField = yAxisMapping?.column;
   const categoryField1 = xAxisMapping?.column;
   const categoryField2 = colorMapping?.column;
-  const metricName = yAxisMapping?.name;
-  const categoryName1 = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const categoryName1 = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const categoryName2 = colorMapping?.name;
 
   // Set up encoding

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
@@ -18,6 +18,12 @@ export const createHeatmapWithBin = (
   const yAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.Y);
 
   const colorFieldColumn = axisColumnMappings?.color as any;
+  const xField = xAxis?.field?.default?.column;
+  const yField = yAxis?.field?.default?.column;
+  const colorField = colorFieldColumn?.column;
+  const xName = xAxis?.title?.text || xAxis?.field?.default?.name;
+  const yName = yAxis?.title?.text || yAxis?.field?.default?.name || 'Y-Axis';
+  const colorName = colorFieldColumn?.name;
 
   const markLayer: any = {
     mark: {
@@ -28,19 +34,19 @@ export const createHeatmapWithBin = (
     },
     encoding: {
       x: {
-        field: xAxis?.field?.default?.column,
+        field: xField,
         type: 'quantitative',
         bin: true,
         axis: applyAxisStyling(xAxis, styles?.grid?.xLines),
       },
       y: {
-        field: yAxis?.field?.default?.column,
+        field: yField,
         type: 'quantitative',
         bin: true,
         axis: applyAxisStyling(yAxis, styles?.grid?.yLines),
       },
       color: {
-        field: colorFieldColumn?.column,
+        field: colorField,
         type: 'quantitative',
         // TODO: a dedicate method to handle scale type is log especially in percentage mode
         bin: !styles.exclusive?.useCustomRanges
@@ -53,29 +59,30 @@ export const createHeatmapWithBin = (
         },
         legend: styles.addLegend
           ? {
-              title: colorFieldColumn?.name || 'Metrics',
+              title: colorName || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: xField, type: 'quantitative', title: xName },
+          { field: yField, type: 'quantitative', title: yName },
+          { field: colorField, type: 'quantitative', title: colorName },
+        ],
+      }),
     },
   };
 
-  enhanceStyle(markLayer, styles, transformedData, colorFieldColumn?.column);
+  enhanceStyle(markLayer, styles, transformedData, colorField);
 
   const baseSpec = {
     $schema: VEGASCHEMA,
     data: { values: transformedData },
-    transform: addTransform(styles, colorFieldColumn?.column),
+    transform: addTransform(styles, colorField),
     layer: [
       markLayer,
-      createlabelLayer(
-        styles,
-        false,
-        colorFieldColumn?.column,
-        xAxis?.field?.default,
-        yAxis?.field?.default
-      ),
+      createlabelLayer(styles, false, colorField, xAxis?.field?.default, yAxis?.field?.default),
     ].filter(Boolean),
   };
   return baseSpec;
@@ -91,6 +98,13 @@ export const createRegularHeatmap = (
   const yAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.Y);
 
   const colorFieldColumn = axisColumnMappings?.color!;
+  const xField = xAxis?.field?.default?.column;
+  const yField = yAxis?.field?.default?.column;
+  const colorField = colorFieldColumn?.column;
+  const xName = xAxis?.title?.text || xAxis?.field?.default?.name;
+  const yName = yAxis?.title?.text || yAxis?.field?.default?.name;
+  const colorName = colorFieldColumn?.name;
+
   const markLayer: any = {
     mark: {
       type: 'rect',
@@ -100,18 +114,18 @@ export const createRegularHeatmap = (
     },
     encoding: {
       x: {
-        field: xAxis?.field?.default?.column,
+        field: xField,
         type: 'nominal',
         axis: applyAxisStyling(xAxis, false),
         // for regular heatmap, both x and y refer to categorical fields, we shall disable grid line for this case
       },
       y: {
-        field: yAxis?.field?.default?.column,
+        field: yField,
         type: 'nominal',
         axis: applyAxisStyling(yAxis, false),
       },
       color: {
-        field: colorFieldColumn?.column,
+        field: colorField,
         type: 'quantitative',
         // TODO: a dedicate method to handle scale type is log especially in percentage mode
         bin: !styles.exclusive?.useCustomRanges
@@ -124,29 +138,30 @@ export const createRegularHeatmap = (
         },
         legend: styles.addLegend
           ? {
-              title: colorFieldColumn?.name || 'Metrics',
+              title: colorName || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: xField, type: 'nominal', title: xName },
+          { field: yField, type: 'nominal', title: yName },
+          { field: colorField, type: 'quantitative', title: colorName },
+        ],
+      }),
     },
   };
 
-  enhanceStyle(markLayer, styles, transformedData, colorFieldColumn?.column);
+  enhanceStyle(markLayer, styles, transformedData, colorField);
 
   const baseSpec = {
     $schema: VEGASCHEMA,
     data: { values: transformedData },
-    transform: addTransform(styles, colorFieldColumn?.column),
+    transform: addTransform(styles, colorField),
     layer: [
       markLayer,
-      createlabelLayer(
-        styles,
-        true,
-        colorFieldColumn?.column,
-        xAxis?.field?.default,
-        yAxis?.field?.default
-      ),
+      createlabelLayer(styles, true, colorField, xAxis?.field?.default, yAxis?.field?.default),
     ].filter(Boolean),
   };
 

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { field } from 'vega';
+import { title } from 'vega-lite/build/src/channeldef';
 import { LineChartStyleControls } from './line_vis_config';
 import { VisColumn, Positions, VEGASCHEMA, AxisColumnMappings, AxisRole } from '../types';
 import {
@@ -33,8 +35,8 @@ export const createSimpleLineChart = (
 
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   const mainLayer = {
@@ -67,6 +69,12 @@ export const createSimpleLineChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 
@@ -114,9 +122,12 @@ export const createLineBarChart = (
   const metric1Field = yAxisMapping?.column;
   const metric2Field = secondYAxisMapping?.column;
   const dateField = xAxisMapping?.column;
-  const metric1Name = yAxisMapping?.name;
-  const metric2Name = secondYAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  // const metric1Name = yAxisMapping?.name;
+  // const metric2Name = secondYAxisMapping?.name;
+  // const dateName = xAxisMapping?.name;
+  const metric1Name = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const metric2Name = styles.valueAxes?.[1]?.title?.text || secondYAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const layers: any[] = [];
 
   const barLayer = {
@@ -159,6 +170,12 @@ export const createLineBarChart = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metric1Field, type: 'quantitative', title: metric1Name },
+        ],
+      }),
     },
   };
 
@@ -195,6 +212,12 @@ export const createLineBarChart = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metric2Field, type: 'quantitative', title: metric2Name },
+        ],
+      }),
     },
   };
 
@@ -247,8 +270,8 @@ export const createMultiLineChart = (
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
   const categoryField = colorColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
@@ -293,6 +316,13 @@ export const createMultiLineChart = (
               }
             : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+          { field: categoryField, type: 'nominal', title: categoryName },
+        ],
+      }),
     },
   };
 
@@ -344,8 +374,8 @@ export const createFacetedMultiLineChart = (
   const dateField = xAxisMapping?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -413,6 +443,13 @@ export const createFacetedMultiLineChart = (
                     }
                   : null,
             },
+            ...(styles.tooltipOptions?.mode !== 'hidden' && {
+              tooltip: [
+                { field: dateField, type: 'temporal', title: dateName },
+                { field: metricField, type: 'quantitative', title: metricName },
+                { field: category1Field, type: 'nominal', title: category1Name },
+              ],
+            }),
           },
         },
         // Add threshold layer to each facet if enabled
@@ -501,8 +538,8 @@ export const createCategoryLineChart = (
 
   const metricField = yAxisColumn?.column;
   const categoryField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const categoryName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const categoryName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   const mainLayer = {
@@ -535,6 +572,12 @@ export const createCategoryLineChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: categoryField, type: 'nominal', title: categoryName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
@@ -20,6 +20,7 @@ export const createPieSpec = (
   const numericField = thetaColumn?.column;
   const numericName = thetaColumn?.name;
   const categoryField = colorColumn?.column;
+  const categoryName = colorColumn?.name;
 
   const encodingBase = {
     theta: {
@@ -34,6 +35,12 @@ export const createPieSpec = (
         ? { title: numericName, orient: styleOptions.legendPosition, symbolLimit: 10 }
         : null,
     },
+    ...(styleOptions.tooltipOptions?.mode !== 'hidden' && {
+      tooltip: [
+        { field: categoryField, type: 'nominal', title: categoryName },
+        { field: numericField, type: 'quantitative', title: numericName },
+      ],
+    }),
   };
 
   const markLayer = {

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
@@ -17,6 +17,11 @@ export const createTwoMetricScatter = (
 ): any => {
   const xAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.X);
   const yAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.Y);
+  const xField = xAxis?.field?.default?.column;
+  const yField = yAxis?.field?.default?.column;
+  const xName = xAxis?.title?.text || xAxis?.field?.default?.name;
+  const yName = yAxis?.title?.text || yAxis?.field?.default?.name;
+
   const markLayer = {
     mark: {
       type: 'point',
@@ -27,15 +32,21 @@ export const createTwoMetricScatter = (
     },
     encoding: {
       x: {
-        field: xAxis?.field?.default?.column,
+        field: xField,
         type: 'quantitative',
         axis: applyAxisStyling(xAxis, styles?.grid?.xLines),
       },
       y: {
-        field: yAxis?.field?.default?.column,
+        field: yField,
         type: 'quantitative',
         axis: applyAxisStyling(yAxis, styles?.grid?.yLines),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: xField, type: 'quantitative', title: xName },
+          { field: yField, type: 'quantitative', title: yName },
+        ],
+      }),
     },
   };
 
@@ -59,6 +70,11 @@ export const createTwoMetricOneCateScatter = (
   const categoryNames = axisColumnMappings?.color?.name!;
   const xAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.X);
   const yAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.Y);
+  const xField = xAxis?.field?.default?.column;
+  const yField = yAxis?.field?.default?.column;
+  const xName = xAxis?.title?.text || xAxis?.field?.default?.name;
+  const yName = yAxis?.title?.text || yAxis?.field?.default?.name;
+
   const markLayer = {
     mark: {
       type: 'point',
@@ -69,12 +85,12 @@ export const createTwoMetricOneCateScatter = (
     },
     encoding: {
       x: {
-        field: xAxis?.field?.default?.column,
+        field: xField,
         type: 'quantitative',
         axis: applyAxisStyling(xAxis, styles?.grid?.xLines),
       },
       y: {
-        field: yAxis?.field?.default?.column,
+        field: yField,
         type: 'quantitative',
         axis: applyAxisStyling(yAxis, styles?.grid?.yLines),
       },
@@ -89,6 +105,13 @@ export const createTwoMetricOneCateScatter = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: xField, type: 'quantitative', title: xName },
+          { field: yField, type: 'quantitative', title: yName },
+          { field: categoryFields, type: 'nominal', title: categoryNames },
+        ],
+      }),
     },
   };
 
@@ -114,6 +137,12 @@ export const createThreeMetricOneCateScatter = (
   const xAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.X);
   const yAxis = getAxisByRole(styles?.StandardAxes ?? [], AxisRole.Y);
   const numericalSize = axisColumnMappings?.size;
+  const xField = xAxis?.field?.default?.column;
+  const yField = yAxis?.field?.default?.column;
+  const sizeField = numericalSize?.column;
+  const xName = xAxis?.title?.text || xAxis?.field?.default?.name;
+  const yName = yAxis?.title?.text || yAxis?.field?.default?.name;
+  const sizeName = numericalSize?.name;
   const markLayer = {
     mark: {
       type: 'point',
@@ -124,12 +153,12 @@ export const createThreeMetricOneCateScatter = (
     },
     encoding: {
       x: {
-        field: xAxis?.field?.default?.column,
+        field: xField,
         type: 'quantitative',
         axis: applyAxisStyling(xAxis, styles?.grid?.xLines),
       },
       y: {
-        field: yAxis?.field?.default?.column,
+        field: yField,
         type: 'quantitative',
         axis: applyAxisStyling(yAxis, styles?.grid?.yLines),
       },
@@ -145,16 +174,24 @@ export const createThreeMetricOneCateScatter = (
           : null,
       },
       size: {
-        field: numericalSize?.column,
+        field: sizeField,
         type: 'quantitative',
         legend: styles?.addLegend
           ? {
-              title: numericalSize?.name || 'Metrics',
+              title: sizeName || 'Metrics',
               orient: styles?.legendPosition,
               symbolLimit: 10,
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: xField, type: 'quantitative', title: xName },
+          { field: yField, type: 'quantitative', title: yName },
+          { field: categoryFields, type: 'nominal', title: categoryNames },
+          { field: sizeField, type: 'quantitative', title: sizeName },
+        ],
+      }),
     },
   };
 


### PR DESCRIPTION
### Description

This PR addresses the issue of generic tooltip field names (e.g., field-00, field-01) in bar, pie, heatmap, and scatter charts by adding explicit tooltip configurations in the Vega specs. The tooltips now use user-modified displayName values from styles.StandardAxes and styles.valueAxes for X, Y, and metric/size axes, falling back to axisColumnMappings names where appropriate. For the COLOR and FACET axes, the original column names from axisColumnMappings are used, as no user-modifiable displayName is available in the provided styles. This ensures that tooltips display meaningful, user-friendly names across all affected chart types, improving the user experience in visualizations.

## Screenshot

### Before
<img width="1972" height="1134" alt="image" src="https://github.com/user-attachments/assets/dd1a3a56-c1c5-4801-8d98-539b17a8f3e0" />

### After
<img width="1968" height="1134" alt="image" src="https://github.com/user-attachments/assets/a75bbb5b-8867-429e-9274-ebc849758d4c" />


## Testing the changes

Take the time-based bar chart as an example:
1. Create a time-based bar chart (createTimeBarChart) with one numerical and one categorical/date column.
2. In the AxesOptions UI, modify the displayName for X and Y axes (e.g., change customer_id to "Customer ID", count() to "Total Count").
3. Hover over a bar to verify the tooltip shows the modified displayName (e.g., Customer ID: value, Total Count: value).
4. Test with unmodified displayName to ensure fallback to original column names.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Add explicit tooltip configurations with user-modified display names for multiple charts

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
