### PR TITLE
Fix explore plugin query panel reset on page reload due to DatasetSelect initialization

### DIFF
--- a/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
@@ -111,8 +111,26 @@ const DatasetSelect: React.FC<DatasetSelectProps> = ({ onSelect, appName }) => {
       if (isMounted.current) {
         setDatasets(fetchedDataViews);
         if (!initialDatasetSet.current && fetchedDataViews.length > 0) {
-          setSelectedDataset(fetchedDataViews[0]);
-          onSelect(fetchedDataViews[0]);
+          // Check if there's already a dataset from query string (URL state)
+          const currentQuery = queryString.getQuery();
+          const existingDataset = currentQuery?.dataset;
+
+          if (existingDataset) {
+            // If there's already a dataset from URL, find it in the fetched datasets
+            const urlDataset = fetchedDataViews.find((d) => d.id === existingDataset.id);
+            if (urlDataset) {
+              setSelectedDataset(urlDataset);
+              // Don't call onSelect during initialization if dataset exists in URL
+            } else {
+              // Fallback to first dataset if URL dataset not found
+              setSelectedDataset(fetchedDataViews[0]);
+              onSelect(fetchedDataViews[0]);
+            }
+          } else {
+            // No dataset in URL, select first one and call onSelect
+            setSelectedDataset(fetchedDataViews[0]);
+            onSelect(fetchedDataViews[0]);
+          }
           initialDatasetSet.current = true;
         }
         setIsLoading(false);
@@ -122,7 +140,7 @@ const DatasetSelect: React.FC<DatasetSelectProps> = ({ onSelect, appName }) => {
         setIsLoading(false);
       }
     }
-  }, [dataViews, onSelect]);
+  }, [dataViews, onSelect, queryString]);
 
   useEffect(() => {
     isMounted.current = true;


### PR DESCRIPTION
### Description

When reload page, the query panel is set twice. See before fix video. 

In the fetchDatasets function, lines 113-117 show the problem:
```
if (!initialDatasetSet.current && fetchedDataViews.length > 0) {
  setSelectedDataset(fetchedDataViews[0]);
  onSelect(fetchedDataViews[0]); // This is calling handleDatasetSelect during initialization!
  initialDatasetSet.current = true;
}
```
The DatasetSelect component is automatically calling
onSelect (which is handleDatasetSelect in Explore) during initialization when it sets the first dataset. This happens even during page reload when we already have a dataset from the URL.


## Screenshot

Before fix, call handleDatasetSelect in Explore then clearEditor() will reset the query panel

https://github.com/user-attachments/assets/07a5769e-45e3-43f0-a45e-9e01752b7a2e

After fix, won't call handleDatasetSelect in Explore when reload. Only switch dataset will call it


https://github.com/user-attachments/assets/a6f021a3-7962-42e8-a250-51349f466b2b



## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
