### PR TITLE
[Explore] Fix Tooltip Display Names for Multiple Chart Types

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -28,8 +28,8 @@ export const createSimpleAreaChart = (
 
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
 
   const layers: any[] = [];
 
@@ -68,6 +68,12 @@ export const createSimpleAreaChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 
@@ -123,8 +129,8 @@ export const createMultiAreaChart = (
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
   const categoryField = colorColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
@@ -232,8 +238,8 @@ export const createFacetedMultiAreaChart = (
   const dateField = xAxisMapping?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -395,8 +401,8 @@ export const createCategoryAreaChart = (
 
   const metricField = yAxisColumn?.column;
   const categoryField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const categoryName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const categoryName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   const mainLayer = {
@@ -488,9 +494,8 @@ export const createStackedAreaChart = (
   const metricField = yAxisMapping?.column;
   const categoryField1 = xAxisMapping?.column; // X-axis (categories)
   const categoryField2 = colorMapping?.column; // Color (stacking)
-
-  const metricName = yAxisMapping?.name;
-  const categoryName1 = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const categoryName1 = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const categoryName2 = colorMapping?.name;
 
   const spec: any = {

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -65,6 +65,20 @@ export const createBarSpec = (
         type: getSchemaByAxis(yAxis),
         axis: applyAxisStyling(yAxis),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+        ],
+      }),
     },
   };
 
@@ -146,6 +160,20 @@ export const createTimeBarChart = (
         type: getSchemaByAxis(yAxis),
         axis: applyAxisStyling(yAxis),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+        ],
+      }),
     },
   };
 
@@ -251,9 +279,17 @@ export const createGroupedTimeBarChart = (
       },
       // Optional: Add tooltip with all information
       tooltip: [
-        { field: xAxis?.column, type: getSchemaByAxis(xAxis), title: xAxis?.name },
+        {
+          field: xAxis?.column,
+          type: getSchemaByAxis(xAxis),
+          title: xAxis?.styles?.title?.text || xAxis?.name,
+        },
         { field: categoryField, type: getSchemaByAxis(colorColumn), title: categoryName },
-        { field: yAxis?.column, type: getSchemaByAxis(yAxis), title: yAxis?.name },
+        {
+          field: yAxis?.column,
+          type: getSchemaByAxis(yAxis),
+          title: yAxis?.styles?.title?.text || yAxis?.name,
+        },
       ],
     },
   };
@@ -306,7 +342,8 @@ export const createFacetedTimeBarChart = (
   const dateField = xAxis?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxis?.name;
+  const metricName = yAxis?.styles?.title?.text || yAxis?.name;
+  const dateName = xAxis?.styles?.title?.text || xAxis?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -374,6 +411,13 @@ export const createFacetedTimeBarChart = (
                   }
                 : null,
             },
+            ...(styles.tooltipOptions?.mode !== 'hidden' && {
+              tooltip: [
+                { field: metricField, type: getSchemaByAxis(yAxis), title: metricName },
+                { field: dateField, type: getSchemaByAxis(xAxis), title: dateName },
+                { field: category1Field, type: 'nominal', title: category1Name },
+              ],
+            }),
           },
         },
 

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
@@ -17,6 +17,8 @@ export const createHeatmapWithBin = (
   const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
 
   const colorFieldColumn = axisColumnMappings?.color as any;
+  const colorField = colorFieldColumn?.column;
+  const colorName = colorFieldColumn?.name;
 
   const markLayer: any = {
     mark: {
@@ -39,7 +41,7 @@ export const createHeatmapWithBin = (
         axis: applyAxisStyling(yAxis),
       },
       color: {
-        field: colorFieldColumn?.column,
+        field: colorField,
         type: getSchemaByAxis(colorFieldColumn),
         // TODO: a dedicate method to handle scale type is log especially in percentage mode
         bin: !styles.exclusive?.useCustomRanges
@@ -52,24 +54,36 @@ export const createHeatmapWithBin = (
         },
         legend: styles.addLegend
           ? {
-              title: colorFieldColumn?.name || 'Metrics',
+              title: colorName || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+          { field: colorField, type: 'quantitative', title: colorName },
+        ],
+      }),
     },
   };
 
-  enhanceStyle(markLayer, styles, transformedData, colorFieldColumn?.column);
+  enhanceStyle(markLayer, styles, transformedData, colorField);
 
   const baseSpec = {
     $schema: VEGASCHEMA,
     data: { values: transformedData },
-    transform: addTransform(styles, colorFieldColumn?.column),
-    layer: [
-      markLayer,
-      createlabelLayer(styles, false, colorFieldColumn?.column, xAxis, yAxis),
-    ].filter(Boolean),
+    transform: addTransform(styles, colorField),
+    layer: [markLayer, createlabelLayer(styles, false, colorField, xAxis, yAxis)].filter(Boolean),
   };
   return baseSpec;
 };
@@ -83,6 +97,9 @@ export const createRegularHeatmap = (
   const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
 
   const colorFieldColumn = axisColumnMappings?.color!;
+  const colorField = colorFieldColumn?.column;
+  const colorName = colorFieldColumn?.name;
+
   const markLayer: any = {
     mark: {
       type: 'rect',
@@ -103,7 +120,7 @@ export const createRegularHeatmap = (
         axis: applyAxisStyling(yAxis, true),
       },
       color: {
-        field: colorFieldColumn?.column,
+        field: colorField,
         type: getSchemaByAxis(colorFieldColumn),
         // TODO: a dedicate method to handle scale type is log especially in percentage mode
         bin: !styles.exclusive?.useCustomRanges
@@ -116,24 +133,36 @@ export const createRegularHeatmap = (
         },
         legend: styles.addLegend
           ? {
-              title: colorFieldColumn?.name || 'Metrics',
+              title: colorName || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+          { field: colorField, type: 'quantitative', title: colorName },
+        ],
+      }),
     },
   };
 
-  enhanceStyle(markLayer, styles, transformedData, colorFieldColumn?.column);
+  enhanceStyle(markLayer, styles, transformedData, colorField);
 
   const baseSpec = {
     $schema: VEGASCHEMA,
     data: { values: transformedData },
-    transform: addTransform(styles, colorFieldColumn?.column),
-    layer: [
-      markLayer,
-      createlabelLayer(styles, true, colorFieldColumn?.column, xAxis, yAxis),
-    ].filter(Boolean),
+    transform: addTransform(styles, colorField),
+    layer: [markLayer, createlabelLayer(styles, true, colorField, xAxis, yAxis)].filter(Boolean),
   };
 
   return baseSpec;

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -33,8 +33,8 @@ export const createSimpleLineChart = (
 
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   const mainLayer = {
@@ -67,6 +67,12 @@ export const createSimpleLineChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 
@@ -114,9 +120,9 @@ export const createLineBarChart = (
   const metric1Field = yAxisMapping?.column;
   const metric2Field = secondYAxisMapping?.column;
   const dateField = xAxisMapping?.column;
-  const metric1Name = yAxisMapping?.name;
-  const metric2Name = secondYAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  const metric1Name = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const metric2Name = styles.valueAxes?.[1]?.title?.text || secondYAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const layers: any[] = [];
 
   const barLayer = {
@@ -159,6 +165,12 @@ export const createLineBarChart = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metric1Field, type: 'quantitative', title: metric1Name },
+        ],
+      }),
     },
   };
 
@@ -195,6 +207,12 @@ export const createLineBarChart = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metric2Field, type: 'quantitative', title: metric2Name },
+        ],
+      }),
     },
   };
 
@@ -247,8 +265,8 @@ export const createMultiLineChart = (
   const metricField = yAxisColumn?.column;
   const dateField = xAxisColumn?.column;
   const categoryField = colorColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const dateName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
@@ -293,6 +311,13 @@ export const createMultiLineChart = (
               }
             : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: dateField, type: 'temporal', title: dateName },
+          { field: metricField, type: 'quantitative', title: metricName },
+          { field: categoryField, type: 'nominal', title: categoryName },
+        ],
+      }),
     },
   };
 
@@ -344,8 +369,8 @@ export const createFacetedMultiLineChart = (
   const dateField = xAxisMapping?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxisMapping?.name;
-  const dateName = xAxisMapping?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
+  const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -413,6 +438,13 @@ export const createFacetedMultiLineChart = (
                     }
                   : null,
             },
+            ...(styles.tooltipOptions?.mode !== 'hidden' && {
+              tooltip: [
+                { field: dateField, type: 'temporal', title: dateName },
+                { field: metricField, type: 'quantitative', title: metricName },
+                { field: category1Field, type: 'nominal', title: category1Name },
+              ],
+            }),
           },
         },
         // Add threshold layer to each facet if enabled
@@ -501,8 +533,8 @@ export const createCategoryLineChart = (
 
   const metricField = yAxisColumn?.column;
   const categoryField = xAxisColumn?.column;
-  const metricName = yAxisColumn?.name;
-  const categoryName = xAxisColumn?.name;
+  const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
+  const categoryName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
 
   const mainLayer = {
@@ -535,6 +567,12 @@ export const createCategoryLineChart = (
           dateColumns
         ),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          { field: categoryField, type: 'nominal', title: categoryName },
+          { field: metricField, type: 'quantitative', title: metricName },
+        ],
+      }),
     },
   };
 

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
@@ -20,6 +20,7 @@ export const createPieSpec = (
   const numericField = thetaColumn?.column;
   const numericName = thetaColumn?.name;
   const categoryField = colorColumn?.column;
+  const categoryName = colorColumn?.name;
 
   const encodingBase = {
     theta: {
@@ -34,6 +35,12 @@ export const createPieSpec = (
         ? { title: numericName, orient: styleOptions.legendPosition, symbolLimit: 10 }
         : null,
     },
+    ...(styleOptions.tooltipOptions?.mode !== 'hidden' && {
+      tooltip: [
+        { field: categoryField, type: 'nominal', title: categoryName },
+        { field: numericField, type: 'quantitative', title: numericName },
+      ],
+    }),
   };
 
   const markLayer = {

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
@@ -36,6 +36,20 @@ export const createTwoMetricScatter = (
         type: getSchemaByAxis(yAxis),
         axis: applyAxisStyling(yAxis),
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+        ],
+      }),
     },
   };
 
@@ -89,6 +103,21 @@ export const createTwoMetricOneCateScatter = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+          { field: categoryFields, type: 'nominal', title: categoryNames },
+        ],
+      }),
     },
   };
 
@@ -156,6 +185,22 @@ export const createThreeMetricOneCateScatter = (
             }
           : null,
       },
+      ...(styles.tooltipOptions?.mode !== 'hidden' && {
+        tooltip: [
+          {
+            field: xAxis?.column,
+            type: getSchemaByAxis(xAxis),
+            title: xAxis?.styles?.title?.text || xAxis?.name,
+          },
+          {
+            field: yAxis?.column,
+            type: getSchemaByAxis(yAxis),
+            title: yAxis?.styles?.title?.text || yAxis?.name,
+          },
+          { field: categoryFields, type: 'nominal', title: categoryNames },
+          { field: numericalSize?.column, type: 'quantitative', title: numericalSize?.name },
+        ],
+      }),
     },
   };
 


### PR DESCRIPTION
### Description

This PR addresses the issue of generic tooltip field names (e.g., field-00, field-01) in bar, pie, heatmap, and scatter charts by adding explicit tooltip configurations in the Vega specs. The tooltips now use user-modified displayName values from styles.StandardAxes and styles.valueAxes for X, Y, and metric/size axes, falling back to axisColumnMappings names where appropriate. For the COLOR and FACET axes, the original column names from axisColumnMappings are used, as no user-modifiable displayName is available in the provided styles. This ensures that tooltips display meaningful, user-friendly names across all affected chart types, improving the user experience in visualizations.

## Screenshot

### Before
<img width="1972" height="1134" alt="image" src="https://github.com/user-attachments/assets/dd1a3a56-c1c5-4801-8d98-539b17a8f3e0" />

### After
<img width="1968" height="1134" alt="image" src="https://github.com/user-attachments/assets/a75bbb5b-8867-429e-9274-ebc849758d4c" />


## Testing the changes

Take the time-based bar chart as an example:
1. Create a time-based bar chart (createTimeBarChart) with one numerical and one categorical/date column.
2. In the AxesOptions UI, modify the displayName for X and Y axes (e.g., change customer_id to "Customer ID", count() to "Total Count").
3. Hover over a bar to verify the tooltip shows the modified displayName (e.g., Customer ID: value, Total Count: value).
4. Test with unmodified displayName to ensure fallback to original column names.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: Add explicit tooltip configurations with user-modified display names for multiple charts

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff