### PR TITLE
[Explore] Prevent saved explore state persistence when navigating back to workspace

### DIFF
--- a/src/core/public/application/application_service.tsx
+++ b/src/core/public/application/application_service.tsx
@@ -92,8 +92,7 @@ const getAppUrl = (mounters: Map<string, Mounter>, appId: string, path: string =
   const appBasePath = mounters.get(appId)?.appRoute
     ? `/${mounters.get(appId)!.appRoute}`
     : `/app/${appId}`;
-  const a = appendAppPath(appBasePath, path);
-  return a;
+  return appendAppPath(appBasePath, path);
 };
 
 const allApplicationsFilter = '__ALL__';
@@ -301,8 +300,7 @@ export class ApplicationService {
         if (!navigatingToSameApp) {
           this.appInternalStates.delete(this.currentAppId$.value!);
         }
-        const b = getAppUrl(availableMounters, appId, path);
-        this.navigate!(b, state, replace);
+        this.navigate!(getAppUrl(availableMounters, appId, path), state, replace);
         this.currentAppId$.next(appId);
       }
     };

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -258,6 +258,7 @@ export class ExplorePlugin
         // If there's no flavor id, by default redirect to the logs flavor.
         if (!flavor) {
           coreStart.application.navigateToApp(`${PLUGIN_ID}/${ExploreFlavor.Logs}`, {
+            path: '#/',
             replace: true,
           });
           return () => {};


### PR DESCRIPTION
### Description

When users navigate away from the Explore plugin after viewing a saved explore and then return to the workspace, the saved explore state (including title and URL parameters) persists unexpectedly. This causes the interface to display the previous saved explore instead of starting with a clean state.

The issue was caused by the URL tracker storing the last visited URL in sessionStorage and restoring it as the app's `defaultPath` when the user returns. When `navigateToApp` is called without an explicit path parameter, it uses this stored `defaultPath`, which contains the saved explore ID and state parameters.

This PR simply added an explicit `path: '#/'` parameter to the `navigateToApp` call when redirecting to the logs flavor. This ensures that users always start with a clean explore interface instead of inheriting the previously stored URL state.


## Screenshot


https://github.com/user-attachments/assets/e92ce3ac-610b-4dee-b40a-4727908b6211



## Changelog

- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
