### PR TITLE
[Manual Backport 2.19] Fix GHSA-vjh7-7g9h-fjfh by bumping elliptic

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "**/d3-color": "^3.1.0",
     "**/flat": "^5.0.2",
     "**/elasticsearch/agentkeepalive": "^4.5.0",
+    "**/elliptic": "^6.6.1",
     "**/eslint/cross-spawn": "^7.0.5",
     "**/es5-ext": "^0.10.63",
     "**/fetch-mock/path-to-regexp": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7624,10 +7624,10 @@ element-resize-detector@^1.2.1:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.3, elliptic@^6.5.4:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.0.tgz#5919ec723286c1edf28685aa89261d4761afa210"
-  integrity sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==
+elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
### Description

Repeat https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10224 to kick in test settings

## Changelog
- skip


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
