### PR TITLE
[Explore] Ensure Chart Clears on Axis Removal

### DIFF
--- a/changelogs/fragments/10230.yml
+++ b/changelogs/fragments/10230.yml
@@ -1,0 +1,2 @@
+fix:
+- Ensure chart clears on axis removal ([#10230](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10230))

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
@@ -132,11 +132,15 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
   const [lastSentMappings, setLastSentMappings] = useState<AxisColumnMappings>({});
 
   useEffect(() => {
-    // Only update currentSelections if currentMapping is not empty and differs from currentSelections
+    // Only update if currentMapping has changed and is not empty
     if (Object.keys(currentMapping).length > 0 && !isEqual(currentSelections, currentMapping)) {
-      setCurrentSelections(currentMapping);
+      // Avoid overwriting if the user has just cleared a selection
+      const hasUserCleared = Object.values(currentSelections).some((col) => col === undefined);
+      if (!hasUserCleared) {
+        setCurrentSelections(currentMapping);
+      }
     }
-  }, [currentMapping]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [currentMapping, currentSelections]);
 
   // Filter out those mapping (combination of axes selection) that no longer be satisify
   // by the current combination of axes selection
@@ -202,7 +206,7 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
       updateVisualization({ rule: undefined, mappings: {} });
       setLastSentMappings({});
     }
-  }, [currentValidSelection, updateVisualization, chartType, lastSentMappings]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [currentValidSelection, updateVisualization, chartType, lastSentMappings, currentSelections]);
 
   const findColumns = useMemo(
     () => (type: VisFieldType) => {
@@ -334,6 +338,7 @@ export const AxisSelector: React.FC<AxesSelectorOptions> = ({
   onChange,
 }) => {
   const styles = useSelector(selectStyleOptions) as AxisSupportedStyles;
+  const selectedOptions = selectedColumn ? [{ label: selectedColumn }] : [];
 
   const getLabel = () => {
     if (styles?.switchAxes && (axisRole === AxisRole.X || axisRole === AxisRole.Y)) {
@@ -350,7 +355,7 @@ export const AxisSelector: React.FC<AxesSelectorOptions> = ({
         <EuiFlexItem>
           <EuiComboBox
             compressed
-            selectedOptions={[{ label: selectedColumn }]}
+            selectedOptions={selectedOptions}
             singleSelection={{ asPlainText: true }}
             options={allColumnOptions}
             onChange={(value) => {
@@ -360,6 +365,7 @@ export const AxisSelector: React.FC<AxesSelectorOptions> = ({
                 onRemove(axisRole);
               }
             }}
+            isClearable={true}
           />
         </EuiFlexItem>
       </EuiFormRow>


### PR DESCRIPTION
### Description

This pull request fixes an issue where the bar chart visualization in the AxesSelectPanel component did not clear when either the X or Y axis was removed. The changes ensure that removing a required axis (X or Y) triggers updateVisualization with an empty mapping and undefined rule, clearing the visualization as expected.

## Screenshot
### Before

https://github.com/user-attachments/assets/e0311aeb-4a94-4113-95e8-7b89842ea57b

### After

https://github.com/user-attachments/assets/b11999c9-cc8d-4501-87aa-b961a6843622


## Testing the changes

1. Run a query that can generate a bar chart.
2. Use the AxesSelectPanel to remove either the X or Y axis by clearing the selection in the EuiComboBox.
3. Verify that the bar chart clears (visualization area shows a placeholder).

## Changelog
- fix: Ensure chart clears on axis removal


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
