### PR TITLE
[Left navigation] fix: type to allow euiIconType / icon to be undefined

### DIFF
--- a/changelogs/fragments/10240.yml
+++ b/changelogs/fragments/10240.yml
@@ -1,0 +1,2 @@
+fix:
+- [Left navigation] fix: type to allow euiIconType / icon to be undefined ([#10240](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10240))

--- a/src/core/public/chrome/nav_group/nav_group_service.ts
+++ b/src/core/public/chrome/nav_group/nav_group_service.ts
@@ -30,7 +30,7 @@ import { ALL_USE_CASE_ID, DEFAULT_APP_CATEGORIES } from '../../../utils';
 export const CURRENT_NAV_GROUP_ID = 'core.chrome.currentNavGroupId';
 
 /** @public */
-export interface ChromeRegistrationNavLink extends Pick<App, 'euiIconType' | 'icon'> {
+export interface ChromeRegistrationNavLink {
   id: string;
   title?: string;
   category?: AppCategory;
@@ -48,6 +48,18 @@ export interface ChromeRegistrationNavLink extends Pick<App, 'euiIconType' | 'ic
    * use addNavLinksToGroup to keep the interfaces consistent.
    */
   showInAllNavGroup?: boolean;
+
+  /**
+   * A EUI iconType that will be used for the app's icon. This icon
+   * takes precendence over the `icon` property.
+   */
+  euiIconType?: App['euiIconType'];
+
+  /**
+   * A URL to an image file used as an icon. Used as a fallback
+   * if `euiIconType` is not provided.
+   */
+  icon?: App['icon'];
 }
 
 export type NavGroupItemInMap = ChromeNavGroup & {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Previously we use 
```
extends Pick<App, 'euiIconType' | 'icon'>
```
And euiIconType / icon becomes required parameters for add applications into nav group. Change the type so that `euiIconType / icon` keep optional.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: [Left navigation] fix: type to allow euiIconType / icon to be undefined

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
