### PR TITLE
Fix banner text font and alignment

### DIFF
--- a/changelogs/fragments/10251.yml
+++ b/changelogs/fragments/10251.yml
@@ -1,2 +1,2 @@
 fix:
-- Fix font size and center alignment for banner. ([#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251))
+- Fix font size and center alignment for banner text. ([#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251))

--- a/changelogs/fragments/10251.yml
+++ b/changelogs/fragments/10251.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix font size and center alignment for banner. ([#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251))

--- a/src/plugins/explore/public/components/experience_banners/classic_experience_banner/classic_experience_banner.scss
+++ b/src/plugins/explore/public/components/experience_banners/classic_experience_banner/classic_experience_banner.scss
@@ -9,14 +9,14 @@
   }
 
   // EuiCallOut wraps children within two divs
-  & > div > div {
+  &>div>div {
     display: flex;
     justify-content: space-between;
     align-items: center;
 
     // Adding some specificity by nesting
     .exploreClassicExperienceBanner__newExperienceButton {
-      font-size: $ouiFontSizeXS;
+      font-size: $ouiFontSizeS;
       height: $ouiSizeL;
     }
   }

--- a/src/plugins/explore/public/components/experience_banners/classic_experience_banner/classic_experience_banner.scss
+++ b/src/plugins/explore/public/components/experience_banners/classic_experience_banner/classic_experience_banner.scss
@@ -9,7 +9,7 @@
   }
 
   // EuiCallOut wraps children within two divs
-  &>div>div {
+  & > div > div {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/src/plugins/explore/public/components/experience_banners/classic_experience_banner/classic_experience_banner.scss
+++ b/src/plugins/explore/public/components/experience_banners/classic_experience_banner/classic_experience_banner.scss
@@ -13,10 +13,10 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    font-size: $ouiFontSizeS;
 
     // Adding some specificity by nesting
     .exploreClassicExperienceBanner__newExperienceButton {
-      font-size: $ouiFontSizeS;
       height: $ouiSizeL;
     }
   }

--- a/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.scss
+++ b/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.scss
@@ -6,19 +6,20 @@
 .exploreNewExperienceBanner {
   display: flex;
   flex-direction: row-reverse;
+  align-items: center;
 
   &__img {
     margin-right: $ouiSizeXS;
   }
 
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-  & > .euiCallOut__closeIcon {
+  &>.euiCallOut__closeIcon {
     position: static;
   }
 
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-  & > .euiText {
+  &>.euiText {
     flex: 1;
-    margin-top: 1px;
+    font-size: $euiFontSizeS;
   }
 }

--- a/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.scss
+++ b/src/plugins/explore/public/components/experience_banners/new_experience_banner/new_experience_banner.scss
@@ -13,12 +13,12 @@
   }
 
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-  &>.euiCallOut__closeIcon {
+  & > .euiCallOut__closeIcon {
     position: static;
   }
 
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-  &>.euiText {
+  & > .euiText {
     flex: 1;
     font-size: $euiFontSizeS;
   }


### PR DESCRIPTION
### Description
Issue - Fonts in the callout banner render too small and the vertical alignment is not centered.
Fix - Font size  changed to 14 px and  vertical center alignment for banner text.


Before - 
<img width="677" height="58" alt="Screenshot 2025-07-08 at 3 21 29 PM" src="https://github.com/user-attachments/assets/b3c8952e-bc3c-4520-bcad-b27f85ade5a7" />
<img width="892" height="55" alt="Screenshot 2025-07-21 at 2 42 45 PM" src="https://github.com/user-attachments/assets/add46a06-a547-40dd-bf25-e0efb215963b" />



After
<img width="895" height="48" alt="Screenshot 2025-07-21 at 2 25 39 PM" src="https://github.com/user-attachments/assets/59e31a5d-ce86-462c-81fc-3b55d2cd1346" />

<img width="912" height="65" alt="Screenshot 2025-07-21 at 2 41 56 PM" src="https://github.com/user-attachments/assets/438622af-860b-40be-a968-311db6edefd4" />





## Changelog

- fix: Fix font size and center alignment for banner text.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
