### PR TITLE
Reset baseline limit for dashboard and discover

### DIFF
--- a/baselines/lighthouse_baseline.json
+++ b/baselines/lighthouse_baseline.json
@@ -5,11 +5,11 @@
   },
   "/app/data-explorer/discover": {
     "first-contentful-paint": 2200,
-    "speed-index": 26000
+    "speed-index": 30000
   },
   "/app/dashboards": {
     "first-contentful-paint": 2200,
-    "speed-index": 28000
+    "speed-index": 30000
   },
   "/app/visualize": {
     "first-contentful-paint": 2200,

--- a/changelogs/fragments/10254.yml
+++ b/changelogs/fragments/10254.yml
@@ -1,0 +1,2 @@
+fix:
+- Update lighthouse baseline limit for dashboard and discover ([#10254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10254))


### PR DESCRIPTION
### Description
The baseline limit for discover and dashboard has increased, so failing the lighthouse ci.  This fix would reset the baseline.
Note: Also, we gotta dig into performance degradation in discover and dashboard separately
<img width="877" height="94" alt="Screenshot 2025-07-21 at 5 00 15 PM" src="https://github.com/user-attachments/assets/3827ab65-611d-4852-aea5-dd1ec69af5c6" />


## Changelog

- fix: Update lighthouse baseline limit for dashboard and discover


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
