### PR TITLE
[Explore] minor update on the edit query placement

### DIFF
--- a/changelogs/fragments/10259.yml
+++ b/changelogs/fragments/10259.yml
@@ -1,0 +1,2 @@
+refactor:
+- Change query editor ui ([#10259](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10259))

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/query_panel_editor.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/query_panel_editor.scss
@@ -76,6 +76,7 @@
 
   &__promptIcon {
     color: $ouiColorDisabledText;
+    filter: brightness(0.65);
     position: absolute;
     left: $ouiSizeXXS;
     top: 9px; // hard-coding to align it to editor

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.scss
@@ -18,14 +18,10 @@
 
   &__query {
     color: $ouiColorDisabledText;
-    flex: 1;
     // stylelint-disable-next-line @osd/stylelint/no_restricted_properties
     font-family: $ouiCodeFontFamily;
-    word-wrap: anywhere;
-  }
-
-  &__rightSection {
-    align-items: center;
-    display: flex;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
@@ -6,11 +6,15 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
-import { EuiButtonEmpty, EuiIcon, EuiText } from '@elastic/eui';
+import { EuiBadge, EuiIcon, EuiText } from '@elastic/eui';
 import { selectLastExecutedTranslatedQuery } from '../../../application/utils/state_management/selectors';
 import { useEditorFocus, useSetEditorTextWithQuery } from '../../../application/hooks';
 import { clearLastExecutedData } from '../../../application/utils/state_management/slices';
 import './query_panel_generated_query.scss';
+
+const editQueryText = i18n.translate('explore.queryPanel.queryPanelGeneratedQuery.editQuery', {
+  defaultMessage: 'Edit query',
+});
 
 export const QueryPanelGeneratedQuery = () => {
   const lastExecutedTranslatedQuery = useSelector(selectLastExecutedTranslatedQuery);
@@ -34,22 +38,17 @@ export const QueryPanelGeneratedQuery = () => {
       <EuiText className="exploreQueryPanelGeneratedQuery__query" size="s">
         {lastExecutedTranslatedQuery}
       </EuiText>
-      <div className="exploreQueryPanelGeneratedQuery__rightSection">
-        <EuiButtonEmpty
-          onClick={onEditClick}
-          data-test-subj="exploreQueryPanelGeneratedQuery_editQuery"
-          size="xs"
-        >
-          <div className="exploreQueryPanelGeneratedQuery__buttonTextWrapper">
-            <EuiIcon type="editorCodeBlock" size="s" />
-            <EuiText size="xs">
-              {i18n.translate('explore.queryPanel.queryPanelGeneratedQuery.editQuery', {
-                defaultMessage: 'Edit query',
-              })}
-            </EuiText>
-          </div>
-        </EuiButtonEmpty>
-      </div>
+      <EuiBadge
+        data-test-subj="exploreQueryPanelGeneratedQuery_editQuery"
+        onClick={onEditClick}
+        onClickAriaLabel={editQueryText}
+        color="hollow"
+      >
+        <div className="exploreQueryPanelGeneratedQuery__buttonTextWrapper">
+          <EuiIcon type="editorCodeBlock" size="s" />
+          <EuiText size="xs">{editQueryText}</EuiText>
+        </div>
+      </EuiBadge>
     </div>
   );
 };


### PR DESCRIPTION
### Description

- some complain that the "Edit query" button was too far away from the generated PPL. Now it is right next to it. Also changed it from button to EuiBadge
- When text is normal length:
<img width="1648" height="206" alt="Screenshot 2025-07-22 at 11 46 36 AM" src="https://github.com/user-attachments/assets/4ca3ace6-97f9-47ab-8057-0e69dd9c922c" />
- when text is overflowing:
<img width="1204" height="154" alt="Screenshot 2025-07-22 at 11 46 54 AM" src="https://github.com/user-attachments/assets/4a04c100-871f-42c9-a37f-4ee3bc627fa6" />

## Changelog
- refactor: change query editor ui

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
