### PR TITLE
[Explore] handle the PPL query that starts with "show"

### DIFF
--- a/changelogs/fragments/10260.yml
+++ b/changelogs/fragments/10260.yml
@@ -1,0 +1,2 @@
+fix:
+- Do not append `source = *` when query starts with `show *` ([#10260](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10260))

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
@@ -201,4 +201,24 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual(query);
   });
+
+  it('should return original query when it starts with "show"', () => {
+    const query: Query = {
+      query: 'show tables',
+      dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
+      language: 'ppl',
+    };
+    const result = getQueryWithSource(query);
+    expect(result).toEqual(query);
+  });
+
+  it('should return original query when it starts with "SHOW" (case insensitive)', () => {
+    const query: Query = {
+      query: 'SHOW TABLES',
+      dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
+      language: 'ppl',
+    };
+    const result = getQueryWithSource(query);
+    expect(result).toEqual(query);
+  });
 });

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
@@ -14,8 +14,9 @@ export const getQueryWithSource = (query: Query): QueryWithQueryAsString => {
   const lowerCaseQuery = queryString.toLowerCase();
   const hasSource = /^\s*(search\s+)?source\s*=/.test(lowerCaseQuery);
   const hasDescribe = /^\s*describe\s+/.test(lowerCaseQuery);
+  const hasShow = /^\s*show\s+/.test(lowerCaseQuery);
 
-  if (hasSource || hasDescribe) {
+  if (hasSource || hasDescribe || hasShow) {
     return { ...query, query: queryString };
   }
 


### PR DESCRIPTION
### Description

- we currently support the omission of "source = *". We magically append "source = *" when it is omitted. However, the times we don't append is if the query starts with:

```
source = *
search source = *
describe *
```

But we also need to not append if the query starts with:

```
show *
```

Ref: https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/cmd/showdatasources.rst


## Changelog
- fix: do not append `source = *` when query starts with `show *`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
