### PR TITLE
[Query Enhancements] improve resources API type definition

### DIFF
--- a/src/plugins/query_enhancements/server/routes/resources/routes.test.ts
+++ b/src/plugins/query_enhancements/server/routes/resources/routes.test.ts
@@ -112,6 +112,6 @@ describe('Resource Routes', () => {
       .post(`${BASE_API}/resources`)
       .send({ ...REQUEST_BODY })
       .expect(503);
-    expect(result.body.message).toEqual('Unable to get resources');
+    expect(result.body.message).toEqual('Unable to get resources: failed');
   });
 });

--- a/src/plugins/query_enhancements/server/routes/resources/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/resources/routes.ts
@@ -3,11 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { schema } from '@osd/config-schema';
-import { IRouter } from 'opensearch-dashboards/server';
+import { schema, TypeOf } from '@osd/config-schema';
+import { IRouter, OpenSearchDashboardsRequest } from 'opensearch-dashboards/server';
 import { BASE_API } from '../../../common';
 import { resourceManagerService } from '../../connections/resource_manager_service';
 import { coerceStatusCode } from '..';
+
+const body = schema.object({
+  connection: schema.object({
+    id: schema.string(),
+    type: schema.string(),
+  }),
+  resource: schema.object({
+    name: schema.maybe(schema.string()),
+    type: schema.string(),
+  }),
+  content: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+});
+
+export type ResourcesRequest<Content = Record<string, unknown>> = OpenSearchDashboardsRequest<
+  unknown,
+  unknown,
+  Omit<TypeOf<typeof body>, 'content'> & {
+    content?: Content;
+  }
+>;
 
 /**
  * Defines routes for resource APIs.
@@ -21,17 +41,7 @@ export function registerResourceRoutes(router: IRouter) {
     {
       path: `${BASE_API}/resources`,
       validate: {
-        body: schema.object({
-          connection: schema.object({
-            id: schema.string(),
-            type: schema.string(),
-          }),
-          resource: schema.object({
-            name: schema.maybe(schema.string()),
-            type: schema.string(),
-          }),
-          content: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-        }),
+        body,
       },
     },
     async (context, request, response) => {
@@ -46,7 +56,7 @@ export function registerResourceRoutes(router: IRouter) {
       } catch (error) {
         const errorObj = error as any;
         return response.customError({
-          body: 'Unable to get resources',
+          body: 'Unable to get resources: ' + errorObj.message,
           ...errorObj,
           statusCode: coerceStatusCode(errorObj.statusCode),
         });

--- a/src/plugins/query_enhancements/server/routes/resources/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/resources/routes.ts
@@ -56,7 +56,7 @@ export function registerResourceRoutes(router: IRouter) {
       } catch (error) {
         const errorObj = error as any;
         return response.customError({
-          body: 'Unable to get resources: ' + errorObj.message,
+          body: 'Unable to get resources: ' + errorObj.message ?? '',
           ...errorObj,
           statusCode: coerceStatusCode(errorObj.statusCode),
         });


### PR DESCRIPTION
### Description

This is a follow up improvement for https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9770. It adds ResourcesRequest API type and includes `errorObj.message` in the response.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

mostly type changes. updated unit test

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
