### PR TITLE
Left collapsible navigation UI update

### DIFF
--- a/src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
@@ -14,6 +14,8 @@ import {
   EuiContextMenuItem,
   EuiTitle,
   EuiToolTip,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import classNames from 'classnames';
@@ -174,15 +176,22 @@ export function NavGroups({
           props.icon
         ) : (
           <SimplePopover
-            anchorPosition="upLeft"
+            anchorPosition="rightUp"
             panelPaddingSize="none"
             button={props.icon || <></>}
             key={navOpen ? undefined : `popover-${appId}`}
+            triggerMode="click"
+            offset={4}
           >
             <EuiPopoverTitle>
-              <EuiTitle size="s">
-                <span>{navLink.link?.title}</span>
-              </EuiTitle>
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                {props.icon && <EuiFlexItem grow={false}>{props.icon}</EuiFlexItem>}
+                <EuiFlexItem>
+                  <EuiTitle size="s">
+                    <span>{navLink.link?.title}</span>
+                  </EuiTitle>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiPopoverTitle>
             <EuiContextMenuPanel
               hasFocus={false}

--- a/src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
@@ -66,7 +66,7 @@ const createNavItem = ({
   let icon = euiListItem.icon;
 
   if (euiListItem.iconType) {
-    icon = <EuiIcon type={euiListItem.iconType} />;
+    icon = <EuiIcon type={euiListItem.iconType} style={{ width: 20, height: 20 }} />;
   }
 
   return {

--- a/src/core/public/chrome/ui/header/simple_popover.test.tsx
+++ b/src/core/public/chrome/ui/header/simple_popover.test.tsx
@@ -34,4 +34,22 @@ describe('<SimplePopover /> spec', () => {
       expect(queryByText('content in popover')).toBeNull();
     });
   });
+
+  it('render the component with click', async () => {
+    const { getByTestId, queryByText } = render(
+      <>
+        <SimplePopover button={<div data-test-subj="test">button</div>} triggerMode="click">
+          content in popover
+        </SimplePopover>
+      </>
+    );
+    await userEvent.click(getByTestId('test'));
+    await waitFor(() => {
+      expect(queryByText('content in popover')).not.toBeNull();
+    });
+    await userEvent.click(getByTestId('test'));
+    await waitFor(() => {
+      expect(queryByText('content in popover')).toBeNull();
+    });
+  });
 });

--- a/src/core/public/chrome/ui/header/simple_popover.tsx
+++ b/src/core/public/chrome/ui/header/simple_popover.tsx
@@ -9,6 +9,7 @@ import { useEffect } from 'react';
 
 interface SimplePopoverProps extends Partial<EuiPopoverProps> {
   button: React.ReactElement;
+  triggerMode?: 'click' | 'hover';
 }
 
 const loopToGetPath = (element: HTMLElement | ParentNode | null) => {
@@ -23,14 +24,21 @@ const loopToGetPath = (element: HTMLElement | ParentNode | null) => {
 };
 
 export const SimplePopover: React.FC<SimplePopoverProps> = (props) => {
-  const { ...others } = props;
+  const { triggerMode = 'hover', ...others } = props;
   const [popVisible, setPopVisible] = useState(false);
   const popoverRef = useRef(null);
   const panelRef = useRef<HTMLElement | null>(null);
   const buttonProps: Partial<React.HTMLAttributes<HTMLButtonElement>> = {};
-  buttonProps.onMouseEnter = () => {
-    setPopVisible(true);
-  };
+
+  if (triggerMode === 'hover') {
+    buttonProps.onMouseEnter = () => {
+      setPopVisible(true);
+    };
+  } else if (triggerMode === 'click') {
+    buttonProps.onClick = (e) => {
+      setPopVisible((flag) => !flag);
+    };
+  }
 
   const outsideHover = useCallback(
     (e) => {
@@ -45,13 +53,16 @@ export const SimplePopover: React.FC<SimplePopoverProps> = (props) => {
   );
 
   useEffect(() => {
+    if (triggerMode !== 'hover') {
+      return;
+    }
     if (popVisible) {
       window.addEventListener('mousemove', outsideHover);
     }
     return () => {
       window.removeEventListener('mousemove', outsideHover);
     };
-  }, [popVisible, outsideHover]);
+  }, [popVisible, outsideHover, triggerMode]);
 
   return (
     <EuiPopover
@@ -60,7 +71,13 @@ export const SimplePopover: React.FC<SimplePopoverProps> = (props) => {
       panelRef={(ref) => (panelRef.current = ref)}
       button={props.button && cloneElement(props.button, buttonProps)}
       isOpen={popVisible}
-      closePopover={() => {}}
+      closePopover={
+        triggerMode === 'click'
+          ? () => {
+              setPopVisible(false);
+            }
+          : () => {}
+      }
     />
   );
 };

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -120,7 +120,7 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$, isNavOpen }:
 
   if (!isNavOpen && currentWorkspace) {
     button = (
-      <EuiFlexGroup justifyContent="center">
+      <EuiFlexGroup alignItems="center" direction="column" gutterSize="none">
         <EuiFlexItem>
           <EuiToolTip content={currentWorkspace.name}>
             <EuiButtonEmpty onClick={onButtonClick} flush="both">


### PR DESCRIPTION
### Description

This PR includes three left navigation updates:
1. Change icon size to 20px
2. Add a triggerMode to SimplePopover, use click mode to trigger left navigation context menu
3. Make workspace selector icon align center


## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
Before

After
<img width="360" height="552" alt="image" src="https://github.com/user-attachments/assets/0fbefee5-2fdc-45da-90af-90578cc255f8" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: Left collapsible navigation UI update

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
