### PR TITLE
[Explore] fix osd url state not synced correctly

### DIFF
--- a/changelogs/fragments/10281.yml
+++ b/changelogs/fragments/10281.yml
@@ -1,0 +1,3 @@
+fix:
+- Url state lost when changing time filter on new discover ([#10281](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10281))
+- Console warning of no title on ButtonIcon component ([#10281](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10281))

--- a/src/plugins/explore/public/application/utils/hooks/use_url_state_sync.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_url_state_sync.ts
@@ -6,10 +6,6 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { syncQueryStateWithUrl } from '../../../../../data/public';
-import {
-  createOsdUrlStateStorage,
-  withNotifyOnErrors,
-} from '../../../../../opensearch_dashboards_utils/public';
 import { ExploreServices } from '../../../types';
 
 /**
@@ -20,14 +16,10 @@ export const useUrlStateSync = (services: ExploreServices) => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    if (!services?.data) return;
+    if (!services?.osdUrlStateStorage) return;
 
     // Create URL state storage
-    const osdUrlStateStorage = createOsdUrlStateStorage({
-      history: services.history(),
-      useHash: services.uiSettings.get('state:storeInSessionStorage', false),
-      ...withNotifyOnErrors(services.toastNotifications),
-    });
+    const osdUrlStateStorage = services.osdUrlStateStorage;
 
     // syncs `_g` portion of url with query services (time, filters, refresh)
     const { stop } = syncQueryStateWithUrl(

--- a/src/plugins/explore/public/components/fields_selector/discover_field_header.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field_header.tsx
@@ -25,6 +25,7 @@ export function DiscoverFieldHeader({ onCollapse }: IDiscoverFieldHeaderProps) {
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiButtonIcon
+          aria-label="Collapse fields panel"
           data-test-subj={'fieldList-collapse-button'}
           iconType={'menuLeft'}
           onClick={onCollapse}


### PR DESCRIPTION
### Description
1. On new discover, changing time filter reset url state, this commit fixed the issue
2. Also fixed a console warning for no title on ButtonIcon component


https://github.com/user-attachments/assets/8f42abe9-4c88-44aa-ac11-03685c192449



<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: url state lost when changing time filter on new discover
- fix: console warning of no title on ButtonIcon component

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
