### PR TITLE
[Explore] query editor performance optimization

### DIFF
--- a/src/plugins/explore/public/application/context/editor_context/editor_context.test.tsx
+++ b/src/plugins/explore/public/application/context/editor_context/editor_context.test.tsx
@@ -4,107 +4,58 @@
  */
 
 import React, { useContext } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
 import { EditorContextProvider, EditorContext } from './editor_context';
-
-// Mock the selectors
-jest.mock('../../utils/state_management/selectors', () => ({
-  selectQueryString: jest.fn(),
-}));
-
-import { selectQueryString } from '../../utils/state_management/selectors';
-
-const mockSelectQueryString = selectQueryString as jest.MockedFunction<typeof selectQueryString>;
 
 // Create a test component that uses the context
 const TestComponent: React.FC = () => {
-  const context = useContext(EditorContext);
+  const editorRef = useContext(EditorContext);
 
   return (
     <div>
-      <div data-test-subj="editor-text">{context.editorText}</div>
-      <div data-test-subj="editor-focused">{context.editorIsFocused.toString()}</div>
-      <button
-        data-test-subj="set-editor-text"
-        onClick={() => context.setEditorText('new editor text')}
-      >
-        Set Editor Text
-      </button>
-      <button data-test-subj="set-editor-focused" onClick={() => context.setEditorIsFocused(true)}>
-        Set Editor Focused
-      </button>
+      <div data-test-subj="editor-ref-exists">{editorRef ? 'true' : 'false'}</div>
+      <div data-test-subj="editor-ref-current">
+        {editorRef.current ? 'has-editor' : 'no-editor'}
+      </div>
     </div>
   );
 };
 
-// Create a mock store
-const createMockStore = (queryString = 'initial query') => {
-  mockSelectQueryString.mockReturnValue(queryString);
-
-  return configureStore({
-    reducer: {
-      explore: () => ({
-        query: {
-          queryString,
-        },
-      }),
-    },
-  });
-};
-
-const renderWithProvider = (component: React.ReactElement, queryString = 'initial query') => {
-  const store = createMockStore(queryString);
-  return render(
-    <Provider store={store}>
-      <EditorContextProvider>{component}</EditorContextProvider>
-    </Provider>
-  );
+const renderWithProvider = (component: React.ReactElement) => {
+  return render(<EditorContextProvider>{component}</EditorContextProvider>);
 };
 
 describe('EditorContext', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('EditorContextProvider', () => {
-    it('should provide context to children', () => {
+    it('should provide editor ref to children', () => {
       renderWithProvider(<TestComponent />);
-      expect(screen.getByTestId('editor-text')).toHaveTextContent('initial query');
-      expect(screen.getByTestId('editor-focused')).toHaveTextContent('false');
+      expect(screen.getByTestId('editor-ref-exists')).toHaveTextContent('true');
+      expect(screen.getByTestId('editor-ref-current')).toHaveTextContent('no-editor');
     });
 
-    it('should initialize with query string from selector', () => {
-      renderWithProvider(<TestComponent />, 'test query');
-      expect(screen.getByTestId('editor-text')).toHaveTextContent('test query');
-      expect(screen.getByTestId('editor-focused')).toHaveTextContent('false');
-    });
-
-    it('should allow updating editor text', () => {
-      renderWithProvider(<TestComponent />);
-
-      fireEvent.click(screen.getByTestId('set-editor-text'));
-
-      expect(screen.getByTestId('editor-text')).toHaveTextContent('new editor text');
-    });
-
-    it('should allow updating editor focus state', () => {
-      renderWithProvider(<TestComponent />);
-
-      fireEvent.click(screen.getByTestId('set-editor-focused'));
-
-      expect(screen.getByTestId('editor-focused')).toHaveTextContent('true');
-    });
-
-    it('should provide editor ref', () => {
+    it('should provide a mutable ref object', () => {
       const TestRefComponent: React.FC = () => {
-        const { editorRef } = useContext(EditorContext);
-        return <div data-test-subj="editor-ref-exists">{editorRef ? 'true' : 'false'}</div>;
+        const editorRef = useContext(EditorContext);
+
+        // Test that we can modify the ref
+        const handleClick = () => {
+          editorRef.current = {} as any;
+        };
+
+        return (
+          <div>
+            <div data-test-subj="editor-ref-type">{typeof editorRef}</div>
+            <div data-test-subj="has-current-prop">{'current' in editorRef ? 'true' : 'false'}</div>
+            <button data-test-subj="modify-ref" onClick={handleClick}>
+              Modify Ref
+            </button>
+          </div>
+        );
       };
 
       renderWithProvider(<TestRefComponent />);
-      expect(screen.getByTestId('editor-ref-exists')).toHaveTextContent('true');
+      expect(screen.getByTestId('editor-ref-type')).toHaveTextContent('object');
+      expect(screen.getByTestId('has-current-prop')).toHaveTextContent('true');
     });
   });
 });

--- a/src/plugins/explore/public/application/context/editor_context/editor_context.tsx
+++ b/src/plugins/explore/public/application/context/editor_context/editor_context.tsx
@@ -3,44 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, {
-  createContext,
-  Dispatch,
-  FC,
-  MutableRefObject,
-  SetStateAction,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { createContext, FC, MutableRefObject, useRef } from 'react';
 import type { monaco } from '@osd/monaco';
-import { useSelector } from 'react-redux';
-import { selectQueryString } from '../../utils/state_management/selectors';
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 type EditorRef = MutableRefObject<IStandaloneCodeEditor | null>;
 
-export interface InternalEditorContextValue {
-  editorRef: EditorRef;
-  editorText: string;
-  setEditorText: Dispatch<SetStateAction<string>>;
-  editorIsFocused: boolean;
-  setEditorIsFocused: Dispatch<SetStateAction<boolean>>;
-}
+export type InternalEditorContextValue = EditorRef;
 
 /**
  * Provides editor refs as well as editor-related state
  *
  * You can access these values via the hooks in the hooks directory.
- * Why so many hooks? We have specific hooks that get specific parts of this only to maximize performance,
- * because text values frequently updates
  */
 export const EditorContext = createContext<InternalEditorContextValue>({
-  editorRef: { current: null },
-  editorText: '',
-  setEditorText: () => {},
-  editorIsFocused: false,
-  setEditorIsFocused: () => {},
+  current: null,
 });
 
 /**
@@ -50,21 +27,7 @@ export const EditorContext = createContext<InternalEditorContextValue>({
  * Since a ref is not serializable, we cannot store it in the Redux store.
  */
 export const EditorContextProvider: FC = ({ children }) => {
-  const queryString = useSelector(selectQueryString);
   const editorRef = useRef<IStandaloneCodeEditor | null>(null);
-  const [editorText, setEditorText] = useState<string>(queryString);
-  const [editorIsFocused, setEditorIsFocused] = useState<boolean>(false);
 
-  const contextValue = useMemo(
-    () => ({
-      editorRef,
-      editorText,
-      setEditorText,
-      editorIsFocused,
-      setEditorIsFocused,
-    }),
-    [editorIsFocused, editorText]
-  );
-
-  return <EditorContext.Provider value={contextValue}>{children}</EditorContext.Provider>;
+  return <EditorContext.Provider value={editorRef}>{children}</EditorContext.Provider>;
 };

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.test.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.test.ts
@@ -73,7 +73,7 @@ describe('useChangeQueryEditor', () => {
 
     (useDatasetContext as jest.Mock).mockReturnValue({ dataset: mockIndexPattern });
     (useSetEditorText as jest.Mock).mockReturnValue(mockSetEditorText);
-    (useEditorFocus as jest.Mock).mockReturnValue({ focusOnEditor: mockFocusOnEditor });
+    (useEditorFocus as jest.Mock).mockReturnValue(mockFocusOnEditor);
     (useSelector as jest.Mock).mockImplementation((selector) => {
       if (selector === selectEditorMode) return EditorMode.Query;
       if (selector === selectQuery) return { language: 'PPL' };

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_change_query_editor/use_change_query_editor.ts
@@ -27,7 +27,7 @@ export const useChangeQueryEditor = () => {
   const setEditorText = useSetEditorText();
   const editorMode = useSelector(selectEditorMode);
   const query = useSelector(selectQuery);
-  const { focusOnEditor } = useEditorFocus();
+  const focusOnEditor = useEditorFocus();
 
   const onAddFilter = useCallback(
     (field: string | IndexPatternField | DataViewField, values: string, operation: '+' | '-') => {

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_focus/use_editor_focus.test.tsx
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_focus/use_editor_focus.test.tsx
@@ -10,67 +10,58 @@ import { useEditorFocus } from './use_editor_focus';
 
 describe('useEditorFocus', () => {
   const mockFocus = jest.fn();
-  const mockSetEditorIsFocused = jest.fn();
+  const mockSetSelection = jest.fn();
+  const mockSetPosition = jest.fn();
+  const mockGetModel = jest.fn();
+  const mockGetFullModelRange = jest.fn();
+  const mockGetLineCount = jest.fn();
+  const mockGetLineMaxColumn = jest.fn();
 
-  const mockEditorRef = {
-    current: {
-      focus: mockFocus,
-    } as any,
+  const mockModel = {
+    getFullModelRange: mockGetFullModelRange,
+    getLineCount: mockGetLineCount,
+    getLineMaxColumn: mockGetLineMaxColumn,
   };
 
-  const mockContextValue: InternalEditorContextValue = {
-    editorRef: mockEditorRef,
-    editorIsFocused: false,
-    setEditorIsFocused: mockSetEditorIsFocused,
-    editorText: '',
-    setEditorText: jest.fn(),
+  const mockEditor = {
+    focus: mockFocus,
+    setSelection: mockSetSelection,
+    setPosition: mockSetPosition,
+    getModel: mockGetModel,
+  };
+
+  const mockEditorRef: InternalEditorContextValue = {
+    current: mockEditor as any,
   };
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <EditorContext.Provider value={mockContextValue}>{children}</EditorContext.Provider>
+    <EditorContext.Provider value={mockEditorRef}>{children}</EditorContext.Provider>
   );
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockGetModel.mockReturnValue(mockModel);
+    mockGetLineCount.mockReturnValue(5);
+    mockGetLineMaxColumn.mockReturnValue(20);
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it('should return editor focus state and functions', () => {
+  it('should return a focus function', () => {
     const { result } = renderHook(() => useEditorFocus(), { wrapper });
 
-    expect(result.current.editorIsFocused).toBe(false);
-    expect(typeof result.current.focusOnEditor).toBe('function');
-    expect(typeof result.current.setEditorIsFocused).toBe('function');
+    expect(typeof result.current).toBe('function');
   });
 
-  it('should reflect current editor focus state', () => {
-    const focusedContextValue: InternalEditorContextValue = {
-      ...mockContextValue,
-      editorIsFocused: true,
-    };
-
-    const focusedWrapper = ({ children }: { children: React.ReactNode }) => (
-      <EditorContext.Provider value={focusedContextValue}>{children}</EditorContext.Provider>
-    );
-
-    const { result } = renderHook(() => useEditorFocus(), { wrapper: focusedWrapper });
-
-    expect(result.current.editorIsFocused).toBe(true);
-  });
-
-  it('should call setEditorIsFocused and focus editor when focusOnEditor is called', () => {
+  it('should focus editor and position cursor at end by default', () => {
     const { result } = renderHook(() => useEditorFocus(), { wrapper });
 
     act(() => {
-      result.current.focusOnEditor();
+      result.current();
     });
-
-    expect(mockSetEditorIsFocused).toHaveBeenCalledWith(true);
-    expect(mockSetEditorIsFocused).toHaveBeenCalledTimes(1);
 
     // Fast-forward timer to trigger the setTimeout
     act(() => {
@@ -78,12 +69,38 @@ describe('useEditorFocus', () => {
     });
 
     expect(mockFocus).toHaveBeenCalledTimes(1);
+    expect(mockGetModel).toHaveBeenCalledTimes(1);
+    expect(mockGetLineCount).toHaveBeenCalledTimes(1);
+    expect(mockGetLineMaxColumn).toHaveBeenCalledWith(5);
+    expect(mockSetPosition).toHaveBeenCalledWith({ lineNumber: 5, column: 20 });
+    expect(mockSetSelection).not.toHaveBeenCalled();
+  });
+
+  it('should select all text when selectAll is true', () => {
+    const mockRange = { startLineNumber: 1, startColumn: 1, endLineNumber: 5, endColumn: 20 };
+    mockGetFullModelRange.mockReturnValue(mockRange);
+
+    const { result } = renderHook(() => useEditorFocus(), { wrapper });
+
+    act(() => {
+      result.current(true);
+    });
+
+    // Fast-forward timer to trigger the setTimeout
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+    expect(mockGetModel).toHaveBeenCalledTimes(1);
+    expect(mockGetFullModelRange).toHaveBeenCalledTimes(1);
+    expect(mockSetSelection).toHaveBeenCalledWith(mockRange);
+    expect(mockSetPosition).not.toHaveBeenCalled();
   });
 
   it('should handle case when editor ref is null', () => {
     const nullRefContextValue: InternalEditorContextValue = {
-      ...mockContextValue,
-      editorRef: { current: null },
+      current: null,
     };
 
     const nullRefWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -93,10 +110,8 @@ describe('useEditorFocus', () => {
     const { result } = renderHook(() => useEditorFocus(), { wrapper: nullRefWrapper });
 
     act(() => {
-      result.current.focusOnEditor();
+      result.current();
     });
-
-    expect(mockSetEditorIsFocused).toHaveBeenCalledWith(true);
 
     // Fast-forward timer
     act(() => {
@@ -107,5 +122,25 @@ describe('useEditorFocus', () => {
     expect(() => {
       jest.runAllTimers();
     }).not.toThrow();
+  });
+
+  it('should handle case when model is null', () => {
+    mockGetModel.mockReturnValue(null);
+
+    const { result } = renderHook(() => useEditorFocus(), { wrapper });
+
+    act(() => {
+      result.current();
+    });
+
+    // Fast-forward timer
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+    expect(mockGetModel).toHaveBeenCalledTimes(1);
+    expect(mockSetSelection).not.toHaveBeenCalled();
+    expect(mockSetPosition).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_focus/use_editor_focus.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_focus/use_editor_focus.ts
@@ -3,24 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext } from 'react';
 import { EditorContext } from '../../../context';
 
 /**
  * Focus related util hook
  */
 export const useEditorFocus = () => {
-  const { editorRef, editorIsFocused, setEditorIsFocused } = useContext(EditorContext);
+  const editorRef = useContext(EditorContext);
 
-  const focusOnEditor = useCallback(() => {
-    setEditorIsFocused(true);
-    // add a delay
-    setTimeout(() => editorRef.current?.focus());
-  }, [editorRef, setEditorIsFocused]);
-
-  return useMemo(() => ({ editorIsFocused, focusOnEditor, setEditorIsFocused }), [
-    editorIsFocused,
-    focusOnEditor,
-    setEditorIsFocused,
-  ]);
+  return useCallback(
+    (selectAll?: boolean) => {
+      // add a delay
+      setTimeout(() => {
+        const model = editorRef.current?.getModel();
+        editorRef.current?.focus();
+        if (selectAll && model) {
+          editorRef.current?.setSelection(model.getFullModelRange());
+        } else if (model) {
+          // Position cursor at the end of the editor
+          const lastLine = model.getLineCount();
+          const lastColumn = model.getLineMaxColumn(lastLine);
+          editorRef.current?.setPosition({ lineNumber: lastLine, column: lastColumn });
+        }
+      });
+    },
+    [editorRef]
+  );
 };

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_ref/use_editor_ref.test.tsx
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_ref/use_editor_ref.test.tsx
@@ -13,13 +13,7 @@ describe('useEditorRef', () => {
     current: null as any,
   };
 
-  const mockContextValue: InternalEditorContextValue = {
-    editorRef: mockEditorRef,
-    editorText: 'test text',
-    setEditorText: jest.fn(),
-    editorIsFocused: false,
-    setEditorIsFocused: jest.fn(),
-  };
+  const mockContextValue: InternalEditorContextValue = mockEditorRef;
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <EditorContext.Provider value={mockContextValue}>{children}</EditorContext.Provider>
@@ -43,10 +37,7 @@ describe('useEditorRef', () => {
 
   it('should return ref with actual editor when set', () => {
     const mockEditor = { focus: jest.fn() } as any;
-    const contextWithEditor: InternalEditorContextValue = {
-      ...mockContextValue,
-      editorRef: { current: mockEditor },
-    };
+    const contextWithEditor: InternalEditorContextValue = { current: mockEditor };
 
     const wrapperWithEditor = ({ children }: { children: React.ReactNode }) => (
       <EditorContext.Provider value={contextWithEditor}>{children}</EditorContext.Provider>

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_ref/use_editor_ref.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_ref/use_editor_ref.ts
@@ -10,7 +10,5 @@ import { EditorContext } from '../../../context';
  * Gives the ref of the editor
  */
 export const useEditorRef = () => {
-  const { editorRef } = useContext(EditorContext);
-
-  return editorRef;
+  return useContext(EditorContext);
 };

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_text/use_editor_text.test.tsx
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_text/use_editor_text.test.tsx
@@ -9,40 +9,39 @@ import { useEditorText } from './use_editor_text';
 import { EditorContext, InternalEditorContextValue } from '../../../context';
 
 describe('useEditorText', () => {
-  const mockEditorContextValue: InternalEditorContextValue = {
-    editorRef: { current: null },
-    editorText: 'SELECT * FROM table',
-    setEditorText: jest.fn(),
-    editorIsFocused: false,
-    setEditorIsFocused: jest.fn(),
+  const mockGetValue = jest.fn();
+
+  const mockEditor = {
+    getValue: mockGetValue,
+  };
+
+  const mockEditorRef: InternalEditorContextValue = {
+    current: mockEditor as any,
   };
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <EditorContext.Provider value={mockEditorContextValue}>{children}</EditorContext.Provider>
+    <EditorContext.Provider value={mockEditorRef}>{children}</EditorContext.Provider>
   );
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return editor text from context', () => {
+  it('should return editor text from Monaco editor getValue()', () => {
+    mockGetValue.mockReturnValue('SELECT * FROM table');
+
     const { result } = renderHook(() => useEditorText(), { wrapper });
 
     expect(result.current).toBe('SELECT * FROM table');
+    expect(mockGetValue).toHaveBeenCalledTimes(1);
   });
 
-  it('should return updated editor text when context changes', () => {
-    const updatedContextValue: InternalEditorContextValue = {
-      ...mockEditorContextValue,
-      editorText: 'SELECT COUNT(*) FROM table',
-    };
+  it('should return updated text when Monaco editor value changes', () => {
+    mockGetValue.mockReturnValue('SELECT COUNT(*) FROM table');
 
-    const updatedWrapper = ({ children }: { children: React.ReactNode }) => (
-      <EditorContext.Provider value={updatedContextValue}>{children}</EditorContext.Provider>
-    );
-
-    const { result } = renderHook(() => useEditorText(), { wrapper: updatedWrapper });
+    const { result } = renderHook(() => useEditorText(), { wrapper });
 
     expect(result.current).toBe('SELECT COUNT(*) FROM table');
+    expect(mockGetValue).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_text/use_editor_text.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_editor_text/use_editor_text.ts
@@ -10,7 +10,7 @@ import { EditorContext } from '../../../context';
  * Gives editor text
  */
 export const useEditorText = () => {
-  const { editorText } = useContext(EditorContext);
+  const editorRef = useContext(EditorContext);
 
-  return editorText;
+  return editorRef.current?.getValue() || '';
 };

--- a/src/plugins/explore/public/application/hooks/editor_hooks/use_set_editor_text/use_set_editor_text.ts
+++ b/src/plugins/explore/public/application/hooks/editor_hooks/use_set_editor_text/use_set_editor_text.ts
@@ -3,14 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import { EditorContext } from '../../../context';
 
 /**
  * setEditorText hook
  */
 export const useSetEditorText = () => {
-  const { setEditorText } = useContext(EditorContext);
+  const editorRef = useContext(EditorContext);
 
-  return setEditorText;
+  return useCallback(
+    (text: string | ((prevText: string) => string)) => {
+      const currentValue = editorRef.current?.getValue() || '';
+      const newValue = typeof text === 'function' ? text(currentValue) : text;
+      editorRef.current?.setValue(newValue);
+    },
+    [editorRef]
+  );
 };

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.test.tsx
@@ -52,11 +52,7 @@ describe('QueryPanelGeneratedQuery', () => {
 
     mockUseDispatch.mockReturnValue(mockDispatch);
     mockUseSetEditorTextWithQuery.mockReturnValue(mockSetEditorTextWithQuery);
-    mockUseEditorFocus.mockReturnValue({
-      focusOnEditor: mockFocusOnEditor,
-      editorIsFocused: false,
-      setEditorIsFocused: jest.fn(),
-    });
+    mockUseEditorFocus.mockReturnValue(mockFocusOnEditor);
 
     mockClearLastExecutedData.mockReturnValue({
       type: 'clearLastExecutedData',
@@ -108,6 +104,7 @@ describe('QueryPanelGeneratedQuery', () => {
         expect(mockSetEditorTextWithQuery).toHaveBeenCalledWith(testQuery);
         expect(mockDispatch).toHaveBeenCalledWith({ type: 'clearLastExecutedData' });
         expect(mockFocusOnEditor).toHaveBeenCalledTimes(1);
+        expect(mockFocusOnEditor).toHaveBeenCalledWith(true);
       });
 
       it('should call functions in correct order', () => {

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
@@ -20,7 +20,7 @@ export const QueryPanelGeneratedQuery = () => {
   const lastExecutedTranslatedQuery = useSelector(selectLastExecutedTranslatedQuery);
   const setEditorTextWithQuery = useSetEditorTextWithQuery();
   const dispatch = useDispatch();
-  const { focusOnEditor } = useEditorFocus();
+  const focusOnEditor = useEditorFocus();
 
   if (!lastExecutedTranslatedQuery) {
     return null;
@@ -29,7 +29,7 @@ export const QueryPanelGeneratedQuery = () => {
   const onEditClick = () => {
     setEditorTextWithQuery(lastExecutedTranslatedQuery);
     dispatch(clearLastExecutedData());
-    focusOnEditor();
+    focusOnEditor(true);
   };
 
   return (

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
@@ -26,7 +26,7 @@ const mockEditorRef = {
 // Mock the hooks
 jest.mock('../../../../application/hooks', () => ({
   useClearEditors: () => mockClearEditors,
-  useEditorFocus: () => ({ focusOnEditor: mockFocusOnEditor }),
+  useEditorFocus: () => mockFocusOnEditor,
   useEditorRef: () => mockEditorRef,
 }));
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
@@ -31,7 +31,7 @@ export const LanguageToggle = () => {
   const isPromptMode = useSelector(selectIsPromptEditorMode);
   const dispatch = useDispatch();
   const editorRef = useEditorRef();
-  const { focusOnEditor } = useEditorFocus();
+  const focusOnEditor = useEditorFocus();
 
   const onButtonClick = () => setIsPopoverOpen(!isPopoverOpen);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);


### PR DESCRIPTION
### Description

- there were complaints that the query editor is a bit sluggish for slower computers
- This PR moves the `editorText` and `editorIsFocused` state out of the `EditorContext` and into the `useQueryPanelEditor` hook. This will increase performance because `EditorContext` lives near the root of the DOM tree, thus causing re-renders whenever text updates. Now that it lives inside `useQuerypanelEditor`, only the QueryPanelEditor will update when text updates
- I've refactored the existing query panel editor hooks to use the editor context to get the value and do things by setting the text value
- I technically didn't need to update the `useEditorIsFocused` nor move the focused state out of the context, but figured might as well
- I also fixed some behavior of focusing. When you are in AI mode and generated PPL from a prompt, and click "EDIT QUEWRY" in the generated PPL, it will not highlight all the text.

## Changelog
- feat: improve query editor performance.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
