### PR TITLE
Standardize exposed fields in datasource picker

### DIFF
--- a/src/plugins/data_source_management/framework/constants.tsx
+++ b/src/plugins/data_source_management/framework/constants.tsx
@@ -98,3 +98,16 @@ export const OBS_S3_DATA_SOURCE = 'observability-s3'; // prefix key for generati
 export const S3_DATA_SOURCE_GROUP_DISPLAY_NAME = 'Amazon S3'; // display group name for Amazon-managed-s3 data sources in data selector
 export const S3_DATA_SOURCE_GROUP_SPARK_DISPLAY_NAME = 'Spark'; // display group name for OpenSearch-spark-s3 data sources in data selector
 export const SECURITY_DASHBOARDS_LOGOUT_URL = '/logout';
+
+/**
+ * The fields exposed in the data source selectors. Can be leveraged in custom dataSourceFilter functions when implementing various
+ * data source pickers.
+ */
+export const DATA_SOURCE_SELECTOR_FIELDS = [
+  'id',
+  'title',
+  'endpoint',
+  'auth.type',
+  'dataSourceVersion',
+  'installedPlugins',
+];

--- a/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_aggregated_view/data_source_aggregated_view.tsx
@@ -30,6 +30,7 @@ import { DataSourceItem } from '../data_source_item';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import './data_source_aggregated_view.scss';
 import { DataSourceMenuPopoverButton } from '../popover_button/popover_button';
+import { DATA_SOURCE_SELECTOR_FIELDS } from '../../../framework/constants';
 
 interface DataSourceAggregatedViewProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -98,13 +99,7 @@ export class DataSourceAggregatedView extends React.Component<
 
   componentDidMount() {
     this._isMounted = true;
-    getDataSourcesWithFields(this.props.savedObjectsClient, [
-      'id',
-      'title',
-      'auth.type',
-      'dataSourceVersion',
-      'installedPlugins',
-    ])
+    getDataSourcesWithFields(this.props.savedObjectsClient, DATA_SOURCE_SELECTOR_FIELDS)
       .then(async (fetchedDataSources) => {
         const allDataSourcesIdToTitleMap = new Map();
 

--- a/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_multi_selectable/data_source_multi_selectable.tsx
@@ -22,6 +22,7 @@ import {
 } from '../utils';
 import { DataSourceBaseState } from '../data_source_menu/types';
 import { DataSourceErrorMenu } from '../data_source_error_menu';
+import { DATA_SOURCE_SELECTOR_FIELDS } from '../../../framework/constants';
 
 export interface DataSourceMultiSeletableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -80,13 +81,10 @@ export class DataSourceMultiSelectable extends React.Component<
       // for data source selectable, get default data source from cache
       const defaultDataSource = (await getDefaultDataSourceId(this.props.uiSettings)) ?? null;
       let selectedOptions: SelectedDataSourceOption[] = [];
-      const fetchedDataSources = await getDataSourcesWithFields(this.props.savedObjectsClient, [
-        'id',
-        'title',
-        'auth.type',
-        'dataSourceVersion',
-        'installedPlugins',
-      ]);
+      const fetchedDataSources = await getDataSourcesWithFields(
+        this.props.savedObjectsClient,
+        DATA_SOURCE_SELECTOR_FIELDS
+      );
 
       if (fetchedDataSources?.length) {
         selectedOptions = fetchedDataSources.map((dataSource) => ({

--- a/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selectable/data_source_selectable.tsx
@@ -40,6 +40,7 @@ import './data_source_selectable.scss';
 import { DataSourceDropDownHeader } from '../drop_down_header';
 import './data_source_selectable.scss';
 import { DataSourceMenuPopoverButton } from '../popover_button/popover_button';
+import { DATA_SOURCE_SELECTOR_FIELDS } from '../../../framework/constants';
 
 interface DataSourceSelectableProps {
   savedObjectsClient: SavedObjectsClientContract;
@@ -182,13 +183,10 @@ export class DataSourceSelectable extends React.Component<
     this._isMounted = true;
 
     try {
-      const fetchedDataSources = await getDataSourcesWithFields(this.props.savedObjectsClient, [
-        'id',
-        'title',
-        'auth.type',
-        'dataSourceVersion',
-        'installedPlugins',
-      ]);
+      const fetchedDataSources = await getDataSourcesWithFields(
+        this.props.savedObjectsClient,
+        DATA_SOURCE_SELECTOR_FIELDS
+      );
 
       const dataSourceOptions: DataSourceOption[] = getFilteredDataSources(
         fetchedDataSources,

--- a/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
@@ -20,6 +20,7 @@ import { DataSourceAttributes } from '../../types';
 import { DataSourceItem } from '../data_source_item';
 import './data_source_selector.scss';
 import { DataSourceOption } from '../data_source_menu/types';
+import { DATA_SOURCE_SELECTOR_FIELDS } from '../../../framework/constants';
 
 export const LocalCluster: DataSourceOption = {
   label: i18n.translate('dataSourcesManagement.localCluster', {
@@ -142,13 +143,10 @@ export class DataSourceSelector extends React.Component<
     this._isMounted = true;
     try {
       // 1. Fetch
-      const fetchedDataSources = await getDataSourcesWithFields(this.props.savedObjectsClient, [
-        'id',
-        'title',
-        'auth.type',
-        'dataSourceVersion',
-        'installedPlugins',
-      ]);
+      const fetchedDataSources = await getDataSourcesWithFields(
+        this.props.savedObjectsClient,
+        DATA_SOURCE_SELECTOR_FIELDS
+      );
 
       // 2. Process
       const dataSourceOptions = getFilteredDataSources(


### PR DESCRIPTION
### Description

Standardizes the set of fields propagated from the data source saved objects to the data source pickers for consumers of the component to use when writing custom logic, such as filtering functions.

### Issues Resolved
N/A

## Screenshot
N/A

## Testing the changes

TODO

## Changelog
<!--
Standardize exposed fields in datasource picker
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
