### PR TITLE
[Explore]bug fix: add one default range for metric + fix threshold in line-bar chart

### DIFF
--- a/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
@@ -248,9 +248,9 @@ describe('to_expression', () => {
       expect(result.layer).toHaveLength(2); // Bar layer + line layer (no threshold or time marker in this test)
 
       // Verify the bar layer
-      expect(result.layer[0]).toHaveProperty('encoding.x.field', 'field-0');
-      expect(result.layer[0]).toHaveProperty('encoding.y.field', 'field-1');
-      expect(result.layer[0]).toHaveProperty('encoding.color.datum', 'value1');
+      expect(result.layer[0].layer[0]).toHaveProperty('encoding.x.field', 'field-0');
+      expect(result.layer[0].layer[0]).toHaveProperty('encoding.y.field', 'field-1');
+      expect(result.layer[0].layer[0]).toHaveProperty('encoding.color.datum', 'value1');
 
       // Verify the line layer
       expect(result.layer[1]).toHaveProperty('encoding.x.field', 'field-0');

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -176,6 +176,10 @@ export const createLineBarChart = (
     },
   };
 
+  const barWithThresholdLayer = {
+    layer: [barLayer],
+  };
+
   const lineLayer = {
     mark: buildMarkConfig(styles, 'line'),
     encoding: {
@@ -218,13 +222,13 @@ export const createLineBarChart = (
     },
   };
 
-  layers.push(barLayer, lineLayer);
-
   // Add threshold layer if enabled
   const thresholdLayer = createThresholdLayer(styles.thresholdLines, styles.tooltipOptions?.mode);
   if (thresholdLayer) {
-    layers.push(thresholdLayer);
+    barWithThresholdLayer.layer.push(thresholdLayer);
   }
+
+  layers.push(barWithThresholdLayer, lineLayer);
 
   // Add time marker layer if enabled
   const timeMarkerLayer = createTimeMarkerLayer(styles);

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.ts
@@ -23,6 +23,7 @@ export const defaultMetricChartStyles: MetricChartStyleControls = {
   fontSize: 60,
   useColor: false,
   colorSchema: ColorSchemas.BLUES,
+  customRanges: [{ min: 0, max: 100 }],
 };
 
 export const createMetricConfig = (): VisualizationType<'metric'> => ({

--- a/src/plugins/explore/public/components/visualizations/pie/pie_exclusive_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_exclusive_vis_options.tsx
@@ -86,13 +86,15 @@ export const PieExclusiveVisOptions = ({ styles, onChange }: PieVisOptionsProps)
           data-test-subj="showLabelsSwitch"
         />
       </EuiFormRow>
-      <DebouncedTruncateField
-        value={styles.truncate ?? 100}
-        onChange={(truncateValue) => updateStyle('truncate', truncateValue)}
-        label={i18n.translate('explore.vis.pie.exclusive.labelTruncate', {
-          defaultMessage: 'Truncate after',
-        })}
-      />
+      {styles.showLabels && (
+        <DebouncedTruncateField
+          value={styles.truncate ?? 100}
+          onChange={(truncateValue) => updateStyle('truncate', truncateValue)}
+          label={i18n.translate('explore.vis.pie.exclusive.labelTruncate', {
+            defaultMessage: 'Truncate after',
+          })}
+        />
+      )}
     </StyleAccordion>
   );
 };

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_exclusive_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_exclusive_vis_options.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ScatterExclusiveVisOptions } from './scatter_exclusive_vis_options';
 import { PointShape } from '../types';
 
@@ -75,37 +75,42 @@ describe('ScatterExclusiveVisOptions', () => {
     expect(rangeInput).toHaveValue(0);
   });
 
-  it('calls onChange when angle is changed', () => {
+  it('calls onChange when angle is changed', async () => {
     render(<ScatterExclusiveVisOptions {...defaultProps} />);
     const rangeInput = screen.getByRole('spinbutton');
 
     fireEvent.change(rangeInput, { target: { value: '90' } });
     fireEvent.blur(rangeInput);
-
-    expect(defaultProps.onChange).toHaveBeenCalledWith({
-      ...defaultProps.styles,
-      angle: 90,
+    await waitFor(() => {
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        ...defaultProps.styles,
+        angle: 90,
+      });
     });
   });
 
-  it('handles angle range limits correctly', () => {
+  it('handles angle range limits correctly', async () => {
     render(<ScatterExclusiveVisOptions {...defaultProps} />);
     const rangeInput = screen.getByRole('spinbutton');
 
     // Test a non-default value first
     fireEvent.change(rangeInput, { target: { value: '180' } });
     fireEvent.blur(rangeInput);
-    expect(defaultProps.onChange).toHaveBeenCalledWith({
-      ...defaultProps.styles,
-      angle: 180,
+    await waitFor(() => {
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        ...defaultProps.styles,
+        angle: 180,
+      });
     });
 
     // Test maximum value
     fireEvent.change(rangeInput, { target: { value: '360' } });
     fireEvent.blur(rangeInput);
-    expect(defaultProps.onChange).toHaveBeenCalledWith({
-      ...defaultProps.styles,
-      angle: 360,
+    await waitFor(() => {
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        ...defaultProps.styles,
+        angle: 360,
+      });
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_exclusive_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_exclusive_vis_options.tsx
@@ -10,6 +10,7 @@ import { ScatterChartStyleControls } from './scatter_vis_config';
 import { PointShape } from '../types';
 import { getPointShapes } from '../utils/collections';
 import { StyleAccordion } from '../style_panel/style_accordion';
+import { useDebouncedNumericValue } from '../utils/use_debounced_value';
 
 interface ScatterVisOptionsProps {
   styles: ScatterChartStyleControls['exclusive'];
@@ -26,6 +27,16 @@ export const ScatterExclusiveVisOptions = ({ styles, onChange }: ScatterVisOptio
       [key]: value,
     });
   };
+
+  const [pointAngle, handlePointAngle] = useDebouncedNumericValue(
+    styles.angle,
+    (val) => onChange({ ...styles, angle: val }),
+    {
+      min: 0,
+      max: 360,
+      defaultValue: 20,
+    }
+  );
 
   const pointShapes = getPointShapes();
   return (
@@ -70,8 +81,8 @@ export const ScatterExclusiveVisOptions = ({ styles, onChange }: ScatterVisOptio
           compressed
           min={0}
           max={360}
-          value={styles.angle}
-          onChange={(e) => updateStyle('angle', Number(e.currentTarget.value))}
+          value={pointAngle}
+          onChange={(e) => handlePointAngle(e.currentTarget.value)}
           showInput
         />
       </EuiFormRow>

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_exclusive_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_exclusive_vis_options.tsx
@@ -34,7 +34,6 @@ export const ScatterExclusiveVisOptions = ({ styles, onChange }: ScatterVisOptio
     {
       min: 0,
       max: 360,
-      defaultValue: 20,
     }
   );
 


### PR DESCRIPTION
### Description
This pr addresses some bugs:
1. add one default range for metric
2. fix threshold in line-bar chart
3. add debouncing for angle options in scatter's exclusive panel
4. disable "Trucate after" option when disable the pie chart's label option

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/c753579c-c773-42cd-b6ec-f6b0a0489c30

<img width="1669" height="907" alt="截屏2025-07-31 07 41 10" src="https://github.com/user-attachments/assets/92e6f67b-b6cd-4ff8-8336-3d748603b634" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: add one default range for metric + fix threshold in line-bar chart
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
