### PR TITLE
[TEST] Fix cigroup 12 and 15

### DIFF
--- a/changelogs/fragments/10322.yml
+++ b/changelogs/fragments/10322.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix cigroup 12 and 15 ([#10322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10322))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/02/saved_queries.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/02/saved_queries.spec.js
@@ -58,11 +58,14 @@ const loadSavedQuery = (config) => {
   // Todo - Date Picker sometimes does not load when expected. Have to set dataset and query language again.
   cy.explore.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
 
-  setDatePickerDatesAndSearchIfRelevant(
-    config.language,
-    'Aug 29, 2020 @ 00:00:00.000',
-    'Aug 30, 2020 @ 00:00:00.000'
-  );
+  // TODO: Change line 68 back the following lines once saved query could load time filter correctly
+  // setDatePickerDatesAndSearchIfRelevant(
+  //   config.language,
+  //   'Aug 29, 2020 @ 00:00:00.000',
+  //   'Aug 30, 2020 @ 00:00:00.000'
+  // );
+
+  setDatePickerDatesAndSearchIfRelevant(config.language);
 
   cy.explore.loadSavedQuery(`${workspaceName}-${config.saveName}`);
   // wait for saved queries to load.

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/05/recent_queries.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/05/recent_queries.spec.js
@@ -95,13 +95,6 @@ const runRecentQueryTests = () => {
                   "I don't want to use the time filter"
                 );
                 cy.explore.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
-                cy.wrap(null).then(() => {
-                  // force Cypress to run this method in order
-                  // shift twice since we added two default query to the recent query list due to change dataset twice
-                  // default query for config.dataset and default query for config.alternativeDataset
-                  reverseList.unshift(config.defaultQuery);
-                  reverseList.unshift(config.defaultQuery);
-                });
                 cy.getElementByTestId('exploreRecentQueriesButton').click({
                   force: true,
                 });
@@ -122,18 +115,11 @@ const runRecentQueryTests = () => {
               },
             },
           ];
-          steps.forEach(({ action }, stepIndex) => {
+          steps.forEach(({ action }) => {
             action();
             cy.getElementByTestIdLike('row-').each(($row, rowIndex) => {
-              let expectedQuery = '';
-              if (rowIndex === 1 && stepIndex >= 1) {
-                expectedQuery = currentBaseQuery + config.alternativeDataset;
-              } else if (rowIndex === 0 && stepIndex >= 1) {
-                expectedQuery = currentBaseQuery + config.dataset;
-              } else {
-                expectedQuery =
-                  currentBaseQuery + config.dataset + currentWhereStatement + reverseList[rowIndex];
-              }
+              const expectedQuery =
+                currentBaseQuery + config.dataset + currentWhereStatement + reverseList[rowIndex];
               expect($row.text()).to.contain(expectedQuery);
             });
           });

--- a/src/plugins/explore/public/components/top_nav/utils/validate_time_range.test.ts
+++ b/src/plugins/explore/public/components/top_nav/utils/validate_time_range.test.ts
@@ -10,11 +10,15 @@ import {
 } from './validate_time_range';
 
 describe('validateTimeRangeWithOrder', () => {
+  const getPastDate = () => new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days ago
+  const getFutureDate = () => new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(); // 1 day in future
+  const getCurrentDate = () => new Date().toISOString();
+
   describe('validateTimeRangeOrder', () => {
     it('should return true for valid time ranges where from < to (assumes valid format)', () => {
       expect(
         validateTimeRangeOrder({
-          from: '2025-07-01T21:15:21.002Z',
+          from: getPastDate(),
           to: 'now',
         })
       ).toBe(true);
@@ -23,17 +27,18 @@ describe('validateTimeRangeWithOrder', () => {
     it('should return false for invalid time ranges where from > to (assumes valid format)', () => {
       expect(
         validateTimeRangeOrder({
-          from: '2025-07-31T21:15:21.002Z',
+          from: getFutureDate(),
           to: 'now',
         })
       ).toBe(false);
     });
 
     it('should return true for equal from and to dates (assumes valid format)', () => {
+      const currentDate = getCurrentDate();
       expect(
         validateTimeRangeOrder({
-          from: '2025-07-22T12:00:00.000Z',
-          to: '2025-07-22T12:00:00.000Z',
+          from: currentDate,
+          to: currentDate,
         })
       ).toBe(true);
     });
@@ -48,7 +53,7 @@ describe('validateTimeRangeWithOrder', () => {
     it('should return true for valid time ranges (both format and logic)', () => {
       expect(
         validateTimeRangeWithOrder({
-          from: '2025-07-01T21:15:21.002Z',
+          from: getPastDate(),
           to: 'now',
         })
       ).toBe(true);
@@ -57,7 +62,7 @@ describe('validateTimeRangeWithOrder', () => {
     it('should return false for invalid time ranges (valid format but invalid logic)', () => {
       expect(
         validateTimeRangeWithOrder({
-          from: '2025-07-31T21:15:21.002Z',
+          from: getFutureDate(),
           to: 'now',
         })
       ).toBe(false);
@@ -77,7 +82,7 @@ describe('validateTimeRangeWithOrder', () => {
     it('should return false for valid time ranges', () => {
       expect(
         isTimeRangeInvalid({
-          from: '2025-07-01T21:15:21.002Z',
+          from: getPastDate(),
           to: 'now',
         })
       ).toBe(false);
@@ -86,7 +91,7 @@ describe('validateTimeRangeWithOrder', () => {
     it('should return true for invalid time ranges (from > to)', () => {
       expect(
         isTimeRangeInvalid({
-          from: '2025-07-31T21:15:21.002Z',
+          from: getFutureDate(),
           to: 'now',
         })
       ).toBe(true);


### PR DESCRIPTION
### Description

Cigroup 12 failure due to: saved query failed to load saved time filter bug
Cigroup 15 failure due to: change in behavior of recent query(default query no longer is included in the recent query)

also include changes from @TackAdam's PR to fix the ciGroup4 failure: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10319/files

Thanks @kavilla for helping on fixing tests and enabling back cypress test videos. https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10269/commits/b63bf5df0992c577cb25dfaefb468d83e762adae

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: fix cigroup 12 and 15

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
