### PR TITLE
[Banner Plugin] Add cache for banner hide

### DIFF
--- a/changelogs/fragments/10325.yml
+++ b/changelogs/fragments/10325.yml
@@ -1,0 +1,2 @@
+fix:
+- Persist banner dismissal across session reloads using sessionStorage ([#10325](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10325))


### PR DESCRIPTION
### Description

This PR ensures the banner dismissal persists for the current session.  
The hidden state is stored in `sessionStorage` and respected on reload.  
Verified working in both standard and private browser sessions.

### Issues Resolved

<!-- Add related issue numbers/links here if applicable -->
- fixes: Banner dismissal not persisting after page reloads

## Screenshot
![iShot_2025-08-03_14 17 24](https://github.com/user-attachments/assets/51d80499-2283-4452-aed3-164f272eae17)

## Testing the changes

1. Start OpenSearch Dashboards.
2. Enable a global banner.
3. Dismiss the banner by clicking the close button.
4. Refresh the page — verify the banner remains hidden.
5. Test the same flow in a private/incognito browser window.
6. Clear sessionStorage manually, refresh, and verify the banner reappears.

## Changelog

- fix: Persist banner dismissal across session reloads using sessionStorage

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff