### PR TITLE
[Banner Plugin] Dynamic Configuration Support for the Banner Plugin

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -385,3 +385,9 @@
 
 # Set the content of the banner
 # banner.content: "This is an important announcement for all users. [Learn more](https://opensearch.org) about OpenSearch."
+
+# Set the external link to fetch banner configuration from
+# If provided, the banner will try to fetch configuration from this URL
+# If the fetch fails, it will fall back to the settings above
+# See the banner plugin README.md for details on the expected JSON structure
+# banner.externalLink: "https://example.com/banner-config.json"

--- a/src/plugins/banner/README.md
+++ b/src/plugins/banner/README.md
@@ -26,7 +26,40 @@ banner.iconType: "iInCircle" # Any valid EUI icon type
 banner.isVisible: true # Whether the banner is initially visible
 banner.useMarkdown: true # Whether to render content as markdown
 banner.size: "m" # Options: s (small), m (medium)
+
+# External configuration
+# Set the external link to fetch banner configuration from
+# If provided, the banner will try to fetch configuration from this URL
+# If the fetch fails, it will fall back to the settings above
+# banner.externalLink: "https://example.com/banner-config.json"
 ```
+
+### External Configuration
+
+You can configure the banner to fetch its configuration from an external JSON endpoint. This is useful for centrally managing banner content across multiple OpenSearch Dashboards instances.
+
+The external JSON file should have the following structure:
+
+```json
+{
+  "content": "Important announcement or notification",
+  "color": "primary",
+  "iconType": "iInCircle",
+  "isVisible": true,
+  "useMarkdown": true,
+  "size": "m"
+}
+```
+
+All fields are optional. Any fields not provided will fall back to the local configuration in `opensearch_dashboards.yml`.
+
+Field descriptions:
+- `content`: The text content of the banner (supports markdown if useMarkdown is true)
+- `color`: The color theme of the banner (options: "primary", "success", "warning")
+- `iconType`: Any valid OUI icon type
+- `isVisible`: Boolean indicating whether the banner should be displayed
+- `useMarkdown`: Boolean indicating whether to render content as markdown
+- `size`: The size of the banner (options: "s" for small, "m" for medium)
 
 ## Usage
 

--- a/src/plugins/banner/common/index.ts
+++ b/src/plugins/banner/common/index.ts
@@ -21,4 +21,5 @@ export interface BannerConfig {
   isVisible: boolean;
   useMarkdown?: boolean;
   size?: 's' | 'm';
+  externalLink?: string;
 }

--- a/src/plugins/banner/server/config.ts
+++ b/src/plugins/banner/server/config.ts
@@ -28,4 +28,5 @@ export const configSchema = schema.object({
   size: schema.oneOf([schema.literal('s'), schema.literal('m')], {
     defaultValue: 'm',
   }),
+  externalLink: schema.maybe(schema.string()),
 });

--- a/src/plugins/banner/server/plugin.ts
+++ b/src/plugins/banner/server/plugin.ts
@@ -13,7 +13,13 @@ import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { BannerPluginSetup, BannerPluginStart } from './types';
 import { BannerPluginConfigType } from './config';
-import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from '../../../core/server';
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  Logger,
+} from '../../../core/server';
 import { defineRoutes } from './routes/get_config';
 import { BannerConfig } from '../common';
 import { getDefaultBannerSettings } from './ui_settings';
@@ -21,9 +27,11 @@ import { getDefaultBannerSettings } from './ui_settings';
 export class BannerPlugin implements Plugin<BannerPluginSetup, BannerPluginStart> {
   private readonly config$: Observable<BannerPluginConfigType>;
   private pluginConfig!: BannerPluginConfigType;
+  private readonly logger: Logger;
 
   constructor(private initializerContext: PluginInitializerContext) {
     this.config$ = this.initializerContext.config.create<BannerPluginConfigType>();
+    this.logger = this.initializerContext.logger.get('banner');
   }
 
   public async setup(core: CoreSetup<BannerPluginStart>) {
@@ -57,6 +65,7 @@ export class BannerPlugin implements Plugin<BannerPluginSetup, BannerPluginStart
       getConfig: (): BannerConfig => ({
         ...this.pluginConfig,
       }),
+      logger: this.logger,
     };
 
     // Register server routes

--- a/src/plugins/banner/server/routes/fetch_external_config.test.ts
+++ b/src/plugins/banner/server/routes/fetch_external_config.test.ts
@@ -1,0 +1,298 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { fetchExternalConfig } from './fetch_external_config';
+import http from 'http';
+import https from 'https';
+import { URL } from 'url';
+import { BannerConfig } from '../../common';
+
+// Mock http and https modules
+jest.mock('http');
+jest.mock('https');
+
+describe('fetchExternalConfig', () => {
+  // Create mock objects
+  const mockLogger = {
+    error: jest.fn(),
+  };
+
+  // Mock response object with EventEmitter-like behavior
+  const createMockResponse = (statusCode: number) => {
+    const listeners: Record<string, Array<(chunk?: any) => void>> = {
+      data: [],
+      end: [],
+    };
+
+    return {
+      statusCode,
+      on: jest.fn((event: string, callback: (chunk?: any) => void) => {
+        if (!listeners[event]) {
+          listeners[event] = [];
+        }
+        listeners[event].push(callback);
+        return this;
+      }),
+      // Helper methods to trigger events in tests
+      emitData: (chunk: string) => {
+        listeners.data.forEach((callback) => callback(chunk));
+      },
+      emitEnd: () => {
+        listeners.end.forEach((callback) => callback());
+      },
+    };
+  };
+
+  // Mock request object with EventEmitter-like behavior
+  const createMockRequest = () => {
+    const listeners: Record<string, Array<(error?: Error) => void>> = {
+      error: [],
+      timeout: [],
+    };
+
+    return {
+      on: jest.fn((event: string, callback: (error?: Error) => void) => {
+        if (!listeners[event]) {
+          listeners[event] = [];
+        }
+        listeners[event].push(callback);
+        return this;
+      }),
+      end: jest.fn(),
+      destroy: jest.fn(),
+      // Helper methods to trigger events in tests
+      emitError: (error: Error) => {
+        listeners.error.forEach((callback) => callback(error));
+      },
+      emitTimeout: () => {
+        listeners.timeout.forEach((callback) => callback());
+      },
+    };
+  };
+
+  beforeEach(() => {
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+    mockLogger.error.mockClear();
+  });
+
+  test('successfully fetches and parses JSON data from HTTP URL', async () => {
+    // Mock data
+    const testUrl = 'http://example.com/banner-config';
+    const mockData = { content: 'Test Banner', color: 'primary' };
+    const mockJsonString = JSON.stringify(mockData);
+
+    // Create mock response
+    const mockResponse = createMockResponse(200);
+
+    // Create mock request
+    const mockRequest = createMockRequest();
+
+    // Mock http.request to return our mock request and call the callback with mock response
+    (http.request as jest.Mock).mockImplementation((url, options, callback) => {
+      callback(mockResponse);
+      return mockRequest;
+    });
+
+    // Start the async function call
+    const resultPromise = fetchExternalConfig(testUrl, mockLogger);
+
+    // Simulate response data events
+    mockResponse.emitData(mockJsonString);
+    mockResponse.emitEnd();
+
+    // Wait for the promise to resolve
+    const result = await resultPromise;
+
+    // Verify results
+    expect(http.request).toHaveBeenCalledWith(
+      testUrl,
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        timeout: 5000,
+      }),
+      expect.any(Function)
+    );
+    expect(mockRequest.end).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  test('successfully fetches and parses JSON data from HTTPS URL', async () => {
+    // Mock data
+    const httpsUrl = 'https://example.com/banner-config';
+    const mockData = { content: 'Test Banner', color: 'primary' };
+    const mockJsonString = JSON.stringify(mockData);
+
+    // Create mock response
+    const mockResponse = createMockResponse(200);
+
+    // Create mock request
+    const mockRequest = createMockRequest();
+
+    // Mock https.request to return our mock request and call the callback with mock response
+    (https.request as jest.Mock).mockImplementation((url, options, callback) => {
+      callback(mockResponse);
+      return mockRequest;
+    });
+
+    // Start the async function call
+    const resultPromise = fetchExternalConfig(httpsUrl, mockLogger);
+
+    // Simulate response data events
+    mockResponse.emitData(mockJsonString);
+    mockResponse.emitEnd();
+
+    // Wait for the promise to resolve
+    const result = await resultPromise;
+
+    // Verify results
+    expect(https.request).toHaveBeenCalledWith(
+      httpsUrl,
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        timeout: 5000,
+      }),
+      expect.any(Function)
+    );
+    expect(mockRequest.end).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  test('handles non-200 status code', async () => {
+    // Mock data
+    const errorUrl = 'http://example.com/banner-config';
+
+    // Create mock response with non-200 status
+    const mockResponse = createMockResponse(404);
+
+    // Create mock request
+    const mockRequest = createMockRequest();
+
+    // Mock http.request
+    (http.request as jest.Mock).mockImplementation((url, options, callback) => {
+      callback(mockResponse);
+      return mockRequest;
+    });
+
+    // Call the function
+    const result = await fetchExternalConfig(errorUrl, mockLogger);
+
+    // Verify results
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith('Error fetching banner config: HTTP status 404');
+  });
+
+  test('handles JSON parsing error', async () => {
+    // Mock data
+    const jsonErrorUrl = 'http://example.com/banner-config';
+    const invalidJson = '{ invalid: json }';
+
+    // Create mock response
+    const mockResponse = createMockResponse(200);
+
+    // Create mock request
+    const mockRequest = createMockRequest();
+
+    // Mock http.request
+    (http.request as jest.Mock).mockImplementation((url, options, callback) => {
+      callback(mockResponse);
+      return mockRequest;
+    });
+
+    // Start the async function call
+    const resultPromise = fetchExternalConfig(jsonErrorUrl, mockLogger);
+
+    // Simulate response data events with invalid JSON
+    mockResponse.emitData(invalidJson);
+    mockResponse.emitEnd();
+
+    // Wait for the promise to resolve
+    const result = await resultPromise;
+
+    // Verify results
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error parsing banner config JSON:')
+    );
+  });
+
+  test('handles request error', async () => {
+    // Mock data
+    const url = 'http://example.com/banner-config';
+    const mockError = new Error('Network error');
+
+    // Create mock request
+    const mockRequest = createMockRequest();
+
+    // Mock http.request
+    (http.request as jest.Mock).mockImplementation(() => {
+      return mockRequest;
+    });
+
+    // Start the async function call
+    const resultPromise = fetchExternalConfig(url, mockLogger);
+
+    // Simulate request error
+    mockRequest.emitError(mockError);
+
+    // Wait for the promise to resolve
+    const result = await resultPromise;
+
+    // Verify results
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith('Error fetching banner config: Network error');
+  });
+
+  test('handles request timeout', async () => {
+    // Mock data
+    const url = 'http://example.com/banner-config';
+
+    // Create mock request
+    const mockRequest = createMockRequest();
+
+    // Mock http.request
+    (http.request as jest.Mock).mockImplementation(() => {
+      return mockRequest;
+    });
+
+    // Start the async function call
+    const resultPromise = fetchExternalConfig(url, mockLogger);
+
+    // Simulate request timeout
+    mockRequest.emitTimeout();
+
+    // Wait for the promise to resolve
+    const result = await resultPromise;
+
+    // Verify results
+    expect(result).toBeNull();
+    expect(mockRequest.destroy).toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith('Request timeout while fetching banner config');
+  });
+
+  test('handles URL parsing error', async () => {
+    // Invalid URL
+    const url = 'invalid-url';
+
+    // Call the function
+    const result = await fetchExternalConfig(url, mockLogger);
+
+    // Verify results
+    expect(result).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error creating request for banner config:')
+    );
+  });
+});

--- a/src/plugins/banner/server/routes/fetch_external_config.ts
+++ b/src/plugins/banner/server/routes/fetch_external_config.ts
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import https from 'https';
+import http from 'http';
+import { URL } from 'url';
+import { BannerConfig } from '../../common';
+
+/**
+ * Fetches banner configuration from an external URL
+ * @param url The URL to fetch the banner configuration from
+ * @param logger Logger instance for logging errors
+ * @returns The banner configuration or null if there was an error
+ */
+export async function fetchExternalConfig(
+  url: string,
+  logger: { error: (message: string) => void }
+): Promise<Partial<BannerConfig> | null> {
+  return new Promise((resolve) => {
+    try {
+      const parsedUrl = new URL(url);
+      const requestModule = parsedUrl.protocol === 'https:' ? https : http;
+
+      const req = requestModule.request(
+        url,
+        {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+          },
+          timeout: 5000, // 5 second timeout
+        },
+        (res) => {
+          if (res.statusCode !== 200) {
+            logger.error(`Error fetching banner config: HTTP status ${res.statusCode}`);
+            resolve(null);
+            return;
+          }
+
+          let data = '';
+          res.on('data', (chunk) => {
+            data += chunk;
+          });
+
+          res.on('end', () => {
+            try {
+              const jsonData = JSON.parse(data);
+              resolve(jsonData);
+            } catch (error) {
+              logger.error(`Error parsing banner config JSON: ${error}`);
+              resolve(null);
+            }
+          });
+        }
+      );
+
+      req.on('error', (error) => {
+        logger.error(`Error fetching banner config: ${error.message}`);
+        resolve(null);
+      });
+
+      req.on('timeout', () => {
+        req.destroy();
+        logger.error('Request timeout while fetching banner config');
+        resolve(null);
+      });
+
+      req.end();
+    } catch (error) {
+      logger.error(`Error creating request for banner config: ${error}`);
+      resolve(null);
+    }
+  });
+}

--- a/src/plugins/banner/server/types.ts
+++ b/src/plugins/banner/server/types.ts
@@ -10,10 +10,12 @@
  */
 
 import { BannerConfig } from '../common';
+import { Logger } from '../../../core/server';
 
 export interface BannerPluginSetup {
   bannerEnabled: () => boolean;
   getConfig: () => BannerConfig;
+  logger: Logger;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
### Description

This PR introduces dynamic configuration support for the banner plugin.  
A new optional `externalLink` setting allows OpenSearch Dashboards to fetch banner configuration  
from a remote JSON endpoint. If fetching fails, the system falls back to local YAML or Advanced Settings.  
This enables centralized banner management across multiple instances.

### Issues Resolved

#9990 

## Screenshot

No direct UI changes, but banner content, style, and visibility can now  
be updated dynamically from an external configuration endpoint.

## Testing the changes

1. Add the following entry to `opensearch_dashboards.yml`:

   ```yaml
   banner.externalLink: "https://example.com/banner-config.json"
````

2. Start OpenSearch Dashboards.

3. Verify the banner loads configuration from the provided endpoint.

4. Simulate a failed request (e.g., invalid URL) — confirm fallback to local configuration.

5. Run unit tests in `fetch_external_config.test.ts`:

   ```bash
   yarn test:jest src/plugins/banner/server/routes/fetch_external_config.test.ts
   ```

6. Validate both HTTP and HTTPS URLs work, including timeout and parsing error scenarios.

## Changelog

- feat: Support dynamic banner config via external JSON endpoint with local fallback

### Check List

* [ ] All tests pass

  * [ ] `yarn test:jest`
  * [ ] `yarn test:jest_integration`
* [ ] New functionality includes testing.
* [ ] New functionality has been documented.
* [ ] Update [[CHANGELOG.md](https://chatgpt.com/g/CHANGELOG.md)](./../CHANGELOG.md)
* [ ] Commits are signed per the DCO using --signoff