### PR TITLE
[Explore] Fix New button URL state management issue

### DIFF
--- a/changelogs/fragments/10332.yml
+++ b/changelogs/fragments/10332.yml
@@ -1,0 +1,2 @@
+fix:
+- [Explore] Fix New button URL state management issue ([#10332](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10332))

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_new/top_nav_new.test.ts
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_new/top_nav_new.test.ts
@@ -25,17 +25,44 @@ describe('newTopNavData', () => {
 });
 
 describe('getNewButtonRun', () => {
-  it('should dispatch resetExploreStateActionCreator', () => {
+  it('should dispatch resetExploreStateActionCreator and navigate to clean URL', () => {
     const visBuilder = new VB.VisualizationBuilder({});
     const clearUrlSpy = jest.spyOn(visBuilder, 'clearUrl');
     jest.spyOn(VB, 'getVisualizationBuilder').mockReturnValue(visBuilder);
 
     const dispatch = jest.fn();
-    const services = ({ store: { dispatch } } as unknown) as ExploreServices;
+    const mockPush = jest.fn();
+    const services = ({
+      store: { dispatch },
+      scopedHistory: { push: mockPush },
+    } as unknown) as ExploreServices;
     const clearEditors = jest.fn();
 
     const run = getNewButtonRun(services, clearEditors);
     run({} as HTMLElement);
+
+    expect(resetExploreStateActionCreator).toHaveBeenCalledWith(services, clearEditors);
+    expect(dispatch).toHaveBeenCalledWith('RESET_ACTION');
+    expect(clearUrlSpy).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('should handle missing scopedHistory gracefully', () => {
+    const visBuilder = new VB.VisualizationBuilder({});
+    const clearUrlSpy = jest.spyOn(visBuilder, 'clearUrl');
+    jest.spyOn(VB, 'getVisualizationBuilder').mockReturnValue(visBuilder);
+
+    const dispatch = jest.fn();
+    const services = ({
+      store: { dispatch },
+      scopedHistory: undefined,
+    } as unknown) as ExploreServices;
+    const clearEditors = jest.fn();
+
+    const run = getNewButtonRun(services, clearEditors);
+
+    // Should not throw when scopedHistory is undefined
+    expect(() => run({} as HTMLElement)).not.toThrow();
 
     expect(resetExploreStateActionCreator).toHaveBeenCalledWith(services, clearEditors);
     expect(dispatch).toHaveBeenCalledWith('RESET_ACTION');

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_new/top_nav_new.ts
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_new/top_nav_new.ts
@@ -29,4 +29,8 @@ export const getNewButtonRun = (
   const visBuilder = getVisualizationBuilder();
   visBuilder.clearUrl();
   services.store.dispatch(resetExploreStateActionCreator(services, clearEditors));
+
+  if (services.scopedHistory) {
+    services.scopedHistory.push('/');
+  }
 };


### PR DESCRIPTION
### Description

The "New" button in the Explore plugin's top navigation had URL state management issues when transitioning from saved explore views back to a clean state. After clicking "New" from a saved explore, the URL would retain the saved explore ID (/#/view/{savedId}) instead of navigating to the clean state (/#/).

**Root cause:** The `getNewButtonRun` function only reset Redux state via `resetExploreStateActionCreator` but did not handle URL navigation. 

This PR added URL navigation to the "New" button handler to ensure complete state reset:
```
if (services.scopedHistory) {
  services.scopedHistory.push('/');
}
```

### Issues Resolved

NA

## Screenshot


https://github.com/user-attachments/assets/55684511-9462-4078-9705-41fe5d0c914f



## Changelog

- fix: [Explore] Fix New button URL state management issue


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
