### PR TITLE
Fix PPL query millisecond precision in date filtering

### DIFF
--- a/changelogs/fragments/10333.yml
+++ b/changelogs/fragments/10333.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix PPL query millisecond precision in date filtering ([#10333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10333))

--- a/src/plugins/query_enhancements/common/utils.test.ts
+++ b/src/plugins/query_enhancements/common/utils.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isPPLSearchQuery, throwFacetError } from './utils';
+import { isPPLSearchQuery, throwFacetError, formatDate } from './utils';
 import { Query } from 'src/plugins/data/common';
 
 describe('throwFacetError', () => {
@@ -110,6 +110,62 @@ describe('throwFacetError', () => {
       expect(err.name).toBeUndefined();
       expect(err.status).toBeUndefined();
     }
+  });
+});
+
+describe('formatDate', () => {
+  it('should format date string with milliseconds', () => {
+    const dateString = '2025-07-30T20:30:31.567Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-07-30 20:30:31.567');
+  });
+
+  it('should format date string with zero milliseconds', () => {
+    const dateString = '2025-07-30T20:30:31.000Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-07-30 20:30:31.000');
+  });
+
+  it('should format date string with single digit milliseconds', () => {
+    const dateString = '2025-07-30T20:30:31.005Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-07-30 20:30:31.005');
+  });
+
+  it('should format date string with double digit milliseconds', () => {
+    const dateString = '2025-07-30T20:30:31.050Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-07-30 20:30:31.050');
+  });
+
+  it('should format date string with maximum milliseconds', () => {
+    const dateString = '2025-07-30T20:30:31.999Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-07-30 20:30:31.999');
+  });
+
+  it('should handle different date formats', () => {
+    const dateString = '2025-01-01T00:00:00.123Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-01-01 00:00:00.123');
+  });
+
+  it('should pad single digit months and days', () => {
+    const dateString = '2025-01-05T09:08:07.456Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-01-05 09:08:07.456');
+  });
+
+  it('should handle leap year dates', () => {
+    const dateString = '2024-02-29T12:34:56.789Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2024-02-29 12:34:56.789');
+  });
+
+  it('should handle end of year dates', () => {
+    const dateString = '2025-12-31T23:59:59.999Z';
+    const result = formatDate(dateString);
+    expect(result).toBe('2025-12-31 23:59:59.999');
   });
 });
 

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -28,7 +28,9 @@ export const formatDate = (dateString: string) => {
     ':' +
     ('0' + date.getMinutes()).slice(-2) +
     ':' +
-    ('0' + date.getSeconds()).slice(-2)
+    ('0' + date.getSeconds()).slice(-2) +
+    '.' +
+    ('00' + date.getMilliseconds()).slice(-3)
   );
 };
 

--- a/src/plugins/query_enhancements/public/search/filters/filter_utils.test.ts
+++ b/src/plugins/query_enhancements/public/search/filters/filter_utils.test.ts
@@ -294,7 +294,7 @@ describe('getTimeFilterCommand', () => {
 
     const result = FilterUtils.getTimeFilterWhereClause('timestamp', timeRange);
     expect(result).toBe(
-      "WHERE `timestamp` >= '2023-01-01 00:00:00' AND `timestamp` <= '2023-01-02 00:00:00'"
+      "WHERE `timestamp` >= '2023-01-01 00:00:00.000' AND `timestamp` <= '2023-01-02 00:00:00.000'"
     );
   });
 });


### PR DESCRIPTION
### Description

Fixed PPL queries to include millisecond precision when filtering by timestamp fields. Previously, milliseconds were stripped from date filters, preventing precise time-based queries.

### Issues Resolved

NA

## Screenshot


* Before
```
WHERE timestamp >= '2025-07-30 20:30:31' AND timestamp <= '2025-07-30 20:30:31'
```

<img width="1562" height="919" alt="Screenshot 2025-08-04 at 1 46 54 PM" src="https://github.com/user-attachments/assets/97d4e854-aa7e-411f-b110-c0c8ee9f1872" />


* After  
```
WHERE timestamp >= '2025-07-30 20:30:31.567' AND timestamp <= '2025-07-30 20:30:31.580'
```

https://github.com/user-attachments/assets/954122ea-ddf2-459f-8f32-0e38af582cf8


## Testing the changes

- Verified with test data containing millisecond differences
- Date picker with millisecond precision now works correctly with PPL queries
- Network requests show milliseconds in WHERE clauses
- Precise filtering returns expected document counts

## Changelog
- fix: Fix PPL query millisecond precision in date filtering



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
