### PR TITLE
[Explore] Fix query execution button issue when use using date picker quick selections

### DIFF
--- a/changelogs/fragments/10336.yml
+++ b/changelogs/fragments/10336.yml
@@ -1,0 +1,2 @@
+fix:
+- [Explore] Fix query execution button issue when use using date picker quick selections ([#10336](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10336))

--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -27,7 +27,7 @@ import { setDateRange } from '../../application/utils/state_management/slices/qu
 import { useClearEditors, useEditorRef } from '../../application/hooks';
 import { onEditorRunActionCreator } from '../../application/utils/state_management/actions/query_editor/on_editor_run/on_editor_run';
 import { QueryExecutionButton } from './query_execution_button';
-import { Query } from '../../../../data/common';
+import { Query, TimeRange } from '../../../../data/common';
 
 export interface TopNavProps {
   savedExplore?: SavedExplore;
@@ -148,10 +148,17 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
     [dispatch]
   );
 
-  const handleQuerySubmit = useCallback(() => {
-    const editorText = editorRef.current?.getValue() || '';
-    dispatch(onEditorRunActionCreator(services, editorText));
-  }, [dispatch, services, editorRef]);
+  const handleQuerySubmit = useCallback(
+    (payload?: { dateRange?: TimeRange; query?: Query }) => {
+      if (payload?.dateRange) {
+        dispatch(setDateRange(payload.dateRange));
+      }
+
+      const editorText = editorRef.current?.getValue() || '';
+      dispatch(onEditorRunActionCreator(services, editorText));
+    },
+    [dispatch, services, editorRef]
+  );
 
   const handleCustomButtonClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
### Description

In the Explore plugin, when users select date ranges from the date picker's "Quick select", "Commonly used", or "Recently used date ranges" options, the query execution button remains as "REFRESH" instead of changing to "UPDATE". 

The issue stems from the date picker event handling logic in query_bar_top_row.tsx. When isQuickSelection is true (for quick select options), the date picker calls onSubmit instead of onChange, which bypasses the handleQueryChange callback that dispatches setDateRange to update the Redux state.

**Before fix**
* Manual changes: onChange → handleQueryChange → setDateRange → Redux updated → Button shows "UPDATE" ✅
* Quick selections: onSubmit → handleQuerySubmit → Bypasses setDateRange → Redux not updated → Button stays "REFRESH" ❌

This PR modified the `handleQuerySubmit` function in src/plugins/explore/public/components/top_nav/top_nav.tsx to:
* Accept an optional payload parameter with dateRange and query properties
* Check for date range updates and dispatch setDateRange when present
* Maintain existing query execution functionality

### Issues Resolved
NA

## Screenshot


https://github.com/user-attachments/assets/a0b05710-db3b-4d3c-b9b4-befeaaabdc05


## Changelog

- fix: [Explore] Fix query execution button issue when use using date picker quick selections



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
