### PR TITLE
[Explore] Refactor generated query to have max height and scrollable

### DIFF
--- a/changelogs/fragments/10337.yml
+++ b/changelogs/fragments/10337.yml
@@ -1,0 +1,2 @@
+refactor:
+- Change generated query UI ([#10337](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10337))

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.scss
@@ -8,20 +8,25 @@
   @include exploreQueryPanelVerticalSeparator;
   @include exploreQueryPanelButton;
 
-  align-items: center;
   color: $ouiTextSubduedColor;
   display: flex;
-  gap: $ouiSizeS;
+  justify-content: space-between;
   padding-left: $ouiSizeXS;
   padding-top: $ouiSizeS;
   padding-bottom: $ouiSizeXXS;
+
+  &__queryWrapper {
+    display: flex;
+    align-items: center;
+  }
 
   &__query {
     color: $ouiColorDisabledText;
     // stylelint-disable-next-line @osd/stylelint/no_restricted_properties
     font-family: $ouiCodeFontFamily;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: normal;
+    padding-left: 12px; // make it aligned with query editor
+    max-height: calc($ouiSize * 3);
+    overflow-y: auto;
   }
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.test.tsx
@@ -91,14 +91,14 @@ describe('QueryPanelGeneratedQuery', () => {
       render(<QueryPanelGeneratedQuery />);
 
       expect(screen.getByText(testQuery)).toBeInTheDocument();
-      expect(screen.getByText('Edit query')).toBeInTheDocument();
+      expect(screen.getByText('Replace query')).toBeInTheDocument();
     });
 
     describe('onEditClick functionality', () => {
       it('should call all required functions when edit button is clicked', () => {
         render(<QueryPanelGeneratedQuery />);
 
-        const editButton = screen.getByTestId('exploreQueryPanelGeneratedQuery_editQuery');
+        const editButton = screen.getByTestId('exploreQueryPanelGeneratedQueryEditButton');
         fireEvent.click(editButton);
 
         expect(mockSetEditorTextWithQuery).toHaveBeenCalledWith(testQuery);
@@ -110,7 +110,7 @@ describe('QueryPanelGeneratedQuery', () => {
       it('should call functions in correct order', () => {
         render(<QueryPanelGeneratedQuery />);
 
-        const editButton = screen.getByTestId('exploreQueryPanelGeneratedQuery_editQuery');
+        const editButton = screen.getByTestId('exploreQueryPanelGeneratedQueryEditButton');
         fireEvent.click(editButton);
 
         // Verify all functions were called

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
@@ -6,14 +6,14 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
-import { EuiBadge, EuiIcon, EuiText } from '@elastic/eui';
+import { EuiButtonEmpty, EuiIcon, EuiText } from '@elastic/eui';
 import { selectLastExecutedTranslatedQuery } from '../../../application/utils/state_management/selectors';
 import { useEditorFocus, useSetEditorTextWithQuery } from '../../../application/hooks';
 import { clearLastExecutedData } from '../../../application/utils/state_management/slices';
 import './query_panel_generated_query.scss';
 
 const editQueryText = i18n.translate('explore.queryPanel.queryPanelGeneratedQuery.editQuery', {
-  defaultMessage: 'Edit query',
+  defaultMessage: 'Replace query',
 });
 
 export const QueryPanelGeneratedQuery = () => {
@@ -34,28 +34,26 @@ export const QueryPanelGeneratedQuery = () => {
 
   return (
     <div className="exploreQueryPanelGeneratedQuery">
-      <EuiIcon type="editorCodeBlock" size="s" />
-      <EuiText
-        className="exploreQueryPanelGeneratedQuery__query"
-        size="s"
-        data-test-subj="exploreQueryPanelGeneratedQuery"
-      >
-        {lastExecutedTranslatedQuery}
-      </EuiText>
-      <EuiBadge
-        data-test-subj="exploreQueryPanelGeneratedQuery_editQuery"
-        onClick={onEditClick}
-        onClickAriaLabel={editQueryText}
-        color="hollow"
-      >
-        <div
-          className="exploreQueryPanelGeneratedQuery__buttonTextWrapper"
-          data-test-subj="exploreQueryPanelGeneratedQueryEditButton"
+      <div className="exploreQueryPanelGeneratedQuery__queryWrapper">
+        <EuiIcon type="editorCodeBlock" size="s" />
+        <EuiText
+          className="exploreQueryPanelGeneratedQuery__query"
+          size="s"
+          data-test-subj="exploreQueryPanelGeneratedQuery"
         >
-          <EuiIcon type="editorCodeBlock" size="s" />
+          {lastExecutedTranslatedQuery}
+        </EuiText>
+      </div>
+      <EuiButtonEmpty
+        data-test-subj="exploreQueryPanelGeneratedQueryEditButton"
+        onClick={onEditClick}
+        size="xs"
+      >
+        <div className="exploreQueryPanelGeneratedQuery__buttonTextWrapper">
+          <EuiIcon type="sortUp" size="s" />
           <EuiText size="xs">{editQueryText}</EuiText>
         </div>
-      </EuiBadge>
+      </EuiButtonEmpty>
     </div>
   );
 };


### PR DESCRIPTION
### Description

- before, the generated query had a line-height set to 1, and it would show ellipses if overflowing. Now we are going to make it scrollable if needed, and never ellipses:

<img width="989" height="295" alt="Screenshot 2025-08-04 at 6 38 20 PM" src="https://github.com/user-attachments/assets/63d9cbf2-efca-456c-8016-e58f4c4d26fb" />

<img width="966" height="444" alt="Screenshot 2025-08-04 at 6 38 39 PM" src="https://github.com/user-attachments/assets/2704c620-1c15-49a2-ab8a-bf74a663c6e3" />

## Changelog
- refactor: change generated query UI

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
