### PR TITLE
[Query enhancements] improve search strategy flexibility

### DIFF
--- a/src/plugins/data/common/data_frames/types.ts
+++ b/src/plugins/data/common/data_frames/types.ts
@@ -146,9 +146,10 @@ export interface QueryFailedStatusResponse {
   body: IDataFrameError;
 }
 
-export type FetchStatusResponse =
+export type FetchStatusResponse = { queryId?: string } & (
   | QueryFailedStatusResponse
   | QuerySuccessStatusResponse
-  | { status?: string };
+  | { status?: string }
+);
 
 export type PollQueryResultsHandler = () => Promise<FetchStatusResponse>;

--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -100,7 +100,7 @@ export interface DatasetTypeConfig {
    * Retrieves the search options to be used for running the query on the data connection associated
    * with this Dataset
    */
-  getSearchOptions?: () => DatasetSearchOptions;
+  getSearchOptions?: (dataset: Dataset) => DatasetSearchOptions;
   /**
    * Combines a list of user selected data structures into a single one to use in discover.
    * @see https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8362.

--- a/src/plugins/query_enhancements/common/types.ts
+++ b/src/plugins/query_enhancements/common/types.ts
@@ -29,6 +29,7 @@ export interface EnhancedFetchContext {
   body?: {
     pollQueryResultsParams?: PollQueryResultsParams;
     timeRange?: TimeRange;
+    options?: Record<string, unknown>;
   };
 }
 

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
@@ -227,6 +227,40 @@ describe('PPLSearchInterceptor', () => {
       expect(spy).toHaveBeenCalledWith(mockRequest, mockOptions.abortSignal, customStrategy);
     });
 
+    it('should pass dataset parameter to getSearchOptions', () => {
+      const mockGetSearchOptions = jest.fn().mockReturnValue({ strategy: SEARCH_STRATEGY.PPL });
+      const mockDatasetService = {
+        getType: jest.fn().mockReturnValue({
+          getSearchOptions: mockGetSearchOptions,
+          languageOverrides: { PPL: { hideDatePicker: true } },
+        }),
+      };
+
+      const expectedDataset = { type: 'DEFAULT', timeFieldName: '@timestamp' };
+
+      const testRequest: IOpenSearchDashboardsSearchRequest = {
+        params: {
+          body: {
+            query: {
+              queries: [{ language: 'PPL', query: 'source=test_index', dataset: expectedDataset }],
+            },
+          },
+        },
+      };
+
+      (mockDataService.query.queryString.getQuery as jest.Mock).mockReturnValue({
+        language: 'PPL',
+        query: 'source=test_index',
+        dataset: expectedDataset,
+      });
+      (mockDataService.query.queryString.getDatasetService as jest.Mock).mockReturnValue(
+        mockDatasetService
+      );
+
+      pplSearchInterceptor.search(testRequest, mockOptions);
+      expect(mockGetSearchOptions).toHaveBeenCalledWith(expectedDataset);
+    });
+
     it('should pass time range when hideDatePicker is false', () => {
       const mockDatasetService = {
         getType: jest.fn().mockReturnValue({

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -78,7 +78,7 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       const datasetTypeConfig = this.queryService.queryString
         .getDatasetService()
         .getType(datasetType);
-      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+      strategy = datasetTypeConfig?.getSearchOptions?.(dataset).strategy ?? strategy;
 
       if (
         dataset?.timeFieldName &&

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -66,7 +66,7 @@ export class SQLSearchInterceptor extends SearchInterceptor {
       const datasetTypeConfig = this.queryService.queryString
         .getDatasetService()
         .getType(datasetType);
-      strategy = datasetTypeConfig?.getSearchOptions?.().strategy ?? strategy;
+      strategy = datasetTypeConfig?.getSearchOptions?.(dataset).strategy ?? strategy;
 
       if (datasetTypeConfig?.languageOverrides?.SQL?.hideDatePicker === false) {
         request.params = {

--- a/src/plugins/query_enhancements/server/routes/index.ts
+++ b/src/plugins/query_enhancements/server/routes/index.ts
@@ -88,6 +88,7 @@ export function defineSearchStrategyRouteProvider(logger: Logger, router: IRoute
               })
             ),
             timeRange: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+            options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
           }),
         },
       },


### PR DESCRIPTION
### Description

Currently search strategy added through query enhancements uses a fixed schema for request body
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/fbb17af2e7b4f35bbabe094c8b3ed54167e5b0dd/src/plugins/query_enhancements/server/routes/index.ts#L76-L91

This works for most cases, but for some datasources like Prometheus, the query may contain some options in additional to string query, for example
```json5
{
  "query": {
    "query": "http_requests_total{job=\"api-server\", status=\"200\"}",
    "language": "PROMQL",
    "dataset": {
      // ...
    },
    "format": "jdbc"
  },
  // ...
  "options": { "queryType": "RANGE", "step": "1000" }
}
```

Adding an `options` field in the search strategy request allows flexibility for these kind of integrations in the future.

Additionally, this PR passes `dataset` to `getSearchOptions`. This gives the flexibility so search option can be decided based on the currently selected dataset, which aligns with the existing comment.

It also declares optional `queryId` in the async query response. This allows initial async query requests to get partial or full results on the response (sync behavior) if backend supports it.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
