### PR TITLE
Fix: Discover plugin shows empty page instead of no-index-patterns UI when no index patterns

### DIFF
--- a/changelogs/fragments/10345.yml
+++ b/changelogs/fragments/10345.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix: Discover plugin shows empty page instead of no-index-patterns UI when no index patterns ([#10345](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10345))

--- a/src/plugins/data_explorer/public/utils/state_management/metadata_slice.ts
+++ b/src/plugins/data_explorer/public/utils/state_management/metadata_slice.ts
@@ -26,9 +26,18 @@ export const getPreloadedState = async ({
       .getStateTransfer(scopedHistory)
       .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
   const isQueryEnhancementEnabled = uiSettings.get(QUERY_ENHANCEMENT_ENABLED_SETTING);
-  const defaultIndexPattern = isQueryEnhancementEnabled
-    ? undefined
-    : await data.indexPatterns.getDefault();
+
+  let defaultIndexPattern;
+  if (!isQueryEnhancementEnabled) {
+    try {
+      defaultIndexPattern = await data.indexPatterns.getDefault();
+    } catch (error) {
+      defaultIndexPattern = undefined;
+    }
+  } else {
+    defaultIndexPattern = undefined;
+  }
+
   const preloadedState: MetadataState = {
     ...initialState,
     originatingApp,


### PR DESCRIPTION
### Description

The issue was in the data-explorer's metadata slice (metadata_slice.ts). When no index patterns exist, the `data.indexPatterns.getDefault()` method throws an error instead of gracefully returning undefined. This error occurred during the data-explorer's preload phase, preventing the entire application from loading properly and stopping the discover plugin from running its conditional logic to show the no-index-patterns UI.

This PR wrapped the data.indexPatterns.getDefault() call in a try-catch block so we could continue with undefined instead of crashing the application. This ensures that when no index patterns exist, the discover plugin can properly render the DiscoverNoIndexPatterns component as intended.

### Issues Resolved

When navigating to the discover plugin with no index patterns, the application shows an empty page instead of displaying the DiscoverNoIndexPatterns component. The URL gets stuck at http://localhost:5601/w/MvlhYH/app/data-explorer/discover without proper state parameters.

## Screenshot

* Without workspace, work properly

https://github.com/user-attachments/assets/89a63665-c5c7-49d7-af84-324936150db3


* With workspace, work properly

https://github.com/user-attachments/assets/035211e2-09b1-4636-bfd3-c6e28950d192



## Changelog

- fix: Fix: Discover plugin shows empty page instead of no-index-patterns UI when no index patterns


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
