### PR TITLE
[Explore] add tooltip to language reference and don't throw error

### DIFF
--- a/changelogs/fragments/10347.yml
+++ b/changelogs/fragments/10347.yml
@@ -1,0 +1,2 @@
+feat:
+- Add tooltip for language reference in explore ([#10347](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10347))

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.scss
@@ -4,6 +4,10 @@
  */
 
 .exploreLanguageReference {
+  &--disabled {
+    color: $ouiColorDisabledText;
+  }
+
   &__popoverBody {
     width: 350px;
   }

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.test.tsx
@@ -160,17 +160,150 @@ describe('LanguageReference', () => {
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('hasSeenInfoBox_PPL', 'true');
     });
   });
+
+  describe('Disabled State for Unsupported Languages', () => {
+    it('should disable button for unsupported language', () => {
+      mockLocalStorage.getItem.mockReturnValue('true');
+
+      const initialState = {
+        query: {
+          language: 'SQL',
+        },
+        queryEditor: {
+          editorMode: EditorMode.Query,
+          promptModeIsAvailable: false,
+        },
+      };
+
+      renderWithProviders(<LanguageReference />, initialState);
+
+      const button = screen.getByTestId('exploreLanguageReference');
+      expect(button).toBeDisabled();
+    });
+
+    it('should not open popover for unsupported language even when clicked', () => {
+      mockLocalStorage.getItem.mockReturnValue('true');
+
+      const initialState = {
+        query: {
+          language: 'SQL',
+        },
+        queryEditor: {
+          editorMode: EditorMode.Query,
+          promptModeIsAvailable: false,
+        },
+      };
+
+      renderWithProviders(<LanguageReference />, initialState);
+
+      const button = screen.getByTestId('exploreLanguageReference');
+
+      // Try to click disabled button
+      fireEvent.click(button);
+
+      // Popover should not open
+      expect(screen.queryByText('Syntax options')).not.toBeInTheDocument();
+    });
+
+    it('should have disabled CSS class for unsupported language', () => {
+      mockLocalStorage.getItem.mockReturnValue('true');
+
+      const initialState = {
+        query: {
+          language: 'SQL',
+        },
+        queryEditor: {
+          editorMode: EditorMode.Query,
+          promptModeIsAvailable: false,
+        },
+      };
+
+      renderWithProviders(<LanguageReference />, initialState);
+
+      const button = screen.getByTestId('exploreLanguageReference');
+      expect(button).toHaveClass('exploreLanguageReference--disabled');
+    });
+
+    it('should not have disabled CSS class for supported language', () => {
+      mockLocalStorage.getItem.mockReturnValue('true');
+
+      const initialState = {
+        query: {
+          language: 'PPL',
+        },
+        queryEditor: {
+          editorMode: EditorMode.Query,
+          promptModeIsAvailable: false,
+        },
+      };
+
+      renderWithProviders(<LanguageReference />, initialState);
+
+      const button = screen.getByTestId('exploreLanguageReference');
+      expect(button).not.toHaveClass('exploreLanguageReference--disabled');
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe('Tooltip Behavior', () => {
+    it('should show correct tooltip for supported language', async () => {
+      mockLocalStorage.getItem.mockReturnValue('true');
+
+      const initialState = {
+        query: {
+          language: 'PPL',
+        },
+        queryEditor: {
+          editorMode: EditorMode.Query,
+          promptModeIsAvailable: false,
+        },
+      };
+
+      renderWithProviders(<LanguageReference />, initialState);
+
+      const button = screen.getByTestId('exploreLanguageReference');
+
+      // Hover to trigger tooltip
+      fireEvent.mouseEnter(button);
+
+      // Check tooltip content for supported language
+      expect(await screen.findByText('Language reference for PPL')).toBeInTheDocument();
+    });
+
+    it('should show correct tooltip for unsupported language', async () => {
+      mockLocalStorage.getItem.mockReturnValue('true');
+
+      const initialState = {
+        query: {
+          language: 'SQL',
+        },
+        queryEditor: {
+          editorMode: EditorMode.Query,
+          promptModeIsAvailable: false,
+        },
+      };
+
+      renderWithProviders(<LanguageReference />, initialState);
+
+      const button = screen.getByTestId('exploreLanguageReference');
+
+      // Hover to trigger tooltip
+      fireEvent.mouseEnter(button);
+
+      // Check tooltip content for unsupported language
+      expect(await screen.findByText('Language reference unavailable for SQL')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('getLanguageReference', () => {
   it('should return PplReference component for PPL language', () => {
     const result = getLanguageReference('PPL');
-    expect(result.type.name).toBe('PplReference');
+    expect(result?.type.name).toBe('PplReference');
   });
 
-  it('should throw error for unsupported language', () => {
-    expect(() => {
-      getLanguageReference('UNSUPPORTED_LANGUAGE');
-    }).toThrow('LanguageReference encountered an unhandled language: UNSUPPORTED_LANGUAGE');
+  it('should return null for unsupported language', () => {
+    const result = getLanguageReference('UNSUPPORTED_LANGUAGE');
+    expect(result).toBeNull();
   });
 });

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.tsx
@@ -4,19 +4,23 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
+import { i18n } from '@osd/i18n';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { EuiButtonIcon, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import { EuiToolTip, EuiButtonIcon, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
 import { selectQueryLanguage } from '../../../../application/utils/state_management/selectors';
 import { PplReference } from './ppl_reference';
 import './language_reference.scss';
+
+export const LANGUAGE_REFERENCE_HANDLED_LANGUAGES = ['PPL'];
 
 export const getLanguageReference = (language: string) => {
   switch (language) {
     case 'PPL':
       return <PplReference />;
     default:
-      throw new Error(`LanguageReference encountered an unhandled language: ${language}`);
+      return null;
   }
 };
 
@@ -24,6 +28,7 @@ export const LanguageReference = () => {
   const language = useSelector(selectQueryLanguage);
   const storageKey = `hasSeenInfoBox_${language}`;
   const [popoverIsOpen, setPopoverIsOpen] = useState(localStorage.getItem(storageKey) !== 'true');
+  const languageIsHandled = LANGUAGE_REFERENCE_HANDLED_LANGUAGES.includes(language);
 
   useEffect(() => {
     if (popoverIsOpen) {
@@ -35,13 +40,35 @@ export const LanguageReference = () => {
     <EuiPopover
       id="languageReferencePopover"
       button={
-        <EuiButtonIcon
-          size="xs"
-          className="exploreLanguageReference"
-          data-test-subj="exploreLanguageReference"
-          iconType="iInCircle"
-          onClick={() => setPopoverIsOpen((value) => !value)}
-        />
+        <EuiToolTip
+          position="left"
+          content={
+            languageIsHandled
+              ? i18n.translate('explore.queryPanel.languageReference.handledTooltip', {
+                  defaultMessage: 'Language reference for {language}',
+                  values: {
+                    language,
+                  },
+                })
+              : i18n.translate('explore.queryPanel.languageReference.unhandledTooltip', {
+                  defaultMessage: 'Language reference unavailable for {language}',
+                  values: {
+                    language,
+                  },
+                })
+          }
+        >
+          <EuiButtonIcon
+            size="xs"
+            className={classNames('exploreLanguageReference', {
+              ['exploreLanguageReference--disabled']: !languageIsHandled,
+            })}
+            data-test-subj="exploreLanguageReference"
+            disabled={!languageIsHandled}
+            iconType="iInCircle"
+            onClick={() => setPopoverIsOpen((value) => !value)}
+          />
+        </EuiToolTip>
       }
       isOpen={popoverIsOpen}
       closePopover={() => setPopoverIsOpen(false)}


### PR DESCRIPTION
### Description

- don't throw error in language reference
- add tooltips for this button
- disable button for when we encountered unhandled language
<img width="743" height="219" alt="Screenshot 2025-08-05 at 3 22 27 PM" src="https://github.com/user-attachments/assets/15cdc347-b8e8-4560-a2b0-3565b25f29bb" />

<img width="441" height="294" alt="Screenshot 2025-08-05 at 3 23 24 PM" src="https://github.com/user-attachments/assets/4b7d4afc-d094-4ceb-8a11-3f6c5f3531b2" />


## Changelog
- feat: add tooltip for language reference in explore

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
