### PR TITLE
[Explore] Fix QueryExecutionButton color inconsistency

### DIFF
--- a/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.test.tsx
+++ b/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.test.tsx
@@ -233,7 +233,7 @@ describe('QueryExecutionButton', () => {
     const button = screen.getByTestId('exploreQueryExecutionButton');
     // Verify the button shows "Update" text when needsUpdate is true
     expect(screen.getByText('Update')).toBeInTheDocument();
-    // Verify the button has the success color (green) when needsUpdate is true
-    expect(button).toHaveClass('euiButton--success');
+    // Verify the button has the primary color (blue) for consistent theming
+    expect(button).toHaveClass('euiButton--primary');
   });
 });

--- a/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.tsx
+++ b/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.tsx
@@ -78,6 +78,7 @@ export const QueryExecutionButton: React.FC<QueryExecutionButtonProps> = ({ onCl
         values: { buttonText },
       })}
       compressed={true}
+      color="primary"
     >
       {buttonText}
     </EuiSuperUpdateButton>


### PR DESCRIPTION
### Description

The QueryExecutionButton in the explore plugin was experiencing inconsistent button colors due to the EuiSuperUpdateButton component's internal color logic.

In the EUI source code (node_modules/@elastic/eui/es/eui_components/date_picker/super_date_picker/super_update_button.js:153), the component has hardcoded color switching:

```
color: needsUpdate || isLoading ? 'success' : 'primary',
```
This causes:

* When needsUpdate={false} → color='primary' (theme's primary color, typically blue) → "Refresh" button
* When needsUpdate={true} → color='success' (always green) → "Update" button

This PR overrides the EUI component's internal color logic by explicitly passing color="primary". This forces the button to always use color='primary' regardless of the needsUpdate state.

### Issues Resolved

NA

## Screenshot

Verified all current supported themes:

https://github.com/user-attachments/assets/a354b3fb-ab7c-43cf-8bdc-2a86cf4f4bfb



## Changelog

- fix: [Explore] Fix QueryExecutionButton color inconsistency


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
