### PR TITLE
[Explore] query panel generated query updates

### DIFF
--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/query_panel_editor.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/query_panel_editor.scss
@@ -2,13 +2,31 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-@import "../shared";
 
 // This is for the animation colors
 /* stylelint-disable  @osd/stylelint/no_restricted_values */
 
 .exploreQueryPanelEditor {
-  @include exploreEditor;
+  border: 1px solid $ouiBorderColor;
+  border-radius: $ouiBorderRadius;
+  cursor: text;
+  padding: $ouiSizeS $ouiSizeXS;
+  position: relative;
+
+  &--focused {
+    border-bottom-width: 2px;
+    border-bottom-color: $ouiColorPrimary;
+    margin-bottom: -1px; // prevent layout shifting due to increase in border width;
+  }
+
+  &__placeholder {
+    position: absolute;
+    left: 29px; // hard-code to match where the text is in editor
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: $ouiFontSizeXS;
+    color: $ouiColorDisabledText;
+  }
 
   &--promptMode {
     padding-left: 27px; // hard-coding to match the start position of query mode. There must be a better way

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.scss
@@ -14,19 +14,34 @@
   padding-left: $ouiSizeXS;
   padding-top: $ouiSizeS;
   padding-bottom: $ouiSizeXXS;
+  position: relative;
 
   &__queryWrapper {
     display: flex;
-    align-items: center;
   }
 
   &__query {
+    @include ouiYScroll;
+
     color: $ouiColorDisabledText;
     // stylelint-disable-next-line @osd/stylelint/no_restricted_properties
     font-family: $ouiCodeFontFamily;
     line-height: normal;
     padding-left: 12px; // make it aligned with query editor
-    max-height: calc($ouiSize * 3);
-    overflow-y: auto;
+    padding-top: 3px;
+    padding-right: 94px; // make edit button appear
+    max-height: calc($ouiSize * 4);
+    word-break: break-all;
+  }
+
+  // This is to not have it centered when query is multi-lined
+  &__icon {
+    margin-top: 7px;
+  }
+
+  &__editButton {
+    position: absolute;
+    right: 0;
+    top: $ouiSizeS;
   }
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_generated_query/query_panel_generated_query.tsx
@@ -35,7 +35,11 @@ export const QueryPanelGeneratedQuery = () => {
   return (
     <div className="exploreQueryPanelGeneratedQuery">
       <div className="exploreQueryPanelGeneratedQuery__queryWrapper">
-        <EuiIcon type="editorCodeBlock" size="s" />
+        <EuiIcon
+          type="editorCodeBlock"
+          size="s"
+          className="exploreQueryPanelGeneratedQuery__icon"
+        />
         <EuiText
           className="exploreQueryPanelGeneratedQuery__query"
           size="s"
@@ -45,6 +49,7 @@ export const QueryPanelGeneratedQuery = () => {
         </EuiText>
       </div>
       <EuiButtonEmpty
+        className="exploreQueryPanelGeneratedQuery__editButton"
         data-test-subj="exploreQueryPanelGeneratedQueryEditButton"
         onClick={onEditClick}
         size="xs"

--- a/src/plugins/explore/public/components/query_panel/shared.scss
+++ b/src/plugins/explore/public/components/query_panel/shared.scss
@@ -3,31 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-$exploreQueryPanelEditToolbarZIndex: 1;
-
-@mixin exploreEditor {
-  border: 1px solid $ouiBorderColor;
-  border-radius: $ouiBorderRadius;
-  cursor: text;
-  padding: $ouiSizeS $ouiSizeXS;
-  position: relative;
-
-  &--focused {
-    border-bottom-width: 2px;
-    border-bottom-color: $ouiColorPrimary;
-    margin-bottom: -1px; // prevent layout shifting due to increase in border width;
-  }
-
-  &__placeholder {
-    position: absolute;
-    left: 29px; // hard-code to match where the text is in editor
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: $ouiFontSizeXS;
-    color: $ouiColorDisabledText;
-  }
-}
-
 @mixin exploreQueryPanelButton {
   &__buttonTextWrapper {
     align-items: center;


### PR DESCRIPTION
### Description

- make the icon in generated query top aligned so that it doesn't get centered when text is multi-line
- move the scrollbar to the right side
- refactor some SCSS. specifically there was a `shared.scss` mixin that was only used in one place, so I removed the mixin and put the code in the css.

<img width="1415" height="364" alt="Screenshot 2025-08-05 at 5 10 56 PM" src="https://github.com/user-attachments/assets/dfed3a0e-d780-495b-bf99-a89b220f9602" />

## Changelog
- chore: query panel generated query ui updates

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
