### PR TITLE
[Explore] fix url state not properly synced with saved search

### DIFF
--- a/changelogs/fragments/10357.yml
+++ b/changelogs/fragments/10357.yml
@@ -1,0 +1,3 @@
+fix:
+- The updated query not properly apply when with the snapshot url of a saved search ([#10357](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10357))
+- The query reset to empty after saving a saved search ([#10357](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10357))

--- a/src/plugins/explore/public/application/utils/hooks/use_initial_query_execution.test.tsx
+++ b/src/plugins/explore/public/application/utils/hooks/use_initial_query_execution.test.tsx
@@ -21,6 +21,7 @@ import { executeQueries } from '../state_management/actions/query_actions';
 import { clearResults } from '../state_management/slices';
 import { detectAndSetOptimalTab } from '../state_management/actions/detect_optimal_tab';
 import { MockStore } from '../state_management/__mocks__';
+import * as CurrentExploreIdHook from './use_current_explore_id';
 
 // Mock Redux actions
 jest.mock('../state_management/actions/query_actions', () => ({
@@ -72,6 +73,8 @@ describe('useInitialQueryExecution', () => {
       }
       return action;
     });
+
+    jest.spyOn(CurrentExploreIdHook, 'useCurrentExploreId').mockReturnValue(undefined);
 
     mockServices = {
       uiSettings: {
@@ -215,6 +218,21 @@ describe('useInitialQueryExecution', () => {
       } as any;
 
       const { result } = renderHookWithProvider(servicesWithSearchDisabled);
+
+      expect(mockServices.data.query.queryString.addToQueryHistory).not.toHaveBeenCalled();
+      expect(mockClearResults).not.toHaveBeenCalled();
+      expect(mockExecuteQueries).not.toHaveBeenCalled();
+      expect(result.current.isInitialized).toBe(false);
+    });
+  });
+
+  describe('when current loading a saved search', () => {
+    beforeEach(() => {
+      jest.spyOn(CurrentExploreIdHook, 'useCurrentExploreId').mockReturnValue('mock-id');
+    });
+
+    it('should not execute query or add to history', () => {
+      const { result } = renderHookWithProvider(mockServices);
 
       expect(mockServices.data.query.queryString.addToQueryHistory).not.toHaveBeenCalled();
       expect(mockClearResults).not.toHaveBeenCalled();

--- a/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
@@ -46,9 +46,11 @@ export const useInitPage = () => {
 
         // Sync query from saved object to data plugin (explore doesn't use filters)
         const searchSourceFields = savedExplore.kibanaSavedObjectMeta;
+        const queryFromUrl = services.osdUrlStateStorage?.get('_q') ?? {};
         if (searchSourceFields?.searchSourceJSON) {
           const searchSource = JSON.parse(searchSourceFields.searchSourceJSON);
-          const query = searchSource.query;
+          const queryFromSavedSearch = searchSource.query;
+          const query = { ...queryFromSavedSearch, ...queryFromUrl };
           if (query) {
             dispatch(setQueryState(query));
             setEditorText(query.query);

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.tsx
@@ -36,7 +36,6 @@ export const LanguageReference = () => {
       id="languageReferencePopover"
       button={
         <EuiButtonIcon
-          aria-label="Language reference"
           size="xs"
           className="exploreLanguageReference"
           data-test-subj="exploreLanguageReference"

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_reference/language_reference.tsx
@@ -36,6 +36,7 @@ export const LanguageReference = () => {
       id="languageReferencePopover"
       button={
         <EuiButtonIcon
+          aria-label="Language reference"
           size="xs"
           className="exploreLanguageReference"
           data-test-subj="exploreLanguageReference"

--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -49,7 +49,7 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
     },
     data,
     uiSettings,
-    history,
+    scopedHistory,
   } = services;
 
   const uiState = useNewStateSelector(selectUIState);
@@ -85,9 +85,9 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
   const osdUrlStateStorage = useMemo(() => {
     return createOsdUrlStateStorage({
       useHash: uiSettings.get('state:storeInSessionStorage', false),
-      history: history(),
+      history: scopedHistory,
     });
-  }, [uiSettings, history]);
+  }, [uiSettings, scopedHistory]);
 
   const { startSyncingQueryStateWithUrl } = useSyncQueryStateWithUrl(
     data.query,

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
@@ -48,7 +48,15 @@ export interface OnSaveProps {
 
 export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern | Dataset }) => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
-  const { core, dashboard, savedObjects, toastNotifications, uiSettings, history, data } = services;
+  const {
+    core,
+    dashboard,
+    savedObjects,
+    toastNotifications,
+    uiSettings,
+    scopedHistory,
+    data,
+  } = services;
   const visualizationBuilder = getVisualizationBuilder();
   const axesMappings = useObservable(visualizationBuilder.axesMapping$);
   const chartConfig = useObservable(visualizationBuilder.styles$);
@@ -59,9 +67,9 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
   const osdUrlStateStorage = useMemo(() => {
     return createOsdUrlStateStorage({
       useHash: uiSettings.get('state:storeInSessionStorage', false),
-      history: history(),
+      history: scopedHistory,
     });
-  }, [uiSettings, history]);
+  }, [uiSettings, scopedHistory]);
 
   const { startSyncingQueryStateWithUrl } = useSyncQueryStateWithUrl(
     data.query,

--- a/src/plugins/explore/public/helpers/save_explore.ts
+++ b/src/plugins/explore/public/helpers/save_explore.ts
@@ -33,7 +33,7 @@ export async function saveSavedExplore({
   openAfterSave: boolean;
   newCopyOnSave?: boolean;
 }): Promise<SaveResult | undefined> {
-  const { toastNotifications, chrome, history, store } = services;
+  const { toastNotifications, chrome, store } = services;
 
   const currentTitle = savedExplore.title;
   savedExplore.title = newTitle;
@@ -77,7 +77,7 @@ export async function saveSavedExplore({
       });
 
       if (id !== originalId) {
-        history().push(`/view/${encodeURIComponent(id)}`);
+        services.scopedHistory?.push(`#/view/${encodeURIComponent(id)}`);
       } else {
         // Update browser title and breadcrumbs
         chrome.docTitle.change(newTitle);


### PR DESCRIPTION
### Description
1. Fixed an issue that the updated query not properly apply when with the snapshot url of a saved search
2. Fixed an issue that the query reset to empty after saving a saved search

Before:

https://github.com/user-attachments/assets/4bc4c807-138c-4a51-9c60-8a05c6045ef6


https://github.com/user-attachments/assets/81674cc0-42a7-424a-9a71-52b3177e7ded

After:

https://github.com/user-attachments/assets/c0dcf8fc-4a82-4fc8-b177-62f9414ca186



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- fix: the updated query not properly apply when with the snapshot url of a saved search
- fix: the query reset to empty after saving a saved search

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
