### PR TITLE
[Explore] Infer tooltip date format dynamically

### DIFF
--- a/changelogs/fragments/10358.yml
+++ b/changelogs/fragments/10358.yml
@@ -1,0 +1,2 @@
+fix:
+- Infer tooltip date format dynamically ([#10358](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10358))

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
@@ -40,8 +40,8 @@ jest.mock('../style_panel/axes/axes_selector', () => ({
   )),
 }));
 jest.mock('../style_panel/legend/legend', () => ({
-  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange, shouldShowLegend }) => (
-    <div data-test-subj="legend-panel" data-show-legend={shouldShowLegend}>
+  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
+    <div data-test-subj="legend-panel">
       <button
         data-test-subj="toggle-legend"
         onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
@@ -304,8 +304,7 @@ describe('AreaVisStyleControls', () => {
 
     render(<AreaVisStyleControls {...props} />);
 
-    const legendPanel = screen.getByTestId('legend-panel');
-    expect(legendPanel).toHaveAttribute('data-show-legend', 'true');
+    expect(screen.getByTestId('legend-panel')).toBeInTheDocument();
   });
 
   test('shows legend when FACET mapping is present', () => {
@@ -326,8 +325,7 @@ describe('AreaVisStyleControls', () => {
 
     render(<AreaVisStyleControls {...props} />);
 
-    const legendPanel = screen.getByTestId('legend-panel');
-    expect(legendPanel).toHaveAttribute('data-show-legend', 'true');
+    expect(screen.getByTestId('legend-panel')).toBeInTheDocument();
   });
 
   test('hides legend when no COLOR or FACET mappings are present', () => {

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
@@ -87,7 +87,6 @@ export const AreaVisStyleControls: React.FC<AreaVisStyleControlsProps> = ({
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                shouldShowLegend={shouldShowLegend}
                 legendOptions={{
                   show: styleOptions.addLegend,
                   position: styleOptions.legendPosition,

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
@@ -262,6 +262,22 @@ describe('Area Chart to_expression', () => {
       expect(thresholdLayer).toHaveProperty('mark.strokeWidth', 2);
       expect(thresholdLayer).toHaveProperty('mark.strokeDash');
     });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: mockNumericalColumns[0],
+        [AxisRole.X]: { ...mockDateColumns[0], column: undefined as any },
+      };
+      const result = createSimpleAreaChart(
+        mockTransformedData,
+        mockNumericalColumns,
+        mockDateColumns,
+        mockStyles,
+        incompleteAxisColumnMappings
+      );
+      const tooltip = result.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
+    });
   });
 
   describe('createMultiAreaChart', () => {
@@ -366,6 +382,24 @@ describe('Area Chart to_expression', () => {
         mockAxisColumnMappings
       );
       expect(customTitleResult).toHaveProperty('title', 'Custom Multi-Area Chart');
+    });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: mockNumericalColumns[0],
+        [AxisRole.COLOR]: mockCategoricalColumns[0],
+        [AxisRole.X]: { ...mockDateColumns[0], column: undefined as any },
+      };
+      const result = createMultiAreaChart(
+        mockTransformedData,
+        mockNumericalColumns,
+        [mockCategoricalColumns[0]],
+        mockDateColumns,
+        mockStyles,
+        incompleteAxisColumnMappings
+      );
+      const tooltip = result.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
     });
   });
 
@@ -521,6 +555,25 @@ describe('Area Chart to_expression', () => {
       expect(thresholdLayer).toHaveProperty('mark.color', '#E7664C');
       expect(thresholdLayer).toHaveProperty('mark.strokeWidth', 2);
       expect(thresholdLayer).toHaveProperty('mark.strokeDash');
+    });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: mockNumericalColumns[0],
+        [AxisRole.COLOR]: mockCategoricalColumns[0],
+        [AxisRole.FACET]: mockCategoricalColumns[1],
+        [AxisRole.X]: { ...mockDateColumns[0], column: undefined as any },
+      };
+      const result = createFacetedMultiAreaChart(
+        mockTransformedData,
+        mockNumericalColumns,
+        mockCategoricalColumns,
+        mockDateColumns,
+        mockStyles,
+        incompleteAxisColumnMappings
+      );
+      const tooltip = result.spec.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -7,7 +7,7 @@ import { AreaChartStyleControls } from './area_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings, AxisRole } from '../types';
 import { buildMarkConfig, createTimeMarkerLayer, applyAxisStyling } from '../line/line_chart_utils';
 import { createThresholdLayer, getStrokeDash } from '../style_panel/threshold/utils';
-import { inferTimeUnitFromTimestamps, timeUnitToFormat } from '../utils/utils';
+import { getTooltipFormat } from '../utils/utils';
 
 /**
  * Create a simple area chart with one metric and one date
@@ -32,12 +32,6 @@ export const createSimpleAreaChart = (
   const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
-
-  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
 
   const mainLayer = {
     mark: {
@@ -81,7 +75,7 @@ export const createSimpleAreaChart = (
             field: dateField,
             type: 'temporal',
             title: dateName,
-            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, dateField),
           },
           { field: metricField, type: 'quantitative', title: metricName },
         ],
@@ -148,12 +142,6 @@ export const createMultiAreaChart = (
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
-  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
-
   const mainLayer = {
     mark: {
       ...buildMarkConfig(styles, 'line'),
@@ -207,7 +195,7 @@ export const createMultiAreaChart = (
             field: dateField,
             type: 'temporal',
             title: dateName,
-            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, dateField),
           },
           { field: categoryField, type: 'nominal', title: categoryName },
           { field: metricField, type: 'quantitative', title: metricName },
@@ -270,12 +258,6 @@ export const createFacetedMultiAreaChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
-
-  const getTooltipFormat = (axis: typeof xAxisMapping, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
 
   return {
     $schema: VEGASCHEMA,
@@ -344,7 +326,7 @@ export const createFacetedMultiAreaChart = (
                   field: dateField,
                   type: 'temporal',
                   title: dateName,
-                  format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+                  format: getTooltipFormat(transformedData, dateField),
                 },
                 { field: category1Field, type: 'nominal', title: category1Name },
                 { field: metricField, type: 'quantitative', title: metricName },

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -7,6 +7,7 @@ import { AreaChartStyleControls } from './area_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings, AxisRole } from '../types';
 import { buildMarkConfig, createTimeMarkerLayer, applyAxisStyling } from '../line/line_chart_utils';
 import { createThresholdLayer, getStrokeDash } from '../style_panel/threshold/utils';
+import { inferTimeUnitFromTimestamps, timeUnitToFormat } from '../utils/utils';
 
 /**
  * Create a simple area chart with one metric and one date
@@ -30,8 +31,13 @@ export const createSimpleAreaChart = (
   const dateField = xAxisColumn?.column;
   const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
-
   const layers: any[] = [];
+
+  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
 
   const mainLayer = {
     mark: {
@@ -71,7 +77,12 @@ export const createSimpleAreaChart = (
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
-          { field: dateField, type: 'temporal', title: dateName },
+          {
+            field: dateField,
+            type: 'temporal',
+            title: dateName,
+            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+          },
           { field: metricField, type: 'quantitative', title: metricName },
         ],
       }),
@@ -137,6 +148,12 @@ export const createMultiAreaChart = (
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
+  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
+
   const mainLayer = {
     mark: {
       ...buildMarkConfig(styles, 'line'),
@@ -186,7 +203,12 @@ export const createMultiAreaChart = (
       // Optional: Add tooltip with all information if tooltip mode is not hidden
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
-          { field: dateField, type: 'temporal', title: dateName },
+          {
+            field: dateField,
+            type: 'temporal',
+            title: dateName,
+            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+          },
           { field: categoryField, type: 'nominal', title: categoryName },
           { field: metricField, type: 'quantitative', title: metricName },
         ],
@@ -248,6 +270,12 @@ export const createFacetedMultiAreaChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
+
+  const getTooltipFormat = (axis: typeof xAxisMapping, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
 
   return {
     $schema: VEGASCHEMA,
@@ -312,7 +340,12 @@ export const createFacetedMultiAreaChart = (
             // Optional: Add tooltip with all information if tooltip mode is not hidden
             ...(styles.tooltipOptions?.mode !== 'hidden' && {
               tooltip: [
-                { field: dateField, type: 'temporal', title: dateName },
+                {
+                  field: dateField,
+                  type: 'temporal',
+                  title: dateName,
+                  format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+                },
                 { field: category1Field, type: 'nominal', title: category1Name },
                 { field: metricField, type: 'quantitative', title: metricName },
               ],

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
@@ -95,32 +95,28 @@ jest.mock('../style_panel/threshold/threshold', () => ({
 }));
 
 jest.mock('../style_panel/legend/legend', () => ({
-  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange, shouldShowLegend }) => {
-    if (!shouldShowLegend) return null;
-    return (
-      <div data-test-subj="mockLegendOptionsPanel">
-        <button
-          data-test-subj="mockLegendShow"
-          onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
-        >
-          Toggle Legend
-        </button>
-        <button
-          data-test-subj="mockLegendPosition"
-          onClick={() => onLegendOptionsChange({ position: 'bottom' })}
-        >
-          Change Position
-        </button>
-        <button
-          data-test-subj="mockLegendBoth"
-          onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
-        >
-          Change Both
-        </button>
-        <div data-test-subj="shouldShowLegend">{shouldShowLegend.toString()}</div>
-      </div>
-    );
-  }),
+  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
+    <div data-test-subj="mockLegendOptionsPanel">
+      <button
+        data-test-subj="mockLegendShow"
+        onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+      >
+        Toggle Legend
+      </button>
+      <button
+        data-test-subj="mockLegendPosition"
+        onClick={() => onLegendOptionsChange({ position: 'bottom' })}
+      >
+        Change Position
+      </button>
+      <button
+        data-test-subj="mockLegendBoth"
+        onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
+      >
+        Change Both
+      </button>
+    </div>
+  )),
 }));
 
 jest.mock('../style_panel/tooltip/tooltip', () => ({
@@ -275,7 +271,6 @@ describe('BarVisStyleControls', () => {
     );
 
     expect(screen.getByTestId('mockLegendOptionsPanel')).toBeInTheDocument();
-    expect(screen.getByTestId('shouldShowLegend')).toHaveTextContent('true');
   });
 
   test('renders legend panel when FACET mapping is present', () => {
@@ -301,7 +296,6 @@ describe('BarVisStyleControls', () => {
     );
 
     expect(screen.getByTestId('mockLegendOptionsPanel')).toBeInTheDocument();
-    expect(screen.getByTestId('shouldShowLegend')).toHaveTextContent('true');
   });
 
   test('calls onStyleChange with correct parameters for legend options', async () => {
@@ -332,6 +326,7 @@ describe('BarVisStyleControls', () => {
     await userEvent.click(screen.getByTestId('mockLegendPosition'));
     expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: 'bottom' });
 
+    jest.clearAllMocks();
     await userEvent.click(screen.getByTestId('mockLegendBoth'));
     expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
     expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: 'top' });

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -106,7 +106,6 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                shouldShowLegend={shouldShowLegend}
                 legendOptions={{
                   show: styleOptions.addLegend,
                   position: styleOptions.legendPosition,

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
@@ -598,6 +598,22 @@ describe('bar to_expression', () => {
         createTimeBarChart(mockData, [mockNumericalColumn], [], defaultBarChartStyles);
       }).toThrow('Time bar chart requires at least one numerical column and one date column');
     });
+
+    test('falls back to default tooltip format when dateField is missing', () => {
+      const fallbackMapping = {
+        [AxisRole.X]: { ...mockDateColumn, column: undefined as any },
+        [AxisRole.Y]: mockNumericalColumn,
+      };
+      const result = createTimeBarChart(
+        mockData,
+        [mockNumericalColumn],
+        [mockDateColumn],
+        defaultBarChartStyles,
+        fallbackMapping
+      );
+      const tooltip = result.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
+    });
   });
 
   describe('createGroupedTimeBarChart', () => {
@@ -807,6 +823,27 @@ describe('bar to_expression', () => {
       }).toThrow(
         'Grouped time bar chart requires at least one numerical column, one categorical column, and one date column'
       );
+    });
+
+    test('falls back to default tooltip format when dateField is missing', () => {
+      const fallbackMapping = {
+        [AxisRole.X]: { ...mockDateColumn, column: undefined as any },
+        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.COLOR]: mockCategoricalColumn,
+      };
+      const result = createGroupedTimeBarChart(
+        mockData,
+        [mockNumericalColumn],
+        [mockCategoricalColumn],
+        [mockDateColumn],
+        defaultBarChartStyles,
+        fallbackMapping
+      );
+      const tooltip = result.encoding.tooltip;
+      expect(tooltip[0].field).toBeUndefined();
+      expect(tooltip[1].field).toBe('category');
+      expect(tooltip[2].field).toBe('count');
+      expect(tooltip[2].format).toBeUndefined();
     });
   });
 
@@ -1021,6 +1058,25 @@ describe('bar to_expression', () => {
       }).toThrow(
         'Faceted time bar chart requires at least one numerical column, two categorical columns, and one date column'
       );
+    });
+
+    test('falls back to default tooltip format when dateField is missing', () => {
+      const fallbackMapping = {
+        [AxisRole.X]: { ...mockDateColumn, column: undefined as any },
+        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.COLOR]: mockCategoricalColumn,
+        [AxisRole.FACET]: mockCategoricalColumn2,
+      };
+      const result = createFacetedTimeBarChart(
+        mockData,
+        [mockNumericalColumn],
+        [mockCategoricalColumn, mockCategoricalColumn2],
+        [mockDateColumn],
+        defaultBarChartStyles,
+        fallbackMapping
+      );
+      const tooltip = result.spec.layer[0].encoding.tooltip;
+      expect(tooltip[1].format).toBe('%b %d, %Y %H:%M:%S');
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -10,8 +10,7 @@ import {
   applyAxisStyling,
   getSwappedAxisRole,
   getSchemaByAxis,
-  inferTimeUnitFromTimestamps,
-  timeUnitToFormat,
+  getTooltipFormat,
 } from '../utils/utils';
 
 // Only set size and binSpacing in manual mode
@@ -155,12 +154,6 @@ export const createTimeBarChart = (
     barMark.strokeWidth = styles.barBorderWidth || 1;
   }
 
-  const getTooltipFormat = (axis: typeof xAxis | typeof yAxis, fallback: string): string => {
-    return axis?.column
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, axis.column)] ?? fallback
-      : fallback;
-  };
-
   const mainLayer = {
     mark: barMark,
     encoding: {
@@ -181,7 +174,7 @@ export const createTimeBarChart = (
             type: getSchemaByAxis(xAxis),
             title: xAxis?.styles?.title?.text || xAxis?.name,
             ...(getSchemaByAxis(xAxis) === 'temporal' && {
-              format: getTooltipFormat(xAxis, '%b %d, %Y %H:%M:%S'),
+              format: getTooltipFormat(transformedData, xAxis?.column),
             }),
           },
           {
@@ -189,7 +182,7 @@ export const createTimeBarChart = (
             type: getSchemaByAxis(yAxis),
             title: yAxis?.styles?.title?.text || yAxis?.name,
             ...(getSchemaByAxis(yAxis) === 'temporal' && {
-              format: getTooltipFormat(yAxis, '%b %d, %Y %H:%M:%S'),
+              format: getTooltipFormat(transformedData, yAxis?.column),
             }),
           },
         ],
@@ -273,12 +266,6 @@ export const createGroupedTimeBarChart = (
     barMark.strokeWidth = styles.barBorderWidth || 1;
   }
 
-  const getTooltipFormat = (axis: typeof xAxis | typeof yAxis, fallback: string): string => {
-    return axis?.column
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, axis.column)] ?? fallback
-      : fallback;
-  };
-
   const spec: any = {
     $schema: VEGASCHEMA,
     title: styles.titleOptions?.show
@@ -314,7 +301,7 @@ export const createGroupedTimeBarChart = (
           type: getSchemaByAxis(xAxis),
           title: xAxis?.styles?.title?.text || xAxis?.name,
           ...(getSchemaByAxis(xAxis) === 'temporal' && {
-            format: getTooltipFormat(xAxis, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, xAxis?.column),
           }),
         },
         { field: categoryField, type: getSchemaByAxis(colorColumn), title: categoryName },
@@ -323,7 +310,7 @@ export const createGroupedTimeBarChart = (
           type: getSchemaByAxis(yAxis),
           title: yAxis?.styles?.title?.text || yAxis?.name,
           ...(getSchemaByAxis(yAxis) === 'temporal' && {
-            format: getTooltipFormat(yAxis, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, yAxis?.column),
           }),
         },
       ],
@@ -404,12 +391,6 @@ export const createFacetedTimeBarChart = (
     barEncodingDefault
   );
 
-  const getTooltipFormat = (axis: typeof xAxis | typeof yAxis, fallback: string): string => {
-    return axis?.column
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, axis.column)] ?? fallback
-      : fallback;
-  };
-
   return {
     $schema: VEGASCHEMA,
     title: styles.titleOptions?.show
@@ -454,7 +435,7 @@ export const createFacetedTimeBarChart = (
                   type: getSchemaByAxis(yAxis),
                   title: metricName,
                   ...(getSchemaByAxis(yAxis) === 'temporal' && {
-                    format: getTooltipFormat(yAxis, '%b %d, %Y %H:%M:%S'),
+                    format: getTooltipFormat(transformedData, yAxis?.column),
                   }),
                 },
                 {
@@ -462,7 +443,7 @@ export const createFacetedTimeBarChart = (
                   type: getSchemaByAxis(xAxis),
                   title: dateName,
                   ...(getSchemaByAxis(xAxis) === 'temporal' && {
-                    format: getTooltipFormat(xAxis, '%b %d, %Y %H:%M:%S'),
+                    format: getTooltipFormat(transformedData, xAxis?.column),
                   }),
                 },
                 { field: category1Field, type: 'nominal', title: category1Name },

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.test.tsx
@@ -146,11 +146,9 @@ jest.mock('./heatmap_exclusive_vis_options', () => ({
 }));
 
 jest.mock('../style_panel/legend/legend', () => {
-  // Import Positions inside the mock to avoid reference error
   const { Positions: PositionsEnum } = jest.requireActual('../types');
-
   return {
-    LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange, shouldShowLegend }) => (
+    LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
       <div data-test-subj="mockLegendOptionsPanel">
         <button
           data-test-subj="mockLegendShow"
@@ -164,11 +162,28 @@ jest.mock('../style_panel/legend/legend', () => {
         >
           Change Position
         </button>
-        <div data-test-subj="shouldShowLegend">{shouldShowLegend.toString()}</div>
       </div>
     )),
   };
 });
+
+jest.mock('../style_panel/title/title', () => ({
+  TitleOptionsPanel: jest.fn(({ titleOptions, onShowTitleChange }) => (
+    <div data-test-subj="mockTitleOptionsPanel">
+      <button
+        data-test-subj="titleModeSwitch"
+        onClick={() => onShowTitleChange({ show: !titleOptions.show })}
+      >
+        Toggle Title
+      </button>
+      <input
+        data-test-subj="titleInput"
+        placeholder="Default title"
+        onChange={(e) => onShowTitleChange({ titleName: e.target.value })}
+      />
+    </div>
+  )),
+}));
 
 jest.mock('../style_panel/tooltip/tooltip', () => ({
   TooltipOptionsPanel: jest.fn(({ tooltipOptions, onTooltipOptionsChange }) => (
@@ -235,6 +250,7 @@ describe('HeatmapVisStyleControls', () => {
     expect(screen.getByTestId('heatmapLabelOptions')).toBeInTheDocument();
     expect(screen.getByTestId('heatmapExclusiveOptions')).toBeInTheDocument();
     expect(screen.queryByTestId('mockLegendOptionsPanel')).toBeInTheDocument();
+    expect(screen.getByTestId('mockTitleOptionsPanel')).toBeInTheDocument();
   });
 
   it('calls onStyleChange with correct parameters for legend options', () => {

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
@@ -82,7 +82,6 @@ export const HeatmapVisStyleControls: React.FC<HeatmapVisStyleControlsProps> = (
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                shouldShowLegend={shouldShowLegend}
                 legendOptions={{
                   show: styleOptions.addLegend,
                   position: styleOptions.legendPosition,

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.test.tsx
@@ -34,33 +34,30 @@ jest.mock('../style_panel/axes/axes_selector', () => ({
     </div>
   )),
 }));
+
 jest.mock('../style_panel/legend/legend', () => ({
-  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange, shouldShowLegend }) => {
-    if (!shouldShowLegend) return null;
-    return (
-      <div data-test-subj="mockLegendOptionsPanel">
-        <button
-          data-test-subj="mockLegendShow"
-          onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
-        >
-          Toggle Legend
-        </button>
-        <button
-          data-test-subj="mockLegendPosition"
-          onClick={() => onLegendOptionsChange({ position: 'bottom' })}
-        >
-          Change Position
-        </button>
-        <button
-          data-test-subj="mockLegendBoth"
-          onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
-        >
-          Change Both
-        </button>
-        <div data-test-subj="shouldShowLegend">{shouldShowLegend.toString()}</div>
-      </div>
-    );
-  }),
+  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
+    <div data-test-subj="mockLegendOptionsPanel">
+      <button
+        data-test-subj="mockLegendShow"
+        onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+      >
+        Toggle Legend
+      </button>
+      <button
+        data-test-subj="mockLegendPosition"
+        onClick={() => onLegendOptionsChange({ position: 'bottom' })}
+      >
+        Change Position
+      </button>
+      <button
+        data-test-subj="mockLegendBoth"
+        onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
+      >
+        Change Both
+      </button>
+    </div>
+  )),
 }));
 
 jest.mock('../style_panel/threshold/threshold', () => ({
@@ -324,7 +321,6 @@ describe('LineVisStyleControls', () => {
     render(<LineVisStyleControls {...propsWithNoLegend} />);
 
     expect(screen.queryByTestId('mockLegendOptionsPanel')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('shouldShowLegend')).not.toBeInTheDocument();
   });
 
   test('renders legend panel when COLOR mapping is present', () => {
@@ -339,7 +335,6 @@ describe('LineVisStyleControls', () => {
     render(<LineVisStyleControls {...propsWithColorMapping} />);
 
     expect(screen.getByTestId('mockLegendOptionsPanel')).toBeInTheDocument();
-    expect(screen.getByTestId('shouldShowLegend')).toHaveTextContent('true');
   });
 
   test('renders legend panel when FACET mapping is present', () => {
@@ -354,7 +349,6 @@ describe('LineVisStyleControls', () => {
     render(<LineVisStyleControls {...propsWithFacetMapping} />);
 
     expect(screen.getByTestId('mockLegendOptionsPanel')).toBeInTheDocument();
-    expect(screen.getByTestId('shouldShowLegend')).toHaveTextContent('true');
   });
 
   test('renders legend panel when Y_SECOND mapping is present', () => {
@@ -369,7 +363,6 @@ describe('LineVisStyleControls', () => {
     render(<LineVisStyleControls {...propsWithYSecondMapping} />);
 
     expect(screen.getByTestId('mockLegendOptionsPanel')).toBeInTheDocument();
-    expect(screen.getByTestId('shouldShowLegend')).toHaveTextContent('true');
   });
 
   test('calls onStyleChange with correct parameters for legend options', async () => {

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
@@ -104,7 +104,6 @@ export const LineVisStyleControls: React.FC<LineVisStyleControlsProps> = ({
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                shouldShowLegend={shouldShowLegend}
                 legendOptions={{
                   show: styleOptions.addLegend,
                   position: styleOptions.legendPosition,

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
@@ -222,6 +222,24 @@ describe('to_expression', () => {
       );
       expect(customTitleResult.title).toBe('Custom Simple Line Chart');
     });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: numericColumn1,
+        [AxisRole.X]: { ...dateColumn, column: undefined as any },
+      };
+
+      const result = createSimpleLineChart(
+        transformedData,
+        [numericColumn1],
+        [dateColumn],
+        styleOptions,
+        incompleteAxisColumnMappings
+      );
+
+      const tooltip = result.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
+    });
   });
 
   describe('createLineBarChart', () => {
@@ -327,6 +345,28 @@ describe('to_expression', () => {
       );
       expect(customTitleResult.title).toBe('Custom Line-Bar Chart');
     });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: numericColumn1,
+        [AxisRole.Y_SECOND]: numericColumn2,
+        [AxisRole.X]: { ...dateColumn, column: undefined as any },
+      };
+
+      const result = createLineBarChart(
+        transformedData,
+        [numericColumn1, numericColumn2],
+        [dateColumn],
+        styleOptions,
+        incompleteAxisColumnMappings
+      );
+
+      const barTooltip = result.layer[0].layer[0].encoding.tooltip;
+      const lineTooltip = result.layer[1].encoding.tooltip;
+
+      expect(barTooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
+      expect(lineTooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
+    });
   });
 
   describe('createMultiLineChart', () => {
@@ -426,6 +466,26 @@ describe('to_expression', () => {
         mockAxisColumnMappings
       );
       expect(customTitleResult.title).toBe('Custom Multi-Line Chart');
+    });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: numericColumn1,
+        [AxisRole.COLOR]: categoricalColumn1,
+        [AxisRole.X]: { ...dateColumn, column: undefined as any },
+      };
+
+      const result = createMultiLineChart(
+        transformedData,
+        [numericColumn1],
+        [categoricalColumn1],
+        [dateColumn],
+        styleOptions,
+        incompleteAxisColumnMappings
+      );
+
+      const tooltip = result.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
     });
   });
 
@@ -545,6 +605,27 @@ describe('to_expression', () => {
         mockAxisColumnMappings
       );
       expect(customTitleResult.title).toBe('Custom Faceted Line Chart');
+    });
+
+    it('should fallback to default tooltip format when dateField is missing', () => {
+      const incompleteAxisColumnMappings: AxisColumnMappings = {
+        [AxisRole.Y]: numericColumn1,
+        [AxisRole.COLOR]: categoricalColumn1,
+        [AxisRole.FACET]: categoricalColumn2,
+        [AxisRole.X]: { ...dateColumn, column: undefined as any },
+      };
+
+      const result = createFacetedMultiLineChart(
+        transformedData,
+        [numericColumn1],
+        [categoricalColumn1, categoricalColumn2],
+        [dateColumn],
+        styleOptions,
+        incompleteAxisColumnMappings
+      );
+
+      const tooltip = result.spec.layer[0].encoding.tooltip;
+      expect(tooltip[0].format).toBe('%b %d, %Y %H:%M:%S');
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -12,6 +12,7 @@ import {
   ValueAxisPosition,
 } from './line_chart_utils';
 import { createThresholdLayer, getStrokeDash } from '../style_panel/threshold/utils';
+import { inferTimeUnitFromTimestamps, timeUnitToFormat } from '../utils/utils';
 
 /**
  * Rule 1: Create a simple line chart with one metric and one date
@@ -36,6 +37,12 @@ export const createSimpleLineChart = (
   const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
+
+  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
 
   const mainLayer = {
     mark: buildMarkConfig(styles, 'line'),
@@ -70,7 +77,12 @@ export const createSimpleLineChart = (
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
-          { field: dateField, type: 'temporal', title: dateName },
+          {
+            field: dateField,
+            type: 'temporal',
+            title: dateName,
+            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+          },
           { field: metricField, type: 'quantitative', title: metricName },
         ],
       }),
@@ -128,6 +140,12 @@ export const createLineBarChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const layers: any[] = [];
 
+  const getTooltipFormat = (axis: typeof xAxisMapping, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
+
   const barLayer = {
     mark: buildMarkConfig(styles, 'bar'),
     encoding: {
@@ -171,7 +189,12 @@ export const createLineBarChart = (
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
-          { field: dateField, type: 'temporal', title: dateName },
+          {
+            field: dateField,
+            type: 'temporal',
+            title: dateName,
+            format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+          },
           { field: metric1Field, type: 'quantitative', title: metric1Name },
         ],
       }),
@@ -217,7 +240,12 @@ export const createLineBarChart = (
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
-          { field: dateField, type: 'temporal', title: dateName },
+          {
+            field: dateField,
+            type: 'temporal',
+            title: dateName,
+            format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+          },
           { field: metric2Field, type: 'quantitative', title: metric2Name },
         ],
       }),
@@ -280,6 +308,12 @@ export const createMultiLineChart = (
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
+  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
+
   const mainLayer = {
     mark: buildMarkConfig(styles, 'line'),
     encoding: {
@@ -324,7 +358,12 @@ export const createMultiLineChart = (
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
-          { field: dateField, type: 'temporal', title: dateName },
+          {
+            field: dateField,
+            type: 'temporal',
+            title: dateName,
+            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+          },
           { field: metricField, type: 'quantitative', title: metricName },
           { field: categoryField, type: 'nominal', title: categoryName },
         ],
@@ -390,6 +429,12 @@ export const createFacetedMultiLineChart = (
   // Create a mark config for the faceted spec
   const facetMarkConfig = buildMarkConfig(styles, 'line');
 
+  const getTooltipFormat = (axis: typeof xAxisMapping, fallback: string): string => {
+    return dateField
+      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
+      : fallback;
+  };
+
   return {
     $schema: VEGASCHEMA,
     title: styles.titleOptions?.show
@@ -448,7 +493,12 @@ export const createFacetedMultiLineChart = (
             },
             ...(styles.tooltipOptions?.mode !== 'hidden' && {
               tooltip: [
-                { field: dateField, type: 'temporal', title: dateName },
+                {
+                  field: dateField,
+                  type: 'temporal',
+                  title: dateName,
+                  format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+                },
                 { field: metricField, type: 'quantitative', title: metricName },
                 { field: category1Field, type: 'nominal', title: category1Name },
               ],

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -12,7 +12,7 @@ import {
   ValueAxisPosition,
 } from './line_chart_utils';
 import { createThresholdLayer, getStrokeDash } from '../style_panel/threshold/utils';
-import { inferTimeUnitFromTimestamps, timeUnitToFormat } from '../utils/utils';
+import { getTooltipFormat } from '../utils/utils';
 
 /**
  * Rule 1: Create a simple line chart with one metric and one date
@@ -37,12 +37,6 @@ export const createSimpleLineChart = (
   const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const layers: any[] = [];
-
-  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
 
   const mainLayer = {
     mark: buildMarkConfig(styles, 'line'),
@@ -81,7 +75,7 @@ export const createSimpleLineChart = (
             field: dateField,
             type: 'temporal',
             title: dateName,
-            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, dateField),
           },
           { field: metricField, type: 'quantitative', title: metricName },
         ],
@@ -140,12 +134,6 @@ export const createLineBarChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const layers: any[] = [];
 
-  const getTooltipFormat = (axis: typeof xAxisMapping, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
-
   const barLayer = {
     mark: buildMarkConfig(styles, 'bar'),
     encoding: {
@@ -193,7 +181,7 @@ export const createLineBarChart = (
             field: dateField,
             type: 'temporal',
             title: dateName,
-            format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, dateField),
           },
           { field: metric1Field, type: 'quantitative', title: metric1Name },
         ],
@@ -244,7 +232,7 @@ export const createLineBarChart = (
             field: dateField,
             type: 'temporal',
             title: dateName,
-            format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, dateField),
           },
           { field: metric2Field, type: 'quantitative', title: metric2Name },
         ],
@@ -308,12 +296,6 @@ export const createMultiLineChart = (
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
 
-  const getTooltipFormat = (axis: typeof xAxisColumn, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
-
   const mainLayer = {
     mark: buildMarkConfig(styles, 'line'),
     encoding: {
@@ -362,7 +344,7 @@ export const createMultiLineChart = (
             field: dateField,
             type: 'temporal',
             title: dateName,
-            format: getTooltipFormat(xAxisColumn, '%b %d, %Y %H:%M:%S'),
+            format: getTooltipFormat(transformedData, dateField),
           },
           { field: metricField, type: 'quantitative', title: metricName },
           { field: categoryField, type: 'nominal', title: categoryName },
@@ -429,12 +411,6 @@ export const createFacetedMultiLineChart = (
   // Create a mark config for the faceted spec
   const facetMarkConfig = buildMarkConfig(styles, 'line');
 
-  const getTooltipFormat = (axis: typeof xAxisMapping, fallback: string): string => {
-    return dateField
-      ? timeUnitToFormat[inferTimeUnitFromTimestamps(transformedData, dateField)] ?? fallback
-      : fallback;
-  };
-
   return {
     $schema: VEGASCHEMA,
     title: styles.titleOptions?.show
@@ -497,7 +473,7 @@ export const createFacetedMultiLineChart = (
                   field: dateField,
                   type: 'temporal',
                   title: dateName,
-                  format: getTooltipFormat(xAxisMapping, '%b %d, %Y %H:%M:%S'),
+                  format: getTooltipFormat(transformedData, dateField),
                 },
                 { field: metricField, type: 'quantitative', title: metricName },
                 { field: category1Field, type: 'nominal', title: category1Name },

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.tsx
@@ -60,7 +60,6 @@ export const PieVisStyleControls: React.FC<PieVisStyleControlsProps> = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <LegendOptionsPanel
-              shouldShowLegend={true}
               legendOptions={{
                 show: styleOptions.addLegend,
                 position: styleOptions.legendPosition,

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.test.tsx
@@ -108,9 +108,8 @@ jest.mock('./scatter_exclusive_vis_options', () => ({
 jest.mock('../style_panel/legend/legend', () => {
   // Import Positions inside the mock to avoid reference error
   const { Positions: PositionsEnum } = jest.requireActual('../types');
-
   return {
-    LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange, shouldShowLegend }) => (
+    LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
       <div data-test-subj="mockLegendOptionsPanel">
         <button
           data-test-subj="mockLegendShow"
@@ -124,11 +123,28 @@ jest.mock('../style_panel/legend/legend', () => {
         >
           Change Position
         </button>
-        <div data-test-subj="shouldShowLegend">{shouldShowLegend.toString()}</div>
       </div>
     )),
   };
 });
+
+jest.mock('../style_panel/title/title', () => ({
+  TitleOptionsPanel: jest.fn(({ titleOptions, onShowTitleChange }) => (
+    <div data-test-subj="mockTitleOptionsPanel">
+      <button
+        data-test-subj="titleModeSwitch"
+        onClick={() => onShowTitleChange({ show: !titleOptions.show })}
+      >
+        Toggle Title
+      </button>
+      <input
+        data-test-subj="titleInput"
+        placeholder="Default title"
+        onChange={(e) => onShowTitleChange({ titleName: e.target.value })}
+      />
+    </div>
+  )),
+}));
 
 jest.mock('../style_panel/tooltip/tooltip', () => ({
   TooltipOptionsPanel: jest.fn(({ tooltipOptions, onTooltipOptionsChange }) => (
@@ -210,6 +226,7 @@ describe('ScatterVisStyleControls (updated structure)', () => {
     expect(screen.getByTestId('mockTooltipOptionsPanel')).toBeInTheDocument();
     expect(screen.getByTestId('scatterExclusiveOptions')).toBeInTheDocument();
     expect(screen.queryByTestId('mockLegendOptionsPanel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mockTitleOptionsPanel')).toBeInTheDocument();
   });
 
   it('renders and shows legend panel when categorical color column is present', () => {

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
@@ -80,7 +80,6 @@ export const ScatterVisStyleControls: React.FC<ScatterVisStyleControlsProps> = (
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                shouldShowLegend={shouldShowLegend}
                 legendOptions={{
                   show: styleOptions.addLegend,
                   position: styleOptions.legendPosition,

--- a/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.test.tsx
@@ -28,11 +28,7 @@ describe('LegendOptionsPanel', () => {
 
   it('renders correctly', () => {
     render(
-      <LegendOptionsPanel
-        legendOptions={mockLegend}
-        onLegendOptionsChange={mockOnLegendChange}
-        shouldShowLegend={true}
-      />
+      <LegendOptionsPanel legendOptions={mockLegend} onLegendOptionsChange={mockOnLegendChange} />
     );
 
     const legendModeSwitch = screen.getByTestId('legendModeSwitch');
@@ -44,11 +40,7 @@ describe('LegendOptionsPanel', () => {
 
   it('update legend mode correctly', () => {
     render(
-      <LegendOptionsPanel
-        legendOptions={mockLegend}
-        onLegendOptionsChange={mockOnLegendChange}
-        shouldShowLegend={true}
-      />
+      <LegendOptionsPanel legendOptions={mockLegend} onLegendOptionsChange={mockOnLegendChange} />
     );
 
     const legendModeSwitch = screen.getByTestId('legendModeSwitch');
@@ -61,11 +53,7 @@ describe('LegendOptionsPanel', () => {
 
   it('update legend position correctly', () => {
     render(
-      <LegendOptionsPanel
-        legendOptions={mockLegend}
-        onLegendOptionsChange={mockOnLegendChange}
-        shouldShowLegend={true}
-      />
+      <LegendOptionsPanel legendOptions={mockLegend} onLegendOptionsChange={mockOnLegendChange} />
     );
 
     const legendPositionSelect = screen.getByTestId('legendPositionSelect');
@@ -74,5 +62,22 @@ describe('LegendOptionsPanel', () => {
     expect(mockOnLegendChange).toHaveBeenLastCalledWith({
       position: Positions.RIGHT,
     });
+  });
+
+  it('returns null when legendOptions is undefined', () => {
+    const { container } = render(
+      <LegendOptionsPanel
+        legendOptions={undefined as any}
+        onLegendOptionsChange={mockOnLegendChange}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when onLegendOptionsChange is undefined', () => {
+    const { container } = render(
+      <LegendOptionsPanel legendOptions={mockLegend} onLegendOptionsChange={undefined as any} />
+    );
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.tsx
@@ -17,15 +17,13 @@ export interface LegendOptions {
 export interface LegendOptionsProps {
   legendOptions: LegendOptions;
   onLegendOptionsChange: (legendOptions: Partial<LegendOptions>) => void;
-  shouldShowLegend?: boolean;
 }
 
 export const LegendOptionsPanel = ({
   legendOptions,
   onLegendOptionsChange,
-  shouldShowLegend = true,
 }: LegendOptionsProps) => {
-  if (!shouldShowLegend || !legendOptions || !onLegendOptionsChange) {
+  if (!legendOptions || !onLegendOptionsChange) {
     return null;
   }
 

--- a/src/plugins/explore/public/components/visualizations/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.test.ts
@@ -12,6 +12,7 @@ import {
   getSwappedAxisRole,
   getSchemaByAxis,
   inferTimeUnitFromTimestamps,
+  getTooltipFormat,
 } from './utils';
 import { AxisRole, Positions, ColorSchemas, VisFieldType, StandardAxes } from '../types';
 
@@ -257,9 +258,27 @@ describe('getSchemaByAxis', () => {
 describe('inferTimeUnitFromTimestamps', () => {
   const field = 'timestamp';
 
-  it('returns second for less than 2 timestamps', () => {
+  it('returns null for undefined data', () => {
+    expect(inferTimeUnitFromTimestamps(undefined as any, field)).toBeNull();
+  });
+
+  it('returns null for empty data array', () => {
+    expect(inferTimeUnitFromTimestamps([], field)).toBeNull();
+  });
+
+  it('returns null for empty field', () => {
     const data = [{ timestamp: '2023-01-01' }];
-    expect(inferTimeUnitFromTimestamps(data, field)).toBe('second');
+    expect(inferTimeUnitFromTimestamps(data, '')).toBeNull();
+  });
+
+  it('returns null for less than 2 valid timestamps', () => {
+    const data = [{ timestamp: '2023-01-01' }];
+    expect(inferTimeUnitFromTimestamps(data, field)).toBeNull();
+  });
+
+  it('returns null for all invalid timestamps', () => {
+    const data = [{ timestamp: 'invalid' }, { timestamp: 'invalid' }];
+    expect(inferTimeUnitFromTimestamps(data, field)).toBeNull();
   });
 
   it('returns second for differences less than 60 seconds', () => {
@@ -297,12 +316,87 @@ describe('inferTimeUnitFromTimestamps', () => {
     expect(inferTimeUnitFromTimestamps(data, field)).toBe('year');
   });
 
-  it('handles invalid timestamps by filtering them out', () => {
+  it('handles invalid timestamps with some valid ones', () => {
     const data = [
       { timestamp: 'invalid' },
       { timestamp: '2023-01-01T00:00:00' },
       { timestamp: '2023-01-01T00:00:30' },
     ];
     expect(inferTimeUnitFromTimestamps(data, field)).toBe('second');
+  });
+});
+
+describe('getTooltipFormat', () => {
+  const field = 'timestamp';
+  const defaultFallback = '%b %d, %Y %H:%M:%S';
+
+  it('returns fallback format when field is empty', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }];
+    expect(getTooltipFormat(data, '', defaultFallback)).toBe(defaultFallback);
+  });
+
+  it('returns fallback format when data is undefined', () => {
+    expect(getTooltipFormat(undefined as any, field, defaultFallback)).toBe(defaultFallback);
+  });
+
+  it('returns fallback format when data is empty', () => {
+    expect(getTooltipFormat([], field, defaultFallback)).toBe(defaultFallback);
+  });
+
+  it('returns fallback format for less than 2 valid timestamps', () => {
+    const data = [{ timestamp: '2023-01-01' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe(defaultFallback);
+  });
+
+  it('returns fallback format for all invalid timestamps', () => {
+    const data = [{ timestamp: 'invalid' }, { timestamp: 'invalid' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe(defaultFallback);
+  });
+
+  it('returns second format for differences less than 60 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2023-01-01T00:00:30' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%b %d, %Y %H:%M:%S');
+  });
+
+  it('returns minute format for differences less than 3600 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2023-01-01T00:01:00' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%b %d, %Y %H:%M');
+  });
+
+  it('returns hour format for differences less than 86400 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2023-01-01T01:00:00' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%b %d, %Y %H:%M');
+  });
+
+  it('returns day format for differences less than 604800 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2023-01-02T00:00:00' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%b %d, %Y');
+  });
+
+  it('returns week format for differences less than 2678400 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2023-01-08T00:00:00' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%b %d, %Y');
+  });
+
+  it('returns month format for differences less than 31536000 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2023-02-01T00:00:00' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%b %Y');
+  });
+
+  it('returns year format for differences greater than or equal to 31536000 seconds', () => {
+    const data = [{ timestamp: '2023-01-01T00:00:00' }, { timestamp: '2024-01-01T00:00:00' }];
+    expect(getTooltipFormat(data, field, defaultFallback)).toBe('%Y');
+  });
+
+  it('uses custom fallback format when provided with invalid timestamps', () => {
+    const customFallback = '%Y-%m-%d';
+    const data = [{ timestamp: 'invalid' }, { timestamp: 'invalid' }];
+    expect(getTooltipFormat(data, field, customFallback)).toBe(customFallback);
+  });
+
+  it('uses custom fallback format when only one valid timestamp is provided', () => {
+    const customFallback = '%Y-%m-%d';
+    const data = [{ timestamp: '2023-01-01T00:00:00' }];
+    expect(getTooltipFormat(data, field, customFallback)).toBe(customFallback);
   });
 });

--- a/src/plugins/explore/public/components/visualizations/utils/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.ts
@@ -245,7 +245,7 @@ export const timeUnitToFormat: { [key: string]: string } = {
  */
 export const inferTimeUnitFromTimestamps = (
   data: Array<Record<string, any>>,
-  field: string
+  field: string | undefined
 ): string | null => {
   if (!data || data.length === 0 || !field) {
     return null;
@@ -288,9 +288,9 @@ export const inferTimeUnitFromTimestamps = (
  */
 export const getTooltipFormat = (
   data: Array<Record<string, any>>,
-  field: string | undefined, // Updated to accept string | undefined
+  field: string | undefined,
   fallback = '%b %d, %Y %H:%M:%S'
 ): string => {
-  const timeUnit = inferTimeUnitFromTimestamps(data, field || ''); // Use empty string if field is undefined
+  const timeUnit = inferTimeUnitFromTimestamps(data, field);
   return timeUnit ? timeUnitToFormat[timeUnit] ?? fallback : fallback;
 };

--- a/src/plugins/explore/public/components/visualizations/utils/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.ts
@@ -237,17 +237,27 @@ export const timeUnitToFormat: { [key: string]: string } = {
   second: '%b %d, %Y %H:%M:%S',
 };
 
+/**
+ * Infers the time unit from timestamps in the data.
+ * @param data The transformed data array
+ * @param field The field name for the temporal axis
+ * @returns The inferred time unit or null if insufficient valid timestamps
+ */
 export const inferTimeUnitFromTimestamps = (
   data: Array<Record<string, any>>,
   field: string
-): string => {
+): string | null => {
+  if (!data || data.length === 0 || !field) {
+    return null;
+  }
+
   const timestamps = data
     .map((row) => new Date(row[field]).getTime())
     .filter((t) => !isNaN(t))
     .sort((a, b) => a - b);
 
   if (timestamps.length < 2) {
-    return 'second';
+    return null;
   }
 
   let minDiff = Number.MAX_SAFE_INTEGER;
@@ -267,4 +277,20 @@ export const inferTimeUnitFromTimestamps = (
   if (seconds < 2678400) return 'week';
   if (seconds < 31536000) return 'month';
   return 'year';
+};
+
+/**
+ * Determines the tooltip format for a temporal axis based on the inferred time unit.
+ * @param data The transformed data array
+ * @param field The field name for the temporal axis
+ * @param fallback The fallback format string (default: '%b %d, %Y %H:%M:%S')
+ * @returns The format string for the tooltip
+ */
+export const getTooltipFormat = (
+  data: Array<Record<string, any>>,
+  field: string | undefined, // Updated to accept string | undefined
+  fallback = '%b %d, %Y %H:%M:%S'
+): string => {
+  const timeUnit = inferTimeUnitFromTimestamps(data, field || ''); // Use empty string if field is undefined
+  return timeUnit ? timeUnitToFormat[timeUnit] ?? fallback : fallback;
 };

--- a/src/plugins/explore/public/components/visualizations/utils/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.ts
@@ -225,3 +225,46 @@ export const getSchemaByAxis = (
       return 'unknown';
   }
 };
+
+export const timeUnitToFormat: { [key: string]: string } = {
+  year: '%Y',
+  quarter: '%Y Q%q',
+  month: '%b %Y',
+  week: '%b %d, %Y',
+  day: '%b %d, %Y',
+  hour: '%b %d, %Y %H:%M',
+  minute: '%b %d, %Y %H:%M',
+  second: '%b %d, %Y %H:%M:%S',
+};
+
+export const inferTimeUnitFromTimestamps = (
+  data: Array<Record<string, any>>,
+  field: string
+): string => {
+  const timestamps = data
+    .map((row) => new Date(row[field]).getTime())
+    .filter((t) => !isNaN(t))
+    .sort((a, b) => a - b);
+
+  if (timestamps.length < 2) {
+    return 'second';
+  }
+
+  let minDiff = Number.MAX_SAFE_INTEGER;
+  for (let i = 1; i < timestamps.length; i++) {
+    const diff = timestamps[i] - timestamps[i - 1];
+    if (diff > 0 && diff < minDiff) {
+      minDiff = diff;
+    }
+  }
+
+  const seconds = minDiff / 1000;
+
+  if (seconds < 60) return 'second';
+  if (seconds < 3600) return 'minute';
+  if (seconds < 86400) return 'hour';
+  if (seconds < 604800) return 'day';
+  if (seconds < 2678400) return 'week';
+  if (seconds < 31536000) return 'month';
+  return 'year';
+};


### PR DESCRIPTION
### Description

This PR updates date format in the chart tooltip. This change automatically determines the appropriate time unit (e.g., seconds, minutes, days) based on the actual timestamp values in the dataset.

## Screenshot
### Before
<img width="3018" height="1716" alt="image" src="https://github.com/user-attachments/assets/2d6b0794-e01d-48d7-882c-421d974607d6" />

### After
<img width="3024" height="1708" alt="image" src="https://github.com/user-attachments/assets/968d7952-dc79-43ff-986a-9b3ad7d18627" />


## Testing the changes

1. Create area/line/bar charts with temporal fields using data with different time granularities (e.g., seconds, minutes, days, months).
2. Hover over data points and verify that the tooltip date format adjusts to match the inferred precision from the dataset.
3. Confirm that fallback formatting (%b %d, %Y %H:%M:%S) is applied when inference fails.

## Changelog
- fix: infer tooltip date format dynamically

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
