### PR TITLE
[Explore] add error boundary to tab content

### DIFF
--- a/changelogs/fragments/10360.yml
+++ b/changelogs/fragments/10360.yml
@@ -1,0 +1,2 @@
+chore:
+- Add error boundary to tab content on Explore page ([#10360](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10360))

--- a/src/plugins/explore/public/components/tabs/tabs.tsx
+++ b/src/plugins/explore/public/components/tabs/tabs.tsx
@@ -5,7 +5,7 @@
 
 import './tabs.scss';
 import React, { useCallback } from 'react';
-import { EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
+import { EuiErrorBoundary, EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import { setActiveTab } from '../../application/utils/state_management/slices';
 import { clearQueryStatusMapByKey } from '../../application/utils/state_management/slices';
@@ -59,7 +59,11 @@ export const ExploreTabs = () => {
     return {
       id: registryTab.id,
       name: registryTab.label,
-      content: <registryTab.component />,
+      content: (
+        <EuiErrorBoundary>
+          <registryTab.component />
+        </EuiErrorBoundary>
+      ),
     };
   });
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Add error boundary to tab content

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

<img width="961" height="485" alt="Screenshot 2025-08-06 at 11 36 39 AM" src="https://github.com/user-attachments/assets/a9c6cb2e-9a3a-472c-976b-2780533c4f98" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: Add error boundary to tab content on Explore page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
