### PR TITLE
Support PATCH calls from dev tools

### DIFF
--- a/packages/osd-dev-utils/src/osd_client/osd_client_requester.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_requester.ts
@@ -70,7 +70,7 @@ export interface ReqOptions {
   description?: string;
   path: string;
   query?: Record<string, any>;
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method: 'GET' | 'PATCH' | 'POST' | 'PUT' | 'DELETE';
   body?: any;
   retries?: number;
 }

--- a/src/core/test_helpers/osd_server.ts
+++ b/src/core/test_helpers/osd_server.ts
@@ -47,7 +47,7 @@ import { CliArgs, Env } from '../server/config';
 import { Root } from '../server/root';
 import OsdServer from '../../legacy/server/osd_server';
 
-export type HttpMethod = 'delete' | 'get' | 'head' | 'post' | 'put';
+export type HttpMethod = 'delete' | 'get' | 'head' | 'patch' | 'post' | 'put';
 
 const DEFAULTS_SETTINGS = {
   server: {

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/worker.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/worker.js
@@ -2076,12 +2076,18 @@ ace.define(
                 next('S');
                 next('T');
                 return 'POST';
+              case 'A':
+                next('A');
+                next('T');
+                next('C');
+                next('H');
+                return 'PATCH';
               default:
                 error('Unexpected \'' + ch + '\'');
             }
             break;
           default:
-            error('Expected one of GET/POST/PUT/DELETE/HEAD');
+            error('Expected one of GET/PATCH/POST/PUT/DELETE/HEAD');
         }
       },
       value, // Place holder for the value function.
@@ -2176,6 +2182,8 @@ ace.define(
         strictWhite();
         if (ch == '{') {
           object();
+        } else if (ch == '[') {
+          array();
         }
         // multi doc request
         strictWhite(); // advance to one new line
@@ -2215,7 +2223,7 @@ ace.define(
             annotate('error', e.message);
             // snap
             const substring = text.substr(at);
-            const nextMatch = substring.search(/^POST|HEAD|GET|PUT|DELETE/m);
+            const nextMatch = substring.search(/^POST|PATCH|HEAD|GET|PUT|DELETE/m);
             if (nextMatch < 1) return;
             reset(at + nextMatch);
           }

--- a/src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js
+++ b/src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js
@@ -994,7 +994,7 @@ describe('Integration', () => {
       {
         name: 'Cursor rows after request end',
         cursor: { lineNumber: 5, column: 1 },
-        autoCompleteSet: ['GET', 'PUT', 'POST', 'DELETE', 'HEAD'],
+        autoCompleteSet: ['GET', 'PATCH', 'PUT', 'POST', 'DELETE', 'HEAD'],
         prefixToAdd: '',
         suffixToAdd: ' ',
       },

--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -789,7 +789,7 @@ export default function ({ coreEditor: editor, parser }: { coreEditor: CoreEdito
   }
 
   function addMethodAutoCompleteSetToContext(context: any) {
-    context.autoCompleteSet = ['GET', 'PUT', 'POST', 'DELETE', 'HEAD'].map((m, i) => ({
+    context.autoCompleteSet = ['GET', 'PATCH', 'PUT', 'POST', 'DELETE', 'HEAD'].map((m, i) => ({
       name: m,
       score: -i,
       meta: i18n.translate('console.autocomplete.addMethodMetaText', { defaultMessage: 'method' }),

--- a/src/plugins/console/public/lib/autocomplete/components/url_pattern_matcher.ts
+++ b/src/plugins/console/public/lib/autocomplete/components/url_pattern_matcher.ts
@@ -68,7 +68,7 @@ export class UrlPatternMatcher {
     // to avoid suggesting endpoints that are incompatible with the
     // method that the user has entered.
     this.methodsData = {};
-    ['HEAD', 'GET', 'PUT', 'POST', 'DELETE'].forEach((method) => {
+    ['HEAD', 'GET', 'PATCH', 'PUT', 'POST', 'DELETE'].forEach((method) => {
       this.methodsData[method] = {
         rootComponent: new SharedComponent('ROOT'),
         parametrizedComponentFactories: parametrizedComponentFactories || {

--- a/src/plugins/console/public/lib/row_parser.ts
+++ b/src/plugins/console/public/lib/row_parser.ts
@@ -66,19 +66,29 @@ export default class RowParser {
       return MODE.BETWEEN_REQUESTS;
     } // empty line or a comment waiting for a new req to start
 
-    if (line.indexOf('}', line.length - 1) >= 0) {
+    // If the current line ends with a closing brace/bracket, decide if the request/doc ends here.
+    const endsWithCloseBrace = line.endsWith('}');
+    const endsWithCloseBracket = line.endsWith(']');
+    if (endsWithCloseBrace || endsWithCloseBracket) {
       // check for a multi doc request (must start a new json doc immediately after this one end.
       lineNumber++;
       if (lineNumber < linesCount + 1) {
         line = (this.editor.getLineValue(lineNumber) || '').trim();
-        if (line.indexOf('{') === 0) {
+        if (line.startsWith('{')) {
           // next line is another doc in a multi doc
           // eslint-disable-next-line no-bitwise
           return MODE.MULTI_DOC_CUR_DOC_END | MODE.IN_REQUEST;
         }
+        // If next line starts with ']' we are still inside an array body,
+        // don't end the request yet — the real end is the line with ']'.
+        if (endsWithCloseBrace && line.startsWith(']')) {
+          return MODE.IN_REQUEST;
+        }
       }
+      // End the request when the current line ends with a closing bracket,
+      // or when it's a lone '}' not followed by another JSON doc.
       // eslint-disable-next-line no-bitwise
-      return MODE.REQUEST_END | MODE.MULTI_DOC_CUR_DOC_END; // end of request
+      return MODE.REQUEST_END | MODE.MULTI_DOC_CUR_DOC_END;
     }
 
     // check for single line requests
@@ -88,7 +98,9 @@ export default class RowParser {
       return MODE.REQUEST_START | MODE.REQUEST_END;
     }
     line = (this.editor.getLineValue(lineNumber) || '').trim();
-    if (line.indexOf('{') !== 0) {
+    // if the next line doesn't begin a JSON body (object or array),
+    // it means the current line is a complete request line (no body)
+    if (!(line.startsWith('{') || line.startsWith('['))) {
       // next line is another request
       // eslint-disable-next-line no-bitwise
       return MODE.REQUEST_START | MODE.REQUEST_END;

--- a/src/plugins/console/server/routes/api/console/proxy/validation_config.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/validation_config.ts
@@ -35,11 +35,11 @@ export type Body = TypeOf<typeof routeValidationConfig.body>;
 
 const acceptedHttpVerb = schema.string({
   validate: (method) => {
-    return ['HEAD', 'GET', 'POST', 'PUT', 'DELETE'].some(
+    return ['HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'].some(
       (verb) => verb.toLowerCase() === method.toLowerCase()
     )
       ? undefined
-      : `Method must be one of, case insensitive ['HEAD', 'GET', 'POST', 'PUT', 'DELETE']. Received '${method}'.`;
+      : `Method must be one of, case insensitive ['HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE']. Received '${method}'.`;
   },
 });
 


### PR DESCRIPTION
### Description

This PR modifies the console plugin to allow PATCH calls from dev tools

### Issues Resolved

Resolves: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10105

## Screenshot

<img width="1708" height="463" alt="Screenshot 2025-08-06 at 5 12 20 PM" src="https://github.com/user-attachments/assets/a7a19622-5fd4-4a93-ac0b-bc86044e5745" />

## Testing the changes

Log into Dev Tools and call a PATCH api. For example: https://docs.opensearch.org/latest/security/access-control/api/#patch-role-mapping

## Changelog

- feat: Add support for PATCH in dev tools

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
