### PR TITLE
[Explore] Introduce facet filter

### DIFF
--- a/changelogs/fragments/10362.yml
+++ b/changelogs/fragments/10362.yml
@@ -1,0 +1,2 @@
+feat:
+- Introduce facet filter ([#10362](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10362))

--- a/src/plugins/explore/public/components/fields_selector/discover_sidebar.scss
+++ b/src/plugins/explore/public/components/fields_selector/discover_sidebar.scss
@@ -56,9 +56,35 @@
   }
 }
 
+.exploreSideBar__facetField {
+  width: 100%;
+
+  /* extra indentation for faceted field */
+  /* stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors */
+  .euiButtonEmpty__content {
+    font-size: $euiFontSizeXS;
+    font-weight: $euiFontWeightSemiBold;
+    justify-content: flex-start;
+    padding-left: $euiSizeM + 2px + $euiSizeM + $euiSizeS;
+  }
+}
+
 .exploreSideBar__item {
   // match fieldGroup condense indent(icon size + text margin)
   padding-left: $euiSizeM + 2px + $euiSizeM + $euiSizeS;
+  padding-right: $euiSizeS;
+  border-radius: $euiSizeXS;
+
+  &:focus,
+  &:hover {
+    background-color: $euiColorLightestShade;
+  }
+}
+
+/* extra indentation for faceted field */
+.exploreSideBar__facetValue {
+  // match fieldGroup condense indent(icon size * 2 + text margin)
+  padding-left: $euiSizeM + 2px + $euiSizeM + $euiSizeS + $euiSizeM + $euiSizeS;
   padding-right: $euiSizeS;
   border-radius: $euiSizeXS;
 

--- a/src/plugins/explore/public/components/fields_selector/discover_sidebar.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_sidebar.tsx
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonEmpty, EuiPanel, EuiSplitPanel } from '@elastic/eui';
+import { EuiSplitPanel } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { I18nProvider } from '@osd/i18n/react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { OpenSearchSearchHit } from '../../types/doc_views_types';
 import { IndexPattern, IndexPatternField, UI_SETTINGS } from '../../../../data/public';
 import { getServices } from '../../application/legacy/discover/opensearch_dashboards_services';
-import { DiscoverField } from './discover_field';
 import { DiscoverFieldSearch } from './discover_field_search';
 import './discover_sidebar.scss';
 import { getDefaultFieldFilter, setFieldFilterProp } from './lib/field_filter';
 import { getDetails } from './lib/get_details';
 import { getIndexPatternFieldList } from './lib/get_index_pattern_field_list';
 import { groupFields } from './lib/group_fields';
-import { FieldDetails } from './types';
 import { DiscoverFieldHeader } from './discover_field_header';
+import { FieldList } from './field_list';
+import { FacetList } from './facet_list';
 
 export interface DiscoverSidebarProps {
   /**
@@ -93,7 +93,7 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
     [hits, selectedIndexPattern]
   );
 
-  const { selectedFields, queryFields, discoveredFields } = useMemo(
+  const { facetedFields, selectedFields, queryFields, discoveredFields } = useMemo(
     () => groupFields(fields, columns, fieldCounts, fieldFilterState),
     [fields, columns, fieldCounts, fieldFilterState]
   );
@@ -154,6 +154,17 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
         >
           {(fields.length > 0 || selectedIndexPattern.fieldsLoading) && (
             <>
+              {facetedFields.length > 0 && (
+                <FacetList
+                  fields={facetedFields}
+                  getDetailsByField={getDetailsByField}
+                  shortDotsEnabled={shortDotsEnabled}
+                  title={i18n.translate('explore.discover.fieldChooser.filter.facetedFieldsTitle', {
+                    defaultMessage: 'Faceted fields',
+                  })}
+                  {...props}
+                />
+              )}
               <FieldList
                 category="selected"
                 fields={selectedFields}
@@ -196,74 +207,3 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
     </I18nProvider>
   );
 }
-
-interface FieldGroupProps extends DiscoverSidebarProps {
-  category: 'query' | 'discovered' | 'selected';
-  title: string;
-  fields: IndexPatternField[];
-  getDetailsByField: (field: IndexPatternField) => FieldDetails;
-  shortDotsEnabled: boolean;
-}
-
-const FieldList = ({
-  category,
-  title,
-  fields,
-  columns,
-  selectedIndexPattern,
-  onAddField,
-  onRemoveField,
-  onAddFilter,
-  getDetailsByField,
-  shortDotsEnabled,
-}: FieldGroupProps) => {
-  const [expanded, setExpanded] = useState(true);
-
-  if (!selectedIndexPattern) return null;
-
-  return (
-    <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
-      <EuiButtonEmpty
-        iconSide="left"
-        color="text"
-        iconType={expanded ? 'arrowDown' : 'arrowRight'}
-        onClick={() => setExpanded(!expanded)}
-        size="xs"
-        className="exploreSideBar_fieldGroup"
-        data-test-subj="dscSideBarFieldGroupButton"
-        aria-label={title}
-        isLoading={!!selectedIndexPattern.fieldsLoading}
-      >
-        {title}
-      </EuiButtonEmpty>
-      {expanded &&
-        fields.map((field: IndexPatternField) => {
-          return (
-            <EuiPanel
-              data-attr-field={field.name}
-              paddingSize="none"
-              hasBorder={false}
-              hasShadow={false}
-              color="transparent"
-              className="exploreSideBar__item"
-              data-test-subj={`fieldList-field`}
-            >
-              {/* The panel cannot exist in the DiscoverField component if the on focus highlight during keyboard navigation is needed */}
-              <DiscoverField
-                selected={category === 'selected'}
-                field={field}
-                columns={columns}
-                indexPattern={selectedIndexPattern}
-                onAddField={onAddField}
-                onRemoveField={onRemoveField}
-                onAddFilter={onAddFilter}
-                getDetails={getDetailsByField}
-                useShortDots={shortDotsEnabled}
-                showSummary={category !== 'discovered'}
-              />
-            </EuiPanel>
-          );
-        })}
-    </EuiPanel>
-  );
-};

--- a/src/plugins/explore/public/components/fields_selector/facet_field.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_field.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+// @ts-ignore
+import stubbedLogstashFields from 'fixtures/logstash_fields';
+import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
+import { FacetField } from './facet_field';
+import { coreMock } from 'opensearch-dashboards/public/mocks';
+import { IndexPatternField } from '../../../../data/public';
+import { getStubIndexPattern } from '../../../../data/public/test_utils';
+
+jest.mock('./facet_value', () => ({
+  FacetValue: ({ bucket }: any) => (
+    <div data-test-subj={`mocked-facet-value-${bucket.display}`}>{bucket.display}</div>
+  ),
+}));
+
+function getProps({ buckets = [], shortDotsEnabled = false } = {}) {
+  const indexPattern = getStubIndexPattern(
+    'logstash-*',
+    (cfg: any) => cfg,
+    'time',
+    stubbedLogstashFields(),
+    coreMock.createSetup()
+  );
+
+  const mockField = new IndexPatternField(
+    {
+      name: 'status',
+      type: 'string',
+      esTypes: ['keyword'],
+      count: 5,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+    },
+    'status'
+  );
+
+  const defaultBuckets =
+    buckets.length > 0
+      ? buckets
+      : [
+          { display: 'success', value: 'success', count: 10, percent: 50 },
+          { display: 'error', value: 'error', count: 5, percent: 25 },
+        ];
+
+  return {
+    field: mockField,
+    selectedIndexPattern: indexPattern,
+    onAddFilter: jest.fn(),
+    getDetailsByField: jest.fn(() => ({ buckets: defaultBuckets, error: '', exists: 1, total: 1 })),
+    shortDotsEnabled,
+  };
+}
+
+describe('FacetField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders field name and icon', () => {
+    const props = getProps();
+    render(<FacetField {...props} />);
+
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByTestId('exploreSideBarFacetFieldButton')).toBeInTheDocument();
+  });
+
+  it('renders facet values when expanded', () => {
+    const props = getProps();
+    render(<FacetField {...props} />);
+
+    expect(screen.getByTestId('mocked-facet-value-success')).toBeInTheDocument();
+    expect(screen.getByTestId('mocked-facet-value-error')).toBeInTheDocument();
+  });
+
+  it('toggles expansion when button is clicked', () => {
+    const props = getProps();
+    render(<FacetField {...props} />);
+
+    const toggleButton = screen.getByTestId('exploreSideBarFacetFieldButton');
+
+    // Initially expanded
+    expect(screen.getByTestId('mocked-facet-value-success')).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(toggleButton);
+
+    // Values should be hidden
+    expect(screen.queryByTestId('mocked-facet-value-success')).not.toBeInTheDocument();
+
+    // Click to expand again
+    fireEvent.click(toggleButton);
+
+    // Values should be visible again
+    expect(screen.getByTestId('mocked-facet-value-success')).toBeInTheDocument();
+  });
+
+  it('shows correct icon based on expansion state', () => {
+    const props = getProps();
+    render(<FacetField {...props} />);
+
+    const toggleButton = screen.getByTestId('exploreSideBarFacetFieldButton');
+
+    // Initially expanded - should show arrowDown
+    expect(toggleButton.querySelector('[data-euiicon-type="arrowDown"]')).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(toggleButton);
+
+    // Should now show arrowRight
+    expect(toggleButton.querySelector('[data-euiicon-type="arrowRight"]')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no index pattern', () => {
+    const props = { ...getProps(), selectedIndexPattern: undefined };
+    const { container } = render(<FacetField {...props} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no buckets', () => {
+    const props = getProps({ buckets: [] });
+    // Override getDetailsByField to return empty buckets
+    props.getDetailsByField = jest.fn(() => ({ buckets: [], error: '', exists: 1, total: 1 }));
+
+    const { container } = render(<FacetField {...props} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('passes shortDotsEnabled to FacetValue components', () => {
+    const props = getProps({ shortDotsEnabled: true });
+    render(<FacetField {...props} />);
+
+    // FacetValue components should render (they're mocked so we just check they exist)
+    expect(screen.getByTestId('mocked-facet-value-success')).toBeInTheDocument();
+    expect(screen.getByTestId('mocked-facet-value-error')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/fields_selector/facet_field.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_field.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import React, { useState } from 'react';
+import { IndexPatternField, IndexPattern } from '../../../../data/public';
+import { Bucket, FieldDetails } from './types';
+import { FieldIcon } from '../../../../opensearch_dashboards_react/public';
+import { FacetValue } from './facet_value';
+import { getFieldTypeName } from './lib/get_field_type_name';
+
+interface FacetFieldProps {
+  field: IndexPatternField;
+  selectedIndexPattern?: IndexPattern;
+  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  getDetailsByField: (field: IndexPatternField) => FieldDetails;
+  shortDotsEnabled: boolean;
+}
+
+export const FacetField = ({
+  field,
+  selectedIndexPattern,
+  onAddFilter,
+  getDetailsByField,
+  shortDotsEnabled,
+}: FacetFieldProps) => {
+  const [expanded, setExpanded] = useState(true);
+  const { buckets } = getDetailsByField(field);
+
+  if (!selectedIndexPattern || buckets.length === 0) return null;
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
+      <EuiButtonEmpty
+        iconSide="left"
+        color="text"
+        iconType={expanded ? 'arrowDown' : 'arrowRight'}
+        onClick={() => setExpanded(!expanded)}
+        size="xs"
+        className="exploreSideBar__facetField"
+        data-test-subj="exploreSideBarFacetFieldButton"
+        aria-label={field.name}
+        isLoading={!!selectedIndexPattern.fieldsLoading}
+      >
+        <EuiFlexGroup
+          gutterSize="s"
+          alignItems="center"
+          responsive={false}
+          data-test-subj="exploreSidebarField"
+        >
+          <EuiFlexItem grow={false}>
+            <FieldIcon
+              type={field.type}
+              label={getFieldTypeName(field.type)}
+              scripted={field.scripted}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs">{field.name}</EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiButtonEmpty>
+      {expanded &&
+        buckets.map((bucket: Bucket, index) => {
+          return (
+            <EuiPanel
+              data-attr-field={field.name}
+              key={field.name + index}
+              paddingSize="none"
+              hasBorder={false}
+              hasShadow={false}
+              color="transparent"
+              className="exploreSideBar__facetValue"
+              data-test-subj={`facetField-value`}
+            >
+              {/* The panel cannot exist in the DiscoverField component if the on focus highlight during keyboard navigation is needed */}
+              <FacetValue
+                field={field}
+                onAddFilter={onAddFilter}
+                useShortDots={shortDotsEnabled}
+                bucket={bucket}
+              />
+            </EuiPanel>
+          );
+        })}
+    </EuiPanel>
+  );
+};

--- a/src/plugins/explore/public/components/fields_selector/facet_list.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_list.test.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+// @ts-ignore
+import stubbedLogstashFields from 'fixtures/logstash_fields';
+import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
+import { FacetList } from './facet_list';
+import { coreMock } from 'opensearch-dashboards/public/mocks';
+import { IndexPatternField } from '../../../../data/public';
+import { getStubIndexPattern } from '../../../../data/public/test_utils';
+
+jest.mock('./facet_field', () => ({
+  FacetField: ({ field }: { field: any }) => (
+    <div data-test-subj={`mocked-facet-field-${field.name}`}>{field.name}</div>
+  ),
+}));
+
+function getProps({
+  title = 'Test Facets',
+  fields = undefined,
+  shortDotsEnabled = false,
+}: {
+  title?: string;
+  fields?: any;
+  shortDotsEnabled?: boolean;
+} = {}) {
+  const indexPattern = getStubIndexPattern(
+    'logstash-*',
+    (cfg: any) => cfg,
+    'time',
+    stubbedLogstashFields(),
+    coreMock.createSetup()
+  );
+
+  const defaultFields = [
+    new IndexPatternField(
+      {
+        name: 'status',
+        type: 'string',
+        esTypes: ['keyword'],
+        count: 5,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'status'
+    ),
+    new IndexPatternField(
+      {
+        name: 'level',
+        type: 'string',
+        esTypes: ['keyword'],
+        count: 3,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'level'
+    ),
+  ];
+
+  const mockFields = fields !== undefined ? fields : defaultFields;
+
+  return {
+    title,
+    fields: mockFields,
+    selectedIndexPattern: indexPattern,
+    onAddFilter: jest.fn(),
+    getDetailsByField: jest.fn(() => ({ buckets: [], error: '', exists: 1, total: 1 })),
+    shortDotsEnabled,
+    // Add missing required properties from DiscoverSidebarProps
+    columns: [],
+    fieldCounts: {},
+    hits: [],
+    onAddField: jest.fn(),
+    onRemoveField: jest.fn(),
+    onReorderFields: jest.fn(),
+    isEnhancementsEnabledOverride: false,
+  };
+}
+
+describe('FacetList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders facet list with title', () => {
+    const props = getProps({ title: 'Available Facets' });
+    render(<FacetList {...props} />);
+
+    expect(screen.getByText('Available Facets')).toBeInTheDocument();
+    expect(screen.getByTestId('exploreSideBarFieldGroupButton')).toBeInTheDocument();
+  });
+
+  it('renders facet field items when expanded', () => {
+    const props = getProps();
+    render(<FacetList {...props} />);
+
+    expect(screen.getByTestId('mocked-facet-field-status')).toBeInTheDocument();
+    expect(screen.getByTestId('mocked-facet-field-level')).toBeInTheDocument();
+  });
+
+  it('toggles expansion when button is clicked', () => {
+    const props = getProps();
+    render(<FacetList {...props} />);
+
+    const toggleButton = screen.getByTestId('exploreSideBarFieldGroupButton');
+
+    // Initially expanded
+    expect(screen.getByTestId('mocked-facet-field-status')).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(toggleButton);
+
+    // Fields should be hidden
+    expect(screen.queryByTestId('mocked-facet-field-status')).not.toBeInTheDocument();
+
+    // Click to expand again
+    fireEvent.click(toggleButton);
+
+    // Fields should be visible again
+    expect(screen.getByTestId('mocked-facet-field-status')).toBeInTheDocument();
+  });
+
+  it('shows correct icon based on expansion state', () => {
+    const props = getProps();
+    render(<FacetList {...props} />);
+
+    const toggleButton = screen.getByTestId('exploreSideBarFieldGroupButton');
+
+    // Initially expanded - should show arrowDown
+    expect(toggleButton.querySelector('[data-euiicon-type="arrowDown"]')).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(toggleButton);
+
+    // Should now show arrowRight
+    expect(toggleButton.querySelector('[data-euiicon-type="arrowRight"]')).toBeInTheDocument();
+  });
+
+  it('renders nothing when selectedIndexPattern is null', () => {
+    const props = { ...getProps(), selectedIndexPattern: undefined };
+    const { container } = render(<FacetList {...props} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('handles empty fields array', () => {
+    const props = getProps({ fields: [] });
+    render(<FacetList {...props} />);
+
+    expect(screen.getByText('Test Facets')).toBeInTheDocument();
+    expect(screen.queryByTestId('mocked-facet-field-status')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/fields_selector/facet_list.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_list.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButtonEmpty, EuiPanel } from '@elastic/eui';
+import React, { useState } from 'react';
+import { IndexPatternField } from '../../../../data/public';
+import { DiscoverSidebarProps } from './discover_sidebar';
+import { FacetField } from './facet_field';
+import { FieldDetails } from './types';
+
+interface FacetListProps extends DiscoverSidebarProps {
+  title: string;
+  fields: IndexPatternField[];
+  getDetailsByField: (field: IndexPatternField) => FieldDetails;
+  shortDotsEnabled: boolean;
+}
+
+export const FacetList = ({
+  title,
+  fields,
+  selectedIndexPattern,
+  onAddFilter,
+  getDetailsByField,
+  shortDotsEnabled,
+}: FacetListProps) => {
+  const [expanded, setExpanded] = useState(true);
+
+  if (!selectedIndexPattern) return null;
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
+      <EuiButtonEmpty
+        iconSide="left"
+        color="text"
+        iconType={expanded ? 'arrowDown' : 'arrowRight'}
+        onClick={() => setExpanded(!expanded)}
+        size="xs"
+        className="exploreSideBarFieldGroup"
+        data-test-subj="exploreSideBarFieldGroupButton"
+        aria-label={title}
+        isLoading={!!selectedIndexPattern.fieldsLoading}
+      >
+        {title}
+      </EuiButtonEmpty>
+      {expanded &&
+        fields.map((field: IndexPatternField, index) => {
+          return (
+            <FacetField
+              key={field.name + index}
+              field={field}
+              getDetailsByField={getDetailsByField}
+              shortDotsEnabled={shortDotsEnabled}
+              onAddFilter={onAddFilter}
+              selectedIndexPattern={selectedIndexPattern}
+            />
+          );
+        })}
+    </EuiPanel>
+  );
+};

--- a/src/plugins/explore/public/components/fields_selector/facet_list.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_list.tsx
@@ -37,7 +37,7 @@ export const FacetList = ({
         iconType={expanded ? 'arrowDown' : 'arrowRight'}
         onClick={() => setExpanded(!expanded)}
         size="xs"
-        className="exploreSideBarFieldGroup"
+        className="exploreSideBar_fieldGroup"
         data-test-subj="exploreSideBarFieldGroupButton"
         aria-label={title}
         isLoading={!!selectedIndexPattern.fieldsLoading}

--- a/src/plugins/explore/public/components/fields_selector/facet_value.scss
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.scss
@@ -8,19 +8,11 @@
     display: block;
   }
 
-  &__buttons {
-    display: none;
-  }
-
-  // On hover or focus-within, hide count and show buttons
+  // On hover or focus-within, hide count
   &:hover,
   &:focus-within {
     .exploreSidebarFacetValue__count {
       display: none;
-    }
-
-    .exploreSidebarFacetValue__buttons {
-      display: block;
     }
   }
 

--- a/src/plugins/explore/public/components/fields_selector/facet_value.scss
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.scss
@@ -1,0 +1,20 @@
+.exploreSidebarFacetValue {
+  &__actionButtons {
+    flex-direction: row;
+  }
+
+  &__actionButton {
+    opacity: 0;
+    transition: opacity $euiAnimSpeedFast;
+
+    @include ouiBreakpoint("xs", "s", "m") {
+      opacity: 1;
+    }
+  }
+
+  &:hover &__actionButton,
+  &:focus &__actionButton,
+  .exploreSidebarField__actionButton:focus {
+    opacity: 1;
+  }
+}

--- a/src/plugins/explore/public/components/fields_selector/facet_value.scss
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.scss
@@ -3,6 +3,27 @@
     flex-direction: row;
   }
 
+  // Show count by default, hide buttons
+  &__count {
+    display: block;
+  }
+
+  &__buttons {
+    display: none;
+  }
+
+  // On hover or focus-within, hide count and show buttons
+  &:hover,
+  &:focus-within {
+    .exploreSidebarFacetValue__count {
+      display: none;
+    }
+
+    .exploreSidebarFacetValue__buttons {
+      display: block;
+    }
+  }
+
   &__actionButton {
     opacity: 0;
     transition: opacity $euiAnimSpeedFast;

--- a/src/plugins/explore/public/components/fields_selector/facet_value.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.test.tsx
@@ -99,6 +99,15 @@ describe('FacetValue', () => {
     expect(screen.getByTestId('field-very.long.field.name.here')).toBeInTheDocument();
   });
 
+  it('renders bucket count', () => {
+    render(<FacetValue {...mockProps} />);
+
+    expect(screen.getByText('10')).toBeInTheDocument();
+
+    const countElement = screen.getByText('10');
+    expect(countElement).toHaveClass('exploreSidebarFacetValue__count');
+  });
+
   it('has correct CSS classes', () => {
     render(<FacetValue {...mockProps} />);
 
@@ -107,6 +116,12 @@ describe('FacetValue', () => {
 
     const actionButtons = container.querySelector('.exploreSidebarFacetValue__actionButtons');
     expect(actionButtons).toBeInTheDocument();
+
+    const countElement = container.querySelector('.exploreSidebarFacetValue__count');
+    expect(countElement).toBeInTheDocument();
+
+    const buttonsContainer = container.querySelector('.exploreSidebarFacetValue__buttons');
+    expect(buttonsContainer).toBeInTheDocument();
 
     const actionButton = container.querySelector('.exploreSidebarFacetValue__actionButton');
     expect(actionButton).toBeInTheDocument();

--- a/src/plugins/explore/public/components/fields_selector/facet_value.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
+import { FacetValue } from './facet_value';
+import { IndexPatternField } from '../../../../data/public';
+
+describe('FacetValue', () => {
+  const mockField = new IndexPatternField(
+    {
+      name: 'status',
+      type: 'string',
+      esTypes: ['keyword'],
+      count: 5,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+    },
+    'status'
+  );
+
+  const mockBucket = {
+    display: 'success',
+    value: 'success',
+    count: 10,
+    percent: 25.5,
+  };
+
+  const mockProps = {
+    field: mockField,
+    bucket: mockBucket,
+    onAddFilter: jest.fn(),
+    useShortDots: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders facet value with display text', () => {
+    render(<FacetValue {...mockProps} />);
+
+    expect(screen.getByText('success')).toBeInTheDocument();
+    expect(screen.getByTestId('field-success')).toBeInTheDocument();
+  });
+
+  it('renders filter buttons', () => {
+    render(<FacetValue {...mockProps} />);
+
+    const filterButtons = screen.getAllByRole('button');
+    expect(filterButtons).toHaveLength(2);
+
+    // Filter for button (magnifyWithPlus)
+    expect(filterButtons[0]).toHaveAttribute('aria-label', 'Filter for success');
+
+    // Filter out button (magnifyWithMinus)
+    expect(filterButtons[1]).toHaveAttribute('aria-label', 'Filter out success');
+  });
+
+  it('calls onAddFilter with positive filter when plus button clicked', () => {
+    render(<FacetValue {...mockProps} />);
+
+    const filterForButton = screen.getByLabelText('Filter for success');
+    fireEvent.click(filterForButton);
+
+    expect(mockProps.onAddFilter).toHaveBeenCalledWith(mockField, 'success', '+');
+  });
+
+  it('calls onAddFilter with negative filter when minus button clicked', () => {
+    render(<FacetValue {...mockProps} />);
+
+    const filterOutButton = screen.getByLabelText('Filter out success');
+    fireEvent.click(filterOutButton);
+
+    expect(mockProps.onAddFilter).toHaveBeenCalledWith(mockField, 'success', '-');
+  });
+
+  it('shows tooltip with bucket display value', () => {
+    render(<FacetValue {...mockProps} />);
+
+    const valueSpan = screen.getByTestId('field-success');
+    expect(valueSpan).toHaveClass('exploreSidebarFacetValue__name');
+  });
+
+  it('handles useShortDots option', () => {
+    const longBucket = {
+      display: 'very.long.field.name.here',
+      value: 'very.long.field.name.here',
+      count: 5,
+      percent: 10,
+    };
+
+    render(<FacetValue {...mockProps} bucket={longBucket} useShortDots={true} />);
+
+    expect(screen.getByTestId('field-very.long.field.name.here')).toBeInTheDocument();
+  });
+
+  it('has correct CSS classes', () => {
+    render(<FacetValue {...mockProps} />);
+
+    const container = screen.getByTestId('exploreSidebarFacetValue');
+    expect(container).toHaveClass('exploreSidebarFacetValue');
+
+    const actionButtons = container.querySelector('.exploreSidebarFacetValue__actionButtons');
+    expect(actionButtons).toBeInTheDocument();
+
+    const actionButton = container.querySelector('.exploreSidebarFacetValue__actionButton');
+    expect(actionButton).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/fields_selector/facet_value.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.test.tsx
@@ -120,9 +120,6 @@ describe('FacetValue', () => {
     const countElement = container.querySelector('.exploreSidebarFacetValue__count');
     expect(countElement).toBeInTheDocument();
 
-    const buttonsContainer = container.querySelector('.exploreSidebarFacetValue__buttons');
-    expect(buttonsContainer).toBeInTheDocument();
-
     const actionButton = container.querySelector('.exploreSidebarFacetValue__actionButton');
     expect(actionButton).toBeInTheDocument();
   });

--- a/src/plugins/explore/public/components/fields_selector/facet_value.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.tsx
@@ -79,36 +79,47 @@ export const FacetValue = ({ field, bucket, onAddFilter, useShortDots }: FacetVa
         <EuiText size="xs">{displayValue}</EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false} className="exploreSidebarFacetValue__actionButtons">
-        <EuiToolTip
-          delay="long"
-          content={i18n.translate('explore.discover.fieldChooser.discoverField.filterForTooltip', {
-            defaultMessage: 'Filter for value',
-          })}
-        >
-          <EuiButtonIcon
-            iconType="magnifyWithPlus"
-            onClick={() => onAddFilter(field, bucket.value, '+')}
-            size="xs"
-            data-test-subj={`fieldToggle-${bucket.display}`}
-            aria-label={filterForLabelAria}
-            className="exploreSidebarFacetValue__actionButton"
-          />
-        </EuiToolTip>
-        <EuiToolTip
-          delay="long"
-          content={i18n.translate('explore.discover.fieldChooser.discoverField.filterOutTooltip', {
-            defaultMessage: 'Filter out value',
-          })}
-        >
-          <EuiButtonIcon
-            iconType="magnifyWithMinus"
-            onClick={() => onAddFilter(field, bucket.value, '-')}
-            size="xs"
-            data-test-subj={`fieldToggle-${bucket.display}`}
-            aria-label={filterOutLabelAria}
-            className="exploreSidebarFacetValue__actionButton"
-          />
-        </EuiToolTip>
+        <EuiText size="xs" className="exploreSidebarFacetValue__count">
+          {bucket.count}
+        </EuiText>
+        <div className="exploreSidebarFacetValue__buttons">
+          <EuiToolTip
+            delay="long"
+            content={i18n.translate(
+              'explore.discover.fieldChooser.discoverField.filterForTooltip',
+              {
+                defaultMessage: 'Filter for value',
+              }
+            )}
+          >
+            <EuiButtonIcon
+              iconType="magnifyWithPlus"
+              onClick={() => onAddFilter(field, bucket.value, '+')}
+              size="xs"
+              data-test-subj={`fieldToggle-${bucket.display}`}
+              aria-label={filterForLabelAria}
+              className="exploreSidebarFacetValue__actionButton"
+            />
+          </EuiToolTip>
+          <EuiToolTip
+            delay="long"
+            content={i18n.translate(
+              'explore.discover.fieldChooser.discoverField.filterOutTooltip',
+              {
+                defaultMessage: 'Filter out value',
+              }
+            )}
+          >
+            <EuiButtonIcon
+              iconType="magnifyWithMinus"
+              onClick={() => onAddFilter(field, bucket.value, '-')}
+              size="xs"
+              data-test-subj={`fieldToggle-${bucket.display}`}
+              aria-label={filterOutLabelAria}
+              className="exploreSidebarFacetValue__actionButton"
+            />
+          </EuiToolTip>
+        </div>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/src/plugins/explore/public/components/fields_selector/facet_value.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.tsx
@@ -79,47 +79,39 @@ export const FacetValue = ({ field, bucket, onAddFilter, useShortDots }: FacetVa
         <EuiText size="xs">{displayValue}</EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false} className="exploreSidebarFacetValue__actionButtons">
+        <EuiToolTip
+          delay="long"
+          content={i18n.translate('explore.discover.fieldChooser.discoverField.filterForTooltip', {
+            defaultMessage: 'Filter for value',
+          })}
+        >
+          <EuiButtonIcon
+            iconType="magnifyWithPlus"
+            onClick={() => onAddFilter(field, bucket.value, '+')}
+            size="xs"
+            data-test-subj={`fieldToggle-${bucket.display}`}
+            aria-label={filterForLabelAria}
+            className="exploreSidebarFacetValue__actionButton"
+          />
+        </EuiToolTip>
+        <EuiToolTip
+          delay="long"
+          content={i18n.translate('explore.discover.fieldChooser.discoverField.filterOutTooltip', {
+            defaultMessage: 'Filter out value',
+          })}
+        >
+          <EuiButtonIcon
+            iconType="magnifyWithMinus"
+            onClick={() => onAddFilter(field, bucket.value, '-')}
+            size="xs"
+            data-test-subj={`fieldToggle-${bucket.display}`}
+            aria-label={filterOutLabelAria}
+            className="exploreSidebarFacetValue__actionButton"
+          />
+        </EuiToolTip>
         <EuiText size="xs" className="exploreSidebarFacetValue__count">
           {bucket.count}
         </EuiText>
-        <div className="exploreSidebarFacetValue__buttons">
-          <EuiToolTip
-            delay="long"
-            content={i18n.translate(
-              'explore.discover.fieldChooser.discoverField.filterForTooltip',
-              {
-                defaultMessage: 'Filter for value',
-              }
-            )}
-          >
-            <EuiButtonIcon
-              iconType="magnifyWithPlus"
-              onClick={() => onAddFilter(field, bucket.value, '+')}
-              size="xs"
-              data-test-subj={`fieldToggle-${bucket.display}`}
-              aria-label={filterForLabelAria}
-              className="exploreSidebarFacetValue__actionButton"
-            />
-          </EuiToolTip>
-          <EuiToolTip
-            delay="long"
-            content={i18n.translate(
-              'explore.discover.fieldChooser.discoverField.filterOutTooltip',
-              {
-                defaultMessage: 'Filter out value',
-              }
-            )}
-          >
-            <EuiButtonIcon
-              iconType="magnifyWithMinus"
-              onClick={() => onAddFilter(field, bucket.value, '-')}
-              size="xs"
-              data-test-subj={`fieldToggle-${bucket.display}`}
-              aria-label={filterOutLabelAria}
-              className="exploreSidebarFacetValue__actionButton"
-            />
-          </EuiToolTip>
-        </div>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/src/plugins/explore/public/components/fields_selector/facet_value.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './facet_value.scss';
+
+import React from 'react';
+import { EuiButtonIcon, EuiToolTip, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { Bucket } from './types';
+import { IndexPatternField } from '../../../../data/public';
+import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
+import './discover_field.scss';
+
+function wrapOnDot(str?: string) {
+  // u200B is a non-width white-space character, which allows
+  // the browser to efficiently word-wrap right after the dot
+  // without us having to draw a lot of extra DOM elements, etc
+  return str ? str.replace(/\./g, '.\u200B') : '';
+}
+
+export interface FacetValueProps {
+  /**
+   * The facet field
+   */
+  field: IndexPatternField;
+  /**
+   * The bucket contains facet field value
+   */
+  bucket: Bucket;
+  /**
+   * Callback to add a filter to filter bar
+   */
+  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  /**
+   * Determines whether the field name is shortened test.sub1.sub2 = t.s.sub2
+   */
+  useShortDots?: boolean;
+}
+
+export const FacetValue = ({ field, bucket, onAddFilter, useShortDots }: FacetValueProps) => {
+  const filterForLabelAria = i18n.translate(
+    'explore.discover.fieldChooser.discoverField.filterForAriaLabel',
+    {
+      defaultMessage: 'Filter for {value}',
+      values: { value: bucket.display },
+    }
+  );
+
+  const filterOutLabelAria = i18n.translate(
+    'explore.discover.fieldChooser.discoverField.filterOutAriaLabel',
+    {
+      defaultMessage: 'Filter out {value}',
+      values: { value: bucket.display },
+    }
+  );
+
+  const displayValue = (
+    <EuiToolTip delay="long" content={bucket.display}>
+      <span
+        data-test-subj={`field-${bucket.display}`}
+        className="exploreSidebarFacetValue__name eui-textBreakWord"
+      >
+        {useShortDots ? wrapOnDot(shortenDottedString(bucket.display)) : wrapOnDot(bucket.display)}
+      </span>
+    </EuiToolTip>
+  );
+
+  return (
+    <EuiFlexGroup
+      gutterSize="s"
+      alignItems="center"
+      responsive={false}
+      className="exploreSidebarFacetValue"
+      data-test-subj="exploreSidebarFacetValue"
+    >
+      <EuiFlexItem grow>
+        <EuiText size="xs">{displayValue}</EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} className="exploreSidebarFacetValue__actionButtons">
+        <EuiToolTip
+          delay="long"
+          content={i18n.translate('explore.discover.fieldChooser.discoverField.filterForTooltip', {
+            defaultMessage: 'Filter for value',
+          })}
+        >
+          <EuiButtonIcon
+            iconType="magnifyWithPlus"
+            onClick={() => onAddFilter(field, bucket.value, '+')}
+            size="xs"
+            data-test-subj={`fieldToggle-${bucket.display}`}
+            aria-label={filterForLabelAria}
+            className="exploreSidebarFacetValue__actionButton"
+          />
+        </EuiToolTip>
+        <EuiToolTip
+          delay="long"
+          content={i18n.translate('explore.discover.fieldChooser.discoverField.filterOutTooltip', {
+            defaultMessage: 'Filter out value',
+          })}
+        >
+          <EuiButtonIcon
+            iconType="magnifyWithMinus"
+            onClick={() => onAddFilter(field, bucket.value, '-')}
+            size="xs"
+            data-test-subj={`fieldToggle-${bucket.display}`}
+            aria-label={filterOutLabelAria}
+            className="exploreSidebarFacetValue__actionButton"
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/plugins/explore/public/components/fields_selector/field_list.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/field_list.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+// @ts-ignore
+import stubbedLogstashFields from 'fixtures/logstash_fields';
+import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
+import { FieldList } from './field_list';
+import { coreMock } from 'opensearch-dashboards/public/mocks';
+import { IndexPatternField } from '../../../../data/public';
+import { getStubIndexPattern } from '../../../../data/public/test_utils';
+
+jest.mock('./discover_field', () => ({
+  DiscoverField: ({ field }: { field: IndexPatternField }) => (
+    <div data-test-subj={`mocked-discover-field-${field.name}`}>{field.name}</div>
+  ),
+}));
+
+function getProps({
+  category = 'discovered',
+  title = 'Test Fields',
+  fields,
+  shortDotsEnabled = false,
+}: {
+  category?: 'query' | 'discovered' | 'selected';
+  title?: string;
+  fields?: IndexPatternField[];
+  shortDotsEnabled?: boolean;
+} = {}) {
+  const indexPattern = getStubIndexPattern(
+    'logstash-*',
+    (cfg: any) => cfg,
+    'time',
+    stubbedLogstashFields(),
+    coreMock.createSetup()
+  );
+
+  const defaultFields = [
+    new IndexPatternField(
+      {
+        name: 'bytes',
+        type: 'number',
+        esTypes: ['long'],
+        count: 10,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'bytes'
+    ),
+    new IndexPatternField(
+      {
+        name: 'extension',
+        type: 'string',
+        esTypes: ['keyword'],
+        count: 5,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'extension'
+    ),
+  ];
+
+  const mockFields = fields !== undefined ? fields : defaultFields;
+
+  return {
+    category,
+    title,
+    fields: mockFields,
+    columns: ['@timestamp'],
+    selectedIndexPattern: indexPattern,
+    onAddField: jest.fn(),
+    onRemoveField: jest.fn(),
+    onAddFilter: jest.fn(),
+    getDetailsByField: jest.fn(() => ({ buckets: [], error: '', exists: 1, total: 1 })),
+    shortDotsEnabled,
+    fieldCounts: {},
+    hits: [],
+    onReorderFields: jest.fn(),
+    isEnhancementsEnabledOverride: false,
+  };
+}
+
+describe('FieldList', () => {
+  it('renders field list with title', () => {
+    const props = getProps({ title: 'Available Fields' });
+    render(<FieldList {...props} />);
+
+    expect(screen.getByText('Available Fields')).toBeInTheDocument();
+    expect(screen.getByTestId('dscSideBarFieldGroupButton')).toBeInTheDocument();
+  });
+
+  it('renders field items when expanded', () => {
+    const props = getProps();
+    render(<FieldList {...props} />);
+
+    expect(screen.getByTestId('mocked-discover-field-bytes')).toBeInTheDocument();
+    expect(screen.getByTestId('mocked-discover-field-extension')).toBeInTheDocument();
+  });
+
+  it('toggles expansion when button is clicked', () => {
+    const props = getProps();
+    render(<FieldList {...props} />);
+
+    const toggleButton = screen.getByTestId('dscSideBarFieldGroupButton');
+
+    // Initially expanded
+    expect(screen.getByTestId('mocked-discover-field-bytes')).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(toggleButton);
+
+    // Fields should be hidden
+    expect(screen.queryByTestId('mocked-discover-field-bytes')).not.toBeInTheDocument();
+
+    // Click to expand again
+    fireEvent.click(toggleButton);
+
+    // Fields should be visible again
+    expect(screen.getByTestId('mocked-discover-field-bytes')).toBeInTheDocument();
+  });
+
+  it('renders nothing when selectedIndexPattern is null', () => {
+    const props = { ...getProps(), selectedIndexPattern: undefined };
+    const { container } = render(<FieldList {...props} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows correct icon based on expansion state', () => {
+    const props = getProps();
+    render(<FieldList {...props} />);
+
+    const toggleButton = screen.getByTestId('dscSideBarFieldGroupButton');
+
+    // Initially expanded - should show arrowDown
+    expect(toggleButton.querySelector('[data-euiicon-type="arrowDown"]')).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(toggleButton);
+
+    // Should now show arrowRight
+    expect(toggleButton.querySelector('[data-euiicon-type="arrowRight"]')).toBeInTheDocument();
+  });
+
+  it('handles empty fields array', () => {
+    const props = getProps({ fields: [] });
+    render(<FieldList {...props} />);
+
+    expect(screen.getByText('Test Fields')).toBeInTheDocument();
+    expect(screen.queryByTestId('mocked-discover-field-bytes')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/fields_selector/field_list.tsx
+++ b/src/plugins/explore/public/components/fields_selector/field_list.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButtonEmpty, EuiPanel } from '@elastic/eui';
+import React, { useState } from 'react';
+import { IndexPatternField } from '../../../../data/public';
+import { DiscoverField } from './discover_field';
+import { DiscoverSidebarProps } from './discover_sidebar';
+import { FieldDetails } from './types';
+
+interface FieldGroupProps extends DiscoverSidebarProps {
+  category: 'query' | 'discovered' | 'selected';
+  title: string;
+  fields: IndexPatternField[];
+  getDetailsByField: (field: IndexPatternField) => FieldDetails;
+  shortDotsEnabled: boolean;
+}
+
+export const FieldList = ({
+  category,
+  title,
+  fields,
+  columns,
+  selectedIndexPattern,
+  onAddField,
+  onRemoveField,
+  onAddFilter,
+  getDetailsByField,
+  shortDotsEnabled,
+}: FieldGroupProps) => {
+  const [expanded, setExpanded] = useState(true);
+
+  if (!selectedIndexPattern) return null;
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
+      <EuiButtonEmpty
+        iconSide="left"
+        color="text"
+        iconType={expanded ? 'arrowDown' : 'arrowRight'}
+        onClick={() => setExpanded(!expanded)}
+        size="xs"
+        className="exploreSideBar_fieldGroup"
+        data-test-subj="dscSideBarFieldGroupButton"
+        aria-label={title}
+        isLoading={!!selectedIndexPattern.fieldsLoading}
+      >
+        {title}
+      </EuiButtonEmpty>
+      {expanded &&
+        fields.map((field: IndexPatternField, index) => {
+          return (
+            <EuiPanel
+              data-attr-field={field.name}
+              key={field.name + index}
+              paddingSize="none"
+              hasBorder={false}
+              hasShadow={false}
+              color="transparent"
+              className="exploreSideBar__item"
+              data-test-subj={`fieldList-field`}
+            >
+              {/* The panel cannot exist in the DiscoverField component if the on focus highlight during keyboard navigation is needed */}
+              <DiscoverField
+                selected={category === 'selected'}
+                field={field}
+                columns={columns}
+                indexPattern={selectedIndexPattern}
+                onAddField={onAddField}
+                onRemoveField={onRemoveField}
+                onAddFilter={onAddFilter}
+                getDetails={getDetailsByField}
+                useShortDots={shortDotsEnabled}
+                showSummary={category !== 'discovered'}
+              />
+            </EuiPanel>
+          );
+        })}
+    </EuiPanel>
+  );
+};

--- a/src/plugins/explore/public/components/fields_selector/lib/group_fields.test.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/group_fields.test.ts
@@ -185,7 +185,7 @@ describe('group_fields', function () {
         displayName: 'Service Name',
       },
       {
-        name: 'span.attributes.http@status_code',
+        name: 'attributes.http.status_code',
         type: 'number',
         esTypes: ['long'],
         count: 1,
@@ -222,7 +222,7 @@ describe('group_fields', function () {
     const columns: string[] = [];
     const fieldCounts = {
       'serviceName\u200b': 1,
-      'span.attributes.http@status_code': 1,
+      'attributes.http.status_code': 1,
       'status.code': 1,
       regularField: 1,
     };
@@ -234,7 +234,7 @@ describe('group_fields', function () {
 
     expect(actual.facetedFields).toHaveLength(3);
     expect(actual.facetedFields.map((f) => f.name)).toContain('serviceName\u200b');
-    expect(actual.facetedFields.map((f) => f.name)).toContain('span.attributes.http@status_code');
+    expect(actual.facetedFields.map((f) => f.name)).toContain('attributes.http.status_code');
     expect(actual.facetedFields.map((f) => f.name)).toContain('status.code');
     expect(actual.queryFields.map((f) => f.name)).toContain('regularField');
   });

--- a/src/plugins/explore/public/components/fields_selector/lib/group_fields.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/group_fields.ts
@@ -31,7 +31,17 @@
 import { IndexPatternField } from '../../../../../data/public';
 import { FieldFilterState, isFieldFiltered } from './field_filter';
 
+// TODO: Use data set defined faceted field
+const FACET_FIELDS = ['serviceName', 'span.attributes.http@status_code', 'status.code'] as const;
+
+function isFacetedField(fieldName: string): fieldName is typeof FACET_FIELDS[number] {
+  // Remove invisiable char
+  const normalizedFieldName = fieldName.replace(/[\u200b-\u200f\uFEFF]/g, '');
+  return (FACET_FIELDS as readonly string[]).includes(normalizedFieldName);
+}
+
 interface GroupedFields {
+  facetedFields: IndexPatternField[];
   selectedFields: IndexPatternField[];
   queryFields: IndexPatternField[];
   discoveredFields: IndexPatternField[];
@@ -47,6 +57,7 @@ export function groupFields(
   fieldFilterState: FieldFilterState
 ): GroupedFields {
   const result: GroupedFields = {
+    facetedFields: [],
     selectedFields: [],
     queryFields: [],
     discoveredFields: [],
@@ -71,6 +82,9 @@ export function groupFields(
   for (const field of fieldsSorted) {
     if (!isFieldFiltered(field, fieldFilterState, fieldCounts) || field.type === '_source') {
       continue;
+    }
+    if (isFacetedField(field.name)) {
+      result.facetedFields.push(field);
     }
     if (columns.includes(field.name)) {
       result.selectedFields.push(field);

--- a/src/plugins/explore/public/components/fields_selector/lib/group_fields.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/group_fields.ts
@@ -32,7 +32,7 @@ import { IndexPatternField } from '../../../../../data/public';
 import { FieldFilterState, isFieldFiltered } from './field_filter';
 
 // TODO: Use data set defined faceted field
-const FACET_FIELDS = ['serviceName', 'span.attributes.http@status_code', 'status.code'] as const;
+const FACET_FIELDS = ['serviceName', 'attributes.http.status_code', 'status.code'] as const;
 
 function isFacetedField(fieldName: string): fieldName is typeof FACET_FIELDS[number] {
   // Remove invisiable char


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

What are facets?

To help users quickly narrow down their search data, facets will provide access filtering commonly understood fields. Currently, we are introducing 3 default facet field(`serviceName`/`span.attributes.http@status_code`/`status.code`).

This PR introduces the UI components of facets filter.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->


https://github.com/user-attachments/assets/73bc6a9a-8e5f-4340-90bf-d21b96245f8b



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: Introduce facet filter

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
