### PR TITLE
[Explore] reset legacy state when changing dataset

### DIFF
--- a/changelogs/fragments/10366.yml
+++ b/changelogs/fragments/10366.yml
@@ -1,0 +1,2 @@
+fix:
+- Reset legacy state when switching dataset ([#10366](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10366))

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/index.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './reset_legacy_state';

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { resetLegacyStateActionCreator } from './reset_legacy_state';
+import { setLegacyState } from '../../slices';
+import { getPreloadedLegacyState } from '../../utils/redux_persistence';
+import { createMockExploreServices } from '../../__mocks__';
+
+jest.mock('../../slices', () => ({
+  setLegacyState: jest.fn(),
+}));
+
+jest.mock('../../utils/redux_persistence', () => ({
+  getPreloadedLegacyState: jest.fn(),
+}));
+
+const mockedSetLegacyState = setLegacyState as jest.MockedFunction<typeof setLegacyState>;
+const mockedGetPreloadedLegacyState = getPreloadedLegacyState as jest.MockedFunction<
+  typeof getPreloadedLegacyState
+>;
+
+describe('resetLegacyStateActionCreator', () => {
+  let mockServices: ReturnType<typeof createMockExploreServices>;
+  let mockDispatch: jest.MockedFunction<any>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServices = createMockExploreServices();
+    mockDispatch = jest.fn();
+  });
+
+  it('should return a function that dispatches setLegacyState with preloaded state', () => {
+    const mockLegacyState = {
+      data: { some: 'data' },
+      metadata: { test: 'metadata' },
+    };
+
+    mockedGetPreloadedLegacyState.mockReturnValue(mockLegacyState as any);
+    mockedSetLegacyState.mockReturnValue({
+      type: 'legacy/setLegacyState',
+      payload: mockLegacyState,
+    } as any);
+
+    // Call the action creator to get the thunk function
+    const thunkFunction = resetLegacyStateActionCreator(mockServices);
+
+    // Verify it returns a function
+    expect(typeof thunkFunction).toBe('function');
+
+    // Call the thunk function with dispatch
+    thunkFunction(mockDispatch);
+
+    // Verify getPreloadedLegacyState was called with services
+    expect(mockedGetPreloadedLegacyState).toHaveBeenCalledWith(mockServices);
+
+    // Verify setLegacyState was called with the preloaded state
+    expect(mockedSetLegacyState).toHaveBeenCalledWith(mockLegacyState);
+
+    // Verify dispatch was called with the setLegacyState action
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'legacy/setLegacyState',
+      payload: mockLegacyState,
+    });
+  });
+});

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { setLegacyState } from '../../slices';
+import { getPreloadedLegacyState } from '../../utils/redux_persistence';
+import { ExploreServices } from '../../../../../types';
+import { AppDispatch } from '../../store';
+
+/**
+ * Action creator for resetting the Legacy state to its preloaded state.
+ */
+export const resetLegacyStateActionCreator = (services: ExploreServices) => (
+  dispatch: AppDispatch
+) => {
+  const state = getPreloadedLegacyState(services);
+
+  dispatch(setLegacyState(state));
+};

--- a/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.test.ts
@@ -12,6 +12,8 @@ import {
   setPromptModeIsAvailable,
   setSummaryAgentIsAvailable,
   clearLastExecutedData,
+  setPatternsField,
+  setUsingRegexPatterns,
 } from '../slices';
 import { clearQueryStatusMap } from '../slices/query_editor/query_editor_slice';
 import { createMockExploreServices, createMockStore, MockStore } from '../__mocks__';
@@ -20,6 +22,7 @@ import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
 import { getSummaryAgentIsAvailable } from '../../get_summary_agent_is_available';
 import * as queryActions from '../actions/query_actions';
 import * as tabActions from '../actions/detect_optimal_tab';
+import * as resetLegacyStateActions from '../actions/reset_legacy_state';
 
 jest.mock('../../get_prompt_mode_is_available', () => ({
   getPromptModeIsAvailable: jest.fn().mockResolvedValue(true),
@@ -37,6 +40,10 @@ jest.mock('../actions/detect_optimal_tab', () => ({
   detectAndSetOptimalTab: jest.fn().mockReturnValue({ type: 'mock/detectOptimalTab' }),
 }));
 
+jest.mock('../actions/reset_legacy_state', () => ({
+  resetLegacyStateActionCreator: jest.fn().mockReturnValue({ type: 'mock/resetLegacyState' }),
+}));
+
 const mockedExecuteQueries = queryActions.executeQueries as jest.MockedFunction<
   typeof queryActions.executeQueries
 >;
@@ -48,6 +55,9 @@ const mockedGetPromptModeIsAvailable = getPromptModeIsAvailable as jest.MockedFu
 >;
 const mockedGetSummaryAgentIsAvailable = getSummaryAgentIsAvailable as jest.MockedFunction<
   typeof getSummaryAgentIsAvailable
+>;
+const mockedResetLegacyStateActionCreator = resetLegacyStateActions.resetLegacyStateActionCreator as jest.MockedFunction<
+  typeof resetLegacyStateActions.resetLegacyStateActionCreator
 >;
 
 describe('createDatasetChangeMiddleware', () => {
@@ -106,6 +116,10 @@ describe('createDatasetChangeMiddleware', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith(clearResults());
     expect(mockStore.dispatch).toHaveBeenCalledWith(clearQueryStatusMap());
     expect(mockStore.dispatch).toHaveBeenCalledWith(clearLastExecutedData());
+    expect(mockStore.dispatch).toHaveBeenCalledWith(setPatternsField(''));
+    expect(mockStore.dispatch).toHaveBeenCalledWith(setUsingRegexPatterns(false));
+    expect(mockStore.dispatch).toHaveBeenCalledWith({ type: 'mock/resetLegacyState' });
+    expect(mockedResetLegacyStateActionCreator).toHaveBeenCalledWith(mockServices);
     expect(mockStore.dispatch).toHaveBeenCalledWith(setPromptModeIsAvailable(true));
     expect(mockStore.dispatch).toHaveBeenCalledWith(setSummaryAgentIsAvailable(true));
 
@@ -137,6 +151,10 @@ describe('createDatasetChangeMiddleware', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith(clearResults());
     expect(mockStore.dispatch).toHaveBeenCalledWith(clearQueryStatusMap());
     expect(mockStore.dispatch).toHaveBeenCalledWith(clearLastExecutedData());
+    expect(mockStore.dispatch).toHaveBeenCalledWith(setPatternsField(''));
+    expect(mockStore.dispatch).toHaveBeenCalledWith(setUsingRegexPatterns(false));
+    expect(mockStore.dispatch).toHaveBeenCalledWith({ type: 'mock/resetLegacyState' });
+    expect(mockedResetLegacyStateActionCreator).toHaveBeenCalledWith(mockServices);
 
     // Verify the executeQueries action was dispatched
     expect(mockedExecuteQueries).toHaveBeenCalledWith({ services: mockServices });

--- a/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.ts
@@ -4,6 +4,7 @@
  */
 
 import { Middleware } from '@reduxjs/toolkit';
+import { AnyAction } from 'redux';
 import { isEqual } from 'lodash';
 import { Dataset, DEFAULT_DATA } from '../../../../../../data/common';
 import { RootState } from '../store';
@@ -22,6 +23,7 @@ import { executeQueries } from '../actions/query_actions';
 import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
 import { getSummaryAgentIsAvailable } from '../../get_summary_agent_is_available';
 import { detectAndSetOptimalTab } from '../actions/detect_optimal_tab';
+import { resetLegacyStateActionCreator } from '../actions/reset_legacy_state';
 
 /**
  * Middleware to handle dataset changes and trigger necessary side effects
@@ -57,6 +59,7 @@ export const createDatasetChangeMiddleware = (
       store.dispatch(clearLastExecutedData());
       store.dispatch(setPatternsField(''));
       store.dispatch(setUsingRegexPatterns(false));
+      store.dispatch((resetLegacyStateActionCreator(services) as unknown) as AnyAction);
 
       const [newPromptModeIsAvailable, newSummaryAgentIsAvailable] = await Promise.allSettled([
         getPromptModeIsAvailable(services),

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
@@ -302,7 +302,7 @@ const getPreloadedTabState = (services: ExploreServices): TabState => {
 /**
  * Get preloaded legacy state (vis_builder approach - defaults only, no saved object loading)
  */
-const getPreloadedLegacyState = (services: ExploreServices): LegacyState => {
+export const getPreloadedLegacyState = (services: ExploreServices): LegacyState => {
   // Only return defaults - NO saved object loading (like vis_builder)
   const defaultColumns = services.uiSettings?.get('defaultColumns') || ['_source'];
 


### PR DESCRIPTION
### Description

- i got a bug ticket where if you are on one dataset, you select some columns, switch dataset, and download CSV, the old selected columns appear
- This was because we were not resetting the legacy state in redux. This resets it

## Changelog
- fix: Reset legacy state when switching dataset

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
