### PR TITLE
[explore] disable language selector from dataset selectors

### DIFF
--- a/changelogs/fragments/10367.yml
+++ b/changelogs/fragments/10367.yml
@@ -1,0 +1,2 @@
+fix:
+- Disable language selector when choosing dataset ([#10367](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10367))

--- a/cypress/utils/commands.explore.js
+++ b/cypress/utils/commands.explore.js
@@ -378,10 +378,6 @@ cy.explore.add(
       .click({ force: true });
     cy.getElementByTestId('datasetSelectorNext').should('be.visible').click();
 
-    if (language) {
-      cy.getElementByTestId('advancedSelectorLanguageSelect').should('be.visible').select(language);
-    }
-
     if (finalAction === 'submit') {
       cy.getElementByTestId('advancedSelectorConfirmButton').should('be.visible').click();
 
@@ -413,10 +409,6 @@ cy.explore.add(
     // this element is sometimes dataSourceName masked by another element
     cy.get(`[title="${index}"]`).should('be.visible').click({ force: true });
     cy.getElementByTestId('datasetSelectorNext').should('be.visible').click();
-
-    if (language) {
-      cy.getElementByTestId('advancedSelectorLanguageSelect').should('be.visible').select(language);
-    }
 
     cy.getElementByTestId('advancedSelectorTimeFieldSelect')
       .should('be.visible')
@@ -471,10 +463,6 @@ cy.explore.add(
       .should('be.visible')
       .click({ force: true });
     cy.getElementByTestId('datasetSelectorNext').should('be.visible').click();
-
-    if (language) {
-      cy.getElementByTestId('advancedSelectorLanguageSelect').should('be.visible').select(language);
-    }
 
     if (finalAction === 'submit') {
       cy.getElementByTestId('advancedSelectorConfirmButton').should('be.visible').click();

--- a/src/plugins/data/public/ui/dataset_selector/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator.tsx
@@ -267,6 +267,7 @@ export const Configurator = ({
                 setLanguage(e.target.value);
                 setDataset({ ...dataset, language: e.target.value });
               }}
+              disabled={services.appName === 'explore'}
               data-test-subj="advancedSelectorLanguageSelect"
             />
           </EuiFormRow>


### PR DESCRIPTION
### Description

- selecting a diff language other than PPL in explore crashes the app. This disables it from the selector if you are in explore app

## Changelog
- fix: disable language selector when choosing dataset

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
