### PR TITLE
[Explore] Resolve ScopedHistory navigation scope error in explore plugin

### DIFF
--- a/changelogs/fragments/10369.yml
+++ b/changelogs/fragments/10369.yml
@@ -1,0 +1,2 @@
+fix:
+- [Explore] Resolve ScopedHistory navigation scope error in explore plugin ([#10369](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10369))

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { VisualizationBuilder } from './visualization_builder';
+import { VisualizationBuilder, resetVisualizationBuilder } from './visualization_builder';
 import { visualizationRegistry } from './visualization_registry';
 import { VisColumn, VisFieldType } from './types';
 
@@ -508,5 +508,16 @@ describe('VisualizationBuilder', () => {
     expect(builder.styles$.value).toBe(undefined);
     expect(builder.axesMapping$.value).toEqual({});
     expect(builder.currentChartType$.value).toBe(undefined);
+  });
+
+  describe('resetVisualizationBuilder', () => {
+    test('should not throw error when called', () => {
+      // Should not throw error regardless of singleton state
+      expect(() => resetVisualizationBuilder()).not.toThrow();
+
+      // Should be safe to call multiple times
+      expect(() => resetVisualizationBuilder()).not.toThrow();
+      expect(() => resetVisualizationBuilder()).not.toThrow();
+    });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.ts
@@ -385,3 +385,10 @@ export const getVisualizationBuilder = () => {
   }
   return visualizationBuilder;
 };
+
+export const resetVisualizationBuilder = () => {
+  if (visualizationBuilder) {
+    visualizationBuilder.dispose();
+    visualizationBuilder = undefined as any;
+  }
+};

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -30,6 +30,7 @@ import {
 } from '../../opensearch_dashboards_utils/public';
 import { ExploreFlavor, PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { ConfigSchema } from '../common/config';
+import { resetVisualizationBuilder } from './components/visualizations/visualization_builder';
 import { generateDocViewsUrl } from './application/legacy/discover/application/components/doc_views/generate_doc_views_url';
 import { DocViewsLinksRegistry } from './application/legacy/discover/application/doc_views_links/doc_views_links_registry';
 import {
@@ -341,7 +342,7 @@ export class ExplorePlugin
         return () => {
           abortAllActiveQueries();
           services.uiActions.detachAction(ABORT_DATA_QUERY_TRIGGER, abortActionId);
-
+          resetVisualizationBuilder();
           appUnMounted();
           unmount();
           unsubscribeStore();


### PR DESCRIPTION
### Issues Resolved
Users encounter a navigation scope error when:
<img width="1659" height="825" alt="Screenshot 2025-08-07 at 12 50 58 PM" src="https://github.com/user-attachments/assets/a58ffe65-fba4-44bf-bd5c-64e34b2cef49" />

1. navigate to app/explore/logs/ 
2. run any query
3. navigate to "Assets" page
4. Filter "explore" type of object
5. Click an explore object to navigate to new discover
6. Click "Update" button


### Description

The issue stems from the **VisualizationBuilder ** retaining stale references to inactive ScopedHistory instances across navigation cycles.

The fix is to implement complete cleanup of the `VisualizationBuilder` singleton on plugin unmount to ensure fresh instances are created with active `ScopedHistory` references.


## Screenshot

Before fix:

https://github.com/user-attachments/assets/44348cbb-03a5-476a-afa5-4adbdcd4ceff



After fix:

https://github.com/user-attachments/assets/31b6398e-98fe-40e1-8285-1853c5a1d7b8





## Changelog

- fix: [Explore] Resolve ScopedHistory navigation scope error in explore plugin


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
