### PR TITLE
[Explore] refactor chart available mappings

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.test.ts
@@ -97,48 +97,28 @@ describe('area_vis_config', () => {
           },
           availableMappings: [
             {
-              mapping: [
-                {
-                  [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-                  [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-                },
-              ],
+              [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+              [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
             },
             {
-              mapping: [
-                {
-                  [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-                  [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-                  [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-                },
-              ],
+              [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+              [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+              [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
             },
             {
-              mapping: [
-                {
-                  [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-                  [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-                  [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-                  [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
-                },
-              ],
+              [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+              [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+              [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+              [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
             },
             {
-              mapping: [
-                {
-                  [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-                  [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-                },
-              ],
+              [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+              [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
             },
             {
-              mapping: [
-                {
-                  [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-                  [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-                  [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
-                },
-              ],
+              [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+              [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+              [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
             },
           ],
         },

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
@@ -120,48 +120,28 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
     },
     availableMappings: [
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
@@ -129,73 +129,52 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
     },
     availableMappings: [
       {
-        mapping: [
-          // TODO the first one should be default?
-          {
-            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-          },
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Categorical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-          },
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Date, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Categorical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-          },
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
-          },
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Date, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
-          },
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+      },
+      {
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+      },
+      {
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
+      },
+      {
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
+      },
+      {
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
+      },
+      {
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 1 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -34,7 +34,7 @@ export const createBarSpec = (
     throw new Error('Bar chart requires at least one numerical column and one categorical column');
   }
 
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const layers: any[] = [];
 
@@ -62,25 +62,25 @@ export const createBarSpec = (
       [categoryAxis]: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       // Value axis (Y or X depending on orientation)
       [valueAxis]: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
           },
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
           },
         ],
       }),
@@ -137,7 +137,7 @@ export const createTimeBarChart = (
     throw new Error('Time bar chart requires at least one numerical column and one date column');
   }
 
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const layers: any[] = [];
 
@@ -160,19 +160,19 @@ export const createTimeBarChart = (
       x: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
             ...(getSchemaByAxis(xAxis) === 'temporal' && {
               format: getTooltipFormat(transformedData, xAxis?.column),
             }),
@@ -180,7 +180,7 @@ export const createTimeBarChart = (
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
             ...(getSchemaByAxis(yAxis) === 'temporal' && {
               format: getTooltipFormat(transformedData, yAxis?.column),
             }),
@@ -247,7 +247,7 @@ export const createGroupedTimeBarChart = (
     );
   }
 
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
   const categoryField = colorColumn?.column;
@@ -277,12 +277,12 @@ export const createGroupedTimeBarChart = (
       x: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       color: {
         field: categoryField,
@@ -299,7 +299,7 @@ export const createGroupedTimeBarChart = (
         {
           field: xAxis?.column,
           type: getSchemaByAxis(xAxis),
-          title: xAxis?.styles?.title?.text || xAxis?.name,
+          title: xAxisStyle?.title?.text || xAxis?.name,
           ...(getSchemaByAxis(xAxis) === 'temporal' && {
             format: getTooltipFormat(transformedData, xAxis?.column),
           }),
@@ -308,7 +308,7 @@ export const createGroupedTimeBarChart = (
         {
           field: yAxis?.column,
           type: getSchemaByAxis(yAxis),
-          title: yAxis?.styles?.title?.text || yAxis?.name,
+          title: yAxisStyle?.title?.text || yAxis?.name,
           ...(getSchemaByAxis(yAxis) === 'temporal' && {
             format: getTooltipFormat(transformedData, yAxis?.column),
           }),
@@ -357,7 +357,7 @@ export const createFacetedTimeBarChart = (
     );
   }
 
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
   const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
   const facetMapping = axisColumnMappings?.[AxisRole.FACET];
 
@@ -365,8 +365,8 @@ export const createFacetedTimeBarChart = (
   const dateField = xAxis?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
-  const metricName = yAxis?.styles?.title?.text || yAxis?.name;
-  const dateName = xAxis?.styles?.title?.text || xAxis?.name;
+  const metricName = yAxisStyle?.title?.text || yAxis?.name;
+  const dateName = xAxisStyle?.title?.text || xAxis?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
 
@@ -411,12 +411,12 @@ export const createFacetedTimeBarChart = (
             x: {
               field: dateField,
               type: getSchemaByAxis(xAxis),
-              axis: applyAxisStyling(xAxis),
+              axis: applyAxisStyling(xAxis, xAxisStyle),
             },
             y: {
               field: metricField,
               type: getSchemaByAxis(yAxis),
-              axis: applyAxisStyling(yAxis),
+              axis: applyAxisStyling(yAxis, yAxisStyle),
             },
             color: {
               field: category1Field,
@@ -474,7 +474,7 @@ export const createStackedBarSpec = (
     );
   }
 
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
   const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
 
   const categoryField2 = colorMapping?.column;
@@ -509,13 +509,13 @@ export const createStackedBarSpec = (
       [categoryAxis]: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       // Value axis (Y or X depending on orientation)
       [valueAxis]: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
         stack: 'zero', // Can be 'zero', 'normalize', or 'center'
       },
       // Color: Second categorical field (stacking)

--- a/src/plugins/explore/public/components/visualizations/chart_type_selector.tsx
+++ b/src/plugins/explore/public/components/visualizations/chart_type_selector.tsx
@@ -27,8 +27,7 @@ interface ChartTypeSelectorProps<T extends ChartType> {
   onChartTypeChange?: (chartType: ChartType) => void;
 }
 
-// TODO: rename it, this is chart type selector option, not rule
-interface AvailableRuleOption {
+interface AvailableChartTypeOption {
   value: string;
   inputDisplay: React.ReactNode;
   iconType?: string;
@@ -78,11 +77,11 @@ export const ChartTypeSelector = <T extends ChartType>({
           id: rule.id,
           name: rule.name,
           matchIndex: rule.matchIndex,
-          toExpression: rule.toExpression,
+          toSpec: rule.toSpec,
         });
       });
       return acc;
-    }, {} as Record<string, AvailableRuleOption>);
+    }, {} as Record<string, AvailableChartTypeOption>);
   }, []); // Only calculate once
 
   // Process chart types to mark unavailable ones as disabled

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.test.ts
@@ -3,43 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
-  createlabelLayer,
+  createLabelLayer,
   getDataBound,
   addTransform,
   setRange,
   enhanceStyle,
 } from './heatmap_chart_utils';
 import * as utils from './heatmap_chart_utils';
-import {
-  LabelAggregationType,
-  VisFieldType,
-  ColorSchemas,
-  ScaleType,
-  CompleteAxisWithStyle,
-  StandardAxes,
-} from '../types';
+import { LabelAggregationType, VisFieldType, ColorSchemas, ScaleType, VisColumn } from '../types';
 
 import { defaultHeatmapChartStyles, HeatmapLabels } from './heatmap_vis_config';
 import * as colorUtil from '../utils/utils';
 
-describe('createlabelLayer', () => {
-  const xAxis: CompleteAxisWithStyle = {
+describe('createLabelLayer', () => {
+  const xAxis: VisColumn = {
     id: 2,
     name: 'category',
     schema: VisFieldType.Categorical,
     column: 'category',
     validValuesCount: 1,
     uniqueValuesCount: 1,
-    styles: {} as StandardAxes,
   };
-  const yAxis: CompleteAxisWithStyle = {
+  const yAxis: VisColumn = {
     id: 3,
     name: 'product',
     schema: VisFieldType.Categorical,
     column: 'product',
     validValuesCount: 1,
     uniqueValuesCount: 1,
-    styles: {} as StandardAxes,
   };
 
   const colorField = 'value';
@@ -58,7 +49,7 @@ describe('createlabelLayer', () => {
         },
       },
     };
-    const result = createlabelLayer(styles, true, colorField, xAxis, yAxis);
+    const result = createLabelLayer(styles, true, colorField, xAxis, yAxis);
     expect(result).toBeNull();
   });
 
@@ -77,7 +68,7 @@ describe('createlabelLayer', () => {
       },
     };
 
-    const result = createlabelLayer(baseStyles, true, colorField, xAxis, yAxis);
+    const result = createLabelLayer(baseStyles, true, colorField, xAxis, yAxis);
 
     expect(result).toEqual({
       mark: {
@@ -123,7 +114,7 @@ describe('createlabelLayer', () => {
       },
     };
 
-    const result = createlabelLayer(styles, false, colorField, xAxis, yAxis);
+    const result = createLabelLayer(styles, false, colorField, xAxis, yAxis);
     expect(result?.encoding.text).toHaveProperty('aggregate', LabelAggregationType.SUM);
   });
 
@@ -142,7 +133,7 @@ describe('createlabelLayer', () => {
       },
     };
 
-    const result = createlabelLayer(baseStyles, false, colorField, xAxis, yAxis);
+    const result = createLabelLayer(baseStyles, false, colorField, xAxis, yAxis);
 
     expect(result?.encoding.text).not.toHaveProperty('aggregate');
     expect(result?.encoding.text).toEqual({

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.ts
@@ -4,17 +4,17 @@
  */
 
 import type { Encoding } from 'vega-lite/build/src/encoding';
-import { LabelAggregationType, ColorSchemas, CompleteAxisWithStyle } from '../types';
+import { LabelAggregationType, ColorSchemas, VisColumn } from '../types';
 import { HeatmapChartStyleControls } from './heatmap_vis_config';
 import { generateColorBySchema } from '../utils/utils';
 
 // isRegular=== true refers to 2 dimension and 1 metric heatmap.
-export const createlabelLayer = (
+export const createLabelLayer = (
   styles: Partial<HeatmapChartStyleControls>,
   isRegular: boolean,
   colorField: string,
-  xAxis?: CompleteAxisWithStyle,
-  yAxis?: CompleteAxisWithStyle
+  xAxis?: VisColumn,
+  yAxis?: VisColumn
 ) => {
   if (!styles.exclusive?.label?.show) {
     return null;

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.test.ts
@@ -78,9 +78,9 @@ describe('createHeatmapeConfig', () => {
     expect(config.ui.availableMappings).toBeDefined();
     expect(config.ui.availableMappings).toHaveLength(1);
 
-    expect(config.ui.availableMappings[0].mapping[0]).toHaveProperty(AxisRole.X);
-    expect(config.ui.availableMappings[0].mapping[0]).toHaveProperty(AxisRole.Y);
-    expect(config.ui.availableMappings[0].mapping[0]).toHaveProperty(AxisRole.COLOR);
+    expect(config.ui.availableMappings[0]).toHaveProperty(AxisRole.X);
+    expect(config.ui.availableMappings[0]).toHaveProperty(AxisRole.Y);
+    expect(config.ui.availableMappings[0]).toHaveProperty(AxisRole.COLOR);
   });
 
   it('should render the HeatmapVisStyleControls component with the provided props', () => {

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.ts
@@ -137,13 +137,9 @@ export const createHeatmapConfig = (): VisualizationType<'heatmap'> => ({
     },
     availableMappings: [
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Categorical, index: 1 },
-            [AxisRole.COLOR]: { type: VisFieldType.Numerical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Categorical, index: 1 },
+        [AxisRole.COLOR]: { type: VisFieldType.Numerical, index: 0 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.test.ts
@@ -10,12 +10,12 @@ import { HeatmapChartStyleControls } from './heatmap_vis_config';
 jest.mock('./heatmap_chart_utils', () => ({
   enhanceStyle: jest.fn(),
   addTransform: jest.fn(() => []),
-  createlabelLayer: jest.fn(() => null),
+  createLabelLayer: jest.fn(() => null),
 }));
 
 jest.mock('../utils/utils', () => ({
   applyAxisStyling: jest.fn(() => ({ title: 'mockAxis' })),
-  getSwappedAxisRole: jest.fn((styles, mappings) => [mappings.x, mappings.y]),
+  getSwappedAxisRole: jest.fn((styles, mappings) => ({ xAxis: mappings.x, yAxis: mappings.y })),
   getSchemaByAxis: jest.fn((axis) => (axis?.schema === 'Numerical' ? 'quantitative' : 'nominal')),
 }));
 

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
@@ -6,7 +6,7 @@
 import { HeatmapChartStyleControls } from './heatmap_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings } from '../types';
 import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis } from '../utils/utils';
-import { createlabelLayer, enhanceStyle, addTransform } from './heatmap_chart_utils';
+import { createLabelLayer, enhanceStyle, addTransform } from './heatmap_chart_utils';
 
 export const createHeatmapWithBin = (
   transformedData: Array<Record<string, any>>,
@@ -14,7 +14,7 @@ export const createHeatmapWithBin = (
   styles: Partial<HeatmapChartStyleControls>,
   axisColumnMappings?: AxisColumnMappings
 ) => {
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const colorFieldColumn = axisColumnMappings?.color as any;
   const colorField = colorFieldColumn?.column;
@@ -32,13 +32,13 @@ export const createHeatmapWithBin = (
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
         bin: true,
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
         bin: true,
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       color: {
         field: colorField,
@@ -64,12 +64,12 @@ export const createHeatmapWithBin = (
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
           },
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
           },
           { field: colorField, type: 'quantitative', title: colorName },
         ],
@@ -83,7 +83,7 @@ export const createHeatmapWithBin = (
     $schema: VEGASCHEMA,
     data: { values: transformedData },
     transform: addTransform(styles, colorField),
-    layer: [markLayer, createlabelLayer(styles, false, colorField, xAxis, yAxis)].filter(Boolean),
+    layer: [markLayer, createLabelLayer(styles, false, colorField, xAxis, yAxis)].filter(Boolean),
     title: styles.titleOptions?.show
       ? styles.titleOptions?.titleName || `${colorName} by ${xAxis?.name} and ${yAxis?.name}`
       : undefined,
@@ -97,7 +97,7 @@ export const createRegularHeatmap = (
   styles: Partial<HeatmapChartStyleControls>,
   axisColumnMappings?: AxisColumnMappings
 ) => {
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const colorFieldColumn = axisColumnMappings?.color!;
   const colorField = colorFieldColumn?.column;
@@ -114,13 +114,13 @@ export const createRegularHeatmap = (
       x: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis, true),
+        axis: applyAxisStyling(xAxis, xAxisStyle, true),
         // for regular heatmap, both x and y refer to categorical fields, we shall disable grid line for this case
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis, true),
+        axis: applyAxisStyling(yAxis, yAxisStyle, true),
       },
       color: {
         field: colorField,
@@ -146,12 +146,12 @@ export const createRegularHeatmap = (
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
           },
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
           },
           { field: colorField, type: 'quantitative', title: colorName },
         ],
@@ -165,7 +165,7 @@ export const createRegularHeatmap = (
     $schema: VEGASCHEMA,
     data: { values: transformedData },
     transform: addTransform(styles, colorField),
-    layer: [markLayer, createlabelLayer(styles, true, colorField, xAxis, yAxis)].filter(Boolean),
+    layer: [markLayer, createLabelLayer(styles, true, colorField, xAxis, yAxis)].filter(Boolean),
     title: styles.titleOptions?.show
       ? styles.titleOptions?.titleName || `${colorName} by ${xAxis?.name} and ${yAxis?.name}`
       : undefined,

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
@@ -121,8 +121,8 @@ describe('line_vis_config', () => {
       const config = createLineConfig();
 
       expect(config.ui.availableMappings).toHaveLength(5);
-      expect(config.ui.availableMappings[0].mapping[0]).toHaveProperty('x');
-      expect(config.ui.availableMappings[0].mapping[0]).toHaveProperty('y');
+      expect(config.ui.availableMappings[0]).toHaveProperty('x');
+      expect(config.ui.availableMappings[0]).toHaveProperty('y');
     });
 
     it('should render the LineVisStyleControls component with the provided props', () => {

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.ts
@@ -123,51 +123,30 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
       defaults: defaultLineChartStyles,
       render: (props) => React.createElement(LineVisStyleControls, props),
     },
-    // TODO: refactor availableMappings to a flatten array
     availableMappings: [
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y_SECOND]: { type: VisFieldType.Numerical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y_SECOND]: { type: VisFieldType.Numerical, index: 1 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.FACET]: { type: VisFieldType.Categorical, index: 1 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.ts
@@ -37,11 +37,7 @@ export const createMetricConfig = (): VisualizationType<'metric'> => ({
     },
     availableMappings: [
       {
-        mapping: [
-          {
-            [AxisRole.Value]: { type: VisFieldType.Numerical, index: 0 },
-          },
-        ],
+        [AxisRole.Value]: { type: VisFieldType.Numerical, index: 0 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.ts
@@ -60,12 +60,8 @@ export const createPieConfig = (): VisualizationType<'pie'> => ({
     },
     availableMappings: [
       {
-        mapping: [
-          {
-            [AxisRole.SIZE]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-          },
-        ],
+        [AxisRole.SIZE]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/rule_repository.test.ts
+++ b/src/plugins/explore/public/components/visualizations/rule_repository.test.ts
@@ -163,7 +163,7 @@ describe('rule_repository', () => {
 
     it('should create a simple line chart expression by default', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 0, 1);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -199,7 +199,7 @@ describe('rule_repository', () => {
 
     it('should create a line bar chart expression by default', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(2, 0, 1);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -235,7 +235,7 @@ describe('rule_repository', () => {
 
     it('should create a multi line chart expression by default', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 1, 1);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -269,7 +269,7 @@ describe('rule_repository', () => {
 
     it('should create a faceted multi line chart expression by default', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 2, 1);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -317,7 +317,7 @@ describe('rule_repository', () => {
     it('should create a regular heatmap expression by default', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 2, 0);
       categoricalColumns[0].uniqueValuesCount = 10;
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -337,7 +337,7 @@ describe('rule_repository', () => {
     it('should create a stacked bar chart expression when chart type is bar', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 2, 0);
       categoricalColumns[0].uniqueValuesCount = 10;
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -373,7 +373,7 @@ describe('rule_repository', () => {
 
     it('should create a pie chart expression by default', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 1, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -394,7 +394,7 @@ describe('rule_repository', () => {
 
     it('should create a bar chart expression when chart type is bar', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 1, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -416,7 +416,7 @@ describe('rule_repository', () => {
 
     it('should create a pie chart expression when chart type is pie', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 1, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -452,7 +452,7 @@ describe('rule_repository', () => {
 
     it('should create a single metric expression', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(1, 0, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -487,7 +487,7 @@ describe('rule_repository', () => {
 
     it('should create a scatter chart expression', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(2, 0, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -522,7 +522,7 @@ describe('rule_repository', () => {
 
     it('should create a scatter chart with category expression', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(2, 1, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,
@@ -557,7 +557,7 @@ describe('rule_repository', () => {
 
     it('should create a scatter chart with three metrics and one category expression', () => {
       const { numericalColumns, categoricalColumns, dateColumns } = createTestColumns(3, 1, 0);
-      const expression = rule?.toExpression?.(
+      const expression = rule?.toSpec?.(
         transformedData,
         numericalColumns,
         categoricalColumns,

--- a/src/plugins/explore/public/components/visualizations/rule_repository.ts
+++ b/src/plugins/explore/public/components/visualizations/rule_repository.ts
@@ -54,7 +54,7 @@ const oneMetricOneDateRule: VisualizationRule = {
     { ...CHART_METADATA.area, priority: 80 },
     { ...CHART_METADATA.bar, priority: 60 },
   ],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -110,7 +110,7 @@ const twoMetricOneDateRule: VisualizationRule = {
     numerical.length === 2 && categorical.length === 0 && date.length === 1,
   chartTypes: [{ ...CHART_METADATA.line, priority: 100 }],
   matchIndex: [2, 0, 1],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -154,7 +154,7 @@ const oneMetricOneCateOneDateRule: VisualizationRule = {
     { ...CHART_METADATA.area, priority: 80 },
     { ...CHART_METADATA.bar, priority: 60 },
   ],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -218,7 +218,7 @@ const oneMetricTwoCateOneDateRule: VisualizationRule = {
     { ...CHART_METADATA.area, priority: 80 },
     { ...CHART_METADATA.bar, priority: 60 },
   ],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -286,7 +286,7 @@ const oneMetricTwoCateHighCardRule: VisualizationRule = {
     { ...CHART_METADATA.bar, priority: 80 },
     { ...CHART_METADATA.area, priority: 60 },
   ],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -349,7 +349,7 @@ const oneMetricTwoCateLowCardRule: VisualizationRule = {
     { ...CHART_METADATA.heatmap, priority: 80 },
     { ...CHART_METADATA.area, priority: 60 },
   ],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -408,7 +408,7 @@ const oneMetricOneCateRule: VisualizationRule = {
     { ...CHART_METADATA.line, priority: 60 },
     { ...CHART_METADATA.area, priority: 40 },
   ],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -478,7 +478,7 @@ const oneMetricRule: VisualizationRule = {
     numerical[0].validValuesCount === 1,
   chartTypes: [{ ...CHART_METADATA.metric, priority: 100 }],
   matchIndex: [1, 0, 0],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -506,7 +506,7 @@ const twoMetricRule: VisualizationRule = {
     numerical.length === 2 && date.length === 0 && categorical.length === 0,
   chartTypes: [{ ...CHART_METADATA.scatter, priority: 100 }],
   matchIndex: [2, 0, 0],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -534,7 +534,7 @@ const twoMetricOneCateRule: VisualizationRule = {
     numerical.length === 2 && date.length === 0 && categorical.length === 1,
   chartTypes: [{ ...CHART_METADATA.scatter, priority: 100 }],
   matchIndex: [2, 1, 0],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -562,7 +562,7 @@ const threeMetricOneCateRule: VisualizationRule = {
     numerical.length === 3 && date.length === 0 && categorical.length === 1,
   chartTypes: [{ ...CHART_METADATA.scatter, priority: 100 }],
   matchIndex: [3, 1, 0],
-  toExpression: (
+  toSpec: (
     transformedData,
     numericalColumns,
     categoricalColumns,
@@ -581,8 +581,6 @@ const threeMetricOneCateRule: VisualizationRule = {
     );
   },
 };
-
-// TODO: add more rules here as needed
 
 // Export all rules
 export const ALL_VISUALIZATION_RULES: VisualizationRule[] = [

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.ts
@@ -108,31 +108,19 @@ export const createScatterConfig = (): VisualizationType<'scatter'> => ({
     },
     availableMappings: [
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
       },
       {
-        mapping: [
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
-            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-            [AxisRole.SIZE]: { type: VisFieldType.Numerical, index: 2 },
-          },
-        ],
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.SIZE]: { type: VisFieldType.Numerical, index: 2 },
       },
     ],
   },

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
@@ -15,7 +15,7 @@ export const createTwoMetricScatter = (
   styles: Partial<ScatterChartStyleControls>,
   axisColumnMappings?: AxisColumnMappings
 ): any => {
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const markLayer = {
     mark: {
@@ -29,24 +29,24 @@ export const createTwoMetricScatter = (
       x: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
           },
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
           },
         ],
       }),
@@ -75,7 +75,7 @@ export const createTwoMetricOneCateScatter = (
   const colorColumn = axisColumnMappings?.color;
   const categoryFields = axisColumnMappings?.color?.column!;
   const categoryNames = axisColumnMappings?.color?.name!;
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
   const markLayer = {
     mark: {
       type: 'point',
@@ -88,12 +88,12 @@ export const createTwoMetricOneCateScatter = (
       x: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       color: {
         field: categoryFields,
@@ -111,12 +111,12 @@ export const createTwoMetricOneCateScatter = (
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
           },
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
           },
           { field: categoryFields, type: 'nominal', title: categoryNames },
         ],
@@ -147,7 +147,7 @@ export const createThreeMetricOneCateScatter = (
   const colorColumn = axisColumnMappings?.color;
   const categoryFields = axisColumnMappings?.color?.column!;
   const categoryNames = axisColumnMappings?.color?.name!;
-  const [xAxis, yAxis] = getSwappedAxisRole(styles, axisColumnMappings);
+  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
   const numericalSize = axisColumnMappings?.size;
   const markLayer = {
@@ -162,12 +162,12 @@ export const createThreeMetricOneCateScatter = (
       x: {
         field: xAxis?.column,
         type: getSchemaByAxis(xAxis),
-        axis: applyAxisStyling(xAxis),
+        axis: applyAxisStyling(xAxis, xAxisStyle),
       },
       y: {
         field: yAxis?.column,
         type: getSchemaByAxis(yAxis),
-        axis: applyAxisStyling(yAxis),
+        axis: applyAxisStyling(yAxis, yAxisStyle),
       },
       color: {
         field: categoryFields,
@@ -196,12 +196,12 @@ export const createThreeMetricOneCateScatter = (
           {
             field: xAxis?.column,
             type: getSchemaByAxis(xAxis),
-            title: xAxis?.styles?.title?.text || xAxis?.name,
+            title: xAxisStyle?.title?.text || xAxis?.name,
           },
           {
             field: yAxis?.column,
             type: getSchemaByAxis(yAxis),
-            title: yAxis?.styles?.title?.text || yAxis?.name,
+            title: yAxisStyle?.title?.text || yAxis?.name,
           },
           { field: categoryFields, type: 'nominal', title: categoryNames },
           { field: numericalSize?.column, type: 'quantitative', title: numericalSize?.name },

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.test.tsx
@@ -118,12 +118,8 @@ describe('AxesSelectPanel', () => {
       ui: {
         availableMappings: [
           {
-            mapping: [
-              {
-                [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-                [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-              },
-            ],
+            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
           },
         ],
       },
@@ -213,12 +209,8 @@ describe('AxesSelectPanel', () => {
       ui: {
         availableMappings: [
           {
-            mapping: [
-              {
-                [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-                [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-              },
-            ],
+            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
           },
         ],
       },
@@ -241,12 +233,8 @@ describe('AxesSelectPanel', () => {
       ui: {
         availableMappings: [
           {
-            mapping: [
-              {
-                [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-                [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-              },
-            ],
+            [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
           },
         ],
       },
@@ -277,13 +265,9 @@ describe('AxesSelectPanel', () => {
       ui: {
         availableMappings: [
           {
-            mapping: [
-              {
-                [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
-                [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-                [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-              },
-            ],
+            [AxisRole.X]: { type: VisFieldType.Date, index: 0 },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+            [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
           },
         ],
       },

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
@@ -94,8 +94,9 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     }
   }, [currentMapping]);
 
-  const possibleMapping = useMemo(
-    () => visualizationRegistry.getVisualizationConfig(chartType)?.ui.availableMappings!,
+  // All axis mappings of the selected chart type
+  const allMappings = useMemo(
+    () => visualizationRegistry.getVisualizationConfig(chartType)?.ui.availableMappings,
     [chartType, visualizationRegistry]
   );
 
@@ -104,25 +105,19 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     [numericalColumns.length, categoricalColumns.length, dateColumns.length]
   );
 
-  // Filter out those mapping (combination of axes selection) that cannot be satisify
-  // by the combination of fields from the query
-  const availableMappingsFromQuery = useMemo(
-    () =>
-      possibleMapping
-        .filter((obj) => {
-          const [ruleNum, ruleCat, ruleDate] = getColumnMatchFromMapping(obj.mapping);
-          const [currNum, currCat, currDate] = columnsCount;
-          return ruleNum <= currNum && ruleCat <= currCat && ruleDate <= currDate;
-        })
-        .flatMap((selection) => selection.mapping),
-    [columnsCount, possibleMapping]
-  );
+  // Filter available chart mappings based on the data's column types
+  // This ensures we only show mappings that are compatible with the current dataset structure
+  const availableMappings = useMemo(() => {
+    if (!allMappings) {
+      return [];
+    }
 
-  // All available axes to be selected are base on current query
-  const allAxisRolesFromQuery = new Set<AxisRole>();
-  availableMappingsFromQuery.forEach((mapping) => {
-    Object.keys(mapping).forEach((role) => allAxisRolesFromQuery.add(role as AxisRole));
-  });
+    return allMappings.filter((mapping) => {
+      const [ruleNum, ruleCat, ruleDate] = getColumnMatchFromMapping(mapping);
+      const [currNum, currCat, currDate] = columnsCount;
+      return ruleNum <= currNum && ruleCat <= currCat && ruleDate <= currDate;
+    });
+  }, [columnsCount, allMappings]);
 
   const [currentSelections, setCurrentSelections] = useState<AxisColumnMappings>({});
 
@@ -135,60 +130,62 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     );
   }, [currentMapping]);
 
-  // Filter out those mapping (combination of axes selection) that no longer be satisify
-  // by the current combination of axes selection
-  const availableMappingsFromSelection = useMemo(
+  // Further filter mappings to only include those that are compatible with the user's current axis selections
+  // This ensures that as users make axis choices, we only show mappings that would work with those choices
+  const remainingMappings = useMemo(
     () =>
-      availableMappingsFromQuery.filter((mapping) => {
+      availableMappings.filter((mapping) => {
         return Object.entries(currentSelections).every(([role, selectedCol]) => {
           if (!selectedCol) return true;
-          const mappingRole = (mapping as any)[role];
+          const mappingRole = mapping[role as AxisRole];
           return mappingRole && mappingRole.type === selectedCol.schema;
         });
       }),
-    [availableMappingsFromQuery, currentSelections]
+    [availableMappings, currentSelections]
   );
 
   // Only displays axis select component base on current selection
   const allAxisRolesFromSelection = new Set<AxisRole>();
-  availableMappingsFromSelection.forEach((mapping) => {
+  remainingMappings.forEach((mapping) => {
     Object.keys(mapping).forEach((role) => allAxisRolesFromSelection.add(role as AxisRole));
   });
 
-  // The one and only one valid mapping base on current selection, will be undefined if current
-  // selection is invalid
-  const currentValidSelection = useMemo(() => {
-    const selectedCount = Object.values(currentSelections).filter(Boolean).length;
-    const mapping = availableMappingsFromSelection.find(
-      (m) => Object.keys(m).length === selectedCount
-    );
-    if (!mapping) return undefined;
-    const possibleSelection = possibleMapping.find((selection) =>
-      selection.mapping.includes(mapping as any)
-    );
-    return possibleSelection
-      ? { mapping, columnMatch: getColumnMatchFromMapping(possibleSelection.mapping) }
-      : undefined;
-  }, [availableMappingsFromSelection, currentSelections, possibleMapping]);
-
   useEffect(() => {
-    if (currentValidSelection) {
+    // Current selected axis mapping
+    const updatedAxes: AxisColumnMappings = {};
+    Object.entries(currentSelections).forEach(([key, value]) => {
+      if (value) {
+        updatedAxes[key as AxisRole] = value;
+      }
+    });
+
+    // Find the mapping based on current selected axis mapping, if found, then current selection is valid
+    const found = remainingMappings.find((m) => {
+      if (Object.keys(m).length === Object.keys(updatedAxes).length) {
+        return Object.keys(m).every(
+          (key) => m[key as AxisRole]?.type === updatedAxes[key as AxisRole]?.schema
+        );
+      }
+      return false;
+    });
+
+    if (found) {
+      // Find a vis rule for the current mapping
       const ruleToUse = ALL_VISUALIZATION_RULES.find((rule) =>
-        isEqual(rule.matchIndex, currentValidSelection.columnMatch)
+        isEqual(rule.matchIndex, getColumnMatchFromMapping(found))
       );
-
+      // If rule can be found, update visualization with the new axes mapping
+      // Limitation: the current implementation will only call updateVisualization() when the select
+      // mapping is valid and has rule mapped, which means partial selections won't trigger visualization
+      // updates until they form a complete valid mapping configuration.
+      // From the user's perspective, this means no visual feedback is provided during the selection
+      // process until a complete valid configuration is achieved, potentially leading to confusion
+      // about whether their partial selections are having any effect.
       if (ruleToUse) {
-        const updatedAxes: AxisColumnMappings = {};
-        Object.entries(currentSelections).forEach(([key, value]) => {
-          if (value) {
-            updatedAxes[key as AxisRole] = value;
-          }
-        });
-
-        updateVisualization({ rule: ruleToUse, mappings: updatedAxes });
+        updateVisualization({ mappings: updatedAxes });
       }
     }
-  }, [currentValidSelection, updateVisualization, currentSelections]);
+  }, [updateVisualization, currentSelections, remainingMappings]);
 
   const findColumns = useMemo(
     () => (type: VisFieldType) => {
@@ -223,33 +220,35 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     }
   };
 
-  if (availableMappingsFromQuery.length === 0) {
+  if (availableMappings.length === 0) {
     return null;
   }
 
-  const getAvailableColumnsForAxis = (axisRole: AxisRole) => {
+  const getAxisOptions = (axisRole: AxisRole) => {
     const availableTypes = new Set<VisFieldType>();
 
     // Get types from current valid mappings
-    availableMappingsFromSelection.forEach((mapping) => {
-      if ((mapping as any)[axisRole]) {
-        availableTypes.add((mapping as any)[axisRole].type);
+    remainingMappings.forEach((mapping) => {
+      const roleColumn = mapping[axisRole];
+      if (roleColumn) {
+        availableTypes.add(roleColumn.type);
       }
     });
 
     // Get types from mappings that would become available if we change this axis
-    availableMappingsFromQuery.forEach((mapping) => {
+    availableMappings.forEach((mapping) => {
       const otherSelections = Object.entries(currentSelections).filter(
         ([role]) => role !== axisRole
       );
       const isCompatible = otherSelections.every(([role, selectedCol]) => {
         if (!selectedCol) return true;
-        const mappingRole = (mapping as any)[role];
+        const mappingRole = mapping[role as AxisRole];
         return mappingRole && mappingRole.type === selectedCol.schema;
       });
 
-      if (isCompatible && (mapping as any)[axisRole]) {
-        availableTypes.add((mapping as any)[axisRole].type);
+      const roleColumn = mapping[axisRole];
+      if (isCompatible && roleColumn) {
+        availableTypes.add(roleColumn.type);
       }
     });
 
@@ -298,7 +297,7 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
               key={axisRole}
               axisRole={axisRole}
               selectedColumn={currentSelection?.name || ''}
-              allColumnOptions={getAvailableColumnsForAxis(axisRole)}
+              allColumnOptions={getAxisOptions(axisRole)}
               switchAxes={switchAxes}
               inputRef={(input) => (i === 0 ? (firstSelectorInput.current = input) : undefined)}
               onRemove={(role) => {

--- a/src/plugins/explore/public/components/visualizations/style_panel/style_panel.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/style_panel.tsx
@@ -10,7 +10,7 @@ import { EuiSpacer } from '@elastic/eui';
 import { ChartTypeSelector } from '../chart_type_selector';
 import { ChartType, StyleOptions } from '../utils/use_visualization_types';
 import { VisualizationBuilder } from '../visualization_builder';
-import { AxisColumnMappings, VisualizationRule } from '../types';
+import { AxisColumnMappings } from '../types';
 import {
   convertMappingsToStrings,
   convertStringsToMappings,
@@ -46,13 +46,15 @@ export const StylePanel = <T extends ChartType>({
   );
 
   const updateVisualization = useCallback(
-    ({ rule, mappings }: { rule?: Partial<VisualizationRule>; mappings: AxisColumnMappings }) => {
+    ({ mappings }: { mappings: AxisColumnMappings }) => {
       visualizationBuilder.setAxesMapping(convertMappingsToStrings(mappings));
     },
     [visualizationBuilder]
   );
 
   // TODO: refactor this and expose an observable from visualizationBuilder
+  // Or refactor visConfig?.ui.style.render() function to accept axesMapping
+  // and compute axisColumnMappings internally
   const axisColumnMappings = useMemo(() => {
     return convertStringsToMappings(axesMapping ?? {}, [
       ...(visualizationData?.categoricalColumns ?? []),

--- a/src/plugins/explore/public/components/visualizations/types.ts
+++ b/src/plugins/explore/public/components/visualizations/types.ts
@@ -7,9 +7,6 @@ import { ChartStyleControlMap } from '../visualizations/utils/use_visualization_
 
 type AxisSupportedChartTypes = 'bar' | 'scatter' | 'heatmap';
 export type AxisSupportedStyles = ChartStyleControlMap[AxisSupportedChartTypes];
-export interface CompleteAxisWithStyle extends Partial<VisColumn> {
-  styles: StandardAxes;
-}
 
 export enum Positions {
   RIGHT = 'right',
@@ -40,8 +37,7 @@ export interface VisualizationRule {
   ) => boolean;
   matchIndex: number[];
   chartTypes: ChartTypeMapping[]; // Each rule can map to multiple chart types with priorities
-  // TODO: rename it, the name is inappropriate, it doesn't create expression
-  toExpression?: (
+  toSpec?: (
     transformedData: Array<Record<string, any>>,
     numericalColumns: VisColumn[],
     categoricalColumns: VisColumn[],

--- a/src/plugins/explore/public/components/visualizations/utils/use_visualization_types.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/use_visualization_types.ts
@@ -36,14 +36,11 @@ export interface ChartStyleControlMap {
   bar: BarChartStyleControls;
   area: AreaChartStyleControls;
   table: TableChartStyleControls;
-  // NOTE: Log table does not have style controls.
-  // log is one of chart types?
-  // logs: {};
 }
 
 export type StyleOptions = ChartStyleControlMap[ChartType];
 
-export type AllChartStyleControls =
+type AllChartStyleControls =
   | LineChartStyleControls
   | PieChartStyleControls
   | BarChartStyleControls
@@ -65,9 +62,7 @@ export interface StyleControlsProps<T extends AllChartStyleControls> {
   updateVisualization: (data: UpdateVisualizationProps) => void;
 }
 
-export interface ChartTypePossibleMapping {
-  mapping: Array<Partial<Record<AxisRole, { type: VisFieldType; index: number }>>>;
-}
+type ChartTypePossibleMapping = Partial<Record<AxisRole, { type: VisFieldType; index: number }>>;
 
 export interface VisualizationType<T extends ChartType> {
   readonly name: string;

--- a/src/plugins/explore/public/components/visualizations/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.test.ts
@@ -8,7 +8,6 @@ import {
   getAxisByRole,
   generateColorBySchema,
   swapAxes,
-  getSwappedAxes,
   getSwappedAxisRole,
   getSchemaByAxis,
   inferTimeUnitFromTimestamps,
@@ -17,36 +16,37 @@ import {
 import { AxisRole, Positions, ColorSchemas, VisFieldType, StandardAxes } from '../types';
 
 describe('applyAxisStyling', () => {
-  const defaultAxisStyle = {
+  const defaultAxis = {
     id: 1,
     name: 'X Value',
     schema: VisFieldType.Numerical,
     column: 'x',
     validValuesCount: 6,
     uniqueValuesCount: 6,
-    styles: {
-      id: 'Axis-1',
-      position: Positions.LEFT,
+  };
+
+  const defaultAxisStyle = {
+    id: 'Axis-1',
+    position: Positions.LEFT,
+    show: true,
+    style: {},
+    labels: {
       show: true,
-      style: {},
-      labels: {
-        show: true,
-        rotate: 45,
-        filter: false,
-        truncate: 10,
-      },
-      title: {
-        text: 'Custom Title',
-      },
-      grid: {
-        showLines: true,
-      },
-      axisRole: AxisRole.X,
+      rotate: 45,
+      filter: false,
+      truncate: 10,
     },
+    title: {
+      text: 'Custom Title',
+    },
+    grid: {
+      showLines: true,
+    },
+    axisRole: AxisRole.X,
   };
 
   it('returns default config with title and labels when style is provided', () => {
-    const config = applyAxisStyling(defaultAxisStyle);
+    const config = applyAxisStyling(defaultAxis, defaultAxisStyle);
     expect(config.grid).toBe(true);
     expect(config.orient).toBe(Positions.LEFT);
     expect(config.title).toBe('Custom Title');
@@ -56,15 +56,7 @@ describe('applyAxisStyling', () => {
   });
 
   it('disables axis when show is false', () => {
-    const hiddenAxisStyle = {
-      ...defaultAxisStyle,
-      styles: {
-        ...defaultAxisStyle.styles,
-        show: false,
-      },
-    };
-
-    const config = applyAxisStyling(hiddenAxisStyle);
+    const config = applyAxisStyling(defaultAxis, { ...defaultAxisStyle, show: false });
     expect(config.title).toBeNull();
     expect(config.labels).toBe(false);
     expect(config.ticks).toBe(false);
@@ -112,86 +104,15 @@ describe('swapAxes', () => {
   });
 });
 
-describe('getSwappedAxes', () => {
-  const x = {
-    id: 1,
-    name: 'X Value',
-    schema: VisFieldType.Categorical,
-    column: 'x',
-    validValuesCount: 6,
-    uniqueValuesCount: 6,
-    styles: {
-      id: 'Axis-1',
-      position: Positions.BOTTOM,
-      show: true,
-      style: {},
-      labels: {
-        show: true,
-        rotate: 45,
-        filter: false,
-        truncate: 10,
-      },
-      title: {
-        text: 'Custom Title',
-      },
-      grid: {
-        showLines: true,
-      },
-      axisRole: AxisRole.X,
-    },
-  };
-  const y = {
-    id: 1,
-    name: 'Y Value',
-    schema: VisFieldType.Numerical,
-    column: 'y',
-    validValuesCount: 6,
-    uniqueValuesCount: 6,
-    styles: {
-      id: 'Axis-1',
-      position: Positions.LEFT,
-      show: true,
-      style: {},
-      labels: {
-        show: true,
-        rotate: 45,
-        filter: false,
-        truncate: 10,
-      },
-      title: {
-        text: 'Custom Title',
-      },
-      grid: {
-        showLines: true,
-      },
-      axisRole: AxisRole.X,
-    },
-  };
-
-  it('returns same axes when switchAxes is false', () => {
-    const [xAxis, yAxis] = getSwappedAxes(x, y, false);
-    expect(xAxis.schema).toBe(VisFieldType.Categorical);
-    expect(yAxis.schema).toBe(VisFieldType.Numerical);
-  });
-
-  it('swaps axes and updates position when switchAxes is true', () => {
-    const [xAxis, yAxis] = getSwappedAxes(x, y, true);
-    expect(xAxis.schema).toBe(VisFieldType.Numerical);
-    expect(yAxis.schema).toBe(VisFieldType.Categorical);
-    expect(xAxis.styles.position).toBe(Positions.BOTTOM);
-    expect(yAxis.styles.position).toBe(Positions.LEFT);
-  });
-});
-
 describe('getSwappedAxisRole', () => {
   it('returns undefined when axes are missing', () => {
-    const [x, y] = getSwappedAxisRole({}, {});
-    expect(x).toBeUndefined();
-    expect(y).toBeUndefined();
+    const { xAxis, yAxis } = getSwappedAxisRole({}, {});
+    expect(xAxis).toBeUndefined();
+    expect(yAxis).toBeUndefined();
   });
 
   it('returns swapped roles if switchAxes is true', () => {
-    const result = getSwappedAxisRole(
+    const { xAxis, yAxis } = getSwappedAxisRole(
       {
         standardAxes: [
           { axisRole: AxisRole.X, position: Positions.BOTTOM } as StandardAxes,
@@ -219,8 +140,8 @@ describe('getSwappedAxisRole', () => {
       }
     );
 
-    expect(result[0]?.schema).toBe(VisFieldType.Numerical);
-    expect(result[1]?.schema).toBe(VisFieldType.Categorical);
+    expect(xAxis?.schema).toBe(VisFieldType.Numerical);
+    expect(yAxis?.schema).toBe(VisFieldType.Categorical);
   });
 });
 

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.ts
@@ -136,7 +136,6 @@ export class VisualizationBuilder {
 
     // Table chart doesn't have axes mapping
     if (chartType === 'table') {
-      // this.setAxesMapping({});
       return;
     }
 
@@ -213,9 +212,9 @@ export class VisualizationBuilder {
         (chart) => chart.type === chartType
       );
       if (isChartTypeInCurrentRule) {
-        const reusedMapping = visConfig.ui.availableMappings.find((obj) =>
-          isEqual(getColumnMatchFromMapping(obj.mapping), currentRule.matchIndex)
-        )?.mapping[0];
+        const reusedMapping = visConfig.ui.availableMappings.find((mapping) =>
+          isEqual(getColumnMatchFromMapping(mapping), currentRule.matchIndex)
+        );
         if (reusedMapping) {
           const updatedMapping: Record<string, string> = {};
           const availableAxesMapping = new Map(Object.entries(axesMapping));

--- a/src/plugins/explore/public/components/visualizations/visualization_container.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.test.tsx
@@ -149,7 +149,7 @@ describe('VisualizationContainer', () => {
       matches: jest.fn(),
       matchIndex: [1, 1, 0],
       chartTypes: [{ type: 'bar', name: 'Bar Chart', priority: 1, icon: 'barChart' }],
-      toExpression: jest.fn(() => 'test-expression'),
+      toSpec: jest.fn(() => 'test-expression'),
     });
 
     jest.spyOn(Utils, 'convertStringsToMappings').mockReturnValue({

--- a/src/plugins/explore/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.tsx
@@ -10,7 +10,7 @@ import { useObservable } from 'react-use';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 
 import './visualization_container.scss';
-import { AxisColumnMappings, VisColumn, VisualizationRule } from './types';
+import { AxisColumnMappings, VisColumn } from './types';
 import { toExpression } from './utils/to_expression';
 import { useDatasetContext } from '../../application/context/dataset_context/dataset_context';
 import { ExploreServices } from '../../types';
@@ -23,7 +23,6 @@ import { TableChartStyleControls } from './table/table_vis_config';
 import { VisualizationEmptyState } from './visualization_empty_state';
 
 export interface UpdateVisualizationProps {
-  rule?: Partial<VisualizationRule>;
   mappings: AxisColumnMappings;
 }
 // TODO: add back notifications
@@ -96,7 +95,7 @@ export const VisualizationContainer = () => {
     const rule = findRuleByIndex(axesMappings ?? {}, columns);
     // const rule = visualizationRegistry.getRules().find((r) => r.id === currentRuleId);
 
-    if (!rule || !rule.toExpression) {
+    if (!rule || !rule.toSpec) {
       return null;
     }
     const axisColumnMappings = convertStringsToMappings(axesMappings ?? {}, [
@@ -113,7 +112,7 @@ export const VisualizationContainer = () => {
       dateColumns: VisColumn[],
       styleOpts: any
     ) => {
-      return rule.toExpression!(
+      return rule.toSpec!(
         transformedData,
         numericalColumns,
         categoricalColumns,

--- a/src/plugins/explore/public/components/visualizations/visualization_container_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_container_utils.test.ts
@@ -160,12 +160,10 @@ describe('visualization_container_utils', () => {
 
   describe('getColumnMatchFromMapping', () => {
     it('counts column types from mapping', () => {
-      const mapping = [
-        {
-          [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
-          [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
-        },
-      ];
+      const mapping = {
+        [AxisRole.X]: { type: VisFieldType.Categorical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 0 },
+      };
 
       const result = getColumnMatchFromMapping(mapping);
 
@@ -173,13 +171,11 @@ describe('visualization_container_utils', () => {
     });
 
     it('handles multiple columns of same type', () => {
-      const mapping = [
-        {
-          [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
-          [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
-          [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
-        },
-      ];
+      const mapping = {
+        [AxisRole.X]: { type: VisFieldType.Numerical, index: 0 },
+        [AxisRole.Y]: { type: VisFieldType.Numerical, index: 1 },
+        [AxisRole.COLOR]: { type: VisFieldType.Categorical, index: 0 },
+      };
 
       const result = getColumnMatchFromMapping(mapping);
 

--- a/src/plugins/explore/public/components/visualizations/visualization_container_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_container_utils.ts
@@ -49,7 +49,7 @@ export const findRuleByIndex = (
 };
 
 export const getColumnMatchFromMapping = (
-  mapping: Array<Record<string, { type: VisFieldType; index: number }>>
+  mapping: Record<string, { type: VisFieldType; index: number }>
 ): number[] => {
   const counts = {
     [VisFieldType.Numerical]: 0,
@@ -57,7 +57,7 @@ export const getColumnMatchFromMapping = (
     [VisFieldType.Date]: 0,
     [VisFieldType.Unknown]: 0,
   };
-  Object.values(mapping[0]).forEach(({ type }) => {
+  Object.values(mapping).forEach(({ type }) => {
     if (type in counts) counts[type]++;
   });
   return [

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.ts
@@ -35,52 +35,6 @@ export class VisualizationRegistry {
     this.rules = [...initialRules];
   }
 
-  /**
-   * Get the matching visualization type based on the columns.
-   * Currently every time this is called, it will browse all rules and find the best match.
-   */
-  getVisualizationType(columns: VisColumn[]) {
-    const numericalColumns = columns.filter((column) => column.schema === VisFieldType.Numerical);
-    const categoricalColumns = columns.filter(
-      (column) => column.schema === VisFieldType.Categorical
-    );
-    const dateColumns = columns.filter((column) => column.schema === VisFieldType.Date);
-
-    const bestMatch = this.findBestMatch(numericalColumns, categoricalColumns, dateColumns);
-
-    if (bestMatch) {
-      const mappingObj = this.getDefaultAxesMapping(
-        bestMatch.rule,
-        bestMatch.chartType.type,
-        numericalColumns,
-        categoricalColumns,
-        dateColumns
-      );
-      return {
-        visualizationType: this.getVisualizationConfig(bestMatch.chartType.type),
-        numericalColumns,
-        categoricalColumns,
-        dateColumns,
-        ruleId: bestMatch.rule.id,
-        availableChartTypes: bestMatch.rule.chartTypes,
-        toExpression: bestMatch.rule.toExpression,
-        axisColumnMappings: mappingObj,
-      };
-    }
-
-    // Render empty state for the user to manually select the columns
-    return {
-      visualizationType: undefined,
-      numericalColumns,
-      categoricalColumns,
-      dateColumns,
-      ruleId: undefined,
-      availableChartTypes: [],
-      toExpression: undefined,
-      axisColumnMappings: {},
-    };
-  }
-
   getDefaultAxesMapping(
     rule: VisualizationRule,
     chartTypeName: string,
@@ -102,12 +56,12 @@ export class VisualizationRegistry {
     };
 
     const possibleMapping = this.getVisualizationConfig(chartTypeName)?.ui.availableMappings;
-    const currentlyDisplayedMapping = possibleMapping?.find(({ mapping }) =>
+    const currentlyDisplayedMapping = possibleMapping?.find((mapping) =>
       isEqual(getColumnMatchFromMapping(mapping), rule.matchIndex)
     );
     return currentlyDisplayedMapping
       ? (Object.fromEntries(
-          Object.entries(currentlyDisplayedMapping!.mapping[0]).map(([role, config]) => [
+          Object.entries(currentlyDisplayedMapping).map(([role, config]) => [
             role,
             config && findColumns(config.type)[config.index],
           ])
@@ -187,7 +141,6 @@ export class VisualizationRegistry {
         return createAreaConfig();
       case 'table':
         return createTableConfig();
-      // TODO: Add other chart types' configs here
       default:
         return;
     }

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -370,7 +370,7 @@ export class ExploreEmbeddable
           dateCols: VisColumn[],
           styleOpts: StyleOptions
         ) => {
-          return matchedRule?.toExpression?.(
+          return matchedRule?.toSpec?.(
             transformedData,
             numericalCols,
             categoricalCols,


### PR DESCRIPTION
### Description
This is a post-initial release refactor and fix PR of new discover, in this PR:
1. Refactor the data structure of `availableMappings` of each chart type to be a flatten list
2. Renamed `rule.toExpression()` to `rule.toSpec()`
3. Cleaned up a few TODOs
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- refactor: refactor the data structure of `availableMappings` of each chart type to be a flatten list
- refactor: renamed `rule.toExpression()` to `rule.toSpec()`
- chore: cleanup TODOs

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
