### PR TITLE
[datasets] allow apps to configure available types in the explorer

### DIFF
--- a/changelogs/fragments/10379.yml
+++ b/changelogs/fragments/10379.yml
@@ -1,0 +1,2 @@
+feat:
+- Allow apps to configure available types in the dataset explorer ([#10379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10379))

--- a/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
@@ -40,12 +40,13 @@ export interface DetailedDataset extends Dataset {
 export interface DatasetSelectProps {
   onSelect: (dataset: Dataset) => void;
   appName: string;
+  supportedTypes?: string[];
 }
 
 /**
  * @experimental This component is experimental and may change in future versions
  */
-const DatasetSelect: React.FC<DatasetSelectProps> = ({ onSelect, appName }) => {
+const DatasetSelect: React.FC<DatasetSelectProps> = ({ onSelect, appName, supportedTypes }) => {
   const { services } = useOpenSearchDashboards<IDataPluginServices>();
   const isMounted = useRef(true);
   const [isOpen, setIsOpen] = useState(false);
@@ -316,6 +317,7 @@ const DatasetSelect: React.FC<DatasetSelectProps> = ({ onSelect, appName }) => {
                         }
                       }}
                       onCancel={() => overlay?.close()}
+                      supportedTypes={supportedTypes}
                     />
                   ),
                   {

--- a/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
@@ -20,10 +20,12 @@ export const AdvancedSelector = ({
   services,
   onSelect,
   onCancel,
+  supportedTypes,
 }: {
   services: IDataPluginServices;
   onSelect: (query: Partial<Query>) => void;
   onCancel: () => void;
+  supportedTypes?: string[];
 }) => {
   const queryString = getQueryService().queryString;
 
@@ -66,6 +68,7 @@ export const AdvancedSelector = ({
       setPath={setPath}
       onNext={(dataset) => setSelectedDataset(dataset)}
       onCancel={onCancel}
+      supportedTypes={supportedTypes}
     />
   );
 };

--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -40,6 +40,7 @@ export const DatasetExplorer = ({
   setPath,
   onNext,
   onCancel,
+  supportedTypes,
 }: {
   services: IDataPluginServices;
   queryString: QueryStringContract;
@@ -47,11 +48,31 @@ export const DatasetExplorer = ({
   setPath: (path: DataStructure[]) => void;
   onNext: (dataset: BaseDataset) => void;
   onCancel: () => void;
+  supportedTypes?: string[];
 }) => {
   const uiSettings = services.uiSettings;
   const [explorerDataset, setExplorerDataset] = useState<BaseDataset | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
   const datasetService = queryString.getDatasetService();
+
+  useEffect(() => {
+    const availableTypes = path[0]?.children;
+    // Prevents the ability to set the supported types to an empty array and causing no option
+    const shouldFilter = availableTypes && supportedTypes?.length;
+
+    if (shouldFilter) {
+      const filteredTypes = availableTypes.filter((type) => supportedTypes!.includes(type.id));
+      if (filteredTypes.length !== availableTypes.length) {
+        setPath([
+          {
+            ...path[0],
+            children: filteredTypes,
+          },
+          ...path.slice(1),
+        ]);
+      }
+    }
+  }, [path, supportedTypes, setPath]);
 
   const fetchNextDataStructure = async (
     nextPath: DataStructure[],

--- a/src/plugins/explore/common/config.ts
+++ b/src/plugins/explore/common/config.ts
@@ -4,9 +4,13 @@
  */
 
 import { schema, TypeOf } from '@osd/config-schema';
+import { DEFAULT_DATA } from '../../data/common';
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
+  supportedTypes: schema.arrayOf(schema.string(), {
+    defaultValue: [DEFAULT_DATA.SET_TYPES.INDEX, DEFAULT_DATA.SET_TYPES.INDEX_PATTERN],
+  }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/explore/public/build_services.ts
+++ b/src/plugins/explore/public/build_services.ts
@@ -7,6 +7,7 @@ import { CoreStart, PluginInitializerContext } from 'opensearch-dashboards/publi
 import { SavedObjectOpenSearchDashboardsServices } from 'src/plugins/saved_objects/public';
 import { Storage } from '../../opensearch_dashboards_utils/public';
 import { RequestAdapter } from '../../inspector/public';
+import { ConfigSchema } from '../common/config';
 
 import { ExploreStartDependencies, ExploreServices } from './types';
 import { createSavedExploreLoader } from './saved_explore';
@@ -22,6 +23,8 @@ export function buildServices(
   tabRegistry: TabRegistryService,
   visualizationRegistry: VisualizationRegistryService
 ): ExploreServices {
+  const config = context.config.get<ConfigSchema>();
+  const supportedTypes = config.supportedTypes;
   const services: SavedObjectOpenSearchDashboardsServices = {
     savedObjectsClient: core.savedObjects.client,
     indexPatterns: plugins.data.indexPatterns,
@@ -86,5 +89,8 @@ export function buildServices(
     expressions: plugins.expressions,
 
     dashboard: plugins.dashboard,
+
+    // Add supportedTypes from config
+    supportedTypes,
   };
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
 import { Dataset, DEFAULT_DATA, EMPTY_QUERY } from '../../../../../../data/common';
@@ -92,5 +92,20 @@ export const DatasetSelectWidget = () => {
     [queryString, dispatch, services]
   );
 
-  return <DatasetSelect onSelect={handleDatasetSelect} appName="explore" />;
+  const supportedTypes = useMemo(() => {
+    return (
+      services.supportedTypes || [
+        DEFAULT_DATA.SET_TYPES.INDEX,
+        DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+      ]
+    );
+  }, [services.supportedTypes]);
+
+  return (
+    <DatasetSelect
+      onSelect={handleDatasetSelect}
+      appName="explore"
+      supportedTypes={supportedTypes}
+    />
+  );
 };

--- a/src/plugins/explore/public/types.ts
+++ b/src/plugins/explore/public/types.ts
@@ -169,4 +169,6 @@ export interface ExploreServices {
   expressions: ExpressionsStart;
 
   dashboard: DashboardStart;
+
+  supportedTypes?: string[];
 }


### PR DESCRIPTION
### Description

By default if no prop is passed then it will display all the types. But if the props are passed in it will only display the supported types by datasetTypeConfig.type

Also, includes the update for explore plugin to set this to only support `INDEXES` and `INDEX_PATTERN`. this is configurable with `explore.supportedTypes`

### Issues Resolved

n/a

## Screenshot

From Discover:
<img width="685" height="317" alt="Screenshot 2025-08-08 at 2 53 05 PM" src="https://github.com/user-attachments/assets/2ae2ab7c-41db-4b38-827a-9b34912e8063" />

From Explore:
<img width="602" height="305" alt="Screenshot 2025-08-08 at 2 53 45 PM" src="https://github.com/user-attachments/assets/c0a80bc2-e380-4858-bb12-c9a5b03056a6" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: allow apps to configure available types in the dataset explorer

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
