### PR TITLE
Add Correlations Plugin - Saved Object Type Registration

### DIFF
--- a/src/plugins/data/common/correlations/types.ts
+++ b/src/plugins/data/common/correlations/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObject, SavedObjectAttributes } from '../../../../core/public';
+
+// @experimental This schema is experimental and might change in future releases.
+export interface CorrelationSavedObjectAttributes extends SavedObjectAttributes {
+  correlationType: string;
+
+  version: string;
+
+  /*
+   * Using any[] for entities to allow flexible correlation structures.
+   * This enables different correlation types and use cases to define their own entity schemas without strict typing constraints.
+   * Each entity can contain different fields like correlatedFields, meta, datasource info.
+   * @experimental - The any[] type is experimental and may be replaced with more specific types in future releases.
+   */
+  entities: any[];
+}
+
+export interface CorrelationSavedObject extends SavedObject<CorrelationSavedObjectAttributes> {
+  type: 'correlations';
+}

--- a/src/plugins/data/server/correlations/correlations_service.ts
+++ b/src/plugins/data/server/correlations/correlations_service.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreSetup } from '../../../../core/server';
+import { correlationsSavedObjectType } from '../saved_objects';
+
+export class CorrelationsService {
+  public setup(core: CoreSetup) {
+    core.savedObjects.registerType(correlationsSavedObjectType);
+  }
+}

--- a/src/plugins/data/server/correlations/index.ts
+++ b/src/plugins/data/server/correlations/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { CorrelationsService } from './correlations_service';

--- a/src/plugins/data/server/index.ts
+++ b/src/plugins/data/server/index.ts
@@ -312,3 +312,5 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
 };
 
 export type { IndexPatternsService } from './index_patterns';
+
+export { correlationsSavedObjectType } from './saved_objects';

--- a/src/plugins/data/server/plugin.ts
+++ b/src/plugins/data/server/plugin.ts
@@ -41,6 +41,7 @@ import { DqlTelemetryService } from './dql_telemetry';
 import { UsageCollectionSetup } from '../../usage_collection/server';
 import { AutocompleteService } from './autocomplete';
 import { FieldFormatsService, FieldFormatsSetup, FieldFormatsStart } from './field_formats';
+import { CorrelationsService } from './correlations';
 import { getUiSettings } from './ui_settings';
 
 export interface DataEnhancements {
@@ -86,6 +87,7 @@ export class DataServerPlugin
   private readonly indexPatterns = new IndexPatternsService();
   private readonly fieldFormats = new FieldFormatsService();
   private readonly queryService = new QueryService();
+  private readonly correlationsService = new CorrelationsService();
   private readonly logger: Logger;
 
   constructor(initializerContext: PluginInitializerContext<ConfigSchema>) {
@@ -104,6 +106,7 @@ export class DataServerPlugin
     this.scriptsService.setup(core);
     this.queryService.setup(core);
     this.autocompleteService.setup(core);
+    this.correlationsService.setup(core);
     this.dqlTelemetryService.setup(core, { usageCollection });
 
     core.uiSettings.register(getUiSettings(core.workspace.isWorkspaceEnabled()));

--- a/src/plugins/data/server/saved_objects/correlations.ts
+++ b/src/plugins/data/server/saved_objects/correlations.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsType } from '../../../../core/server';
+
+// @experimental This schema is experimental and might change in future releases.
+export const correlationsSavedObjectType: SavedObjectsType = {
+  name: 'correlations',
+  hidden: false,
+  namespaceType: 'single',
+  management: {
+    icon: 'link',
+    defaultSearchField: 'correlationType',
+    importableAndExportable: true,
+    getTitle(obj) {
+      return `Correlation ${obj.id}`;
+    },
+  },
+  mappings: {
+    properties: {
+      correlationType: {
+        type: 'keyword',
+      },
+      version: {
+        type: 'keyword',
+      },
+      entities: {
+        type: 'object',
+        enabled: false,
+      },
+    },
+  },
+  migrations: {},
+};

--- a/src/plugins/data/server/saved_objects/index.ts
+++ b/src/plugins/data/server/saved_objects/index.ts
@@ -32,3 +32,4 @@ export { querySavedObjectType } from './query';
 export { indexPatternSavedObjectType } from './index_patterns';
 export { dqlTelemetry } from './dql_telemetry';
 export { searchTelemetry } from './search_telemetry';
+export { correlationsSavedObjectType } from './correlations';


### PR DESCRIPTION
### Description

This PR introduces a new plugin called "correlations" that registers a saved object type for storing correlation. 
This plugin provides a foundation for managing correlations between traces and logs

Object added for Correlations

```
{
  "id": "trace-to-logs-correlation-5678",
  "type": "correlations",
  "migrationVersion": "1.0.0",
  "updatedAt": "2025-07-16T10:15:30.000Z",
  "attributes": {
    "type": "APM-Correlation",
    "entities": [
      {
        "tracesDataset":{
          "id":"refernces[0].id"
        }
      },
      {
        "logsDataset":{
          "id":"refernces[1].id",
          "meta": {
            "logServiceNameField": "service.name",
            "logSpanIdField": "span_id",
            "logTraceIdField": "trace_id",
            "timestamp": "@timestamp"
          }
        }
      },
      {
        "<Plugin-name>DataConnection":{
          "id": "refernces[2].id"
        }
      }
    ]
  },
  "references": [
    {
      "name": "entities[0].index",
      "type": "index-pattern",
      "id": "6ff30050-72ec-11f0-b9fd-951b6e375a38"
    },
    {
      "name": "entities[1].index",
      "type": "index-pattern",
      "id": "72048c50-731a-11f0-8fdf-87b448b7eb0b"
    },
    {
      "name": "<plugin>DataConnection",
      "type": "data-connection",
      "id": "1234567890"
    }
  ]
}

```

## Changelog

-feat: adds a correlation plugin which creates a saved object for the related traces and logs


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
