### PR TITLE
[Explore] Preserve active tab when saving and loading explores in dashboards

### DIFF
--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -106,6 +106,7 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
         tabState,
         flavorId,
         tabDefinition,
+        activeTabId: uiState.activeTabId,
       },
       clearEditors,
       savedExplore
@@ -120,6 +121,7 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
     flavorId,
     tabDefinition,
     clearEditors,
+    uiState.activeTabId,
   ]);
 
   useEffect(() => {

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/get_top_nav_links.test.ts
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/get_top_nav_links.test.ts
@@ -21,13 +21,23 @@ const indexPattern = {} as any;
 const savedExplore = {} as any;
 const clearEditors = jest.fn();
 
+const mockDataset = {} as any;
+const mockTabState = {} as any;
+const mockTabDefinition = { id: 'logs' } as any;
+
 describe('getTopNavLinks', () => {
   it('returns save, open, new, and share links when all capabilities and services are present', () => {
     const links = getTopNavLinks(
       mockServices(),
       startSyncingQueryStateWithUrl,
       searchContext,
-      indexPattern,
+      {
+        dataset: mockDataset,
+        tabState: mockTabState,
+        flavorId: 'logs',
+        tabDefinition: mockTabDefinition,
+        activeTabId: 'logs',
+      },
       clearEditors,
       savedExplore
     );
@@ -48,7 +58,14 @@ describe('getTopNavLinks', () => {
       services,
       startSyncingQueryStateWithUrl,
       searchContext,
-      indexPattern,
+      {
+        dataset: mockDataset,
+        tabState: mockTabState,
+        flavorId: 'logs',
+        tabDefinition: mockTabDefinition,
+        activeTabId: 'logs',
+      },
+      clearEditors,
       savedExplore
     );
     expect(links).toHaveLength(3);
@@ -63,7 +80,14 @@ describe('getTopNavLinks', () => {
       services,
       startSyncingQueryStateWithUrl,
       searchContext,
-      indexPattern,
+      {
+        dataset: mockDataset,
+        tabState: mockTabState,
+        flavorId: 'logs',
+        tabDefinition: mockTabDefinition,
+        activeTabId: 'logs',
+      },
+      clearEditors,
       savedExplore
     );
     expect(links).toHaveLength(3);
@@ -81,7 +105,14 @@ describe('getTopNavLinks', () => {
       services,
       startSyncingQueryStateWithUrl,
       searchContext,
-      indexPattern,
+      {
+        dataset: mockDataset,
+        tabState: mockTabState,
+        flavorId: 'logs',
+        tabDefinition: mockTabDefinition,
+        activeTabId: 'logs',
+      },
+      clearEditors,
       savedExplore
     );
     expect(links).toHaveLength(2);

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/get_top_nav_links.ts
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/get_top_nav_links.ts
@@ -25,6 +25,7 @@ export const getTopNavLinks = (
     tabState: TabState;
     flavorId: string | null;
     tabDefinition: TabDefinition | undefined;
+    activeTabId: string;
   },
   clearEditors: ReturnType<typeof useClearEditors>,
   savedExplore?: SavedExplore

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.test.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.test.tsx
@@ -54,6 +54,7 @@ const mockSaveStateProps = {
     supportedLanguages: ['PPL'],
     component: {} as any,
   },
+  activeTabId: 'logs',
 };
 
 const mockSavedExplore = ({

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.tsx
@@ -45,6 +45,7 @@ export interface SaveStateProps {
   tabState: TabState;
   flavorId: string | null;
   tabDefinition: TabDefinition | undefined;
+  activeTabId: string;
 }
 
 export const getSaveButtonRun = (
@@ -65,12 +66,14 @@ export const getSaveButtonRun = (
     const visualizationBuilder = getVisualizationBuilder();
     const axesMapping = visualizationBuilder.axesMapping$.value;
     const visConfig = visualizationBuilder.styles$.value;
+
     const savedExploreWithState = saveStateToSavedObject(
       savedExplore,
       saveStateProps.flavorId ?? 'logs',
       saveStateProps.tabDefinition!,
       { axesMapping, chartType: visConfig?.type, styleOptions: visConfig?.styles },
-      saveStateProps.dataset
+      saveStateProps.dataset,
+      saveStateProps.activeTabId
     );
     const result = await saveSavedExplore({
       savedExplore: savedExploreWithState,

--- a/src/plugins/explore/public/saved_explore/transforms.ts
+++ b/src/plugins/explore/public/saved_explore/transforms.ts
@@ -31,7 +31,8 @@ export const saveStateToSavedObject = (
   flavorId: string,
   tabDefinition: TabDefinition,
   visState?: VisState,
-  dataset?: IndexPattern | Dataset
+  dataset?: IndexPattern | Dataset,
+  activeTabId?: string
 ): SavedExplore => {
   // Serialize the state into the saved object
   obj.type = flavorId;
@@ -43,8 +44,9 @@ export const saveStateToSavedObject = (
     params: visState?.styleOptions ?? {},
     axesMapping: visState?.axesMapping,
   });
+
   obj.uiState = JSON.stringify({
-    activeTab: tabDefinition.id,
+    activeTab: activeTabId || tabDefinition.id,
   });
   obj.searchSourceFields = { index: dataset };
 


### PR DESCRIPTION
## Issues 
When users save an explore visualization from the "Visualization" or "Patterns" tab and then load it in a dashboard, the explore always displays the "Logs" tab instead of preserving the originally active tab.

## Description

#### The Root Cause

The issue was in the save process where the system was saving `tabDefinition.id` instead of the current `activeTabId` from the UI state. This meant that regardless of which tab was active when saving, the saved explore would always default to the tab definition's ID rather than the user's actual selection.

#### The fix
In this PR, we modified the save process to capture and use the current `activeTabId` from the UI state




## Screenshot


https://github.com/user-attachments/assets/fdf23abb-d0dd-42f1-bf0b-daf67dde2951




## Changelog

- fix: [Explore] Preserve active tab when saving and loading explores in dashboards


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
