### PR TITLE
[Bug] Correlation saved object entities to not be strict

### DIFF
--- a/src/plugins/data/server/index.ts
+++ b/src/plugins/data/server/index.ts
@@ -312,3 +312,5 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
 };
 
 export type { IndexPatternsService } from './index_patterns';
+
+export { correlationsSavedObjectType } from './saved_objects';

--- a/src/plugins/data/server/index.ts
+++ b/src/plugins/data/server/index.ts
@@ -312,5 +312,3 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
 };
 
 export type { IndexPatternsService } from './index_patterns';
-
-export { correlationsSavedObjectType } from './saved_objects';

--- a/src/plugins/data/server/saved_objects/correlations.ts
+++ b/src/plugins/data/server/saved_objects/correlations.ts
@@ -28,7 +28,7 @@ export const correlationsSavedObjectType: SavedObjectsType = {
       },
       entities: {
         type: 'object',
-        enabled: true,
+        enabled: false,
       },
     },
   },


### PR DESCRIPTION
### Description

This PR changes the [entities](vscode-file://vscode-app/Users/sumukhhs/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) field mapping in the correlations saved object type from [enabled: true](vscode-file://vscode-app/Users/sumukhhs/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [enabled: false](vscode-file://vscode-app/Users/sumukhhs/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to be able to add non strict entities which and not to index it


## Changelog
-bug: correlation object to have entities field which is dynamic and not strict

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
