### PR TITLE
[Explore] Traces - Trace default columns UI setting

### DIFF
--- a/changelogs/fragments/10406.yml
+++ b/changelogs/fragments/10406.yml
@@ -1,0 +1,2 @@
+feat:
+- Add experimental default trace columns UI setting for Explore traces tab and apply it. ([#10406](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10406))

--- a/src/plugins/explore/common/index.ts
+++ b/src/plugins/explore/common/index.ts
@@ -16,6 +16,7 @@ export const CONTEXT_DEFAULT_SIZE_SETTING = 'context:defaultSize';
 export const CONTEXT_STEP_SETTING = 'context:step';
 export const CONTEXT_TIE_BREAKER_FIELDS_SETTING = 'context:tieBreakerFields';
 export const MODIFY_COLUMNS_ON_SWITCH = 'discover:modifyColumnsOnSwitch';
+export const DEFAULT_TRACE_COLUMNS_SETTING = 'explore:defaultTraceColumns';
 export const EXPLORE_DEFAULT_LANGUAGE = 'PPL';
 
 export enum ExploreFlavor {

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.test.ts
@@ -31,13 +31,13 @@ describe('resetLegacyStateActionCreator', () => {
     mockDispatch = jest.fn();
   });
 
-  it('should return a function that dispatches setLegacyState with preloaded state', () => {
+  it('should return a function that dispatches setLegacyState with preloaded state', async () => {
     const mockLegacyState = {
       data: { some: 'data' },
       metadata: { test: 'metadata' },
     };
 
-    mockedGetPreloadedLegacyState.mockReturnValue(mockLegacyState as any);
+    mockedGetPreloadedLegacyState.mockResolvedValue(mockLegacyState as any);
     mockedSetLegacyState.mockReturnValue({
       type: 'legacy/setLegacyState',
       payload: mockLegacyState,
@@ -49,8 +49,8 @@ describe('resetLegacyStateActionCreator', () => {
     // Verify it returns a function
     expect(typeof thunkFunction).toBe('function');
 
-    // Call the thunk function with dispatch
-    thunkFunction(mockDispatch);
+    // Call the thunk function with dispatch and await it
+    await thunkFunction(mockDispatch);
 
     // Verify getPreloadedLegacyState was called with services
     expect(mockedGetPreloadedLegacyState).toHaveBeenCalledWith(mockServices);

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_legacy_state/reset_legacy_state.ts
@@ -11,10 +11,10 @@ import { AppDispatch } from '../../store';
 /**
  * Action creator for resetting the Legacy state to its preloaded state.
  */
-export const resetLegacyStateActionCreator = (services: ExploreServices) => (
+export const resetLegacyStateActionCreator = (services: ExploreServices) => async (
   dispatch: AppDispatch
 ) => {
-  const state = getPreloadedLegacyState(services);
+  const state = await getPreloadedLegacyState(services);
 
   dispatch(setLegacyState(state));
 };

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts
@@ -6,9 +6,10 @@
 import { getPreloadedState, loadReduxState, persistReduxState } from './redux_persistence';
 import { ExploreServices } from '../../../../types';
 import { RootState } from '../store';
-import { EXPLORE_DEFAULT_LANGUAGE } from '../../../../../common';
+import { EXPLORE_DEFAULT_LANGUAGE, DEFAULT_TRACE_COLUMNS_SETTING } from '../../../../../common';
 import { ColorSchemas } from '../../../../components/visualizations/types';
 import { EditorMode, QueryExecutionStatus } from '../types';
+import { of } from 'rxjs';
 
 // Mock the getPromptModeIsAvailable function
 jest.mock('../../get_prompt_mode_is_available', () => ({
@@ -26,7 +27,7 @@ jest.mock('../../../../components/visualizations/metric/metric_vis_config', () =
     title: '',
     fontSize: 60,
     useColor: false,
-    colorSchema: 'blues' as any,
+    colorSchema: 'blues',
   },
 }));
 
@@ -38,6 +39,11 @@ describe('redux_persistence', () => {
       osdUrlStateStorage: {
         set: jest.fn(),
         get: jest.fn(),
+      },
+      core: {
+        application: {
+          currentAppId$: of('explore/logs'),
+        },
       },
       data: {
         query: {
@@ -68,6 +74,7 @@ describe('redux_persistence', () => {
       uiSettings: {
         get: jest.fn((key) => {
           if (key === 'defaultColumns') return ['_source'];
+          if (key === DEFAULT_TRACE_COLUMNS_SETTING) return ['traceID', 'spanID'];
           return undefined;
         }),
       },

--- a/src/plugins/explore/server/plugin.ts
+++ b/src/plugins/explore/server/plugin.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../core/server';
 import { capabilitiesProvider } from './capabilities_provider';
 import { exploreSavedObjectType } from './saved_objects';
+import { traceUiSettings } from './trace_ui_settings';
 
 import { ExplorePluginSetup, ExplorePluginStart } from './types';
 
@@ -37,6 +38,7 @@ export class ExplorePlugin implements Plugin<ExplorePluginSetup, ExplorePluginSt
       });
     });
     // core.uiSettings.register(uiSettings);
+    core.uiSettings.register(traceUiSettings);
     core.savedObjects.registerType(exploreSavedObjectType);
 
     return {};

--- a/src/plugins/explore/server/trace_ui_settings.ts
+++ b/src/plugins/explore/server/trace_ui_settings.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { schema } from '@osd/config-schema';
+
+import { UiSettingsParams } from 'opensearch-dashboards/server';
+import { DEFAULT_TRACE_COLUMNS_SETTING } from '../common';
+
+export const traceUiSettings: Record<string, UiSettingsParams> = {
+  [DEFAULT_TRACE_COLUMNS_SETTING]: {
+    name: i18n.translate('explore.advancedSettings.defaultTraceColumnsTitle', {
+      defaultMessage: 'Default trace columns',
+    }),
+    value: [
+      'spanId',
+      'status.code',
+      'attributes.http.status_code',
+      'serviceName',
+      'name',
+      'durationInNanos',
+    ],
+    description: i18n.translate('explore.advancedSettings.defaultTraceColumnsText', {
+      defaultMessage: 'Experimental: Columns displayed by default in the Explore traces tab',
+    }),
+    category: ['explore'],
+    schema: schema.arrayOf(schema.string()),
+  },
+};


### PR DESCRIPTION
### Description
Add experimental default trace columns UI setting for Explore traces tab and apply it.
<img width="1522" height="476" alt="Setting" src="https://github.com/user-attachments/assets/c26e74dd-7a1f-4bce-a3cb-e789a6777fb4" />

Add the default columns only to trace page:

https://github.com/user-attachments/assets/0afba0d0-0066-43dc-8d5d-e35cd20fbbba


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

-feat: Add experimental default trace columns UI setting for Explore traces tab and apply it.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
