### PR TITLE
[Keyboard-shortcuts] add keyboard shortcuts configuration option 

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -385,3 +385,6 @@
 
 # Set the content of the banner
 # banner.content: "This is an important announcement for all users. [Learn more](https://opensearch.org) about OpenSearch."
+
+# Set the value to true to enable the keyboard shortcuts
+opensearchDashboards.keyboardShortcuts.enabled: false 

--- a/src/core/public/core_system.ts
+++ b/src/core/public/core_system.ts
@@ -243,7 +243,9 @@ export class CoreSystem {
         overlays,
         workspaces,
       });
-      const keyboardShortcut = this.keyboardShortcut.start();
+      const keyboardShortcut = this.keyboardShortcut.start({
+        enabled: injectedMetadata.getKeyboardShortcuts().enabled,
+      });
 
       this.coreApp.start({ application, http, notifications, uiSettings });
 

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -76,6 +76,9 @@ export interface InjectedMetadataParams {
     };
     branding: Branding;
     survey?: string;
+    keyboardShortcuts: {
+      enabled: boolean;
+    };
   };
 }
 
@@ -153,6 +156,10 @@ export class InjectedMetadataService {
       getSurvey: () => {
         return this.state.survey;
       },
+
+      getKeyboardShortcuts: () => {
+        return this.state.keyboardShortcuts;
+      },
     };
   }
 }
@@ -188,6 +195,9 @@ export interface InjectedMetadataSetup {
   };
   getBranding: () => Branding;
   getSurvey: () => string | undefined;
+  getKeyboardShortcuts: () => {
+    enabled: boolean;
+  };
 }
 
 /** @internal */

--- a/src/core/public/keyboard_shortcut/keyboard_shortcut_service.test.ts
+++ b/src/core/public/keyboard_shortcut/keyboard_shortcut_service.test.ts
@@ -150,14 +150,14 @@ describe('KeyboardShortcutService', () => {
 
   describe('Private Method Testing', () => {
     it('should normalize keys to lowercase', () => {
-      // @ts-expect-error - Testing private method
+      // @ts-expect-error
       const result = service.getNormalizedKey('CTRL+S');
       expect(result).toBe('ctrl+s');
     });
 
     it('should create namespaced ID correctly', () => {
       const shortcut = { id: 'Save', pluginId: 'Editor' };
-      // @ts-expect-error - Testing private method
+      // @ts-expect-error
       const result = service.getNamespacedId(shortcut);
       expect(result).toBe('save.editor');
     });
@@ -396,6 +396,107 @@ describe('KeyboardShortcutService', () => {
       );
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Configuration Support', () => {
+    it('should start with keyboard shortcuts enabled by default', () => {
+      const start = service.start();
+      const shortcut: ShortcutDefinition = {
+        id: 'save',
+        pluginId: 'editor',
+        name: 'Save Document',
+        category: 'editing',
+        keys: 'ctrl+s',
+        execute: mockExecute,
+      };
+
+      start.register(shortcut);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 's',
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      document.dispatchEvent(event);
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should start with keyboard shortcuts enabled when explicitly configured', () => {
+      const start = service.start({ enabled: true });
+      const shortcut: ShortcutDefinition = {
+        id: 'save',
+        pluginId: 'editor',
+        name: 'Save Document',
+        category: 'editing',
+        keys: 'ctrl+s',
+        execute: mockExecute,
+      };
+
+      start.register(shortcut);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 's',
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      document.dispatchEvent(event);
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not register shortcuts when disabled', () => {
+      const start = service.start({ enabled: false });
+      const shortcut: ShortcutDefinition = {
+        id: 'save',
+        pluginId: 'editor',
+        name: 'Save Document',
+        category: 'editing',
+        keys: 'ctrl+s',
+        execute: mockExecute,
+      };
+
+      start.register(shortcut);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 's',
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      document.dispatchEvent(event);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should not add event listener when disabled', () => {
+      service.start({ enabled: false });
+      expect(document.addEventListener).not.toHaveBeenCalled();
+    });
+
+    it('should not register shortcuts during setup when service will be disabled', () => {
+      const setup = service.setup();
+      const shortcut: ShortcutDefinition = {
+        id: 'save',
+        pluginId: 'editor',
+        name: 'Save Document',
+        category: 'editing',
+        keys: 'ctrl+s',
+        execute: mockExecute,
+      };
+
+      setup.register(shortcut);
+
+      service.start({ enabled: false });
+
+      const event = new KeyboardEvent('keydown', {
+        key: 's',
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      document.dispatchEvent(event);
+      expect(mockExecute).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/core/public/keyboard_shortcut/keyboard_shortcut_service.ts
+++ b/src/core/public/keyboard_shortcut/keyboard_shortcut_service.ts
@@ -18,6 +18,7 @@ import { KeyboardShortcutSetup, KeyboardShortcutStart, ShortcutDefinition } from
 export class KeyboardShortcutService {
   private shortcutsMapByKey = new Map<string, ShortcutDefinition[]>();
   private namespacedIdToKeyLookup = new Map<string, string>();
+  private enabled = true;
 
   public setup(): KeyboardShortcutSetup {
     return {
@@ -25,8 +26,12 @@ export class KeyboardShortcutService {
     };
   }
 
-  public start(): KeyboardShortcutStart {
-    this.startEventListener();
+  public start(config?: { enabled: boolean }): KeyboardShortcutStart {
+    this.enabled = config?.enabled ?? true;
+
+    if (this.enabled) {
+      this.startEventListener();
+    }
 
     return {
       register: (shortcut) => this.register(shortcut),
@@ -70,6 +75,11 @@ export class KeyboardShortcutService {
   };
 
   private register(shortcut: ShortcutDefinition): void {
+    // If keyboard shortcuts are disabled, don't register new shortcuts
+    if (!this.enabled) {
+      return;
+    }
+
     const key = this.getNormalizedKey(shortcut.keys);
     const namespacedId = this.getNamespacedId(shortcut);
 

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -100,6 +100,9 @@ export const config = {
       }),
     }),
     futureNavigation: schema.boolean({ defaultValue: false }),
+    keyboardShortcuts: schema.object({
+      enabled: schema.boolean({ defaultValue: true }),
+    }),
   }),
   deprecations,
 };

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -168,6 +168,9 @@ export class RenderingService {
               useExpandedHeader: brandingAssignment.useExpandedHeader,
             },
             survey: opensearchDashboardsConfig.survey.url,
+            keyboardShortcuts: {
+              enabled: opensearchDashboardsConfig.keyboardShortcuts.enabled,
+            },
           },
         };
 

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -75,6 +75,9 @@ export interface RenderingMetadata {
     };
     branding: Branding;
     survey?: string;
+    keyboardShortcuts: {
+      enabled: boolean;
+    };
   };
 }
 

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -257,6 +257,9 @@ export default () =>
         users: Joi.array().items(Joi.string()).default([]),
       }),
       futureNavigation: Joi.boolean().default(false),
+      keyboardShortcuts: Joi.object({
+        enabled: Joi.boolean().default(true),
+      }),
     }).default(),
 
     savedObjects: HANDLED_IN_NEW_PLATFORM,

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -428,6 +428,32 @@ export class DiscoverPlugin
       return { core, plugins };
     };
 
+    // Register dashboard navigation shortcuts
+    if (core.keyboardShortcut) {
+      core.keyboardShortcut.register({
+        id: 'nav.dashboard',
+        name: 'Go to dashboard',
+        pluginId: 'dashboard',
+        category: 'navigation',
+        keys: 'shift+g',
+        execute: () => {
+          // Only enable shortcut when workspace is selected
+          const currentWorkspace = core.workspaces.currentWorkspace$.getValue();
+          const isInitialized = core.workspaces.initialized$.getValue();
+          if (!isInitialized || !currentWorkspace) {
+            // eslint-disable-next-line no-console
+            console.log('Dashboard shortcut disabled: no workspace selected');
+            return;
+          }
+          // eslint-disable-next-line no-console
+          console.log('Pressed g+d - Navigating to dashboard!');
+          // eslint-disable-next-line no-console
+          console.log('pressed: g (first) → b (second)');
+          core.application.navigateToApp('dashboards');
+        },
+      });
+    }
+
     this.initializeServices();
 
     return {


### PR DESCRIPTION
### Description

This change adds a configuration option to control the keyboard shortcuts feature in OpenSearch Dashboards. The `opensearchDashboards.keyboardShortcuts.enabled` setting in the YAML configuration file allows to enable or disable keyboard shortcuts.

Since the keyboard shortcuts implementation is still in development and not fully complete, this configuration is set to `false` by default to prevent any potential issues in production environments. Once the feature implementation is finalized, it can be easily enabled by changing this configuration value to `true`.

## Changelog

- feat: Add keyboard shortcuts configuration option to opensearch_dashboards.yml

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
