### PR TITLE
Feature/partial results

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "**/load-bmfont/phin": "^3.7.1",
     "**/loader-utils": "^2.0.4",
     "**/minimist": "^1.2.6",
+    "**/minimatch": "^5.1.6",
     "**/nanoid": "^3.3.8",
     "**/node-jose": "^2.2.0",
     "**/nth-check": "^2.0.1",
@@ -166,7 +167,9 @@
     "**/json5": "^2.2.3",
     "**/mime": "^3.0.0",
     "**/performance-now": "^2.1.0",
-    "**/prismjs": "^1.30.0"
+    "**/prismjs": "^1.30.0",
+    "**/sha.js": "^2.4.12",
+    "**/cipher-base": "^1.0.5"
   },
   "workspaces": {
     "packages": [

--- a/src/plugins/data/public/search/expressions/opensearchaggs.ts
+++ b/src/plugins/data/public/search/expressions/opensearchaggs.ts
@@ -201,23 +201,22 @@ const handleCourierRequest = async ({
 
   (searchSource as any).finalResponse = resp;
 
-  function extractSumOtherDocCount(aggregations) {
+  function extractSumOtherDocCount(aggregations: any): number {
     let results = 0;
 
-    function traverse(obj, path = '') {
+    function traverse(obj: any): void {
       if (typeof obj !== 'object' || obj === null) {
         return;
       }
 
-      // Check if current object has sum_other_doc_count
+      // Check if current object has sum_other_doc_count, if sum_other_doc_count >0 it indicates some buckets were dropped due to bucket size limit
       if (obj.hasOwnProperty('sum_other_doc_count')) {
         results += obj.sum_other_doc_count;
       }
 
       // Recursively traverse all properties
       Object.keys(obj).forEach((key) => {
-        const newPath = path ? `${path}.${key}` : key;
-        traverse(obj[key], newPath);
+        traverse(obj[key]);
       });
     }
 
@@ -324,7 +323,7 @@ export const opensearchaggs = (): OpenSearchaggsExpressionFunctionDefinition => 
       abortSignal: (abortSignal as unknown) as AbortSignal,
     });
 
-    const table: OpenSearchDashboardsDatatable & { meta?: any } = {
+    const table: OpenSearchDashboardsDatatable = {
       type: 'opensearch_dashboards_datatable',
       rows: response.rows,
       columns: response.columns.map((column: any) => {

--- a/src/plugins/data/public/search/expressions/opensearchaggs.ts
+++ b/src/plugins/data/public/search/expressions/opensearchaggs.ts
@@ -338,7 +338,7 @@ export const opensearchaggs = (): OpenSearchaggsExpressionFunctionDefinition => 
         }
         return cleanedColumn;
       }),
-      meta: (response as any).meta, // ✅ This line now works
+      meta: (response as any).meta,
     };
 
     return table;

--- a/src/plugins/expressions/common/expression_types/specs/opensearch_dashboards_datatable.ts
+++ b/src/plugins/expressions/common/expression_types/specs/opensearch_dashboards_datatable.ts
@@ -55,6 +55,11 @@ export interface OpenSearchDashboardsDatatable {
   type: typeof name;
   columns: OpenSearchDashboardsDatatableColumn[];
   rows: OpenSearchDashboardsDatatableRow[];
+  /**
+   * Optional metadata describing the whole datatable. Producers may attach
+   * arbitrary information such as total hits, partial results flags, etc.
+   */
+  meta?: Record<string, unknown>;
 }
 
 export const opensearchDashboardsDatatable = {

--- a/src/plugins/vis_type_table/public/components/table_vis_app.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_app.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { EuiCallOut } from '@elastic/eui';
 import './table_vis_app.scss';
 import React, { useEffect } from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
@@ -23,6 +23,9 @@ interface TableVisAppProps {
   visData: TableVisData;
   visConfig: TableVisConfig;
   handlers: IInterpreterRenderHandlers;
+  meta?: {
+    sumOtherDocCount?: number;
+  };
 }
 
 export const TableVisApp = ({
@@ -30,6 +33,7 @@ export const TableVisApp = ({
   visData: { table, tableGroups, direction },
   visConfig,
   handlers,
+  meta,
 }: TableVisAppProps) => {
   // Rendering is asynchronous, completed by handlers.done()
   useEffect(() => {
@@ -38,6 +42,7 @@ export const TableVisApp = ({
 
   const tableUiState: TableUiState = getTableUIState(handlers.uiState as PersistedState);
   const showNoResult = table ? table.rows.length === 0 : tableGroups?.length === 0;
+  const shouldShowWarning = meta?.sumOtherDocCount && meta.sumOtherDocCount > 0;
 
   return (
     <I18nProvider>
@@ -49,6 +54,12 @@ export const TableVisApp = ({
             direction={direction === 'column' ? 'row' : 'column'}
             alignItems={direction === 'column' ? 'flexStart' : 'stretch'}
           >
+            {shouldShowWarning && (
+              <EuiCallOut title="Warning: Partial results" color="warning" iconType="alert">
+                Some data was omitted due to bucket size limits.
+              </EuiCallOut>
+            )}
+
             {table ? (
               <TableVisComponent
                 table={table}

--- a/src/plugins/vis_type_table/public/components/table_vis_app.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_app.tsx
@@ -7,6 +7,8 @@ import './table_vis_app.scss';
 import React, { useEffect } from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { I18nProvider } from '@osd/i18n/react';
+import { FormattedMessage } from '@osd/i18n/react';
+import { i18n } from '@osd/i18n';
 import { IInterpreterRenderHandlers } from 'src/plugins/expressions';
 import { EuiFlexGroup } from '@elastic/eui';
 import { PersistedState } from '../../../visualizations/public';
@@ -17,7 +19,6 @@ import { TableVisComponent } from './table_vis_component';
 import { TableVisComponentGroup } from './table_vis_component_group';
 import { getTableUIState, TableUiState } from '../utils';
 import { VisualizationContainer } from '../../../visualizations/public';
-
 interface TableVisAppProps {
   services: CoreStart;
   visData: TableVisData;
@@ -55,8 +56,16 @@ export const TableVisApp = ({
             alignItems={direction === 'column' ? 'flexStart' : 'stretch'}
           >
             {shouldShowWarning && (
-              <EuiCallOut title="Warning: Partial results" color="warning" iconType="alert">
-                Some data was omitted due to bucket size limits.
+              <EuiCallOut
+                title={i18n.translate('visTypeTable.tableVis.warning.partialResultsTitle', {
+                  defaultMessage: 'Warning: Partial results',
+                })}
+                color="warning"
+                iconType="alert"
+              >
+                {i18n.translate('visTypeTable.tableVis.warning.partialResultsDescription', {
+                  defaultMessage: 'Some data was omitted due to bucket size limits.',
+                })}
               </EuiCallOut>
             )}
 

--- a/src/plugins/vis_type_table/public/components/table_vis_app_partial_warning.test.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_app_partial_warning.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TableVisApp } from './table_vis_app';
+
+jest.mock('./table_vis_component_group', () => ({
+  TableVisComponentGroup: () => <div data-test-subj="TableVisComponentGroup" />,
+}));
+
+jest.mock('./table_vis_component', () => ({
+  TableVisComponent: () => <div data-test-subj="TableVisComponent" />,
+}));
+
+/**
+ * Minimal mocks required by TableVisApp. At this component-scope
+ * we only stub the fields the component actually touches.
+ */
+const coreMock = {} as any;
+const handlersMock: any = {
+  done: jest.fn(),
+  event: jest.fn(),
+  uiState: {
+    on: jest.fn(),
+    off: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+};
+
+const baseVisData = {
+  table: {
+    rows: [{ col1: 'value' }],
+    columns: [{ id: 'col1', name: 'Column 1' }],
+    formattedColumns: [],
+  },
+  direction: 'row' as const,
+};
+
+describe('TableVisApp – partial results warning', () => {
+  it('renders an EuiCallOut when sumOtherDocCount > 0', () => {
+    render(
+      <TableVisApp
+        services={coreMock}
+        handlers={handlersMock}
+        visConfig={{} as any}
+        visData={baseVisData as any}
+        meta={{ sumOtherDocCount: 5 }}
+      />
+    );
+
+    expect(screen.getByText(/partial results/i)).toBeInTheDocument();
+  });
+
+  it('does not render the call-out when sumOtherDocCount is 0 or undefined', () => {
+    render(
+      <TableVisApp
+        services={coreMock}
+        handlers={handlersMock}
+        visConfig={{} as any}
+        visData={baseVisData as any}
+        meta={{ sumOtherDocCount: 0 }}
+      />
+    );
+
+    expect(screen.queryByText(/partial results/i)).toBeNull();
+  });
+});

--- a/src/plugins/vis_type_table/public/table_vis_fn.ts
+++ b/src/plugins/vis_type_table/public/table_vis_fn.ts
@@ -12,7 +12,9 @@ import {
 } from '../../expressions/public';
 import { TableVisConfig } from './types';
 
-export type Input = OpenSearchDashboardsDatatable;
+export type Input = OpenSearchDashboardsDatatable & {
+  meta?: { sumOtherDocCount?: number };
+};
 
 interface Arguments {
   visConfig: string | null;
@@ -22,6 +24,7 @@ export interface TableVisRenderValue {
   visData: TableVisData;
   visType: 'table';
   visConfig: TableVisConfig;
+  meta?: { sumOtherDocCount?: number };
 }
 
 export type TableVisExpressionFunctionDefinition = ExpressionFunctionDefinition<
@@ -56,6 +59,7 @@ export const createTableVisFn = (): TableVisExpressionFunctionDefinition => ({
         visData: convertedData,
         visType: 'table',
         visConfig,
+        meta: input.meta,
       },
     };
   },

--- a/src/plugins/vis_type_table/public/table_vis_renderer.tsx
+++ b/src/plugins/vis_type_table/public/table_vis_renderer.tsx
@@ -17,13 +17,19 @@ export const getTableVisRenderer: (
   name: 'table_vis',
   displayName: 'table visualization',
   reuseDomNode: true,
-  render: async (domNode, { visData, visConfig }, handlers) => {
+  render: async (domNode, { visData, visConfig, meta }, handlers) => {
     handlers.onDestroy(() => {
       unmountComponentAtNode(domNode);
     });
 
     render(
-      <TableVisApp services={core} visData={visData} visConfig={visConfig} handlers={handlers} />,
+      <TableVisApp
+        services={core}
+        visData={visData}
+        visConfig={visConfig}
+        handlers={handlers}
+        meta={meta}
+      />,
       domNode
     );
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10405,13 +10405,14 @@ ci-info@^4.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.2.0.tgz#cbd21386152ebfe1d56f280a3b5feccbd96764c7"
   integrity sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==
 
-cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3, cipher-base@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.7.tgz#bd094bfef42634ccfd9e13b9fc73274997111e39"
+  integrity sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==
   dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
+    inherits "^2.0.4"
+    safe-buffer "^5.2.1"
+    to-buffer "^1.2.2"
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -19083,40 +19084,12 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^5.0.1, minimatch@^5.1.6:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@^5.1.6, minimatch@^8.0.2, minimatch@^9.0.4, minimatch@~3.0.4:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
-
-minimatch@^8.0.2:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
-  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
-  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@~3.0.4:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.8.tgz#5e6a59bd11e2ab0de1cfb843eb2d82e546c321c1"
-  integrity sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==
-  dependencies:
-    brace-expansion "^1.1.7"
 
 minimist-options@4.1.0, minimist-options@^4.0.2:
   version "4.1.0"
@@ -23169,15 +23142,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.4.0, sha.js@^2.4.8:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
-
-sha.js@^2.4.11:
+sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.12, sha.js@^2.4.8:
   version "2.4.12"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.12.tgz#eb8b568bf383dfd1867a32c3f2b74eb52bdbf23f"
   integrity sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==
@@ -24855,6 +24820,15 @@ to-buffer@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.2.1.tgz#2ce650cdb262e9112a18e65dc29dcb513c8155e0"
   integrity sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==
+  dependencies:
+    isarray "^2.0.5"
+    safe-buffer "^5.2.1"
+    typed-array-buffer "^1.0.3"
+
+to-buffer@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.2.2.tgz#ffe59ef7522ada0a2d1cb5dfe03bb8abc3cdc133"
+  integrity sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==
   dependencies:
     isarray "^2.0.5"
     safe-buffer "^5.2.1"


### PR DESCRIPTION
### Description

When the max bucket size is hit and in the aggregation response partial or no results are returned, the response should clearly inform users that the results are incomplete.

This PR adds a partial results warning in the table visualization when results are truncated due to the bucket limit.

OpenSearch already exposes sum_other_doc_count in the aggregation response, which allows us to detect partial results (> 0 means some buckets were dropped due to the bucket size limit).







### Issues Resolved
closes #10374 


## Screenshot

<img width="1512" height="857" alt="Screenshot 2025-08-18 at 7 34 37 PM" src="https://github.com/user-attachments/assets/1d6557f0-8e51-4f49-8e50-abedd954a42a" />



## Testing the changes

1. Create a table visualization.
2. Set bucket size very small (e.g. 1–2). A "Partial results" warning should appear.
3. Increase bucket size to a higher value. The warning should disappear and show complete results.

## Changelog
- skip



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
