### PR TITLE
Add common VSCode launch configurations to `launch.json`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
      * Attaches a debugger to an already running OSD instance
      */
     {
-      "name": "Attach Debugger to running Dashboards Server",
+      "name": "Attach debugger to running Dashboards",
       "type": "pwa-node",
       "request": "attach",
       "port": 9229
@@ -14,7 +14,7 @@
      * Starts the OSD instance only
      */
     {
-      "name": "Start Dashboards Server",
+      "name": "Start Dashboards",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "yarn",
@@ -29,10 +29,10 @@
     },
     /**
      * Starts the OpenSearch snapshot server
-     * - Everytime the server is stopped, data will NOT be persisted. Thus, if you need to persist data, you can add a configuration to spin up your OpenSearch cluster of choice
+     * - Everytime this launch configuration runs, it overwrites your previous data. Thus, if you need to persist data, you can add a configuration in your VSCode workspace to run '${workspaceFolder}/.opensearch/{version}/bin/opensearch'
      */
     {
-      "name": "Start OpenSearch Cluster Snapshot",
+      "name": "Start OpenSearch cluster snapshot",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "yarn",
@@ -54,7 +54,7 @@
      */
     {
       "name": "Start Dashboards with OpenSearch Cluster Snapshot",
-      "configurations": ["Start OpenSearch Cluster Snapshot", "Start Dashboards Server"],
+      "configurations": ["Start OpenSearch cluster snapshot", "Start Dashboards"],
       // If either Dashboards or OpenSearch server is stopped, both servers will be stopped (set this to false to stop an individual server without stopping all servers)
       "stopAll": true
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,62 @@
 {
   "version": "0.2.0",
   "configurations": [
-      {
-          "type": "pwa-node",
-          "request": "attach",
-          "name": "attach-to-service",
-          "port": 9229
-      }
+    /**
+     * Attaches a debugger to an already running OSD instance
+     */
+    {
+      "name": "Attach Debugger to running Dashboards Server",
+      "type": "pwa-node",
+      "request": "attach",
+      "port": 9229
+    },
+    /**
+     * Starts the OSD instance only
+     */
+    {
+      "name": "Start Dashboards Server",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "args": ["start", "--no-base-path"],
+      "cwd": "${workspaceFolder}",
+      "runtimeArgs": [],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    /**
+     * Starts the OpenSearch snapshot server
+     * - Everytime the server is stopped, data will NOT be persisted. Thus, if you need to persist data, you can add a configuration to spin up your OpenSearch cluster of choice
+     */
+    {
+      "name": "Start OpenSearch Cluster Snapshot",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "args": ["opensearch", "snapshot"],
+      "cwd": "${workspaceFolder}",
+      "runtimeArgs": [],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ],
+  "compounds": [
+    /**
+     * This is the run configuration to startup OSD end-to-end
+     * 1. Starts up OpenSearch Snapshot server
+     * 2. Starts up Dashboards server
+     */
+    {
+      "name": "Start Dashboards with OpenSearch Cluster Snapshot",
+      "configurations": ["Start OpenSearch Cluster Snapshot", "Start Dashboards Server"],
+      // If either Dashboards or OpenSearch server is stopped, both servers will be stopped (set this to false to stop an individual server without stopping all servers)
+      "stopAll": true
+    }
   ]
 }

--- a/changelogs/fragments/10426.yml
+++ b/changelogs/fragments/10426.yml
@@ -1,0 +1,2 @@
+chore:
+- Add common Dashboards run configurations ([#10426](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10426))


### PR DESCRIPTION
Signed-off-by: Huy Nguyen <73027756+huyaboo@users.noreply.github.com>

### Description

This change adds some common OSD run configurations for VSCode users. This allows for quick one-click launches with debugging capabilities:
1. Start the Dashboards server only (with default yml configurations)
2. Start the OpenSearch snapshot cluster only
3. Start both Dashboards and OpenSearch snapshot cluster together (for a one-click end-to-end debugging environment) 

### Issues Resolved

Related to #9688

## Testing the changes

Ran the configurations in my VSCode IDE instance

## Changelog
- chore: add common Dashboards run configurations

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
