### PR TITLE
[Keyboard-shortcuts] Suppress keyboard shortcut conflict warnings in production builds

### DIFF
--- a/changelogs/fragments/10430.yml
+++ b/changelogs/fragments/10430.yml
@@ -1,0 +1,2 @@
+fix:
+- Update the console warn and throw error message ([#10430](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10430))

--- a/src/core/public/keyboard_shortcut/key_parser.ts
+++ b/src/core/public/keyboard_shortcut/key_parser.ts
@@ -35,9 +35,7 @@ export class KeyStringParser {
     const lowercasedKeyString = keyString.toLowerCase();
     if (!VALID_KEY_STRING_REGEX.test(lowercasedKeyString)) {
       throw new Error(
-        `Invalid key combination: "${keyString}". ` +
-          `Use supported keys (a-z, 0-9, punctuation, arrows, special keys) with valid modifiers (cmd, alt, shift). ` +
-          `Examples: "cmd+s", "alt+shift+a", "g+d"`
+        `Invalid key combination: "${keyString}". Please refer to our documentation to see what is valid.`
       );
     }
 

--- a/src/core/public/keyboard_shortcut/keyboard_shortcut_service.test.ts
+++ b/src/core/public/keyboard_shortcut/keyboard_shortcut_service.test.ts
@@ -405,7 +405,9 @@ describe('KeyboardShortcutService', () => {
         execute: mockExecute,
       };
 
-      expect(() => start.register(shortcut)).toThrow('Invalid key combination: "invalid+++key"');
+      expect(() => start.register(shortcut)).toThrow(
+        'Invalid key combination: "invalid+++key". Please refer to our documentation to see what is valid.'
+      );
     });
 
     it('should throw error for duplicate shortcut registration', () => {

--- a/src/core/public/keyboard_shortcut/keyboard_shortcut_service.ts
+++ b/src/core/public/keyboard_shortcut/keyboard_shortcut_service.ts
@@ -70,13 +70,15 @@ export class KeyboardShortcutService {
       const conflictingShortcuts = existingShortcuts
         .map((s) => `${s.id} (${s.pluginId})`)
         .join(', ');
-      // eslint-disable-next-line no-console
-      console.warn(
-        `keyboard shortcut conflict detected for key "${shortcut.keys}". ` +
-          `New shortcut "${shortcut.id}" from plugin "${shortcut.pluginId}" ` +
-          `conflicts with active shortcuts: ${conflictingShortcuts}. ` +
-          `The new shortcut will take precedence when the key is pressed.`
-      );
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `keyboard shortcut conflict detected for key "${shortcut.keys}". ` +
+            `New shortcut "${shortcut.id}" from plugin "${shortcut.pluginId}" ` +
+            `conflicts with active shortcuts: ${conflictingShortcuts}. ` +
+            `The new shortcut will take precedence when the key is pressed.`
+        );
+      }
     }
 
     this.shortcutsMapByKey.set(key, [...existingShortcuts, shortcut]);


### PR DESCRIPTION
### Description

The PR is about add environment-based conditional logging to keyboard shortcut conflict warnings to prevent them from appearing in production builds while preserving them for development debugging.

Added `process.env.NODE_ENV !== 'production'` condition around `console.warn` in keyboard shortcut service
Updated the throw error message for invalid keyString


## Changelog

- fix: Update the console warn and throw error message

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
