### PR TITLE
Revert "[Explore] Default to AI mode when available instead of PPL"

### DIFF
--- a/changelogs/fragments/10385.yml
+++ b/changelogs/fragments/10385.yml
@@ -1,2 +1,0 @@
-feat:
-- [Explore] Default to AI mode when available instead of PPL ([#10385](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10385))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/01/ai_editor.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/01/ai_editor.spec.js
@@ -89,18 +89,18 @@ const runAiEditorTests = () => {
         cy.explore.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
         setDatePickerDatesIfRelevant(config.language.name);
 
-        cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('AI');
+        cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('PPL');
 
         // Test via keyboard clicks
-        cy.explore.setQueryEditor('{esc}');
-        cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('PPL');
         cy.explore.setQueryEditor(' ');
         cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('AI');
+        cy.explore.setQueryEditor('{esc}');
+        cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('PPL');
 
         // Test via toggle
         cy.getElementByTestId('queryPanelFooterLanguageToggle').click();
-        cy.getElementByTestId('queryPanelFooterLanguageToggle-PPL').click();
-        cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('PPL');
+        cy.getElementByTestId('queryPanelFooterLanguageToggle-AI').click();
+        cy.getElementByTestId('queryPanelFooterLanguageToggle').contains('AI');
       });
 
       // filtering only works for indexed fields
@@ -110,10 +110,9 @@ const runAiEditorTests = () => {
           setDatePickerDatesIfRelevant(config.language.name);
           // fire query so that we have data to add filter on
           cy.explore.updateTopNav({ log: false });
-          cy.explore.setQueryEditor(' give me all errors');
-
           cy.getElementByTestId('exploreTabs').should('exist');
 
+          cy.explore.setQueryEditor(' ');
           cy.getElementByTestId('field-category-showDetails').click({ force: true });
           cy.getElementByTestId('plus-category-Network').click();
           cy.getElementByTestId('exploreQueryPanelEditor').should('contain.text', 'category');

--- a/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.test.ts
@@ -14,12 +14,10 @@ import {
   clearLastExecutedData,
   setPatternsField,
   setUsingRegexPatterns,
-  setEditorMode,
 } from '../slices';
 import { clearQueryStatusMap } from '../slices/query_editor/query_editor_slice';
 import { createMockExploreServices, createMockStore, MockStore } from '../__mocks__';
 import { DEFAULT_DATA } from '../../../../../../data/common';
-import { EditorMode } from '../types';
 import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
 import { getSummaryAgentIsAvailable } from '../../get_summary_agent_is_available';
 import * as queryActions from '../actions/query_actions';
@@ -123,7 +121,6 @@ describe('createDatasetChangeMiddleware', () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith({ type: 'mock/resetLegacyState' });
     expect(mockedResetLegacyStateActionCreator).toHaveBeenCalledWith(mockServices);
     expect(mockStore.dispatch).toHaveBeenCalledWith(setPromptModeIsAvailable(true));
-    expect(mockStore.dispatch).toHaveBeenCalledWith(setEditorMode(EditorMode.Prompt));
     expect(mockStore.dispatch).toHaveBeenCalledWith(setSummaryAgentIsAvailable(true));
 
     // Verify the executeQueries action was dispatched

--- a/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.ts
@@ -9,7 +9,6 @@ import { isEqual } from 'lodash';
 import { Dataset, DEFAULT_DATA } from '../../../../../../data/common';
 import { RootState } from '../store';
 import { ExploreServices } from '../../../../types';
-import { EditorMode } from '../types';
 import {
   clearResults,
   setPromptModeIsAvailable,
@@ -18,7 +17,6 @@ import {
   setSummaryAgentIsAvailable,
   setPatternsField,
   setUsingRegexPatterns,
-  setEditorMode,
 } from '../slices';
 import { clearQueryStatusMap } from '../slices/query_editor/query_editor_slice';
 import { executeQueries } from '../actions/query_actions';
@@ -73,14 +71,6 @@ export const createDatasetChangeMiddleware = (
         newPromptModeIsAvailable.value !== queryEditor.promptModeIsAvailable
       ) {
         store.dispatch(setPromptModeIsAvailable(newPromptModeIsAvailable.value));
-
-        // Switch to Prompt mode when AI becomes available
-        if (newPromptModeIsAvailable.value) {
-          store.dispatch(setEditorMode(EditorMode.Prompt));
-        } else if (queryEditor.editorMode === EditorMode.Prompt) {
-          // Switch to Query mode when AI becomes unavailable and user is in Prompt mode
-          store.dispatch(setEditorMode(EditorMode.Query));
-        }
       }
 
       if (

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts
@@ -11,16 +11,6 @@ import { ColorSchemas } from '../../../../components/visualizations/types';
 import { EditorMode, QueryExecutionStatus } from '../types';
 import { of } from 'rxjs';
 
-// Mock the getPromptModeIsAvailable function
-jest.mock('../../get_prompt_mode_is_available', () => ({
-  getPromptModeIsAvailable: jest.fn(() => Promise.resolve(false)),
-}));
-
-// Mock the getSummaryAgentIsAvailable function
-jest.mock('../../get_summary_agent_is_available', () => ({
-  getSummaryAgentIsAvailable: jest.fn(() => Promise.resolve(false)),
-}));
-
 jest.mock('../../../../components/visualizations/metric/metric_vis_config', () => ({
   defaultMetricChartStyles: {
     showTitle: true,
@@ -363,32 +353,9 @@ describe('redux_persistence', () => {
       expect(result.legacy.columns).toEqual(['_source']);
     });
 
-    it('should set correct editor mode from DEFAULT_EDITOR_MODE when AI is not available', async () => {
+    it('should set correct editor mode from DEFAULT_EDITOR_MODE', async () => {
       const result = await getPreloadedState(mockServices);
       expect(result.queryEditor.editorMode).toBe(EditorMode.Query);
-      expect(result.queryEditor.promptModeIsAvailable).toBe(false);
-    });
-
-    it('should set editor mode to Prompt when AI is available', async () => {
-      // Import and cast the mocked function
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { getPromptModeIsAvailable } = require('../../get_prompt_mode_is_available');
-
-      // Mock the function to return true for this test
-      (getPromptModeIsAvailable as jest.Mock).mockImplementation(() => Promise.resolve(true));
-
-      // Create a mock dataset to trigger the AI availability check
-      const mockDataset = { id: 'test-dataset', title: 'test-dataset', type: 'INDEX_PATTERN' };
-      (mockServices.data.query.queryString.getQuery as jest.Mock).mockReturnValue({
-        dataset: mockDataset,
-      });
-
-      const result = await getPreloadedState(mockServices);
-      expect(result.queryEditor.editorMode).toBe(EditorMode.Prompt);
-      expect(result.queryEditor.promptModeIsAvailable).toBe(true);
-
-      // Reset the mock back to default behavior
-      (getPromptModeIsAvailable as jest.Mock).mockImplementation(() => Promise.resolve(false));
     });
 
     it('should initialize meta state with isInitialized false', async () => {

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.ts
@@ -25,7 +25,6 @@ import {
 import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
 import { getSummaryAgentIsAvailable } from '../../get_summary_agent_is_available';
 import { DEFAULT_EDITOR_MODE } from '../constants';
-import { EditorMode } from '../types';
 
 /**
  * Persists Redux state to URL
@@ -276,7 +275,7 @@ const getPreloadedQueryEditorState = async (
     },
     promptModeIsAvailable,
     promptToQueryIsLoading: false,
-    editorMode: promptModeIsAvailable ? EditorMode.Prompt : DEFAULT_EDITOR_MODE,
+    editorMode: DEFAULT_EDITOR_MODE,
     lastExecutedTranslatedQuery: '',
     summaryAgentIsAvailable,
     lastExecutedPrompt: '',


### PR DESCRIPTION
### Description

This reverts commit 046e8c9c3d4996324c59cd1122a46bbdb15fe3ee to set PPL as the default mode even when AI is available.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->


## Changelog

- feat: Revert "[Explore] Default to AI mode when available instead of PPL"


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
