### PR TITLE
[Explore] disable charts in traces

### DIFF
--- a/changelogs/fragments/10444.yml
+++ b/changelogs/fragments/10444.yml
@@ -1,0 +1,2 @@
+chore:
+- Disable charts in traces ([#10444](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10444))

--- a/src/plugins/explore/public/components/container/bottom_container/bottom_right_container/bottom_right_container.test.tsx
+++ b/src/plugins/explore/public/components/container/bottom_container/bottom_right_container/bottom_right_container.test.tsx
@@ -67,16 +67,24 @@ jest.mock('../../../../application/utils/state_management/actions/query_actions'
   defaultPrepareQueryString: jest.fn(() => 'mock-query-string'),
 }));
 
+// Mock useFlavorId hook
+jest.mock('../../../../helpers/use_flavor_id', () => ({
+  useFlavorId: jest.fn(() => 'logs'),
+}));
+
 // Import components and hooks after mocks
 import { BottomRightContainer } from './bottom_right_container';
 import { QueryExecutionStatus } from '../../../../application/utils/state_management/types';
 import { useDatasetContext } from '../../../../application/context';
 import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
+import { useFlavorId } from '../../../../helpers/use_flavor_id';
+import { ExploreFlavor } from '../../../../../common';
 
 const mockUseDatasetContext = useDatasetContext as jest.MockedFunction<typeof useDatasetContext>;
 const mockUseOpenSearchDashboards = useOpenSearchDashboards as jest.MockedFunction<
   typeof useOpenSearchDashboards
 >;
+const mockUseFlavorId = useFlavorId as jest.MockedFunction<typeof useFlavorId>;
 
 describe('BottomRightContainer', () => {
   const createMockStore = (status: QueryExecutionStatus = QueryExecutionStatus.UNINITIALIZED) => {
@@ -121,6 +129,7 @@ describe('BottomRightContainer', () => {
     mockUseOpenSearchDashboards.mockReturnValue({
       services: mockServices,
     } as any);
+    mockUseFlavorId.mockReturnValue(ExploreFlavor.Logs);
   });
 
   const renderComponent = (status: QueryExecutionStatus = QueryExecutionStatus.UNINITIALIZED) => {
@@ -264,5 +273,33 @@ describe('BottomRightContainer', () => {
 
     renderComponent(QueryExecutionStatus.NO_RESULTS);
     expect(screen.getByTestId('no-results')).toBeInTheDocument();
+  });
+
+  it('should not render chart container when flavor is traces', () => {
+    mockUseDatasetContext.mockReturnValue({
+      dataset: { timeFieldName: 'timestamp' } as any,
+      isLoading: false,
+      error: null,
+    });
+    mockUseFlavorId.mockReturnValue(ExploreFlavor.Traces);
+
+    renderComponent(QueryExecutionStatus.READY);
+
+    expect(screen.queryByTestId('chart-container')).not.toBeInTheDocument();
+    expect(screen.getByTestId('explore-tabs-vis-style-panel')).toBeInTheDocument();
+  });
+
+  it('should render chart container when flavor is not traces', () => {
+    mockUseDatasetContext.mockReturnValue({
+      dataset: { timeFieldName: 'timestamp' } as any,
+      isLoading: false,
+      error: null,
+    });
+    mockUseFlavorId.mockReturnValue(ExploreFlavor.Logs);
+
+    renderComponent(QueryExecutionStatus.READY);
+
+    expect(screen.getByTestId('chart-container')).toBeInTheDocument();
+    expect(screen.getByTestId('explore-tabs-vis-style-panel')).toBeInTheDocument();
   });
 });

--- a/src/plugins/explore/public/components/container/bottom_container/bottom_right_container/bottom_right_container.tsx
+++ b/src/plugins/explore/public/components/container/bottom_container/bottom_right_container/bottom_right_container.tsx
@@ -18,11 +18,14 @@ import { executeQueries } from '../../../../application/utils/state_management/a
 import { DiscoverChartContainer } from '../../../../components/chart/discover_chart_container';
 import { useDatasetContext } from '../../../../application/context';
 import { ResizableVisControlAndTabs } from './resizable_vis_control_and_tabs';
+import { useFlavorId } from '../../../../helpers/use_flavor_id';
+import { ExploreFlavor } from '../../../../../common';
 
 export const BottomRightContainer = () => {
   const dispatch = useDispatch();
   const { dataset } = useDatasetContext();
   const { services } = useOpenSearchDashboards<ExploreServices>();
+  const flavorId = useFlavorId();
 
   const onRefresh = () => {
     if (services) {
@@ -78,7 +81,7 @@ export const BottomRightContainer = () => {
   if (status === QueryExecutionStatus.READY || status === QueryExecutionStatus.ERROR) {
     return (
       <>
-        <DiscoverChartContainer />
+        {flavorId !== ExploreFlavor.Traces && <DiscoverChartContainer />}
         <CanvasPanel>
           <ResizableVisControlAndTabs />
         </CanvasPanel>


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Temporarily aisabling charts on Traces page, because currently these charts are built base on query result which is restricted by the query response size(`ppl` currently has limit on response with first 10k result), we want to move aggregation query base implementation, which will imrove the accuracy against large size data but will add cost by making extra query.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: Disable charts in traces

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
