### PR TITLE
[Keyboard-shortcuts] Add useKeyboardShortcut hook for registering keyboard shortcuts in React components

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -425,6 +425,7 @@ export {
   KeyboardShortcutSetup,
   KeyboardShortcutStart,
   ShortcutDefinition,
+  useKeyboardShortcuts,
 } from './keyboard_shortcut';
 
 export { debounce } from './utils';

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -425,7 +425,7 @@ export {
   KeyboardShortcutSetup,
   KeyboardShortcutStart,
   ShortcutDefinition,
-  useKeyboardShortcuts,
+  useKeyboardShortcut,
 } from './keyboard_shortcut';
 
 export { debounce } from './utils';

--- a/src/core/public/keyboard_shortcut/index.ts
+++ b/src/core/public/keyboard_shortcut/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { KeyboardShortcutService } from './keyboard_shortcut_service';
-export { useKeyboardShortcuts } from './use_keyboard_shortcut';
+export { useKeyboardShortcut } from './use_keyboard_shortcut';
 export type {
   KeyboardShortcutSetup,
   KeyboardShortcutStart,

--- a/src/core/public/keyboard_shortcut/index.ts
+++ b/src/core/public/keyboard_shortcut/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { KeyboardShortcutService } from './keyboard_shortcut_service';
+export { useKeyboardShortcuts } from './use_keyboard_shortcut';
 export type {
   KeyboardShortcutSetup,
   KeyboardShortcutStart,

--- a/src/core/public/keyboard_shortcut/use_keyboard_shortcut.test.ts
+++ b/src/core/public/keyboard_shortcut/use_keyboard_shortcut.test.ts
@@ -3,255 +3,215 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { renderHook } from '@testing-library/react-hooks';
-import { useKeyboardShortcuts } from './use_keyboard_shortcut';
+import { useKeyboardShortcut } from './use_keyboard_shortcut';
 import { ShortcutDefinition, KeyboardShortcutStart } from './types';
-describe('useKeyboardShortcuts', () => {
+
+describe('useKeyboardShortcut', () => {
   let mockKeyboardShortcutService: jest.Mocked<KeyboardShortcutStart>;
-  let mockShortcuts: ShortcutDefinition[];
-  let consoleErrorSpy: jest.SpyInstance;
+  let mockShortcut: ShortcutDefinition;
   let consoleWarnSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockKeyboardShortcutService = {
       register: jest.fn(),
       unregister: jest.fn(),
     };
-    mockShortcuts = [
-      {
-        id: 'test-shortcut-1',
-        pluginId: 'testPlugin',
-        name: 'Test Shortcut 1',
-        category: 'test',
-        keys: 'cmd+s',
-        execute: jest.fn(),
-      },
-      {
-        id: 'test-shortcut-2',
-        pluginId: 'testPlugin',
-        name: 'Test Shortcut 2',
-        category: 'test',
-        keys: 'cmd+c',
-        execute: jest.fn(),
-      },
-    ];
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    mockShortcut = {
+      id: 'test-shortcut',
+      pluginId: 'testPlugin',
+      name: 'Test Shortcut',
+      category: 'test',
+      keys: 'cmd+s',
+      execute: jest.fn(),
+    };
+
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
+
   afterEach(() => {
     jest.clearAllMocks();
-    consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
   });
+
   describe('successful registration', () => {
-    it('should register all shortcuts when service is available', () => {
+    it('should register shortcut when service is available', () => {
       renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
+        useKeyboardShortcut({
+          shortcut: mockShortcut,
           keyboardShortcutService: mockKeyboardShortcutService,
         })
       );
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcuts[0]);
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcuts[1]);
-      // Note: registeredShortcutIds is computed from ref and may not be immediately available in tests
-      // In real usage, components re-render after useEffect and get the correct values
+
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(1);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcut);
     });
-    it('should unregister shortcuts on unmount', () => {
+
+    it('should unregister shortcut on unmount', () => {
       const { unmount } = renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
+        useKeyboardShortcut({
+          shortcut: mockShortcut,
           keyboardShortcutService: mockKeyboardShortcutService,
         })
       );
+
       unmount();
-      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(2);
-      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledWith({
-        id: 'test-shortcut-1',
-        pluginId: 'testPlugin',
-      });
-      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledWith({
-        id: 'test-shortcut-2',
-        pluginId: 'testPlugin',
-      });
-    });
-    it('should re-register shortcuts when shortcuts array changes', () => {
-      const newShortcuts = [
-        {
-          id: 'new-shortcut',
-          pluginId: 'testPlugin',
-          name: 'New Shortcut',
-          category: 'test',
-          keys: 'cmd+n',
-          execute: jest.fn(),
-        },
-      ];
-      const { rerender } = renderHook(
-        ({ shortcuts }) =>
-          useKeyboardShortcuts({
-            shortcuts,
-            keyboardShortcutService: mockKeyboardShortcutService,
-          }),
-        { initialProps: { shortcuts: mockShortcuts } }
-      );
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
-      rerender({ shortcuts: newShortcuts });
-      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(2);
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(3); // 2 initial + 1 new
-      expect(mockKeyboardShortcutService.register).toHaveBeenLastCalledWith(newShortcuts[0]);
-    });
-  });
-  describe('service unavailable', () => {
-    it('should handle null keyboard shortcut service gracefully', () => {
-      const { result } = renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
-          keyboardShortcutService: null,
-        })
-      );
-      expect(mockKeyboardShortcutService.register).not.toHaveBeenCalled();
-      expect(result.current.registeredShortcutIds).toEqual([]);
-    });
-    it('should not log warning in production when service is unavailable', () => {
-      const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-      renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
-          keyboardShortcutService: null,
-        })
-      );
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      process.env.NODE_ENV = originalEnv;
-    });
-  });
-  describe('error handling', () => {
-    it('should continue registering other shortcuts when one fails', () => {
-      mockKeyboardShortcutService.register
-        .mockImplementationOnce(() => {
-          throw new Error('Registration failed');
-        })
-        .mockImplementationOnce(() => {});
-      renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
-          keyboardShortcutService: mockKeyboardShortcutService,
-        })
-      );
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to register shortcut test-shortcut-1:',
-        expect.any(Error)
-      );
-    });
-    it('should only unregister successfully registered shortcuts', () => {
-      mockKeyboardShortcutService.register
-        .mockImplementationOnce(() => {
-          throw new Error('Registration failed');
-        })
-        .mockImplementationOnce(() => {});
-      const { unmount } = renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
-          keyboardShortcutService: mockKeyboardShortcutService,
-        })
-      );
-      unmount();
+
       expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(1);
       expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledWith({
-        id: 'test-shortcut-2',
+        id: 'test-shortcut',
         pluginId: 'testPlugin',
       });
     });
-    it('should handle unregistration errors gracefully', () => {
-      const { unmount } = renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
-          keyboardShortcutService: mockKeyboardShortcutService,
+
+    it('should re-register shortcut when shortcut definition changes', () => {
+      const newShortcut = {
+        id: 'new-shortcut',
+        pluginId: 'testPlugin',
+        name: 'New Shortcut',
+        category: 'test',
+        keys: 'cmd+n',
+        execute: jest.fn(),
+      };
+
+      const { rerender } = renderHook(
+        ({ shortcut }) =>
+          useKeyboardShortcut({
+            shortcut,
+            keyboardShortcutService: mockKeyboardShortcutService,
+          }),
+        { initialProps: { shortcut: mockShortcut } }
+      );
+
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(1);
+
+      rerender({ shortcut: newShortcut });
+
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(1);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      expect(mockKeyboardShortcutService.register).toHaveBeenLastCalledWith(newShortcut);
+    });
+  });
+
+  describe('service unavailable', () => {
+    it('should handle null keyboard shortcut service gracefully', () => {
+      renderHook(() =>
+        useKeyboardShortcut({
+          shortcut: mockShortcut,
+          keyboardShortcutService: null,
         })
       );
-      mockKeyboardShortcutService.unregister.mockImplementation(() => {
-        throw new Error('Unregistration failed');
-      });
-      unmount();
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Failed to unregister shortcut test-shortcut-1:',
-        expect.any(Error)
-      );
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Failed to unregister shortcut test-shortcut-2:',
-        expect.any(Error)
-      );
+
+      expect(mockKeyboardShortcutService.register).not.toHaveBeenCalled();
     });
-    it('should not log errors in production', () => {
-      const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
+  });
+
+  describe('error handling', () => {
+    it('should let registration errors bubble up (crash immediately)', () => {
       mockKeyboardShortcutService.register.mockImplementation(() => {
         throw new Error('Registration failed');
       });
-      renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: mockShortcuts,
+
+      // Errors in useEffect are caught by React's error boundary, not by expect().toThrow()
+      // We verify the error is thrown by checking that register was called and threw
+      expect(() => {
+        renderHook(() =>
+          useKeyboardShortcut({
+            shortcut: mockShortcut,
+            keyboardShortcutService: mockKeyboardShortcutService,
+          })
+        );
+      }).not.toThrow(); // renderHook itself doesn't throw
+
+      // But we can verify the service method was called and would have thrown
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcut);
+      expect(mockKeyboardShortcutService.register).toThrow('Registration failed');
+    });
+
+    it('should handle unregistration errors gracefully', () => {
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcut({
+          shortcut: mockShortcut,
           keyboardShortcutService: mockKeyboardShortcutService,
         })
       );
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      mockKeyboardShortcutService.unregister.mockImplementation(() => {
+        throw new Error('Unregistration failed');
+      });
+
+      unmount();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to unregister shortcut test-shortcut:',
+        expect.any(Error)
+      );
+    });
+
+    it('should not log unregistration errors in production', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcut({
+          shortcut: mockShortcut,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+
+      mockKeyboardShortcutService.unregister.mockImplementation(() => {
+        throw new Error('Unregistration failed');
+      });
+
+      unmount();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
       process.env.NODE_ENV = originalEnv;
     });
   });
+
   describe('dependencies', () => {
-    it('should re-register shortcuts when dependencies change', () => {
+    it('should re-register shortcut when dependencies change', () => {
       let dependency = 'initial';
+
       const { rerender } = renderHook(
         ({ dep }) =>
-          useKeyboardShortcuts({
-            shortcuts: mockShortcuts,
+          useKeyboardShortcut({
+            shortcut: mockShortcut,
             keyboardShortcutService: mockKeyboardShortcutService,
             dependencies: [dep],
           }),
         { initialProps: { dep: dependency } }
       );
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(1);
+
       dependency = 'changed';
       rerender({ dep: dependency });
-      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(2);
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(4); // 2 initial + 2 re-register
+
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(1);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
     });
+
     it('should not re-register when dependencies do not change', () => {
       const dependency = 'constant';
+
       const { rerender } = renderHook(
         ({ dep }) =>
-          useKeyboardShortcuts({
-            shortcuts: mockShortcuts,
+          useKeyboardShortcut({
+            shortcut: mockShortcut,
             keyboardShortcutService: mockKeyboardShortcutService,
             dependencies: [dep],
           }),
         { initialProps: { dep: dependency } }
       );
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(1);
+
       rerender({ dep: dependency });
-      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
-      expect(mockKeyboardShortcutService.unregister).not.toHaveBeenCalled();
-    });
-  });
-  describe('empty shortcuts', () => {
-    it('should handle empty shortcuts array', () => {
-      const { result } = renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: [],
-          keyboardShortcutService: mockKeyboardShortcutService,
-        })
-      );
-      expect(mockKeyboardShortcutService.register).not.toHaveBeenCalled();
-      expect(result.current.registeredShortcutIds).toEqual([]);
-    });
-    it('should not attempt cleanup with empty shortcuts', () => {
-      const { unmount } = renderHook(() =>
-        useKeyboardShortcuts({
-          shortcuts: [],
-          keyboardShortcutService: mockKeyboardShortcutService,
-        })
-      );
-      unmount();
+
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(1);
       expect(mockKeyboardShortcutService.unregister).not.toHaveBeenCalled();
     });
   });

--- a/src/core/public/keyboard_shortcut/use_keyboard_shortcut.test.ts
+++ b/src/core/public/keyboard_shortcut/use_keyboard_shortcut.test.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { useKeyboardShortcuts } from './use_keyboard_shortcut';
+import { ShortcutDefinition, KeyboardShortcutStart } from './types';
+describe('useKeyboardShortcuts', () => {
+  let mockKeyboardShortcutService: jest.Mocked<KeyboardShortcutStart>;
+  let mockShortcuts: ShortcutDefinition[];
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  beforeEach(() => {
+    mockKeyboardShortcutService = {
+      register: jest.fn(),
+      unregister: jest.fn(),
+    };
+    mockShortcuts = [
+      {
+        id: 'test-shortcut-1',
+        pluginId: 'testPlugin',
+        name: 'Test Shortcut 1',
+        category: 'test',
+        keys: 'cmd+s',
+        execute: jest.fn(),
+      },
+      {
+        id: 'test-shortcut-2',
+        pluginId: 'testPlugin',
+        name: 'Test Shortcut 2',
+        category: 'test',
+        keys: 'cmd+c',
+        execute: jest.fn(),
+      },
+    ];
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+  describe('successful registration', () => {
+    it('should register all shortcuts when service is available', () => {
+      renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcuts[0]);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcuts[1]);
+      // Note: registeredShortcutIds is computed from ref and may not be immediately available in tests
+      // In real usage, components re-render after useEffect and get the correct values
+    });
+    it('should unregister shortcuts on unmount', () => {
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      unmount();
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(2);
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledWith({
+        id: 'test-shortcut-1',
+        pluginId: 'testPlugin',
+      });
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledWith({
+        id: 'test-shortcut-2',
+        pluginId: 'testPlugin',
+      });
+    });
+    it('should re-register shortcuts when shortcuts array changes', () => {
+      const newShortcuts = [
+        {
+          id: 'new-shortcut',
+          pluginId: 'testPlugin',
+          name: 'New Shortcut',
+          category: 'test',
+          keys: 'cmd+n',
+          execute: jest.fn(),
+        },
+      ];
+      const { rerender } = renderHook(
+        ({ shortcuts }) =>
+          useKeyboardShortcuts({
+            shortcuts,
+            keyboardShortcutService: mockKeyboardShortcutService,
+          }),
+        { initialProps: { shortcuts: mockShortcuts } }
+      );
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      rerender({ shortcuts: newShortcuts });
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(2);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(3); // 2 initial + 1 new
+      expect(mockKeyboardShortcutService.register).toHaveBeenLastCalledWith(newShortcuts[0]);
+    });
+  });
+  describe('service unavailable', () => {
+    it('should handle null keyboard shortcut service gracefully', () => {
+      const { result } = renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: null,
+        })
+      );
+      expect(mockKeyboardShortcutService.register).not.toHaveBeenCalled();
+      expect(result.current.registeredShortcutIds).toEqual([]);
+    });
+    it('should not log warning in production when service is unavailable', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: null,
+        })
+      );
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      process.env.NODE_ENV = originalEnv;
+    });
+  });
+  describe('error handling', () => {
+    it('should continue registering other shortcuts when one fails', () => {
+      mockKeyboardShortcutService.register
+        .mockImplementationOnce(() => {
+          throw new Error('Registration failed');
+        })
+        .mockImplementationOnce(() => {});
+      renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to register shortcut test-shortcut-1:',
+        expect.any(Error)
+      );
+    });
+    it('should only unregister successfully registered shortcuts', () => {
+      mockKeyboardShortcutService.register
+        .mockImplementationOnce(() => {
+          throw new Error('Registration failed');
+        })
+        .mockImplementationOnce(() => {});
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      unmount();
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(1);
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledWith({
+        id: 'test-shortcut-2',
+        pluginId: 'testPlugin',
+      });
+    });
+    it('should handle unregistration errors gracefully', () => {
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      mockKeyboardShortcutService.unregister.mockImplementation(() => {
+        throw new Error('Unregistration failed');
+      });
+      unmount();
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to unregister shortcut test-shortcut-1:',
+        expect.any(Error)
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to unregister shortcut test-shortcut-2:',
+        expect.any(Error)
+      );
+    });
+    it('should not log errors in production', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      mockKeyboardShortcutService.register.mockImplementation(() => {
+        throw new Error('Registration failed');
+      });
+      renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: mockShortcuts,
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      process.env.NODE_ENV = originalEnv;
+    });
+  });
+  describe('dependencies', () => {
+    it('should re-register shortcuts when dependencies change', () => {
+      let dependency = 'initial';
+      const { rerender } = renderHook(
+        ({ dep }) =>
+          useKeyboardShortcuts({
+            shortcuts: mockShortcuts,
+            keyboardShortcutService: mockKeyboardShortcutService,
+            dependencies: [dep],
+          }),
+        { initialProps: { dep: dependency } }
+      );
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      dependency = 'changed';
+      rerender({ dep: dependency });
+      expect(mockKeyboardShortcutService.unregister).toHaveBeenCalledTimes(2);
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(4); // 2 initial + 2 re-register
+    });
+    it('should not re-register when dependencies do not change', () => {
+      const dependency = 'constant';
+      const { rerender } = renderHook(
+        ({ dep }) =>
+          useKeyboardShortcuts({
+            shortcuts: mockShortcuts,
+            keyboardShortcutService: mockKeyboardShortcutService,
+            dependencies: [dep],
+          }),
+        { initialProps: { dep: dependency } }
+      );
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      rerender({ dep: dependency });
+      expect(mockKeyboardShortcutService.register).toHaveBeenCalledTimes(2);
+      expect(mockKeyboardShortcutService.unregister).not.toHaveBeenCalled();
+    });
+  });
+  describe('empty shortcuts', () => {
+    it('should handle empty shortcuts array', () => {
+      const { result } = renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: [],
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      expect(mockKeyboardShortcutService.register).not.toHaveBeenCalled();
+      expect(result.current.registeredShortcutIds).toEqual([]);
+    });
+    it('should not attempt cleanup with empty shortcuts', () => {
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcuts({
+          shortcuts: [],
+          keyboardShortcutService: mockKeyboardShortcutService,
+        })
+      );
+      unmount();
+      expect(mockKeyboardShortcutService.unregister).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/core/public/keyboard_shortcut/use_keyboard_shortcut.test.ts
+++ b/src/core/public/keyboard_shortcut/use_keyboard_shortcut.test.ts
@@ -112,8 +112,6 @@ describe('useKeyboardShortcut', () => {
         throw new Error('Registration failed');
       });
 
-      // Errors in useEffect are caught by React's error boundary, not by expect().toThrow()
-      // We verify the error is thrown by checking that register was called and threw
       expect(() => {
         renderHook(() =>
           useKeyboardShortcut({
@@ -121,9 +119,8 @@ describe('useKeyboardShortcut', () => {
             keyboardShortcutService: mockKeyboardShortcutService,
           })
         );
-      }).not.toThrow(); // renderHook itself doesn't throw
+      }).not.toThrow();
 
-      // But we can verify the service method was called and would have thrown
       expect(mockKeyboardShortcutService.register).toHaveBeenCalledWith(mockShortcut);
       expect(mockKeyboardShortcutService.register).toThrow('Registration failed');
     });

--- a/src/core/public/keyboard_shortcut/use_keyboard_shortcut.ts
+++ b/src/core/public/keyboard_shortcut/use_keyboard_shortcut.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useEffect, useRef, useMemo } from 'react';
+import { ShortcutDefinition, KeyboardShortcutStart } from './types';
+interface UseKeyboardShortcutsProps {
+  shortcuts: ShortcutDefinition[];
+  keyboardShortcutService: KeyboardShortcutStart | null;
+  dependencies?: React.DependencyList;
+}
+/**
+ * Hook for registering keyboard shortcuts in functional React components
+ *
+ * Provides robust error handling and cleanup logic:
+ * - Continues registering other shortcuts even if some fail
+ * - Tracks only successfully registered shortcuts for accurate cleanup
+ * - Automatic cleanup when component unmounts or dependencies change
+ *
+ *
+ * @param shortcuts - Array of shortcut definitions to register
+ * @param keyboardShortcutService - The keyboard shortcut service from CoreStart
+ * @param dependencies - React dependency array for re-registration
+ * @returns Object with registered shortcut IDs
+ *
+ * @example
+ * ```typescript
+ * function MyComponent() {
+ *   const { keyboardShortcut } = useOpenSearchDashboards().services;
+ *
+ *   // useMemo prevents shortcuts array from being recreated on every render
+ *   // Without useMemo, useEffect would re-run constantly, causing shortcuts
+ *   // to be unregistered and re-registered on every component render
+ *   const shortcuts = useMemo(() => [
+ *     {
+ *       id: 'save',
+ *       pluginId: 'myPlugin',
+ *       name: 'Save Document',
+ *       category: 'editing',
+ *       keys: 'cmd+s',
+ *       execute: () => handleSave()
+ *     }
+ *   ], []); // Empty deps = stable reference until component unmounts
+ *
+ *   const { registeredShortcutIds } = useKeyboardShortcuts({
+ *     shortcuts,
+ *     keyboardShortcutService: keyboardShortcut
+ *   });
+ *
+ *   return <div>Registered {registeredShortcutIds.length} shortcuts</div>;
+ * }
+ * ```
+ */
+export function useKeyboardShortcuts({
+  shortcuts,
+  keyboardShortcutService,
+  dependencies = [],
+}: UseKeyboardShortcutsProps) {
+  // useRef is used instead of useState for tracking registered shortcuts because:
+  // We don't want to trigger re-renders when updating the tracking array
+  // The cleanup function needs access to the current value (closure issue with useState)
+  // Better performance - no unnecessary re-renders during registration process
+  // The ref value persists across renders and is mutable without causing re-renders
+  const successfullyRegistered = useRef<ShortcutDefinition[]>([]);
+  useEffect(() => {
+    if (!keyboardShortcutService) {
+      return;
+    }
+    // Clear previous registrations
+    successfullyRegistered.current = [];
+    // Register all shortcuts and track successful ones
+    // continue registering other shortcuts even if some fail
+    shortcuts.forEach((shortcut) => {
+      try {
+        keyboardShortcutService.register(shortcut);
+        successfullyRegistered.current.push(shortcut);
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.error(`Failed to register shortcut ${shortcut.id}:`, error);
+        }
+      }
+    });
+    // Cleanup function - only unregister successfully registered shortcuts
+    return () => {
+      if (keyboardShortcutService && successfullyRegistered.current.length > 0) {
+        successfullyRegistered.current.forEach((shortcut) => {
+          try {
+            keyboardShortcutService.unregister({
+              id: shortcut.id,
+              pluginId: shortcut.pluginId,
+            });
+          } catch (error) {
+            if (process.env.NODE_ENV !== 'production') {
+              // eslint-disable-next-line no-console
+              console.warn(`Failed to unregister shortcut ${shortcut.id}:`, error);
+            }
+          }
+        });
+        successfullyRegistered.current = [];
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyboardShortcutService, shortcuts, ...(dependencies || [])]);
+  return {
+    registeredShortcutIds: successfullyRegistered.current.map(
+      (shortcut) => `${shortcut.id}.${shortcut.pluginId}`
+    ),
+  };
+}


### PR DESCRIPTION
### Description

This PR introduces a new React hook `useKeyboardShortcut` for registering keyboard shortcuts in functional components with proper lifecycle management and error handling.

- Simple API for registering single keyboard shortcuts

- Automatic cleanup when component unmounts or dependencies change


###


## Changelog

- feat: Add useKeyboardShortcut hook for registering keyboard shortcuts in React components

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
