### PR TITLE
[Autocomplete] Provide Context Specific Suggestion inside Quotes

### DIFF
--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
@@ -31,6 +31,49 @@ import {
 } from './constants';
 import { Documentation } from './ppl_documentation';
 
+// Centralized function to generate appropriate insertion text based on context
+function getInsertText(
+  text: string,
+  type: 'field' | 'value' | 'keyword' | 'function' | 'table',
+  plainInsert: boolean = false,
+  options: {
+    needsBackticks?: boolean;
+    isStringValue?: boolean;
+    hasOptionalParam?: boolean;
+    isSnippet?: boolean;
+  } = {}
+): string {
+  const {
+    needsBackticks = false,
+    isStringValue = false,
+    hasOptionalParam = false,
+    isSnippet = false,
+  } = options;
+
+  if (plainInsert) {
+    return text;
+  } else {
+    // Normal behavior when not in quotes
+    switch (type) {
+      case 'field':
+        return needsBackticks ? `\`${text}\` ` : `${text} `;
+      case 'value':
+        return isStringValue ? `"${text}" ` : `${text} `;
+      case 'keyword':
+        return `${text} `;
+      case 'function':
+        if (isSnippet) {
+          return hasOptionalParam ? `${text}() $0` : `${text}($0)`;
+        }
+        return `${text}()`;
+      case 'table':
+        return `${text} `;
+      default:
+        return `${text} `;
+    }
+  }
+}
+
 export const getDefaultSuggestions = async ({
   selectionStart,
   selectionEnd,
@@ -138,8 +181,10 @@ export const getSimplifiedPPLSuggestions = async ({
       column: column || selectionEnd,
     });
     const finalSuggestions: QuerySuggestion[] = [];
+    const isInQuotes = suggestions.isInQuote || false;
+    const isInBackQuote = suggestions.isInBackQuote || false;
 
-    if (suggestions.suggestColumns) {
+    if (suggestions.suggestColumns && (isInBackQuote || !isInQuotes)) {
       const initialFields = indexPattern.fields;
 
       // Get available fields from symbol table based on current query context
@@ -154,12 +199,13 @@ export const getSimplifiedPPLSuggestions = async ({
       finalSuggestions.push(
         ...formatAvailableFieldsToSuggestions(
           availableFields,
-          (f: string) =>
-            suggestions.suggestFieldsInAggregateFunction
-              ? `${f}`
-              : f.includes('.') || f.includes('@')
-              ? `\`${f}\` `
-              : `${f} `,
+          (f: string) => {
+            if (suggestions.suggestFieldsInAggregateFunction) {
+              return getInsertText(f, 'field', true);
+            }
+            const needsBackticks = f.includes('.') || f.includes('@');
+            return getInsertText(f, 'field', isInBackQuote, { needsBackticks });
+          },
           (f: string) => {
             return f.startsWith('_') ? `99` : `3`; // This devalues all the Field Names that start _ so that appear further down the autosuggest wizard
           }
@@ -167,7 +213,7 @@ export const getSimplifiedPPLSuggestions = async ({
       );
     }
 
-    if (suggestions.suggestValuesForColumn) {
+    if (suggestions.suggestValuesForColumn && (isInQuotes || !isInBackQuote)) {
       finalSuggestions.push(
         ...formatValuesToSuggestions(
           await fetchColumnValues(
@@ -177,7 +223,10 @@ export const getSimplifiedPPLSuggestions = async ({
             indexPattern,
             datasetType
           ).catch(() => []),
-          (val: any) => (typeof val === 'string' ? `"${val}" ` : `${val} `)
+          (val: any) => {
+            const isStringValue = typeof val === 'string';
+            return getInsertText(val?.toString() || '', 'value', isInQuotes, { isStringValue });
+          }
         )
       );
     }
@@ -187,7 +236,10 @@ export const getSimplifiedPPLSuggestions = async ({
         ...Object.entries(PPL_AGGREGATE_FUNCTIONS).map(([af, prop]) => ({
           text: `${af}()`,
           type: monaco.languages.CompletionItemKind.Module,
-          insertText: prop?.optionalParam ? `${af}() $0` : `${af}($0)`,
+          insertText: getInsertText(af, 'function', isInQuotes, {
+            hasOptionalParam: prop?.optionalParam,
+            isSnippet: true,
+          }),
           insertTextRules: monaco.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
           sortText: '67',
           detail: SuggestionItemDetailsTags.AggregateFunction,
@@ -199,7 +251,7 @@ export const getSimplifiedPPLSuggestions = async ({
       finalSuggestions.push({
         text: indexPattern.title,
         type: monaco.languages.CompletionItemKind.Struct,
-        insertText: `${indexPattern.title} `,
+        insertText: getInsertText(indexPattern.title, 'table', isInQuotes),
         detail: SuggestionItemDetailsTags.Table,
       });
     }
@@ -207,7 +259,7 @@ export const getSimplifiedPPLSuggestions = async ({
     if (suggestions.suggestRenameAs) {
       finalSuggestions.push({
         text: 'as',
-        insertText: 'as ',
+        insertText: getInsertText('as', 'keyword', isInQuotes),
         type: monaco.languages.CompletionItemKind.Keyword,
         detail: SuggestionItemDetailsTags.Keyword,
       });
@@ -226,9 +278,10 @@ export const getSimplifiedPPLSuggestions = async ({
               type:
                 KEYWORD_ITEM_KIND_MAP.get(keywordDetails.type) ??
                 monaco.languages.CompletionItemKind.Function,
-              insertText: keywordDetails?.optionalParam
-                ? `${functionName}() $0`
-                : `${functionName}($0)`,
+              insertText: getInsertText(functionName, 'function', isInQuotes, {
+                hasOptionalParam: keywordDetails?.optionalParam,
+                isSnippet: true,
+              }),
               insertTextRules: monaco.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
               detail: keywordDetails.type,
               sortText: keywordDetails.importance,
@@ -240,7 +293,7 @@ export const getSimplifiedPPLSuggestions = async ({
               type:
                 KEYWORD_ITEM_KIND_MAP.get(keywordDetails.type) ??
                 monaco.languages.CompletionItemKind.Keyword,
-              insertText: `${sk.value.toLowerCase()} `,
+              insertText: getInsertText(sk.value.toLowerCase(), 'keyword', isInQuotes),
               detail: keywordDetails.type,
               sortText: keywordDetails.importance,
               documentation: Documentation[sk.value.toUpperCase()] ?? '',
@@ -248,7 +301,7 @@ export const getSimplifiedPPLSuggestions = async ({
           } else {
             return {
               text: sk.value.toLowerCase(),
-              insertText: `${sk.value.toLowerCase()} `,
+              insertText: getInsertText(sk.value.toLowerCase(), 'keyword', isInQuotes),
               type: monaco.languages.CompletionItemKind.Keyword,
               detail: SuggestionItemDetailsTags.Keyword,
               // sortText is the only option to sort suggestions, compares strings

--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion_simplified.test.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion_simplified.test.ts
@@ -447,5 +447,26 @@ describe('ppl code_completion', () => {
       const resultField2 = results.find((result) => result.text === 'host@name');
       expect(resultField2?.insertText).toBe('`host@name` ');
     });
+
+    it('should suggest fields/values based on context within quotes', async () => {
+      // Suggesting Fields
+      const query = 'source = test-index | where ``';
+      const position = new monaco.Position(1, query.length);
+
+      const results = await getSimpleSuggestions(query, position);
+      const resultField = results.find((result) => result.text === 'resource.attributes.host');
+      expect(resultField?.insertText).toBe('resource.attributes.host');
+
+      const mockedValues = ['value1', 'value2'];
+      jest.spyOn(utils, 'fetchColumnValues').mockResolvedValue(mockedValues);
+
+      // Suggesting Values
+      const query1 = 'source = test-index | where field1 = ""';
+      const position1 = new monaco.Position(1, query1.length);
+      const results1 = await getSimpleSuggestions(query1, position1);
+
+      const resultValue = results1.find((result) => result.text === 'value1');
+      expect(resultValue?.insertText).toBe('value1');
+    });
   });
 });

--- a/src/plugins/data/public/antlr/opensearch_ppl/simplified_ppl_grammar/opensearch_ppl_autocomplete.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/simplified_ppl_grammar/opensearch_ppl_autocomplete.ts
@@ -342,10 +342,19 @@ export function enrichAutocompleteResult(
     shouldSuggestConstraints,
     ...suggestionsFromRules
   } = processVisitedRules(rules, cursorTokenIndex, tokenStream);
+
+  const currentToken = tokenStream?.get(cursorTokenIndex);
+  const isInBackQuotes = currentToken?.type === OpenSearchPPLParser.BQUOTA_STRING;
+  const isInQuotes =
+    currentToken?.type === OpenSearchPPLParser.DQUOTA_STRING ||
+    currentToken?.type === OpenSearchPPLParser.SQUOTA_STRING;
+
   const result: OpenSearchPplAutocompleteResult = {
     ...baseResult,
     ...suggestionsFromRules,
     suggestColumns: shouldSuggestColumns ? ({} as TableContextSuggestion) : undefined,
+    isInQuote: isInQuotes,
+    isInBackQuote: isInBackQuotes,
   };
   return result;
 }

--- a/src/plugins/data/public/antlr/shared/types.ts
+++ b/src/plugins/data/public/antlr/shared/types.ts
@@ -103,6 +103,8 @@ export interface OpenSearchPplAutocompleteResult extends AutocompleteResultBase 
   suggestSourcesOrTables?: SourceOrTableSuggestion;
   suggestRenameAs?: boolean;
   suggestFieldsInAggregateFunction?: boolean;
+  isInBackQuote?: boolean;
+  isInQuote?: boolean;
 }
 
 export enum TableOrViewSuggestion {

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -61,7 +61,7 @@ const promptModePlaceholder = i18n.translate(
   }
 );
 
-const TRIGGER_CHARACTERS = [' ', '='];
+const TRIGGER_CHARACTERS = [' ', '=', "'", '"', '`'];
 
 const languageConfiguration: LanguageConfiguration = {
   autoClosingPairs: [
@@ -70,6 +70,7 @@ const languageConfiguration: LanguageConfiguration = {
     { open: '{', close: '}' },
     { open: '"', close: '"' },
     { open: "'", close: "'" },
+    { open: '`', close: '`' },
   ],
   wordPattern: /@?\w[\w@'.-]*[?!,;:"]*/, // Consider tokens containing . @ as words while applying suggestions. Refer https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10118#discussion_r2201428532 for details.
 };


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
Currently , when user uses  quotes, they don;'t see any suggestions. This PR aims at extending the autoComplete suggestion while user is within quotes. 

Before:

https://github.com/user-attachments/assets/8a6f90be-74c3-4136-9e63-a690c176719c


After:

https://github.com/user-attachments/assets/a1658d93-6b6b-47e2-bed0-27f8e432a7a2

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: Provide Context Specific Suggestion inside Quotes 

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
