### PR TITLE
chore: migrate away from `glob-all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,6 @@
     "font-awesome": "4.7.0",
     "getos": "^3.2.1",
     "glob": "^7.1.7",
-    "glob-all": "^3.2.1",
     "globby": "^11.1.0",
     "handlebars": "4.7.7",
     "hjson": "3.2.1",

--- a/packages/osd-eslint-import-resolver-opensearch-dashboards/package.json
+++ b/packages/osd-eslint-import-resolver-opensearch-dashboards/package.json
@@ -16,7 +16,6 @@
     "debug": "^2.6.9",
     "eslint-import-resolver-node": "0.3.2",
     "eslint-import-resolver-webpack": "0.13.8",
-    "glob-all": "^3.2.1",
     "lru-cache": "^4.1.5",
     "resolve": "^1.7.1",
     "webpack": "npm:@amoo-miki/webpack@4.46.0-xxhash.1"

--- a/src/cli_plugin/install/download.test.js
+++ b/src/cli_plugin/install/download.test.js
@@ -34,7 +34,7 @@ import http from 'http';
 
 import sinon from 'sinon';
 import nock from 'nock';
-import glob from 'glob-all';
+import glob from 'glob';
 import del from 'del';
 
 import { Logger } from '../lib/logger';

--- a/src/cli_plugin/install/pack.test.js
+++ b/src/cli_plugin/install/pack.test.js
@@ -32,7 +32,7 @@ import { join } from 'path';
 import { mkdir } from 'fs/promises';
 
 import sinon from 'sinon';
-import glob from 'glob-all';
+import glob from 'glob';
 import del from 'del';
 
 import { Logger } from '../lib/logger';

--- a/src/cli_plugin/remove/remove.test.js
+++ b/src/cli_plugin/remove/remove.test.js
@@ -32,7 +32,7 @@ import { join } from 'path';
 import { mkdir, writeFile } from 'fs/promises';
 
 import sinon from 'sinon';
-import glob from 'glob-all';
+import glob from 'glob';
 import del from 'del';
 
 import { Logger } from '../lib/logger';

--- a/src/dev/typescript/projects.ts
+++ b/src/dev/typescript/projects.ts
@@ -39,7 +39,7 @@ export const PROJECTS = [
   new Project(resolve(REPO_ROOT, 'src/test_utils/tsconfig.json')),
   new Project(resolve(REPO_ROOT, 'src/core/tsconfig.json')),
 
-  // NOTE: using glob.sync rather than glob-all or globby
+  // NOTE: using glob.sync rather than globby
   // because it takes less than 10 ms, while the other modules
   // both took closer to 1000ms.
   ...glob

--- a/yarn.lock
+++ b/yarn.lock
@@ -14624,14 +14624,6 @@ github-slugger@^1.0.0, github-slugger@^1.1.1:
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.5.0.tgz#17891bbc73232051474d68bd867a34625c955f7d"
   integrity sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==
 
-glob-all@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/glob-all/-/glob-all-3.3.0.tgz#2019896fbaeb37bc451809cf0cb1e5d2b3e345b2"
-  integrity sha512-30gCh9beSb+YSAh0vsoIlBRm4bSlyMa+5nayax1EJhjwYrCohX0aDxcxvWVe3heOrJikbHgRs75Af6kPLcumew==
-  dependencies:
-    glob "^7.1.2"
-    yargs "^15.3.1"
-
 glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@^6.0.0, glob-parent@~5.1.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
@@ -14690,7 +14682,7 @@ glob@^10.3.7:
     minipass "^7.1.2"
     path-scurry "^1.11.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -26999,7 +26991,7 @@ yargs-unparser@^2.0.0:
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
 
-yargs@^15.0.2, yargs@^15.3.1, yargs@^15.4.1:
+yargs@^15.0.2, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Remove `glob-all` references from OSD codebase since all of its usage doesn't involve [array of patterns at all, which is the only advantage over `glob`](https://github.com/jpillora/node-glob-all?tab=readme-ov-file#glob-all)

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

N/A

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

N/A

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

Green CI

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: migrate away from `glob-all`

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
