### PR TITLE
[Explore] Update dataset interface in fields selector component

### DIFF
--- a/changelogs/fragments/10483.yml
+++ b/changelogs/fragments/10483.yml
@@ -1,0 +1,2 @@
+chore:
+- Update dataset interface in fields selector component ([#10483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10483))

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -48,7 +48,7 @@ import { overlayServiceMock } from './overlays/overlay_service.mock';
 import { savedObjectsServiceMock } from './saved_objects/saved_objects_service.mock';
 import { uiSettingsServiceMock } from './ui_settings/ui_settings_service.mock';
 import { workspacesServiceMock } from './workspace/workspaces_service.mock';
-
+import { keyboardShortcutServiceMock } from './keyboard_shortcut/keyboard_shortcut_service.mock';
 export { applicationServiceMock } from './application/application_service.mock';
 export { scopedHistoryMock } from './application/scoped_history.mock';
 export { chromeServiceMock } from './chrome/chrome_service.mock';
@@ -62,6 +62,7 @@ export { overlayServiceMock } from './overlays/overlay_service.mock';
 export { savedObjectsServiceMock } from './saved_objects/saved_objects_service.mock';
 export { uiSettingsServiceMock } from './ui_settings/ui_settings_service.mock';
 export { workspacesServiceMock } from './workspace/workspaces_service.mock';
+export { keyboardShortcutServiceMock } from './keyboard_shortcut/keyboard_shortcut_service.mock';
 
 function createCoreSetupMock({
   basePath = '',
@@ -89,6 +90,7 @@ function createCoreSetupMock({
       getBranding: injectedMetadataServiceMock.createSetupContract().getBranding,
     },
     workspaces: workspacesServiceMock.createSetupContract(),
+    keyboardShortcut: keyboardShortcutServiceMock.createSetup(),
   };
 
   return mock;
@@ -111,6 +113,7 @@ function createCoreStartMock({ basePath = '' } = {}) {
     },
     fatalErrors: fatalErrorsServiceMock.createStartContract(),
     workspaces: workspacesServiceMock.createStartContract(),
+    keyboardShortcut: keyboardShortcutServiceMock.createStart(),
   };
 
   return mock;

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -884,6 +884,11 @@ exports[`Dashboard top nav render in embed mode 1`] = `
               "getBranding": [MockFunction],
               "getInjectedVar": [MockFunction],
             },
+            "keyboardShortcut": Object {
+              "register": [MockFunction],
+              "unregister": [MockFunction],
+              "useKeyboardShortcut": [MockFunction],
+            },
             "navigation": Object {
               "ui": Object {
                 "HeaderControl": [Function],
@@ -2036,6 +2041,11 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
             "injectedMetadata": Object {
               "getBranding": [MockFunction],
               "getInjectedVar": [MockFunction],
+            },
+            "keyboardShortcut": Object {
+              "register": [MockFunction],
+              "unregister": [MockFunction],
+              "useKeyboardShortcut": [MockFunction],
             },
             "navigation": Object {
               "ui": Object {
@@ -3190,6 +3200,11 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
               "getBranding": [MockFunction],
               "getInjectedVar": [MockFunction],
             },
+            "keyboardShortcut": Object {
+              "register": [MockFunction],
+              "unregister": [MockFunction],
+              "useKeyboardShortcut": [MockFunction],
+            },
             "navigation": Object {
               "ui": Object {
                 "HeaderControl": [Function],
@@ -4342,6 +4357,11 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
             "injectedMetadata": Object {
               "getBranding": [MockFunction],
               "getInjectedVar": [MockFunction],
+            },
+            "keyboardShortcut": Object {
+              "register": [MockFunction],
+              "unregister": [MockFunction],
+              "useKeyboardShortcut": [MockFunction],
             },
             "navigation": Object {
               "ui": Object {
@@ -5496,6 +5516,11 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
               "getBranding": [MockFunction],
               "getInjectedVar": [MockFunction],
             },
+            "keyboardShortcut": Object {
+              "register": [MockFunction],
+              "unregister": [MockFunction],
+              "useKeyboardShortcut": [MockFunction],
+            },
             "navigation": Object {
               "ui": Object {
                 "HeaderControl": [Function],
@@ -6648,6 +6673,11 @@ exports[`Dashboard top nav render with all components 1`] = `
             "injectedMetadata": Object {
               "getBranding": [MockFunction],
               "getInjectedVar": [MockFunction],
+            },
+            "keyboardShortcut": Object {
+              "register": [MockFunction],
+              "unregister": [MockFunction],
+              "useKeyboardShortcut": [MockFunction],
             },
             "navigation": Object {
               "ui": Object {

--- a/src/plugins/explore/public/components/fields_selector/discover_field.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field.test.tsx
@@ -34,8 +34,8 @@ import stubbedLogstashFields from 'fixtures/logstash_fields';
 import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
 import { DiscoverField } from './discover_field';
 import { coreMock } from 'opensearch-dashboards/public/mocks';
-import { IndexPatternField } from '../../../../data/public';
-import { getStubIndexPattern } from '../../../../data/public/test_utils';
+import { DataViewField } from '../../../../data/public';
+import { getStubDataView } from '../../../../data/public/data_views/data_view.stub';
 
 jest.mock('../../application/legacy/discover/opensearch_dashboards_services', () => ({
   getServices: () => ({
@@ -70,9 +70,9 @@ function getProps({
   selected?: boolean;
   showSummary?: boolean;
   useShortDots?: boolean;
-  field?: IndexPatternField;
+  field?: DataViewField;
 }) {
-  const indexPattern = getStubIndexPattern(
+  const dataSet = getStubDataView(
     'logstash-*',
     (cfg: any) => cfg,
     'time',
@@ -82,22 +82,21 @@ function getProps({
 
   const finalField =
     field ??
-    new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    ({
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      filterable: true,
+    } as DataViewField);
 
   const props = {
-    indexPattern,
+    dataSet,
     columns: [],
     field: finalField,
     getDetails: jest.fn(() => ({ buckets: [], error: '', exists: 1, total: 1 })),
@@ -144,17 +143,18 @@ describe('discover sidebar field', function () {
     expect(screen.queryByTestId('field-bytes-showDetails')).toBeNull();
   });
   it('should not allow clicking on _source', function () {
-    const field = new IndexPatternField(
-      {
-        name: '_source',
-        type: '_source',
-        esTypes: ['_source'],
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      '_source'
-    );
+    const field = {
+      name: '_source',
+      type: '_source',
+      esTypes: ['_source'],
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: '_source',
+      count: 0,
+      scripted: false,
+      filterable: false,
+    } as DataViewField;
     const props = getProps({
       selected: true,
       field,

--- a/src/plugins/explore/public/components/fields_selector/discover_field.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field.tsx
@@ -42,7 +42,7 @@ import { i18n } from '@osd/i18n';
 import { DiscoverFieldDetails } from './discover_field_details';
 import { FieldIcon } from '../../../../opensearch_dashboards_react/public';
 import { FieldDetails } from './types';
-import { IndexPatternField, IndexPattern } from '../../../../data/public';
+import { DataViewField, DataView } from '../../../../data/public';
 import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
 import { getFieldTypeName } from './lib/get_field_type_name';
 import './discover_field.scss';
@@ -55,11 +55,11 @@ export interface DiscoverFieldProps {
   /**
    * The displayed field
    */
-  field: IndexPatternField;
+  field: DataViewField;
   /**
-   * The currently selected index pattern
+   * The currently selected data view
    */
-  indexPattern: IndexPattern;
+  dataSet: DataView;
   /**
    * Callback to add/select the field
    */
@@ -67,7 +67,7 @@ export interface DiscoverFieldProps {
   /**
    * Callback to add a filter to filter bar
    */
-  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  onAddFilter: (field: DataViewField | string, value: string, type: '+' | '-') => void;
   /**
    * Callback to remove/deselect a the field
    * @param fieldName
@@ -76,7 +76,7 @@ export interface DiscoverFieldProps {
   /**
    * Retrieve details data for the field
    */
-  getDetails: (field: IndexPatternField) => FieldDetails;
+  getDetails: (field: DataViewField) => FieldDetails;
   /**
    * Determines whether the field is selected
    */
@@ -97,7 +97,7 @@ export const DiscoverField = ({
   onAddField,
   onRemoveField,
   columns,
-  indexPattern,
+  dataSet,
   onAddFilter,
   getDetails,
   useShortDots,
@@ -128,7 +128,7 @@ export const DiscoverField = ({
 
   const [infoIsOpen, setOpen] = useState(false);
 
-  const toggleDisplay = (f: IndexPatternField) => {
+  const toggleDisplay = (f: DataViewField) => {
     if (selected) {
       onRemoveField(f.name);
     } else {
@@ -258,7 +258,7 @@ export const DiscoverField = ({
                 columns={columns}
                 details={getDetails(field)}
                 field={field}
-                indexPattern={indexPattern}
+                dataSet={dataSet}
                 onAddFilter={onAddFilter}
               />
             )}

--- a/src/plugins/explore/public/components/fields_selector/discover_field_bucket.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field_bucket.tsx
@@ -40,13 +40,13 @@ import {
 import { i18n } from '@osd/i18n';
 import { StringFieldProgressBar } from './string_progress_bar';
 import { Bucket } from './types';
-import { IndexPatternField } from '../../../../data/public';
+import { DataViewField } from '../../../../data/public';
 import './discover_field_bucket.scss';
 
 interface Props {
   bucket: Bucket;
-  field: IndexPatternField;
-  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  field: DataViewField;
+  onAddFilter: (field: DataViewField | string, value: string, type: '+' | '-') => void;
 }
 
 export function DiscoverFieldBucket({ field, bucket, onAddFilter }: Props) {

--- a/src/plugins/explore/public/components/fields_selector/discover_field_details.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field_details.test.tsx
@@ -37,8 +37,8 @@ import stubbedLogstashFields from 'fixtures/logstash_fields';
 import { mountWithIntl, nextTick } from 'test_utils/enzyme_helpers';
 import { DiscoverFieldDetails } from './discover_field_details';
 import { coreMock } from 'opensearch-dashboards/public/mocks';
-import { IndexPatternField } from '../../../../data/public';
-import { getStubIndexPattern } from '../../../../data/public/test_utils';
+import { DataViewField } from '../../../../data/public';
+import { getStubDataView } from '../../../../data/public/data_views/data_view.stub';
 
 const mockGetHref = jest.fn();
 const mockGetTriggerCompatibleActions = jest.fn();
@@ -49,7 +49,7 @@ jest.mock('../../application/legacy/discover/opensearch_dashboards_services', ()
   }),
 }));
 
-const indexPattern = getStubIndexPattern(
+const dataSet = getStubDataView(
   'logstash-*',
   (cfg: any) => cfg,
   'time',
@@ -61,7 +61,7 @@ describe('discover sidebar field details', function () {
   const defaultProps = {
     columns: [],
     details: { buckets: [], error: '', exists: 1, total: 1 },
-    indexPattern,
+    dataSet,
     onAddFilter: jest.fn(),
   };
 
@@ -74,25 +74,24 @@ describe('discover sidebar field details', function () {
     ]);
   });
 
-  function mountComponent(field: IndexPatternField, props?: Record<string, any>) {
+  function mountComponent(field: DataViewField, props?: Record<string, any>) {
     const compProps = { ...defaultProps, ...props, field };
     return mountWithIntl(<DiscoverFieldDetails {...compProps} />);
   }
 
   it('should render buckets if they exist', async function () {
-    const visualizableField = new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    const visualizableField = {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      visualizable: true,
+    } as DataViewField;
     const buckets = [1, 2, 3].map((n) => ({
       display: `display-${n}`,
       value: `value-${n}`,
@@ -126,19 +125,18 @@ describe('discover sidebar field details', function () {
   });
 
   it('should only render buckets if they exist', async function () {
-    const visualizableField = new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    const visualizableField = {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      visualizable: true,
+    } as DataViewField;
     const comp = mountComponent(visualizableField);
     expect(findTestSubject(comp, 'fieldVisualizeContainer').length).toBe(1);
     expect(findTestSubject(comp, 'fieldVisualizeError').length).toBe(0);
@@ -159,19 +157,18 @@ describe('discover sidebar field details', function () {
   });
 
   it('should render a details error', async function () {
-    const visualizableField = new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    const visualizableField = {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      visualizable: true,
+    } as DataViewField;
     const errText = 'Some error';
     const comp = mountComponent(visualizableField, {
       details: { ...defaultProps.details, error: errText },
@@ -191,19 +188,18 @@ describe('discover sidebar field details', function () {
 
   it('should handle promise rejection from isFieldVisualizable', async function () {
     mockGetTriggerCompatibleActions.mockRejectedValue(new Error('Async error'));
-    const visualizableField = new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    const visualizableField = {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      visualizable: true,
+    } as DataViewField;
     const comp = mountComponent(visualizableField);
 
     await act(async () => {
@@ -216,19 +212,18 @@ describe('discover sidebar field details', function () {
 
   it('should handle promise rejection from getVisualizeHref', async function () {
     mockGetHref.mockRejectedValue(new Error('Async error'));
-    const visualizableField = new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    const visualizableField = {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      visualizable: true,
+    } as DataViewField;
     const comp = mountComponent(visualizableField);
 
     await act(async () => {
@@ -240,19 +235,18 @@ describe('discover sidebar field details', function () {
   });
 
   it('should enable the visualize link for a number field', async function () {
-    const visualizableField = new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    );
+    const visualizableField = {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+      visualizable: true,
+    } as DataViewField;
     const comp = mountComponent(visualizableField);
 
     await act(async () => {
@@ -265,19 +259,17 @@ describe('discover sidebar field details', function () {
 
   it('should disable the visualize link for an _id field', async function () {
     expect.assertions(1);
-    const conflictField = new IndexPatternField(
-      {
-        name: '_id',
-        type: 'string',
-        esTypes: ['_id'],
-        count: 0,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'test'
-    );
+    const conflictField = {
+      name: '_id',
+      type: 'string',
+      esTypes: ['_id'],
+      count: 0,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: '_id',
+    } as DataViewField;
     const comp = mountComponent(conflictField);
 
     await act(async () => {
@@ -288,19 +280,17 @@ describe('discover sidebar field details', function () {
   });
 
   it('should disable the visualize link for an unknown field', async function () {
-    const unknownField = new IndexPatternField(
-      {
-        name: 'test',
-        type: 'unknown',
-        esTypes: ['double'],
-        count: 0,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'test'
-    );
+    const unknownField = {
+      name: 'test',
+      type: 'unknown',
+      esTypes: ['double'],
+      count: 0,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'test',
+    } as DataViewField;
     const comp = mountComponent(unknownField);
 
     await act(async () => {

--- a/src/plugins/explore/public/components/fields_selector/discover_field_details.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field_details.tsx
@@ -39,21 +39,21 @@ import {
   getVisualizeHref,
 } from './lib/visualize_trigger_utils';
 import { Bucket, FieldDetails } from './types';
-import { IndexPatternField, IndexPattern } from '../../../../data/public';
+import { DataViewField, DataView } from '../../../../data/public';
 
 interface DiscoverFieldDetailsProps {
   columns: string[];
   details: FieldDetails;
-  field: IndexPatternField;
-  indexPattern: IndexPattern;
-  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  field: DataViewField;
+  dataSet: DataView;
+  onAddFilter: (field: DataViewField | string, value: string, type: '+' | '-') => void;
 }
 
 export function DiscoverFieldDetails({
   columns,
   details,
   field,
-  indexPattern,
+  dataSet,
   onAddFilter,
 }: DiscoverFieldDetailsProps) {
   const warnings = getWarnings(field);
@@ -62,23 +62,21 @@ export function DiscoverFieldDetails({
 
   useEffect(() => {
     const checkIfVisualizable = async () => {
-      const visualizable = await isFieldVisualizable(field, indexPattern.id, columns).catch(
-        () => false
-      );
+      const visualizable = await isFieldVisualizable(field, dataSet.id, columns).catch(() => false);
 
       setShowVisualizeLink(visualizable);
       if (visualizable) {
-        const href = await getVisualizeHref(field, indexPattern.id, columns).catch(() => '');
+        const href = await getVisualizeHref(field, dataSet.id, columns).catch(() => '');
         setVisualizeLink(href || '');
       }
     };
     checkIfVisualizable();
-  }, [field, indexPattern.id, columns]);
+  }, [field, dataSet.id, columns]);
 
   const handleVisualizeLinkClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     // regular link click. let the uiActions code handle the navigation and show popup if needed
     event.preventDefault();
-    triggerVisualizeActions(field, indexPattern.id, columns);
+    triggerVisualizeActions(field, dataSet.id, columns);
   };
 
   return (
@@ -128,7 +126,7 @@ export function DiscoverFieldDetails({
       {!details.error && (
         <EuiPopoverFooter>
           <EuiText size="xs" textAlign="center">
-            {!indexPattern.metaFields.includes(field.name) && !field.scripted ? (
+            {!dataSet.metaFields.includes(field.name) && !field.scripted ? (
               <EuiLink onClick={() => onAddFilter('_exists_', field.name, '+')}>
                 <FormattedMessage
                   id="explore.discover.fieldChooser.detailViews.existsText"

--- a/src/plugins/explore/public/components/fields_selector/discover_field_header.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field_header.tsx
@@ -12,15 +12,14 @@ export interface IDiscoverFieldHeaderProps {
 }
 
 export function DiscoverFieldHeader({ onCollapse }: IDiscoverFieldHeaderProps) {
+  const fieldsHeaderText = i18n.translate('explore.discover.fieldChooser.Header', {
+    defaultMessage: 'Fields',
+  });
   return (
     <EuiFlexGroup responsive={false} gutterSize="xs">
       <EuiFlexItem>
         <EuiText size="xs">
-          <h5>
-            {i18n.translate('explore.discover.fieldChooser.Header', {
-              defaultMessage: 'Fields',
-            })}
-          </h5>
+          <h5>{fieldsHeaderText}</h5>
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/fields_selector/discover_sidebar.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_sidebar.test.tsx
@@ -37,7 +37,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { DiscoverSidebar, DiscoverSidebarProps } from './discover_sidebar';
 import { coreMock } from 'opensearch-dashboards/public/mocks';
-import { getStubIndexPattern } from '../../../../data/public/test_utils';
+import { getStubDataView } from '../../../../data/public/data_views/data_view.stub';
 import { OpenSearchSearchHit } from '../../types/doc_views_types';
 import * as fieldFilter from './lib/field_filter';
 
@@ -69,7 +69,7 @@ jest.mock('../../application/legacy/discover/opensearch_dashboards_services', ()
 }));
 
 jest.mock('./lib/get_index_pattern_field_list', () => ({
-  getIndexPatternFieldList: jest.fn((indexPattern) => indexPattern.fields),
+  getIndexPatternFieldList: jest.fn((dataSet) => dataSet.fields),
 }));
 
 jest.mock('./field_list', () => ({
@@ -100,7 +100,7 @@ jest.mock('./facet_list', () => ({
 
 function getCompProps(customFields?: any[]): DiscoverSidebarProps {
   const fields = customFields || stubbedLogstashFields();
-  const indexPattern = getStubIndexPattern(
+  const dataSet = getStubDataView(
     'logstash-*',
     (cfg: any) => cfg,
     'time',
@@ -109,14 +109,14 @@ function getCompProps(customFields?: any[]): DiscoverSidebarProps {
   );
 
   // @ts-expect-error _.each() is passing additional args to flattenHit
-  const hits = _.each(_.cloneDeep(realHits), indexPattern.flattenHit) as Array<
+  const hits = _.each(_.cloneDeep(realHits), dataSet.flattenHit) as Array<
     OpenSearchSearchHit<Record<string, any>>
   >;
 
   const fieldCounts: Record<string, number> = {};
 
   for (const hit of hits) {
-    for (const key of Object.keys(indexPattern.flattenHit(hit))) {
+    for (const key of Object.keys(dataSet.flattenHit(hit))) {
       fieldCounts[key] = (fieldCounts[key] || 0) + 1;
     }
   }
@@ -133,7 +133,7 @@ function getCompProps(customFields?: any[]): DiscoverSidebarProps {
     onAddFilter: jest.fn(),
     onAddField: jest.fn(),
     onRemoveField: jest.fn(),
-    selectedIndexPattern: indexPattern,
+    selectedDataSet: dataSet,
     onReorderFields: jest.fn(),
     isEnhancementsEnabledOverride: false,
   };

--- a/src/plugins/explore/public/components/fields_selector/discover_sidebar.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_sidebar.tsx
@@ -8,7 +8,7 @@ import { i18n } from '@osd/i18n';
 import { I18nProvider } from '@osd/i18n/react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { OpenSearchSearchHit } from '../../types/doc_views_types';
-import { IndexPattern, IndexPatternField, UI_SETTINGS } from '../../../../data/public';
+import { DataView, DataViewField, UI_SETTINGS } from '../../../../data/public';
 import { getServices } from '../../application/legacy/discover/opensearch_dashboards_services';
 import { DiscoverFieldSearch } from './discover_field_search';
 import './discover_sidebar.scss';
@@ -44,7 +44,7 @@ export interface DiscoverSidebarProps {
   /**
    * Callback function when adding a filter from sidebar
    */
-  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  onAddFilter: (field: DataViewField | string, value: string, type: '+' | '-') => void;
   /**
    * Callback function when removing a field
    * @param fieldName
@@ -55,9 +55,9 @@ export interface DiscoverSidebarProps {
    */
   onCollapse?: () => void;
   /**
-   * Currently selected index pattern
+   * Currently selected data set
    */
-  selectedIndexPattern?: IndexPattern;
+  selectedDataSet?: DataView;
   isEnhancementsEnabledOverride: boolean;
 }
 
@@ -66,7 +66,7 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
     columns,
     fieldCounts,
     hits,
-    selectedIndexPattern,
+    selectedDataSet,
     isEnhancementsEnabledOverride,
     onCollapse,
   } = props;
@@ -77,8 +77,8 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
   }, []);
 
   const fields = useMemo(() => {
-    return getIndexPatternFieldList(selectedIndexPattern, fieldCounts);
-  }, [selectedIndexPattern, fieldCounts]);
+    return getIndexPatternFieldList(selectedDataSet, fieldCounts);
+  }, [selectedDataSet, fieldCounts]);
 
   const onChangeFieldSearch = useCallback(
     (field: string, value: string | boolean | undefined) => {
@@ -89,12 +89,12 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
   );
 
   const getDetailsByField = useCallback(
-    (ipField: IndexPatternField) => getDetails(ipField, hits, selectedIndexPattern),
-    [hits, selectedIndexPattern]
+    (ipField: DataViewField) => getDetails(ipField, hits, selectedDataSet),
+    [hits, selectedDataSet]
   );
 
   const { facetedFields, selectedFields, queryFields, discoveredFields } = useMemo(
-    () => groupFields(fields, columns, fieldCounts, fieldFilterState),
+    () => groupFields(fields as DataViewField[], columns, fieldCounts, fieldFilterState),
     [fields, columns, fieldCounts, fieldFilterState]
   );
 
@@ -110,7 +110,7 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
     return result;
   }, [fields]);
 
-  if (!selectedIndexPattern || !fields) {
+  if (!selectedDataSet || !fields) {
     return null;
   }
 
@@ -152,7 +152,7 @@ export function DiscoverSidebar(props: DiscoverSidebarProps) {
           className="eui-yScroll exploreSideBar_fieldListContainer"
           paddingSize="none"
         >
-          {(fields.length > 0 || selectedIndexPattern.fieldsLoading) && (
+          {(fields.length > 0 || selectedDataSet.fieldsLoading) && (
             <>
               {facetedFields.length > 0 && (
                 <FacetList

--- a/src/plugins/explore/public/components/fields_selector/facet_field.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_field.test.tsx
@@ -9,8 +9,8 @@ import stubbedLogstashFields from 'fixtures/logstash_fields';
 import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
 import { FacetField } from './facet_field';
 import { coreMock } from 'opensearch-dashboards/public/mocks';
-import { IndexPatternField } from '../../../../data/public';
-import { getStubIndexPattern } from '../../../../data/public/test_utils';
+import { DataViewField } from '../../../../data/public';
+import { getStubDataView } from '../../../../data/public/data_views/data_view.stub';
 
 jest.mock('./facet_value', () => ({
   FacetValue: ({ bucket }: any) => (
@@ -19,7 +19,7 @@ jest.mock('./facet_value', () => ({
 }));
 
 function getProps({ buckets = [], shortDotsEnabled = false } = {}) {
-  const indexPattern = getStubIndexPattern(
+  const dataSet = getStubDataView(
     'logstash-*',
     (cfg: any) => cfg,
     'time',
@@ -27,19 +27,17 @@ function getProps({ buckets = [], shortDotsEnabled = false } = {}) {
     coreMock.createSetup()
   );
 
-  const mockField = new IndexPatternField(
-    {
-      name: 'status',
-      type: 'string',
-      esTypes: ['keyword'],
-      count: 5,
-      scripted: false,
-      searchable: true,
-      aggregatable: true,
-      readFromDocValues: true,
-    },
-    'status'
-  );
+  const mockField = {
+    name: 'status',
+    type: 'string',
+    esTypes: ['keyword'],
+    count: 5,
+    scripted: false,
+    searchable: true,
+    aggregatable: true,
+    readFromDocValues: true,
+    displayName: 'status',
+  } as DataViewField;
 
   const defaultBuckets =
     buckets.length > 0
@@ -51,7 +49,7 @@ function getProps({ buckets = [], shortDotsEnabled = false } = {}) {
 
   return {
     field: mockField,
-    selectedIndexPattern: indexPattern,
+    selectedDataSet: dataSet,
     onAddFilter: jest.fn(),
     getDetailsByField: jest.fn(() => ({ buckets: defaultBuckets, error: '', exists: 1, total: 1 })),
     shortDotsEnabled,
@@ -117,8 +115,8 @@ describe('FacetField', () => {
     expect(toggleButton.querySelector('[data-euiicon-type="arrowRight"]')).toBeInTheDocument();
   });
 
-  it('renders nothing when no index pattern', () => {
-    const props = { ...getProps(), selectedIndexPattern: undefined };
+  it('renders nothing when no data set', () => {
+    const props = { ...getProps(), selectedDataSet: undefined };
     const { container } = render(<FacetField {...props} />);
 
     expect(container.firstChild).toBeNull();

--- a/src/plugins/explore/public/components/fields_selector/facet_field.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_field.tsx
@@ -5,23 +5,23 @@
 
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
 import React, { useState } from 'react';
-import { IndexPatternField, IndexPattern } from '../../../../data/public';
+import { DataViewField, DataView } from '../../../../data/public';
 import { Bucket, FieldDetails } from './types';
 import { FieldIcon } from '../../../../opensearch_dashboards_react/public';
 import { FacetValue } from './facet_value';
 import { getFieldTypeName } from './lib/get_field_type_name';
 
 interface FacetFieldProps {
-  field: IndexPatternField;
-  selectedIndexPattern?: IndexPattern;
-  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
-  getDetailsByField: (field: IndexPatternField) => FieldDetails;
+  field: DataViewField;
+  selectedDataSet?: DataView;
+  onAddFilter: (field: DataViewField | string, value: string, type: '+' | '-') => void;
+  getDetailsByField: (field: DataViewField) => FieldDetails;
   shortDotsEnabled: boolean;
 }
 
 export const FacetField = ({
   field,
-  selectedIndexPattern,
+  selectedDataSet,
   onAddFilter,
   getDetailsByField,
   shortDotsEnabled,
@@ -29,7 +29,7 @@ export const FacetField = ({
   const [expanded, setExpanded] = useState(true);
   const { buckets } = getDetailsByField(field);
 
-  if (!selectedIndexPattern || buckets.length === 0) return null;
+  if (!selectedDataSet || buckets.length === 0) return null;
 
   return (
     <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
@@ -42,7 +42,7 @@ export const FacetField = ({
         className="exploreSideBar__facetField"
         data-test-subj="exploreSideBarFacetFieldButton"
         aria-label={field.name}
-        isLoading={!!selectedIndexPattern.fieldsLoading}
+        isLoading={!!selectedDataSet.fieldsLoading}
       >
         <EuiFlexGroup
           gutterSize="s"

--- a/src/plugins/explore/public/components/fields_selector/facet_list.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_list.test.tsx
@@ -9,8 +9,8 @@ import stubbedLogstashFields from 'fixtures/logstash_fields';
 import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
 import { FacetList } from './facet_list';
 import { coreMock } from 'opensearch-dashboards/public/mocks';
-import { IndexPatternField } from '../../../../data/public';
-import { getStubIndexPattern } from '../../../../data/public/test_utils';
+import { DataViewField } from '../../../../data/public';
+import { getStubDataView } from '../../../../data/public/data_views/data_view.stub';
 
 jest.mock('./facet_field', () => ({
   FacetField: ({ field }: { field: any }) => (
@@ -27,7 +27,7 @@ function getProps({
   fields?: any;
   shortDotsEnabled?: boolean;
 } = {}) {
-  const indexPattern = getStubIndexPattern(
+  const dataSet = getStubDataView(
     'logstash-*',
     (cfg: any) => cfg,
     'time',
@@ -36,32 +36,28 @@ function getProps({
   );
 
   const defaultFields = [
-    new IndexPatternField(
-      {
-        name: 'status',
-        type: 'string',
-        esTypes: ['keyword'],
-        count: 5,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'status'
-    ),
-    new IndexPatternField(
-      {
-        name: 'level',
-        type: 'string',
-        esTypes: ['keyword'],
-        count: 3,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'level'
-    ),
+    {
+      name: 'status',
+      type: 'string',
+      esTypes: ['keyword'],
+      count: 5,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'status',
+    } as DataViewField,
+    {
+      name: 'level',
+      type: 'string',
+      esTypes: ['keyword'],
+      count: 3,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'level',
+    } as DataViewField,
   ];
 
   const mockFields = fields !== undefined ? fields : defaultFields;
@@ -69,7 +65,7 @@ function getProps({
   return {
     title,
     fields: mockFields,
-    selectedIndexPattern: indexPattern,
+    selectedDataSet: dataSet,
     onAddFilter: jest.fn(),
     getDetailsByField: jest.fn(() => ({ buckets: [], error: '', exists: 1, total: 1 })),
     shortDotsEnabled,
@@ -143,8 +139,8 @@ describe('FacetList', () => {
     expect(toggleButton.querySelector('[data-euiicon-type="arrowRight"]')).toBeInTheDocument();
   });
 
-  it('renders nothing when selectedIndexPattern is null', () => {
-    const props = { ...getProps(), selectedIndexPattern: undefined };
+  it('renders nothing when selectedDataSet is null', () => {
+    const props = { ...getProps(), selectedDataSet: undefined };
     const { container } = render(<FacetList {...props} />);
 
     expect(container.firstChild).toBeNull();

--- a/src/plugins/explore/public/components/fields_selector/facet_list.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_list.tsx
@@ -5,29 +5,29 @@
 
 import { EuiButtonEmpty, EuiPanel } from '@elastic/eui';
 import React, { useState } from 'react';
-import { IndexPatternField } from '../../../../data/public';
+import { DataViewField } from '../../../../data/public';
 import { DiscoverSidebarProps } from './discover_sidebar';
 import { FacetField } from './facet_field';
 import { FieldDetails } from './types';
 
 interface FacetListProps extends DiscoverSidebarProps {
   title: string;
-  fields: IndexPatternField[];
-  getDetailsByField: (field: IndexPatternField) => FieldDetails;
+  fields: DataViewField[];
+  getDetailsByField: (field: DataViewField) => FieldDetails;
   shortDotsEnabled: boolean;
 }
 
 export const FacetList = ({
   title,
   fields,
-  selectedIndexPattern,
+  selectedDataSet,
   onAddFilter,
   getDetailsByField,
   shortDotsEnabled,
 }: FacetListProps) => {
   const [expanded, setExpanded] = useState(true);
 
-  if (!selectedIndexPattern) return null;
+  if (!selectedDataSet) return null;
 
   return (
     <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
@@ -40,12 +40,12 @@ export const FacetList = ({
         className="exploreSideBar_fieldGroup"
         data-test-subj="exploreSideBarFieldGroupButton"
         aria-label={title}
-        isLoading={!!selectedIndexPattern.fieldsLoading}
+        isLoading={!!selectedDataSet.fieldsLoading}
       >
         {title}
       </EuiButtonEmpty>
       {expanded &&
-        fields.map((field: IndexPatternField, index) => {
+        fields.map((field: DataViewField, index) => {
           return (
             <FacetField
               key={field.name + index}
@@ -53,7 +53,7 @@ export const FacetList = ({
               getDetailsByField={getDetailsByField}
               shortDotsEnabled={shortDotsEnabled}
               onAddFilter={onAddFilter}
-              selectedIndexPattern={selectedIndexPattern}
+              selectedDataSet={selectedDataSet}
             />
           );
         })}

--- a/src/plugins/explore/public/components/fields_selector/facet_value.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { EuiButtonIcon, EuiToolTip, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { Bucket } from './types';
-import { IndexPatternField } from '../../../../data/public';
+import { DataViewField } from '../../../../data/public';
 import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
 import './discover_field.scss';
 
@@ -24,7 +24,7 @@ export interface FacetValueProps {
   /**
    * The facet field
    */
-  field: IndexPatternField;
+  field: DataViewField;
   /**
    * The bucket contains facet field value
    */
@@ -32,7 +32,7 @@ export interface FacetValueProps {
   /**
    * Callback to add a filter to filter bar
    */
-  onAddFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
+  onAddFilter: (field: DataViewField | string, value: string, type: '+' | '-') => void;
   /**
    * Determines whether the field name is shortened test.sub1.sub2 = t.s.sub2
    */

--- a/src/plugins/explore/public/components/fields_selector/field_list.test.tsx
+++ b/src/plugins/explore/public/components/fields_selector/field_list.test.tsx
@@ -9,11 +9,11 @@ import stubbedLogstashFields from 'fixtures/logstash_fields';
 import { render, screen, fireEvent } from 'test_utils/testing_lib_helpers';
 import { FieldList } from './field_list';
 import { coreMock } from 'opensearch-dashboards/public/mocks';
-import { IndexPatternField } from '../../../../data/public';
-import { getStubIndexPattern } from '../../../../data/public/test_utils';
+import { DataViewField } from '../../../../data/public';
+import { getStubDataView } from '../../../../data/public/data_views/data_view.stub';
 
 jest.mock('./discover_field', () => ({
-  DiscoverField: ({ field }: { field: IndexPatternField }) => (
+  DiscoverField: ({ field }: { field: DataViewField }) => (
     <div data-test-subj={`mocked-discover-field-${field.name}`}>{field.name}</div>
   ),
 }));
@@ -26,10 +26,10 @@ function getProps({
 }: {
   category?: 'query' | 'discovered' | 'selected';
   title?: string;
-  fields?: IndexPatternField[];
+  fields?: DataViewField[];
   shortDotsEnabled?: boolean;
 } = {}) {
-  const indexPattern = getStubIndexPattern(
+  const dataSet = getStubDataView(
     'logstash-*',
     (cfg: any) => cfg,
     'time',
@@ -38,32 +38,28 @@ function getProps({
   );
 
   const defaultFields = [
-    new IndexPatternField(
-      {
-        name: 'bytes',
-        type: 'number',
-        esTypes: ['long'],
-        count: 10,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'bytes'
-    ),
-    new IndexPatternField(
-      {
-        name: 'extension',
-        type: 'string',
-        esTypes: ['keyword'],
-        count: 5,
-        scripted: false,
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: true,
-      },
-      'extension'
-    ),
+    {
+      name: 'bytes',
+      type: 'number',
+      esTypes: ['long'],
+      count: 10,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'bytes',
+    } as DataViewField,
+    {
+      name: 'extension',
+      type: 'string',
+      esTypes: ['keyword'],
+      count: 5,
+      scripted: false,
+      searchable: true,
+      aggregatable: true,
+      readFromDocValues: true,
+      displayName: 'extension',
+    } as DataViewField,
   ];
 
   const mockFields = fields !== undefined ? fields : defaultFields;
@@ -73,7 +69,7 @@ function getProps({
     title,
     fields: mockFields,
     columns: ['@timestamp'],
-    selectedIndexPattern: indexPattern,
+    selectedDataSet: dataSet,
     onAddField: jest.fn(),
     onRemoveField: jest.fn(),
     onAddFilter: jest.fn(),
@@ -125,8 +121,8 @@ describe('FieldList', () => {
     expect(screen.getByTestId('mocked-discover-field-bytes')).toBeInTheDocument();
   });
 
-  it('renders nothing when selectedIndexPattern is null', () => {
-    const props = { ...getProps(), selectedIndexPattern: undefined };
+  it('renders nothing when selectedDataSet is null', () => {
+    const props = { ...getProps(), selectedDataSet: undefined };
     const { container } = render(<FieldList {...props} />);
 
     expect(container.firstChild).toBeNull();

--- a/src/plugins/explore/public/components/fields_selector/field_list.tsx
+++ b/src/plugins/explore/public/components/fields_selector/field_list.tsx
@@ -5,7 +5,7 @@
 
 import { EuiButtonEmpty, EuiPanel } from '@elastic/eui';
 import React, { useState } from 'react';
-import { IndexPatternField } from '../../../../data/public';
+import { DataViewField } from '../../../../data/public';
 import { DiscoverField } from './discover_field';
 import { DiscoverSidebarProps } from './discover_sidebar';
 import { FieldDetails } from './types';
@@ -13,8 +13,8 @@ import { FieldDetails } from './types';
 interface FieldGroupProps extends DiscoverSidebarProps {
   category: 'query' | 'discovered' | 'selected';
   title: string;
-  fields: IndexPatternField[];
-  getDetailsByField: (field: IndexPatternField) => FieldDetails;
+  fields: DataViewField[];
+  getDetailsByField: (field: DataViewField) => FieldDetails;
   shortDotsEnabled: boolean;
 }
 
@@ -23,7 +23,7 @@ export const FieldList = ({
   title,
   fields,
   columns,
-  selectedIndexPattern,
+  selectedDataSet,
   onAddField,
   onRemoveField,
   onAddFilter,
@@ -32,7 +32,7 @@ export const FieldList = ({
 }: FieldGroupProps) => {
   const [expanded, setExpanded] = useState(true);
 
-  if (!selectedIndexPattern) return null;
+  if (!selectedDataSet) return null;
 
   return (
     <EuiPanel hasBorder={false} hasShadow={false} color="transparent" paddingSize="none">
@@ -45,12 +45,12 @@ export const FieldList = ({
         className="exploreSideBar_fieldGroup"
         data-test-subj="dscSideBarFieldGroupButton"
         aria-label={title}
-        isLoading={!!selectedIndexPattern.fieldsLoading}
+        isLoading={!!selectedDataSet.fieldsLoading}
       >
         {title}
       </EuiButtonEmpty>
       {expanded &&
-        fields.map((field: IndexPatternField, index) => {
+        fields.map((field: DataViewField, index) => {
           return (
             <EuiPanel
               data-attr-field={field.name}
@@ -67,7 +67,7 @@ export const FieldList = ({
                 selected={category === 'selected'}
                 field={field}
                 columns={columns}
-                indexPattern={selectedIndexPattern}
+                dataSet={selectedDataSet}
                 onAddField={onAddField}
                 onRemoveField={onRemoveField}
                 onAddFilter={onAddFilter}

--- a/src/plugins/explore/public/components/fields_selector/fields_selector_panel.tsx
+++ b/src/plugins/explore/public/components/fields_selector/fields_selector_panel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useRef, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { IndexPattern, UI_SETTINGS } from '../../../../data/public';
+import { UI_SETTINGS } from '../../../../data/public';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import {
   addColumn,
@@ -99,7 +99,7 @@ export function DiscoverPanel({ collapsePanel }: IDiscoverPanelProps) {
           })
         );
       }}
-      selectedIndexPattern={(dataset as unknown) as IndexPattern}
+      selectedDataSet={dataset}
       onAddFilter={onAddFilter}
       onCollapse={collapsePanel}
       isEnhancementsEnabledOverride={isEnhancementsEnabledOverride}

--- a/src/plugins/explore/public/components/fields_selector/lib/field_calculator.test.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/field_calculator.test.ts
@@ -145,7 +145,7 @@ describe('field_calculator', function () {
       const extensions = getFieldValues({
         hits,
         field: indexPattern.fields.getByName('extension') as IndexPatternField,
-        indexPattern,
+        dataSet: indexPattern,
       });
       expect(extensions).toBeInstanceOf(Array);
       expect(
@@ -160,7 +160,7 @@ describe('field_calculator', function () {
       const types = getFieldValues({
         hits,
         field: indexPattern.fields.getByName('_type') as IndexPatternField,
-        indexPattern,
+        dataSet: indexPattern,
       });
       expect(types).toBeInstanceOf(Array);
       expect(
@@ -179,7 +179,7 @@ describe('field_calculator', function () {
         hits: _.cloneDeep(realHits),
         field: indexPattern.fields.getByName('extension') as IndexPatternField,
         count: 3,
-        indexPattern,
+        dataSet: indexPattern,
       };
     });
 

--- a/src/plugins/explore/public/components/fields_selector/lib/field_calculator.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/field_calculator.ts
@@ -29,7 +29,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { IndexPattern, IndexPatternField } from '../../../../../data/public';
+import { DataView, DataViewField } from '../../../../../data/public';
 import { FieldValueCounts } from '../types';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 
@@ -37,8 +37,8 @@ const NO_ANALYSIS_TYPES = ['geo_point', 'geo_shape', 'attachment'];
 
 interface FieldValuesParams {
   hits: Array<OpenSearchSearchHit<Record<string, any>>>;
-  field: IndexPatternField;
-  indexPattern: IndexPattern;
+  field: DataViewField;
+  dataSet: DataView;
 }
 
 interface FieldValueCountsParams extends FieldValuesParams {
@@ -46,14 +46,14 @@ interface FieldValueCountsParams extends FieldValuesParams {
   grouped?: boolean;
 }
 
-const getFieldValues = ({ hits, field, indexPattern }: FieldValuesParams) => {
+const getFieldValues = ({ hits, field, dataSet: indexPattern }: FieldValuesParams) => {
   const name = field.name;
   const flattenHit = indexPattern.flattenHit;
   return hits.map((hit) => flattenHit(hit)[name]);
 };
 
 const getFieldValueCounts = (params: FieldValueCountsParams): FieldValueCounts => {
-  const { hits, field, indexPattern, count = 5, grouped = false } = params;
+  const { hits, field, dataSet: indexPattern, count = 5, grouped = false } = params;
   const { type: fieldType } = field;
 
   if (NO_ANALYSIS_TYPES.includes(fieldType)) {
@@ -70,7 +70,7 @@ const getFieldValueCounts = (params: FieldValueCountsParams): FieldValueCounts =
     };
   }
 
-  const allValues = getFieldValues({ hits, field, indexPattern });
+  const allValues = getFieldValues({ hits, field, dataSet: indexPattern });
   const missing = allValues.filter((v) => v === undefined || v === null).length;
 
   try {

--- a/src/plugins/explore/public/components/fields_selector/lib/field_filter.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/field_filter.ts
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { IndexPatternField } from '../../../../../data/public';
+import { DataViewField } from '../../../../../data/public';
 
 export interface FieldFilterState {
   missing: boolean;
@@ -69,7 +69,7 @@ export function setFieldFilterProp(
 }
 
 export function isFieldFiltered(
-  field: IndexPatternField,
+  field: DataViewField,
   filterState: FieldFilterState,
   fieldCounts: Record<string, number>
 ): boolean {

--- a/src/plugins/explore/public/components/fields_selector/lib/get_details.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/get_details.ts
@@ -31,13 +31,13 @@
 // @ts-ignore
 import { i18n } from '@osd/i18n';
 import { getFieldValueCounts } from './field_calculator';
-import { IndexPattern, IndexPatternField } from '../../../../../data/public';
+import { DataView, DataViewField } from '../../../../../data/public';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 
 export function getDetails(
-  field: IndexPatternField,
+  field: DataViewField,
   hits: Array<OpenSearchSearchHit<Record<string, any>>>,
-  indexPattern?: IndexPattern
+  dataSet?: DataView
 ) {
   const defaultDetails = {
     error: '',
@@ -45,11 +45,11 @@ export function getDetails(
     total: 0,
     buckets: [],
   };
-  if (!indexPattern) {
+  if (!dataSet) {
     return {
       ...defaultDetails,
       error: i18n.translate('explore.discover.fieldChooser.noIndexPatternSelectedErrorMessage', {
-        defaultMessage: 'Index pattern not specified.',
+        defaultMessage: 'Data view not specified.',
       }),
     };
   }
@@ -58,14 +58,14 @@ export function getDetails(
     ...getFieldValueCounts({
       hits,
       field,
-      indexPattern,
+      dataSet,
       count: 5,
       grouped: false,
     }),
   };
   if (details.buckets) {
     for (const bucket of details.buckets) {
-      bucket.display = indexPattern.getFormatterForField(field).convert(bucket.value);
+      bucket.display = dataSet.getFormatterForField(field).convert(bucket.value);
     }
   }
 

--- a/src/plugins/explore/public/components/fields_selector/lib/get_index_pattern_field_list.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/get_index_pattern_field_list.ts
@@ -29,25 +29,22 @@
  */
 
 import { difference } from 'lodash';
-import { DataView, IndexPattern, IndexPatternField } from '../../../../../data/public';
+import { DataView, DataViewField } from '../../../../../data/public';
 
-export function getIndexPatternFieldList(
-  indexPattern?: IndexPattern | DataView,
-  fieldCounts?: Record<string, number>
-) {
-  if (!indexPattern || !fieldCounts) return [];
+export function getIndexPatternFieldList(dataSet?: DataView, fieldCounts?: Record<string, number>) {
+  if (!dataSet || !fieldCounts) return [];
 
   const fieldNamesInDocs = Object.keys(fieldCounts);
-  const fieldNamesInIndexPattern = indexPattern.fields.getAll().map((fld) => fld.name);
-  const unknownTypes: IndexPatternField[] = [];
+  const fieldNamesInIndexPattern = dataSet.fields.getAll().map((fld) => fld.name);
+  const unknownTypes: DataViewField[] = [];
 
   difference(fieldNamesInDocs, fieldNamesInIndexPattern).forEach((unknownFieldName) => {
     unknownTypes.push({
       displayName: String(unknownFieldName),
       name: String(unknownFieldName),
       type: 'unknown',
-    } as IndexPatternField);
+    } as DataViewField);
   });
 
-  return [...indexPattern.fields.getAll(), ...unknownTypes];
+  return [...dataSet.fields.getAll(), ...unknownTypes];
 }

--- a/src/plugins/explore/public/components/fields_selector/lib/get_warnings.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/get_warnings.ts
@@ -29,9 +29,9 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { IndexPatternField } from '../../../../../data/public';
+import { DataViewField } from '../../../../../data/public';
 
-export function getWarnings(field: IndexPatternField) {
+export function getWarnings(field: DataViewField) {
   let warnings = [];
 
   if (field.scripted) {

--- a/src/plugins/explore/public/components/fields_selector/lib/group_fields.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/group_fields.ts
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import { IndexPatternField } from '../../../../../data/public';
+import { DataViewField } from '../../../../../data/public';
 import { FieldFilterState, isFieldFiltered } from './field_filter';
 
 // TODO: Use data set defined faceted field
@@ -47,17 +47,17 @@ function isFacetedField(fieldName: string): fieldName is typeof FACET_FIELDS[num
 }
 
 interface GroupedFields {
-  facetedFields: IndexPatternField[];
-  selectedFields: IndexPatternField[];
-  queryFields: IndexPatternField[];
-  discoveredFields: IndexPatternField[];
+  facetedFields: DataViewField[];
+  selectedFields: DataViewField[];
+  queryFields: DataViewField[];
+  discoveredFields: DataViewField[];
 }
 
 /**
  * group the fields into selected, popular and unpopular, filter by fieldFilterState
  */
 export function groupFields(
-  fields: IndexPatternField[] | null,
+  fields: DataViewField[] | null,
   columns: string[],
   fieldCounts: Record<string, number>,
   fieldFilterState: FieldFilterState
@@ -77,7 +77,7 @@ export function groupFields(
   // https://github.com/opensearch-project/OpenSearch-Dashboards/blob/d7004dc5b0392477fdd54ac66b29d231975a173b/src/plugins/data/common/index_patterns/fields/field_list.ts
   const fieldsArray = Array.from(fields);
 
-  const compareFn = (a: IndexPatternField, b: IndexPatternField) => {
+  const compareFn = (a: DataViewField, b: DataViewField) => {
     if (!a.displayName) {
       return 0;
     }

--- a/src/plugins/explore/public/components/fields_selector/lib/visualize_trigger_utils.ts
+++ b/src/plugins/explore/public/components/fields_selector/lib/visualize_trigger_utils.ts
@@ -35,7 +35,7 @@ import {
   visualizeGeoFieldTrigger,
 } from '../../../../../ui_actions/public';
 import { getUiActions } from '../../../application/legacy/discover/opensearch_dashboards_services';
-import { IndexPatternField, OSD_FIELD_TYPES } from '../../../../../data/public';
+import { DataViewField, OSD_FIELD_TYPES } from '../../../../../data/public';
 
 function getTriggerConstant(type: string) {
   return type === OSD_FIELD_TYPES.GEO_POINT || type === OSD_FIELD_TYPES.GEO_SHAPE
@@ -64,7 +64,7 @@ async function getCompatibleActions(
 }
 
 export async function getVisualizeHref(
-  field: IndexPatternField,
+  field: DataViewField,
   indexPatternId: string | undefined,
   contextualFields: string[]
 ) {
@@ -88,7 +88,7 @@ export async function getVisualizeHref(
 }
 
 export function triggerVisualizeActions(
-  field: IndexPatternField,
+  field: DataViewField,
   indexPatternId: string | undefined,
   contextualFields: string[]
 ) {
@@ -103,7 +103,7 @@ export function triggerVisualizeActions(
 }
 
 export async function isFieldVisualizable(
-  field: IndexPatternField,
+  field: DataViewField,
   indexPatternId: string | undefined,
   contextualFields: string[]
 ) {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Update fields selector component interface to consume `DataView`/`DataSet` instead of `IndexPattern`.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: Update dataset interface in fields selector component

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
