### PR TITLE
[Explore] Patterns Flyout 'search with pattern' redirect

### DIFF
--- a/src/plugins/explore/public/components/patterns_table/patterns_table_columns.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_columns.tsx
@@ -19,7 +19,15 @@ export const patternsTableColumns = (
     width: '40px', // roughly size of the EuiButtonIcon
     name: <></>, // intentionally empty
     render: (record: PatternsFlyoutRecord) => {
-      return <EuiButtonIcon iconType={'inspect'} onClick={() => openPatternsTableFlyout(record)} />;
+      return (
+        <EuiButtonIcon
+          aria-label={i18n.translate('explore.patterns.table.column.openPatternTableFlyout', {
+            defaultMessage: 'Open pattern table flyout',
+          })}
+          iconType={'inspect'}
+          onClick={() => openPatternsTableFlyout(record)}
+        />
+      );
     },
   },
   {

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.test.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.test.tsx
@@ -5,175 +5,44 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { EXPLORE_LOGS_TAB_ID } from '../../../../common';
 import { PatternsFlyoutUpdateSearch } from './patterns_flyout_update_search';
+import { PatternsFlyoutProvider } from './patterns_flyout_context';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 
-jest.mock(
-  '@elastic/eui',
-  () => ({
-    EuiButton: ({ children, onClick, 'aria-label': ariaLabel }: any) => (
-      <button onClick={onClick} aria-label={ariaLabel}>
-        {children}
-      </button>
-    ),
-  }),
-  { virtual: true }
+const mockStore = createStore(
+  (
+    state = {
+      query: { query: 'test query', language: 'PPL' },
+      tab: {
+        patterns: {
+          patternsField: 'message',
+          usingRegexPatterns: false,
+        },
+      },
+    }
+  ) => state
 );
 
-const mockDispatch = jest.fn();
-const mockSetEditorText = jest.fn();
-const mockExecuteQueries = jest.fn().mockReturnValue({ type: 'EXECUTE_QUERIES' });
-const mockClosePatternsTableFlyout = jest.fn();
-const mockGetQueryWithSource = jest
-  .fn()
-  .mockReturnValue({ query: 'source query', language: 'PPL' });
-const mockBrainUpdateSearchPatternQuery = jest.fn().mockReturnValue('updated brain query');
-const mockRegexUpdateSearchPatternQuery = jest.fn().mockReturnValue('updated regex query');
-const mockSetActiveTab = jest.fn().mockReturnValue({ type: 'SET_ACTIVE_TAB' });
-const mockSetQueryStringWithHistory = jest
-  .fn()
-  .mockReturnValue({ type: 'SET_QUERY_STRING_WITH_HISTORY' });
-const mockServices = {};
-
-jest.mock('react-redux', () => ({
-  useDispatch: () => mockDispatch,
-  useSelector: jest.fn(),
-}));
-
-jest.mock('../../../application/hooks', () => ({
-  useSetEditorText: () => mockSetEditorText,
-}));
-
-jest.mock('./patterns_flyout_context', () => ({
-  usePatternsFlyoutContext: () => ({
-    closePatternsTableFlyout: mockClosePatternsTableFlyout,
-  }),
-}));
-
-jest.mock('../utils/utils', () => ({
-  brainUpdateSearchPatternQuery: (...args: any[]) => mockBrainUpdateSearchPatternQuery(...args),
-  regexUpdateSearchPatternQuery: (...args: any[]) => mockRegexUpdateSearchPatternQuery(...args),
-}));
-
-jest.mock('../../../application/utils/state_management/slices', () => ({
-  setActiveTab: (...args: any[]) => mockSetActiveTab(...args),
-  setQueryStringWithHistory: (...args: any[]) => mockSetQueryStringWithHistory(...args),
-}));
-
-jest.mock('../../../application/utils/languages', () => ({
-  getQueryWithSource: (...args: any[]) => mockGetQueryWithSource(...args),
-}));
-
-jest.mock('../../../application/utils/state_management/actions/query_actions', () => ({
-  executeQueries: jest.fn().mockImplementation(() => mockExecuteQueries()),
-}));
-
-jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
-  useOpenSearchDashboards: () => ({ services: mockServices }),
-}));
-
-jest.mock('../../../application/utils/state_management/selectors', () => ({
-  selectQuery: jest.fn().mockName('selectQuery'),
-  selectPatternsField: jest.fn().mockName('selectPatternsField'),
-  selectUsingRegexPatterns: jest.fn().mockName('selectUsingRegexPatterns'),
-}));
+const renderWithProvider = (ui: React.ReactElement) => {
+  return render(
+    <Provider store={mockStore}>
+      <PatternsFlyoutProvider>{ui}</PatternsFlyoutProvider>
+    </Provider>
+  );
+};
 
 describe('PatternsFlyoutUpdateSearch', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    const useSelector = require('react-redux').useSelector;
-    const {
-      selectQuery,
-      selectPatternsField,
-      selectUsingRegexPatterns,
-    } = require('../../../application/utils/state_management/selectors');
-
-    useSelector.mockImplementation((selector: any) => {
-      if (selector === selectQuery) return { query: 'test query', language: 'PPL' };
-      if (selector === selectPatternsField) return 'message';
-      if (selector === selectUsingRegexPatterns) return false;
-      return selector;
-    });
-  });
-
   it('should render the update search button', () => {
-    render(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
+    renderWithProvider(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
 
     expect(screen.getByRole('button', { name: /update search with pattern/i })).toBeInTheDocument();
     expect(screen.getByText('Update search')).toBeInTheDocument();
   });
 
   it('should render with the correct pattern string', () => {
-    render(<PatternsFlyoutUpdateSearch patternString="custom pattern" />);
+    renderWithProvider(<PatternsFlyoutUpdateSearch patternString="custom pattern" />);
 
     expect(screen.getByRole('button', { name: /update search with pattern/i })).toBeInTheDocument();
-  });
-
-  it('should call all expected functions when button is clicked', async () => {
-    const user = userEvent.setup();
-
-    render(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
-    const button = screen.getByRole('button', { name: /update search with pattern/i });
-    await user.click(button);
-
-    expect(mockGetQueryWithSource).toHaveBeenCalled();
-    expect(mockBrainUpdateSearchPatternQuery).toHaveBeenCalled();
-    expect(mockSetQueryStringWithHistory).toHaveBeenCalled();
-    expect(mockSetEditorText).toHaveBeenCalled();
-    expect(mockSetActiveTab).toHaveBeenCalledWith(EXPLORE_LOGS_TAB_ID);
-    expect(mockExecuteQueries).toHaveBeenCalled();
-    expect(mockClosePatternsTableFlyout).toHaveBeenCalled();
-  });
-
-  it('should use regexUpdateSearchPatternQuery when usingRegexPatterns is true', async () => {
-    const user = userEvent.setup();
-
-    const useSelector = require('react-redux').useSelector;
-    const {
-      selectQuery,
-      selectPatternsField,
-      selectUsingRegexPatterns,
-    } = require('../../../application/utils/state_management/selectors');
-
-    useSelector.mockImplementation((selector: any) => {
-      if (selector === selectQuery) return { query: 'test query', language: 'PPL' };
-      if (selector === selectPatternsField) return 'message';
-      if (selector === selectUsingRegexPatterns) return true;
-      return selector;
-    });
-
-    render(<PatternsFlyoutUpdateSearch patternString="regex pattern" />);
-
-    const button = screen.getByRole('button', { name: /update search with pattern/i });
-
-    await user.click(button);
-
-    expect(mockRegexUpdateSearchPatternQuery).toHaveBeenCalled();
-    expect(mockBrainUpdateSearchPatternQuery).not.toHaveBeenCalled();
-  });
-
-  it('should throw an error when there is no pattern field', () => {
-    const useSelector = require('react-redux').useSelector;
-    const {
-      selectQuery,
-      selectPatternsField,
-      selectUsingRegexPatterns,
-    } = require('../../../application/utils/state_management/selectors');
-
-    useSelector.mockImplementation((selector: any) => {
-      if (selector === selectQuery) return { query: 'test query', language: 'PPL' };
-      if (selector === selectPatternsField) return null;
-      if (selector === selectUsingRegexPatterns) return false;
-      return selector;
-    });
-
-    render(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
-    const button = screen.getByRole('button', { name: /update search with pattern/i });
-
-    expect(() => {
-      button.click();
-    }).toThrow('no patterns field');
   });
 });

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.test.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.test.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EXPLORE_LOGS_TAB_ID } from '../../../../common';
+import { PatternsFlyoutUpdateSearch } from './patterns_flyout_update_search';
+
+jest.mock(
+  '@elastic/eui',
+  () => ({
+    EuiButton: ({ children, onClick, 'aria-label': ariaLabel }: any) => (
+      <button onClick={onClick} aria-label={ariaLabel}>
+        {children}
+      </button>
+    ),
+  }),
+  { virtual: true }
+);
+
+const mockDispatch = jest.fn();
+const mockSetEditorText = jest.fn();
+const mockExecuteQueries = jest.fn().mockReturnValue({ type: 'EXECUTE_QUERIES' });
+const mockClosePatternsTableFlyout = jest.fn();
+const mockGetQueryWithSource = jest
+  .fn()
+  .mockReturnValue({ query: 'source query', language: 'PPL' });
+const mockBrainUpdateSearchPatternQuery = jest.fn().mockReturnValue('updated brain query');
+const mockRegexUpdateSearchPatternQuery = jest.fn().mockReturnValue('updated regex query');
+const mockSetActiveTab = jest.fn().mockReturnValue({ type: 'SET_ACTIVE_TAB' });
+const mockSetQueryStringWithHistory = jest
+  .fn()
+  .mockReturnValue({ type: 'SET_QUERY_STRING_WITH_HISTORY' });
+const mockServices = {};
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../application/hooks', () => ({
+  useSetEditorText: () => mockSetEditorText,
+}));
+
+jest.mock('./patterns_flyout_context', () => ({
+  usePatternsFlyoutContext: () => ({
+    closePatternsTableFlyout: mockClosePatternsTableFlyout,
+  }),
+}));
+
+jest.mock('../utils/utils', () => ({
+  brainUpdateSearchPatternQuery: (...args: any[]) => mockBrainUpdateSearchPatternQuery(...args),
+  regexUpdateSearchPatternQuery: (...args: any[]) => mockRegexUpdateSearchPatternQuery(...args),
+}));
+
+jest.mock('../../../application/utils/state_management/slices', () => ({
+  setActiveTab: (...args: any[]) => mockSetActiveTab(...args),
+  setQueryStringWithHistory: (...args: any[]) => mockSetQueryStringWithHistory(...args),
+}));
+
+jest.mock('../../../application/utils/languages', () => ({
+  getQueryWithSource: (...args: any[]) => mockGetQueryWithSource(...args),
+}));
+
+jest.mock('../../../application/utils/state_management/actions/query_actions', () => ({
+  executeQueries: jest.fn().mockImplementation(() => mockExecuteQueries()),
+}));
+
+jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
+  useOpenSearchDashboards: () => ({ services: mockServices }),
+}));
+
+jest.mock('../../../application/utils/state_management/selectors', () => ({
+  selectQuery: jest.fn().mockName('selectQuery'),
+  selectPatternsField: jest.fn().mockName('selectPatternsField'),
+  selectUsingRegexPatterns: jest.fn().mockName('selectUsingRegexPatterns'),
+}));
+
+describe('PatternsFlyoutUpdateSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const useSelector = require('react-redux').useSelector;
+    const {
+      selectQuery,
+      selectPatternsField,
+      selectUsingRegexPatterns,
+    } = require('../../../application/utils/state_management/selectors');
+
+    useSelector.mockImplementation((selector: any) => {
+      if (selector === selectQuery) return { query: 'test query', language: 'PPL' };
+      if (selector === selectPatternsField) return 'message';
+      if (selector === selectUsingRegexPatterns) return false;
+      return selector;
+    });
+  });
+
+  it('should render the update search button', () => {
+    render(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
+
+    expect(screen.getByRole('button', { name: /update search with pattern/i })).toBeInTheDocument();
+    expect(screen.getByText('Update search')).toBeInTheDocument();
+  });
+
+  it('should render with the correct pattern string', () => {
+    render(<PatternsFlyoutUpdateSearch patternString="custom pattern" />);
+
+    expect(screen.getByRole('button', { name: /update search with pattern/i })).toBeInTheDocument();
+  });
+
+  it('should call all expected functions when button is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
+    const button = screen.getByRole('button', { name: /update search with pattern/i });
+    await user.click(button);
+
+    expect(mockGetQueryWithSource).toHaveBeenCalled();
+    expect(mockBrainUpdateSearchPatternQuery).toHaveBeenCalled();
+    expect(mockSetQueryStringWithHistory).toHaveBeenCalled();
+    expect(mockSetEditorText).toHaveBeenCalled();
+    expect(mockSetActiveTab).toHaveBeenCalledWith(EXPLORE_LOGS_TAB_ID);
+    expect(mockExecuteQueries).toHaveBeenCalled();
+    expect(mockClosePatternsTableFlyout).toHaveBeenCalled();
+  });
+
+  it('should use regexUpdateSearchPatternQuery when usingRegexPatterns is true', async () => {
+    const user = userEvent.setup();
+
+    const useSelector = require('react-redux').useSelector;
+    const {
+      selectQuery,
+      selectPatternsField,
+      selectUsingRegexPatterns,
+    } = require('../../../application/utils/state_management/selectors');
+
+    useSelector.mockImplementation((selector: any) => {
+      if (selector === selectQuery) return { query: 'test query', language: 'PPL' };
+      if (selector === selectPatternsField) return 'message';
+      if (selector === selectUsingRegexPatterns) return true;
+      return selector;
+    });
+
+    render(<PatternsFlyoutUpdateSearch patternString="regex pattern" />);
+
+    const button = screen.getByRole('button', { name: /update search with pattern/i });
+
+    await user.click(button);
+
+    expect(mockRegexUpdateSearchPatternQuery).toHaveBeenCalled();
+    expect(mockBrainUpdateSearchPatternQuery).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error when there is no pattern field', () => {
+    const useSelector = require('react-redux').useSelector;
+    const {
+      selectQuery,
+      selectPatternsField,
+      selectUsingRegexPatterns,
+    } = require('../../../application/utils/state_management/selectors');
+
+    useSelector.mockImplementation((selector: any) => {
+      if (selector === selectQuery) return { query: 'test query', language: 'PPL' };
+      if (selector === selectPatternsField) return null;
+      if (selector === selectUsingRegexPatterns) return false;
+      return selector;
+    });
+
+    render(<PatternsFlyoutUpdateSearch patternString="test pattern" />);
+    const button = screen.getByRole('button', { name: /update search with pattern/i });
+
+    expect(() => {
+      button.click();
+    }).toThrow('no patterns field');
+  });
+});

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { i18n } from '@osd/i18n';
+import { EuiButton } from '@elastic/eui';
+import { EXPLORE_LOGS_TAB_ID } from '../../../../common';
+import { usePatternsFlyoutContext } from './patterns_flyout_context';
+import { ExploreServices } from '../../../types';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import {
+  setActiveTab,
+  setQueryStringWithHistory,
+} from '../../../application/utils/state_management/slices';
+import { useSetEditorText } from '../../../application/hooks';
+import { executeQueries } from '../../../application/utils/state_management/actions/query_actions';
+
+export const PatternsFlyoutUpdateSearch = () => {
+  const { closePatternsTableFlyout } = usePatternsFlyoutContext();
+  const { services } = useOpenSearchDashboards<ExploreServices>();
+  const dispatch = useDispatch();
+  const setEditorText = useSetEditorText();
+
+  return (
+    <EuiButton
+      aria-label={i18n.translate('explore.patterns.flyout.updateSearchWithPattern', {
+        defaultMessage: 'Update search with pattern',
+      })}
+      iconType={'continuityBelow'}
+      onClick={() => {
+        const newQuery = 'source = opensearch_dashboards_sample_data_logs | fields agent';
+        dispatch(setQueryStringWithHistory(newQuery));
+        setEditorText(newQuery);
+        dispatch(setActiveTab(EXPLORE_LOGS_TAB_ID));
+        dispatch(executeQueries({ services }));
+        closePatternsTableFlyout();
+      }}
+    >
+      {i18n.translate('explore.patterns.flyout.updateSearch', {
+        defaultMessage: 'Update search',
+      })}
+    </EuiButton>
+  );
+};

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_update_search.tsx
@@ -32,8 +32,10 @@ export interface PatternsFlyoutUpdateSearchProps {
 export const PatternsFlyoutUpdateSearch = ({ patternString }: PatternsFlyoutUpdateSearchProps) => {
   const { closePatternsTableFlyout } = usePatternsFlyoutContext();
   const { services } = useOpenSearchDashboards<ExploreServices>();
-  const dispatch = useDispatch();
+
   const setEditorText = useSetEditorText();
+  const dispatch = useDispatch();
+
   const query = useSelector(selectQuery);
   const patternsField = useSelector(selectPatternsField);
   const usingRegexPatterns = useSelector(selectUsingRegexPatterns);

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_table_flyout.test.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_table_flyout.test.tsx
@@ -13,6 +13,12 @@ jest.mock('./patterns_flyout_context', () => ({
   usePatternsFlyoutContext: jest.fn(),
 }));
 
+jest.mock('./patterns_flyout_update_search', () => ({
+  PatternsFlyoutUpdateSearch: ({ patternString }: { patternString: string }) => (
+    <div data-testid="mock-update-search">Update Search: {patternString}</div>
+  ),
+}));
+
 describe('PatternsTableFlyout', () => {
   const mockClosePatternsTableFlyout = jest.fn();
 

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_table_flyout.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_table_flyout.tsx
@@ -55,7 +55,7 @@ export const PatternsTableFlyout = () => {
           <>
             <EuiFlexGroup justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
-                <PatternsFlyoutUpdateSearch />
+                <PatternsFlyoutUpdateSearch patternString={record.pattern} />
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer size="m" />

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_table_flyout.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_table_flyout.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { usePatternsFlyoutContext } from './patterns_flyout_context';
+import { PatternsFlyoutUpdateSearch } from './patterns_flyout_update_search';
 
 export interface PatternsFlyoutRecord {
   pattern: string;
@@ -52,6 +53,12 @@ export const PatternsTableFlyout = () => {
           />
         ) : (
           <>
+            <EuiFlexGroup justifyContent="flexEnd">
+              <EuiFlexItem grow={false}>
+                <PatternsFlyoutUpdateSearch />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
             <EuiPanel>
               <EuiFlexGroup>
                 <EuiFlexItem>

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.tsx
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.tsx
@@ -26,6 +26,22 @@ export const brainPatternQuery = (queryBase: string, patternsField: string) => {
   return `${queryBase} | patterns \`${patternsField}\` method=brain mode=aggregation | sort - pattern_count`;
 };
 
+export const regexUpdateSearchPatternQuery = (
+  queryBase: string,
+  patternsField: string,
+  patternString: string
+) => {
+  return `${queryBase} | patterns \`${patternsField}\` | where patterns_field = '${patternString}'`;
+};
+
+export const brainUpdateSearchPatternQuery = (
+  queryBase: string,
+  patternsField: string,
+  patternString: string
+) => {
+  return `${queryBase} | patterns \`${patternsField}\` method=brain | where patterns_field = '${patternString}'`;
+};
+
 // Checks if the value is a valid, finite number. Used for patterns table
 export const isValidFiniteNumber = (val: number) => {
   return !isNaN(val) && isFinite(val);


### PR DESCRIPTION
### Description

Implements 'search with pattern' functionality in the Patterns' tab flyout.
This button, when clicked, will create a query that will select every document with that pattern for the row in the pattern table, and open the logs tab with this query.


https://github.com/user-attachments/assets/0deab5a6-45b2-4e95-afeb-7c0453267f7d

For example, within the opensearch sample flights index, the most common pattern for `Origin` is `<*> <*> <*> International Airport`. The query will be 
```
source = opensearch_dashboards_sample_data_flights | patterns `Origin` method=brain | where patterns_field = '<*> <*> <*> Airport'
```

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
