### PR TITLE
fix: make global setting nullable when getting / updating workspace scope settings

### DIFF
--- a/changelogs/fragments/10528.yml
+++ b/changelogs/fragments/10528.yml
@@ -1,0 +1,2 @@
+fix:
+- Make global setting nullable when getting / updating workspace scope settings ([#10528](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10528))


### PR DESCRIPTION
### Description

When global config setting does not exist, the wrapped update / get function will throw not found error, triggering the upgrade process which will finally calls `savedObjectsClient.create('config', '<current_workspace>_3.1.0')`, resulting in a saved object with id: <current_workspace>_3.1.0. And the workspace level config update will fail due to doc conflict check.

#### Before fix

https://github.com/user-attachments/assets/d80a37ed-28c4-44b6-95d9-a1a487f9bae0

#### After fix

https://github.com/user-attachments/assets/2960a070-5dd5-45ae-9129-0a7e3d35531a

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: make global setting nullable when getting / updating workspace scope settings

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
