### PR TITLE
Fix result table error ui

### DIFF
--- a/changelogs/fragments/10532.yml
+++ b/changelogs/fragments/10532.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix result table error ui ([#10532](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10532))

--- a/src/plugins/explore/public/components/tabs/error_guard/error_guard.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/error_guard.tsx
@@ -41,7 +41,7 @@ export const ErrorGuard = ({ registryTab, children }: ErrorGuardProps): JSX.Elem
         <EuiTitle size="l">
           <h1>{error.message.reason || errorDefaultTitle}</h1>
         </EuiTitle>
-        <div className="exploreErrorPanel__errorsSection">
+        <div className="exploreErrorGuard__errorsSection">
           <ErrorCodeBlock title={detailsText} text={error.message.details} />
           {error.message.type ? (
             <ErrorCodeBlock title={typeText} text={error.message.type} />


### PR DESCRIPTION
### Description
The error ui was broken for result table.
Fix - 
The css class name was applied wrong which is reverted in the pr now.

## Screenshot
Previous

<img width="1274" height="777" alt="Screenshot 2025-09-16 at 3 01 03 PM" src="https://github.com/user-attachments/assets/8ba81df7-fcbb-4dba-8975-6857424532db" />



After Fix -

Dekstop
<img width="1416" height="874" alt="Screenshot 2025-09-16 at 2 56 02 PM" src="https://github.com/user-attachments/assets/22337371-d5c0-4acc-bd07-e4fd59dad54a" />

## Changelog
- fix: Fix result table error ui


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
