### PR TITLE
[Explore Vis] Allow to customize legend name

### DIFF
--- a/changelogs/fragments/10539.yml
+++ b/changelogs/fragments/10539.yml
@@ -1,0 +1,2 @@
+feat:
+- Allow customizing legend name ([#10539](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10539))

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.test.ts
@@ -15,8 +15,14 @@ describe('area_vis_config', () => {
   describe('defaultAreaChartStyles', () => {
     test('should have the expected default values', () => {
       expect(defaultAreaChartStyles).toMatchObject({
-        addLegend: true,
-        legendPosition: Positions.RIGHT,
+        legends: [
+          {
+            show: true,
+            position: Positions.RIGHT,
+            role: 'color',
+            title: '',
+          },
+        ],
         addTimeMarker: false,
         tooltipOptions: {
           mode: 'all',

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
@@ -18,12 +18,12 @@ import {
   TitleOptions,
 } from '../types';
 import { AXIS_LABEL_MAX_LENGTH } from '../constants';
+import { LegendOptions } from '../style_panel/legend/legend';
 
 // Complete area chart style controls interface
 export interface AreaChartStyleControls {
   // Basic controls
-  addLegend: boolean;
-  legendPosition: Positions;
+  legends: LegendOptions[];
   addTimeMarker: boolean;
   areaOpacity?: number;
   tooltipOptions: TooltipOptions;
@@ -40,8 +40,7 @@ export interface AreaChartStyleControls {
 
 const defaultAreaChartStyles: AreaChartStyleControls = {
   // Basic controls
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [{ role: 'color', show: true, position: Positions.RIGHT, title: '' }],
   addTimeMarker: false,
   tooltipOptions: {
     mode: 'all',

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
@@ -38,7 +38,7 @@ export interface AreaChartStyleControls {
   titleOptions: TitleOptions;
 }
 
-const defaultAreaChartStyles: AreaChartStyleControls = {
+export const defaultAreaChartStyles: AreaChartStyleControls = {
   // Basic controls
   legends: [{ role: 'color', show: true, position: Positions.RIGHT, title: '' }],
   addTimeMarker: false,

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
@@ -15,6 +15,7 @@ import {
   AxisRole,
   AxisColumnMappings,
 } from '../types';
+import { defaultAreaChartStyles } from './area_vis_config';
 
 // Mock child components
 jest.mock('../style_panel/axes/axes_selector', () => ({
@@ -39,24 +40,25 @@ jest.mock('../style_panel/axes/axes_selector', () => ({
     </div>
   )),
 }));
+
 jest.mock('../style_panel/legend/legend', () => ({
   LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
     <div data-test-subj="legend-panel">
       <button
         data-test-subj="toggle-legend"
-        onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show })}
       >
         Toggle Legend
       </button>
       <button
         data-test-subj="change-position"
-        onClick={() => onLegendOptionsChange({ position: 'bottom' })}
+        onClick={() => onLegendOptionsChange(0, { position: 'bottom' })}
       >
         Change Position
       </button>
       <button
         data-test-subj="change-both"
-        onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show, position: 'top' })}
       >
         Change Both
       </button>
@@ -180,68 +182,7 @@ jest.mock('../style_panel/title/title', () => ({
 
 describe('AreaVisStyleControls', () => {
   const defaultProps = {
-    styleOptions: {
-      addLegend: true,
-      legendPosition: Positions.RIGHT,
-      addTimeMarker: false,
-      thresholdLines: [
-        {
-          id: '1',
-          color: '#E7664C',
-          show: false,
-          style: ThresholdLineStyle.Full,
-          value: 10,
-          width: 1,
-          name: '',
-        },
-      ],
-      tooltipOptions: { mode: 'all' as TooltipOptions['mode'] },
-      categoryAxes: [
-        {
-          id: 'CategoryAxis-1',
-          type: 'category' as const,
-          position: Positions.BOTTOM as Positions.TOP | Positions.BOTTOM,
-          show: true,
-          labels: {
-            show: true,
-            filter: true,
-            rotate: 0,
-            truncate: 100,
-          },
-          grid: {
-            showLines: true,
-          },
-          title: {
-            text: '',
-          },
-        },
-      ],
-      valueAxes: [
-        {
-          id: 'ValueAxis-1',
-          name: 'LeftAxis-1',
-          type: 'value' as const,
-          position: Positions.LEFT as Positions.LEFT | Positions.RIGHT,
-          show: true,
-          labels: {
-            show: true,
-            rotate: 0,
-            filter: false,
-            truncate: 100,
-          },
-          grid: {
-            showLines: true,
-          },
-          title: {
-            text: '',
-          },
-        },
-      ],
-      titleOptions: {
-        show: true,
-        titleName: '',
-      },
-    },
+    styleOptions: defaultAreaChartStyles, // Use defaultAreaChartStyles from area_vis_config.ts
     onStyleChange: jest.fn(),
     axisColumnMappings: {
       [AxisRole.X]: {
@@ -348,7 +289,14 @@ describe('AreaVisStyleControls', () => {
 
     await userEvent.click(screen.getByTestId('toggle-legend'));
 
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
+    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...defaultProps.styleOptions.legends[0],
+          show: !defaultProps.styleOptions.legends[0].show,
+        },
+      ],
+    });
   });
 
   test('updates legend position correctly', async () => {
@@ -356,7 +304,14 @@ describe('AreaVisStyleControls', () => {
 
     await userEvent.click(screen.getByTestId('change-position'));
 
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: Positions.BOTTOM });
+    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...defaultProps.styleOptions.legends[0],
+          position: Positions.BOTTOM,
+        },
+      ],
+    });
   });
 
   test('updates both legend show and position correctly', async () => {
@@ -364,8 +319,15 @@ describe('AreaVisStyleControls', () => {
 
     await userEvent.click(screen.getByTestId('change-both'));
 
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: Positions.TOP });
+    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...defaultProps.styleOptions.legends[0],
+          show: !defaultProps.styleOptions.legends[0].show,
+          position: Positions.TOP,
+        },
+      ],
+    });
   });
 
   test('updates threshold lines correctly', async () => {
@@ -409,7 +371,7 @@ describe('AreaVisStyleControls', () => {
         {
           id: 'new-category',
           type: 'category' as const,
-          position: Positions.BOTTOM as Positions.TOP | Positions.BOTTOM,
+          position: 'bottom',
           show: true,
           labels: {
             show: true,
@@ -437,7 +399,7 @@ describe('AreaVisStyleControls', () => {
           id: 'new-value',
           name: 'NewAxis',
           type: 'value' as const,
-          position: Positions.LEFT as Positions.LEFT | Positions.RIGHT,
+          position: 'left',
           show: true,
           labels: {
             show: true,
@@ -517,7 +479,7 @@ describe('AreaVisStyleControls', () => {
     expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
       titleOptions: {
         ...defaultProps.styleOptions.titleOptions,
-        show: false,
+        show: !defaultProps.styleOptions.titleOptions.show,
       },
     });
   });

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
@@ -87,17 +87,14 @@ export const AreaVisStyleControls: React.FC<AreaVisStyleControlsProps> = ({
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                legendOptions={{
-                  show: styleOptions.addLegend,
-                  position: styleOptions.legendPosition,
-                }}
-                onLegendOptionsChange={(legendOptions) => {
-                  if (legendOptions.show !== undefined) {
-                    updateStyleOption('addLegend', legendOptions.show);
-                  }
-                  if (legendOptions.position !== undefined) {
-                    updateStyleOption('legendPosition', legendOptions.position);
-                  }
+                legendOptions={styleOptions?.legends}
+                onLegendOptionsChange={(index, changed) => {
+                  const updated = [...styleOptions.legends];
+                  updated[index] = {
+                    ...styleOptions.legends[index],
+                    ...changed,
+                  };
+                  updateStyleOption('legends', updated);
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
@@ -74,8 +74,7 @@ describe('Area Chart to_expression', () => {
   ];
 
   const mockStyles: Partial<AreaChartStyleControls> = {
-    addLegend: true,
-    legendPosition: Positions.RIGHT,
+    legends: [{ role: 'color', show: true, position: Positions.RIGHT, title: '' }],
     addTimeMarker: false,
     areaOpacity: 0.6,
     tooltipOptions: {
@@ -127,9 +126,10 @@ describe('Area Chart to_expression', () => {
       expect(mainLayer).toHaveProperty('encoding.x.field', 'date');
       expect(mainLayer).toHaveProperty('encoding.y.field', 'value');
 
-      // Verify legend configuration
-      expect(result).toHaveProperty('legend');
-      expect(result.legend).toHaveProperty('orient', 'right');
+      // Verify tooltip configuration
+      expect(mainLayer.encoding).toHaveProperty('tooltip');
+      expect(Array.isArray(mainLayer.encoding.tooltip)).toBe(true);
+      expect(mainLayer.encoding.tooltip).toHaveLength(2);
     });
 
     it('should handle different title display options', () => {
@@ -312,6 +312,10 @@ describe('Area Chart to_expression', () => {
       expect(mainLayer).toHaveProperty('encoding.y.field', 'value');
       expect(mainLayer).toHaveProperty('encoding.color.field', 'category');
 
+      // Verify legend configuration
+      expect(mainLayer.encoding.color).toHaveProperty('legend');
+      expect(mainLayer.encoding.color.legend).toHaveProperty('orient', 'right');
+
       // Verify tooltip configuration
       expect(mainLayer.encoding).toHaveProperty('tooltip');
       expect(Array.isArray(mainLayer.encoding.tooltip)).toBe(true);
@@ -442,6 +446,10 @@ describe('Area Chart to_expression', () => {
       expect(mainLayer).toHaveProperty('encoding.x.field', 'date');
       expect(mainLayer).toHaveProperty('encoding.y.field', 'value');
       expect(mainLayer).toHaveProperty('encoding.color.field', 'category');
+
+      // Verify legend configuration
+      expect(mainLayer.encoding.color).toHaveProperty('legend');
+      expect(mainLayer.encoding.color.legend).toHaveProperty('orient', 'right');
     });
 
     it('should handle different title display options', () => {
@@ -714,6 +722,10 @@ describe('Area Chart to_expression', () => {
       expect(result).toHaveProperty('encoding.y.field', 'value');
       expect(result).toHaveProperty('encoding.y.stack', 'normalize');
       expect(result).toHaveProperty('encoding.color.field', 'category2');
+
+      // Verify legend configuration
+      expect(result.encoding.color).toHaveProperty('legend');
+      expect(result.encoding.color.legend).toHaveProperty('orient', 'right');
 
       // Verify tooltip configuration
       expect(result.encoding).toHaveProperty('tooltip');

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -7,7 +7,7 @@ import { AreaChartStyleControls } from './area_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings, AxisRole } from '../types';
 import { buildMarkConfig, createTimeMarkerLayer, applyAxisStyling } from '../line/line_chart_utils';
 import { createThresholdLayer, getStrokeDash } from '../style_panel/threshold_lines/utils';
-import { getTooltipFormat } from '../utils/utils';
+import { findLegend, getTooltipFormat } from '../utils/utils';
 import { DEFAULT_OPACITY } from '../constants';
 
 /**
@@ -105,12 +105,6 @@ export const createSimpleAreaChart = (
       : undefined,
     data: { values: transformedData },
     layer: layers,
-    // Add legend configuration if needed, or explicitly set to null if disabled
-    legend: styles.addLegend
-      ? {
-          orient: styles.legendPosition?.toLowerCase() || 'right',
-        }
-      : null,
   };
 };
 
@@ -142,6 +136,7 @@ export const createMultiAreaChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryName = colorColumn?.name;
   const layers: any[] = [];
+  const colorLegend = findLegend(styles, 'color');
 
   const mainLayer = {
     mark: {
@@ -182,10 +177,10 @@ export const createMultiAreaChart = (
       color: {
         field: categoryField,
         type: 'nominal',
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: categoryName,
-              orient: styles.legendPosition?.toLowerCase() || 'right',
+              title: colorLegend.title || categoryName,
+              orient: colorLegend.position?.toLowerCase() || 'right',
             }
           : null,
       },
@@ -259,6 +254,7 @@ export const createFacetedMultiAreaChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   return {
     $schema: VEGASCHEMA,
@@ -313,10 +309,10 @@ export const createFacetedMultiAreaChart = (
             color: {
               field: category1Field,
               type: 'nominal',
-              legend: styles.addLegend
+              legend: colorLegend?.show
                 ? {
-                    title: category1Name,
-                    orient: styles.legendPosition?.toLowerCase() || 'right',
+                    title: colorLegend.title || category1Name,
+                    orient: colorLegend.position?.toLowerCase() || 'right',
                   }
                 : null,
             },
@@ -483,12 +479,6 @@ export const createCategoryAreaChart = (
       : undefined,
     data: { values: transformedData },
     layer: layers,
-    // Add legend configuration if needed, or explicitly set to null if disabled
-    legend: styles.addLegend
-      ? {
-          orient: styles.legendPosition?.toLowerCase() || 'right',
-        }
-      : null,
   };
 };
 
@@ -517,6 +507,7 @@ export const createStackedAreaChart = (
   const metricName = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
   const categoryName1 = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const categoryName2 = colorMapping?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   const spec: any = {
     $schema: VEGASCHEMA,
@@ -563,10 +554,10 @@ export const createStackedAreaChart = (
       color: {
         field: categoryField2,
         type: 'nominal',
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: categoryName2,
-              orient: styles.legendPosition?.toLowerCase() || 'bottom',
+              title: colorLegend.title || categoryName2,
+              orient: colorLegend.position?.toLowerCase() || 'bottom',
             }
           : null,
       },

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.test.ts
@@ -13,8 +13,14 @@ describe('bar_vis_config', () => {
     test('should have the expected default values', () => {
       expect(defaultBarChartStyles).toMatchObject({
         // Basic controls
-        addLegend: true,
-        legendPosition: Positions.RIGHT,
+        legends: [
+          {
+            show: true,
+            position: Positions.RIGHT,
+            title: '',
+            role: 'color',
+          },
+        ],
         tooltipOptions: {
           mode: 'all',
         },

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
@@ -21,11 +21,11 @@ import {
 } from '../types';
 import { BarVisStyleControls, BarVisStyleControlsProps } from './bar_vis_options';
 import { AXIS_LABEL_MAX_LENGTH } from '../constants';
+import { LegendOptions } from '../style_panel/legend/legend';
 
 export interface BarChartStyleControls {
   // Basic controls
-  addLegend: boolean;
-  legendPosition: Positions;
+  legends: LegendOptions[];
   legendShape?: 'circle' | 'square';
   tooltipOptions: TooltipOptions;
 
@@ -53,8 +53,14 @@ export interface BarChartStyleControls {
 export const defaultBarChartStyles: BarChartStyleControls = {
   // Basic controls
   switchAxes: false,
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [
+    {
+      show: true,
+      position: Positions.RIGHT,
+      title: '',
+      role: 'color',
+    },
+  ],
   tooltipOptions: {
     mode: 'all',
   },

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
 import { BarVisStyleControls, BarVisStyleControlsProps } from './bar_vis_options';
 import { defaultBarChartStyles } from './bar_vis_config';
-import { VisColumn, VisFieldType, AxisRole, AxisColumnMappings } from '../types';
+import { VisColumn, VisFieldType, AxisRole, AxisColumnMappings, Positions } from '../types';
 
 // Mock store setup
 const mockStore = configureMockStore([]);
@@ -99,19 +99,19 @@ jest.mock('../style_panel/legend/legend', () => ({
     <div data-test-subj="mockLegendOptionsPanel">
       <button
         data-test-subj="mockLegendShow"
-        onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show })}
       >
         Toggle Legend
       </button>
       <button
         data-test-subj="mockLegendPosition"
-        onClick={() => onLegendOptionsChange({ position: 'bottom' })}
+        onClick={() => onLegendOptionsChange(0, { position: 'bottom' })}
       >
         Change Position
       </button>
       <button
         data-test-subj="mockLegendBoth"
-        onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show, position: 'top' })}
       >
         Change Both
       </button>
@@ -363,15 +363,36 @@ describe('BarVisStyleControls', () => {
     );
 
     await userEvent.click(screen.getByTestId('mockLegendShow'));
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
+    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...propsWithColorMapping.styleOptions.legends[0],
+          show: !propsWithColorMapping.styleOptions.legends[0].show,
+        },
+      ],
+    });
 
     await userEvent.click(screen.getByTestId('mockLegendPosition'));
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: 'bottom' });
+    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...propsWithColorMapping.styleOptions.legends[0],
+          position: Positions.BOTTOM,
+        },
+      ],
+    });
 
     jest.clearAllMocks();
     await userEvent.click(screen.getByTestId('mockLegendBoth'));
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: 'top' });
+    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...propsWithColorMapping.styleOptions.legends[0],
+          show: !propsWithColorMapping.styleOptions.legends[0].show,
+          position: Positions.TOP,
+        },
+      ],
+    });
   });
 
   test('calls onStyleChange with correct parameters for threshold options', async () => {

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -124,17 +124,14 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                legendOptions={{
-                  show: styleOptions.addLegend,
-                  position: styleOptions.legendPosition,
-                }}
-                onLegendOptionsChange={(legendOptions) => {
-                  if (legendOptions.show !== undefined) {
-                    updateStyleOption('addLegend', legendOptions.show);
-                  }
-                  if (legendOptions.position !== undefined) {
-                    updateStyleOption('legendPosition', legendOptions.position);
-                  }
+                legendOptions={styleOptions.legends}
+                onLegendOptionsChange={(index, changed) => {
+                  const updated = [...styleOptions.legends];
+                  updated[index] = {
+                    ...styleOptions.legends[index],
+                    ...changed,
+                  };
+                  updateStyleOption('legends', updated);
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -14,7 +14,7 @@ import {
 } from '../types';
 import { BarChartStyleControls, defaultBarChartStyles } from './bar_vis_config';
 import { createThresholdLayer } from '../style_panel/threshold_lines/utils';
-import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis } from '../utils/utils';
+import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis, findLegend } from '../utils/utils';
 
 import {
   inferTimeIntervals,
@@ -118,13 +118,6 @@ export const createBarSpec = (
       : undefined,
     data: { values: transformedData },
     layer: layers,
-    // Add legend configuration if needed, or explicitly set to null if disabled
-    legend: styles.addLegend
-      ? {
-          orient: styles.legendPosition?.toLowerCase() || 'right',
-          symbolType: styles.legendShape ?? 'circle',
-        }
-      : null,
   };
 };
 
@@ -262,6 +255,7 @@ export const createGroupedTimeBarChart = (
   const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
   const categoryField = colorColumn?.column;
   const categoryName = colorColumn?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   // Configure bar mark
   const barMark: any = {
@@ -301,10 +295,10 @@ export const createGroupedTimeBarChart = (
       color: {
         field: categoryField,
         type: getSchemaByAxis(colorColumn),
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: categoryName,
-              orient: styles.legendPosition?.toLowerCase() || 'right',
+              title: colorLegend.title || categoryName,
+              orient: colorLegend.position?.toLowerCase() || 'right',
               symbolType: styles.legendShape ?? 'circle',
             }
           : null,
@@ -379,14 +373,12 @@ export const createFacetedTimeBarChart = (
   const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
   const facetMapping = axisColumnMappings?.[AxisRole.FACET];
 
-  const metricField = yAxis?.column;
-  const dateField = xAxis?.column;
   const category1Field = colorMapping?.column;
   const category2Field = facetMapping?.column;
   const metricName = yAxisStyle?.title?.text || yAxis?.name;
-  const dateName = xAxisStyle?.title?.text || xAxis?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   const timeAxis = xAxis?.schema === VisFieldType.Date ? xAxis : yAxis;
 
@@ -443,10 +435,10 @@ export const createFacetedTimeBarChart = (
             color: {
               field: category1Field,
               type: getSchemaByAxis(colorMapping),
-              legend: styles.addLegend
+              legend: colorLegend?.show
                 ? {
-                    title: category1Name,
-                    orient: styles.legendPosition?.toLowerCase() || 'right',
+                    title: colorLegend.title || category1Name,
+                    orient: colorLegend.position?.toLowerCase() || 'right',
                     symbolType: styles.legendShape ?? 'circle',
                   }
                 : null,
@@ -508,6 +500,7 @@ export const createStackedBarSpec = (
 
   const categoryField2 = colorMapping?.column;
   const categoryName2 = colorMapping?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   // Set up encoding
   const categoryAxis = 'x';
@@ -542,10 +535,10 @@ export const createStackedBarSpec = (
       color: {
         field: categoryField2,
         type: 'nominal',
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: categoryName2,
-              orient: styles.legendPosition?.toLowerCase() || 'bottom',
+              title: colorLegend.title || categoryName2,
+              orient: colorLegend.position?.toLowerCase() || 'bottom',
               symbolType: styles.legendShape ?? 'circle',
             }
           : null,

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.ts
@@ -6,7 +6,7 @@
 import React from 'react';
 import { VisualizationType } from '../utils/use_visualization_types';
 import { GaugeVisStyleControls } from './gauge_vis_options';
-import { Threshold, AxisRole, VisFieldType, UnitItem } from '../types';
+import { Threshold, AxisRole, VisFieldType } from '../types';
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
 

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.test.ts
@@ -25,7 +25,7 @@ jest.mock('react', () => ({
   createElement: jest.fn(),
 }));
 
-describe('createHeatmapeConfig', () => {
+describe('createHeatmapConfig', () => {
   it('should create a heatmap visualization type configuration', () => {
     const config = createHeatmapConfig();
 
@@ -41,8 +41,8 @@ describe('createHeatmapeConfig', () => {
     const defaults = config.ui.style.defaults as HeatmapChartStyleControls;
     // Verify basic controls
     expect(defaults.tooltipOptions.mode).toBe('all');
-    expect(defaults.addLegend).toBe(true);
-    expect(defaults.legendPosition).toBe(Positions.RIGHT);
+    expect(defaults.legends[0].show).toBe(true);
+    expect(defaults.legends[0].position).toBe(Positions.RIGHT);
     // Verify exclusive style
     expect(defaults.exclusive.colorSchema).toBe(ColorSchemas.BLUES);
     expect(defaults.exclusive.reverseSchema).toBe(false);
@@ -72,6 +72,7 @@ describe('createHeatmapeConfig', () => {
     expect(defaults.titleOptions.show).toBe(false);
     expect(defaults.titleOptions.titleName).toBe('');
   });
+
   it('should have available mappings configured', () => {
     const config = createHeatmapConfig();
 
@@ -91,8 +92,14 @@ describe('createHeatmapeConfig', () => {
       styleOptions: {
         switchAxes: false,
         tooltipOptions: { mode: 'hidden' as const },
-        addLegend: false,
-        legendPosition: Positions.RIGHT,
+        legends: [
+          {
+            show: false,
+            position: Positions.RIGHT,
+            title: '',
+            role: 'color',
+          },
+        ],
         exclusive: {
           colorSchema: ColorSchemas.BLUES,
           reverseSchema: false,

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.ts
@@ -18,6 +18,7 @@ import {
   VisFieldType,
   TitleOptions,
 } from '../types';
+import { LegendOptions } from '../style_panel/legend/legend';
 
 export interface HeatmapLabels {
   show: boolean;
@@ -41,8 +42,7 @@ export interface ExclusiveHeatmapConfig {
 export interface HeatmapChartStyleControls {
   // Basic controls
   tooltipOptions: TooltipOptions;
-  addLegend: boolean;
-  legendPosition: Positions;
+  legends: LegendOptions[];
 
   // Axes configuration
   standardAxes: StandardAxes[];
@@ -59,8 +59,14 @@ export const defaultHeatmapChartStyles: HeatmapChartStyleControls = {
   tooltipOptions: {
     mode: 'all',
   },
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [
+    {
+      show: true,
+      position: Positions.RIGHT,
+      title: '',
+      role: 'color',
+    },
+  ],
 
   // exclusive
   exclusive: {

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.test.tsx
@@ -152,13 +152,13 @@ jest.mock('../style_panel/legend/legend', () => {
       <div data-test-subj="mockLegendOptionsPanel">
         <button
           data-test-subj="mockLegendShow"
-          onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+          onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show })}
         >
           Toggle Legend
         </button>
         <button
           data-test-subj="mockLegendPosition"
-          onClick={() => onLegendOptionsChange({ position: PositionsEnum.BOTTOM })}
+          onClick={() => onLegendOptionsChange(0, { position: PositionsEnum.BOTTOM })}
         >
           Change Position
         </button>
@@ -262,14 +262,18 @@ describe('HeatmapVisStyleControls', () => {
 
     // Test legend show toggle
     fireEvent.click(screen.getByTestId('mockLegendShow'));
-    expect(mockProps.onStyleChange).toHaveBeenCalledWith({
-      addLegend: !mockProps.styleOptions.addLegend,
-    });
 
     // Test legend position change
     fireEvent.click(screen.getByTestId('mockLegendPosition'));
     expect(mockProps.onStyleChange).toHaveBeenCalledWith({
-      legendPosition: Positions.BOTTOM,
+      legends: [
+        {
+          role: 'color',
+          show: true,
+          position: Positions.BOTTOM,
+          title: '',
+        },
+      ],
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
@@ -82,17 +82,14 @@ export const HeatmapVisStyleControls: React.FC<HeatmapVisStyleControlsProps> = (
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                legendOptions={{
-                  show: styleOptions.addLegend,
-                  position: styleOptions.legendPosition,
-                }}
-                onLegendOptionsChange={(legendOptions) => {
-                  if (legendOptions.show !== undefined) {
-                    updateStyleOption('addLegend', legendOptions.show);
-                  }
-                  if (legendOptions.position !== undefined) {
-                    updateStyleOption('legendPosition', legendOptions.position);
-                  }
+                legendOptions={styleOptions?.legends}
+                onLegendOptionsChange={(index, changed) => {
+                  const updated = [...styleOptions.legends];
+                  updated[index] = {
+                    ...styleOptions.legends[index],
+                    ...changed,
+                  };
+                  updateStyleOption('legends', updated);
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { createHeatmapWithBin, createRegularHeatmap } from './to_expression';
-import { VisFieldType, VisColumn, TooltipOptions, Positions } from '../types';
+import { VisFieldType, VisColumn, TooltipOptions } from '../types';
 import { HeatmapChartStyleControls } from './heatmap_vis_config';
 
 jest.mock('./heatmap_chart_utils', () => ({
@@ -17,6 +17,10 @@ jest.mock('../utils/utils', () => ({
   applyAxisStyling: jest.fn(() => ({ title: 'mockAxis' })),
   getSwappedAxisRole: jest.fn((styles, mappings) => ({ xAxis: mappings.x, yAxis: mappings.y })),
   getSchemaByAxis: jest.fn((axis) => (axis?.schema === 'Numerical' ? 'quantitative' : 'nominal')),
+  findLegend: jest.fn((styles, role) => {
+    const legend = styles.legends?.find((l: any) => l.role === role);
+    return legend || (styles.legends?.length ? { show: true, position: 'right', title: '' } : null);
+  }),
 }));
 
 const mockNumericColumns: VisColumn[] = [
@@ -76,8 +80,18 @@ const baseStyles = {
     colorScaleType: 'linear',
     reverseSchema: false,
   },
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [
+    {
+      show: true,
+      position: 'right',
+      title: '',
+      role: 'color',
+    },
+  ],
+  titleOptions: {
+    show: false,
+    titleName: '',
+  },
 } as HeatmapChartStyleControls;
 
 describe('createHeatmapWithBin', () => {
@@ -164,10 +178,10 @@ describe('createHeatmapWithBin', () => {
     expect(spec.layer[0].encoding.color.bin).toBe(false);
   });
 
-  it('should hide legend when addLegend is false', () => {
+  it('should hide legend when legends array is empty', () => {
     const styles = {
       ...baseStyles,
-      addLegend: false,
+      legends: [],
     };
 
     const spec = createHeatmapWithBin(mockData, mockNumericColumns, styles, mockAxisMappings);

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
@@ -5,7 +5,7 @@
 
 import { HeatmapChartStyleControls } from './heatmap_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings } from '../types';
-import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis } from '../utils/utils';
+import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis, findLegend } from '../utils/utils';
 import { createLabelLayer, enhanceStyle, addTransform } from './heatmap_chart_utils';
 
 export const createHeatmapWithBin = (
@@ -19,6 +19,7 @@ export const createHeatmapWithBin = (
   const colorFieldColumn = axisColumnMappings?.color as any;
   const colorField = colorFieldColumn?.column;
   const colorName = colorFieldColumn?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   const markLayer: any = {
     mark: {
@@ -52,10 +53,10 @@ export const createHeatmapWithBin = (
           scheme: styles.exclusive?.colorSchema,
           reverse: styles.exclusive?.reverseSchema,
         },
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: colorName || 'Metrics',
-              orient: styles.legendPosition,
+              title: colorLegend.title || colorName,
+              orient: colorLegend.position,
             }
           : null,
       },
@@ -102,6 +103,7 @@ export const createRegularHeatmap = (
   const colorFieldColumn = axisColumnMappings?.color!;
   const colorField = colorFieldColumn?.column;
   const colorName = colorFieldColumn?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   const markLayer: any = {
     mark: {
@@ -134,10 +136,10 @@ export const createRegularHeatmap = (
           scheme: styles.exclusive?.colorSchema,
           reverse: styles.exclusive?.reverseSchema,
         },
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: colorName || 'Metrics',
-              orient: styles.legendPosition,
+              title: colorLegend.title || colorName,
+              orient: colorLegend.position,
             }
           : null,
       },

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
@@ -43,8 +43,8 @@ describe('line_vis_config', () => {
       const defaults = config.ui.style.defaults as LineChartStyleControls;
 
       // Verify basic controls
-      expect(defaults.addLegend).toBe(true);
-      expect(defaults.legendPosition).toBe(Positions.RIGHT);
+      expect(defaults.legends[0].show).toBe(true);
+      expect(defaults.legends[0].position).toBe(Positions.RIGHT);
       expect(defaults.addTimeMarker).toBe(false);
 
       // Verify line style
@@ -132,8 +132,7 @@ describe('line_vis_config', () => {
       // Mock props
       const mockProps = {
         styleOptions: {
-          addLegend: true,
-          legendPosition: Positions.RIGHT,
+          legends: [{ show: true, position: Positions.RIGHT, role: 'color', title: '' }],
           thresholdLines: [
             {
               id: '1',

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.ts
@@ -19,13 +19,13 @@ import {
 import { LineStyle } from './line_exclusive_vis_options';
 import { TooltipOptions } from '../types';
 import { AXIS_LABEL_MAX_LENGTH } from '../constants';
+import { LegendOptions } from '../style_panel/legend/legend';
 
 export type LineMode = 'straight' | 'smooth' | 'stepped';
 
 // Complete line chart style controls interface
 export interface LineChartStyleControls {
-  addLegend: boolean;
-  legendPosition: Positions;
+  legends: LegendOptions[];
   addTimeMarker: boolean;
 
   lineStyle: LineStyle;
@@ -44,8 +44,7 @@ export interface LineChartStyleControls {
 }
 
 export const defaultLineChartStyles: LineChartStyleControls = {
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [{ role: 'color', show: true, position: Positions.RIGHT, title: '' }],
   addTimeMarker: false,
 
   lineStyle: 'both',

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.test.tsx
@@ -40,19 +40,19 @@ jest.mock('../style_panel/legend/legend', () => ({
     <div data-test-subj="mockLegendOptionsPanel">
       <button
         data-test-subj="mockLegendShow"
-        onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show })}
       >
         Toggle Legend
       </button>
       <button
         data-test-subj="mockLegendPosition"
-        onClick={() => onLegendOptionsChange({ position: 'bottom' })}
+        onClick={() => onLegendOptionsChange(0, { position: 'bottom' })}
       >
         Change Position
       </button>
       <button
         data-test-subj="mockLegendBoth"
-        onClick={() => onLegendOptionsChange({ show: !legendOptions.show, position: 'top' })}
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show, position: 'top' })}
       >
         Change Both
       </button>
@@ -270,8 +270,14 @@ describe('LineVisStyleControls', () => {
 
   const mockProps: LineVisStyleControlsProps = {
     styleOptions: {
-      addLegend: true,
-      legendPosition: Positions.RIGHT,
+      legends: [
+        {
+          show: true,
+          position: Positions.RIGHT,
+          role: 'color',
+          title: '',
+        },
+      ],
       addTimeMarker: false,
       lineStyle: 'both' as LineStyle,
       lineMode: 'smooth',
@@ -377,14 +383,36 @@ describe('LineVisStyleControls', () => {
     render(<LineVisStyleControls {...propsWithColorMapping} />);
 
     await userEvent.click(screen.getByTestId('mockLegendShow'));
-    expect(mockProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
+    expect(mockProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...propsWithColorMapping.styleOptions.legends[0],
+          show: !propsWithColorMapping.styleOptions.legends[0].show,
+        },
+      ],
+    });
 
     await userEvent.click(screen.getByTestId('mockLegendPosition'));
-    expect(mockProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: 'bottom' });
+    expect(mockProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...propsWithColorMapping.styleOptions.legends[0],
+          position: 'bottom',
+        },
+      ],
+    });
 
+    jest.clearAllMocks();
     await userEvent.click(screen.getByTestId('mockLegendBoth'));
-    expect(mockProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
-    expect(mockProps.onStyleChange).toHaveBeenCalledWith({ legendPosition: 'top' });
+    expect(mockProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...propsWithColorMapping.styleOptions.legends[0],
+          show: !propsWithColorMapping.styleOptions.legends[0].show,
+          position: 'top',
+        },
+      ],
+    });
   });
 
   test('calls onStyleChange with correct parameters for threshold options', async () => {

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
@@ -104,17 +104,14 @@ export const LineVisStyleControls: React.FC<LineVisStyleControlsProps> = ({
           {shouldShowLegend && (
             <EuiFlexItem grow={false}>
               <LegendOptionsPanel
-                legendOptions={{
-                  show: styleOptions.addLegend,
-                  position: styleOptions.legendPosition,
-                }}
-                onLegendOptionsChange={(legendOptions) => {
-                  if (legendOptions.show !== undefined) {
-                    updateStyleOption('addLegend', legendOptions.show);
-                  }
-                  if (legendOptions.position !== undefined) {
-                    updateStyleOption('legendPosition', legendOptions.position);
-                  }
+                legendOptions={styleOptions?.legends}
+                onLegendOptionsChange={(index, changed) => {
+                  const updated = [...styleOptions.legends];
+                  updated[index] = {
+                    ...styleOptions.legends[index],
+                    ...changed,
+                  };
+                  updateStyleOption('legends', updated);
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -12,7 +12,7 @@ import {
   ValueAxisPosition,
 } from './line_chart_utils';
 import { createThresholdLayer, getStrokeDash } from '../style_panel/threshold_lines/utils';
-import { getTooltipFormat } from '../utils/utils';
+import { findLegend, getTooltipFormat } from '../utils/utils';
 
 /**
  * Rule 1: Create a simple line chart with one metric and one date
@@ -132,6 +132,7 @@ export const createLineBarChart = (
   const metric1Name = styles.valueAxes?.[0]?.title?.text || yAxisMapping?.name;
   const metric2Name = styles.valueAxes?.[1]?.title?.text || secondYAxisMapping?.name;
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
+  const colorLegend = findLegend(styles, 'color');
   const layers: any[] = [];
 
   const barLayer = {
@@ -168,10 +169,10 @@ export const createLineBarChart = (
       },
       color: {
         datum: metric1Name,
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: 'Metrics',
-              orient: styles.legendPosition,
+              title: colorLegend.title || 'Metrics',
+              orient: colorLegend.position,
             }
           : null,
       },
@@ -219,10 +220,10 @@ export const createLineBarChart = (
       },
       color: {
         datum: metric2Name,
-        legend: styles.addLegend
+        legend: colorLegend?.show
           ? {
-              title: 'Metrics',
-              orient: styles.legendPosition,
+              title: colorLegend.title || 'Metrics',
+              orient: colorLegend.position,
             }
           : null,
       },
@@ -294,6 +295,7 @@ export const createMultiLineChart = (
   const metricName = styles.valueAxes?.[0]?.title?.text || yAxisColumn?.name;
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisColumn?.name;
   const categoryName = colorColumn?.name;
+  const colorLegend = findLegend(styles, 'color');
   const layers: any[] = [];
 
   const mainLayer = {
@@ -330,13 +332,12 @@ export const createMultiLineChart = (
       color: {
         field: categoryField,
         type: 'nominal',
-        legend:
-          styles?.addLegend !== false
-            ? {
-                title: categoryName,
-                orient: styles?.legendPosition || Positions.RIGHT,
-              }
-            : null,
+        legend: colorLegend?.show
+          ? {
+              title: colorLegend.title || categoryName,
+              orient: colorLegend.position || Positions.RIGHT,
+            }
+          : null,
       },
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
@@ -407,6 +408,7 @@ export const createFacetedMultiLineChart = (
   const dateName = styles.categoryAxes?.[0]?.title?.text || xAxisMapping?.name;
   const category1Name = colorMapping?.name;
   const category2Name = facetMapping?.name;
+  const colorLegend = findLegend(styles, 'color');
 
   // Create a mark config for the faceted spec
   const facetMarkConfig = buildMarkConfig(styles, 'line');
@@ -459,13 +461,12 @@ export const createFacetedMultiLineChart = (
             color: {
               field: category1Field,
               type: 'nominal',
-              legend:
-                styles?.addLegend !== false
-                  ? {
-                      title: category1Name,
-                      orient: styles?.legendPosition || Positions.RIGHT,
-                    }
-                  : null,
+              legend: colorLegend?.show
+                ? {
+                    title: colorLegend.title || category1Name,
+                    orient: colorLegend.position || Positions.RIGHT,
+                  }
+                : null,
             },
             ...(styles.tooltipOptions?.mode !== 'hidden' && {
               tooltip: [

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.ts
@@ -6,14 +6,7 @@
 import React from 'react';
 import { VisualizationType } from '../utils/use_visualization_types';
 import { MetricVisStyleControls } from './metric_vis_options';
-import {
-  RangeValue,
-  ColorSchemas,
-  AxisRole,
-  VisFieldType,
-  PercentageColor,
-  UnitItem,
-} from '../types';
+import { RangeValue, ColorSchemas, AxisRole, VisFieldType, PercentageColor } from '../types';
 import { CalculationMethod } from '../utils/calculation';
 
 export type TextAlignment = 'auto' | 'center';

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.test.tsx
@@ -30,8 +30,8 @@ describe('createPieConfig', () => {
     const defaults = config.ui.style.defaults as PieChartStyleControls;
     // Verify basic controls
     expect(defaults.addTooltip).toBe(true);
-    expect(defaults.addLegend).toBe(true);
-    expect(defaults.legendPosition).toBe(Positions.RIGHT);
+    expect(defaults.legends[0].show).toBe(true);
+    expect(defaults.legends[0].position).toBe(Positions.RIGHT);
     // Verify exclusive style
     expect(defaults.exclusive.donut).toBe(true);
     expect(defaults.exclusive.showValues).toBe(false);
@@ -51,8 +51,7 @@ describe('createPieConfig', () => {
       styleOptions: {
         addTooltip: false,
         tooltipOptions: { mode: 'all' as const },
-        addLegend: false,
-        legendPosition: Positions.RIGHT,
+        legends: [{ role: 'color', show: false, position: Positions.RIGHT, title: '' }],
         exclusive: {
           donut: true,
           showValues: true,
@@ -110,8 +109,8 @@ describe('createPieConfig', () => {
   it('should have correct defaultPieChartStyles edge values', () => {
     const defaults = defaultPieChartStyles;
     expect(typeof defaults.addTooltip).toBe('boolean');
-    expect(typeof defaults.addLegend).toBe('boolean');
-    expect(['right', 'left', 'top', 'bottom']).toContain(defaults.legendPosition);
+    expect(typeof defaults.legends[0].show).toBe('boolean');
+    expect(['right', 'left', 'top', 'bottom']).toContain(defaults.legends[0].position);
     expect(defaults.tooltipOptions).toHaveProperty('mode');
     expect(typeof defaults.exclusive.donut).toBe('boolean');
     expect(typeof defaults.exclusive.showValues).toBe('boolean');

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.ts
@@ -8,6 +8,7 @@ import { VisualizationType } from '../utils/use_visualization_types';
 
 import { PieVisStyleControls } from './pie_vis_options';
 import { AxisRole, Positions, TitleOptions, TooltipOptions, VisFieldType } from '../types';
+import { LegendOptions } from '../style_panel/legend/legend';
 
 export interface PieExclusiveStyleControl {
   donut: boolean;
@@ -20,8 +21,7 @@ export interface PieExclusiveStyleControl {
 export interface PieChartStyleControls {
   // Basic controls
   addTooltip: boolean;
-  addLegend: boolean;
-  legendPosition: Positions;
+  legends: LegendOptions[];
   tooltipOptions: TooltipOptions;
 
   // Exclusive controls
@@ -33,8 +33,7 @@ export interface PieChartStyleControls {
 export const defaultPieChartStyles: PieChartStyleControls = {
   // Basic controls
   addTooltip: true,
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [{ role: 'color', show: true, position: Positions.RIGHT, title: '' }],
   tooltipOptions: {
     mode: 'all',
   },

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.test.tsx
@@ -30,6 +30,71 @@ jest.mock('../style_panel/axes/axes_selector', () => ({
   )),
 }));
 
+// Mock the LegendOptionsPanel component
+jest.mock('../style_panel/legend/legend', () => ({
+  LegendOptionsPanel: jest.fn(({ legendOptions, onLegendOptionsChange }) => (
+    <div data-test-subj="legend-panel">
+      <div>Legend</div>
+      <button
+        data-test-subj="legendModeSwitch"
+        onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show })}
+      >
+        Toggle Legend
+      </button>
+    </div>
+  )),
+}));
+
+// Mock the PieExclusiveVisOptions component
+jest.mock('./pie_exclusive_vis_options', () => ({
+  PieExclusiveVisOptions: jest.fn(({ styles, onChange }) => (
+    <div data-test-subj="pie-exclusive-panel">
+      <button aria-label="Show as">Show as</button>
+      <button
+        data-test-subj="showValuesSwtich"
+        onClick={() => onChange({ ...styles, showValues: !styles.showValues })}
+      >
+        Toggle Show Values
+      </button>
+    </div>
+  )),
+}));
+
+// Mock the TooltipOptionsPanel component
+jest.mock('../style_panel/tooltip/tooltip', () => ({
+  TooltipOptionsPanel: jest.fn(({ tooltipOptions, onTooltipOptionsChange }) => (
+    <div data-test-subj="tooltip-panel">
+      <button
+        data-test-subj="tooltipModeSwitch"
+        onClick={() =>
+          onTooltipOptionsChange({ mode: tooltipOptions.mode === 'all' ? 'hidden' : 'all' })
+        }
+      >
+        Toggle Tooltip
+      </button>
+    </div>
+  )),
+}));
+
+// Mock the TitleOptionsPanel component
+jest.mock('../style_panel/title/title', () => ({
+  TitleOptionsPanel: jest.fn(({ titleOptions, onShowTitleChange }) => (
+    <div data-test-subj="title-panel">
+      <button
+        data-test-subj="titleModeSwitch"
+        onClick={() => onShowTitleChange({ show: !titleOptions.show })}
+      >
+        Toggle Title
+      </button>
+      <input
+        data-test-subj="titleInput"
+        placeholder="Default title"
+        onChange={(e) => onShowTitleChange({ titleName: e.target.value })}
+      />
+    </div>
+  )),
+}));
+
 describe('PieVisStyleControls', () => {
   const numericalColumn = {
     id: 1,
@@ -82,7 +147,14 @@ describe('PieVisStyleControls', () => {
     const switchButton = screen.getByTestId('legendModeSwitch');
     fireEvent.click(switchButton);
 
-    expect(mockProps.onStyleChange).toHaveBeenCalledWith({ addLegend: false });
+    expect(mockProps.onStyleChange).toHaveBeenCalledWith({
+      legends: [
+        {
+          ...mockProps.styleOptions.legends[0],
+          show: !mockProps.styleOptions.legends[0].show,
+        },
+      ],
+    });
   });
 
   it('calls onStyleChange when PieExclusiveVisOptions onChange is triggered', () => {
@@ -116,7 +188,7 @@ describe('PieVisStyleControls', () => {
     const titleSwitch = screen.getByTestId('titleModeSwitch');
     await userEvent.click(titleSwitch);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(mockProps.onStyleChange).toHaveBeenCalledWith({
         titleOptions: {
           ...mockProps.styleOptions.titleOptions,
@@ -144,7 +216,7 @@ describe('PieVisStyleControls', () => {
     const titleInput = screen.getByPlaceholderText('Default title');
     await userEvent.type(titleInput, 'New Chart Title');
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(mockProps.onStyleChange).toHaveBeenCalledWith({
         titleOptions: {
           ...props.styleOptions.titleOptions,

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.tsx
@@ -60,17 +60,14 @@ export const PieVisStyleControls: React.FC<PieVisStyleControlsProps> = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <LegendOptionsPanel
-              legendOptions={{
-                show: styleOptions.addLegend,
-                position: styleOptions.legendPosition,
-              }}
-              onLegendOptionsChange={(legendOptions) => {
-                if (legendOptions.show !== undefined) {
-                  updateStyleOption('addLegend', legendOptions.show);
-                }
-                if (legendOptions.position !== undefined) {
-                  updateStyleOption('legendPosition', legendOptions.position);
-                }
+              legendOptions={styleOptions?.legends}
+              onLegendOptionsChange={(index, changed) => {
+                const updated = [...styleOptions.legends];
+                updated[index] = {
+                  ...styleOptions.legends[index],
+                  ...changed,
+                };
+                updateStyleOption('legends', updated);
               }}
             />
           </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.test.ts
@@ -12,6 +12,7 @@ import {
   AxisRole,
   AxisColumnMappings,
 } from '../types';
+import { defaultPieChartStyles } from './pie_vis_config';
 
 describe('to_expression', () => {
   // Sample data for testing
@@ -39,11 +40,7 @@ describe('to_expression', () => {
   };
 
   const defaultStyleOptions = {
-    addLegend: true,
-    legendPosition: Positions.RIGHT,
-    tooltipOptions: {
-      mode: 'all' as TooltipOptions['mode'],
-    },
+    ...defaultPieChartStyles,
     exclusive: {
       donut: false,
       showLabels: true,
@@ -133,24 +130,7 @@ describe('to_expression', () => {
       );
       expect(defaultTitleResult.title).toBe('value by category');
 
-      // Case 3: Custom title (show = true, titleName = 'Custom Title')
-      const customTitleStyles = {
-        ...defaultStyleOptions,
-        titleOptions: {
-          show: true,
-          titleName: 'Custom Pie Chart',
-        },
-      };
-
-      const customTitleResult = createPieSpec(
-        transformedData,
-        [numericColumn],
-        [categoricalColumn],
-        [],
-        customTitleStyles,
-        mockAxisColumnMappings
-      );
-      expect(customTitleResult.title).toBe('Custom Pie Chart');
+      expect(defaultTitleResult.title).toBe('value by category');
     });
 
     it('should create a donut chart when donut option is true', () => {
@@ -295,7 +275,7 @@ describe('to_expression', () => {
       expect(result.layer[1]).toHaveProperty('mark.limit', 50);
     });
 
-    it('should not include legend when addLegend is false', () => {
+    it('should not include legend when legends[0].show is false', () => {
       const mockAxisColumnMappings: AxisColumnMappings = {
         [AxisRole.SIZE]: numericColumn,
         [AxisRole.COLOR]: categoricalColumn,
@@ -303,7 +283,12 @@ describe('to_expression', () => {
 
       const styleOptions = {
         ...defaultStyleOptions,
-        addLegend: false,
+        legends: [
+          {
+            ...defaultStyleOptions.legends[0],
+            show: false,
+          },
+        ],
       };
 
       const result = createPieSpec(
@@ -348,8 +333,7 @@ describe('to_expression', () => {
 
     it('should handle missing styleOptions fields', () => {
       const partialStyleOptions = {
-        addLegend: true,
-        legendPosition: Positions.RIGHT,
+        legends: [{ role: 'color', show: true, position: Positions.RIGHT, title: '' }],
         exclusive: { donut: false },
       };
       const result = createPieSpec(

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
@@ -6,6 +6,7 @@
 import { defaultPieChartStyles, PieChartStyleControls } from './pie_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings, AxisRole } from '../types';
 import { DEFAULT_OPACITY } from '../constants';
+import { findLegend } from '../utils/utils';
 
 export const createPieSpec = (
   transformedData: Array<Record<string, any>>,
@@ -22,6 +23,7 @@ export const createPieSpec = (
   const numericName = thetaColumn?.name;
   const categoryField = colorColumn?.column;
   const categoryName = colorColumn?.name;
+  const colorLegend = findLegend(styleOptions, 'color');
 
   const encodingBase = {
     theta: {
@@ -32,8 +34,12 @@ export const createPieSpec = (
     color: {
       field: categoryField,
       type: 'nominal',
-      legend: styleOptions.addLegend
-        ? { title: numericName, orient: styleOptions.legendPosition, symbolLimit: 10 }
+      legend: colorLegend?.show
+        ? {
+            title: colorLegend.title || numericName,
+            orient: colorLegend.position,
+            symbolLimit: 10,
+          }
         : null,
     },
   };

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.test.tsx
@@ -30,8 +30,10 @@ describe('createScatterConfig', () => {
     const defaults = config.ui.style.defaults as ScatterChartStyleControls;
     // Verify basic controls
     expect(defaults.tooltipOptions.mode).toBe('all');
-    expect(defaults.addLegend).toBe(true);
-    expect(defaults.legendPosition).toBe(Positions.RIGHT);
+    expect(defaults.legends[0].show).toBe(true); // Color legend
+    expect(defaults.legends[0].position).toBe(Positions.RIGHT);
+    expect(defaults.legends[1].show).toBe(true); // Size legend
+    expect(defaults.legends[1].position).toBe(Positions.RIGHT);
     // Verify exclusive style
     expect(defaults.exclusive.pointShape).toBe(PointShape.CIRCLE);
     expect(defaults.exclusive.angle).toBe(0);
@@ -58,14 +60,20 @@ describe('createScatterConfig', () => {
         tooltipOptions: {
           mode: 'hidden' as 'hidden',
         },
-        addLegend: false,
-        legendPosition: Positions.RIGHT,
+        legends: [
+          { role: 'color', show: false, position: Positions.RIGHT, title: '' },
+          { role: 'size', show: false, position: Positions.RIGHT, title: '' },
+        ],
         exclusive: {
           pointShape: PointShape.CIRCLE,
           angle: 0,
           filled: false,
         },
         standardAxes: [] as StandardAxes[],
+        titleOptions: {
+          show: false,
+          titleName: '',
+        },
       } as ScatterChartStyleControls,
       onStyleChange: jest.fn(),
       numericalColumns: [],

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.ts
@@ -16,6 +16,7 @@ import {
   TitleOptions,
 } from '../types';
 import { AXIS_LABEL_MAX_LENGTH } from '../constants';
+import { LegendOptions } from '../style_panel/legend/legend';
 
 export interface ExclusiveScatterConfig {
   pointShape: PointShape;
@@ -26,8 +27,7 @@ export interface ExclusiveScatterConfig {
 export interface ScatterChartStyleControls {
   // Basic controls
   tooltipOptions: TooltipOptions;
-  addLegend: boolean;
-  legendPosition: Positions;
+  legends: LegendOptions[];
   // Axes configuration
   standardAxes: StandardAxes[];
 
@@ -42,8 +42,10 @@ export const defaultScatterChartStyles: ScatterChartStyleControls = {
   tooltipOptions: {
     mode: 'all',
   },
-  addLegend: true,
-  legendPosition: Positions.RIGHT,
+  legends: [
+    { role: 'color', show: true, position: Positions.RIGHT, title: '' },
+    { role: 'size', show: true, position: Positions.RIGHT, title: '' },
+  ],
 
   // exclusive
   exclusive: {

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.test.tsx
@@ -67,12 +67,13 @@ jest.mock('@osd/i18n', () => ({
 }));
 
 jest.mock('./scatter_exclusive_vis_options', () => ({
-  ScatterExclusiveVisOptions: jest.fn(({ onChange }) => (
+  ScatterExclusiveVisOptions: jest.fn(({ styles, onChange }) => (
     <div data-test-subj="scatterExclusiveOptions">
       <button
         data-test-subj="changeScatterStyle"
         onClick={() =>
           onChange({
+            ...styles,
             pointShape: 'circle',
           })
         }
@@ -84,17 +85,18 @@ jest.mock('./scatter_exclusive_vis_options', () => ({
         data-test-subj="changeScatterFilled"
         onClick={() =>
           onChange({
-            filled: 'true',
+            ...styles,
+            filled: true,
           })
         }
       >
         Update Scatter Filled
       </button>
-
       <button
         data-test-subj="changeScatterAngled"
         onClick={() =>
           onChange({
+            ...styles,
             angle: 180,
           })
         }
@@ -113,13 +115,13 @@ jest.mock('../style_panel/legend/legend', () => {
       <div data-test-subj="mockLegendOptionsPanel">
         <button
           data-test-subj="mockLegendShow"
-          onClick={() => onLegendOptionsChange({ show: !legendOptions.show })}
+          onClick={() => onLegendOptionsChange(0, { show: !legendOptions[0].show })}
         >
           Toggle Legend
         </button>
         <button
           data-test-subj="mockLegendPosition"
-          onClick={() => onLegendOptionsChange({ position: PositionsEnum.BOTTOM })}
+          onClick={() => onLegendOptionsChange(0, { position: PositionsEnum.BOTTOM })}
         >
           Change Position
         </button>
@@ -252,13 +254,31 @@ describe('ScatterVisStyleControls (updated structure)', () => {
     // Test legend show toggle
     fireEvent.click(screen.getByTestId('mockLegendShow'));
     expect(propsWithCategoryColor.onStyleChange).toHaveBeenCalledWith({
-      addLegend: !mockProps.styleOptions.addLegend,
+      legends: [
+        {
+          ...propsWithCategoryColor.styleOptions.legends[0],
+          show: !propsWithCategoryColor.styleOptions.legends[0].show,
+        },
+        {
+          ...propsWithCategoryColor.styleOptions.legends[1],
+          show: !propsWithCategoryColor.styleOptions.legends[1].show,
+        },
+      ],
     });
 
     // Test legend position change
     fireEvent.click(screen.getByTestId('mockLegendPosition'));
     expect(propsWithCategoryColor.onStyleChange).toHaveBeenCalledWith({
-      legendPosition: Positions.BOTTOM,
+      legends: [
+        {
+          ...propsWithCategoryColor.styleOptions.legends[0],
+          position: Positions.BOTTOM,
+        },
+        {
+          ...propsWithCategoryColor.styleOptions.legends[1],
+          position: Positions.BOTTOM,
+        },
+      ],
     });
   });
 
@@ -323,6 +343,7 @@ describe('ScatterVisStyleControls (updated structure)', () => {
     fireEvent.click(screen.getByTestId('changeScatterStyle'));
     expect(onStyleChange).toHaveBeenCalledWith({
       exclusive: {
+        ...updatedProps.styleOptions.exclusive,
         pointShape: 'circle',
       },
     });
@@ -330,13 +351,15 @@ describe('ScatterVisStyleControls (updated structure)', () => {
     fireEvent.click(screen.getByTestId('changeScatterFilled'));
     expect(onStyleChange).toHaveBeenCalledWith({
       exclusive: {
-        filled: 'true',
+        ...updatedProps.styleOptions.exclusive,
+        filled: true,
       },
     });
 
     fireEvent.click(screen.getByTestId('changeScatterAngled'));
     expect(onStyleChange).toHaveBeenCalledWith({
       exclusive: {
+        ...updatedProps.styleOptions.exclusive,
         angle: 180,
       },
     });
@@ -383,7 +406,7 @@ describe('ScatterVisStyleControls (updated structure)', () => {
     const titleInput = screen.getByPlaceholderText('Default title');
     await userEvent.type(titleInput, 'New Chart Title');
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(mockProps.onStyleChange).toHaveBeenCalledWith({
         titleOptions: {
           ...props.styleOptions.titleOptions,

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.test.ts
@@ -71,8 +71,10 @@ describe('Scatter Chart to_expression', () => {
   const mockDateColumns: VisColumn[] = [];
 
   const mockStyles: Partial<ScatterChartStyleControls> = {
-    addLegend: true,
-    legendPosition: Positions.RIGHT,
+    legends: [
+      { role: 'color', show: true, position: Positions.RIGHT, title: '' },
+      { role: 'size', show: true, position: Positions.RIGHT, title: '' },
+    ],
     tooltipOptions: {
       mode: 'all',
     },
@@ -413,7 +415,7 @@ describe('Scatter Chart to_expression', () => {
       expect(customTitleResult.title).toBe('Custom Colored Scatter Chart');
     });
 
-    it('should include legend when addLegend is true', () => {
+    it('should include legend when legends[0].show is true', () => {
       const mockAxisColumnMappings: AxisColumnMappings = {
         [AxisRole.X]: mockNumericalColumns[0],
         [AxisRole.Y]: mockNumericalColumns[1],
@@ -435,10 +437,29 @@ describe('Scatter Chart to_expression', () => {
       expect(markLayer.encoding.color.legend).toHaveProperty('orient', Positions.RIGHT);
     });
 
-    it('should not include legend when addLegend is false', () => {
+    it('should not include legend when legends[0].show is false', () => {
       const stylesWithoutLegend = {
         ...mockStyles,
-        addLegend: false,
+        legends: [
+          {
+            ...(mockStyles.legends?.[0] ?? {
+              role: 'color',
+              show: false,
+              position: Positions.RIGHT,
+              title: '',
+            }),
+            show: false,
+          },
+          {
+            ...(mockStyles.legends?.[1] ?? {
+              role: 'size',
+              show: false,
+              position: Positions.RIGHT,
+              title: '',
+            }),
+            show: false,
+          },
+        ],
       };
 
       const mockAxisColumnMappings: AxisColumnMappings = {
@@ -567,7 +588,7 @@ describe('Scatter Chart to_expression', () => {
       expect(customTitleResult.title).toBe('Custom Sized Scatter Chart');
     });
 
-    it('should include size legend when addLegend is true', () => {
+    it('should include size legend when legends[1].show is true', () => {
       const mockAxisColumnMappings: AxisColumnMappings = {
         [AxisRole.X]: mockNumericalColumns[0],
         [AxisRole.Y]: mockNumericalColumns[1],
@@ -585,15 +606,35 @@ describe('Scatter Chart to_expression', () => {
       );
 
       const markLayer = result.layer[0];
+      expect(markLayer.encoding.size).toBeDefined();
       expect(markLayer.encoding.size.legend).toBeDefined();
       expect(markLayer.encoding.size.legend).toHaveProperty('title', 'Size');
       expect(markLayer.encoding.size.legend).toHaveProperty('orient', Positions.RIGHT);
     });
 
-    it('should not include size legend when addLegend is false', () => {
+    it('should not include size legend when legends[1].show is false', () => {
       const stylesWithoutLegend = {
         ...mockStyles,
-        addLegend: false,
+        legends: [
+          {
+            ...(mockStyles.legends?.[0] ?? {
+              role: 'color',
+              show: false,
+              position: Positions.RIGHT,
+              title: '',
+            }),
+            show: false,
+          },
+          {
+            ...(mockStyles.legends?.[1] ?? {
+              role: 'size',
+              show: false,
+              position: Positions.RIGHT,
+              title: '',
+            }),
+            show: false,
+          },
+        ],
       };
 
       const mockAxisColumnMappings: AxisColumnMappings = {
@@ -613,7 +654,7 @@ describe('Scatter Chart to_expression', () => {
       );
 
       const markLayer = result.layer[0];
-      expect(markLayer.encoding.size.legend).toBeNull();
+      expect(markLayer.encoding.size).toBeUndefined();
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
@@ -5,7 +5,7 @@
 
 import { ScatterChartStyleControls } from './scatter_vis_config';
 import { VisColumn, VEGASCHEMA, AxisColumnMappings } from '../types';
-import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis } from '../utils/utils';
+import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis, findLegend } from '../utils/utils';
 
 export const createTwoMetricScatter = (
   transformedData: Array<Record<string, any>>,
@@ -76,6 +76,8 @@ export const createTwoMetricOneCateScatter = (
   const categoryFields = axisColumnMappings?.color?.column!;
   const categoryNames = axisColumnMappings?.color?.name!;
   const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
+
+  const colorLegend = findLegend(styles, 'color');
   const markLayer = {
     mark: {
       type: 'point',
@@ -98,10 +100,10 @@ export const createTwoMetricOneCateScatter = (
       color: {
         field: categoryFields,
         type: getSchemaByAxis(colorColumn),
-        legend: styles?.addLegend
+        legend: colorLegend?.show
           ? {
-              title: categoryNames || 'Metrics',
-              orient: styles?.legendPosition,
+              title: colorLegend.title || categoryNames,
+              orient: colorLegend.position,
               symbolLimit: 10,
             }
           : null,
@@ -149,6 +151,8 @@ export const createThreeMetricOneCateScatter = (
   const categoryNames = axisColumnMappings?.color?.name!;
   const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getSwappedAxisRole(styles, axisColumnMappings);
 
+  const colorLegend = findLegend(styles, 'color');
+  const sizeLegend = findLegend(styles, 'size');
   const numericalSize = axisColumnMappings?.size;
   const markLayer = {
     mark: {
@@ -172,25 +176,26 @@ export const createThreeMetricOneCateScatter = (
       color: {
         field: categoryFields,
         type: getSchemaByAxis(colorColumn),
-        legend: styles?.addLegend
+        legend: colorLegend?.show
           ? {
-              title: categoryNames || 'Metrics',
-              orient: styles?.legendPosition,
+              title: colorLegend.title || categoryNames,
+              orient: colorLegend.position,
               symbolLimit: 10,
             }
           : null,
       },
-      size: {
-        field: numericalSize?.column,
-        type: getSchemaByAxis(numericalSize),
-        legend: styles?.addLegend
-          ? {
-              title: numericalSize?.name || 'Metrics',
-              orient: styles?.legendPosition,
+      ...(numericalSize &&
+        sizeLegend?.show && {
+          size: {
+            field: numericalSize.column,
+            type: getSchemaByAxis(numericalSize),
+            legend: {
+              title: sizeLegend.title || numericalSize.name,
+              orient: sizeLegend.position,
               symbolLimit: 10,
-            }
-          : null,
-      },
+            },
+          },
+        }),
       ...(styles.tooltipOptions?.mode !== 'hidden' && {
         tooltip: [
           {

--- a/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.test.tsx
@@ -15,10 +15,14 @@ jest.mock('@osd/i18n', () => ({
 }));
 
 describe('LegendOptionsPanel', () => {
-  const mockLegend = {
-    show: true,
-    position: Positions.BOTTOM,
-  };
+  const mockLegend = [
+    {
+      show: true,
+      position: Positions.BOTTOM,
+      role: 'color',
+      title: '',
+    },
+  ];
 
   const mockOnLegendChange = jest.fn();
 
@@ -46,7 +50,7 @@ describe('LegendOptionsPanel', () => {
     const legendModeSwitch = screen.getByTestId('legendModeSwitch');
 
     fireEvent.click(legendModeSwitch);
-    expect(mockOnLegendChange).toHaveBeenLastCalledWith({
+    expect(mockOnLegendChange).toHaveBeenLastCalledWith(0, {
       show: false,
     });
   });
@@ -59,7 +63,7 @@ describe('LegendOptionsPanel', () => {
     const legendPositionSelect = screen.getByTestId('legendPositionSelect');
 
     fireEvent.change(legendPositionSelect, { target: { value: Positions.RIGHT } });
-    expect(mockOnLegendChange).toHaveBeenLastCalledWith({
+    expect(mockOnLegendChange).toHaveBeenLastCalledWith(0, {
       position: Positions.RIGHT,
     });
   });

--- a/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.tsx
@@ -131,6 +131,7 @@ export const LegendOptionsPanel = ({
               options={legendPositionOptions}
               value={legendOptions[0]?.position}
               onChange={(e) => handlePositionChange(e.target.value as Positions)}
+              onMouseUp={(e) => e.stopPropagation()}
               data-test-subj="legendPositionSelect"
             />
           </EuiFormRow>

--- a/src/plugins/explore/public/components/visualizations/utils/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { LegendOptions } from '../style_panel/legend/legend';
 import {
   StandardAxes,
   ColorSchemas,
@@ -295,4 +296,11 @@ export function getThresholdByValue<T>(
   }
 
   return undefined;
+}
+
+export function findLegend<T extends { legends?: LegendOptions[] }>(
+  styles: T,
+  role: string
+): LegendOptions | undefined {
+  return styles?.legends?.find((l) => l.role === role);
 }


### PR DESCRIPTION
### Description

This PR enhances visualization by allowing users to customize the legend name. 

## Screenshot

### Single legend
<img width="2978" height="1428" alt="image" src="https://github.com/user-attachments/assets/e67c0919-2863-4ef8-82c3-f62c023fe37b" />

### Multiple legends
<img width="2976" height="1548" alt="image" src="https://github.com/user-attachments/assets/415c1768-b618-4487-a755-f690df0dd572" />

## Changelog
- feat: Allow customizing legend name

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
