### PR TITLE
[Explore] Patterns tab Error Handling updates

### DIFF
--- a/changelogs/fragments/10540.yml
+++ b/changelogs/fragments/10540.yml
@@ -1,0 +1,5 @@
+feat:
+- Custom patterns error page ([#10540](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10540))
+
+fix:
+- Prevent general query error from hiding tabs ([#10540](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10540))

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -64,7 +64,11 @@ export const registerBuiltInTabs = (
 
       const preparedQuery = getQueryWithSource(query);
       if (!patternsField) {
-        patternsField = findDefaultPatternsField(services);
+        try {
+          patternsField = findDefaultPatternsField(services);
+        } catch {
+          return preparedQuery.query;
+        }
       }
 
       if (state.tab.patterns.usingRegexPatterns)

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
@@ -251,9 +251,7 @@ describe('utils', () => {
         tabRegistry: { getTab: jest.fn().mockReturnValue({ id: 'logs' }) },
       } as any;
 
-      expect(() => findDefaultPatternsField(services)).toThrow(
-        'Unexpectedly cannot find a longest default patterns field'
-      );
+      expect(() => findDefaultPatternsField(services)).toThrow('Cannot access hits from logs tab');
       expect(setPatternsField).not.toHaveBeenCalled();
       expect(queryActions.defaultPrepareQueryString).toHaveBeenCalledWith(state.query);
     });
@@ -277,9 +275,7 @@ describe('utils', () => {
         tabRegistry: { getTab: jest.fn().mockReturnValue({ id: 'logs' }) },
       } as any;
 
-      expect(() => findDefaultPatternsField(services)).toThrow(
-        'Unexpectedly cannot find a longest default patterns field'
-      );
+      expect(() => findDefaultPatternsField(services)).toThrow('Cannot access hits from logs tab');
       expect(setPatternsField).not.toHaveBeenCalled();
       expect(queryActions.defaultPrepareQueryString).toHaveBeenCalledWith(state.query);
     });

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.ts
@@ -215,8 +215,12 @@ export const findDefaultPatternsField = (services: ExploreServices): string => {
     return field.type === 'string';
   });
 
+  if (!logResults?.hits?.hits?.[0]) {
+    throw new Error('Cannot access hits from logs tab');
+  }
+
   // Get the first hit if available
-  const firstHit = logResults?.hits?.hits?.[0];
+  const firstHit = logResults.hits.hits[0];
 
   if (firstHit && firstHit._source && filteredFields) {
     // Find the field with the longest value

--- a/src/plugins/explore/public/components/tabs/error_guard/error_guard.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/error_guard.tsx
@@ -11,6 +11,8 @@ import { EuiErrorBoundary, EuiFlexGroup, EuiIcon, EuiTitle } from '@elastic/eui'
 import { ErrorCodeBlock } from './error_code_block';
 import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
 import { useTabError } from '../../../application/utils/hooks/use_tab_error';
+import { EXPLORE_PATTERNS_TAB_ID } from '../../../../common';
+import { PatternsErrorGuard } from './patterns_error_guard';
 
 const errorDefaultTitle = i18n.translate('explore.errorPanel.defaultTitle', {
   defaultMessage: 'An error occurred while executing the query',
@@ -34,7 +36,9 @@ export const ErrorGuard = ({ registryTab, children }: ErrorGuardProps): JSX.Elem
     return <EuiErrorBoundary>{children}</EuiErrorBoundary>;
   }
 
-  return (
+  return registryTab.id === EXPLORE_PATTERNS_TAB_ID ? (
+    <PatternsErrorGuard registryTab={registryTab} />
+  ) : (
     <EuiErrorBoundary>
       <EuiFlexGroup direction="column" alignItems="center" className="exploreErrorGuard">
         <EuiIcon type="alert" size="xl" color="red" />

--- a/src/plugins/explore/public/components/tabs/error_guard/patterns_error_guard.test.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/patterns_error_guard.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PatternsErrorGuard } from './patterns_error_guard';
+import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+
+const mockStore = configureMockStore([]);
+
+const mockTabDefinition: TabDefinition = {
+  id: 'test-patterns-tab',
+  label: 'Test Patterns Tab',
+  component: () => <div>Test Component</div>,
+  flavor: ['logs'] as any,
+  supportedLanguages: ['PPL'],
+};
+
+describe('PatternsErrorGuard', () => {
+  it('renders with prepareQuery function', () => {
+    const store = mockStore({
+      query: {
+        language: 'PPL',
+      },
+    });
+
+    const customTabDefinition = {
+      ...mockTabDefinition,
+      prepareQuery: () => 'Custom prepared query',
+    };
+
+    render(
+      <Provider store={store}>
+        <PatternsErrorGuard registryTab={customTabDefinition} />
+      </Provider>
+    );
+
+    expect(screen.getByText('No valid patterns found')).toBeInTheDocument();
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('Custom prepared query')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/tabs/error_guard/patterns_error_guard.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/patterns_error_guard.tsx
@@ -8,24 +8,23 @@ import './error_guard.scss';
 import React from 'react';
 import { i18n } from '@osd/i18n';
 import {
-  EuiAccordion,
+  EuiCodeBlock,
+  EuiEmptyPrompt,
   EuiErrorBoundary,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiText,
 } from '@elastic/eui';
 import { useSelector } from 'react-redux';
 import { RootState } from 'src/plugins/data_explorer/public';
-import { ErrorCodeBlock } from './error_code_block';
 import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
 import { defaultPrepareQueryString } from '../../../application/utils/state_management/actions/query_actions';
 
 const detailsText = i18n.translate('explore.patternsErrorPanel.details', {
-  defaultMessage: 'Details (pattern query attempted)',
+  defaultMessage: 'Details',
 });
 const noValidPatternsText = i18n.translate('explore.patternsErrorPanel.noValidPatterns', {
-  defaultMessage: 'No valid pattern found',
+  defaultMessage: 'No valid patterns found',
 });
 
 export interface PatternsErrorGuardProps {
@@ -39,32 +38,27 @@ export const PatternsErrorGuard = ({ registryTab }: PatternsErrorGuardProps) => 
 
   return (
     <EuiErrorBoundary>
-      <EuiFlexGroup
-        direction="column"
-        alignItems="center"
-        className="exploreErrorGuard"
-        gutterSize="l"
-      >
-        <EuiFlexItem grow={false}>
-          <EuiAccordion
-            id={'no_valid_patterns'}
-            buttonContent={
-              <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
-                <EuiFlexItem grow={false}>
-                  <EuiIcon type={'navInfo'} />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiText>{noValidPatternsText}</EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            }
-          >
-            <div className="exploreErrorGuard__errorsSection">
-              <ErrorCodeBlock title={detailsText} text={patternsQuery} />
-            </div>
-          </EuiAccordion>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiEmptyPrompt
+        iconType="editorCodeBlock"
+        iconColor="default"
+        title={
+          <EuiText size="s">
+            <h2>{noValidPatternsText}</h2>
+          </EuiText>
+        }
+        body={
+          <EuiFlexGroup direction="column" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiText size="s" textAlign="left">
+                <b>{detailsText}</b>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCodeBlock isCopyable={true}>{patternsQuery}</EuiCodeBlock>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      />
     </EuiErrorBoundary>
   );
 };

--- a/src/plugins/explore/public/components/tabs/error_guard/patterns_error_guard.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/patterns_error_guard.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './error_guard.scss';
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import {
+  EuiAccordion,
+  EuiErrorBoundary,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+} from '@elastic/eui';
+import { useSelector } from 'react-redux';
+import { RootState } from 'src/plugins/data_explorer/public';
+import { ErrorCodeBlock } from './error_code_block';
+import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
+import { defaultPrepareQueryString } from '../../../application/utils/state_management/actions/query_actions';
+
+const detailsText = i18n.translate('explore.patternsErrorPanel.details', {
+  defaultMessage: 'Details (pattern query attempted)',
+});
+const noValidPatternsText = i18n.translate('explore.patternsErrorPanel.noValidPatterns', {
+  defaultMessage: 'No valid pattern found',
+});
+
+export interface PatternsErrorGuardProps {
+  registryTab: TabDefinition;
+}
+
+export const PatternsErrorGuard = ({ registryTab }: PatternsErrorGuardProps) => {
+  const query = useSelector((state: RootState) => state.query);
+  const prepareQuery = registryTab.prepareQuery || defaultPrepareQueryString;
+  const patternsQuery = prepareQuery(query);
+
+  return (
+    <EuiErrorBoundary>
+      <EuiFlexGroup
+        direction="column"
+        alignItems="center"
+        className="exploreErrorGuard"
+        gutterSize="l"
+      >
+        <EuiFlexItem grow={false}>
+          <EuiAccordion
+            id={'no_valid_patterns'}
+            buttonContent={
+              <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiIcon type={'navInfo'} />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText>{noValidPatternsText}</EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            }
+          >
+            <div className="exploreErrorGuard__errorsSection">
+              <ErrorCodeBlock title={detailsText} text={patternsQuery} />
+            </div>
+          </EuiAccordion>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiErrorBoundary>
+  );
+};

--- a/src/plugins/explore/public/components/tabs/patterns_tab.tsx
+++ b/src/plugins/explore/public/components/tabs/patterns_tab.tsx
@@ -6,9 +6,6 @@ import React from 'react';
 import { ActionBar } from './action_bar/action_bar';
 import { PatternsContainer } from '../patterns_table/patterns_container';
 
-/**
- * Logs tab component for displaying log entries
- */
 export const PatternsTab = () => {
   return (
     <div className="explore-logs-tab tab-container">


### PR DESCRIPTION
### Description

<img width="2544" height="1298" alt="image" src="https://github.com/user-attachments/assets/fa5a7772-e08d-4fa1-9ce3-eff9e6f86cf9" />
Invalid query doesn't error out the page anymore (the 'errors' popping up from an incorrect query were not thrown as before), and now there is a UI page that shows the pattern query attempted.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- feat: Custom patterns error page
- fix: Prevent general query error from hiding tabs

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
