### PR TITLE
[Query enhancements] support `supportedAppNames` for type config

### DIFF
--- a/src/plugins/data/public/query/query_string/dataset_service/types.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/types.ts
@@ -64,6 +64,8 @@ export interface DatasetTypeConfig {
     isFieldLoadAsync?: boolean;
     /** Optional cacheOptions determines if the data structure is cacheable. Defaults to false */
     cacheOptions?: boolean;
+    /** Optional list of supported apps. If undefined, it will show up in all apps */
+    supportedAppNames?: string[];
   };
   /**
    * Converts a DataStructure to a Dataset.

--- a/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
@@ -37,6 +37,11 @@ export const AdvancedSelector = ({
       children: queryString
         .getDatasetService()
         .getTypes()
+        .filter(
+          (type) =>
+            type.meta.supportedAppNames === undefined ||
+            type.meta.supportedAppNames.includes(services.appName)
+        )
         .map((type) => {
           return {
             id: type.id,


### PR DESCRIPTION
### Description

We have Classic Discover and new Discover (Explore), and some dataset type config might change between them. It would be easier to duplicate and keep the logic separate, but we don't want to show both in Discover picker. By supporting `supportedAppNames`, we can indicate which app the dataset type config should appear.

For backward compatibility, if a dataset type config does not specify this option, it will show up in all versions of Discover.

Note that https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10379 added `explore.supportedTypes` configuration, but this does not allowing controlling Classic Discover behavior, and we also cannot put an exhaustive supported types to Classic Discover.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
