### PR TITLE
[Explore] add a flag to config discover vis theme from localStorage for development

### DIFF
--- a/changelogs/fragments/10548.yml
+++ b/changelogs/fragments/10548.yml
@@ -1,0 +1,2 @@
+refactor:
+- Add a flag to config discover vis theme from localStorage for development ([#10548](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10548))

--- a/src/plugins/explore/public/components/visualizations/theme/default_colors.ts
+++ b/src/plugins/explore/public/components/visualizations/theme/default_colors.ts
@@ -3,51 +3,69 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { darkMode } from '@osd/ui-shared-deps/theme';
+import { euiPaletteColorBlind } from '@elastic/eui';
+import { darkMode, euiThemeVars } from '@osd/ui-shared-deps/theme';
 
 export const getColors = () => {
-  if (darkMode) {
+  // Temporary change to rollout discover visualization theme changes for development before OUI theme changes
+  // been implemented accordingly.
+  const isExperimental =
+    localStorage.getItem('__DEVELOPMENT__.discover.vis.theme') === 'experimental';
+  if (isExperimental) {
+    if (darkMode) {
+      return {
+        statusBlue: '#006CE0',
+        statusGreen: '#00BD6B',
+        statusYellow: '#F90',
+        statusOrange: '#FF6A3D',
+        statusRed: '#DB0000',
+        text: '#FFF',
+        grid: '#27252C',
+        categories: [
+          '#7598FF',
+          '#A669E2',
+          '#FF4B14',
+          '#F90',
+          '#006CE0',
+          '#008559',
+          '#EB003B',
+          '#FFE8BD',
+          '#00A4BD',
+          '#D600BA',
+        ],
+      };
+    }
     return {
-      statusBlue: '#006CE0',
+      statusBlue: '#004A9E',
       statusGreen: '#00BD6B',
       statusYellow: '#F90',
       statusOrange: '#FF6A3D',
       statusRed: '#DB0000',
-      text: '#FFF',
-      grid: '#27252C',
+      text: '#313131',
+      grid: '#F5F7FF',
       categories: [
-        '#7598FF',
+        '#5C7FFF',
         '#A669E2',
         '#FF4B14',
         '#F90',
-        '#006CE0',
-        '#008559',
+        '#003B8F',
+        '#005237',
         '#EB003B',
-        '#FFE8BD',
+        '#7A2B00',
         '#00A4BD',
-        '#D600BA',
+        '#B2008F',
       ],
     };
   }
+
   return {
     statusBlue: '#004A9E',
     statusGreen: '#00BD6B',
     statusYellow: '#F90',
     statusOrange: '#FF6A3D',
     statusRed: '#DB0000',
-    text: '#313131',
-    grid: '#F5F7FF',
-    categories: [
-      '#5C7FFF',
-      '#A669E2',
-      '#FF4B14',
-      '#F90',
-      '#003B8F',
-      '#005237',
-      '#EB003B',
-      '#7A2B00',
-      '#00A4BD',
-      '#B2008F',
-    ],
+    text: euiThemeVars.euiTextColor,
+    grid: euiThemeVars.euiColorChartLines,
+    categories: euiPaletteColorBlind(),
   };
 };


### PR DESCRIPTION
### Description
Enable experimental discover visualization theme by adding this to localStroage: `__DEVELOPMENT__.discover.vis.theme: experimental`, this is just for development purpose so we can rollout discover visualization theme changes which are depended by subsequence PRs without changing the current vis color palettes.

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- refactor: add a flag to config discover vis theme from localStorage for development

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
