### PR TITLE
Trace:Details Filter out spans without timestamp nano field

### DIFF
--- a/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.test.tsx
@@ -179,6 +179,8 @@ describe('TraceDetails', () => {
       name: 'operation-1',
       startTime: '2023-01-01T00:00:00Z',
       endTime: '2023-01-01T00:00:01Z',
+      startTimeUnixNano: '2023-01-01T00:00:00.000000000Z',
+      endTimeUnixNano: '2023-01-01T00:00:01.000000000Z',
       durationInNanos: 1000000000,
     },
     {
@@ -188,6 +190,8 @@ describe('TraceDetails', () => {
       name: 'operation-2',
       startTime: '2023-01-01T00:00:01Z',
       endTime: '2023-01-01T00:00:02Z',
+      startTimeUnixNano: '2023-01-01T00:00:01.000000000Z',
+      endTimeUnixNano: '2023-01-01T00:00:02.000000000Z',
       durationInNanos: 1000000000,
     },
   ];
@@ -430,6 +434,8 @@ describe('TraceDetails', () => {
         name: 'operation-1',
         startTime: '2023-01-01T00:00:02Z', // Later start time
         parentSpanId: 'parent-1', // Has parent
+        startTimeUnixNano: '2023-01-01T00:00:02.000000000Z',
+        endTimeUnixNano: '2023-01-01T00:00:03.000000000Z',
       },
       {
         spanId: 'span-2',
@@ -438,6 +444,8 @@ describe('TraceDetails', () => {
         name: 'operation-2',
         startTime: '2023-01-01T00:00:01Z', // Earlier start time
         parentSpanId: 'parent-2', // Has parent
+        startTimeUnixNano: '2023-01-01T00:00:01.000000000Z',
+        endTimeUnixNano: '2023-01-01T00:00:02.000000000Z',
       },
     ];
 
@@ -453,6 +461,45 @@ describe('TraceDetails', () => {
 
     await waitFor(() => {
       expect(document.querySelector('[data-testid="span-detail-sidebar"]')).toBeInTheDocument();
+    });
+  });
+
+  it('filters spans without timestamp fields', async () => {
+    const mockDataWithoutTimestamps = [
+      {
+        spanId: 'span-1',
+        traceId: 'test-trace-id',
+        serviceName: 'service-a',
+        name: 'operation-1',
+        startTime: '2023-01-01T00:00:00Z',
+        endTime: null,
+        startTimeUnixNano: '2023-01-01T00:00:00.000000000Z',
+        endTimeUnixNano: null,
+      },
+      {
+        spanId: 'span-2',
+        traceId: 'test-trace-id',
+        serviceName: 'service-b',
+        name: 'operation-2',
+        startTime: null,
+        endTime: '2023-01-01T00:00:02Z',
+        startTimeUnixNano: null,
+        endTimeUnixNano: '2023-01-01T00:00:02.000000000Z',
+      },
+    ];
+
+    mockTransformPPLDataToTraceHits.mockImplementation(() => mockDataWithoutTimestamps);
+
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <TraceDetails />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="no-match-message"]')).toBeInTheDocument();
     });
   });
 
@@ -616,6 +663,8 @@ describe('TraceDetails', () => {
         serviceName: 'service-a',
         name: 'operation-1',
         status: { code: 2 }, // Error
+        startTimeUnixNano: '2023-01-01T00:00:00.000000000Z',
+        endTimeUnixNano: '2023-01-01T00:00:01.000000000Z',
       },
       {
         spanId: 'span-2',
@@ -623,6 +672,8 @@ describe('TraceDetails', () => {
         serviceName: 'service-b',
         name: 'operation-2',
         status: { code: 0 }, // No error
+        startTimeUnixNano: '2023-01-01T00:00:01.000000000Z',
+        endTimeUnixNano: '2023-01-01T00:00:02.000000000Z',
       },
     ];
 

--- a/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
@@ -233,6 +233,7 @@ export const TraceDetails: React.FC<TraceDetailsProps> = ({
         }
       });
     }
+    hits = hits.filter((hit) => !!hit.startTimeUnixNano && !!hit.endTimeUnixNano);
 
     setTransformedHits(hits);
     if (spanFilters.length === 0) {

--- a/src/plugins/explore/public/components/doc_viewer/trace_details_view/trace_details_view.tsx
+++ b/src/plugins/explore/public/components/doc_viewer/trace_details_view/trace_details_view.tsx
@@ -150,7 +150,10 @@ export function TraceDetailsView({ hit }: DocViewRenderProps) {
           filters: [],
         });
 
-        const transformed = transformPPLDataToTraceHits(response);
+        let transformed = transformPPLDataToTraceHits(response);
+        transformed = transformed.filter(
+          (transformedHit) => !!transformedHit.startTimeUnixNano && !!transformedHit.endTimeUnixNano
+        );
         setTransformedHits(transformed);
       } catch (err) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
### Description
Filter out spans missing the `startTimeUnixNano` or `endTimeUnixNano` field since they will show as having a negative duration in the span timeline. 

### Issues Resolved

## Screenshot

Before: 
<img width="1145" height="723" alt="Screenshot 2025-09-22 at 12 16 24 PM" src="https://github.com/user-attachments/assets/89a5f78f-29e0-4743-ac87-68d283ca475f" />

After:
<img width="1143" height="612" alt="Screenshot 2025-09-22 at 12 15 51 PM" src="https://github.com/user-attachments/assets/21cb9c11-6a8c-4dfc-abbb-4eea24afe84c" />



## Testing the changes

## Changelog

### Check List

- [ x ] All tests pass
  - [ x ] `yarn test:jest`
  - [ x ] `yarn test:jest_integration`
- [ x ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ x ] Commits are signed per the DCO using --signoff
