### PR TITLE
[Explore] show query panel even if there are no datasets

### DIFF
--- a/changelogs/fragments/10557.yml
+++ b/changelogs/fragments/10557.yml
@@ -1,0 +1,2 @@
+feat:
+- Show query panel in Explore even if there are no datasets ([#10557](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10557))

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -18,7 +18,6 @@ import { useUrlStateSync } from '../../utils/hooks/use_url_state_sync';
 import { useTimefilterSubscription } from '../../utils/hooks/use_timefilter_subscription';
 import { useHeaderVariants } from '../../utils/hooks/use_header_variants';
 import { NewExperienceBanner } from '../../../components/experience_banners/new_experience_banner';
-import { useDatasetContext } from '../../context';
 import { BottomContainer } from '../../../components/container/bottom_container';
 import { TopNav } from '../../../components/top_nav/top_nav';
 import { useInitPage } from '../../../application/utils/hooks/use_page_initialization';
@@ -36,7 +35,6 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
   setHeaderActionMenu,
 }) => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
-  const { dataset, isLoading } = useDatasetContext();
   const { savedExplore } = useInitPage();
   const { keyboardShortcut } = services;
   const dispatch = useDispatch();
@@ -94,7 +92,7 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
             <NewExperienceBanner />
 
             <div className="dscCanvas__queryPanel">
-              {dataset && !isLoading ? <QueryPanel /> : null}
+              <QueryPanel />
             </div>
 
             {/* Main content area with resizable panels under QueryPanel */}


### PR DESCRIPTION
### Description

Currently Discover shows a blank page when there is associated datasource (opensearch cluster) but no index-pattern. This is confusing to the user, because they should be able to still search the cluster using `Indexes` without creating an index-pattern, but they must create an index pattern first in order to see the dataset picker that will be used to pick `Indexes`.

This PR allows selecting/creating a dataset when there's no current dataset selected.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- feat: show query panel in Explore even if there are no datasets

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
