### PR TITLE
Add '_q' to list of allowed url params

### DIFF
--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.test.ts
@@ -32,6 +32,39 @@ import { mockStorage } from '../../storage/hashed_item_store/mock';
 import { HashedItemStore } from '../../storage/hashed_item_store';
 import { hashUrl, unhashUrl } from './hash_unhash_url';
 
+interface Param {
+  rison: string;
+  hash: string;
+  state: any;
+}
+
+const stateParamsFixture: { [key: string]: Param } = {
+  _g: { rison: '(yes:!t)', hash: 'h@4e60e02', state: { yes: true } },
+  _a: { rison: '(yes:!f)', hash: 'h@61fa078', state: { yes: false } },
+  _someOther: { rison: '(yes:!f)', hash: 'willNotBeHashed', state: undefined },
+  _q: { rison: '(name:opensearch)', hash: 'h@68be80e', state: { name: 'opensearch' } },
+};
+
+const createExpandedQueryParamString = (params: { [key: string]: any } = stateParamsFixture) => {
+  return Object.keys(params)
+    .map((key: string) => `${key}=${params[key].rison}`)
+    .join('&');
+};
+
+const createHashedQueryParamString = (params: { [key: string]: Param } = stateParamsFixture) => {
+  return Object.keys(params)
+    .map((key: string) => `${key}=${params[key].hash}`)
+    .join('&');
+};
+
+const assertParamIsInStore = (param: Param) => {
+  expect(mockStorage.getItem(param.hash)).toEqual(JSON.stringify(param.state));
+};
+
+const assertPersistedIndexKeyIsPresent = () => {
+  expect(mockStorage.getItem(HashedItemStore.PERSISTED_INDEX_KEY)).toBeTruthy();
+};
+
 describe('hash unhash url', () => {
   beforeEach(() => {
     mockStorage.clear();
@@ -124,62 +157,53 @@ describe('hash unhash url', () => {
     describe('replaces expanded state with hash', () => {
       it('if uses single state param', () => {
         const stateParamKey = '_g';
-        const stateParamValue = '(yes:!t)';
-        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey}=${stateParamValue}`;
+        const stateParam = stateParamsFixture[stateParamKey];
+        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey}=${stateParam.rison}`;
+
         const result = hashUrl(url);
-        expect(result).toMatchInlineSnapshot(
-          `"https://localhost:5601/app/discover#/?foo=bar&_g=h@4e60e02"`
-        );
-        expect(mockStorage.getItem('osd.hashedItemsIndex.v1')).toBeTruthy();
-        expect(mockStorage.getItem('h@4e60e02')).toEqual(JSON.stringify({ yes: true }));
+
+        const expectedUrl = `"https://localhost:5601/app/discover#/?foo=bar&_g=h@4e60e02"`;
+        expect(result).toMatchInlineSnapshot(expectedUrl);
+        assertPersistedIndexKeyIsPresent();
+        assertParamIsInStore(stateParam);
       });
 
       it('if uses multiple states params', () => {
-        const stateParamKey1 = '_g';
-        const stateParamValue1 = '(yes:!t)';
-        const stateParamKey2 = '_a';
-        const stateParamValue2 = '(yes:!f)';
-        const stateParamKey3 = '_b';
-        const stateParamValue3 = '(yes:!f)';
-        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey1}=${stateParamValue1}&${stateParamKey2}=${stateParamValue2}&${stateParamKey3}=${stateParamValue3}`;
-        const result = hashUrl(url);
-        expect(result).toMatchInlineSnapshot(
-          `"https://localhost:5601/app/discover#/?foo=bar&_g=h@4e60e02&_a=h@61fa078&_b=(yes:!f)"`
-        );
-        expect(mockStorage.getItem('h@4e60e02')).toEqual(JSON.stringify({ yes: true }));
-        expect(mockStorage.getItem('h@61fa078')).toEqual(JSON.stringify({ yes: false }));
+        const givenExpandedUrl = `https://localhost:5601/app/discover#/?foo=bar&${createExpandedQueryParamString()}`;
+
+        const actualUrl = hashUrl(givenExpandedUrl);
+
+        const expectedUrl = `"https://localhost:5601/app/discover#/?foo=bar&_g=h@4e60e02&_a=h@61fa078&_someOther=(yes:!f)&_q=h@68be80e"`;
+        expect(actualUrl).toMatchInlineSnapshot(expectedUrl);
+        assertParamIsInStore(stateParamsFixture._g);
+        assertParamIsInStore(stateParamsFixture._a);
+        assertParamIsInStore(stateParamsFixture._q);
+        assertParamIsInStore(stateParamsFixture._g);
         if (!HashedItemStore.PERSISTED_INDEX_KEY) {
           // This is very brittle and depends upon HashedItemStore implementation details,
           // so let's protect ourselves from accidentally breaking this test.
           throw new Error('Missing HashedItemStore.PERSISTED_INDEX_KEY');
         }
-        expect(mockStorage.getItem(HashedItemStore.PERSISTED_INDEX_KEY)).toBeTruthy();
-        expect(mockStorage.length).toBe(3);
+        assertPersistedIndexKeyIsPresent();
+        expect(mockStorage.length).toBe(4);
       });
 
       it('hashes only allow-listed properties', () => {
-        const stateParamKey1 = '_g';
-        const stateParamValue1 = '(yes:!t)';
-        const stateParamKey2 = '_a';
-        const stateParamValue2 = '(yes:!f)';
-        const stateParamKey3 = '_someother';
-        const stateParamValue3 = '(yes:!f)';
-        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey1}=${stateParamValue1}&${stateParamKey2}=${stateParamValue2}&${stateParamKey3}=${stateParamValue3}`;
-        const result = hashUrl(url);
-        expect(result).toMatchInlineSnapshot(
-          `"https://localhost:5601/app/discover#/?foo=bar&_g=h@4e60e02&_a=h@61fa078&_someother=(yes:!f)"`
-        );
+        const url = `https://localhost:5601/app/discover#/?foo=bar&${createExpandedQueryParamString()}`;
 
-        expect(mockStorage.length).toBe(3); // 2 hashes + HashedItemStoreSingleton.PERSISTED_INDEX_KEY
+        const actualUrl = hashUrl(url);
+
+        const expectedUrl = `"https://localhost:5601/app/discover#/?foo=bar&_g=h@4e60e02&_a=h@61fa078&_someOther=(yes:!f)&_q=h@68be80e"`;
+        expect(actualUrl).toMatchInlineSnapshot(expectedUrl);
+        expect(mockStorage.length).toBe(4); // 3 hashes + HashedItemStoreSingleton.PERSISTED_INDEX_KEY
       });
     });
 
     it('throws error if unable to hash url', () => {
-      const stateParamKey1 = '_g';
-      const stateParamValue1 = '(yes:!t)';
+      const stateParamKey = '_g';
       mockStorage.setStubbedSizeLimit(1);
 
-      const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey1}=${stateParamValue1}`;
+      const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey}=${stateParamsFixture[stateParamKey].rison}`;
       expect(() => hashUrl(url)).toThrowError();
     });
   });
@@ -258,58 +282,50 @@ describe('hash unhash url', () => {
     describe('replaces expanded state with hash', () => {
       it('if uses single state param', () => {
         const stateParamKey = '_g';
-        const stateParamValueHashed = 'h@4e60e02';
-        const state = { yes: true };
-        mockStorage.setItem(stateParamValueHashed, JSON.stringify(state));
+        const param = stateParamsFixture[stateParamKey];
+        mockStorage.setItem(param.hash, JSON.stringify(param.state));
+        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey}=${param.hash}`;
 
-        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey}=${stateParamValueHashed}`;
-        const result = unhashUrl(url);
-        expect(result).toMatchInlineSnapshot(
+        const actualUrl = unhashUrl(url);
+
+        expect(actualUrl).toMatchInlineSnapshot(
           `"https://localhost:5601/app/discover#/?foo=bar&_g=(yes:!t)"`
         );
       });
 
       it('if uses multiple state param', () => {
-        const stateParamKey1 = '_g';
-        const stateParamValueHashed1 = 'h@4e60e02';
-        const state1 = { yes: true };
-
-        const stateParamKey2 = '_a';
-        const stateParamValueHashed2 = 'h@61fa078';
-        const state2 = { yes: false };
-
-        mockStorage.setItem(stateParamValueHashed1, JSON.stringify(state1));
-        mockStorage.setItem(stateParamValueHashed2, JSON.stringify(state2));
-
-        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey1}=${stateParamValueHashed1}&${stateParamKey2}=${stateParamValueHashed2}`;
-        const result = unhashUrl(url);
-        expect(result).toMatchInlineSnapshot(
-          `"https://localhost:5601/app/discover#/?foo=bar&_g=(yes:!t)&_a=(yes:!f)"`
+        ['_g', '_a'].forEach((key) =>
+          mockStorage.setItem(
+            stateParamsFixture[key].hash,
+            JSON.stringify(stateParamsFixture[key].state)
+          )
         );
+        const hashedQueryParamString = createHashedQueryParamString({
+          _g: stateParamsFixture._g,
+          _a: stateParamsFixture._a,
+        });
+
+        const givenUrl = `https://localhost:5601/app/discover#/?foo=bar&${hashedQueryParamString}`;
+        const actualUrl = unhashUrl(givenUrl);
+
+        const expectedExpandedUrl = `"https://localhost:5601/app/discover#/?foo=bar&_g=(yes:!t)&_a=(yes:!f)"`;
+        expect(actualUrl).toMatchInlineSnapshot(expectedExpandedUrl);
       });
 
       it('un-hashes only allow-listed properties', () => {
-        const stateParamKey1 = '_g';
-        const stateParamValueHashed1 = 'h@4e60e02';
-        const state1 = { yes: true };
-
-        const stateParamKey2 = '_a';
-        const stateParamValueHashed2 = 'h@61fa078';
-        const state2 = { yes: false };
-
-        const stateParamKey3 = '_someother';
-        const stateParamValueHashed3 = 'h@61fa078';
-        const state3 = { yes: false };
-
-        mockStorage.setItem(stateParamValueHashed1, JSON.stringify(state1));
-        mockStorage.setItem(stateParamValueHashed2, JSON.stringify(state2));
-        mockStorage.setItem(stateParamValueHashed3, JSON.stringify(state3));
-
-        const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey1}=${stateParamValueHashed1}&${stateParamKey2}=${stateParamValueHashed2}&${stateParamKey3}=${stateParamValueHashed3}`;
-        const result = unhashUrl(url);
-        expect(result).toMatchInlineSnapshot(
-          `"https://localhost:5601/app/discover#/?foo=bar&_g=(yes:!t)&_a=(yes:!f)&_someother=h@61fa078"`
+        const paramKeys = Object.keys(stateParamsFixture);
+        paramKeys.forEach((key) =>
+          mockStorage.setItem(
+            stateParamsFixture[key].hash,
+            JSON.stringify(stateParamsFixture[key].state)
+          )
         );
+        const givenHashedUrl = `https://localhost:5601/app/discover#/?foo=bar&${createHashedQueryParamString()}`;
+
+        const actualUrl = unhashUrl(givenHashedUrl);
+
+        const expectedUrl = `"https://localhost:5601/app/discover#/?foo=bar&_g=(yes:!t)&_a=(yes:!f)&_someOther=willNotBeHashed&_q=(name:opensearch)"`;
+        expect(actualUrl).toMatchInlineSnapshot(expectedUrl);
       });
     });
 
@@ -326,15 +342,10 @@ describe('hash unhash url', () => {
 
   describe('hash unhash url integration', () => {
     it('hashing and unhashing url should produce the same result', () => {
-      const stateParamKey1 = '_g';
-      const stateParamValue1 = '(yes:!t)';
-      const stateParamKey2 = '_a';
-      const stateParamValue2 = '(yes:!f)';
-      const stateParamKey3 = '_someother';
-      const stateParamValue3 = '(yes:!f)';
-      const url = `https://localhost:5601/app/discover#/?foo=bar&${stateParamKey1}=${stateParamValue1}&${stateParamKey2}=${stateParamValue2}&${stateParamKey3}=${stateParamValue3}`;
-      const result = unhashUrl(hashUrl(url));
-      expect(url).toEqual(result);
+      const expectedUrl = `https://localhost:5601/app/discover#/?foo=bar&${createExpandedQueryParamString()}`;
+      const actualUrl = unhashUrl(hashUrl(expectedUrl));
+
+      expect(actualUrl).toEqual(expectedUrl);
     });
   });
 });

--- a/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/state_management/url/hash_unhash_url.ts
@@ -47,7 +47,7 @@ export const hashUrl = createQueryReplacer(hashQuery);
 // naive hack, but this allows to decouple these utils from AppState, GlobalState for now
 // when removing AppState, GlobalState and migrating to IState containers,
 // need to make sure that apps explicitly passing this allow-list to hash
-const __HACK_HARDCODED_LEGACY_HASHABLE_PARAMS = ['_g', '_a', '_s'];
+const __HACK_HARDCODED_LEGACY_HASHABLE_PARAMS = ['_g', '_a', '_s', '_q'];
 function createQueryMapper(queryParamMapper: (q: string) => string | null) {
   return (
     query: IParsedUrlQuery,


### PR DESCRIPTION
### Description

This PR fixes issue #10460 as well as backports a [fix regarding link sharing ](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529/)

When sharing discovery links while the setting 'UseSessionStorage' for url params is activated url parameters have to be resolved (e.g. loaded from the session storage) before beeing useful for sharing.

Currently, the there is a parameter (_q) that's been explicitely excluded from the process of resolution, resulting in an error, when the shared link is beeing used on another machine. 

### Issues Resolved

#10460 

## Changelog

- add Parameter '_q' to the whitelist for parameter expansion
- refactor tests to improve maintainability
- backport fix from [this PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529/)



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
