### PR TITLE
Fix focus  add/remove column 

### DIFF
--- a/changelogs/fragments/10582.yml
+++ b/changelogs/fragments/10582.yml
@@ -1,0 +1,2 @@
+fix:
+- Remove index from field key to fix column focus issue ([#10582](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10582))

--- a/src/plugins/explore/public/components/fields_selector/field_list.tsx
+++ b/src/plugins/explore/public/components/fields_selector/field_list.tsx
@@ -50,11 +50,11 @@ export const FieldList = ({
         {title}
       </EuiButtonEmpty>
       {expanded &&
-        fields.map((field: DataViewField, index) => {
+        fields.map((field: DataViewField) => {
           return (
             <EuiPanel
               data-attr-field={field.name}
-              key={field.name + index}
+              key={field.name}
               paddingSize="none"
               hasBorder={false}
               hasShadow={false}


### PR DESCRIPTION
### Description

 Changed the React key from field.name + index to just field.name since:
  - Field names are unique and stable identifiers
  - This ensures React correctly tracks each field component across re-renders
  - Focus management will now work properly when fields are added/removed
  

## Screenshot


https://github.com/user-attachments/assets/fdd47fed-6a1b-4c20-b3b9-f43843abc3ed


## Changelog
- fix:  Remove index from field key to fix column focus issue


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
