### PR TITLE
Add Query Snippet Suggestions

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/05/autocomplete_ui.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/05/autocomplete_ui.spec.js
@@ -117,17 +117,6 @@ export const runAutocompleteTests = () => {
             validateQueryResults('unique_category', 'Development');
           });
 
-          it('should validate that error markers are shown for invalide query', () => {
-            cy.explore.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
-            setDatePickerDatesAndSearchIfRelevant(config.language);
-            cy.wait(2000);
-            cy.explore.clearQueryEditor();
-
-            createInvalidQuery(config); // use keyboard
-
-            validateEditorContainsError();
-          });
-
           it('should validate that error markers are shown for invalid query', () => {
             cy.explore.setDataset(config.dataset, DATASOURCE_NAME, config.datasetType);
             setDatePickerDatesAndSearchIfRelevant(config.language);

--- a/cypress/utils/apps/explore/autocomplete.js
+++ b/cypress/utils/apps/explore/autocomplete.js
@@ -36,7 +36,19 @@ export const typeAndVerifySuggestion = (input, expectedSuggestion) => {
   cy.get('.suggest-widget')
     .should('be.visible')
     .within(() => {
-      cy.get('.monaco-list-row').should('exist').contains(expectedSuggestion);
+      cy.get('.monaco-list-row')
+        .should('exist')
+        .then(($rows) => {
+          const matchFound = $rows.toArray().some((row) => {
+            const extractedSuggestion = Cypress.$(row)
+              .find('.monaco-icon-label-container .label-name')
+              .text();
+            return (
+              extractedSuggestion.trim().toLowerCase() === expectedSuggestion.trim().toLowerCase()
+            );
+          });
+          expect(matchFound).to.be.true;
+        });
     });
 };
 
@@ -51,7 +63,10 @@ export const selectSpecificSuggestion = (suggestionText) => {
       cy.get('.monaco-list-row.focused').then(() => {
         cy.get('.monaco-list-row').then(($rows) => {
           const exactMatch = $rows.filter((_, row) => {
-            return Cypress.$(row).text().includes(suggestionText);
+            const extractedSuggestion = Cypress.$(row)
+              .find('.monaco-icon-label-container .label-name')
+              .text();
+            return extractedSuggestion.trim().toLowerCase() === suggestionText.trim().toLowerCase();
           });
 
           if (exactMatch.length > 0) {
@@ -203,9 +218,23 @@ export const selectSuggestion = (suggestionText, useKeyboard = false) => {
         .some((row) => Cypress.$(row).text().includes(suggestionText));
 
       if (isVisible) {
+        const getMatchingSuggestion = ($rows) => {
+          return $rows.toArray().find((row) => {
+            const $row = Cypress.$(row);
+            const extractedSuggestion = $row
+              .find('.monaco-icon-label-container .label-name')
+              .text();
+            return extractedSuggestion.trim().toLowerCase() === suggestionText.trim().toLowerCase();
+          });
+        };
+
         if (useKeyboard) {
-          const highlightedRow = $rows.filter('.focused').text();
-          if (highlightedRow.includes(suggestionText)) {
+          const highlightedRow = $rows.filter('.focused');
+          const extractedSuggestion = highlightedRow
+            .find('.monaco-icon-label-container .label-name')
+            .text();
+          cy.log('Pikachu says:', extractedSuggestion);
+          if (extractedSuggestion.trim().toLowerCase() === suggestionText.trim().toLowerCase()) {
             return cy.get('.inputarea').trigger('keydown', {
               key: 'Tab',
               keyCode: 9,
@@ -214,7 +243,10 @@ export const selectSuggestion = (suggestionText, useKeyboard = false) => {
             });
           }
         } else {
-          return cy.get('.monaco-list-row').contains(suggestionText).click({ force: true });
+          const matchingRow = getMatchingSuggestion($rows);
+          if (matchingRow) {
+            return cy.wrap(matchingRow).click({ force: true });
+          }
         }
       }
       return cy

--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
@@ -31,6 +31,25 @@ import {
   KEYWORD_ITEM_KIND_MAP,
 } from './constants';
 import { Documentation } from './ppl_documentation';
+import { getPPLQuerySnippetForSuggestions } from '../../query_snippet_suggestions/ppl/suggestions';
+
+// Utility function to extract query text up to cursor position
+const extractQueryTillCursor = (
+  fullQuery: string,
+  cursorPosition: { lineNumber: number; column: number }
+) => {
+  const lines = fullQuery.split('\n');
+
+  // Get all lines before the cursor line
+  const linesBefore = lines.slice(0, cursorPosition.lineNumber - 1);
+
+  // Get the current line up to cursor position
+  const currentLine = lines[cursorPosition.lineNumber - 1] || '';
+  const currentLineUpToCursor = currentLine.slice(0, cursorPosition.column - 1);
+
+  // Combine all text up to cursor
+  return [...linesBefore, currentLineUpToCursor].join('\n');
+};
 // Centralized function to generate appropriate insertion text based on context
 function getInsertText(
   text: string,
@@ -350,7 +369,18 @@ export const getSimplifiedPPLSuggestions = async ({
         );
       }
     }
-    return finalSuggestions;
+
+    const queryTillCursor =
+      position && position.lineNumber && position.column
+        ? extractQueryTillCursor(query, {
+            lineNumber: position.lineNumber,
+            column: position.column,
+          })
+        : query.slice(0, selectionEnd);
+
+    const querySnippetSuggestions = await getPPLQuerySnippetForSuggestions(queryTillCursor);
+
+    return [...finalSuggestions, ...querySnippetSuggestions];
   } catch (e) {
     return [];
   }

--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion_simplified.test.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion_simplified.test.ts
@@ -10,8 +10,18 @@ import { IDataPluginServices } from '../../types';
 import { QuerySuggestion } from '../../autocomplete';
 import * as utils from '../shared/utils';
 import { PPL_AGGREGATE_FUNCTIONS } from './constants';
+import * as querySnippets from '../../query_snippet_suggestions/ppl/suggestions';
 
 describe('ppl code_completion', () => {
+  // Mock the query snippet suggestions function at the top level
+  beforeEach(() => {
+    jest.spyOn(querySnippets, 'getPPLQuerySnippetForSuggestions').mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const mockIndexPattern = {
     title: 'test-index',
     fields: [
@@ -467,6 +477,98 @@ describe('ppl code_completion', () => {
 
       const resultValue = results1.find((result) => result.text === 'value1');
       expect(resultValue?.insertText).toBe('value1');
+    });
+
+    it('should include query snippet suggestions in results', async () => {
+      const mockSnippetSuggestions = [
+        {
+          text: 'stats count() by field1',
+          insertText: 'stats count() by field1 ',
+          type: monaco.languages.CompletionItemKind.Reference,
+          detail: 'Saved Query Snippet',
+        },
+      ];
+
+      // Override the default mock for this specific test
+      (querySnippets.getPPLQuerySnippetForSuggestions as jest.Mock).mockResolvedValue(
+        mockSnippetSuggestions
+      );
+
+      const result = await getSimpleSuggestions('source = test-index | ');
+
+      expect(querySnippets.getPPLQuerySnippetForSuggestions).toHaveBeenCalled();
+      checkSuggestionsContain(result, {
+        text: 'stats count() by field1',
+        type: monaco.languages.CompletionItemKind.Reference,
+      });
+    });
+
+    it('should pass correct query text to snippet suggestions', async () => {
+      const query = 'source = test-index | where field1 = "value" | ';
+      const position = new monaco.Position(1, query.length);
+
+      await getSimpleSuggestions(query, position);
+
+      expect(querySnippets.getPPLQuerySnippetForSuggestions).toHaveBeenCalledWith(query.trim());
+    });
+
+    it('should handle multiline queries correctly for snippet suggestions', async () => {
+      const query = `source = test-index
+      | where field1 = "value"
+      | `;
+      const position = new monaco.Position(3, 7); // Line 3, column 7
+
+      await getSimpleSuggestions(query, position);
+
+      const expectedQueryTillCursor = `source = test-index
+      | where field1 = "value"
+      `;
+      expect(querySnippets.getPPLQuerySnippetForSuggestions).toHaveBeenCalledWith(
+        expectedQueryTillCursor
+      );
+    });
+
+    describe('extractQueryTillCursor behavior', () => {
+      it('should handle single line queries correctly', async () => {
+        const query = 'source = test-index | where field1 = "value" ';
+        const position = new monaco.Position(1, 25); // At "value"
+
+        await getSimpleSuggestions(query, position);
+
+        expect(querySnippets.getPPLQuerySnippetForSuggestions).toHaveBeenCalledWith(
+          'source = test-index | wh'
+        );
+      });
+
+      it('should handle multiline queries and extract text up to cursor', async () => {
+        const query = `source = test-index
+| where field1 = "value"
+| stats count()`;
+        const position = new monaco.Position(2, 10); // Line 2, column 10
+
+        await getSimpleSuggestions(query, position);
+
+        const expectedExtracted = `source = test-index
+| where f`;
+        expect(querySnippets.getPPLQuerySnippetForSuggestions).toHaveBeenCalledWith(
+          expectedExtracted
+        );
+      });
+
+      it('should handle empty lines correctly', async () => {
+        const query = `source = test-index
+
+| where field1 = "value"`;
+        const position = new monaco.Position(2, 1); // Empty line
+
+        await getSimpleSuggestions(query, position);
+
+        const expectedExtracted = `source = test-index
+`;
+        expect(querySnippets.getPPLQuerySnippetForSuggestions).toHaveBeenCalledWith(
+          expectedExtracted
+        );
+      });
     });
   });
 });

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -71,6 +71,7 @@ import {
   setUiService,
   setUiSettings,
   setDataViews,
+  setSavedObjects,
 } from './services';
 import { opensearchaggs } from './search/expressions';
 import {
@@ -228,6 +229,7 @@ export class DataPublicPlugin
     setOverlays(overlays);
     setUiSettings(uiSettings);
     setApplication(application);
+    setSavedObjects(savedObjects);
 
     const fieldFormats = this.fieldFormatsService.start();
     setFieldFormats(fieldFormats);

--- a/src/plugins/data/public/query_snippet_suggestions/ppl/suggestions.test.ts
+++ b/src/plugins/data/public/query_snippet_suggestions/ppl/suggestions.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { monaco } from '@osd/monaco';
+import {
+  getPPLQuerySnippetForSuggestions,
+  convertQueryToMonacoSuggestion,
+  extractSnippetsFromQuery,
+} from './suggestions';
+import { getUserPastQueries } from '../utils';
+import { QuerySnippetItem } from '../types';
+
+jest.mock('../utils');
+
+const mockGetUserPastQueries = getUserPastQueries as jest.MockedFunction<typeof getUserPastQueries>;
+
+describe('PPL Query Snippet Suggestions', () => {
+  const mockQueries: QuerySnippetItem[] = [
+    {
+      id: '1',
+      query: {
+        query: 'source = logs | where status = "error" | stats count() by host',
+        language: 'PPL',
+      },
+      title: 'Error logs by host',
+      source: 'Saved Query',
+    },
+    {
+      id: '2',
+      query: {
+        query: 'source = metrics | fields timestamp, cpu_usage | sort timestamp desc',
+        language: 'PPL',
+      },
+      title: 'CPU metrics',
+      source: 'Recent Query',
+    },
+    {
+      id: '3',
+      query: {
+        query: 'source = traces | where service = "api" | head 100',
+        language: 'PPL',
+      },
+      source: 'Saved Search',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserPastQueries.mockResolvedValue(mockQueries);
+  });
+
+  describe('extractSnippetsFromQuery', () => {
+    it('should split query by pipe separator', () => {
+      const query = 'source = logs | where status = "error" | stats count() by host';
+      const result = extractSnippetsFromQuery(query);
+
+      expect(result).toEqual([
+        'source = logs ',
+        ' where status = "error" ',
+        ' stats count() by host',
+      ]);
+    });
+
+    it('should handle query without pipes', () => {
+      const query = 'source = logs';
+      const result = extractSnippetsFromQuery(query);
+
+      expect(result).toEqual(['source = logs']);
+    });
+
+    it('should handle empty query', () => {
+      const query = '';
+      const result = extractSnippetsFromQuery(query);
+
+      expect(result).toEqual(['']);
+    });
+  });
+
+  describe('convertQueryToMonacoSuggestion', () => {
+    it('should convert queries to Monaco suggestions without user query', () => {
+      const result = convertQueryToMonacoSuggestion(mockQueries, '');
+
+      expect(result).toHaveLength(9); // 3 queries with 3, 3, 3 segments each
+
+      // Check first suggestion
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          text: 'source = logs',
+          type: monaco.languages.CompletionItemKind.Reference,
+          detail: 'Saved Query Snippet',
+          sortText: '0',
+          documentation: expect.stringContaining(
+            'source = logs | where status = "error" | stats count() by host'
+          ),
+        })
+      );
+    });
+
+    it('should convert queries to Monaco suggestions with user query', () => {
+      const result = convertQueryToMonacoSuggestion(mockQueries, 'source = logs | ');
+
+      expect(result).toHaveLength(9);
+
+      // Check that suggestions don't have insertText in base conversion
+      const firstSuggestion = result.find((s) => s.text === 'source = logs');
+      expect(firstSuggestion?.insertText).toBeUndefined();
+    });
+
+    it('should deduplicate identical snippets', () => {
+      const duplicateQueries: QuerySnippetItem[] = [
+        {
+          id: '1',
+          query: { query: 'source = logs | where status = "error"', language: 'PPL' },
+          source: 'Saved Query',
+        },
+        {
+          id: '2',
+          query: { query: 'source = logs | where status = "error"', language: 'PPL' },
+          source: 'Recent Query',
+        },
+      ];
+
+      const result = convertQueryToMonacoSuggestion(duplicateQueries, '');
+
+      // Should only have 2 unique suggestions (source = logs, where status = "error")
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getPPLQuerySnippetForSuggestions', () => {
+    it('should return all suggestions when user query is empty', async () => {
+      const result = await getPPLQuerySnippetForSuggestions('');
+
+      expect(mockGetUserPastQueries).toHaveBeenCalledWith('PPL');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should filter suggestions based on current query segment', async () => {
+      const result = await getPPLQuerySnippetForSuggestions('source = logs | whe');
+
+      const whereResult = result.find((s) => s.text.startsWith('where'));
+      expect(whereResult).toBeDefined();
+      expect(whereResult?.insertText).toBe('re status = "error" '); // Should complete "whe" to "where status = "error"" with trailing space
+    });
+
+    it('should return empty array when no matching suggestions', async () => {
+      const result = await getPPLQuerySnippetForSuggestions('source = logs | xyz');
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle queries with multiple pipe segments', async () => {
+      const result = await getPPLQuerySnippetForSuggestions(
+        'source = logs | where status = "error" | st'
+      );
+
+      const statsResult = result.find((s) => s.text.startsWith('stats'));
+      expect(statsResult).toBeDefined();
+      expect(statsResult?.insertText).toBe('ats count() by host ');
+    });
+
+    it('should not return suggestions that match exactly', async () => {
+      const result = await getPPLQuerySnippetForSuggestions(
+        'source = logs | where status = "error"'
+      );
+
+      // Should not include exact matches
+      expect(result.find((s) => s.text === 'where status = "error"')).toBeUndefined();
+    });
+
+    it('should handle empty current segment', async () => {
+      const result = await getPPLQuerySnippetForSuggestions('source = logs | ');
+
+      expect(result).toHaveLength(0); // Should return empty array when current segment is empty after pipe
+    });
+
+    it('should be case insensitive', async () => {
+      const result = await getPPLQuerySnippetForSuggestions('source = logs | WHERE');
+
+      const whereResult = result.find((s) => s.text.startsWith('where'));
+      expect(whereResult).toBeDefined();
+    });
+
+    it('should handle getUserPastQueries returning empty array', async () => {
+      mockGetUserPastQueries.mockResolvedValue([]);
+
+      const result = await getPPLQuerySnippetForSuggestions('source = logs | whe');
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/plugins/data/public/query_snippet_suggestions/ppl/suggestions.ts
+++ b/src/plugins/data/public/query_snippet_suggestions/ppl/suggestions.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { monaco } from '@osd/monaco';
+import { QuerySuggestion } from '../../autocomplete';
+import { QuerySnippetItem } from '../types';
+import { getUserPastQueries } from '../utils';
+
+const languageId = 'PPL';
+
+export const extractSnippetsFromQuery = (query: string) => {
+  const pplQuerySegments = query.split('|');
+
+  return pplQuerySegments;
+};
+
+export const convertQueryToMonacoSuggestion = (
+  queries: QuerySnippetItem[],
+  userQuery: string
+): QuerySuggestion[] => {
+  const textMap = new Map<string, QuerySuggestion>();
+
+  queries.forEach((query) => {
+    // Process each query to create Monaco suggestions
+    const snippets = extractSnippetsFromQuery(query.query.query as string);
+    snippets.forEach((snippet) => {
+      const trimmedSnippet = snippet.trim().toLowerCase();
+
+      // Only add if we haven't seen this text before
+      if (!textMap.has(trimmedSnippet)) {
+        textMap.set(trimmedSnippet, {
+          text: trimmedSnippet,
+          type: monaco.languages.CompletionItemKind.Reference,
+          detail: `${query.source} Snippet`,
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
+          // sortText is the only option to sort suggestions, compares strings
+          sortText: '0',
+          documentation: `Derived From:\n\`\`\`ppl\n${query.query.query}\n\`\`\``,
+        });
+      }
+    });
+  });
+
+  return Array.from(textMap.values());
+};
+
+export const getPPLQuerySnippetForSuggestions = async (
+  userQuery: string
+): Promise<QuerySuggestion[]> => {
+  // Fetfch all User Queries
+  const userQueries = await getUserPastQueries(languageId);
+
+  const suggestions = convertQueryToMonacoSuggestion(userQueries, userQuery);
+
+  // Extract the last Segment from the query
+  const userQuerySegments = userQuery.split('|');
+  const currentUserQuerySegment = userQuerySegments.pop()?.trim().toLowerCase();
+
+  // Using currentUserQuery to do a prefix filtering of the Query Segments
+  if (currentUserQuerySegment) {
+    return suggestions
+      .filter((suggestion) => {
+        return (
+          suggestion.text.startsWith(currentUserQuerySegment) &&
+          currentUserQuerySegment !== suggestion.text
+        );
+      })
+      .map((suggestion) => ({
+        ...suggestion,
+        insertText: suggestion.text.slice(currentUserQuerySegment.length).trim() + ' ',
+      }));
+  }
+
+  return [];
+};

--- a/src/plugins/data/public/query_snippet_suggestions/types.ts
+++ b/src/plugins/data/public/query_snippet_suggestions/types.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Query } from '../../common';
+
+export interface QuerySnippetItem {
+  id: string;
+  query: Query;
+  title?: string;
+  description?: string;
+  timestamp?: number;
+  source: 'Saved Query' | 'Recent Query' | 'Saved Search';
+}

--- a/src/plugins/data/public/query_snippet_suggestions/utils.test.ts
+++ b/src/plugins/data/public/query_snippet_suggestions/utils.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getUserPastQueries,
+  transformSavedQueryToSnippet,
+  transformSavedSearchToSnippet,
+  transformRecentQueryToSnippet,
+} from './utils';
+import { getQueryService, getSavedObjects } from '../services';
+import { SavedQuery } from '../query';
+
+jest.mock('../services');
+
+const mockGetQueryService = getQueryService as jest.MockedFunction<typeof getQueryService>;
+const mockGetSavedObjects = getSavedObjects as jest.MockedFunction<typeof getSavedObjects>;
+
+describe('Query Snippet Utils', () => {
+  const mockSavedQueries: SavedQuery[] = [
+    {
+      id: '1',
+      attributes: {
+        title: 'Error Logs Query',
+        description: 'Query to find error logs',
+        query: {
+          query: 'source = logs | where level = "error"',
+          language: 'PPL',
+        },
+      },
+    },
+    {
+      id: '2',
+      attributes: {
+        title: 'SQL Query',
+        description: 'SQL query example',
+        query: {
+          query: 'SELECT * FROM logs WHERE level = "error"',
+          language: 'SQL',
+        },
+      },
+    },
+  ];
+
+  const mockSavedSearches = {
+    savedObjects: [
+      {
+        id: 'search1',
+        attributes: {
+          title: 'Log Search',
+          description: 'Search for logs',
+          kibanaSavedObjectMeta: {
+            searchSourceJSON: JSON.stringify({
+              query: {
+                query: 'source = logs | head 100',
+                language: 'PPL',
+              },
+            }),
+          },
+        },
+      },
+      {
+        id: 'search2',
+        attributes: {
+          title: 'SQL Search',
+          kibanaSavedObjectMeta: {
+            searchSourceJSON: JSON.stringify({
+              query: {
+                query: 'SELECT * FROM logs LIMIT 100',
+                language: 'SQL',
+              },
+            }),
+          },
+        },
+      },
+    ],
+  };
+
+  const mockRecentQueries = [
+    {
+      id: 'recent1',
+      query: {
+        query: 'source = metrics | stats avg(cpu)',
+        language: 'PPL',
+      },
+      time: 1609459200000,
+    },
+    {
+      id: 'recent2',
+      query: {
+        query: 'SELECT AVG(cpu) FROM metrics',
+        language: 'SQL',
+      },
+      time: 1609459100000,
+    },
+  ];
+
+  const mockQueryService = {
+    savedQueries: {
+      getAllSavedQueries: jest.fn(),
+    },
+    queryString: {
+      getQueryHistory: jest.fn(),
+    },
+  };
+
+  const mockSavedObjectsClient = {
+    client: {
+      find: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetQueryService.mockReturnValue(mockQueryService as any);
+    mockGetSavedObjects.mockReturnValue(mockSavedObjectsClient as any);
+    mockQueryService.savedQueries.getAllSavedQueries.mockResolvedValue(mockSavedQueries);
+    mockQueryService.queryString.getQueryHistory.mockReturnValue(mockRecentQueries);
+    mockSavedObjectsClient.client.find.mockResolvedValue(mockSavedSearches);
+  });
+
+  describe('transformSavedQueryToSnippet', () => {
+    it('should transform saved query to snippet', () => {
+      const result = transformSavedQueryToSnippet(mockSavedQueries[0]);
+
+      expect(result).toEqual({
+        id: '1',
+        query: {
+          query: 'source = logs | where level = "error"',
+          language: 'PPL',
+        },
+        title: 'Error Logs Query',
+        description: 'Query to find error logs',
+        source: 'Saved Query',
+      });
+    });
+  });
+
+  describe('transformSavedSearchToSnippet', () => {
+    it('should transform saved search to snippet', () => {
+      const result = transformSavedSearchToSnippet(mockSavedSearches.savedObjects[0]);
+
+      expect(result).toEqual({
+        id: 'search1',
+        query: {
+          query: 'source = logs | head 100',
+          language: 'PPL',
+        },
+        title: 'Log Search',
+        description: 'Search for logs',
+        source: 'Saved Search',
+      });
+    });
+
+    it('should handle malformed searchSourceJSON', () => {
+      const malformedSearch = {
+        id: 'malformed',
+        attributes: {
+          title: 'Malformed Search',
+          kibanaSavedObjectMeta: {
+            searchSourceJSON: 'invalid json',
+          },
+        },
+      };
+
+      const result = transformSavedSearchToSnippet(malformedSearch);
+
+      expect(result).toEqual({
+        id: 'malformed',
+        query: undefined,
+        title: 'Malformed Search',
+        description: undefined,
+        source: 'Saved Search',
+      });
+    });
+
+    it('should handle missing searchSourceJSON', () => {
+      const searchWithoutJSON = {
+        id: 'no-json',
+        attributes: {
+          title: 'No JSON Search',
+        },
+      };
+
+      const result = transformSavedSearchToSnippet(searchWithoutJSON);
+
+      expect(result).toEqual({
+        id: 'no-json',
+        query: undefined,
+        title: 'No JSON Search',
+        description: undefined,
+        source: 'Saved Search',
+      });
+    });
+  });
+
+  describe('transformRecentQueryToSnippet', () => {
+    it('should transform recent query to snippet', () => {
+      const result = transformRecentQueryToSnippet(mockRecentQueries[0]);
+
+      expect(result).toEqual({
+        id: 'recent1',
+        query: {
+          query: 'source = metrics | stats avg(cpu)',
+          language: 'PPL',
+        },
+        timestamp: 1609459200000,
+        source: 'Recent Query',
+      });
+    });
+  });
+
+  describe('getUserPastQueries', () => {
+    it('should fetch and combine all query types for PPL', async () => {
+      const result = await getUserPastQueries('PPL');
+
+      expect(mockQueryService.savedQueries.getAllSavedQueries).toHaveBeenCalled();
+      expect(mockSavedObjectsClient.client.find).toHaveBeenCalledWith({
+        type: 'explore',
+        perPage: 1000,
+        page: 1,
+      });
+      expect(mockQueryService.queryString.getQueryHistory).toHaveBeenCalled();
+
+      // Should return 3 PPL queries (1 saved query + 1 saved search + 1 recent query)
+      expect(result).toHaveLength(3);
+
+      // Check each type is present
+      expect(result.some((q) => q.source === 'Saved Query')).toBeTruthy();
+      expect(result.some((q) => q.source === 'Saved Search')).toBeTruthy();
+      expect(result.some((q) => q.source === 'Recent Query')).toBeTruthy();
+    });
+
+    it('should filter queries by language (case insensitive)', async () => {
+      const result = await getUserPastQueries('ppl');
+
+      // Should only return PPL queries, not SQL
+      result.forEach((query) => {
+        expect(query.query?.language?.toLowerCase()).toBe('ppl');
+      });
+    });
+
+    it('should handle empty results from all sources', async () => {
+      mockQueryService.savedQueries.getAllSavedQueries.mockResolvedValue([]);
+      mockSavedObjectsClient.client.find.mockResolvedValue({ savedObjects: [] });
+      mockQueryService.queryString.getQueryHistory.mockReturnValue([]);
+
+      const result = await getUserPastQueries('PPL');
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/plugins/data/public/query_snippet_suggestions/utils.ts
+++ b/src/plugins/data/public/query_snippet_suggestions/utils.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IQueryStart, SavedQuery } from '../query';
+import { QuerySnippetItem } from './types';
+import { getQueryService, getSavedObjects } from '../services';
+
+export const transformSavedQueryToSnippet = (savedQuery: SavedQuery): QuerySnippetItem => {
+  return {
+    id: savedQuery.id,
+    query: savedQuery.attributes.query,
+    title: savedQuery.attributes.title,
+    description: savedQuery.attributes.description,
+    source: 'Saved Query',
+  };
+};
+
+export const transformSavedSearchToSnippet = (savedSearch: any): QuerySnippetItem => {
+  let query;
+  try {
+    const searchSourceJSON = savedSearch.attributes.kibanaSavedObjectMeta?.searchSourceJSON;
+    query = searchSourceJSON ? JSON.parse(searchSourceJSON)?.query : undefined;
+  } catch (e) {
+    query = undefined;
+  }
+
+  return {
+    id: savedSearch.id,
+    query,
+    title: savedSearch.attributes.title,
+    description: savedSearch.attributes.description,
+    source: 'Saved Search',
+  };
+};
+
+export const transformRecentQueryToSnippet = (historyItem: any): QuerySnippetItem => {
+  return {
+    id: historyItem.id,
+    query: historyItem.query,
+    timestamp: historyItem.time,
+    source: 'Recent Query',
+  };
+};
+
+const getAllSavedQueries = async (queryService: IQueryStart, language: string) => {
+  const savedQueries = await queryService.savedQueries.getAllSavedQueries();
+  return savedQueries
+    .filter((savedQuery: SavedQuery) => {
+      const savedQueryLanguage = savedQuery.attributes.query.language?.toLowerCase();
+      return savedQueryLanguage === language.toLowerCase();
+    })
+    .map(transformSavedQueryToSnippet);
+};
+
+const getAllSavedSearches = async (language: string) => {
+  const savedObjects = getSavedObjects();
+  const response = await savedObjects.client.find({
+    type: 'explore',
+    perPage: 1000,
+    page: 1,
+  });
+
+  const savedSearches = response.savedObjects.map(transformSavedSearchToSnippet);
+
+  return savedSearches.filter((savedSearch: QuerySnippetItem) => {
+    const searchLanguage = savedSearch.query?.language?.toLowerCase();
+    return searchLanguage === language.toLowerCase();
+  });
+};
+
+const getAllRecentQueries = async (queryService: IQueryStart, language: string) => {
+  const recentQueries = queryService.queryString.getQueryHistory();
+  return recentQueries
+    .filter((historyItem: any) => {
+      const recentQueryLanguage = historyItem.query.language?.toLowerCase();
+      return recentQueryLanguage === language.toLowerCase();
+    })
+    .map(transformRecentQueryToSnippet);
+};
+
+export const getUserPastQueries = async (language: string): Promise<QuerySnippetItem[]> => {
+  const queryService = getQueryService();
+
+  const [savedQueries, savedSearches, recentQueries] = await Promise.all([
+    getAllSavedQueries(queryService, language),
+    getAllSavedSearches(language),
+    getAllRecentQueries(queryService, language),
+  ]);
+
+  return [...savedQueries, ...savedSearches, ...recentQueries];
+};

--- a/src/plugins/data/public/services.ts
+++ b/src/plugins/data/public/services.ts
@@ -67,6 +67,10 @@ export const [getUiService, setUiService] = createGetterSetter<DataPublicPluginS
 
 export const [getApplication, setApplication] = createGetterSetter<ApplicationStart>('Application');
 
+export const [getSavedObjects, setSavedObjects] = createGetterSetter<CoreStart['savedObjects']>(
+  'SavedObjects'
+);
+
 let useNewSavedQueriesUI = false;
 
 export function getUseNewSavedQueriesUI() {


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
This PR aims at introducing Query Snippet Suggestions to the Autocomplete Service for Explore. 
We would like the augment autocomplete suggestions for users based on the past queries of users stored as Saved Searches, Recent Queries and Saved Queries. 

**Architecture:**
<img width="921" height="751" alt="image" src="https://github.com/user-attachments/assets/47728121-c29d-4043-9b80-a0b2055a1dec" />

**Flow Diagram**
<img width="871" height="757" alt="image" src="https://github.com/user-attachments/assets/9f831c67-bb88-4f0b-a79b-4149b0e5df29" />


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->


https://github.com/user-attachments/assets/36c200ce-1875-4bd7-8285-0246fa3752a8


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: Add Query Snippet Suggestions to Autocomplete

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
