### PR TITLE
Fix inconsistent icons in table fields

### DIFF
--- a/changelogs/fragments/10584.yml
+++ b/changelogs/fragments/10584.yml
@@ -1,0 +1,2 @@
+fix:
+- Inconsistent icons in table fields ([#10584](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10584))

--- a/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/discover/public/application/components/default_discover_table/table_cell.tsx
@@ -49,7 +49,7 @@ const TableCellUI = ({
           <EuiButtonIcon
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '+')}
-            iconType="plusInCircle"
+            iconType="magnifyWithPlus"
             aria-label={i18n.translate('discover.filterForValue', {
               defaultMessage: 'Filter for value',
             })}
@@ -65,7 +65,7 @@ const TableCellUI = ({
           <EuiButtonIcon
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '-')}
-            iconType="minusInCircle"
+            iconType="magnifyWithMinus"
             aria-label={i18n.translate('discover.filterOutValue', {
               defaultMessage: 'Filter out value',
             })}

--- a/src/plugins/explore/public/application/legacy/discover/application/components/default_discover_table/table_cell.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/default_discover_table/table_cell.tsx
@@ -49,7 +49,7 @@ const TableCellUI = ({
           <EuiButtonIcon
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '+')}
-            iconType="plusInCircle"
+            iconType="magnifyWithPlus"
             aria-label={i18n.translate('explore.explore.discover.filterForValue', {
               defaultMessage: 'Filter for value',
             })}
@@ -65,7 +65,7 @@ const TableCellUI = ({
           <EuiButtonIcon
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '-')}
-            iconType="minusInCircle"
+            iconType="magnifyWithMinus"
             aria-label={i18n.translate('explore.explore.discover.filterOutValue', {
               defaultMessage: 'Filter out value',
             })}

--- a/src/plugins/explore/public/components/data_table/table_cell/table_cell.tsx
+++ b/src/plugins/explore/public/components/data_table/table_cell/table_cell.tsx
@@ -56,7 +56,7 @@ export const TableCellUI = ({
           <EuiButtonIcon
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '+')}
-            iconType="plusInCircle"
+            iconType="magnifyWithPlus"
             aria-label={i18n.translate('explore.filterForValue', {
               defaultMessage: 'Filter for value',
             })}
@@ -72,7 +72,7 @@ export const TableCellUI = ({
           <EuiButtonIcon
             size="xs"
             onClick={() => onFilter?.(columnId, fieldMapping, '-')}
-            iconType="minusInCircle"
+            iconType="magnifyWithMinus"
             aria-label={i18n.translate('explore.filterOutValue', {
               defaultMessage: 'Filter out value',
             })}


### PR DESCRIPTION
### Description

This PR, 
  Replaced plusInCircle → magnifyWithPlus
  Replaced minusInCircle → magnifyWithMinus
  
  Now all filter action buttons consistently use magnifyWithPlus and magnifyWithMinus icons across:
  - Table cell hover overlays
  - Expanded table row views
  - Both explore and discover plugins
  
## Screenshot
Explore 
<img width="835" height="316" alt="Screenshot 2025-09-26 at 11 32 22 AM" src="https://github.com/user-attachments/assets/5ddf6a32-552f-4526-9022-11b30d17b73d" />

Discover - 
<img width="742" height="362" alt="Screenshot 2025-09-26 at 11 34 00 AM" src="https://github.com/user-attachments/assets/b170ff1d-df92-4d09-a65f-f87463cacce4" />



## Changelog
- fix: Inconsistent icons in table fields

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
