### PR TITLE
vis(vega): default set flag exposeDebugObjectToWindow to true

### DIFF
--- a/changelogs/fragments/10590.yml
+++ b/changelogs/fragments/10590.yml
@@ -1,0 +1,2 @@
+chore:
+- Change exposeDebugObjectToWindow default value to true ([#10590](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10590))

--- a/src/plugins/vis_type_vega/config.ts
+++ b/src/plugins/vis_type_vega/config.ts
@@ -33,7 +33,7 @@ import { schema, TypeOf } from '@osd/config-schema';
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
   enableExternalUrls: schema.boolean({ defaultValue: false }),
-  exposeDebugObjectToWindow: schema.boolean({ defaultValue: false }),
+  exposeDebugObjectToWindow: schema.boolean({ defaultValue: true }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;


### PR DESCRIPTION
### Description
Change the flag `exposeDebugObjectToWindow` which was introduced by https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10511 default value to `true` to make it backward compatible

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

- chore: change exposeDebugObjectToWindow default value to true

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
