### PR TITLE
Insert dataset names with backquotes

### DIFF
--- a/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/code_completion.ts
@@ -67,7 +67,7 @@ function getInsertText(
         }
         return `${text}()`;
       case 'table':
-        return `${text} `;
+        return `\`${text}\` `;
       default:
         return `${text} `;
     }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

While inserting Dataset names we used to insert it without backquotes, This causes issues when user used indexPatterns like `*`. This change inserts the dataset names with backQuotes to avoid the above scenario.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

https://github.com/user-attachments/assets/2b172f14-dbac-4909-b15d-b8932b42c0a1


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Insert dataset names with backquotes

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
