### PR TITLE
[explore] clear editor after datset change

### DIFF
--- a/changelogs/fragments/10597.yml
+++ b/changelogs/fragments/10597.yml
@@ -1,0 +1,2 @@
+fix:
+- Clear editor after dataset change in explore ([#10597](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10597))

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.test.tsx
@@ -20,6 +20,7 @@ const mockGetQuery = jest.fn();
 const mockToastAddError = jest.fn();
 const mockToastAddWarning = jest.fn();
 const mockUseFlavorId = jest.fn();
+const mockClearEditors = jest.fn();
 
 jest.doMock('react-redux', () => {
   const actual = jest.requireActual('react-redux');
@@ -94,6 +95,7 @@ jest.doMock('../../../../../../opensearch_dashboards_react/public', () => ({
       http: {},
     },
   }),
+  withOpenSearchDashboards: (Component: any) => (props: any) => <Component {...props} />,
 }));
 
 jest.doMock('../../utils', () => ({
@@ -135,6 +137,10 @@ jest.doMock('../../../../../common', () => ({
   ExploreFlavor: {
     Traces: 'traces',
   },
+}));
+
+jest.doMock('../../../../application/hooks', () => ({
+  useClearEditors: () => mockClearEditors,
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -217,6 +223,7 @@ describe('DatasetSelectWidget', () => {
         dataset: { id: 'test-dataset', type: 'index_pattern' },
       });
       expect(mockDispatch).toHaveBeenCalledWith(mockSetQueryWithHistory());
+      expect(mockClearEditors).toHaveBeenCalled();
     });
   });
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.tsx
@@ -18,12 +18,14 @@ import { setQueryWithHistory } from '../../../../application/utils/state_managem
 import { selectQuery } from '../../../../application/utils/state_management/selectors';
 import { useFlavorId } from '../../../../helpers/use_flavor_id';
 import { ExploreFlavor } from '../../../../../common';
+import { useClearEditors } from '../../../../application/hooks';
 
 export const DatasetSelectWidget = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const flavorId = useFlavorId();
   const dispatch = useDispatch();
   const currentQuery = useSelector(selectQuery);
+  const clearEditors = useClearEditors();
 
   const {
     data: {
@@ -92,13 +94,14 @@ export const DatasetSelectWidget = () => {
             ...queryString.getQuery(),
           })
         );
+        clearEditors();
       } catch (error) {
         services.notifications?.toasts.addError(error, {
           title: 'Error selecting dataset',
         });
       }
     },
-    [queryString, dispatch, services]
+    [queryString, dispatch, clearEditors, services.notifications?.toasts]
   );
 
   const supportedTypes = useMemo(() => {


### PR DESCRIPTION
### Description

- when switching dataset, clear editor when switching dataset. We already set the query service to be an empty string, now we gotta do so for the query editor

## Changelog
- fix: clear editor after dataset change in explore

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
