### PR TITLE
Fix source command detection if we have a field expression before source

### DIFF
--- a/changelogs/fragments/10598.yml
+++ b/changelogs/fragments/10598.yml
@@ -1,0 +1,2 @@
+fix:
+- Source command detection if we have a field expression before source ([#10598](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10598))

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
@@ -221,4 +221,14 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual(query);
   });
+
+  it('should handle if we have a field Expression infront of SOURCE command', () => {
+    const query: Query = {
+      query: 'unique_category = "Configuration" source = `data_logs_small_time_1*`',
+      dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
+      language: 'ppl',
+    };
+    const result = getQueryWithSource(query);
+    expect(result).toEqual(query);
+  });
 });

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
@@ -12,7 +12,7 @@ import { QueryWithQueryAsString } from '../../types';
 export const getQueryWithSource = (query: Query): QueryWithQueryAsString => {
   const queryString = typeof query.query === 'string' ? query.query : '';
   const lowerCaseQuery = queryString.toLowerCase();
-  const hasSource = /^\s*(search\s+)?source\s*=/.test(lowerCaseQuery);
+  const hasSource = /^[^|]*\bsource\s*=/.test(lowerCaseQuery);
   const hasDescribe = /^\s*describe\s+/.test(lowerCaseQuery);
   const hasShow = /^\s*show\s+/.test(lowerCaseQuery);
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
The PPL grammar defines searchCommand as follows
```
searchCommand
   : (SEARCH)? (searchExpression)* fromClause? (searchExpression)*     # searchFrom
```
However when we write a query 
```
`attributes.EnvName` = "Production" SOURCE = logs-otel-v1* 
```
It gives no result. 

The issue lies with us appending source = <dataset> at the beginning of the query. 

Query Being sent:
```
"source = logs-otel-v1* `attributes.EnvName` = \"Production\" SOURCE = logs-otel-v1* | WHERE `time` >= '2024-06-23 17:39:57.609' AND `time` <= '2025-09-23 17:39:57.609'"
```

This treats the second SOURCE as a column name creating failures.

This PR fixes the Source Command detection Logic, expanding the logic to check the first | and check if it contains source = or not.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

Before:
https://github.com/user-attachments/assets/0be09f44-b271-4d3b-ba50-32261c2bde80


After:
https://github.com/user-attachments/assets/ccc9ed0a-9467-4be3-958d-81fc65afcb50



## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Source command detection if we have a field expression before source

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
