### PR TITLE
Revert "[Explore] backtick the dataset name when source=* and describe=* is omitted (#10573)

### DIFF
--- a/changelogs/fragments/10573.yml
+++ b/changelogs/fragments/10573.yml
@@ -1,2 +1,0 @@
-chore:
-- Add backticks when source is omitted ([#10573](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10573))

--- a/src/plugins/explore/public/application/utils/languages/ppl/default_prepare_ppl_query/default_prepare_ppl_query.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/default_prepare_ppl_query/default_prepare_ppl_query.test.ts
@@ -16,20 +16,20 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset` level="error"',
+      query: 'source = test-dataset level="error"',
     });
   });
 
   it('should handle query that already has source', () => {
     const query: Query = {
-      query: 'source=`existing-index` | where level="error" | stats count by host',
+      query: 'source=existing-index | where level="error" | stats count by host',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source=`existing-index` | where level="error"',
+      query: 'source=existing-index | where level="error"',
     });
   });
 
@@ -42,7 +42,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset`',
+      query: 'source = test-dataset',
     });
   });
 
@@ -55,7 +55,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset`',
+      query: 'source = test-dataset',
     });
   });
 
@@ -68,33 +68,33 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset` | where level="error"',
+      query: 'source = test-dataset | where level="error"',
     });
   });
 
   it('should handle search source queries with stats', () => {
     const query: Query = {
-      query: 'search source=`logs-*` | where @timestamp > now()-1d | stats count by level',
+      query: 'search source=logs-* | where @timestamp > now()-1d | stats count by level',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'search source=`logs-*` | where @timestamp > now()-1d',
+      query: 'search source=logs-* | where @timestamp > now()-1d',
     });
   });
 
   it('should preserve case in source queries when stripping stats', () => {
     const query: Query = {
-      query: 'SOURCE=`LOGS-*` | WHERE level="ERROR" | STATS count by host',
+      query: 'SOURCE=LOGS-* | WHERE level="ERROR" | STATS count by host',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'SOURCE=`LOGS-*` | WHERE level="ERROR"',
+      query: 'SOURCE=LOGS-* | WHERE level="ERROR"',
     });
   });
 });

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
@@ -16,13 +16,13 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset`',
+      query: 'source = test-dataset',
     });
   });
 
   it('should return original query when it starts with "source" (case sensitive)', () => {
     const query: Query = {
-      query: 'source=`existing-index` | where field=value',
+      query: 'source=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -32,7 +32,7 @@ describe('getQueryWithSource', () => {
 
   it('should return original query when it starts with "SOURCE" (case insensitive)', () => {
     const query: Query = {
-      query: 'SOURCE=`existing-index` | where field=value',
+      query: 'SOURCE=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -42,7 +42,7 @@ describe('getQueryWithSource', () => {
 
   it('should return original query when it starts with "search source" (case sensitive)', () => {
     const query: Query = {
-      query: 'search source=`existing-index` | where field=value',
+      query: 'search source=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -52,7 +52,7 @@ describe('getQueryWithSource', () => {
 
   it('should return original query when it starts with "SEARCH SOURCE" (case insensitive)', () => {
     const query: Query = {
-      query: 'SEARCH SOURCE=`existing-index` | where field=value',
+      query: 'SEARCH SOURCE=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -62,7 +62,7 @@ describe('getQueryWithSource', () => {
 
   it('should handle flexible whitespace between source and =', () => {
     const query: Query = {
-      query: 'source   =`existing-index` | where field=value',
+      query: 'source   =existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -72,7 +72,7 @@ describe('getQueryWithSource', () => {
 
   it('should handle no whitespace between source and =', () => {
     const query: Query = {
-      query: 'source=`existing-index` | where field=value',
+      query: 'source=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -82,7 +82,7 @@ describe('getQueryWithSource', () => {
 
   it('should handle flexible whitespace between search, source and =', () => {
     const query: Query = {
-      query: 'search    source   =`existing-index` | where field=value',
+      query: 'search    source   =existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -92,7 +92,7 @@ describe('getQueryWithSource', () => {
 
   it('should handle single space between search and source with no space before =', () => {
     const query: Query = {
-      query: 'search source=`existing-index` | where field=value',
+      query: 'search source=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -109,7 +109,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset`',
+      query: 'source = test-dataset',
     });
   });
 
@@ -122,7 +122,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset`',
+      query: 'source = test-dataset',
     });
   });
 
@@ -135,7 +135,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset` | where level="error"',
+      query: 'source = test-dataset | where level="error"',
     });
   });
 
@@ -148,13 +148,13 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = `test-dataset`   | where level="error"',
+      query: 'source = test-dataset   | where level="error"',
     });
   });
 
   it('should handle leading whitespace before source', () => {
     const query: Query = {
-      query: ' source = `data_logs_small_time_1*` | where unique_category = "Configuration"',
+      query: ' source = data_logs_small_time_1* | where unique_category = "Configuration"',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -164,7 +164,7 @@ describe('getQueryWithSource', () => {
 
   it('should handle leading whitespace before search source', () => {
     const query: Query = {
-      query: '  search source=`existing-index` | where field=value',
+      query: '  search source=existing-index | where field=value',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -184,7 +184,7 @@ describe('getQueryWithSource', () => {
 
   it('should return original query when it starts with "DESCRIBE" (case insensitive)', () => {
     const query: Query = {
-      query: 'DESCRIBE `table_name`',
+      query: 'DESCRIBE table_name',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
@@ -194,7 +194,7 @@ describe('getQueryWithSource', () => {
 
   it('should handle leading whitespace before describe', () => {
     const query: Query = {
-      query: '  describe `table_name`',
+      query: '  describe table_name',
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
@@ -24,9 +24,9 @@ export const getQueryWithSource = (query: Query): QueryWithQueryAsString => {
 
   let queryStringWithSource: string;
   if (queryString.trim() === '') {
-    queryStringWithSource = `source = \`${datasetTitle}\``;
+    queryStringWithSource = `source = ${datasetTitle}`;
   } else {
-    queryStringWithSource = `source = \`${datasetTitle}\` ${queryString}`;
+    queryStringWithSource = `source = ${datasetTitle} ${queryString}`;
   }
 
   return {


### PR DESCRIPTION
This reverts commit cdf9f6c4c52a564005b3e54dcc7bf3094503aae9.

@joshuali925 called out that this is a breaking change due to the fact that some scenarios the source will have backticks.

We will think of a better s

## Changelog
- chore: revert 'add backticks when source is omitted'

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
