### PR TITLE
[Explore Vis] Allow to customize legend name

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.ts
@@ -26,6 +26,7 @@ export interface AreaChartStyleOptions {
   // Basic controls
   addLegend?: boolean;
   legendPosition?: Positions;
+  legendTitle?: string;
   addTimeMarker?: boolean;
   areaOpacity?: number;
   tooltipOptions?: TooltipOptions;
@@ -53,6 +54,7 @@ const defaultAreaChartStyles: AreaChartStyle = {
   // Basic controls
   addLegend: true,
   legendPosition: Positions.RIGHT,
+  legendTitle: '',
   addTimeMarker: false,
   tooltipOptions: {
     mode: 'all',

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
@@ -96,6 +96,9 @@ export const AreaVisStyleControls: React.FC<AreaVisStyleControlsProps> = ({
                   if (legendOptions.position !== undefined) {
                     updateStyleOption('legendPosition', legendOptions.position);
                   }
+                  if (legendOptions.title !== undefined) {
+                    updateStyleOption('legendTitle', legendOptions.title);
+                  }
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -109,6 +109,7 @@ export const createSimpleAreaChart = (
     legend: styles.addLegend
       ? {
           orient: styles.legendPosition?.toLowerCase() || 'right',
+          title: styles.legendTitle || undefined,
         }
       : null,
   };
@@ -184,7 +185,7 @@ export const createMultiAreaChart = (
         type: 'nominal',
         legend: styles.addLegend
           ? {
-              title: categoryName,
+              title: styles.legendTitle || categoryName,
               orient: styles.legendPosition?.toLowerCase() || 'right',
             }
           : null,
@@ -316,7 +317,7 @@ export const createFacetedMultiAreaChart = (
               type: 'nominal',
               legend: styles.addLegend
                 ? {
-                    title: category1Name,
+                    title: styles.legendTitle || category1Name,
                     orient: styles.legendPosition?.toLowerCase() || 'right',
                   }
                 : null,
@@ -466,6 +467,7 @@ export const createCategoryAreaChart = (
     legend: styles.addLegend
       ? {
           orient: styles.legendPosition?.toLowerCase() || 'right',
+          title: styles.legendTitle || undefined,
         }
       : null,
   };
@@ -544,7 +546,7 @@ export const createStackedAreaChart = (
         type: 'nominal',
         legend: styles.addLegend
           ? {
-              title: categoryName2,
+              title: styles.legendTitle || categoryName2,
               orient: styles.legendPosition?.toLowerCase() || 'bottom',
             }
           : null,

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.ts
@@ -28,6 +28,7 @@ export interface BarChartStyleOptions {
   // Basic controls
   addLegend?: boolean;
   legendPosition?: Positions;
+  legendTitle?: string;
   legendShape?: 'circle' | 'square';
   tooltipOptions?: TooltipOptions;
 
@@ -66,6 +67,7 @@ export const defaultBarChartStyles: BarChartStyle = {
   switchAxes: false,
   addLegend: true,
   legendPosition: Positions.RIGHT,
+  legendTitle: '',
   tooltipOptions: {
     mode: 'all',
   },

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -120,22 +120,27 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
             />
           </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <LegendOptionsPanel
-              legendOptions={{
-                show: styleOptions.addLegend,
-                position: styleOptions.legendPosition,
-              }}
-              onLegendOptionsChange={(legendOptions) => {
-                if (legendOptions.show !== undefined) {
-                  updateStyleOption('addLegend', legendOptions.show);
-                }
-                if (legendOptions.position !== undefined) {
-                  updateStyleOption('legendPosition', legendOptions.position);
-                }
-              }}
-            />
-          </EuiFlexItem>
+          {hasColorMapping && (
+            <EuiFlexItem grow={false}>
+              <LegendOptionsPanel
+                legendOptions={{
+                  show: styleOptions.addLegend,
+                  position: styleOptions.legendPosition,
+                }}
+                onLegendOptionsChange={(legendOptions) => {
+                  if (legendOptions.show !== undefined) {
+                    updateStyleOption('addLegend', legendOptions.show);
+                  }
+                  if (legendOptions.position !== undefined) {
+                    updateStyleOption('legendPosition', legendOptions.position);
+                  }
+                  if (legendOptions.title !== undefined) {
+                    updateStyleOption('legendTitle', legendOptions.title);
+                  }
+                }}
+              />
+            </EuiFlexItem>
+          )}
 
           <EuiFlexItem grow={false}>
             <TitleOptionsPanel

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -123,6 +123,7 @@ export const createBarSpec = (
     legend: styles.addLegend
       ? {
           orient: styles.legendPosition?.toLowerCase() || 'right',
+          title: styles.legendTitle || undefined,
           symbolType: styles.legendShape ?? 'circle',
         }
       : null,
@@ -302,7 +303,7 @@ export const createGroupedTimeBarChart = (
         type: getSchemaByAxis(colorColumn),
         legend: styles.addLegend
           ? {
-              title: categoryName,
+              title: styles.legendTitle || categoryName,
               orient: styles.legendPosition?.toLowerCase() || 'right',
               symbolType: styles.legendShape ?? 'circle',
             }
@@ -436,7 +437,7 @@ export const createFacetedTimeBarChart = (
               type: getSchemaByAxis(colorMapping),
               legend: styles.addLegend
                 ? {
-                    title: category1Name,
+                    title: styles.legendTitle || category1Name,
                     orient: styles.legendPosition?.toLowerCase() || 'right',
                     symbolType: styles.legendShape ?? 'circle',
                   }
@@ -535,7 +536,7 @@ export const createStackedBarSpec = (
         type: 'nominal',
         legend: styles.addLegend
           ? {
-              title: categoryName2,
+              title: styles.legendTitle || categoryName2,
               orient: styles.legendPosition?.toLowerCase() || 'bottom',
               symbolType: styles.legendShape ?? 'circle',
             }

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.ts
@@ -52,6 +52,7 @@ export interface HeatmapChartStyleOptions {
   tooltipOptions?: TooltipOptions;
   addLegend?: boolean;
   legendPosition?: Positions;
+  legendTitle?: string;
 
   // Axes configuration
   standardAxes?: StandardAxes[];
@@ -74,6 +75,7 @@ export const defaultHeatmapChartStyles: HeatmapChartStyle = {
   },
   addLegend: true,
   legendPosition: Positions.RIGHT,
+  legendTitle: '',
 
   // exclusive
   exclusive: {

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
@@ -103,6 +103,9 @@ export const HeatmapVisStyleControls: React.FC<HeatmapVisStyleControlsProps> = (
                   if (legendOptions.position !== undefined) {
                     updateStyleOption('legendPosition', legendOptions.position);
                   }
+                  if (legendOptions.title !== undefined) {
+                    updateStyleOption('legendTitle', legendOptions.title);
+                  }
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
@@ -54,7 +54,7 @@ export const createHeatmapWithBin = (
         },
         legend: styles.addLegend
           ? {
-              title: colorName || 'Metrics',
+              title: styles.legendTitle || colorName || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
@@ -136,7 +136,7 @@ export const createRegularHeatmap = (
         },
         legend: styles.addLegend
           ? {
-              title: colorName || 'Metrics',
+              title: styles.legendTitle || colorName || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.ts
@@ -28,6 +28,7 @@ export type LineMode = 'straight' | 'smooth' | 'stepped';
 export interface LineChartStyleOptions {
   addLegend?: boolean;
   legendPosition?: Positions;
+  legendTitle?: string;
   addTimeMarker?: boolean;
 
   lineStyle?: LineStyle;
@@ -53,6 +54,7 @@ export type LineChartStyle = Required<Omit<LineChartStyleOptions, 'thresholdLine
 export const defaultLineChartStyles: LineChartStyle = {
   addLegend: true,
   legendPosition: Positions.RIGHT,
+  legendTitle: '',
   addTimeMarker: false,
 
   lineStyle: 'both',

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
@@ -113,6 +113,9 @@ export const LineVisStyleControls: React.FC<LineVisStyleControlsProps> = ({
                   if (legendOptions.position !== undefined) {
                     updateStyleOption('legendPosition', legendOptions.position);
                   }
+                  if (legendOptions.title !== undefined) {
+                    updateStyleOption('legendTitle', legendOptions.title);
+                  }
                 }}
               />
             </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -170,7 +170,7 @@ export const createLineBarChart = (
         datum: metric1Name,
         legend: styles.addLegend
           ? {
-              title: 'Metrics',
+              title: styles.legendTitle || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
@@ -221,7 +221,7 @@ export const createLineBarChart = (
         datum: metric2Name,
         legend: styles.addLegend
           ? {
-              title: 'Metrics',
+              title: styles.legendTitle || 'Metrics',
               orient: styles.legendPosition,
             }
           : null,
@@ -333,7 +333,7 @@ export const createMultiLineChart = (
         legend:
           styles?.addLegend !== false
             ? {
-                title: categoryName,
+                title: styles.legendTitle || categoryName,
                 orient: styles?.legendPosition || Positions.RIGHT,
               }
             : null,
@@ -464,7 +464,7 @@ export const createFacetedMultiLineChart = (
               legend:
                 styles?.addLegend !== false
                   ? {
-                      title: category1Name,
+                      title: styles.legendTitle || category1Name,
                       orient: styles?.legendPosition || Positions.RIGHT,
                     }
                   : null,

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.ts
@@ -23,6 +23,7 @@ export interface PieChartStyleOptions {
   addTooltip?: boolean;
   addLegend?: boolean;
   legendPosition?: Positions;
+  legendTitle?: string;
   tooltipOptions?: TooltipOptions;
 
   // Exclusive controls
@@ -38,6 +39,7 @@ export const defaultPieChartStyles: PieChartStyle = {
   addTooltip: true,
   addLegend: true,
   legendPosition: Positions.RIGHT,
+  legendTitle: '',
   tooltipOptions: {
     mode: 'all',
   },

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_options.tsx
@@ -71,6 +71,9 @@ export const PieVisStyleControls: React.FC<PieVisStyleControlsProps> = ({
                 if (legendOptions.position !== undefined) {
                   updateStyleOption('legendPosition', legendOptions.position);
                 }
+                if (legendOptions.title !== undefined) {
+                  updateStyleOption('legendTitle', legendOptions.title);
+                }
               }}
             />
           </EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
@@ -33,7 +33,11 @@ export const createPieSpec = (
       field: categoryField,
       type: 'nominal',
       legend: styleOptions.addLegend
-        ? { title: numericName, orient: styleOptions.legendPosition, symbolLimit: 10 }
+        ? {
+            title: styleOptions.legendTitle || numericName,
+            orient: styleOptions.legendPosition,
+            symbolLimit: 10,
+          }
         : null,
     },
   };

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.ts
@@ -31,6 +31,8 @@ export interface ScatterChartStyleOptions {
   tooltipOptions?: TooltipOptions;
   addLegend?: boolean;
   legendPosition?: Positions;
+  legendTitle?: string;
+  legendTitle2?: string;
   // Axes configuration
   standardAxes?: StandardAxes[];
 
@@ -52,6 +54,8 @@ export const defaultScatterChartStyles: ScatterChartStyle = {
   },
   addLegend: true,
   legendPosition: Positions.RIGHT,
+  legendTitle: '',
+  legendTitle2: '',
 
   // exclusive
   exclusive: {

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
@@ -41,6 +41,8 @@ export const ScatterVisStyleControls: React.FC<ScatterVisStyleControlsProps> = (
   // visualization is generated in this case so we shouldn't display style option panels.
   const hasMappingSelected = !isEmpty(axisColumnMappings);
   const hasColorMapping = !!axisColumnMappings?.[AxisRole.COLOR];
+  const hasSizeMapping = !!axisColumnMappings?.[AxisRole.SIZE];
+
   return (
     <EuiFlexGroup direction="column" gutterSize="none">
       <EuiFlexItem>
@@ -86,22 +88,31 @@ export const ScatterVisStyleControls: React.FC<ScatterVisStyleControlsProps> = (
             />
           </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <LegendOptionsPanel
-              legendOptions={{
-                show: styleOptions.addLegend,
-                position: styleOptions.legendPosition,
-              }}
-              onLegendOptionsChange={(legendOptions) => {
-                if (legendOptions.show !== undefined) {
-                  updateStyleOption('addLegend', legendOptions.show);
-                }
-                if (legendOptions.position !== undefined) {
-                  updateStyleOption('legendPosition', legendOptions.position);
-                }
-              }}
-            />
-          </EuiFlexItem>
+          {hasColorMapping && (
+            <EuiFlexItem grow={false}>
+              <LegendOptionsPanel
+                legendOptions={{
+                  show: styleOptions.addLegend,
+                  position: styleOptions.legendPosition,
+                }}
+                onLegendOptionsChange={(legendOptions) => {
+                  if (legendOptions.show !== undefined) {
+                    updateStyleOption('addLegend', legendOptions.show);
+                  }
+                  if (legendOptions.position !== undefined) {
+                    updateStyleOption('legendPosition', legendOptions.position);
+                  }
+                  if (legendOptions.title !== undefined) {
+                    updateStyleOption('legendTitle', legendOptions.title);
+                  }
+                  if (legendOptions.title2 !== undefined) {
+                    updateStyleOption('legendTitle2', legendOptions.title2);
+                  }
+                }}
+                hasTwoLegends={hasSizeMapping}
+              />
+            </EuiFlexItem>
+          )}
 
           <EuiFlexItem grow={false}>
             <TitleOptionsPanel

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
@@ -108,7 +108,7 @@ export const createTwoMetricOneCateScatter = (
         type: getSchemaByAxis(colorColumn),
         legend: styles?.addLegend
           ? {
-              title: categoryNames || 'Metrics',
+              title: styles?.legendTitle || categoryNames || 'Metrics',
               orient: styles?.legendPosition,
               symbolLimit: 10,
             }
@@ -185,7 +185,7 @@ export const createThreeMetricOneCateScatter = (
         type: getSchemaByAxis(colorColumn),
         legend: styles?.addLegend
           ? {
-              title: categoryNames || 'Metrics',
+              title: styles?.legendTitle || categoryNames || 'Metrics',
               orient: styles?.legendPosition,
               symbolLimit: 10,
             }
@@ -196,7 +196,7 @@ export const createThreeMetricOneCateScatter = (
         type: getSchemaByAxis(numericalSize),
         legend: styles?.addLegend
           ? {
-              title: numericalSize?.name || 'Metrics',
+              title: styles?.legendTitle2 || numericalSize?.name || 'Metrics',
               orient: styles?.legendPosition,
               symbolLimit: 10,
             }

--- a/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/legend/legend.tsx
@@ -8,20 +8,25 @@ import React from 'react';
 import { EuiFormRow, EuiSpacer, EuiSwitch, EuiSelect } from '@elastic/eui';
 import { Positions } from '../../types';
 import { StyleAccordion } from '../style_accordion';
+import { DebouncedFieldText } from '../utils';
 
 export interface LegendOptions {
   show: boolean;
   position: Positions;
+  title?: string;
+  title2?: string;
 }
 
 export interface LegendOptionsProps {
   legendOptions: LegendOptions;
   onLegendOptionsChange: (legendOptions: Partial<LegendOptions>) => void;
+  hasTwoLegends?: boolean;
 }
 
 export const LegendOptionsPanel = ({
   legendOptions,
   onLegendOptionsChange,
+  hasTwoLegends = false,
 }: LegendOptionsProps) => {
   if (!legendOptions || !onLegendOptionsChange) {
     return null;
@@ -89,6 +94,49 @@ export const LegendOptionsPanel = ({
               data-test-subj="legendPositionSelect"
             />
           </EuiFormRow>
+          <EuiSpacer size="s" />
+          <EuiFormRow
+            label={
+              hasTwoLegends
+                ? i18n.translate('explore.stylePanel.legend.colorTitle', {
+                    defaultMessage: 'Color legend title',
+                  })
+                : i18n.translate('explore.stylePanel.legend.title', {
+                    defaultMessage: 'Legend title',
+                  })
+            }
+          >
+            <DebouncedFieldText
+              value={legendOptions.title || ''}
+              onChange={(value: string) => onLegendOptionsChange({ title: value })}
+              data-test-subj="legendTitleInput"
+              placeholder={
+                hasTwoLegends
+                  ? i18n.translate('explore.stylePanel.legend.colorTitle.placeholder', {
+                      defaultMessage: 'Color legend name',
+                    })
+                  : i18n.translate('explore.stylePanel.legend.title.placeholder', {
+                      defaultMessage: 'Legend name',
+                    })
+              }
+            />
+          </EuiFormRow>
+          {hasTwoLegends && (
+            <EuiFormRow
+              label={i18n.translate('explore.stylePanel.legend.title2', {
+                defaultMessage: 'Size legend title',
+              })}
+            >
+              <DebouncedFieldText
+                value={legendOptions.title2 || ''}
+                onChange={(value: string) => onLegendOptionsChange({ title2: value })}
+                data-test-subj="legendTitle2Input"
+                placeholder={i18n.translate('explore.stylePanel.legend.title2.placeholder', {
+                  defaultMessage: 'Size legend name',
+                })}
+              />
+            </EuiFormRow>
+          )}
         </>
       )}
     </StyleAccordion>


### PR DESCRIPTION
### Description

This PR enhances visualization by allowing users to customize the legend name. 

## Screenshot

### Single legend
<img width="2978" height="1428" alt="image" src="https://github.com/user-attachments/assets/e67c0919-2863-4ef8-82c3-f62c023fe37b" />

### Multiple legends
<img width="2976" height="1548" alt="image" src="https://github.com/user-attachments/assets/415c1768-b618-4487-a755-f690df0dd572" />

## Changelog
- feat: Allow customizing legend name

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
