### PR TITLE
Trace:Details Handle undefined items in span table

### DIFF
--- a/changelogs/fragments/10608.yml
+++ b/changelogs/fragments/10608.yml
@@ -1,0 +1,2 @@
+fix:
+- Handle undefined items in span table ([#10608](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10608))

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_table.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_table.test.tsx
@@ -476,6 +476,12 @@ describe('SpanCell', () => {
     fireEvent.click(screen.getByText('test-span'));
     expect(openFlyoutMock).not.toHaveBeenCalled();
   });
+
+  it('handles undefined item', () => {
+    render(<SpanCell {...defaultProps} items={[]} />);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
 });
 
 describe('HierarchyServiceSpanCell', () => {
@@ -533,6 +539,12 @@ describe('HierarchyServiceSpanCell', () => {
 
     fireEvent.click(screen.getByText('hierarchy-service'));
     expect(openFlyoutMock).not.toHaveBeenCalled();
+  });
+
+  it('handles undefined item', () => {
+    render(<HierarchyServiceSpanCell {...defaultProps} items={[]} />);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
   });
 });
 

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_table.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_table.tsx
@@ -151,10 +151,10 @@ export const HierarchyServiceSpanCell = ({
   setExpandedRows: React.Dispatch<React.SetStateAction<Set<string>>>;
 }) => {
   const item = items[rowIndex];
-  const value = item[columnId];
+  const value = item?.[columnId];
 
   const isRowSelected =
-    props.selectedSpanId && props.selectedSpanId === item.spanId && !disableInteractions;
+    item && props.selectedSpanId && props.selectedSpanId === item.spanId && !disableInteractions;
 
   useEffect(() => {
     if (isRowSelected) {
@@ -164,14 +164,14 @@ export const HierarchyServiceSpanCell = ({
     } else {
       setCellProps?.({ className: ['treeCell--firstColumn'] });
     }
-  }, [props.selectedSpanId, item.spanId, disableInteractions, isRowSelected, setCellProps]);
+  }, [props.selectedSpanId, item?.spanId, disableInteractions, isRowSelected, setCellProps]);
 
-  const indentation = `${(item.level || 0) * 20}px`;
-  const isExpanded = expandedRows.has(item.spanId);
+  const indentation = `${(item?.level || 0) * 20}px`;
+  const isExpanded = expandedRows.has(item?.spanId);
 
   const cellContent = (
     <div className="exploreSpanDetailTable__hierarchyCell" style={{ paddingLeft: indentation }}>
-      {item.children && item.children.length > 0 ? (
+      {item?.children && item.children.length > 0 ? (
         <EuiIcon
           type={isExpanded ? 'arrowDown' : 'arrowRight'}
           onClick={() => {
@@ -195,7 +195,7 @@ export const HierarchyServiceSpanCell = ({
     </div>
   );
 
-  return disableInteractions ? (
+  return disableInteractions || !item ? (
     cellContent
   ) : (
     <button onClick={() => props.openFlyout(item.spanId)}>{cellContent}</button>
@@ -223,16 +223,21 @@ export const SpanCell = ({
   const item = items[adjustedRowIndex];
 
   useEffect(() => {
-    if (props.selectedSpanId && props.selectedSpanId === item.spanId && !disableInteractions) {
+    if (
+      item &&
+      props.selectedSpanId &&
+      props.selectedSpanId === item.spanId &&
+      !disableInteractions
+    ) {
       setCellProps?.({ className: 'exploreSpanDetailTable__selectedRow' });
     } else {
       setCellProps?.({});
     }
-  }, [props.selectedSpanId, item.spanId, disableInteractions]);
+  }, [props.selectedSpanId, item?.spanId, disableInteractions]);
 
   const cellContent = renderSpanCellValue({ item, columnId });
 
-  return disableInteractions ? (
+  return disableInteractions || !item ? (
     cellContent
   ) : (
     <button


### PR DESCRIPTION
### Description

Fixes a bug where undefined spans are not handled properly when paginating through the span detail table. 

### Issues Resolved

## Screenshot
Before: 
<img width="1470" height="735" alt="Screenshot 2025-09-30 at 10 05 52 AM" src="https://github.com/user-attachments/assets/0837bca3-dfa8-472c-8444-7e66d5ecb0c5" />


After:
<img width="1159" height="691" alt="Screenshot 2025-09-30 at 10 06 37 AM" src="https://github.com/user-attachments/assets/09f4b8ba-1e19-4622-a14f-457aeec74c8b" />


## Testing the changes

## Changelog
- fix: handle undefined items in span table

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
