### PR TITLE
Fix CI/CD failure: Cannot find module @osd/optimizer/target/cli

### DIFF
--- a/changelogs/fragments/10613.yml
+++ b/changelogs/fragments/10613.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix CI/CD failure: Cannot find module @osd/optimizer/target/cli ([#10613](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10613))

--- a/scripts/build_opensearch_dashboards_platform_plugins.js
+++ b/scripts/build_opensearch_dashboards_platform_plugins.js
@@ -28,4 +28,25 @@
  * under the License.
  */
 
+var execSync = require('child_process').execSync;
+var existsSync = require('fs').existsSync;
+var path = require('path');
+
+// Check if optimizer CLI exists
+var optimizerCliPath = path.resolve(__dirname, '../packages/osd-optimizer/target/cli.js');
+
+if (!existsSync(optimizerCliPath)) {
+  console.log('Building @osd/optimizer package...');
+  try {
+    execSync('yarn workspace @osd/optimizer build', {
+      stdio: 'inherit',
+      cwd: path.resolve(__dirname, '..'),
+    });
+  } catch (error) {
+    console.error('Failed to build @osd/optimizer package');
+    process.exit(1);
+  }
+}
+
+// Now require the CLI
 require('@osd/optimizer/target/cli');


### PR DESCRIPTION
### Description

CI/CD workflows are failing with the following errors:

* Module Not Found Error:
```
Error: Cannot find module '@osd/optimizer/target/cli'
Require stack:
- /path/to/OpenSearch-Dashboards/scripts/build_opensearch_dashboards_platform_plugins.js

```

This occurs because the build_opensearch_dashboards_platform_plugins.js script directly requires @osd/optimizer/target/cli without ensuring the optimizer package has been built first. While yarn osd bootstrap should build all packages, it sometimes fails silently in CI environments, especially on Windows. 

Try to modify scripts/build_opensearch_dashboards_platform_plugins_safe.js which checks if @osd/optimizer/target/cli exists before requiring it. Automatically builds the optimizer package if missing using `yarn workspace @osd/optimizer build`.

* Windows Worker Timeout Error (occurring after the first issue was partially resolved):
```
ERROR UNHANDLED ERROR
ERROR Error: process did not automatically exit within 30 seconds (previous code: 0); forcing exit...
Error: Process completed with exit code 1.
```
The error shows previous code: 0 (success), indicating workers completed successfully but didn't exit within the 30-second timeout. This is a Windows-specific issue with Node.js worker processes not exiting cleanly. 

The solution reduced timeout on Windows from 30 seconds to 5 seconds (faster feedback). If process completed successfully (code 0) but didn't exit, force exit without error.

### Test
<img width="1143" height="494" alt="Screenshot 2025-09-30 at 10 05 19 PM" src="https://github.com/user-attachments/assets/241b68df-180a-4ac8-b138-c06809f328de" />

No failures on windows after fix for first run


### Issues Resolved

NA



## Changelog

- fix: Fix CI/CD failure: Cannot find module @osd/optimizer/target/cli


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
