### PR TITLE
Bumps cypress-request to 3.0.9

### DIFF
--- a/changelogs/fragments/10618.yml
+++ b/changelogs/fragments/10618.yml
@@ -1,2 +1,2 @@
 chore:
-- Bumps cypress to 14.5.3 ([#10618](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10618))
+- Bumps cypress-request to 3.0.9 ([#10618](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10618))

--- a/changelogs/fragments/10618.yml
+++ b/changelogs/fragments/10618.yml
@@ -1,0 +1,2 @@
+chore:
+- Bumps cypress to 14.5.3 ([#10618](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10618))

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "**/@babel/runtime": "^7.27.0",
     "**/@babel/runtime-corejs3": "^7.27.0",
     "**/@babel/traverse": "^7.27.0",
-    "**/@cypress/request": "^3.0.0",
+    "**/@cypress/request": "^3.0.9",
     "**/cipher-base": "^1.0.5",
     "**/sha.js": "^2.4.12",
     "**/@types/node": "~20.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,10 +3650,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@cypress/request@^3.0.0", "@cypress/request@^3.0.6":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.8.tgz#992f1f42ba03ebb14fa5d97290abe9d015ed0815"
-  integrity sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==
+"@cypress/request@^3.0.6", "@cypress/request@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.9.tgz#8ed6e08fea0c62998b5552301023af7268f11625"
+  integrity sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -3661,7 +3661,7 @@
     combined-stream "~1.0.6"
     extend "~3.0.2"
     forever-agent "~0.6.1"
-    form-data "~4.0.0"
+    form-data "~4.0.4"
     http-signature "~1.4.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -15688,7 +15688,7 @@ form-data-encoder@1.7.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
   integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
 
-form-data@^3.0.0, form-data@^4.0.0, form-data@^4.0.4, form-data@~4.0.0:
+form-data@^3.0.0, form-data@^4.0.0, form-data@^4.0.4, form-data@~4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==


### PR DESCRIPTION
### Description

Resolves CVE-2025-7783

## Changelog
- chore: Bumps cypress-request to 3.0.9

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
