### PR TITLE
Fix Column Value Caching for Autocomplete

### DIFF
--- a/changelogs/fragments/10621.yml
+++ b/changelogs/fragments/10621.yml
@@ -1,0 +1,2 @@
+fix:
+- Column Value Caching for Autocomplete ([#10621](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10621))

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -16,7 +16,6 @@ import {
 import { QueryExecutionStatus } from '../types';
 import { setResults } from '../slices';
 import { Query, DataView } from 'src/plugins/data/common';
-import { DataPublicPluginStart } from '../../../../../../data/public';
 import { ExploreServices } from '../../../../types';
 import { SAMPLE_SIZE_SETTING } from '../../../../../common';
 
@@ -439,7 +438,7 @@ describe('Query Actions - Comprehensive Test Suite', () => {
       expect(mockGetFieldValueCounts).toHaveBeenCalledWith({
         hits: rawResults.hits.hits,
         field: mockField,
-        indexPattern: mockDatasetWithFields,
+        dataSet: mockDatasetWithFields,
         count: 5,
         grouped: false,
       });

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -123,7 +123,7 @@ const updateFieldTopQueryValues = (hits: any[], dataset: DataView): void => {
       const result = getFieldValueCounts({
         hits,
         field,
-        indexPattern: dataset, // DataView extends IndexPattern
+        dataSet: dataset, // DataView extends IndexPattern
         count: 5,
         grouped: false,
       });


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
The Column Value Caching was broken due to the wrong params being passed.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

https://github.com/user-attachments/assets/2924fb79-a118-4165-9471-2da1dcec0a63

The first suggestions are the values from the hits cached, the next set are fetched from API call and cached for subsequent calls. 

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Column Value Caching for Autocomplete


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
