### PR TITLE
feat(trace-details): improve timeline loading state with spinner

### DIFF
--- a/changelogs/fragments/10629.yml
+++ b/changelogs/fragments/10629.yml
@@ -1,0 +1,2 @@
+feat:
+- Improve timeline loading state with spinner ([#10629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10629))

--- a/src/plugins/explore/public/components/doc_viewer/trace_details_view/trace_details_view.tsx
+++ b/src/plugins/explore/public/components/doc_viewer/trace_details_view/trace_details_view.tsx
@@ -7,6 +7,7 @@ import './trace_details_view.scss';
 import React, { useMemo, useState } from 'react';
 import { EuiEmptyPrompt, EuiText, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { EuiLoadingSpinner, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { TRACE_ID_FIELD_PATHS, SPAN_ID_FIELD_PATHS } from '../../../utils/trace_field_constants';
 import { SpanDetailPanel } from '../../../application/pages/traces/trace_details/public/traces/span_detail_panel';
 import { DocViewRenderProps } from '../../../types/doc_views_types';
@@ -214,11 +215,18 @@ export function TraceDetailsView({ hit }: DocViewRenderProps) {
     <div className="exploreTraceDetailsView">
       {isLoading ? (
         <div className="exploreTraceDetailsView__loadingContainer">
-          <EuiText>
-            {i18n.translate('explore.docViews.traceDetails.loading', {
-              defaultMessage: 'Loading trace gantt chart...',
-            })}
-          </EuiText>
+          <EuiFlexGroup direction="column" alignItems="center" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="xl" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                {i18n.translate('explore.docViews.traceDetails.loading', {
+                  defaultMessage: 'Loading...',
+                })}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </div>
       ) : transformedHits.length > 0 ? (
         <SpanDetailPanel


### PR DESCRIPTION
### Description

Enhances the trace detail page timeline loading state by adding a centered loading spinner with text feedback. This improves user experience by providing clear visual indication when the timeline data is being fetched.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
Before
<img width="1079" height="498" alt="Screenshot 2025-10-02 at 8 27 14 AM" src="https://github.com/user-attachments/assets/836e91bc-af54-4c27-b308-6179b799124c" />

After
<img width="1084" height="464" alt="Screenshot 2025-10-02 at 8 46 32 AM" src="https://github.com/user-attachments/assets/cb5a2263-ec14-48b8-9789-bcfeacd3c5d8" />


## Testing the changes
To verify this change:
1. Navigate to the trace detail page
2. Clear browser cache or use network throttling to slow down data loading
3. Verify that:
   - A centered loading spinner appears while timeline data loads
   - "Loading..." text is displayed below the spinner
   - Spinner and text are properly centered on the page
   - Loading state is replaced by timeline content once data loads

## Changelog
- feat: improve timeline loading state with spinner


### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
