### PR TITLE
Trace Details: Add Timeline waterfall bars column to SpanDetailTableHierarchy + Bugfixes

### DIFF
--- a/changelogs/fragments/10610.yml
+++ b/changelogs/fragments/10610.yml
@@ -1,0 +1,2 @@
+fix:
+- Add Timeline waterfall bars column to SpanDetailTableHierarchy ([#10610](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10610))

--- a/changelogs/fragments/10610.yml
+++ b/changelogs/fragments/10610.yml
@@ -1,2 +1,0 @@
-fix:
-- Add Timeline waterfall bars column to SpanDetailTableHierarchy ([#10610](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10610))

--- a/changelogs/fragments/10637.yml
+++ b/changelogs/fragments/10637.yml
@@ -1,0 +1,2 @@
+fix:
+- Add Timeline waterfall bars column to SpanDetailTableHierarchy ([#10637](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10637))

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_data_adapter.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_data_adapter.ts
@@ -10,6 +10,7 @@ import {
   resolveServiceNameFromSpan,
   hasNanosecondPrecision,
 } from '../traces/ppl_resolve_helpers';
+import { parseHighPrecisionTimestamp } from '../utils/span_timerange_utils';
 
 interface SpanSource {
   traceId: string;
@@ -79,38 +80,6 @@ interface VegaGanttData {
 interface HierarchicalSpan extends SpanData {
   children: HierarchicalSpan[];
   level: number;
-}
-
-function parseHighPrecisionTimestamp(timestampStr: string): number {
-  if (!timestampStr) return 0;
-
-  try {
-    let normalizedTimestamp = timestampStr;
-
-    if (timestampStr.includes(' ') && !timestampStr.includes('T')) {
-      normalizedTimestamp = timestampStr.replace(' ', 'T');
-      if (!normalizedTimestamp.includes('Z')) {
-        normalizedTimestamp += 'Z';
-      }
-    }
-
-    const date = new Date(normalizedTimestamp);
-
-    const fractionalMatch = timestampStr.match(/\.(\d+)/);
-    if (fractionalMatch) {
-      const fractionalPart = fractionalMatch[1];
-      const millisecondsFromFraction = parseFloat('0.' + fractionalPart) * 1000;
-
-      const baseMs = Math.floor(date.getTime() / 1000) * 1000;
-      const secondsMs = date.getSeconds() * 1000;
-
-      return baseMs + secondsMs + millisecondsFromFraction;
-    }
-
-    return date.getTime();
-  } catch (error) {
-    return 0;
-  }
 }
 
 function buildHierarchicalStructure(spans: SpanData[]): HierarchicalSpan[] {

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_panel.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_panel.tsx
@@ -106,7 +106,7 @@ export function SpanDetailPanel(props: {
     () => (
       <div className="exploreSpanDetailPanel__tableContainer">
         <SpanDetailTableHierarchy
-          hiddenColumns={['traceId', 'traceGroup', 'startTime', 'endTime']}
+          hiddenColumns={['traceId', 'traceGroup', 'startTime', 'endTime', 'parentSpanId']}
           openFlyout={(spanId: string) => {
             if (onSpanSelect) {
               onSpanSelect(spanId);
@@ -116,10 +116,11 @@ export function SpanDetailPanel(props: {
           payloadData={payloadData}
           filters={spanFilters}
           selectedSpanId={props.selectedSpanId}
+          colorMap={colorMap}
         />
       </div>
     ),
-    [onSpanSelect, payloadData, spanFilters, availableWidth, props.selectedSpanId]
+    [onSpanSelect, payloadData, spanFilters, availableWidth, props.selectedSpanId, colorMap]
   );
 
   const parsedData = useMemo(() => {

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_table.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_detail_table.test.tsx
@@ -18,6 +18,14 @@ jest.mock('../utils/helper_functions', () => ({
   nanoToMilliSec: jest.fn((nanos: number) => nanos / 1000000),
 }));
 
+jest.mock('../utils/span_timerange_utils', () => ({
+  calculateTraceTimeRange: jest.fn(() => ({
+    durationMs: 1000,
+    startTimeMs: 0,
+    endTimeMs: 1000,
+  })),
+}));
+
 jest.mock('../utils/custom_datagrid', () => ({
   RenderCustomDataGrid: jest.fn(({ toolbarButtons, props }) => {
     const mockData = {

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_header.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_header.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TimelineHeader } from './timeline_header';
+
+jest.mock('./timeline_ruler', () => ({
+  TimelineRuler: jest.fn(() => <div data-test-subj="timeline-ruler" />),
+}));
+
+describe('TimelineHeader', () => {
+  const mockProps = {
+    traceTimeRange: {
+      durationMs: 1000,
+      startTimeMs: 0,
+      endTimeMs: 1000,
+    },
+  };
+
+  it('should render timeline text and TimelineRuler component', () => {
+    const { getByText, getByTestId } = render(<TimelineHeader {...mockProps} />);
+
+    expect(getByText('Timeline')).toBeInTheDocument();
+    expect(getByTestId('timeline-ruler')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_header.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_header.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { TimelineRuler, TimelineRulerProps } from './timeline_ruler';
+
+export type TimelineHeaderProps = TimelineRulerProps;
+
+export const TimelineHeader: React.FC<TimelineHeaderProps> = (props) => {
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs">
+          <b>
+            {i18n.translate('explore.spanDetailTable.column.timeline', {
+              defaultMessage: 'Timeline',
+            })}
+          </b>
+        </EuiText>
+      </EuiFlexItem>
+      <TimelineRuler {...props} />
+    </EuiFlexGroup>
+  );
+};

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler.scss
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler.scss
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.exploreTimelineRuler {
+  color: $euiColorMediumShade;
+
+  &__baseline {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background-color: currentColor;
+  }
+
+  &__tickContainer {
+    position: absolute;
+    bottom: 0;
+    transform: translateX(-50%);
+
+    .exploreTimelineRuler__label {
+      font-size: $euiFontSizeXS;
+      line-height: 1;
+      white-space: nowrap;
+      margin-bottom: 2px;
+
+      &--first {
+        text-align: left;
+        margin-left: 50%;
+      }
+
+      &--last {
+        position: relative;
+        right: 50%;
+        text-align: right;
+      }
+
+      &--center {
+        text-align: center;
+      }
+    }
+
+    .exploreTimelineRuler__tick {
+      height: 8px;
+      width: 2px;
+      background-color: currentColor;
+      margin: 0 auto;
+    }
+  }
+}

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TimelineRuler } from './timeline_ruler';
+import { useTimelineTicks } from './timeline_ruler_hooks';
+
+jest.mock('./timeline_ruler_hooks');
+
+const mockUseTimelineTicks = useTimelineTicks as jest.MockedFunction<typeof useTimelineTicks>;
+
+describe('TimelineRuler', () => {
+  const mockTraceTimeRange = {
+    durationMs: 1000,
+    startTimeMs: 0,
+    endTimeMs: 1000,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render ticks with correct labels and offsets', () => {
+    const mockTicks = [
+      { value: 0, offsetPercent: 0 },
+      { value: 250, offsetPercent: 25 },
+      { value: 500, offsetPercent: 50 },
+      { value: 750, offsetPercent: 75 },
+      { value: 1000, offsetPercent: 100 },
+    ];
+    mockUseTimelineTicks.mockReturnValue(mockTicks);
+
+    const { getByTestId } = render(<TimelineRuler traceTimeRange={mockTraceTimeRange} />);
+
+    mockTicks.forEach((tick) => {
+      const container = getByTestId(`tick-container-${tick.value}`);
+      const label = getByTestId(`tick-label-${tick.value}`);
+      const mark = getByTestId(`tick-mark-${tick.value}`);
+
+      expect(container).toHaveStyle({ left: `${tick.offsetPercent}%` });
+      expect(label).toHaveTextContent(`${tick.value}ms`);
+      expect(mark).toBeInTheDocument();
+    });
+  });
+
+  it('should apply correct CSS classes for first, last, and center ticks', () => {
+    const mockTicks = [
+      { value: 0, offsetPercent: 0 },
+      { value: 500, offsetPercent: 50 },
+      { value: 1000, offsetPercent: 100 },
+    ];
+    mockUseTimelineTicks.mockReturnValue(mockTicks);
+
+    const { getByTestId } = render(<TimelineRuler traceTimeRange={mockTraceTimeRange} />);
+
+    expect(getByTestId('tick-label-0')).toHaveClass('exploreTimelineRuler__label--first');
+    expect(getByTestId('tick-label-500')).toHaveClass('exploreTimelineRuler__label--center');
+    expect(getByTestId('tick-label-1000')).toHaveClass('exploreTimelineRuler__label--last');
+  });
+
+  it('should pass correct parameters to useTimelineTicks', () => {
+    mockUseTimelineTicks.mockReturnValue([]);
+
+    render(<TimelineRuler traceTimeRange={mockTraceTimeRange} paddingPercent={5} />);
+
+    expect(mockUseTimelineTicks).toHaveBeenCalledWith(1000, 0, 8, 5);
+  });
+
+  it('should render empty when no ticks are provided', () => {
+    mockUseTimelineTicks.mockReturnValue([]);
+
+    const { container } = render(<TimelineRuler traceTimeRange={mockTraceTimeRange} />);
+
+    expect(container.querySelectorAll('.exploreTimelineRuler__tickContainer')).toHaveLength(0);
+  });
+});

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { TraceTimeRange } from '../../utils/span_timerange_utils';
+import './timeline_ruler.scss';
+import { useTimelineTicks } from './timeline_ruler_hooks';
+
+export interface TimelineRulerProps {
+  traceTimeRange: TraceTimeRange;
+  paddingPercent?: number;
+}
+
+export const TimelineRuler: React.FC<TimelineRulerProps> = ({
+  traceTimeRange,
+  paddingPercent = 2,
+}) => {
+  const ticks = useTimelineTicks(traceTimeRange.durationMs, 0, 8, paddingPercent);
+
+  return (
+    <div className="exploreTimelineRuler" style={{ height: '30px', position: 'relative' }}>
+      <div className="exploreTimelineRuler__baseline" />
+      {ticks.map((tick, index) => {
+        const labelClassName =
+          index === 0
+            ? 'exploreTimelineRuler__label--first'
+            : index === ticks.length - 1
+            ? 'exploreTimelineRuler__label--last'
+            : 'exploreTimelineRuler__label--center';
+
+        return (
+          <div
+            key={tick.value}
+            className="exploreTimelineRuler__tickContainer"
+            style={{ left: `${tick.offsetPercent}%` }}
+            data-test-subj={`tick-container-${tick.value}`}
+          >
+            <div
+              className={`exploreTimelineRuler__label ${labelClassName}`}
+              data-test-subj={`tick-label-${tick.value}`}
+            >
+              {tick.value}ms
+            </div>
+            <div
+              className="exploreTimelineRuler__tick"
+              data-test-subj={`tick-mark-${tick.value}`}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler_hooks.test.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler_hooks.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useTimelineTicks } from './timeline_ruler_hooks';
+
+describe('useTimelineTicks', () => {
+  it('should generate ticks for basic range', () => {
+    const { result } = renderHook(() => useTimelineTicks(1000, 0, 8));
+
+    expect(result.current).toHaveLength(6);
+    expect(result.current[0]).toEqual({ value: 0, offsetPercent: 0 });
+    expect(result.current[5]).toEqual({ value: 1000, offsetPercent: 100 });
+  });
+
+  it('should respect container padding', () => {
+    const { result } = renderHook(() => useTimelineTicks(100, 0, 8, 10));
+
+    expect(result.current[0].offsetPercent).toBe(10);
+    expect(result.current[result.current.length - 1].offsetPercent).toBe(90);
+  });
+
+  it('should generate ticks based on desired count', () => {
+    const { result } = renderHook(() => useTimelineTicks(100, 0, 5));
+
+    expect(result.current.length).toBeGreaterThan(0);
+    expect(result.current.length).toBeLessThanOrEqual(10);
+  });
+
+  it('should handle non-zero minimum values', () => {
+    const { result } = renderHook(() => useTimelineTicks(150, 50, 8));
+
+    expect(result.current[0].value).toBeGreaterThanOrEqual(50);
+    expect(result.current[0].offsetPercent).toBe(10);
+  });
+
+  it('should generate nice step values', () => {
+    const { result } = renderHook(() => useTimelineTicks(1000, 0, 8));
+
+    const steps = result.current.slice(1).map((tick, i) => tick.value - result.current[i].value);
+    expect(steps.every((step) => step === steps[0])).toBe(true);
+  });
+
+  it('should round values to 2 decimal places', () => {
+    const { result } = renderHook(() => useTimelineTicks(3.333, 0, 8));
+
+    result.current.forEach((tick) => {
+      expect(tick.value).toBe(Math.round(tick.value * 100) / 100);
+    });
+  });
+
+  it('should return empty array when range is zero', () => {
+    const { result } = renderHook(() => useTimelineTicks(100, 100, 8));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return empty array when range is negative', () => {
+    const { result } = renderHook(() => useTimelineTicks(50, 100, 8));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return empty array when desiredTickCount is less than 2', () => {
+    const { result } = renderHook(() => useTimelineTicks(100, 0, 1));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('should handle floating point precision correctly', () => {
+    const { result } = renderHook(() => useTimelineTicks(0.3, 0.1, 3));
+
+    expect(result.current.length).toBeGreaterThan(0);
+    result.current.forEach((tick) => {
+      expect(tick.value).toBeGreaterThanOrEqual(0.1);
+      expect(tick.value).toBeLessThanOrEqual(0.3);
+    });
+  });
+
+  it('should not exceed max value in ticks', () => {
+    const { result } = renderHook(() => useTimelineTicks(97, 0, 8));
+
+    result.current.forEach((tick) => {
+      expect(tick.value).toBeLessThanOrEqual(97);
+    });
+  });
+});

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler_hooks.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_ruler_hooks.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useMemo } from 'react';
+
+export interface Tick {
+  value: number;
+  offsetPercent: number;
+}
+
+/**
+ * Generates timeline tick marks with "nice" values and positions.
+ * Takes a min/max range and desired tick count, then calculates evenly-spaced
+ * ticks with human-readable values (1, 2, 5, 10, etc.) and their percentage
+ * positions within the container, accounting for padding.
+ */
+export const useTimelineTicks = (
+  max: number,
+  min: number,
+  desiredTickCount: number,
+  containerPadding: number = 0
+): Tick[] => {
+  return useMemo(() => {
+    const range = max - min;
+    if (range <= 0 || desiredTickCount < 2) return [];
+
+    // Step 1: Calculate a "nice" step size
+    const roughStep = range / (desiredTickCount - 1);
+    const stepMagnitude = Math.pow(10, Math.floor(Math.log10(roughStep)));
+    const normalizedStep = roughStep / stepMagnitude;
+
+    // Choose nice step values: 1, 2, 5, or 10 (times the magnitude)
+    let niceStepMultiplier;
+    if (normalizedStep <= 1) niceStepMultiplier = 1;
+    else if (normalizedStep <= 2) niceStepMultiplier = 2;
+    else if (normalizedStep <= 5) niceStepMultiplier = 5;
+    else niceStepMultiplier = 10;
+
+    const niceStep = niceStepMultiplier * stepMagnitude;
+
+    // Step 2: Generate tick values using the nice step
+    const ticks: Tick[] = [];
+    const availableWidth = 100 - containerPadding * 2;
+
+    // Start from the first nice value >= min
+    const firstTick = Math.ceil(min / niceStep) * niceStep;
+
+    for (let tickValue = firstTick; tickValue <= max; tickValue += niceStep) {
+      const value = Math.round(tickValue * 100) / 100;
+
+      // Calculate position as percentage of the original range
+      const positionInRange = (value - min) / range;
+      const offsetPercent = Math.round(containerPadding + positionInRange * availableWidth);
+
+      ticks.push({ value, offsetPercent });
+    }
+
+    return ticks;
+  }, [max, min, containerPadding, desiredTickCount]);
+};

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TimelineWaterfallBar } from './timeline_waterfall_bar';
+import { useTimelineBarColor, useTimelineBarRange } from './timeline_waterfall_bar_hooks';
+import { Span } from '../span_detail_table';
+
+jest.mock('./timeline_waterfall_bar_hooks');
+
+const mockUseTimelineBarColor = useTimelineBarColor as jest.MockedFunction<
+  typeof useTimelineBarColor
+>;
+const mockUseTimelineBarRange = useTimelineBarRange as jest.MockedFunction<
+  typeof useTimelineBarRange
+>;
+
+describe('TimelineWaterfallBar', () => {
+  const mockSpan: Span = {
+    spanId: 'span-1',
+    children: [],
+    serviceName: 'test-service',
+    startTime: 1000,
+    endTime: 2000,
+  } as Span;
+
+  const mockTraceTimeRange = {
+    durationMs: 5000,
+    startTimeMs: 1000,
+    endTimeMs: 6000,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTimelineBarColor.mockReturnValue('#ff0000');
+    mockUseTimelineBarRange.mockReturnValue({
+      timelineBarOffsetPercent: 20,
+      timelineBarWidthPercent: 30,
+      durationMs: 1500,
+      relativeStart: 1000,
+      relativeEnd: 2500,
+    });
+  });
+
+  it('should render timeline-bar-offset with correct width', () => {
+    const { getByTestId } = render(
+      <TimelineWaterfallBar
+        span={mockSpan}
+        traceTimeRange={mockTraceTimeRange}
+        paddingPercent={2}
+      />
+    );
+
+    const offsetElement = getByTestId('timeline-bar-offset');
+    expect(offsetElement).toHaveStyle({ width: '22%' }); // 2 + 20
+  });
+
+  it('should render timeline-bar with correct width and color', () => {
+    const { getByTestId } = render(
+      <TimelineWaterfallBar span={mockSpan} traceTimeRange={mockTraceTimeRange} />
+    );
+
+    const barElement = getByTestId('timeline-bar');
+    expect(barElement).toHaveStyle({
+      width: '30%',
+      backgroundColor: '#ff0000',
+      cursor: 'pointer',
+    });
+  });
+
+  it('should render tooltip with correct Duration, Start, and End values on hover', async () => {
+    const { getByTestId } = render(
+      <TimelineWaterfallBar span={mockSpan} traceTimeRange={mockTraceTimeRange} />
+    );
+
+    const toolTipAnchor = getByTestId('timeline-bar-tooltip-anchor');
+    fireEvent.mouseEnter(toolTipAnchor);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Duration: 1500 ms')).toBeInTheDocument();
+        expect(screen.getByText('Start: 1000 ms')).toBeInTheDocument();
+        expect(screen.getByText('End: 2500 ms')).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+  });
+});

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiToolTip, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { Span } from '../span_detail_table';
+import { TraceTimeRange } from '../../utils/span_timerange_utils';
+import { useTimelineBarColor, useTimelineBarRange } from './timeline_waterfall_bar_hooks';
+
+export interface TimelineWaterfallBarProps {
+  span: Span;
+  traceTimeRange: TraceTimeRange;
+  colorMap?: Record<string, string>;
+  paddingPercent?: number;
+}
+
+export const TimelineWaterfallBar: React.FC<TimelineWaterfallBarProps> = ({
+  span,
+  traceTimeRange,
+  colorMap,
+  paddingPercent = 2,
+}) => {
+  const timelineBarColor = useTimelineBarColor(span, colorMap);
+  const {
+    timelineBarOffsetPercent,
+    timelineBarWidthPercent,
+    durationMs,
+    relativeStart,
+    relativeEnd,
+  } = useTimelineBarRange(span, traceTimeRange, paddingPercent);
+
+  return (
+    <EuiFlexGroup gutterSize="none" alignItems="center">
+      <EuiFlexItem
+        grow={false}
+        style={{ width: `${paddingPercent + timelineBarOffsetPercent}%` }}
+        data-test-subj="timeline-bar-offset"
+      />
+      <EuiFlexItem
+        grow={false}
+        style={{
+          width: `${timelineBarWidthPercent}%`,
+          backgroundColor: timelineBarColor,
+          cursor: 'pointer',
+        }}
+        data-test-subj="timeline-bar"
+      >
+        <EuiToolTip
+          content={
+            <EuiFlexGroup
+              direction="column"
+              gutterSize="none"
+              data-testid="timeline-tooltip-content"
+            >
+              <EuiFlexItem>
+                <EuiText size="s">Duration: {durationMs} ms</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="s">Start: {relativeStart} ms</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="s">End: {relativeEnd} ms</EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+        >
+          <div
+            style={{ height: '1.25rem', width: '100%' }}
+            data-test-subj="timeline-bar-tooltip-anchor"
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar_hooks.test.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar_hooks.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useTimelineBarColor, useTimelineBarRange } from './timeline_waterfall_bar_hooks';
+import { calculateSpanTimeRange } from '../../utils/span_timerange_utils';
+import { resolveServiceNameFromSpan } from '../ppl_resolve_helpers';
+import { Span } from '../span_detail_table';
+
+jest.mock('../../utils/span_timerange_utils');
+jest.mock('../ppl_resolve_helpers');
+
+const mockCalculateSpanTimeRange = calculateSpanTimeRange as jest.MockedFunction<
+  typeof calculateSpanTimeRange
+>;
+const mockResolveServiceNameFromSpan = resolveServiceNameFromSpan as jest.MockedFunction<
+  typeof resolveServiceNameFromSpan
+>;
+
+describe('timeline_waterfall_bar_hooks', () => {
+  const mockSpan: Span = {
+    spanId: 'span-1',
+    children: [],
+    serviceName: 'test-service',
+    startTime: 1000,
+    endTime: 2000,
+  } as Span;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useTimelineBarColor', () => {
+    it('should return color from colorMap when service name exists', () => {
+      mockResolveServiceNameFromSpan.mockReturnValue('test-service');
+      const colorMap = { 'test-service': '#ff0000' };
+
+      const { result } = renderHook(() => useTimelineBarColor(mockSpan, colorMap));
+
+      expect(result.current).toBe('#ff0000');
+    });
+
+    it('should return default color when service name not in colorMap', () => {
+      mockResolveServiceNameFromSpan.mockReturnValue('unknown-service');
+      const colorMap = { 'test-service': '#ff0000' };
+
+      const { result } = renderHook(() => useTimelineBarColor(mockSpan, colorMap));
+
+      expect(result.current).toBe('#ff7f00');
+    });
+
+    it('should use span.serviceName when resolveServiceNameFromSpan returns empty string', () => {
+      mockResolveServiceNameFromSpan.mockReturnValue('');
+      const colorMap = { 'test-service': '#00ff00' };
+
+      const { result } = renderHook(() => useTimelineBarColor(mockSpan, colorMap));
+
+      expect(result.current).toBe('#00ff00');
+    });
+
+    it('should use "unknown" when both resolveServiceNameFromSpan and span.serviceName are not present', () => {
+      mockResolveServiceNameFromSpan.mockReturnValue('');
+      const spanWithoutService = { ...mockSpan, serviceName: undefined };
+      const colorMap = { unknown: '#0000ff' };
+
+      const { result } = renderHook(() => useTimelineBarColor(spanWithoutService, colorMap));
+
+      expect(result.current).toBe('#0000ff');
+    });
+
+    it('should return default color when colorMap is undefined', () => {
+      mockResolveServiceNameFromSpan.mockReturnValue('test-service');
+
+      const { result } = renderHook(() => useTimelineBarColor(mockSpan));
+
+      expect(result.current).toBe('#ff7f00');
+    });
+  });
+
+  describe('useTimelineBarRange', () => {
+    const traceTimeRange = {
+      durationMs: 5000,
+      startTimeMs: 1000,
+      endTimeMs: 6000,
+    };
+
+    it('should calculate correct timeline bar range', () => {
+      mockCalculateSpanTimeRange.mockReturnValue({
+        durationMs: 1000,
+        startTimeMs: 2000,
+        endTimeMs: 3000,
+      });
+
+      const { result } = renderHook(() => useTimelineBarRange(mockSpan, traceTimeRange));
+
+      expect(result.current).toEqual({
+        timelineBarOffsetPercent: 20, // (2000 - 1000) / 5000 * 100
+        timelineBarWidthPercent: 20, // 1000 / 5000 * 100
+        durationMs: 1000,
+        relativeStart: 1000, // 2000 - 1000
+        relativeEnd: 2000, // 3000 - 1000
+      });
+    });
+
+    it('should ensure minimum width of 1 percent', () => {
+      mockCalculateSpanTimeRange.mockReturnValue({
+        durationMs: 10, // Very small duration
+        startTimeMs: 1000,
+        endTimeMs: 1010,
+      });
+
+      const { result } = renderHook(() => useTimelineBarRange(mockSpan, traceTimeRange));
+
+      expect(result.current.timelineBarWidthPercent).toBe(1);
+    });
+
+    it('should handle span at trace start', () => {
+      mockCalculateSpanTimeRange.mockReturnValue({
+        durationMs: 500,
+        startTimeMs: 1000, // Same as trace start
+        endTimeMs: 1500,
+      });
+
+      const { result } = renderHook(() => useTimelineBarRange(mockSpan, traceTimeRange));
+
+      expect(result.current).toEqual({
+        timelineBarOffsetPercent: 0,
+        timelineBarWidthPercent: 10, // 500 / 5000 * 100
+        durationMs: 500,
+        relativeStart: 0,
+        relativeEnd: 500,
+      });
+    });
+
+    it('should handle span at trace end', () => {
+      mockCalculateSpanTimeRange.mockReturnValue({
+        durationMs: 1000,
+        startTimeMs: 5000,
+        endTimeMs: 6000, // Same as trace end
+      });
+
+      const { result } = renderHook(() => useTimelineBarRange(mockSpan, traceTimeRange));
+
+      expect(result.current).toEqual({
+        timelineBarOffsetPercent: 80, // (5000 - 1000) / 5000 * 100
+        timelineBarWidthPercent: 20, // 1000 / 5000 * 100
+        durationMs: 1000,
+        relativeStart: 4000, // 5000 - 1000
+        relativeEnd: 5000, // 6000 - 1000
+      });
+    });
+
+    it('should adjust calculations when paddingPercent is provided', () => {
+      mockCalculateSpanTimeRange.mockReturnValue({
+        durationMs: 1000,
+        startTimeMs: 2000,
+        endTimeMs: 3000,
+      });
+
+      const { result } = renderHook(() => useTimelineBarRange(mockSpan, traceTimeRange, 5));
+
+      expect(result.current).toEqual({
+        timelineBarOffsetPercent: 18, // 20 * (100 - 10) / 100 = 18
+        timelineBarWidthPercent: 18, // 20 * (100 - 10) / 100 = 18
+        durationMs: 1000,
+        relativeStart: 1000,
+        relativeEnd: 2000,
+      });
+    });
+  });
+});

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar_hooks.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/timeline_waterfall_bar/timeline_waterfall_bar_hooks.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useMemo } from 'react';
+import { Span } from '../span_detail_table';
+import { resolveServiceNameFromSpan } from '../ppl_resolve_helpers';
+import { calculateSpanTimeRange, TraceTimeRange } from '../../utils/span_timerange_utils';
+import { round } from '../../utils/helper_functions';
+
+interface TimelineBarRange {
+  timelineBarOffsetPercent: number;
+  timelineBarWidthPercent: number;
+  durationMs: number;
+  relativeStart: number;
+  relativeEnd: number;
+}
+
+export const useTimelineBarColor = (span: Span, colorMap?: Record<string, string>): string => {
+  return useMemo(() => {
+    const serviceName = resolveServiceNameFromSpan(span) || span.serviceName || 'unknown';
+    return colorMap?.[serviceName] || '#ff7f00';
+  }, [span, colorMap]);
+};
+
+export const useTimelineBarRange = (
+  span: Span,
+  traceTimeRange: TraceTimeRange,
+  paddingPercent: number = 0
+): TimelineBarRange => {
+  const {
+    durationMs: spanDuration,
+    startTimeMs: spanStartTime,
+    endTimeMs: spanEndTime,
+  } = useMemo(() => calculateSpanTimeRange(span), [span]);
+  const { durationMs: traceDuration, startTimeMs: traceStartTime } = traceTimeRange;
+
+  return useMemo(() => {
+    const availableWidth = 100 - paddingPercent * 2;
+    const rawOffsetPercent = ((spanStartTime - traceStartTime) / traceDuration) * 100;
+    const rawWidthPercent = (spanDuration / traceDuration) * 100;
+
+    return {
+      timelineBarOffsetPercent: Math.round((rawOffsetPercent * availableWidth) / 100),
+      timelineBarWidthPercent: Math.max(Math.round((rawWidthPercent * availableWidth) / 100), 1),
+      durationMs: spanDuration,
+      relativeStart: round(spanStartTime - traceStartTime, 3),
+      relativeEnd: round(spanEndTime - traceStartTime, 3),
+    };
+  }, [spanDuration, spanStartTime, spanEndTime, traceDuration, traceStartTime, paddingPercent]);
+};

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/utils/span_timerange_utils.test.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/utils/span_timerange_utils.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  calculateSpanTimeRange,
+  calculateTraceTimeRange,
+  parseHighPrecisionTimestamp,
+} from './span_timerange_utils';
+import { Span } from '../traces/span_detail_table';
+import { hasNanosecondPrecision } from '../traces/ppl_resolve_helpers';
+
+jest.mock('../traces/ppl_resolve_helpers');
+const mockHasNanosecondPrecision = jest.mocked(hasNanosecondPrecision);
+
+describe('span_timerange_utils', () => {
+  describe('parseHighPrecisionTimestamp', () => {
+    it('should return 0 for empty string', () => {
+      expect(parseHighPrecisionTimestamp('')).toBe(0);
+    });
+
+    it('should parse ISO timestamp', () => {
+      const result = parseHighPrecisionTimestamp('2023-01-01T00:00:00.000Z');
+      expect(result).toBe(1672531200000);
+    });
+
+    it('should parse timestamp with space and add Z', () => {
+      const result = parseHighPrecisionTimestamp('2023-01-01 00:00:00.000');
+      expect(result).toBe(1672531200000);
+    });
+
+    it('should handle fractional seconds', () => {
+      const result = parseHighPrecisionTimestamp('2023-01-01T00:00:00.123Z');
+      expect(result).toBe(1672531200123);
+    });
+
+    it('should correctly parse high-precision timestamps with many decimal places', () => {
+      // Test case for the bug fix: timestamps with high precision fractional seconds
+      const startTime = '2025-10-01 20:27:43.971744429';
+      const endTime = '2025-10-01 20:27:44.00006722';
+
+      const startMs = parseHighPrecisionTimestamp(startTime);
+      const endMs = parseHighPrecisionTimestamp(endTime);
+
+      // The duration should be approximately 28.322 ms (from the bug report)
+      const durationMs = endMs - startMs;
+
+      // Should be around 28-29 ms, not 1000+ ms as in the original bug
+      expect(durationMs).toBeGreaterThan(25);
+      expect(durationMs).toBeLessThan(35);
+
+      // More specific check - should be close to 28.322 ms
+      expect(Math.abs(durationMs - 28.322)).toBeLessThan(1);
+    });
+
+    it('should return 0 for invalid timestamp', () => {
+      const result = parseHighPrecisionTimestamp('invalid');
+      expect(isNaN(result) || result === 0).toBe(true);
+    });
+  });
+
+  describe('calculateSpanTimeRange', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should calculate duration from timestamps when both have nanosecond precision', () => {
+      mockHasNanosecondPrecision.mockReturnValue(true);
+
+      const span: Span = {
+        spanId: 'test',
+        children: [],
+        startTime: '2023-01-01T00:00:00.000Z',
+        endTime: '2023-01-01T00:00:01.000Z',
+        durationInNanos: 1000000000,
+      } as Span;
+
+      const result = calculateSpanTimeRange(span);
+      expect(result.startTimeMs).toBe(1672531200000);
+      expect(result.endTimeMs).toBe(1672531201000);
+      expect(result.durationMs).toBe(1000);
+    });
+
+    it('should use span duration field as fallback when timestamps lack nanosecond precision', () => {
+      mockHasNanosecondPrecision.mockReturnValue(false);
+
+      const span: Span = {
+        spanId: 'test',
+        children: [],
+        startTime: '2023-01-01T00:00:00.000Z',
+        endTime: '2023-01-01T00:00:01.000Z',
+        durationInNanos: 500000000,
+      } as Span;
+
+      const result = calculateSpanTimeRange(span);
+      expect(result.startTimeMs).toBe(1672531200000);
+      expect(result.endTimeMs).toBe(1672531201000);
+      expect(result.durationMs).toBe(500);
+    });
+  });
+
+  describe('calculateTraceTimeRange', () => {
+    it('should return zero values for empty spans array', () => {
+      const result = calculateTraceTimeRange([]);
+      expect(result).toEqual({ durationMs: 0, startTimeMs: 0, endTimeMs: 0 });
+    });
+
+    it('should calculate trace time range from multiple spans', () => {
+      const spans: Span[] = [
+        {
+          spanId: 'span1',
+          children: [],
+          startTime: '2023-01-01T00:00:00.000Z',
+          endTime: '2023-01-01T00:00:01.000Z',
+        } as Span,
+        {
+          spanId: 'span2',
+          children: [],
+          startTime: '2023-01-01T00:00:00.500Z',
+          endTime: '2023-01-01T00:00:02.000Z',
+        } as Span,
+      ];
+
+      const result = calculateTraceTimeRange(spans);
+      expect(result.startTimeMs).toBe(1672531200000);
+      expect(result.endTimeMs).toBe(1672531202000);
+      expect(result.durationMs).toBe(2000);
+    });
+  });
+});

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/utils/span_timerange_utils.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/utils/span_timerange_utils.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Span } from '../traces/span_detail_table';
+import { hasNanosecondPrecision } from '../traces/ppl_resolve_helpers';
+import { extractSpanDuration } from './span_data_utils';
+import { nanoToMilliSec, round } from './helper_functions';
+
+export interface SpanTimeRange {
+  durationMs: number;
+  startTimeMs: number;
+  endTimeMs: number;
+}
+
+export type TraceTimeRange = SpanTimeRange;
+
+export const calculateSpanTimeRange = (span: Span): SpanTimeRange => {
+  const startTimeMs = round(parseHighPrecisionTimestamp(span.startTime), 3);
+  const endTimeMs = round(parseHighPrecisionTimestamp(span.endTime), 3);
+
+  let durationMs = 0;
+  // If both timestamps have nanosecond precision, use duration calculated from start and end
+  if (hasNanosecondPrecision(startTimeMs) && hasNanosecondPrecision(endTimeMs)) {
+    durationMs = round(endTimeMs - startTimeMs, 3);
+  } else {
+    // fallback to duration from span field
+    durationMs = round(nanoToMilliSec(Math.max(0, extractSpanDuration(span))), 3);
+  }
+
+  return {
+    durationMs,
+    startTimeMs,
+    endTimeMs,
+  };
+};
+
+// Nominally the root span should have timerange encompassing all its children,
+// but in case of bugs or malformed test data check all spans to get accurate trace timerange
+export const calculateTraceTimeRange = (spans: Span[]): TraceTimeRange => {
+  if (!spans || spans.length === 0) {
+    return { durationMs: 0, startTimeMs: 0, endTimeMs: 0 };
+  }
+
+  let minStartTime = Infinity;
+  let maxEndTime = -Infinity;
+
+  spans.forEach((span) => {
+    const startTime = parseHighPrecisionTimestamp(span.startTime);
+    const endTime = parseHighPrecisionTimestamp(span.endTime);
+
+    if (startTime < minStartTime) {
+      minStartTime = startTime;
+    }
+    if (endTime > maxEndTime) {
+      maxEndTime = endTime;
+    }
+  });
+
+  // Initialized min and max with infinity and then bound to zero to handle edge case
+  // where endTime large negative value, to prevent relative waterfall bar scaling issue.
+  // Edge case caused by still in progress span
+  const startTimeMs = minStartTime === Infinity ? 0 : round(minStartTime, 3);
+  const endTimeMs = maxEndTime === -Infinity ? 0 : round(maxEndTime, 3);
+  const durationMs = round(endTimeMs - startTimeMs, 3);
+
+  return {
+    durationMs,
+    startTimeMs,
+    endTimeMs,
+  };
+};
+
+export const parseHighPrecisionTimestamp = (timestampStr: string): number => {
+  if (!timestampStr) return 0;
+
+  try {
+    let normalizedTimestamp = timestampStr;
+
+    if (timestampStr.includes(' ') && !timestampStr.includes('T')) {
+      normalizedTimestamp = timestampStr.replace(' ', 'T');
+      if (!normalizedTimestamp.includes('Z')) {
+        normalizedTimestamp += 'Z';
+      }
+    }
+
+    const date = new Date(normalizedTimestamp);
+
+    const fractionalMatch = timestampStr.match(/\.(\d+)/);
+    if (fractionalMatch) {
+      const fractionalPart = fractionalMatch[1];
+      const millisecondsFromFraction = parseFloat('0.' + fractionalPart) * 1000;
+
+      // Get the base timestamp without milliseconds, then add the high-precision fractional part
+      const baseMs = Math.floor(date.getTime() / 1000) * 1000;
+
+      return baseMs + millisecondsFromFraction;
+    }
+
+    return date.getTime();
+  } catch (error) {
+    return 0;
+  }
+};


### PR DESCRIPTION
### Description
Remake of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10610
Add new Timeline waterfall bars column to Tree view table on Trace details page. This is intended to replace the separate Timeline gantt chart as an inline solution to the table for a more cohesive view of the spans.

TimelineWaterfallBar renders waterfall bar for a span's time range

* Responsive offset and width within "Timeline" column of span table's "Tree view" (SpanDetailTableHierarchy)
* Color-coded bars based on service name
* Interactive tooltip that displays span's Duration, Start, and End milliseconds

useTimelineBarRange calculates relative bar offset and width based on each span's time range and overall trace time range along with any optional padding

* Returned timelineBarOffsetPercent and timelineBarWidthPercent determine bar positioning and size
* Returned durationMs, relativeStart, and relativeEnd are passed to bar tooltip

useTimelineBarColor determines color of bar based on span's service name

TimelineRuler renders a ruler with evenly spaced "nice" millisecond measurements to visually compare the waterfall bars

useTimelineTicks calculates optimal tick mark offsets and values for timeline ruler based on overall trace time range (min, max) and desired number of tick marks. Also takes any optional padding into account for scaling.

TimelineHeader renders the Timeline column header, which combines "Timeline" text translation with the TimelineRuler

The span table's "Tree view" has been modified to include new "Timeline" column before the "Duration" column and also hide the "Parent Id" by default to give the "Timeline" column more space.

A new span_timerange_utils.ts file has also been added with helper functions for calculating both span and trace time range (durationMs, startTimeMs, endTimeMs).

TODO Follow up items

* Some columns in the "Tree view" table will be combined or moved to the Span details flyout to give the "Timeline" column even more space
* The "Service legend" will be moved in the "Timeline" column header and removed from Trace details tabs header
* The separate "Timeline" tab and gantt chart will be removed from the Trace details page

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
<img width="1444" height="875" alt="Screenshot 2025-10-02 at 6 20 23 PM" src="https://github.com/user-attachments/assets/07c7a8f3-7e91-43cf-961d-92a7bd252f00" />

## Testing the changes
1. In an OSD workspace that contains traces, go to the Traces page.
2. Click any trace to go to the details page of that trace.
3. Go to the "Tree view" tab.
4. Validate that the waterfall bars in the "Timeline" column render.
5. Validate the waterfall bars' positioning and widths relative to each other are correct by comparing their "Duration", "Start", and "End" values from their tooltips.
6. Validate the waterfall bars' positioning and widths are accurate relative to the ruler on in the "Timeline" column header
7. Validate the water fall bar colors match the color specified for each service in the "Service legend".
8. Click drag the "Timeline" column to change its width and validate that the ruler and waterfall bars change width while keeping relative scale.

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
