### PR TITLE
chat(feat): implement plugin configuration controls for chat and context_provider plugins

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -407,5 +407,11 @@
 # @experimental Set the value to true to enable discover traces
 # explore.discoverTraces.enabled: true
 
-# @experimental Enable Chat Plugin
-# chat.enabled: true
+# @experimental Set the enabled value to true and provide an AG-UI agent to enable chat
+# chat:
+  # enabled: true
+  # agUiUrl: "http://your-ai-agent-url:port"
+
+# @experimental Set the value to true to enable context provider
+# contextProvider:
+#   enabled: true

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -26,7 +26,14 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
 
   public start(core: CoreStart, deps: AppPluginStartDependencies): ChatPluginStart {
     // Get configuration
-    const config = this.initializerContext.config.get<{ agUiUrl: string }>();
+    const config = this.initializerContext.config.get<{ enabled: boolean; agUiUrl?: string }>();
+
+    // Check if chat plugin is enabled and has required agUiUrl
+    if (!config.enabled || !config.agUiUrl) {
+      return {
+        chatService: undefined,
+      };
+    }
 
     // Initialize chat service with configured AG-UI URL
     this.chatService = new ChatService(config.agUiUrl);

--- a/src/plugins/chat/public/types.ts
+++ b/src/plugins/chat/public/types.ts
@@ -12,7 +12,7 @@ import { ChatService } from './services/chat_service';
 export interface ChatPluginSetup {}
 
 export interface ChatPluginStart {
-  chatService: ChatService;
+  chatService: ChatService | undefined;
 }
 
 export interface AppPluginStartDependencies {

--- a/src/plugins/context_provider/opensearch_dashboards.json
+++ b/src/plugins/context_provider/opensearch_dashboards.json
@@ -2,9 +2,10 @@
   "id": "contextProvider",
   "version": "1.0.0",
   "opensearchDashboardsVersion": "opensearchDashboards",
-  "server": false,
+  "server": true,
   "ui": true,
   "requiredPlugins": [],
   "optionalPlugins": [],
-  "requiredBundles": ["opensearchDashboardsUtils"]
+  "requiredBundles": ["opensearchDashboardsUtils"],
+  "configPath": ["contextProvider"]
 }

--- a/src/plugins/context_provider/public/index.ts
+++ b/src/plugins/context_provider/public/index.ts
@@ -3,21 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
 import { ContextProviderPlugin } from './plugin';
+import { PluginInitializerContext } from '../../../core/public';
 
 /**
  * @experimental This plugin is experimental and will change in future releases.
  */
-export function plugin() {
-  return new ContextProviderPlugin();
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new ContextProviderPlugin(initializerContext);
 }
 
 export { ContextProviderPlugin };

--- a/src/plugins/context_provider/public/types.ts
+++ b/src/plugins/context_provider/public/types.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AssistantAction } from './hooks/use_assistant_action';
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ContextProviderSetupDeps {}
 
@@ -35,4 +37,9 @@ export interface AssistantContextStore {
 
 export interface ContextProviderStart {
   getAssistantContextStore(): AssistantContextStore;
+  hooks: {
+    usePageContext: (options?: any) => string;
+    useDynamicContext: (contextOptions: any) => string;
+    useAssistantAction: <T = any>(action: AssistantAction<T>) => void;
+  };
 }

--- a/src/plugins/context_provider/server/config.ts
+++ b/src/plugins/context_provider/server/config.ts
@@ -7,7 +7,6 @@ import { schema, TypeOf } from '@osd/config-schema';
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
-  agUiUrl: schema.maybe(schema.string()),
 });
 
-export type ChatConfigType = TypeOf<typeof configSchema>;
+export type ContextProviderConfigType = TypeOf<typeof configSchema>;

--- a/src/plugins/context_provider/server/index.ts
+++ b/src/plugins/context_provider/server/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
+import { ContextProviderServerPlugin } from './plugin';
+import { configSchema, ContextProviderConfigType } from './config';
+
+export const config: PluginConfigDescriptor<ContextProviderConfigType> = {
+  schema: configSchema,
+  exposeToBrowser: {
+    enabled: true,
+  },
+};
+
+/**
+ * @experimental This plugin is experimental and will change in future releases.
+ */
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new ContextProviderServerPlugin(initializerContext);
+}
+
+export { ContextProviderServerPluginSetup, ContextProviderServerPluginStart } from './types';

--- a/src/plugins/context_provider/server/plugin.ts
+++ b/src/plugins/context_provider/server/plugin.ts
@@ -11,14 +11,14 @@ import {
   Logger,
 } from '../../../core/server';
 
-import { ChatPluginSetup, ChatPluginStart } from './types';
-import { defineRoutes } from './routes';
+import { ContextProviderServerPluginSetup, ContextProviderServerPluginStart } from './types';
 
 /**
  * @experimental
- * Chat plugin for AI-powered interactions. This plugin is experimental and will change in future releases.
+ * Context Provider plugin for React hooks-based context capture system. This plugin is experimental and will change in future releases.
  */
-export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
+export class ContextProviderServerPlugin
+  implements Plugin<ContextProviderServerPluginSetup, ContextProviderServerPluginStart> {
   private readonly logger: Logger;
 
   constructor(initializerContext: PluginInitializerContext) {
@@ -26,17 +26,12 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
   }
 
   public setup(core: CoreSetup) {
-    this.logger.debug('chat: Setup');
-    const router = core.http.createRouter();
-
-    // Register server side APIs
-    defineRoutes(router);
-
+    this.logger.debug('contextProvider: Setup');
     return {};
   }
 
   public start(core: CoreStart) {
-    this.logger.debug('chat: Started');
+    this.logger.debug('contextProvider: Started');
     return {};
   }
 

--- a/src/plugins/context_provider/server/types.ts
+++ b/src/plugins/context_provider/server/types.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextProviderServerPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextProviderServerPluginStart {}

--- a/src/plugins/explore/opensearch_dashboards.json
+++ b/src/plugins/explore/opensearch_dashboards.json
@@ -20,7 +20,7 @@
     "expressions",
     "dashboard"
   ],
-  "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils", "dashboard", "contextProvider"],
-  "optionalPlugins": ["home", "share"],
+  "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils", "dashboard"],
+  "optionalPlugins": ["home", "share", "contextProvider"],
   "configPath": ["explore"]
 }

--- a/src/plugins/explore/public/application/index.tsx
+++ b/src/plugins/explore/public/application/index.tsx
@@ -11,7 +11,10 @@ import { Store } from 'redux';
 import { AppMountParameters } from '../../../../core/public';
 import { ExploreServices } from '../types';
 import { LogsPage } from './pages/logs';
-import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
+import {
+  OpenSearchDashboardsContextProvider,
+  useOpenSearchDashboards,
+} from '../../../opensearch_dashboards_react/public';
 import { DatasetProvider } from './context';
 import { ExploreFlavor } from '../../common';
 import { TracesPage } from './pages/traces';
@@ -28,13 +31,14 @@ interface ExploreRouteProps {
 type ExploreComponentProps = ExploreRouteProps &
   Partial<Pick<AppMountParameters, 'setHeaderActionMenu'>>;
 
+const NOOP_PAGE_CONTEXT_HOOK = (options?: any): string => '';
+
 // Component that handles page context for all Explore flavors
 const ExplorePageContextProvider: React.FC<{
   children: React.ReactNode;
-  services: ExploreServices;
-}> = ({ children, services }) => {
-  const usePageContext = services.contextProvider?.hooks?.usePageContext || (() => {});
-
+}> = ({ children }) => {
+  const { services } = useOpenSearchDashboards<ExploreServices>();
+  const usePageContext = services.contextProvider?.hooks?.usePageContext || NOOP_PAGE_CONTEXT_HOOK;
   usePageContext({
     description: 'Explore application page context',
     convert: (urlState: any) => ({
@@ -92,7 +96,7 @@ export const renderApp = (
           <EditorContextProvider>
             <DatasetProvider>
               <services.core.i18n.Context>
-                <ExplorePageContextProvider services={services}>
+                <ExplorePageContextProvider>
                   <Switch>
                     {/* View route for saved searches */}
                     {/* TODO: Do we need this? We might not need to, please revisit */}

--- a/src/plugins/explore/public/application/index.tsx
+++ b/src/plugins/explore/public/application/index.tsx
@@ -18,7 +18,6 @@ import { TracesPage } from './pages/traces';
 import { MetricsPage } from './pages/metrics';
 import { EditorContextProvider } from './context';
 import { TraceDetails } from './pages/traces/trace_details/trace_view';
-import { usePageContext } from '../../../context_provider/public';
 
 // Route component props interface
 interface ExploreRouteProps {
@@ -32,10 +31,13 @@ type ExploreComponentProps = ExploreRouteProps &
 // Component that handles page context for all Explore flavors
 const ExplorePageContextProvider: React.FC<{
   children: React.ReactNode;
-}> = ({ children }) => {
+  services: ExploreServices;
+}> = ({ children, services }) => {
+  const usePageContext = services.contextProvider?.hooks?.usePageContext || (() => {});
+
   usePageContext({
     description: 'Explore application page context',
-    convert: (urlState) => ({
+    convert: (urlState: any) => ({
       appId: 'explore',
       timeRange: urlState._g?.time,
       query: {
@@ -90,7 +92,7 @@ export const renderApp = (
           <EditorContextProvider>
             <DatasetProvider>
               <services.core.i18n.Context>
-                <ExplorePageContextProvider>
+                <ExplorePageContextProvider services={services}>
                   <Switch>
                     {/* View route for saved searches */}
                     {/* TODO: Do we need this? We might not need to, please revisit */}

--- a/src/plugins/explore/public/build_services.ts
+++ b/src/plugins/explore/public/build_services.ts
@@ -63,6 +63,7 @@ export function buildServices(
     },
     navigation: plugins.navigation,
     share: plugins.share,
+    contextProvider: plugins.contextProvider,
     opensearchDashboardsLegacy: plugins.opensearchDashboardsLegacy,
     urlForwarding: plugins.urlForwarding,
     timefilter: plugins.data.query.timefilter.timefilter,

--- a/src/plugins/explore/public/components/data_table/data_table.tsx
+++ b/src/plugins/explore/public/components/data_table/data_table.tsx
@@ -15,7 +15,6 @@ import {
   DocViewsRegistry,
   OpenSearchSearchHit,
 } from '../../types/doc_views_types';
-import { ExploreServices } from '../../types';
 import { TableRow } from './table_row/table_row';
 import { LegacyDisplayedColumn } from '../../helpers/data_table_helper';
 import { Pagination } from './pagination/pagination';
@@ -34,7 +33,6 @@ export interface DataTableProps {
   onFilter: DocViewFilterFn;
   onClose?: () => void;
   scrollToTop?: () => void;
-  services?: ExploreServices;
 }
 
 // ToDo: These would need to be read from an upcoming config panel
@@ -257,7 +255,6 @@ const DataTableUI = ({
   onFilter,
   onClose,
   scrollToTop,
-  services,
 }: DataTableProps) => {
   const columnNames = columns.map((column) => column.name);
 
@@ -542,7 +539,6 @@ const DataTableUI = ({
                   onClose={onClose}
                   isShortDots={isShortDots}
                   docViewsRegistry={docViewsRegistry}
-                  services={services}
                 />
               );
             }

--- a/src/plugins/explore/public/components/data_table/data_table.tsx
+++ b/src/plugins/explore/public/components/data_table/data_table.tsx
@@ -15,6 +15,7 @@ import {
   DocViewsRegistry,
   OpenSearchSearchHit,
 } from '../../types/doc_views_types';
+import { ExploreServices } from '../../types';
 import { TableRow } from './table_row/table_row';
 import { LegacyDisplayedColumn } from '../../helpers/data_table_helper';
 import { Pagination } from './pagination/pagination';
@@ -33,6 +34,7 @@ export interface DataTableProps {
   onFilter: DocViewFilterFn;
   onClose?: () => void;
   scrollToTop?: () => void;
+  services?: ExploreServices;
 }
 
 // ToDo: These would need to be read from an upcoming config panel
@@ -255,6 +257,7 @@ const DataTableUI = ({
   onFilter,
   onClose,
   scrollToTop,
+  services,
 }: DataTableProps) => {
   const columnNames = columns.map((column) => column.name);
 
@@ -539,6 +542,7 @@ const DataTableUI = ({
                   onClose={onClose}
                   isShortDots={isShortDots}
                   docViewsRegistry={docViewsRegistry}
+                  services={services}
                 />
               );
             }

--- a/src/plugins/explore/public/components/data_table/explore_data_table.test.tsx
+++ b/src/plugins/explore/public/components/data_table/explore_data_table.test.tsx
@@ -70,7 +70,7 @@ jest.mock('../../application/legacy/discover/opensearch_dashboards_services', ()
 }));
 
 jest.mock('./data_table', () => ({
-  DataTable: ({ rows, services }: { rows: any[]; services?: any }) => (
+  DataTable: ({ rows }: { rows: any[] }) => (
     <div data-test-subj="data-table">Data Table with {rows.length} rows</div>
   ),
 }));

--- a/src/plugins/explore/public/components/data_table/explore_data_table.test.tsx
+++ b/src/plugins/explore/public/components/data_table/explore_data_table.test.tsx
@@ -70,7 +70,7 @@ jest.mock('../../application/legacy/discover/opensearch_dashboards_services', ()
 }));
 
 jest.mock('./data_table', () => ({
-  DataTable: ({ rows }: { rows: any[] }) => (
+  DataTable: ({ rows, services }: { rows: any[]; services?: any }) => (
     <div data-test-subj="data-table">Data Table with {rows.length} rows</div>
   ),
 }));

--- a/src/plugins/explore/public/components/data_table/explore_data_table.tsx
+++ b/src/plugins/explore/public/components/data_table/explore_data_table.tsx
@@ -145,7 +145,6 @@ const ExploreDataTableComponent = () => {
             scrollToTop={scrollToTop}
             onAddColumn={onAddColumn}
             onRemoveColumn={onRemoveColumn}
-            services={services}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/plugins/explore/public/components/data_table/explore_data_table.tsx
+++ b/src/plugins/explore/public/components/data_table/explore_data_table.tsx
@@ -145,6 +145,7 @@ const ExploreDataTableComponent = () => {
             scrollToTop={scrollToTop}
             onAddColumn={onAddColumn}
             onRemoveColumn={onRemoveColumn}
+            services={services}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/plugins/explore/public/components/data_table/table_row/table_row.test.tsx
+++ b/src/plugins/explore/public/components/data_table/table_row/table_row.test.tsx
@@ -6,12 +6,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TableRow, TableRowProps } from './table_row';
-import { useDynamicContext } from '../../../../../context_provider/public';
-
-// Mock the context provider hook
-jest.mock('../../../../../context_provider/public', () => ({
-  useDynamicContext: jest.fn(),
-}));
 
 // Mock the child components
 jest.mock('../table_cell/source_field_table_cell', () => ({
@@ -39,7 +33,7 @@ jest.mock('./expanded_table_row/expanded_table_row', () => ({
 }));
 
 describe('TableRow', () => {
-  let mockUseDynamicContext: jest.Mock;
+  const mockUseDynamicContext = jest.fn();
 
   const mockDataset = {
     fields: {
@@ -80,6 +74,14 @@ describe('TableRow', () => {
     registry: [],
   } as any;
 
+  const mockServices = {
+    contextProvider: {
+      hooks: {
+        useDynamicContext: mockUseDynamicContext,
+      },
+    },
+  };
+
   const defaultProps: TableRowProps = {
     row: mockRow,
     columns: ['timestamp', 'message'],
@@ -90,13 +92,11 @@ describe('TableRow', () => {
     onClose: jest.fn(),
     isShortDots: false,
     docViewsRegistry: mockDocViewsRegistry,
+    services: mockServices as any,
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Mock useDynamicContext
-    mockUseDynamicContext = useDynamicContext as jest.Mock;
     mockUseDynamicContext.mockReturnValue('test-context-id');
   });
 

--- a/src/plugins/explore/public/components/data_table/table_row/table_row.tsx
+++ b/src/plugins/explore/public/components/data_table/table_row/table_row.tsx
@@ -11,12 +11,12 @@
 
 import React, { useCallback, useState, useMemo } from 'react';
 import { IndexPattern, DataView as Dataset } from 'src/plugins/data/public';
-import { useDynamicContext } from '../../../../../context_provider/public';
 import {
   DocViewFilterFn,
   DocViewsRegistry,
   OpenSearchSearchHit,
 } from '../../../types/doc_views_types';
+import { ExploreServices } from '../../../types';
 import { ExpandedTableRow } from './expanded_table_row/expanded_table_row';
 import { TableRowContent } from './table_row_content';
 
@@ -31,6 +31,7 @@ export interface TableRowProps {
   onClose?: () => void;
   isShortDots: boolean;
   docViewsRegistry: DocViewsRegistry;
+  services?: ExploreServices;
 }
 
 export const TableRowUI = ({
@@ -44,6 +45,7 @@ export const TableRowUI = ({
   onClose,
   isShortDots,
   docViewsRegistry,
+  services,
 }: TableRowProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const handleExpanding = useCallback(() => setIsExpanded((prevState) => !prevState), [
@@ -65,7 +67,8 @@ export const TableRowUI = ({
     };
   }, [isExpanded, index, row._source, row._id]);
 
-  // Register dynamic context when row is expanded
+  // Register dynamic context when row is expanded using dependency injection
+  const useDynamicContext = services?.contextProvider?.hooks?.useDynamicContext || (() => {});
   useDynamicContext(expandedContext);
 
   return (

--- a/src/plugins/explore/public/components/data_table/table_row/table_row.tsx
+++ b/src/plugins/explore/public/components/data_table/table_row/table_row.tsx
@@ -17,8 +17,12 @@ import {
   OpenSearchSearchHit,
 } from '../../../types/doc_views_types';
 import { ExploreServices } from '../../../types';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { ExpandedTableRow } from './expanded_table_row/expanded_table_row';
 import { TableRowContent } from './table_row_content';
+
+// Create stable NOOP hook reference outside component to avoid re-renders
+const NOOP_DYNAMIC_CONTEXT_HOOK = (options?: any): string => '';
 
 export interface TableRowProps {
   row: OpenSearchSearchHit<Record<string, unknown>>;
@@ -31,7 +35,6 @@ export interface TableRowProps {
   onClose?: () => void;
   isShortDots: boolean;
   docViewsRegistry: DocViewsRegistry;
-  services?: ExploreServices;
 }
 
 export const TableRowUI = ({
@@ -45,8 +48,8 @@ export const TableRowUI = ({
   onClose,
   isShortDots,
   docViewsRegistry,
-  services,
 }: TableRowProps) => {
+  const { services } = useOpenSearchDashboards<ExploreServices>();
   const [isExpanded, setIsExpanded] = useState(false);
   const handleExpanding = useCallback(() => setIsExpanded((prevState) => !prevState), [
     setIsExpanded,
@@ -67,8 +70,9 @@ export const TableRowUI = ({
     };
   }, [isExpanded, index, row._source, row._id]);
 
-  // Register dynamic context when row is expanded using dependency injection
-  const useDynamicContext = services?.contextProvider?.hooks?.useDynamicContext || (() => {});
+  // Register dynamic context when row is expanded
+  const useDynamicContext =
+    services.contextProvider?.hooks?.useDynamicContext || NOOP_DYNAMIC_CONTEXT_HOOK;
   useDynamicContext(expandedContext);
 
   return (

--- a/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.test.tsx
@@ -9,15 +9,12 @@ import { renderHook } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { usePPLExecuteQueryAction } from './ppl_execute_query_action';
-import { useAssistantAction } from '../../../../../context_provider/public';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { loadQueryActionCreator } from '../../../application/utils/state_management/actions/query_editor/load_query';
 import { useDispatch } from 'react-redux';
 
 // Mock dependencies
-jest.mock('../../../../../context_provider/public', () => ({
-  useAssistantAction: jest.fn(),
-}));
+const mockUseAssistantAction = jest.fn();
 
 jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
   useOpenSearchDashboards: jest.fn(),
@@ -36,22 +33,25 @@ describe('usePPLExecuteQueryAction', () => {
   let mockSetEditorTextWithQuery: jest.Mock;
   let mockServices: any;
   let store: any;
-  let mockUseAssistantAction: jest.Mock;
   let mockUseOpenSearchDashboards: jest.Mock;
   let mockLoadQueryActionCreator: jest.Mock;
   let mockUseDispatch: jest.Mock;
 
   beforeEach(() => {
     // Get the mocked functions
-    mockUseAssistantAction = useAssistantAction as jest.Mock;
     mockUseOpenSearchDashboards = useOpenSearchDashboards as jest.Mock;
     mockLoadQueryActionCreator = loadQueryActionCreator as jest.Mock;
     mockUseDispatch = useDispatch as jest.Mock;
 
-    // Mock services
+    // Mock services with contextProvider dependency injection
     mockServices = {
       data: { query: { queryString: { getQuery: jest.fn() } } },
       notifications: { toasts: { addSuccess: jest.fn(), addError: jest.fn() } },
+      contextProvider: {
+        hooks: {
+          useAssistantAction: mockUseAssistantAction,
+        },
+      },
     };
 
     // Setup mocks

--- a/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.tsx
+++ b/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { EuiPanel, EuiText, EuiSpacer, EuiCode, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
-import { useAssistantAction } from '../../../../../context_provider/public';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../../types';
 import { loadQueryActionCreator } from '../../../application/utils/state_management/actions/query_editor/load_query';
@@ -23,6 +22,9 @@ export function usePPLExecuteQueryAction(
 ) {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const dispatch = useDispatch();
+
+  const useAssistantAction =
+    services.contextProvider?.hooks?.useAssistantAction || ((_action: any) => {});
 
   useAssistantAction<PPLExecuteQueryArgs>({
     name: 'execute_ppl_query',
@@ -45,7 +47,7 @@ export function usePPLExecuteQueryAction(
       },
       required: ['query'],
     },
-    handler: async (args) => {
+    handler: async (args: any) => {
       try {
         // Check if we should auto-execute
         const shouldExecute = args.autoExecute !== false; // Default to true
@@ -80,7 +82,7 @@ export function usePPLExecuteQueryAction(
         };
       }
     },
-    render: ({ status, args, result }) => {
+    render: ({ status, args, result }: any) => {
       if (!args) return null;
 
       const getStatusColor = () => {

--- a/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.tsx
+++ b/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.tsx
@@ -17,14 +17,15 @@ interface PPLExecuteQueryArgs {
   description?: string;
 }
 
+const NOOP_ASSISTANT_ACTION_HOOK = (_action: any) => {};
+
 export function usePPLExecuteQueryAction(
   setEditorTextWithQuery: ReturnType<typeof useSetEditorTextWithQuery>
 ) {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const dispatch = useDispatch();
-
   const useAssistantAction =
-    services.contextProvider?.hooks?.useAssistantAction || ((_action: any) => {});
+    services.contextProvider?.hooks?.useAssistantAction || NOOP_ASSISTANT_ACTION_HOOK;
 
   useAssistantAction<PPLExecuteQueryArgs>({
     name: 'execute_ppl_query',

--- a/src/plugins/explore/public/types.ts
+++ b/src/plugins/explore/public/types.ts
@@ -37,6 +37,7 @@ import { VisualizationsSetup, VisualizationsStart } from 'src/plugins/visualizat
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
 import { ExpressionsPublicPlugin, ExpressionsStart } from 'src/plugins/expressions/public';
 import { NavigationPublicPluginStart as NavigationStart } from '../../navigation/public';
+import { ContextProviderStart } from '../../context_provider/public';
 import { Storage, IOsdUrlStateStorage } from '../../opensearch_dashboards_utils/public';
 import { ScopedHistory } from '../../../core/public';
 import { SavedExploreLoader, SavedExplore } from './saved_explore';
@@ -90,6 +91,7 @@ export interface ExploreSetupDependencies {
   opensearchDashboardsLegacy: OpenSearchDashboardsLegacySetup;
   urlForwarding: UrlForwardingSetup;
   home?: HomePublicPluginSetup;
+  contextProvider?: ContextProviderStart;
   visualizations: VisualizationsSetup;
   data: DataPublicPluginSetup;
   usageCollection: UsageCollectionSetup;
@@ -113,6 +115,7 @@ export interface ExploreStartDependencies {
   visualizations: VisualizationsStart;
   expressions: ExpressionsStart;
   dashboard: DashboardStart;
+  contextProvider?: ContextProviderStart;
 }
 
 // ============================================================================
@@ -174,6 +177,7 @@ export interface ExploreServices {
   visualizationRegistry: VisualizationRegistryService;
   queryPanelActionsRegistry: QueryPanelActionsRegistryService;
   expressions: ExpressionsStart;
+  contextProvider?: ContextProviderStart;
 
   dashboard: DashboardStart;
   keyboardShortcut?: KeyboardShortcutStart;


### PR DESCRIPTION
### Description

We want to disable contextProvider and chat completely from browser and server side when no explore or when not config/ Need to use contextProvider as optionalPlugins not requiredBundles. Otherwise contextProvider will be loaded into browser. In this PR we change to use dependency injection for contextProvider. The challenge is that React hooks can't be passed through dependency injection in the traditional way because they need to be called at the component level and follow the rules of hooks. Therefore, we need to update the contextProvider plugin to 1) expose its hooks through the plugin's start interface, so they can be accessed via dependency injection 2) add a server side. Otherwise no way to read configuration from `opensearch_dashboards.yml` so plugin always loaded in browser regardless of settings. Also without server we could not use `optionalPlugins` pattern (requires server component). No change on how we use the hooks, only change how we import them. 

* Fixed chat.enabled to properly disable plugin when set to false or when chat.agUiUrl is missing 
* Added contextProvider.enabled with server-side validation and dependency injection pattern

#### Both server side and browser: 
No chat when explore is enabled but chat.enabled is false or no chat.agUiUrl. 
No contextProvider when explore is enabled but contextProvider.enable is false
<img width="1470" height="701" alt="Screenshot 2025-10-02 at 9 34 13 PM" src="https://github.com/user-attachments/assets/1f2e733f-1b9c-4663-8fd9-1e3a7201956e" />
<img width="1326" height="80" alt="Screenshot 2025-10-02 at 9 33 49 PM" src="https://github.com/user-attachments/assets/d70be777-ff3e-448e-9326-acdfcf220541" />


Setup chat when explore is enabled and both chat.enabled and chat.agUiUrl are configed. 
Setup contextProvider when explore is enabled and contextProvider.enable is true
<img width="1329" height="118" alt="Screenshot 2025-10-02 at 9 33 39 PM" src="https://github.com/user-attachments/assets/76161966-c561-4110-8580-fef3f0fb3e7c" />

<img width="933" height="431" alt="Screenshot 2025-10-02 at 9 30 34 PM" src="https://github.com/user-attachments/assets/4a8c4dec-ae4a-45b0-b676-a7cb265e74c7" />

No chat or contextProvider when no explore
<img width="1327" height="158" alt="Screenshot 2025-10-02 at 9 34 56 PM" src="https://github.com/user-attachments/assets/f249255c-b17d-414a-adfe-47711d479339" />

### Issues Resolved

NA


## Changelog
- feat: chat(feat): implement plugin configuration controls for chat and context_provider plugins



### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
