### PR TITLE
Test fix CI group 4 / Cypress group 13+15

### DIFF
--- a/changelogs/fragments/10649.yml
+++ b/changelogs/fragments/10649.yml
@@ -1,0 +1,2 @@
+test:
+- Fix CI group 4 test failures ([#10649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10649))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/03/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/03/inspect.spec.js
@@ -42,6 +42,22 @@ const inspectTestSuite = () => {
         dataSource: DATASOURCE_NAME,
         isEnhancement: true,
       });
+      cy.osd.grabDataSourceId(workspaceName, DATASOURCE_NAME);
+      cy.get('@WORKSPACE_ID').then((workspaceID) => {
+        cy.get('@DATASOURCE_ID').then((dataSourceId) => {
+          cy.request({
+            method: 'POST',
+            url: `${BASE_PATH}/w/${workspaceID}/api/sample_data/flights?data_source_id=${dataSourceId}`,
+            headers: {
+              'Content-Type': 'application/json',
+              'osd-xsrf': true,
+            },
+            failOnStatusCode: false,
+          }).then((response) => {
+            expect(response.status).to.eq(200);
+          });
+        });
+      });
     });
 
     after(() => {
@@ -90,20 +106,6 @@ const inspectTestSuite = () => {
     });
 
     it('should test visualizations inspect', () => {
-      cy.osd.navigateToWorkSpaceSpecificPage({
-        url: BASE_PATH,
-        workspaceName: workspaceName,
-        page: 'import_sample_data',
-        isEnhancement: true,
-      });
-
-      // adding a wait here as sometimes the button doesn't click below
-      cy.wait(3000);
-
-      cy.getElementByTestId('addSampleDataSetflights').should('be.visible').click();
-
-      cy.getElementByTestId('sampleDataSetInstallToast').should('exist');
-
       cy.osd.navigateToWorkSpaceSpecificPage({
         url: BASE_PATH,
         workspaceName: workspaceName,

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/inspect.spec.js
@@ -42,6 +42,22 @@ const inspectTestSuite = () => {
         dataSource: DATASOURCE_NAME,
         isEnhancement: true,
       });
+      cy.osd.grabDataSourceId(workspaceName, DATASOURCE_NAME);
+      cy.get('@WORKSPACE_ID').then((workspaceID) => {
+        cy.get('@DATASOURCE_ID').then((dataSourceId) => {
+          cy.request({
+            method: 'POST',
+            url: `${BASE_PATH}/w/${workspaceID}/api/sample_data/flights?data_source_id=${dataSourceId}`,
+            headers: {
+              'Content-Type': 'application/json',
+              'osd-xsrf': true,
+            },
+            failOnStatusCode: false,
+          }).then((response) => {
+            expect(response.status).to.eq(200);
+          });
+        });
+      });
     });
 
     after(() => {
@@ -96,20 +112,6 @@ const inspectTestSuite = () => {
     });
 
     it('should test visualizations inspect', () => {
-      cy.osd.navigateToWorkSpaceSpecificPage({
-        url: BASE_PATH,
-        workspaceName: workspaceName,
-        page: 'import_sample_data',
-        isEnhancement: true,
-      });
-
-      // adding a wait here as sometimes the button doesn't click below
-      cy.wait(3000);
-
-      cy.getElementByTestId('addSampleDataSetflights').should('be.visible').click();
-
-      cy.getElementByTestId('sampleDataSetInstallToast').should('exist');
-
       cy.osd.navigateToWorkSpaceSpecificPage({
         url: BASE_PATH,
         workspaceName: workspaceName,

--- a/cypress/utils/apps/explore/recent_queries.js
+++ b/cypress/utils/apps/explore/recent_queries.js
@@ -31,19 +31,7 @@ export const BaseQuery = {
   },
 };
 
-export const TestQueries = [
-  'bytes_transferred >',
-  'bytes_transferred < 8000',
-  'bytes_transferred > 8000',
-  'status_code = 404',
-  'status_code = 501',
-  'status_code = 503',
-  'status_code = 400',
-  'status_code = 401',
-  'status_code = 403',
-  'status_code = 200',
-  'event_sequence_number > 10000000',
-];
+export const TestQueries = ['bytes_transferred >', 'bytes_transferred < 8000'];
 
 /**
  * The configurations needed for recent queries tests

--- a/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts
@@ -599,7 +599,7 @@ describe('redux_persistence', () => {
       (mockServices.data.dataViews!.get as jest.Mock).mockResolvedValue({
         id: 'logs-dataset',
         title: 'Logs Dataset',
-        signalType: SignalType.LOGS,
+        signalType: CORE_SIGNAL_TYPES.LOGS,
       });
 
       const result = await loadReduxState(mockServices);
@@ -636,7 +636,7 @@ describe('redux_persistence', () => {
       (tracesServices.data.dataViews!.get as jest.Mock).mockResolvedValue({
         id: 'logs-dataset',
         title: 'Logs Dataset',
-        signalType: SignalType.LOGS,
+        signalType: CORE_SIGNAL_TYPES.LOGS,
       });
 
       // Mock dataset service to return a traces dataset
@@ -654,9 +654,9 @@ describe('redux_persistence', () => {
       // Mock dataViews.get for the fetched traces dataset
       (tracesServices.data.dataViews!.get as jest.Mock).mockImplementation((id) => {
         if (id === 'traces-dataset') {
-          return Promise.resolve({ signalType: SignalType.TRACES });
+          return Promise.resolve({ signalType: CORE_SIGNAL_TYPES.TRACES });
         }
-        return Promise.resolve({ signalType: SignalType.LOGS });
+        return Promise.resolve({ signalType: CORE_SIGNAL_TYPES.LOGS });
       });
 
       const result = await loadReduxState(tracesServices);
@@ -692,9 +692,9 @@ describe('redux_persistence', () => {
       // Mock dataViews.get to return TRACES signal type (incompatible with logs)
       (logsServices.data.dataViews!.get as jest.Mock).mockImplementation((id) => {
         if (id === 'traces-dataset') {
-          return Promise.resolve({ signalType: SignalType.TRACES });
+          return Promise.resolve({ signalType: CORE_SIGNAL_TYPES.TRACES });
         }
-        return Promise.resolve({ signalType: SignalType.LOGS });
+        return Promise.resolve({ signalType: CORE_SIGNAL_TYPES.LOGS });
       });
 
       // Mock dataset service to return a logs dataset
@@ -738,7 +738,7 @@ describe('redux_persistence', () => {
           return Promise.reject(new Error('Dataset not found'));
         }
         if (id === 'fallback-dataset') {
-          return Promise.resolve({ signalType: SignalType.LOGS });
+          return Promise.resolve({ signalType: CORE_SIGNAL_TYPES.LOGS });
         }
         return Promise.reject(new Error('Unknown dataset'));
       });


### PR DESCRIPTION
### Description
Test fix CI group 4
Test was failing to incorrect import usage leading to undefined

import { CORE_SIGNAL_TYPES } from '../../../../../../data/common';
Before:
```
SignalType.LOGS
```
After:
```
CORE_SIGNAL_TYPES.TRACES
```

```
yarn test:jest src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts --silent
yarn run v1.22.22
$ scripts/use_node scripts/jest src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts --silent
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/plugins/vis_type_vega/public/expressions/__mocks__/index.ts
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts

jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts
    * <rootDir>/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts

 PASS  src/plugins/explore/public/application/utils/state_management/utils/redux_persistence.test.ts (8.519 s)
  redux_persistence
    persistReduxState
      ✓ should persist query and app state to URL storage (2 ms)
      ✓ should handle missing osdUrlStateStorage gracefully
      ✓ should handle errors gracefully
    loadReduxState
      ✓ should load state from URL storage when available (2 ms)
      ✓ should fallback to preloaded state when URL storage is not available (1 ms)
      ✓ should use preloaded state for missing sections
      ✓ should handle errors and fallback to preloaded state (1 ms)
    getPreloadedState
      ✓ should return complete preloaded state with correct UI defaults (1 ms)
      ✓ should handle dataset initialization (1 ms)
      ✓ should handle missing dataset service gracefully
      ✓ should use default columns from uiSettings (1 ms)
      ✓ should fallback to default columns when uiSettings is not available
      ✓ should set correct editor mode from DEFAULT_EDITOR_MODE
      ✓ should initialize meta state with isInitialized false (1 ms)
    loadReduxState with meta state
      ✓ should use preloaded meta state when not provided in URL
      ✓ should use meta state from URL when provided
    getPreloadedMetaState
      ✓ should return meta state with isInitialized false
      ✓ should always initialize meta state consistently (1 ms)
    SignalType filtering
      ✓ should accept Traces datasets for Traces flavor
      ✓ should reject non-Traces datasets for Traces flavor (1 ms)
      ✓ should accept non-Traces datasets for non-Traces flavor
      ✓ should reject Traces datasets for non-Traces flavor
    loadReduxState with SignalType validation for URL datasets
      ✓ should validate URL dataset against current flavor and use it if compatible
      ✓ should reject incompatible URL dataset and fetch new one for traces flavor (1 ms)
      ✓ should reject traces dataset for logs flavor and fetch compatible one
      ✓ should handle URL dataset validation errors gracefully

Test Suites: 1 passed, 1 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        9.558 s, estimated 13 s
✨  Done in 17.63s.
```

Also fix ci group 15
Reduce runtime of recent queries cypress by removing redundant checks on functionality.
This long run-time was causing memory fault crash on test.

Locally time reduction of 3:48 (Much more on server side running)

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10647
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10648

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
Before: 8:32
<img width="1458" height="861" alt="Old" src="https://github.com/user-attachments/assets/f97f50f1-f570-464d-b57a-cce37eb0fdd2" />
After: 4:44
<img width="1452" height="861" alt="Cypress" src="https://github.com/user-attachments/assets/164a8c32-160e-4af5-8c3b-87d2aa41fce6" />


## Changelog


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
