### PR TITLE
fix: Trace Details code block scrollbar to scroll on edge

### DIFF
--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_tabs/span_raw_span_tab.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_tabs/span_raw_span_tab.tsx
@@ -26,13 +26,7 @@ export const SpanRawSpanTab: React.FC<SpanRawSpanTabProps> = ({ selectedSpan }) 
 
   return (
     <>
-      <EuiCodeBlock
-        language="json"
-        paddingSize="s"
-        isCopyable
-        overflowHeight={600}
-        whiteSpace="pre"
-      >
+      <EuiCodeBlock language="json" paddingSize="s" isCopyable>
         {JSON.stringify(selectedSpan, null, 2)}
       </EuiCodeBlock>
     </>


### PR DESCRIPTION
### Description

Trace Details page now has scrollbar that does not scroll in the middle of the code block

### Issues Resolved

## Screenshot
Before
<img width="422" height="674" alt="image (13)" src="https://github.com/user-attachments/assets/39b62fce-789d-4b1a-bfaf-bbf34ac83967" />

After
![tracesCodeScrolling](https://github.com/user-attachments/assets/9c178846-b61d-40cf-bb68-2fbe8edf2790)

## Testing the changes

## Changelog
- fix: Traces code block scrollbar to scroll on edge

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
