### PR TITLE
Cypress CI15 Fix

### DIFF
--- a/changelogs/fragments/10656.yml
+++ b/changelogs/fragments/10656.yml
@@ -1,0 +1,2 @@
+test:
+- Reduce runtime of recent queries cypress ([#10656](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10656))

--- a/cypress/utils/apps/explore/recent_queries.js
+++ b/cypress/utils/apps/explore/recent_queries.js
@@ -31,19 +31,7 @@ export const BaseQuery = {
   },
 };
 
-export const TestQueries = [
-  'bytes_transferred >',
-  'bytes_transferred < 8000',
-  'bytes_transferred > 8000',
-  'status_code = 404',
-  'status_code = 501',
-  'status_code = 503',
-  'status_code = 400',
-  'status_code = 401',
-  'status_code = 403',
-  'status_code = 200',
-  'event_sequence_number > 10000000',
-];
+export const TestQueries = ['bytes_transferred >', 'bytes_transferred < 8000'];
 
 /**
  * The configurations needed for recent queries tests


### PR DESCRIPTION
### Description
Reduce runtime of recent queries cypress by removing redundant checks on functionality.
This long run-time was causing memory fault crash on test.

Locally time reduction of 3:48 (Much more on server side running)


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10648

## Screenshot
Before: 8:32
<img width="1458" height="861" alt="Old" src="https://github.com/user-attachments/assets/0aaebf36-12f8-4e93-92e6-e6eedbfab050" />


After: 4:44 time
<img width="1452" height="861" alt="Cypress" src="https://github.com/user-attachments/assets/53107784-abd4-4af7-971b-422248bd45e5" />

## Testing the changes


<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
