### PR TITLE
make inspect.spec.js use api call to make visualizations

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/03/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/03/inspect.spec.js
@@ -42,6 +42,7 @@ const inspectTestSuite = () => {
         dataSource: DATASOURCE_NAME,
         isEnhancement: true,
       });
+      cy.osd.grabDataSourceId(workspaceName, DATASOURCE_NAME);
       cy.get('@WORKSPACE_ID').then((workspaceID) => {
         cy.get('@DATASOURCE_ID').then((dataSourceId) => {
           cy.request({

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/03/inspect.spec.js
@@ -42,6 +42,7 @@ const inspectTestSuite = () => {
         dataSource: DATASOURCE_NAME,
         isEnhancement: true,
       });
+      cy.osd.grabDataSourceId(workspaceName, DATASOURCE_NAME);
       cy.get('@WORKSPACE_ID').then((workspaceID) => {
         cy.get('@DATASOURCE_ID').then((dataSourceId) => {
           cy.request({


### PR DESCRIPTION
### Description

- partial solves #10648
- add sample data via API call rather than a manual creation

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
