### PR TITLE
Workspace framework updates

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -122,6 +122,7 @@ export {
   OBSERVABILITY_USE_CASE_ID,
   SECURITY_ANALYTICS_USE_CASE_ID,
   ENABLE_AI_FEATURES,
+  UseCaseId,
 } from '../utils';
 export {
   AppCategory,

--- a/src/core/utils/default_nav_groups.ts
+++ b/src/core/utils/default_nav_groups.ts
@@ -6,11 +6,19 @@
 import { i18n } from '@osd/i18n';
 import { ChromeNavGroup, NavGroupType } from '../types';
 
-export const ALL_USE_CASE_ID = 'all';
-export const OBSERVABILITY_USE_CASE_ID = 'observability';
-export const SECURITY_ANALYTICS_USE_CASE_ID = 'security-analytics';
-export const ESSENTIAL_USE_CASE_ID = 'essentials';
-export const SEARCH_USE_CASE_ID = 'search';
+export enum UseCaseId {
+  ALL_USE_CASE_ID = 'all',
+  OBSERVABILITY_USE_CASE_ID = 'observability',
+  SECURITY_ANALYTICS_USE_CASE_ID = 'security-analytics',
+  ESSENTIAL_USE_CASE_ID = 'essentials',
+  SEARCH_USE_CASE_ID = 'search',
+}
+
+export const ALL_USE_CASE_ID = UseCaseId.ALL_USE_CASE_ID;
+export const OBSERVABILITY_USE_CASE_ID = UseCaseId.OBSERVABILITY_USE_CASE_ID;
+export const SECURITY_ANALYTICS_USE_CASE_ID = UseCaseId.SECURITY_ANALYTICS_USE_CASE_ID;
+export const ESSENTIAL_USE_CASE_ID = UseCaseId.ESSENTIAL_USE_CASE_ID;
+export const SEARCH_USE_CASE_ID = UseCaseId.SEARCH_USE_CASE_ID;
 
 const defaultNavGroups = {
   dataAdministration: {

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -57,4 +57,5 @@ export {
   ESSENTIAL_USE_CASE_ID,
   OBSERVABILITY_USE_CASE_ID,
   SECURITY_ANALYTICS_USE_CASE_ID,
+  UseCaseId,
 } from './default_nav_groups';

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -35,6 +35,7 @@ import { navigateToAppWithinWorkspace } from '../utils/workspace';
 import { WorkspaceCreatorForm } from './workspace_creator_form';
 import { optionIdToWorkspacePermissionModesMap } from '../workspace_form/constants';
 import { getUseCaseFeatureConfig } from '../../../../../core/public';
+import { UseCaseService } from '../../services';
 
 export interface WorkspaceCreatorProps {
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
@@ -51,20 +52,22 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
       savedObjects,
       dataSourceManagement,
       navigationUI: { HeaderControl },
+      useCaseService,
     },
   } = useOpenSearchDashboards<{
     workspaceClient: WorkspaceClient;
     dataSourceManagement?: DataSourceManagementPluginSetup;
     navigationUI: NavigationPublicPluginStart['ui'];
+    useCaseService: UseCaseService;
   }>();
   const [isFormSubmitting, setIsFormSubmitting] = useState(false);
   const [goToCollaborators, setGoToCollaborators] = useState(false);
   const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
 
-  const { isOnlyAllowEssential, availableUseCases } = useFormAvailableUseCases({
+  const { availableUseCases } = useFormAvailableUseCases({
     savedObjects,
     registeredUseCases$,
-    onlyAllowEssentialEnabled: true,
+    useCaseService,
   });
 
   const location = useLocation();
@@ -194,8 +197,7 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
   const isFormReadyToRender =
     application &&
     savedObjects &&
-    // Default values only worked for component mount, should wait for isOnlyAllowEssential and availableUseCases loaded
-    isOnlyAllowEssential !== undefined &&
+    // Default values only worked for component mount, should wait for availableUseCases loaded
     availableUseCases !== undefined;
 
   return (

--- a/src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.test.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.test.ts
@@ -5,18 +5,23 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { BehaviorSubject } from 'rxjs';
 import { WorkspaceUseCase } from '../../types';
-import { DEFAULT_NAV_GROUPS } from '../../../../../core/public';
+import { DEFAULT_NAV_GROUPS, UseCaseId } from '../../../../../core/public';
 import { savedObjectsServiceMock } from '../../../../../core/public/mocks';
-import { getIsOnlyAllowEssentialUseCase } from '../../utils';
+import { areAllDataSourcesOpenSearchServerless } from '../../utils';
+import { UseCaseService } from '../../services';
 
 import { useFormAvailableUseCases } from './use_form_available_use_cases';
 
 jest.mock('../../utils', () => ({
-  getIsOnlyAllowEssentialUseCase: jest.fn(),
+  areAllDataSourcesOpenSearchServerless: jest.fn(),
 }));
 
 describe('useFormAvailableUseCases', () => {
   const mockSavedObjectsClient = savedObjectsServiceMock.createStartContract();
+
+  const mockUseCaseService = {
+    supportedUseCasesForServerless: [UseCaseId.ESSENTIAL_USE_CASE_ID],
+  } as UseCaseService;
 
   const mockUseCases: WorkspaceUseCase[] = [
     {
@@ -47,12 +52,15 @@ describe('useFormAvailableUseCases', () => {
     jest.clearAllMocks();
   });
 
-  it('should return available use cases when onlyAllowEssentialEnabled is false', () => {
+  it('should return available use cases when data sources are not serverless', () => {
     const registeredUseCases$ = new BehaviorSubject(mockUseCases);
+    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockResolvedValue(false);
+
     const { result } = renderHook(() =>
       useFormAvailableUseCases({
-        onlyAllowEssentialEnabled: false,
+        savedObjects: mockSavedObjectsClient,
         registeredUseCases$,
+        useCaseService: mockUseCaseService,
       })
     );
 
@@ -67,21 +75,20 @@ describe('useFormAvailableUseCases', () => {
     ]);
   });
 
-  it('should return only essential use case when onlyAllowEssentialEnabled is true', async () => {
+  it('should return only supported serverless use cases when all data sources are serverless', async () => {
     const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    (getIsOnlyAllowEssentialUseCase as jest.Mock).mockResolvedValue(true);
+    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockResolvedValue(true);
 
     const { result, waitForNextUpdate } = renderHook(() =>
       useFormAvailableUseCases({
-        onlyAllowEssentialEnabled: true,
         savedObjects: mockSavedObjectsClient,
         registeredUseCases$,
+        useCaseService: mockUseCaseService,
       })
     );
 
     await waitForNextUpdate();
 
-    expect(result.current.isOnlyAllowEssential).toBe(true);
     expect(result.current.availableUseCases).toEqual([
       expect.objectContaining({
         ...DEFAULT_NAV_GROUPS.essentials,
@@ -90,21 +97,22 @@ describe('useFormAvailableUseCases', () => {
     ]);
   });
 
-  it('should handle error when fetching isOnlyAllowEssential', async () => {
+  it('should handle error when fetching serverless status and default to non-serverless behavior', async () => {
     const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    (getIsOnlyAllowEssentialUseCase as jest.Mock).mockRejectedValue(new Error('Failed to fetch'));
+    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockRejectedValue(
+      new Error('Failed to fetch')
+    );
 
     const { result, waitForNextUpdate } = renderHook(() =>
       useFormAvailableUseCases({
-        onlyAllowEssentialEnabled: true,
         savedObjects: mockSavedObjectsClient,
         registeredUseCases$,
+        useCaseService: mockUseCaseService,
       })
     );
 
     await waitForNextUpdate();
 
-    expect(result.current.isOnlyAllowEssential).toBe(false);
     expect(result.current.availableUseCases).toEqual([
       expect.objectContaining({
         id: 'useCase1',
@@ -116,25 +124,112 @@ describe('useFormAvailableUseCases', () => {
     ]);
   });
 
-  it('should not update isOnlyAllowEssential after unmount', async () => {
+  it('should not update serverless status after unmount', async () => {
     const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    const getIsOnlyAllowEssentialUseCaseMock = (getIsOnlyAllowEssentialUseCase as jest.Mock).mockImplementation(
+    const areAllDataSourcesServerlessMock = (areAllDataSourcesOpenSearchServerless as jest.Mock).mockImplementation(
       () =>
         new Promise((resolve) => {
-          setTimeout(() => resolve(false), 0);
+          setTimeout(() => resolve(true), 0);
         })
     );
     const { unmount, result } = renderHook(() =>
       useFormAvailableUseCases({
-        onlyAllowEssentialEnabled: true,
         savedObjects: mockSavedObjectsClient,
         registeredUseCases$,
+        useCaseService: mockUseCaseService,
       })
     );
 
-    expect(result.current.isOnlyAllowEssential).toBeUndefined();
+    // Initially should show non-serverless behavior (all use cases)
+    expect(result.current.availableUseCases).toEqual([
+      expect.objectContaining({
+        id: 'useCase1',
+        title: 'Use Case 1',
+        systematic: false,
+      }),
+      expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
+      expect.objectContaining(DEFAULT_NAV_GROUPS.all),
+    ]);
+
     unmount();
-    await getIsOnlyAllowEssentialUseCaseMock.mock.results[0].value;
-    expect(result.current.isOnlyAllowEssential).toBeUndefined();
+    await areAllDataSourcesServerlessMock.mock.results[0].value;
+
+    // After unmount, the result should remain unchanged
+    expect(result.current.availableUseCases).toEqual([
+      expect.objectContaining({
+        id: 'useCase1',
+        title: 'Use Case 1',
+        systematic: false,
+      }),
+      expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
+      expect.objectContaining(DEFAULT_NAV_GROUPS.all),
+    ]);
+  });
+
+  it('should return undefined when registeredUseCases is undefined', () => {
+    const registeredUseCases$ = new BehaviorSubject(undefined as any);
+
+    const { result } = renderHook(() =>
+      useFormAvailableUseCases({
+        savedObjects: mockSavedObjectsClient,
+        registeredUseCases$,
+        useCaseService: mockUseCaseService,
+      })
+    );
+
+    expect(result.current.availableUseCases).toBeUndefined();
+  });
+
+  it('should work without savedObjects parameter', () => {
+    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
+
+    const { result } = renderHook(() =>
+      useFormAvailableUseCases({
+        registeredUseCases$,
+        useCaseService: mockUseCaseService,
+      })
+    );
+
+    // Should default to non-serverless behavior when no savedObjects provided
+    expect(result.current.availableUseCases).toEqual([
+      expect.objectContaining({
+        id: 'useCase1',
+        title: 'Use Case 1',
+        systematic: false,
+      }),
+      expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
+      expect.objectContaining(DEFAULT_NAV_GROUPS.all),
+    ]);
+  });
+
+  it('should handle multiple supported serverless use cases', async () => {
+    const multiServerlessUseCaseService = {
+      supportedUseCasesForServerless: [UseCaseId.ESSENTIAL_USE_CASE_ID, 'useCase1' as UseCaseId],
+    } as UseCaseService;
+
+    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
+    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockResolvedValue(true);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFormAvailableUseCases({
+        savedObjects: mockSavedObjectsClient,
+        registeredUseCases$,
+        useCaseService: multiServerlessUseCaseService,
+      })
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.availableUseCases).toEqual([
+      expect.objectContaining({
+        id: 'useCase1',
+        title: 'Use Case 1',
+        disabled: false, // Should not be disabled when multiple use cases are supported
+      }),
+      expect.objectContaining({
+        ...DEFAULT_NAV_GROUPS.essentials,
+        disabled: false, // Should not be disabled when multiple use cases are supported
+      }),
+    ]);
   });
 });

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -299,12 +299,13 @@ export class WorkspacePlugin
       const [coreStart, { navigation }] = await core.getStartServices();
       const workspaceClient = coreStart.workspaces.client$.getValue() as WorkspaceClient;
 
-      const services = {
+      const services: Services = {
         ...coreStart,
         workspaceClient,
         dataSourceManagement,
         collaboratorTypes: this.collaboratorTypes,
         navigationUI: navigation.ui,
+        useCaseService: this.useCase,
       };
 
       return renderApp(params, services, {
@@ -435,6 +436,8 @@ export class WorkspacePlugin
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
     });
 
+    const useCase = this.useCase;
+
     if (core.chrome.navGroup.getNavGroupEnabled() && contentManagement) {
       // workspace essential use case overview
       core.application.register({
@@ -453,6 +456,7 @@ export class WorkspacePlugin
             dataSourceManagement,
             contentManagement: contentManagementStart,
             navigationUI: navigationStart.ui,
+            useCaseService: useCase,
           };
 
           return renderUseCaseOverviewApp(params, services, ESSENTIAL_OVERVIEW_PAGE_ID);
@@ -490,6 +494,7 @@ export class WorkspacePlugin
             dataSourceManagement,
             contentManagement: contentManagementStart,
             navigationUI: navigationStart.ui,
+            useCaseService: useCase,
           };
 
           return renderUseCaseOverviewApp(params, services, ANALYTICS_ALL_OVERVIEW_PAGE_ID);
@@ -561,6 +566,8 @@ export class WorkspacePlugin
       ui: {
         AddCollaboratorsModal,
       },
+      registerSupportedUseCasesForServerlessCollections: this.useCase
+        .registerSupportedUseCasesForServerlessCollections,
     };
   }
 
@@ -662,6 +669,7 @@ export class WorkspacePlugin
         workspaceClient,
         navigationUI: navigation.ui,
         collaboratorTypes: this.collaboratorTypes,
+        useCaseService: this.useCase,
       };
       contentManagement.registerContentProvider({
         id: 'default_workspace_list',

--- a/src/plugins/workspace/public/services/use_case_service.ts
+++ b/src/plugins/workspace/public/services/use_case_service.ts
@@ -15,6 +15,7 @@ import {
   WorkspacesSetup,
   DEFAULT_NAV_GROUPS,
   ALL_USE_CASE_ID,
+  UseCaseId,
 } from '../../../../core/public';
 import {
   WORKSPACE_DETAIL_APP_ID,
@@ -36,6 +37,14 @@ export interface UseCaseServiceSetupDeps {
 
 export class UseCaseService {
   private workspaceAndManageWorkspaceCategorySubscription?: Subscription;
+  private supportedUseCasesForServerlessCollections = new Set<UseCaseId>([
+    UseCaseId.ESSENTIAL_USE_CASE_ID,
+  ]);
+
+  public get supportedUseCasesForServerless(): UseCaseId[] {
+    return Array.from(this.supportedUseCasesForServerlessCollections);
+  }
+
   constructor() {}
 
   /**
@@ -218,4 +227,8 @@ export class UseCaseService {
   stop() {
     this.workspaceAndManageWorkspaceCategorySubscription?.unsubscribe();
   }
+
+  registerSupportedUseCasesForServerlessCollections = (useCaseIds: UseCaseId[]) => {
+    useCaseIds.forEach((id) => this.supportedUseCasesForServerlessCollections.add(id));
+  };
 }

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -10,7 +10,7 @@ import { NavigationPublicPluginStart } from '../../../plugins/navigation/public'
 import { ContentManagementPluginStart } from '../../../plugins/content_management/public';
 import { DataSourceAttributes } from '../../../plugins/data_source/common/data_sources';
 import type { AddCollaboratorsModal } from './components/add_collaborators_modal';
-import { WorkspaceCollaboratorTypesService } from './services';
+import { UseCaseService, WorkspaceCollaboratorTypesService } from './services';
 
 export type Services = CoreStart & {
   workspaceClient: WorkspaceClient;
@@ -18,6 +18,7 @@ export type Services = CoreStart & {
   navigationUI?: NavigationPublicPluginStart['ui'];
   contentManagement?: ContentManagementPluginStart;
   collaboratorTypes: WorkspaceCollaboratorTypesService;
+  useCaseService: UseCaseService;
 };
 
 export interface WorkspaceUseCaseFeature {
@@ -53,4 +54,5 @@ export interface WorkspacePluginSetup {
   ui: {
     AddCollaboratorsModal: typeof AddCollaboratorsModal;
   };
+  registerSupportedUseCasesForServerlessCollections: UseCaseService['registerSupportedUseCasesForServerlessCollections'];
 }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -13,7 +13,7 @@ import {
   convertNavGroupToWorkspaceUseCase,
   isEqualWorkspaceUseCase,
   prependWorkspaceToBreadcrumbs,
-  getIsOnlyAllowEssentialUseCase,
+  areAllDataSourcesOpenSearchServerless,
   mergeDataSourcesWithConnections,
   fetchDataSourceConnections,
   getUseCaseUrl,
@@ -507,7 +507,7 @@ describe('workspace utils: getIsOnlyAllowEssentialUseCase', () => {
         },
       ],
     });
-    expect(await getIsOnlyAllowEssentialUseCase(mockedSavedObjectClient)).toBe(true);
+    expect(await areAllDataSourcesOpenSearchServerless(mockedSavedObjectClient)).toBe(true);
   });
 
   it('should return false when not all data sources are serverless', async () => {
@@ -535,7 +535,7 @@ describe('workspace utils: getIsOnlyAllowEssentialUseCase', () => {
         },
       ],
     });
-    expect(await getIsOnlyAllowEssentialUseCase(mockedSavedObjectClient)).toBe(false);
+    expect(await areAllDataSourcesOpenSearchServerless(mockedSavedObjectClient)).toBe(false);
   });
 });
 

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -396,8 +396,10 @@ export const mergeDataSourcesWithConnections = (
   return result;
 };
 
-// If all connected data sources are serverless, will only allow to select essential use case.
-export const getIsOnlyAllowEssentialUseCase = async (client: SavedObjectsStart['client']) => {
+// If all connected data sources are serverless, will use the list of registered use cases specifically for serverless collections.
+export const areAllDataSourcesOpenSearchServerless = async (
+  client: SavedObjectsStart['client']
+) => {
   const allDataSources = await getDataSourcesList(client);
   if (allDataSources.length > 0) {
     return allDataSources.every(

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -49,7 +49,7 @@ import {
   SavedObjectsPermissionControl,
   SavedObjectsPermissionControlContract,
 } from './permission_control/client';
-import { updateDashboardAdminStateForRequest } from './utils';
+import { translatePermissionsToRole, updateDashboardAdminStateForRequest } from './utils';
 import { WorkspaceIdConsumerWrapper } from './saved_objects/workspace_id_consumer_wrapper';
 import { WorkspaceUiSettingsClientWrapper } from './saved_objects/workspace_ui_settings_client_wrapper';
 import { uiSettings } from './ui_settings';
@@ -297,6 +297,8 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
 
     return {
       client: this.client,
+      permissionsControlClient: this.permissionControl,
+      translatePermissionsToModeId: translatePermissionsToRole,
     };
   }
 

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -14,6 +14,8 @@ import {
   WorkspaceFindOptions,
 } from '../../../core/server';
 import { PermissionModeId } from '../../../core/server';
+import { SavedObjectsPermissionControlContract } from './permission_control/client';
+import { translatePermissionsToRole } from './utils';
 export interface WorkspaceAttributeWithPermission extends WorkspaceAttribute {
   permissions?: Permissions;
   permissionMode?: PermissionModeId;
@@ -165,6 +167,8 @@ export type IResponse<T> =
 
 export interface WorkspacePluginSetup {
   client: IWorkspaceClientImpl;
+  permissionControlClient?: SavedObjectsPermissionControlContract;
+  translatePermissionsToModeId: typeof translatePermissionsToRole;
 }
 
 export interface WorkspacePluginStart {


### PR DESCRIPTION
### Description
This PR has 2 sets of changes:
1. Exposes the permission control client and relevant utility that can be used together with the Workspace plugin server client to determine the permission mode id for the current user for a given workspace id. This will be leveraged in other plugins to gate user actions based on permission mode. For e.g. in security analytics we can block detector creation if user has read only permissions

2. On create workspace page, it limits the use case type to `essentials` if all the data sources connected to the application are OpenSearch Serverless Collections. This PR refactors the logic to allow plugins to specify the use case types they want to be supported for collections. By default the list include `essentials` use case type.


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
