### PR TITLE
[Explore] add backticks to source for explore

### DIFF
--- a/changelogs/fragments/10661.yml
+++ b/changelogs/fragments/10661.yml
@@ -1,0 +1,2 @@
+fix:
+- Temporarily add backticks to explore's data source command ([#10661](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10661))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/01/saved_explore.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/01/saved_explore.spec.js
@@ -59,7 +59,7 @@ const runSavedExploreTests = () => {
 
       // Set query input
       cy.explore.clearQueryEditor();
-      const query = `source=${INDEX_PATTERN_WITH_TIME} | stats count() by category`;
+      const query = `source=\`${INDEX_PATTERN_WITH_TIME}\` | stats count() by category`;
       cy.explore.setQueryEditor(query, { submit: false });
 
       // Run the query
@@ -106,7 +106,7 @@ const runSavedExploreTests = () => {
 
       // Update the saved search with a new query
       cy.explore.clearQueryEditor();
-      const newQuery = `source=${INDEX_PATTERN_WITH_TIME} | stats count()`;
+      const newQuery = `source=\`${INDEX_PATTERN_WITH_TIME}\` | stats count()`;
       cy.explore.setQueryEditor(newQuery, { submit: false });
 
       // Run the query

--- a/src/plugins/explore/public/application/utils/languages/ppl/default_prepare_ppl_query/default_prepare_ppl_query.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/default_prepare_ppl_query/default_prepare_ppl_query.test.ts
@@ -16,7 +16,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset level="error"',
+      query: 'source = `test-dataset` level="error"',
     });
   });
 
@@ -29,7 +29,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source=existing-index | where level="error"',
+      query: 'source=`existing-index` | where level="error"',
     });
   });
 
@@ -42,7 +42,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset',
+      query: 'source = `test-dataset`',
     });
   });
 
@@ -55,7 +55,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset',
+      query: 'source = `test-dataset`',
     });
   });
 
@@ -68,7 +68,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset | where level="error"',
+      query: 'source = `test-dataset` | where level="error"',
     });
   });
 
@@ -81,7 +81,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'search source=logs-* | where @timestamp > now()-1d',
+      query: 'search source=`logs-*` | where @timestamp > now()-1d',
     });
   });
 
@@ -94,7 +94,7 @@ describe('defaultPreparePplQuery', () => {
     const result = defaultPreparePplQuery(query);
     expect(result).toEqual({
       ...query,
-      query: 'SOURCE=LOGS-* | WHERE level="ERROR"',
+      query: 'SOURCE=`LOGS-*` | WHERE level="ERROR"',
     });
   });
 });

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
@@ -86,6 +86,16 @@ describe('getQueryWithSource', () => {
     expect(result).toEqual({ ...query, query: 'source=`existing-index` | where field=value' });
   });
 
+  it('should handle no whitespace between source and dataSource and pipe', () => {
+    const query: Query = {
+      query: 'source=existing-index|where field=value',
+      dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
+      language: 'ppl',
+    };
+    const result = getQueryWithSource(query);
+    expect(result).toEqual({ ...query, query: 'source=`existing-index`|where field=value' });
+  });
+
   it('should handle flexible whitespace between search, source and =', () => {
     const query: Query = {
       query: 'search    source   =existing-index | where field=value',

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
@@ -16,7 +16,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset',
+      query: 'source = `test-dataset`',
     });
   });
 
@@ -27,7 +27,7 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({ ...query, query: 'source=`existing-index` | where field=value' });
   });
 
   it('should return original query when it starts with "SOURCE" (case insensitive)', () => {
@@ -37,7 +37,7 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({ ...query, query: 'SOURCE=`existing-index` | where field=value' });
   });
 
   it('should return original query when it starts with "search source" (case sensitive)', () => {
@@ -47,7 +47,10 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({
+      ...query,
+      query: 'search source=`existing-index` | where field=value',
+    });
   });
 
   it('should return original query when it starts with "SEARCH SOURCE" (case insensitive)', () => {
@@ -57,7 +60,10 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({
+      ...query,
+      query: 'SEARCH SOURCE=`existing-index` | where field=value',
+    });
   });
 
   it('should handle flexible whitespace between source and =', () => {
@@ -67,7 +73,7 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({ ...query, query: 'source   =`existing-index` | where field=value' });
   });
 
   it('should handle no whitespace between source and =', () => {
@@ -77,7 +83,7 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({ ...query, query: 'source=`existing-index` | where field=value' });
   });
 
   it('should handle flexible whitespace between search, source and =', () => {
@@ -87,7 +93,10 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({
+      ...query,
+      query: 'search    source   =`existing-index` | where field=value',
+    });
   });
 
   it('should handle single space between search and source with no space before =', () => {
@@ -97,7 +106,10 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({
+      ...query,
+      query: 'search source=`existing-index` | where field=value',
+    });
   });
 
   it('should prepend source for empty query string', () => {
@@ -109,7 +121,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset',
+      query: 'source = `test-dataset`',
     });
   });
 
@@ -122,7 +134,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset',
+      query: 'source = `test-dataset`',
     });
   });
 
@@ -135,7 +147,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset | where level="error"',
+      query: 'source = `test-dataset` | where level="error"',
     });
   });
 
@@ -148,7 +160,7 @@ describe('getQueryWithSource', () => {
     const result = getQueryWithSource(query);
     expect(result).toEqual({
       ...query,
-      query: 'source = test-dataset   | where level="error"',
+      query: 'source = `test-dataset`   | where level="error"',
     });
   });
 
@@ -159,7 +171,10 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({
+      ...query,
+      query: ' source = `data_logs_small_time_1*` | where unique_category = "Configuration"',
+    });
   });
 
   it('should handle leading whitespace before search source', () => {
@@ -169,7 +184,10 @@ describe('getQueryWithSource', () => {
       language: 'ppl',
     };
     const result = getQueryWithSource(query);
-    expect(result).toEqual(query);
+    expect(result).toEqual({
+      ...query,
+      query: '  search source=`existing-index` | where field=value',
+    });
   });
 
   it('should return original query when it starts with "describe"', () => {

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
@@ -23,7 +23,7 @@ export const getQueryWithSource = (query: Query): QueryWithQueryAsString => {
   if (query.dataset && ['INDEXES', 'INDEX_PATTERN'].includes(query.dataset.type)) {
     if (hasSource) {
       // Replace source=anything with source=`anything` (handling spaces around = and ensuring anything is not already backticked)
-      const updatedQuery = queryString.replace(/(\bsource\s*=\s*)([^`\s][^\s]*)/gi, '$1`$2`');
+      const updatedQuery = queryString.replace(/(\bsource\s*=\s*)([^`\s][^\s|]*)/gi, '$1`$2`');
       return { ...query, query: updatedQuery };
     }
 

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
@@ -16,11 +16,25 @@ export const getQueryWithSource = (query: Query): QueryWithQueryAsString => {
   const hasDescribe = /^\s*describe\s+/.test(lowerCaseQuery);
   const hasShow = /^\s*show\s+/.test(lowerCaseQuery);
 
+  // Temporarily adding backticks to dataset type INDEXES or INDEX_PATTERNS to until these two issues are resolved:
+  // https://github.com/opensearch-project/sql/issues/4444
+  // https://github.com/opensearch-project/sql/issues/4445
+  let datasetTitle: string;
+  if (query.dataset && ['INDEXES', 'INDEX_PATTERN'].includes(query.dataset.type)) {
+    if (hasSource) {
+      // Replace source=anything with source=`anything` (handling spaces around = and ensuring anything is not already backticked)
+      const updatedQuery = queryString.replace(/(\bsource\s*=\s*)([^`\s][^\s]*)/gi, '$1`$2`');
+      return { ...query, query: updatedQuery };
+    }
+
+    datasetTitle = `\`${query.dataset.title}\``;
+  } else {
+    datasetTitle = query.dataset?.title || '';
+  }
+
   if (hasSource || hasDescribe || hasShow) {
     return { ...query, query: queryString };
   }
-
-  const datasetTitle = query.dataset?.title || '';
 
   let queryStringWithSource: string;
   if (queryString.trim() === '') {

--- a/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.test.ts
@@ -27,7 +27,7 @@ describe('createQuerySyncMiddleware', () => {
 
     expect(mockNext).toHaveBeenCalledWith(action);
     expect(mockServices.data.query.queryString.setQuery).toHaveBeenCalledWith({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });
@@ -41,7 +41,7 @@ describe('createQuerySyncMiddleware', () => {
 
     expect(mockNext).toHaveBeenCalledWith(action);
     expect(mockServices.data.query.queryString.setQuery).toHaveBeenCalledWith({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });
@@ -58,12 +58,16 @@ describe('createQuerySyncMiddleware', () => {
   it('should not sync when queries are equal but still add to history if requested', () => {
     // Mock getQuery to return the same query as in state
     mockServices.data.query.queryString.getQuery = jest.fn().mockReturnValue({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });
 
-    const action = setQueryWithHistory({ query: 'source=hello', language: 'PPL' });
+    const action = setQueryWithHistory({
+      query: 'source=`hello`',
+      language: 'PPL',
+      dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' } as any,
+    });
 
     middleware(action);
 
@@ -84,12 +88,12 @@ describe('createQuerySyncMiddleware', () => {
   it('should not sync when queries are equal and not add to history for setQueryState', () => {
     // Mock getQuery to return the same query as in state
     mockServices.data.query.queryString.getQuery = jest.fn().mockReturnValue({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });
 
-    const action = setQueryState({ query: 'source=hello', language: 'PPL' });
+    const action = setQueryState({ query: 'source=`hello`', language: 'PPL' });
 
     middleware(action);
 
@@ -131,7 +135,7 @@ describe('createQuerySyncMiddleware', () => {
   it('should add to history even when queries are equal if action has addToHistory meta', () => {
     // Mock getQuery to return the same query as in state
     mockServices.data.query.queryString.getQuery = jest.fn().mockReturnValue({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });
@@ -166,7 +170,7 @@ describe('createQuerySyncMiddleware', () => {
 
     expect(mockNext).toHaveBeenCalledWith(action);
     expect(mockServices.data.query.queryString.setQuery).toHaveBeenCalledWith({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });
@@ -183,7 +187,7 @@ describe('createQuerySyncMiddleware', () => {
   it('should not sync when queries are equal but still add to history for setQueryStringWithHistory', () => {
     // Mock getQuery to return the same query as in state
     mockServices.data.query.queryString.getQuery = jest.fn().mockReturnValue({
-      query: 'source=hello',
+      query: 'source=`hello`',
       language: 'PPL',
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     });


### PR DESCRIPTION
### Description

- we found two edge conditions where the PPL grammar needs updated:

https://github.com/opensearch-project/sql/issues/4444
https://github.com/opensearch-project/sql/issues/4445

- This is a temporary workaround to remedy this issue.
- If user manually types these queries in, or uses autocomplete to help them, we still show syntax error, but the query will work.

## Changelog
- fix: temporarily add backticks to explore's data source command

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
