### PR TITLE
Trace:Details Highlight faults and errors on gantt chart

### DIFF
--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_chart_spec.test.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_chart_spec.test.ts
@@ -70,9 +70,10 @@ describe('gantt_chart_spec', () => {
     // Check data sources
     expect(spec.data).toBeDefined();
     if (spec.data) {
-      expect(spec.data.length).toBe(2);
+      expect(spec.data.length).toBe(3);
       expect(spec.data[0].name).toBe('spans');
       expect(spec.data[1].name).toBe('error_spans');
+      expect(spec.data[2].name).toBe('fault_spans');
 
       // Check error_spans filter
       expect((spec.data[1] as any).source).toBe('spans');
@@ -81,7 +82,17 @@ describe('gantt_chart_spec', () => {
         expect(spec.data[1].transform.length).toBe(1);
         const transform = spec.data[1].transform[0] as any;
         expect(transform.type).toBe('filter');
-        expect(transform.expr).toBe('datum.hasError');
+        expect(transform.expr).toBe('datum.hasClientError');
+      }
+
+      // Check fault_spans filter
+      expect((spec.data[2] as any).source).toBe('spans');
+
+      if (spec.data[2].transform && spec.data[2].transform.length > 0) {
+        expect(spec.data[2].transform.length).toBe(1);
+        const transform = spec.data[2].transform[0] as any;
+        expect(transform.type).toBe('filter');
+        expect(transform.expr).toBe('datum.hasServerFault');
       }
     }
   });
@@ -155,6 +166,11 @@ describe('gantt_chart_spec', () => {
         (mark) => mark.type === 'symbol' && mark.from && (mark.from as any).data === 'error_spans'
       );
       expect(errorIndicators).toBeDefined();
+
+      const faultIndicators = spec.marks.find(
+        (mark) => mark.type === 'symbol' && mark.from && (mark.from as any).data === 'fault_spans'
+      );
+      expect(faultIndicators).toBeDefined();
 
       const textLabels = spec.marks.filter((mark) => mark.type === 'text');
       expect(textLabels.length).toBeGreaterThan(0);

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_chart_spec.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_chart_spec.ts
@@ -79,7 +79,17 @@ export function createGanttSpec(
         transform: [
           {
             type: 'filter',
-            expr: 'datum.hasError',
+            expr: 'datum.hasClientError',
+          },
+        ],
+      },
+      {
+        name: 'fault_spans',
+        source: 'spans',
+        transform: [
+          {
+            type: 'filter',
+            expr: 'datum.hasServerFault',
           },
         ],
       },
@@ -176,7 +186,7 @@ export function createGanttSpec(
       // Error indicators
       {
         type: 'symbol',
-        from: { data: 'error_spans' },
+        from: { data: 'fault_spans' },
         encode: {
           enter: {
             y: { scale: 'yscale', field: 'label', band: 0.5 },
@@ -184,6 +194,29 @@ export function createGanttSpec(
             size: { value: 120 },
             shape: { value: 'triangle-up' },
             fill: { value: '#c14125' },
+            stroke: { value: 'white' },
+            strokeWidth: { value: 1 },
+            tooltip: {
+              signal:
+                "'" +
+                i18n.translate('explore.ganttChart.tooltip.faultInSpan', {
+                  defaultMessage: 'Fault in span',
+                }) +
+                "'",
+            },
+          },
+        },
+      },
+      {
+        type: 'symbol',
+        from: { data: 'error_spans' },
+        encode: {
+          enter: {
+            y: { scale: 'yscale', field: 'label', band: 0.5 },
+            x: { value: 5 }, // Position after serviceName text (which ends at x: -5)
+            size: { value: 120 },
+            shape: { value: 'triangle-up' },
+            fill: { value: '#F5A700' },
             stroke: { value: 'white' },
             strokeWidth: { value: 1 },
             tooltip: {
@@ -294,19 +327,27 @@ export function createGanttSpec(
             x: { scale: 'xscale', field: 'endTime', offset: 8 },
             text: {
               signal:
-                'datum.hasError ? "' +
+                'datum.hasServerFault ? "' +
+                i18n.translate('explore.ganttChart.label.fault', {
+                  defaultMessage: 'Fault',
+                }) +
+                '" : datum.hasClientError ? "' +
                 i18n.translate('explore.ganttChart.label.error', {
                   defaultMessage: 'Error',
                 }) +
                 '" : datum.duration + " ms"',
             },
             fill: {
-              signal: `datum.hasError ? "#c14125" : "${isDarkMode ? '#ffffff' : '#000000'}"`,
+              signal: `datum.hasServerFault ? "#c14125" : datum.hasClientError ? "#F5A700" : "${
+                isDarkMode ? '#ffffff' : '#000000'
+              }"`,
             },
           },
           hover: {
             fill: {
-              signal: `datum.hasError ? "#d14a2a" : "${isDarkMode ? '#cccccc' : '#333333'}"`,
+              signal: `datum.hasServerFault ? "#d14a2a" : datum.hasClientError ? "#F5A700" : "${
+                isDarkMode ? '#cccccc' : '#333333'
+              }"`,
             },
           },
         },

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_data_adapter.test.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_data_adapter.test.ts
@@ -29,6 +29,11 @@ describe('gantt_data_adapter', () => {
       endTime: '2023-01-01T10:00:00.080Z',
       durationInNanos: 60000000,
       'status.code': 0,
+      attributes: {
+        http: {
+          status_code: 400,
+        },
+      },
     },
     {
       spanId: 'span-3',
@@ -92,16 +97,22 @@ describe('gantt_data_adapter', () => {
     expect(span1?.hasError).toBe(false);
 
     // Check that error spans are marked correctly
+    const span2 = result.values.find((span) => span.spanId === 'span-2');
+    expect(span2).toBeDefined();
+    expect(span2?.hasError).toBe(true);
+    expect(span2?.hasClientError).toBe(true);
+    expect(span2?.hasServerFault).toBe(false);
+
+    // Check that fault spans are marked correctly
     const span3 = result.values.find((span) => span.spanId === 'span-3');
     expect(span3).toBeDefined();
     expect(span3?.hasError).toBe(true);
+    expect(span3?.hasServerFault).toBe(true);
+    expect(span3?.hasClientError).toBe(false);
 
     // Check that hierarchy levels are set correctly
     expect(span1?.level).toBe(0); // Root span
-
-    const span2 = result.values.find((span) => span.spanId === 'span-2');
     expect(span2?.level).toBe(1); // Child span
-
     expect(span3?.level).toBe(1); // Child span
   });
 

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_data_adapter.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/gantt_chart_vega/gantt_data_adapter.ts
@@ -9,7 +9,10 @@ import {
   isSpanError,
   resolveServiceNameFromSpan,
   hasNanosecondPrecision,
+  isSpanClientError,
+  isSpanServerFault,
 } from '../traces/ppl_resolve_helpers';
+import { extractHttpStatusCode } from '../utils/span_data_utils';
 
 interface SpanSource {
   traceId: string;
@@ -23,6 +26,7 @@ interface SpanSource {
   'status.code': number;
   traceGroup?: string;
   kind?: string;
+  'http.status_code'?: number;
 }
 
 interface SpanData {
@@ -56,6 +60,7 @@ function getSpanSource(span: SpanData): SpanSource {
     'status.code': span['status.code'] || 0,
     traceGroup: span.traceGroup,
     kind: span.kind,
+    'http.status_code': extractHttpStatusCode(span),
   };
 }
 
@@ -68,6 +73,8 @@ interface VegaSpan {
   duration: number;
   level: number;
   hasError: boolean;
+  hasClientError: boolean;
+  hasServerFault: boolean;
   color: string;
 }
 
@@ -259,6 +266,8 @@ export function convertToVegaGanttData(
       duration,
       level,
       hasError: isSpanError(source),
+      hasClientError: isSpanClientError(source),
+      hasServerFault: isSpanServerFault(source),
       color: serviceColorMap[serviceName],
     };
   });

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/ppl_resolve_helpers.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/ppl_resolve_helpers.tsx
@@ -261,7 +261,11 @@ export function resolveInstrumentationScopeFromDatarows(
 }
 
 export function isSpanError(span: any): boolean {
-  if (!span) return false;
+  return isSpanClientError(span) || isSpanServerFault(span);
+}
+
+export function isSpanServerFault(span: any): boolean {
+  if (!span || isSpanClientError(span)) return false;
 
   if (span['status.code'] === 2) {
     return true;
@@ -275,11 +279,16 @@ export function isSpanError(span: any): boolean {
   }
 
   const httpStatusCode = extractHttpStatusCode(span);
-  if (httpStatusCode && httpStatusCode >= 400) {
+  if (httpStatusCode && httpStatusCode >= 500) {
     return true;
   }
 
   return false;
+}
+
+export function isSpanClientError(span: any): boolean {
+  const httpStatusCode = extractHttpStatusCode(span);
+  return !!httpStatusCode && 400 <= httpStatusCode && httpStatusCode < 500;
 }
 
 function extractHttpStatusCode(span: any): number | undefined {


### PR DESCRIPTION
### Description

Highlights spans with server faults (5xxs) and client errors (4xxs) on the trace gantt chart. 

### Issues Resolved

## Screenshot
[
<img width="1432" height="800" alt="Screenshot 2025-10-07 at 10 43 20 AM" src="https://github.com/user-attachments/assets/1f10ecae-9092-4fd8-8592-ccee0d4fdbaa" />
](url)

## Testing the changes

## Changelog
- fix: highlight fault and error spans

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
