### PR TITLE
Ensure the disabled prop gets passed to the EuiSideNavItem for navlinks

### DIFF
--- a/src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
@@ -72,6 +72,7 @@ export function NavGroups({
       buttonClassName: 'nav-link-item-btn',
       'data-test-subj': euiListItem['data-test-subj'],
       'aria-label': link.title,
+      disabled: euiListItem.isDisabled,
     };
   };
   const createSideNavItem = (


### PR DESCRIPTION
### Description
Ensure the disabled prop gets passed to the EuiSideNavItem for navlinks

## Screenshot
- This change will respect the AppNavlinkStatus field from app registration
<img width="259" height="101" alt="image" src="https://github.com/user-attachments/assets/a00d3030-9579-4d5d-bf90-08c24894211e" />


## Changelog
- fix: Ensure the disabled prop gets passed to the EuiSideNavItem for navlinks

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
