### PR TITLE
[Explore] fix explore storybook by bringing over mocks from discover to explore

### DIFF
--- a/src/plugins/explore/public/__mock__/index.test.mock.ts
+++ b/src/plugins/explore/public/__mock__/index.test.mock.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DataSource } from 'src/plugins/data/public';
+
+interface DataSourceConfig {
+  name: string;
+  type: string;
+  metadata: any;
+  id: string;
+}
+
+export class MockS3DataSource extends DataSource {
+  constructor({ id, name, type, metadata }: DataSourceConfig) {
+    super({ id, name, type, metadata });
+  }
+
+  async getDataSet(dataSetParams?: any) {
+    return { dataSets: [this.getName()] };
+  }
+
+  async testConnection(): Promise<boolean> {
+    return true;
+  }
+
+  async runQuery(queryParams: any) {
+    return { data: {} };
+  }
+}

--- a/src/plugins/explore/public/__mock__/index_pattern_mock.ts
+++ b/src/plugins/explore/public/__mock__/index_pattern_mock.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { indexPatterns, IndexPattern, IndexPatternField } from '../../../data/public';
+import { IIndexPatternFieldList } from '../../../data/common';
+
+// Initial data of index pattern fields
+const fieldsData = [
+  {
+    name: '_id',
+    type: 'string',
+    scripted: false,
+    aggregatable: true,
+    filterable: true,
+    searchable: true,
+    sortable: true,
+  },
+  {
+    name: '_index',
+    type: 'string',
+    scripted: false,
+    filterable: true,
+    aggregatable: true,
+    searchable: true,
+    sortable: true,
+  },
+  {
+    name: '_source',
+    type: '_source',
+    scripted: false,
+    aggregatable: false,
+    filterable: false,
+    searchable: false,
+    sortable: false,
+  },
+];
+
+// Create a mock object for index pattern fields with methods: getAll, getByName and getByType
+export const indexPatternFieldMock = {
+  getAll: () => fieldsData,
+  getByName: (name) => fieldsData.find((field) => field.name === name),
+  getByType: (type) => fieldsData.filter((field) => field.type === type),
+} as IIndexPatternFieldList;
+
+// Create a mock for the initial index pattern
+export const indexPatternInitialMock = ({
+  id: '123',
+  title: 'test_index',
+  fields: indexPatternFieldMock,
+  timeFieldName: 'order_date',
+  formatHit: (hit: any) => (hit.fields ? hit.fields : hit._source),
+  flattenHit: undefined,
+  formatField: undefined,
+  metaFields: ['_id', '_index', '_source'],
+  getFieldByName: () => ({}),
+} as unknown) as IndexPattern;
+
+// Add a flattenHit method to the initial index pattern mock using flattenHitWrapper
+const flatternHitMock = indexPatterns.flattenHitWrapper(
+  indexPatternInitialMock,
+  indexPatternInitialMock.metaFields
+);
+indexPatternInitialMock.flattenHit = flatternHitMock;
+
+// Add a formatField method to the initial index pattern mock
+const formatFieldMock = (hit: Record<string, any>, field: string) => {
+  return field === '_source' ? hit._source : indexPatternInitialMock.flattenHit(hit)[field];
+};
+indexPatternInitialMock.formatField = formatFieldMock;
+
+// Export the fully set up index pattern mock
+export const indexPatternMock = indexPatternInitialMock;
+
+// Export a function that allows customization of index pattern mocks, by adding extra fields to the fieldsData
+export const getMockedIndexPatternWithCustomizedFields = (fields: IndexPatternField[]) => {
+  const customizedFieldsData = [...fieldsData, ...fields];
+  const customizedFieldsMock = {
+    getAll: () => customizedFieldsData,
+    getByName: (name) => customizedFieldsData.find((field) => field.name === name),
+    getByType: (type) => customizedFieldsData.filter((field) => field.type === type),
+  } as IIndexPatternFieldList;
+
+  return {
+    ...indexPatternMock,
+    fields: customizedFieldsMock,
+  };
+};
+
+// Export a function that allows customization of index pattern mocks with both extra fields and time field
+export const getMockedIndexPatternWithTimeField = (
+  fields: IndexPatternField[],
+  timeFiledName: string
+) => {
+  const indexPatternWithTimeFieldMock = getMockedIndexPatternWithCustomizedFields(fields);
+
+  return {
+    ...indexPatternWithTimeFieldMock,
+    timeFieldName: timeFiledName,
+  };
+};

--- a/src/plugins/explore/public/components/data_table/data_table.stories.tsx
+++ b/src/plugins/explore/public/components/data_table/data_table.stories.tsx
@@ -6,7 +6,7 @@ import { i18n } from '@osd/i18n';
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { indexPatternMock } from '../../../../discover/public';
+import { indexPatternMock } from '../../__mock__/index_pattern_mock';
 import { DataTable, DataTableProps } from './data_table';
 import { mockColumns, mockRows } from './data_table.mocks';
 import { DocViewsRegistry } from '../../types/doc_views_types';

--- a/src/plugins/explore/public/components/data_table/data_table.test.tsx
+++ b/src/plugins/explore/public/components/data_table/data_table.test.tsx
@@ -10,7 +10,7 @@ import { act, render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataTable } from './data_table';
 import { DocViewsRegistry, OpenSearchSearchHit } from '../../types/doc_views_types';
-import { indexPatternMock } from '../../../../discover/public';
+import { indexPatternMock } from '../../__mock__/index_pattern_mock';
 import { mockColumns, mockRows } from './data_table.mocks';
 import { DocViewTable } from '../doc_viewer/doc_viewer_table/table';
 import { JsonCodeBlock } from '../doc_viewer/json_code_block/json_code_block';

--- a/src/plugins/explore/public/components/doc_viewer/doc_viewer.stories.tsx
+++ b/src/plugins/explore/public/components/doc_viewer/doc_viewer.stories.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import type { ComponentStory } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { indexPatternMock } from '../../../../discover/public';
+import { indexPatternMock } from '../../__mock__/index_pattern_mock';
 import { DocViewer } from './doc_viewer';
 import { DocViewRenderProps, DocViewsRegistry } from '../../types/doc_views_types';
 import { DocViewTable } from './doc_viewer_table/table';

--- a/src/plugins/explore/public/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/plugins/explore/public/components/doc_viewer/doc_viewer.test.tsx
@@ -7,7 +7,7 @@ import { i18n } from '@osd/i18n';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { indexPatternMock } from 'src/plugins/discover/public';
+import { indexPatternMock } from '../../__mock__/index_pattern_mock';
 import { DocViewRenderProps, DocViewsRegistry } from '../../types/doc_views_types';
 import { DocViewer } from './doc_viewer';
 import { DocViewTable } from './doc_viewer_table/table';


### PR DESCRIPTION
### Description

- `yarn storybook explore` was not working for some time, as the build would fail with lots of errors
- issue was that we were importing `indexPatternMock` from the discover plugin like this:

```
  import { indexPatternMock } from '../../../../discover/public';
```

- This was breaking storybook because this import would bring in the entire discover plugin with its plugin initialization code and dependencies, which were failing to resolve properly.


## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
