### PR TITLE
Test Fixes: utils + opensearchdsl

### DIFF
--- a/src/plugins/data/public/search/expressions/opensearchdsl.test.ts
+++ b/src/plugins/data/public/search/expressions/opensearchdsl.test.ts
@@ -68,7 +68,13 @@ describe('opensearchdsl', () => {
       } catch (error) {
         errorMessage = error.message;
       }
-      expect(errorMessage).toEqual('Unexpected token i in JSON at position 0');
+      // Different Node.js versions produce different JSON error message formats
+      // Handle both formats to ensure tests pass in different environments
+      const expectedMessages = [
+        'Unexpected token i in JSON at position 0', // Node.js 18+
+        `Unexpected token 'i', "invalid json" is not valid JSON`, // Older Node.js versions
+      ];
+      expect(expectedMessages).toContain(errorMessage);
     });
 
     test('adds filters', async () => {

--- a/src/plugins/data/public/search/expressions/opensearchdsl.test.ts
+++ b/src/plugins/data/public/search/expressions/opensearchdsl.test.ts
@@ -68,7 +68,7 @@ describe('opensearchdsl', () => {
       } catch (error) {
         errorMessage = error.message;
       }
-      expect(errorMessage).toEqual(`Unexpected token 'i', "invalid json" is not valid JSON`);
+      expect(errorMessage).toEqual('Unexpected token i in JSON at position 0');
     });
 
     test('adds filters', async () => {

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -18,19 +18,19 @@ import { API } from './constants';
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString);
   return (
-    date.getFullYear() +
+    date.getUTCFullYear() +
     '-' +
-    ('0' + (date.getMonth() + 1)).slice(-2) +
+    ('0' + (date.getUTCMonth() + 1)).slice(-2) +
     '-' +
-    ('0' + date.getDate()).slice(-2) +
+    ('0' + date.getUTCDate()).slice(-2) +
     ' ' +
-    ('0' + date.getHours()).slice(-2) +
+    ('0' + date.getUTCHours()).slice(-2) +
     ':' +
-    ('0' + date.getMinutes()).slice(-2) +
+    ('0' + date.getUTCMinutes()).slice(-2) +
     ':' +
-    ('0' + date.getSeconds()).slice(-2) +
+    ('0' + date.getUTCSeconds()).slice(-2) +
     '.' +
-    ('00' + date.getMilliseconds()).slice(-3)
+    ('00' + date.getUTCMilliseconds()).slice(-3)
   );
 };
 


### PR DESCRIPTION
### Description
Additional failure on the CI running
```
 FAIL  src/plugins/data/public/search/expressions/opensearchdsl.test.ts
  ● opensearchdsl › correctly handles input › throws on invalid json input

    expect(received).toEqual(expected) // deep equality

    Expected: "Unexpected token i in JSON at position 0"
    Received: "Unexpected token 'i', \"invalid json\" is not valid JSON"

      69 |         errorMessage = error.message;
      70 |       }
    > 71 |       expect(errorMessage).toEqual('Unexpected token i in JSON at position 0');
         |                            ^
      72 |     });
      73 |
      74 |     test('adds filters', async () => {

      at Object.<anonymous> (src/plugins/data/public/search/expressions/opensearchdsl.test.ts:71:28)
```
This means the JSON error message format depends on the JavaScript engine version. The different environments are running different versions of Node.js or V8, which produce different error message formats.
Proposed fix:
```
      // Different Node.js versions produce different JSON error message formats
      // Handle both formats to ensure tests pass in different environments
      const expectedMessages = [
        'Unexpected token i in JSON at position 0', // Node.js 18+
        `Unexpected token 'i', "invalid json" is not valid JSON` // Older Node.js versions
      ];
      expect(expectedMessages).toContain(errorMessage);
    });
```


Test failing before:
```
 yarn test:jest src/plugins/query_enhancements/common/utils.test.ts
yarn run v1.22.22
$ scripts/use_node scripts/jest src/plugins/query_enhancements/common/utils.test.ts
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/plugins/vis_type_vega/public/expressions/__mocks__/index.ts
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts

jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts
    * <rootDir>/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts

 FAIL  src/plugins/query_enhancements/common/utils.test.ts
  throwFacetError
    ✓ should throw an error with message from response.data.body.message (6 ms)
    ✓ should throw an error with message from response.data.body if it is a string
    ✓ should throw an error with message from response.data if body is undefined (1 ms)
    ✓ should throw an error with message from Error object
    ✓ should throw an error with stringified message if response.data.body is a plain object (1 ms)
    ✓ should throw an error with default message if no valid message is found
  formatDate
    ✕ should format date string with milliseconds (2 ms)
    ✕ should format date string with zero milliseconds
    ✕ should format date string with single digit milliseconds (1 ms)
    ✕ should format date string with double digit milliseconds
    ✕ should format date string with maximum milliseconds
    ✕ should handle different date formats (1 ms)
    ✕ should pad single digit months and days
    ✕ should handle leap year dates
    ✕ should handle end of year dates
  isPPLSearchQuery
    ✓ should return false if query language is not PPL
    ✓ should return false if query is not string
    ✓ should return false if query is not using search command
    ✓ should return true if query is using search command

  ● formatDate › should format date string with milliseconds

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-07-30 20:30:31.567"
    Received: "2025-07-30 13:30:31.567"

      118 |     const dateString = '2025-07-30T20:30:31.567Z';
      119 |     const result = formatDate(dateString);
    > 120 |     expect(result).toBe('2025-07-30 20:30:31.567');
          |                    ^
      121 |   });
      122 |
      123 |   it('should format date string with zero milliseconds', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:120:20)

  ● formatDate › should format date string with zero milliseconds

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-07-30 20:30:31.000"
    Received: "2025-07-30 13:30:31.000"

      124 |     const dateString = '2025-07-30T20:30:31.000Z';
      125 |     const result = formatDate(dateString);
    > 126 |     expect(result).toBe('2025-07-30 20:30:31.000');
          |                    ^
      127 |   });
      128 |
      129 |   it('should format date string with single digit milliseconds', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:126:20)

  ● formatDate › should format date string with single digit milliseconds

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-07-30 20:30:31.005"
    Received: "2025-07-30 13:30:31.005"

      130 |     const dateString = '2025-07-30T20:30:31.005Z';
      131 |     const result = formatDate(dateString);
    > 132 |     expect(result).toBe('2025-07-30 20:30:31.005');
          |                    ^
      133 |   });
      134 |
      135 |   it('should format date string with double digit milliseconds', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:132:20)

  ● formatDate › should format date string with double digit milliseconds

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-07-30 20:30:31.050"
    Received: "2025-07-30 13:30:31.050"

      136 |     const dateString = '2025-07-30T20:30:31.050Z';
      137 |     const result = formatDate(dateString);
    > 138 |     expect(result).toBe('2025-07-30 20:30:31.050');
          |                    ^
      139 |   });
      140 |
      141 |   it('should format date string with maximum milliseconds', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:138:20)

  ● formatDate › should format date string with maximum milliseconds

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-07-30 20:30:31.999"
    Received: "2025-07-30 13:30:31.999"

      142 |     const dateString = '2025-07-30T20:30:31.999Z';
      143 |     const result = formatDate(dateString);
    > 144 |     expect(result).toBe('2025-07-30 20:30:31.999');
          |                    ^
      145 |   });
      146 |
      147 |   it('should handle different date formats', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:144:20)

  ● formatDate › should handle different date formats

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-01-01 00:00:00.123"
    Received: "2024-12-31 16:00:00.123"

      148 |     const dateString = '2025-01-01T00:00:00.123Z';
      149 |     const result = formatDate(dateString);
    > 150 |     expect(result).toBe('2025-01-01 00:00:00.123');
          |                    ^
      151 |   });
      152 |
      153 |   it('should pad single digit months and days', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:150:20)

  ● formatDate › should pad single digit months and days

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-01-05 09:08:07.456"
    Received: "2025-01-05 01:08:07.456"

      154 |     const dateString = '2025-01-05T09:08:07.456Z';
      155 |     const result = formatDate(dateString);
    > 156 |     expect(result).toBe('2025-01-05 09:08:07.456');
          |                    ^
      157 |   });
      158 |
      159 |   it('should handle leap year dates', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:156:20)

  ● formatDate › should handle leap year dates

    expect(received).toBe(expected) // Object.is equality

    Expected: "2024-02-29 12:34:56.789"
    Received: "2024-02-29 04:34:56.789"

      160 |     const dateString = '2024-02-29T12:34:56.789Z';
      161 |     const result = formatDate(dateString);
    > 162 |     expect(result).toBe('2024-02-29 12:34:56.789');
          |                    ^
      163 |   });
      164 |
      165 |   it('should handle end of year dates', () => {

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:162:20)

  ● formatDate › should handle end of year dates

    expect(received).toBe(expected) // Object.is equality

    Expected: "2025-12-31 23:59:59.999"
    Received: "2025-12-31 15:59:59.999"

      166 |     const dateString = '2025-12-31T23:59:59.999Z';
      167 |     const result = formatDate(dateString);
    > 168 |     expect(result).toBe('2025-12-31 23:59:59.999');
          |                    ^
      169 |   });
      170 | });
      171 |

      at Object.<anonymous> (src/plugins/query_enhancements/common/utils.test.ts:168:20)

Test Suites: 1 failed, 1 total
Tests:       9 failed, 10 passed, 19 total
Snapshots:   0 total
Time:        2.361 s
Ran all test suites matching /src\/plugins\/query_enhancements\/common\/utils.test.ts/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
❯ yarn test:jest src/plugins/data/public/search/expressions/opensearchdsl.test.ts
yarn run v1.22.22
$ scripts/use_node scripts/jest src/plugins/data/public/search/expressions/opensearchdsl.test.ts
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/plugins/vis_type_vega/public/expressions/__mocks__/index.ts
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts

jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts
    * <rootDir>/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts

 FAIL  src/plugins/data/public/search/expressions/opensearchdsl.test.ts
  opensearchdsl
    ✓ correctly handles filter, query and timerange on context
    correctly handles input
      ✕ throws on invalid json input (3 ms)
      ✓ adds filters (3 ms)
      ✓ adds filters to query with filters
      ✓ adds query (1 ms)
      ✓ adds query to a query with filters
      ✓ ignores timerange (1 ms)

  ● opensearchdsl › correctly handles input › throws on invalid json input

    expect(received).toEqual(expected) // deep equality

    Expected: "Unexpected token 'i', \"invalid json\" is not valid JSON"
    Received: "Unexpected token i in JSON at position 0"

      69 |         errorMessage = error.message;
      70 |       }
    > 71 |       expect(errorMessage).toEqual(`Unexpected token 'i', "invalid json" is not valid JSON`);
         |                            ^
      72 |     });
      73 |
      74 |     test('adds filters', async () => {

      at Object.<anonymous> (src/plugins/data/public/search/expressions/opensearchdsl.test.ts:71:28)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 6 passed, 7 total
Snapshots:   6 passed, 6 total
Time:        3.661 s
```

Test fixed after :
```
 yarn test:jest src/plugins/query_enhancements/common/utils.test.ts
yarn run v1.22.22
$ scripts/use_node scripts/jest src/plugins/query_enhancements/common/utils.test.ts
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/plugins/vis_type_vega/public/expressions/__mocks__/index.ts
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts

jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts
    * <rootDir>/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts

 PASS  src/plugins/query_enhancements/common/utils.test.ts
  throwFacetError
    ✓ should throw an error with message from response.data.body.message (10 ms)
    ✓ should throw an error with message from response.data.body if it is a string
    ✓ should throw an error with message from response.data if body is undefined (1 ms)
    ✓ should throw an error with message from Error object
    ✓ should throw an error with stringified message if response.data.body is a plain object (1 ms)
    ✓ should throw an error with default message if no valid message is found
  formatDate
    ✓ should format date string with milliseconds
    ✓ should format date string with zero milliseconds
    ✓ should format date string with single digit milliseconds
    ✓ should format date string with double digit milliseconds
    ✓ should format date string with maximum milliseconds (1 ms)
    ✓ should handle different date formats
    ✓ should pad single digit months and days
    ✓ should handle leap year dates
    ✓ should handle end of year dates
  isPPLSearchQuery
    ✓ should return false if query language is not PPL
    ✓ should return false if query is not string
    ✓ should return false if query is not using search command
    ✓ should return true if query is using search command (1 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        2.94 s
Ran all test suites matching /src\/plugins\/query_enhancements\/common\/utils.test.ts/i.
✨  Done in 8.83s.
❯ yarn test:jest src/plugins/data/public/search/expressions/opensearchdsl.test.ts
yarn run v1.22.22
$ scripts/use_node scripts/jest src/plugins/data/public/search/expressions/opensearchdsl.test.ts
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/plugins/vis_type_vega/public/expressions/__mocks__/index.ts
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts

jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/core/server/saved_objects/import/__mocks__/index.ts
    * <rootDir>/src/plugins/explore/public/application/utils/state_management/__mocks__/index.ts

 PASS  src/plugins/data/public/search/expressions/opensearchdsl.test.ts
  opensearchdsl
    ✓ correctly handles filter, query and timerange on context
    correctly handles input
      ✓ throws on invalid json input (2 ms)
      ✓ adds filters (3 ms)
      ✓ adds filters to query with filters (1 ms)
      ✓ adds query
      ✓ adds query to a query with filters (1 ms)
      ✓ ignores timerange

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   6 passed, 6 total
Time:        3.917 s
Ran all test suites matching /src\/plugins\/data\/public\/search\/expressions\/opensearchdsl.test.ts/i.
✨  Done in 9.13s.
```

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
