### PR TITLE
Transpile vega-lite during build since it has modern js code

### DIFF
--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -221,7 +221,7 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
             /* vega-lite and some of its dependencies don't have es5 builds
              * so we need to build from source and transpile for webpack v4
              */
-            /[\/\\]node_modules[\/\\](?!vega-(lite-next|label|functions|scenegraph)[\/\\])/,
+            /[\/\\]node_modules[\/\\](?!vega-(lite-next|lite|label|functions|scenegraph)[\/\\])/,
 
             // Don't attempt to look into release artifacts of the plugins
             /[\/\\]plugins[\/\\][^\/\\]+[\/\\]build[\/\\]/,


### PR DESCRIPTION
### Description
vega-lite was recently updated from 4.x to 5.x which introduced some code that needs to be transpiled for build to work correctly in plugins using this dependency. This PR updates the webpack config to add entry for vega-lite to the list of node_modules packages that should be transpiled using babel

### Issues Resolved
N/A

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
