### PR TITLE
Disable query assist when AI feature is off

### DIFF
--- a/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/utils/create_extension.tsx
@@ -133,7 +133,9 @@ export const createQueryAssistExtension = (
       }
     },
     isEnabled$: () =>
-      getAvailableLanguages$(http, data).pipe(map((languages) => languages.length > 0)),
+      getAvailableLanguages$(http, data).pipe(
+        map((languages) => languages.length > 0 && assistantEnabled$.value)
+      ),
     getComponent: (dependencies) => {
       // only show the component if user is on a supported language.
       return (


### PR DESCRIPTION
### Description

Disable isEnabled$ for queryAssist when assistantEnabled$ is false

### Issues Resolved

Fix discover text to PPL still available after toggle off the AI feature flag button

## Screenshot

https://github.com/user-attachments/assets/92fcd878-89e4-4ef7-86cf-e2c23280e195


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.


Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
