### PR TITLE
Fix Add to Dashboard Modal showing only Last 20 Dashboards

### DIFF
--- a/src/plugins/explore/public/application/utils/hooks/use_existing_dashboard.test.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_existing_dashboard.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useExistingDashboard } from './use_existing_dashboard';
+import { SavedObjectsClientContract } from 'src/core/public';
+import { DashboardInterface } from '../../../components/visualizations/add_to_dashboard_button';
+
+// Mock saved objects client
+const mockSavedObjectsClient = ({
+  find: jest.fn(),
+} as unknown) as SavedObjectsClientContract;
+
+const mockDashboards: DashboardInterface[] = [
+  {
+    id: 'dashboard-1',
+    attributes: { title: 'Dashboard 1' },
+    type: 'dashboard',
+    references: [],
+  } as DashboardInterface,
+  {
+    id: 'dashboard-2',
+    attributes: { title: 'Dashboard 2' },
+    type: 'dashboard',
+    references: [],
+  } as DashboardInterface,
+];
+
+describe('useExistingDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should load dashboards when loadAllDashboards is called', async () => {
+    (mockSavedObjectsClient.find as jest.Mock).mockResolvedValue({
+      savedObjects: mockDashboards,
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useExistingDashboard(mockSavedObjectsClient)
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.dashboardsToShow).toEqual([]);
+
+    act(() => {
+      result.current.loadAllDashboards();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitForNextUpdate();
+
+    expect(mockSavedObjectsClient.find).toHaveBeenCalledWith({
+      type: 'dashboard',
+    });
+    expect(result.current.dashboardsToShow).toEqual(mockDashboards);
+    expect(result.current.selectedDashboard).toBe(null);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should not load dashboards on mount by default', () => {
+    const { result } = renderHook(() => useExistingDashboard(mockSavedObjectsClient));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockSavedObjectsClient.find).not.toHaveBeenCalled();
+    expect(result.current.dashboardsToShow).toEqual([]);
+  });
+
+  it('should search dashboards with search term', async () => {
+    (mockSavedObjectsClient.find as jest.Mock).mockResolvedValue({
+      savedObjects: [mockDashboards[0]],
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useExistingDashboard(mockSavedObjectsClient)
+    );
+
+    act(() => {
+      result.current.searchDashboards('Dashboard 1');
+    });
+
+    expect(result.current.isSearching).toBe(true);
+
+    await waitForNextUpdate();
+
+    expect(mockSavedObjectsClient.find).toHaveBeenCalledWith({
+      type: 'dashboard',
+      search: '*Dashboard 1*',
+      searchFields: ['title'],
+      perPage: 100,
+    });
+    expect(result.current.dashboardsToShow).toEqual([mockDashboards[0]]);
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it('should clear search when empty search term is provided', async () => {
+    const { result } = renderHook(() => useExistingDashboard(mockSavedObjectsClient));
+
+    act(() => {
+      result.current.searchDashboards('');
+    });
+
+    expect(result.current.dashboardsToShow).toEqual([]);
+    expect(result.current.searchValue).toBe('');
+    expect(mockSavedObjectsClient.find).not.toHaveBeenCalled();
+  });
+
+  it('should set selected dashboard', () => {
+    const { result } = renderHook(() => useExistingDashboard(mockSavedObjectsClient));
+
+    act(() => {
+      result.current.setSelectedDashboard(mockDashboards[1]);
+    });
+
+    expect(result.current.selectedDashboard).toEqual(mockDashboards[1]);
+  });
+
+  it('should allow removing selected dashboard', () => {
+    const { result } = renderHook(() => useExistingDashboard(mockSavedObjectsClient));
+
+    // First set a dashboard
+    act(() => {
+      result.current.setSelectedDashboard(mockDashboards[0]);
+    });
+
+    expect(result.current.selectedDashboard).toEqual(mockDashboards[0]);
+
+    // Then clear/remove it
+    act(() => {
+      result.current.setSelectedDashboard(null);
+    });
+
+    expect(result.current.selectedDashboard).toBe(null);
+  });
+
+  it('should show dashboards from search results when searching', async () => {
+    (mockSavedObjectsClient.find as jest.Mock)
+      .mockResolvedValueOnce({ savedObjects: mockDashboards }) // for loadAllDashboards
+      .mockResolvedValueOnce({ savedObjects: [mockDashboards[0]] }); // for searchDashboards
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useExistingDashboard(mockSavedObjectsClient)
+    );
+
+    // Load dashboards first
+    act(() => {
+      result.current.loadAllDashboards();
+    });
+
+    await waitForNextUpdate();
+
+    // Initially shows all dashboards
+    expect(result.current.dashboardsToShow).toEqual(mockDashboards);
+
+    // After search, shows search results
+    act(() => {
+      result.current.searchDashboards('Dashboard 1');
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.dashboardsToShow).toEqual([mockDashboards[0]]);
+  });
+
+  it('should handle errors gracefully', async () => {
+    (mockSavedObjectsClient.find as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useExistingDashboard(mockSavedObjectsClient)
+    );
+
+    act(() => {
+      result.current.loadAllDashboards();
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.dashboardsToShow).toEqual([]);
+    expect(result.current.selectedDashboard).toBe(null);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/plugins/explore/public/application/utils/hooks/use_existing_dashboard.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_existing_dashboard.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback } from 'react';
+import { SavedObjectsClientContract } from 'src/core/public';
+import { DashboardInterface } from '../../../components/visualizations/add_to_dashboard_button';
+
+export interface UseExistingDashboardReturn {
+  selectedDashboard: DashboardInterface | null;
+  dashboardsToShow: DashboardInterface[];
+  searchValue: string;
+  isLoading: boolean;
+  isSearching: boolean;
+  error: Error | null;
+  setSelectedDashboard: (dashboard: DashboardInterface | null) => void;
+  searchDashboards: (searchTerm: string) => Promise<void>;
+  loadAllDashboards: () => Promise<void>;
+}
+
+export const useExistingDashboard = (
+  savedObjectsClient: SavedObjectsClientContract
+): UseExistingDashboardReturn => {
+  const [dashboards, setDashboards] = useState<DashboardInterface[]>([]);
+  const [selectedDashboard, setSelectedDashboard] = useState<DashboardInterface | null>(null);
+  const [searchResults, setSearchResults] = useState<DashboardInterface[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSearching, setIsSearching] = useState<boolean>(false);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadAllDashboards = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await savedObjectsClient.find({
+        type: 'dashboard',
+      });
+      const dashboardList = res.savedObjects as DashboardInterface[];
+      setDashboards(dashboardList);
+    } catch (err) {
+      setError(err as Error);
+      setDashboards([]);
+      setSelectedDashboard(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [savedObjectsClient]);
+
+  const searchDashboards = useCallback(
+    async (searchTerm: string) => {
+      if (!searchTerm.trim()) {
+        setSearchResults([]);
+        setSearchValue('');
+        return;
+      }
+
+      setIsSearching(true);
+      try {
+        const res = await savedObjectsClient.find({
+          type: 'dashboard',
+          search: `*${searchTerm}*`,
+          searchFields: ['title'],
+          perPage: 100,
+        });
+        setSearchResults(res.savedObjects as DashboardInterface[]);
+        setSearchValue(searchTerm);
+      } catch (err) {
+        setSearchResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    },
+    [savedObjectsClient]
+  );
+
+  // Computed value: which dashboards to show
+  const dashboardsToShow = searchValue.trim() ? searchResults : dashboards;
+
+  return {
+    // Data
+    selectedDashboard,
+    dashboardsToShow,
+    searchValue,
+
+    // Loading states
+    isLoading,
+    isSearching,
+    error,
+
+    // Actions
+    setSelectedDashboard,
+    searchDashboards,
+    loadAllDashboards,
+  };
+};

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.test.tsx
@@ -365,13 +365,10 @@ describe('AddToDashboardModal', () => {
     const comboBoxInput = screen.getByTestId('selectExistingDashboard').querySelector('input');
     fireEvent.click(comboBoxInput!);
 
+    // Select Dashboard One from the dropdown
     await waitFor(() => {
-      const options = screen.getAllByText('Dashboard One');
-      // Click on the dropdown option, not the selected pill
-      const dropdownOption = options.find((el) => el.closest('.euiComboBoxOption'));
-      if (dropdownOption) {
-        fireEvent.click(dropdownOption);
-      }
+      const option = screen.getByText('Dashboard One');
+      fireEvent.click(option);
     });
 
     const addButton = screen.getByRole('button', { name: 'Add' });


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
The Add to Dashboard Modal only shows 20 Dashboards in the drop down. This is because of the following 
```
        const res = await savedObjectsClient.find({
          type: 'dashboard',
        });
``` 
Without the pagination, it only shows 20 results due to the default value of perpage optional parameter. 

This PR updates the Selection to use a EuiComboBox. Where by default we show the last 20 Dashboards in dropdown but if you type in Search Term it now shows all the Dashboards matching the search term. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

https://github.com/user-attachments/assets/e77a3f1c-70a3-4af7-a344-57a75d27ac6a


## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: Add to Dashboard Modal showing only Last 20 Dashboards

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
