### PR TITLE
add dynamic config tgo csp report only

### DIFF
--- a/src/core/server/core_route_handler_context.ts
+++ b/src/core/server/core_route_handler_context.ts
@@ -117,6 +117,9 @@ class CoreUiSettingsRouteHandlerContext {
 class CoreDynamicConfigRouteHandlerContext {
   #client?: IDynamicConfigurationClient;
   #asyncLocalStore?: AsyncLocalStorageContext;
+  #createStoreFromRequest?: (
+    req: OpenSearchDashboardsRequest
+  ) => AsyncLocalStorageContext | undefined;
 
   constructor(private readonly dynamicConfigServiceStart: InternalDynamicConfigServiceStart) {}
 
@@ -128,6 +131,11 @@ class CoreDynamicConfigRouteHandlerContext {
   public get asyncLocalStore() {
     this.#asyncLocalStore = this.dynamicConfigServiceStart.getAsyncLocalStore();
     return this.#asyncLocalStore;
+  }
+
+  public createStoreFromRequest(req: OpenSearchDashboardsRequest) {
+    this.#createStoreFromRequest = this.dynamicConfigServiceStart.createStoreFromRequest;
+    return this.#createStoreFromRequest(req);
   }
 }
 

--- a/src/core/server/http_resources/http_resources_service.ts
+++ b/src/core/server/http_resources/http_resources_service.ts
@@ -79,26 +79,36 @@ export class HttpResourcesService implements CoreService<InternalHttpResourcesSe
         route: RouteConfig<P, Q, B, 'get'>,
         handler: HttpResourcesRequestHandler<P, Q, B>
       ) => {
-        return router.get<P, Q, B>(route, (context, request, response) => {
+        return router.get<P, Q, B>(route, async (context, request, response) => {
           return handler(context, request, {
             ...response,
-            ...this.createResponseToolkit(deps, context, request, response),
+            ...(await this.createResponseToolkit(deps, context, request, response)),
           });
         });
       },
     };
   }
 
-  private createResponseToolkit(
+  private async createResponseToolkit(
     deps: SetupDeps,
     context: RequestHandlerContext,
     request: OpenSearchDashboardsRequest,
     response: OpenSearchDashboardsResponseFactory
-  ): HttpResourcesServiceToolkit {
+  ): Promise<HttpResourcesServiceToolkit> {
     const cspHeader = deps.http.csp.header;
 
+    const dynamicConfigClient = context.core.dynamicConfig.client;
+    const dynamicConfigStore = context.core.dynamicConfig.createStoreFromRequest(request);
+
+    const cspReportOnlyDynamicConfig = await dynamicConfigClient.getConfig(
+      { pluginConfigPath: 'csp-report-only' },
+      dynamicConfigStore ? { asyncLocalStorageContext: dynamicConfigStore } : undefined
+    );
+
     const cspReportOnly = deps.http.cspReportOnly;
-    const cspReportOnlyHeaders = cspReportOnly.isEmitting
+    const cspReportOnlyIsEmitting =
+      cspReportOnlyDynamicConfig?.isEmitting ?? cspReportOnly.isEmitting;
+    const cspReportOnlyHeaders = cspReportOnlyIsEmitting
       ? {
           'content-security-policy-report-only': cspReportOnly.cspReportOnlyHeader,
           'reporting-endpoints': cspReportOnly.reportingEndpointsHeader,

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -58,7 +58,7 @@ import {
   OpenSearchServiceStart,
   IScopedClusterClient,
 } from './opensearch';
-import { HttpServiceSetup, HttpServiceStart } from './http';
+import { HttpServiceSetup, HttpServiceStart, OpenSearchDashboardsRequest } from './http';
 import { HttpResources } from './http_resources';
 
 import { PluginsServiceSetup, PluginsServiceStart, PluginOpaqueId } from './plugins';
@@ -451,6 +451,9 @@ export interface RequestHandlerContext {
     dynamicConfig: {
       client: IDynamicConfigurationClient;
       asyncLocalStore: AsyncLocalStorageContext | undefined;
+      createStoreFromRequest: (
+        req: OpenSearchDashboardsRequest
+      ) => AsyncLocalStorageContext | undefined;
     };
     auditor: Auditor;
   };

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -253,6 +253,8 @@ function createCoreRequestHandlerContextMock() {
     dynamicConfig: {
       client: dynamicConfigServiceMock.createInternalStartContract().getClient(),
       asyncLocalStore: dynamicConfigServiceMock.createInternalStartContract().getAsyncLocalStore(),
+      createStoreFromRequest: dynamicConfigServiceMock.createInternalStartContract()
+        .createStoreFromRequest,
     },
   };
 }

--- a/src/legacy/ui/ui_render/ui_render_mixin.js
+++ b/src/legacy/ui/ui_render/ui_render_mixin.js
@@ -306,6 +306,7 @@ export function uiRenderMixin(osdServer, server, config) {
 
   async function renderApp(h) {
     const { http } = osdServer.newPlatform.setup.core;
+    const { dynamicConfig } = osdServer.newPlatform.start.core;
     const { savedObjects } = osdServer.newPlatform.start.core;
     const { rendering } = osdServer.newPlatform.__internals;
     const req = OpenSearchDashboardsRequest.from(h.request);
@@ -325,7 +326,17 @@ export function uiRenderMixin(osdServer, server, config) {
       .type('text/html')
       .header('content-security-policy', http.csp.header);
 
-    if (http.cspReportOnly.isEmitting) {
+    const dynamicConfigClient = dynamicConfig.getClient();
+    const dynamicConfigStore = dynamicConfig.createStoreFromRequest(req);
+
+    const cspReportOnlyDynamicConfig = await dynamicConfigClient.getConfig(
+      { pluginConfigPath: 'csp-report-only' },
+      dynamicConfigStore ? { asyncLocalStorageContext: dynamicConfigStore } : undefined
+    );
+    const cspReportOnlyIsEmitting =
+      cspReportOnlyDynamicConfig?.isEmitting ?? http.cspReportOnly.isEmitting;
+
+    if (cspReportOnlyIsEmitting) {
       output.header('content-security-policy-report-only', http.cspReportOnly.cspReportOnlyHeader);
 
       if (http.cspReportOnly.reportingEndpointsHeader) {


### PR DESCRIPTION
### Description

- add dynamic config to csp report only so that we can dynamically update whether it is being emitted or not.

## Changelog
- feat: add dynamic config support to csp report only

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
