### PR TITLE
[Explore] fix: add appName back to context

### DIFF
--- a/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
@@ -43,6 +43,7 @@ export interface DetailedDataset extends Dataset {
 
 export interface DatasetSelectProps {
   onSelect: (dataset: Dataset) => void;
+  appName: string;
   supportedTypes?: string[];
   signalType: string | null;
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/dataset_select/dataset_select.tsx
@@ -228,6 +228,7 @@ export const DatasetSelectWidget = () => {
     <div ref={containerRef} className="exploreDatasetSelectWrapper">
       <DatasetSelect
         onSelect={handleDatasetSelect}
+        appName="explore"
         supportedTypes={supportedTypes}
         signalType={flavorId}
       />


### PR DESCRIPTION
### Description

Fix https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10690#discussion_r2516020848

appName is coming from context, which is created from props. removing appName makes `services.appName` undefined

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
