### PR TITLE
Add a dashboard breadcrumb when user naviagte from dashboard

### DIFF
--- a/changelogs/fragments/10904.yml
+++ b/changelogs/fragments/10904.yml
@@ -1,0 +1,2 @@
+feat:
+- Add a dashboard breadcrumb when user naviagte from dashboard ([#10904](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10904))

--- a/src/plugins/dataset_management/public/components/dataset_table/dataset_table_v2/hooks/use_dataset_selector.tsx
+++ b/src/plugins/dataset_management/public/components/dataset_table/dataset_table_v2/hooks/use_dataset_selector.tsx
@@ -62,7 +62,7 @@ export const useDatasetSelector = ({
                       'datasetManagement.dataset.titleExistsLabel',
                       {
                         values: { title: query.dataset.title },
-                        defaultMessage: "An index pattern with the title '{title}' already exists.",
+                        defaultMessage: "An dataset with the title '{title}' already exists.",
                       }
                     );
 

--- a/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
@@ -57,7 +57,13 @@ export const useInitPage = () => {
         // If user came from a dashboard, show dashboard name as a breadcrumb
         if (previousPage && previousPage.meta?.type === 'dashboard') {
           breadcrumbs.push({
-            text: `Dashboard:${previousPage.label}`,
+            text: 'Dashboard',
+            onClick: () => {
+              services.core.application.navigateToApp('dashboards', { path: '#/' });
+            },
+          });
+          breadcrumbs.push({
+            text: `${previousPage.label}`,
             ...breadcrumbConfig,
           });
         }

--- a/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
@@ -63,7 +63,7 @@ export const useInitPage = () => {
             },
           });
           breadcrumbs.push({
-            text: `${previousPage.label}`,
+            text: previousPage.label,
             ...breadcrumbConfig,
           });
         }

--- a/src/plugins/explore/public/helpers/save_explore.ts
+++ b/src/plugins/explore/public/helpers/save_explore.ts
@@ -81,7 +81,7 @@ export async function saveSavedExplore({
       } else {
         // Update browser title and breadcrumbs
         chrome.docTitle.change(newTitle);
-        chrome.setBreadcrumbs([...getRootBreadcrumbs(), { text: savedExplore.title }]);
+        chrome.setBreadcrumbs([{ text: savedExplore.title }]);
       }
 
       store.dispatch(setSavedSearch(id));

--- a/src/plugins/explore/public/utils/get_previous_page_breadcrumb.ts
+++ b/src/plugins/explore/public/utils/get_previous_page_breadcrumb.ts
@@ -28,28 +28,8 @@ export interface GetBreadcrumbOptions {
  * @param options - Configuration options
  * @returns Previous page info with breadcrumb config
  */
-export function getPreviousPageBreadcrumb(options: GetBreadcrumbOptions): PreviousPageInfo;
-export function getPreviousPageBreadcrumb(
-  chrome: ChromeStart,
-  currentPageId?: string
-): PreviousPageInfo;
-export function getPreviousPageBreadcrumb(
-  optionsOrChrome: GetBreadcrumbOptions | ChromeStart,
-  currentPageId?: string
-): PreviousPageInfo {
-  // Handle both function signatures for backward compatibility
-  const chrome =
-    'chrome' in optionsOrChrome
-      ? (optionsOrChrome as GetBreadcrumbOptions).chrome
-      : optionsOrChrome;
-  const application =
-    'application' in optionsOrChrome
-      ? (optionsOrChrome as GetBreadcrumbOptions).application
-      : undefined;
-  const pageId =
-    'currentPageId' in optionsOrChrome
-      ? (optionsOrChrome as GetBreadcrumbOptions).currentPageId
-      : currentPageId;
+export function getPreviousPageBreadcrumb(options: GetBreadcrumbOptions): PreviousPageInfo {
+  const { chrome, application, currentPageId: pageId } = options;
   const recentlyAccessed = chrome.recentlyAccessed.get();
 
   // Get the most recently accessed page (first item, which is most recent)

--- a/src/plugins/explore/public/utils/get_previous_page_breadcrumb.ts
+++ b/src/plugins/explore/public/utils/get_previous_page_breadcrumb.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ChromeStart, ChromeRecentlyAccessedHistoryItem, ApplicationStart } from 'src/core/public';
+
+export interface BreadcrumbConfig {
+  href?: string;
+  onClick?: () => void;
+}
+
+export interface PreviousPageInfo {
+  breadcrumbConfig: BreadcrumbConfig;
+  previousPage?: ChromeRecentlyAccessedHistoryItem;
+}
+
+export interface GetBreadcrumbOptions {
+  chrome: ChromeStart;
+  application?: ApplicationStart;
+  currentPageId?: string;
+}
+
+/**
+ * Get breadcrumb configuration that navigates to the previous page
+ * Uses chrome.recentlyAccessed to determine where the user came from
+ *
+ * @param options - Configuration options
+ * @returns Previous page info with breadcrumb config
+ */
+export function getPreviousPageBreadcrumb(options: GetBreadcrumbOptions): PreviousPageInfo;
+export function getPreviousPageBreadcrumb(
+  chrome: ChromeStart,
+  currentPageId?: string
+): PreviousPageInfo;
+export function getPreviousPageBreadcrumb(
+  optionsOrChrome: GetBreadcrumbOptions | ChromeStart,
+  currentPageId?: string
+): PreviousPageInfo {
+  // Handle both function signatures for backward compatibility
+  const chrome =
+    'chrome' in optionsOrChrome
+      ? (optionsOrChrome as GetBreadcrumbOptions).chrome
+      : optionsOrChrome;
+  const application =
+    'application' in optionsOrChrome
+      ? (optionsOrChrome as GetBreadcrumbOptions).application
+      : undefined;
+  const pageId =
+    'currentPageId' in optionsOrChrome
+      ? (optionsOrChrome as GetBreadcrumbOptions).currentPageId
+      : currentPageId;
+  const recentlyAccessed = chrome.recentlyAccessed.get();
+
+  // Get the most recently accessed page (first item, which is most recent)
+  // Skip if it's the current page
+  const previousPage =
+    recentlyAccessed.length > 0 && recentlyAccessed[0].id !== pageId
+      ? recentlyAccessed[0]
+      : undefined;
+
+  if (previousPage && previousPage.link) {
+    // We found a previous page - construct the full URL with workspace ID
+    let href = previousPage.link;
+
+    // Check if the current URL has a workspace ID and the previous page link doesn't
+    const currentPathname = window.location.pathname;
+    const workspaceMatch = currentPathname.match(/\/w\/([^/]+)\//);
+
+    if (workspaceMatch && !href.includes('/w/')) {
+      // Add workspace ID to the href
+      const workspaceId = workspaceMatch[1];
+      href = `/w/${workspaceId}${href}`;
+    }
+
+    // If application service is available, use onClick with navigateToUrl for SPA navigation
+    if (application) {
+      return {
+        breadcrumbConfig: {
+          onClick: () => {
+            application.navigateToUrl(href);
+          },
+        },
+        previousPage,
+      };
+    }
+
+    // Fallback to href (may cause hard refresh)
+    return { breadcrumbConfig: { href }, previousPage };
+  } else {
+    // No previous page found, fallback to explore home
+    return { breadcrumbConfig: { href: '#/' } };
+  }
+}


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

Summary

  Implement dynamic breadcrumbs in Explore plugin that navigate users back to the page they came from dashboard, providing better navigation context.

  Changes

  Smart Breadcrumb Navigation

  - Breadcrumbs now dynamically reflect where the user navigated from using chrome.recentlyAccessed
  - When accessing an Explore view from a Dashboard, breadcrumb shows: [Dashboard Name] > [Explore Title]
  - When accessing from elsewhere, shows only: [Explore Title]
  - Clicking the Dashboard breadcrumb navigates back to that specific Dashboard

  Implementation Details

  - Created getPreviousPageBreadcrumb() utility to detect previous page from chrome.recentlyAccessed
  - Automatically adds workspace ID to navigation URLs when needed
  - Uses application.navigateToUrl() for smooth SPA navigation (no page refresh)
  - Applied to all breadcrumb locations: use_page_initialization.ts, save_explore.ts, breadcrumbs.ts

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->


https://github.com/user-attachments/assets/318a996b-0e5d-4173-9795-1fcc92856ec5



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- feat: Add a dashboard breadcrumb when user naviagte from dashboard

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
