### PR TITLE
Fix failing CI

### DIFF
--- a/test/common/config.js
+++ b/test/common/config.js
@@ -44,7 +44,17 @@ export default function () {
     opensearchTestCluster: {
       license: 'oss',
       from: 'snapshot',
-      serverArgs: ['search.concurrent_segment_search.mode=none'],
+      serverArgs: [
+        'search.concurrent_segment_search.mode=none',
+        // Disable disk-based shard allocation to prevent index creation blocks in CI
+        'cluster.routing.allocation.disk.threshold_enabled=false',
+        // Set very low disk watermarks for testing
+        'cluster.routing.allocation.disk.watermark.low=1gb',
+        'cluster.routing.allocation.disk.watermark.high=500mb',
+        'cluster.routing.allocation.disk.watermark.flood_stage=100mb',
+        // Disable read-only index block when disk space is low
+        'cluster.blocks.read_only_allow_delete=false',
+      ],
     },
 
     osdTestServer: {


### PR DESCRIPTION
### Description
Fix failing CI
Error:

```
ResponseError: index_create_block_exception: [index_create_block_exception] Reason: blocked by: [FORBIDDEN/10/cluster 
```

Caused by: 
OpenSearch is blocking index creation due to disk watermark protection mechanisms. In CI environments with limited disk space, OpenSearch automatically enables protective settings that prevent index creation when disk usage is high.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip
### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
