### PR TITLE
Enable mend remediate to create PRs

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -11,5 +11,13 @@
   },
   "issueSettings": {
     "minSeverityLevel": "LOW"
+  },
+  "remediateSettings": {
+    "addLabels": [
+      "skip-changelog"
+    ],
+    "workflowRules": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
### Description

This setting allows whitesource tool to create pull requests in the repo for the detected CVEs. I tried clicking on create automated PR here: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10921
There was no action. Looks like a setting was missing. 

### Issues Resolved

Related https://github.com/opensearch-project/opensearch-build/issues/5803

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
