### PR TITLE
refactor(explore): change `getQueryWithSource` to `prepareQueryForLanguage`

### DIFF
--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -17,7 +17,7 @@ import {
   ENABLE_EXPERIMENTAL_SETTING,
 } from '../../common';
 import { VisTab } from '../components/tabs/vis_tab';
-import { getQueryWithSource } from './utils/languages';
+import { prepareQueryForLanguage } from './utils/languages';
 import {
   brainPatternQuery,
   findDefaultPatternsField,
@@ -68,7 +68,7 @@ export const registerBuiltInTabs = (
         // Get the selected patterns field from the Redux state
         let patternsField = state.tab.patterns.patternsField;
 
-        const preparedQuery = getQueryWithSource(query);
+        const preparedQuery = prepareQueryForLanguage(query);
         if (!patternsField) {
           try {
             patternsField = findDefaultPatternsField(services);
@@ -107,7 +107,7 @@ export const registerBuiltInTabs = (
             patternsField = findDefaultPatternsField(services);
           }
           const query = state.query;
-          const preparedQuery = getQueryWithSource(query);
+          const preparedQuery = prepareQueryForLanguage(query);
           services.store.dispatch(setUsingRegexPatterns(true));
           services.store.dispatch(
             executeTabQuery({
@@ -148,10 +148,9 @@ export const registerBuiltInTabs = (
     order: 20,
     supportedLanguages: [EXPLORE_DEFAULT_LANGUAGE],
 
-    // No query transformation for visualizations tab
-    // Visualization tab owner will implement their own prepareQuery
+    // Prepare query based on language
     prepareQuery: (query) => {
-      const preparedQuery = getQueryWithSource(query);
+      const preparedQuery = prepareQueryForLanguage(query);
       return preparedQuery.query;
     },
 

--- a/src/plugins/explore/public/application/utils/languages/index.ts
+++ b/src/plugins/explore/public/application/utils/languages/index.ts
@@ -5,3 +5,4 @@
 
 export * from './ppl';
 export * from './types';
+export * from './prepare_query';

--- a/src/plugins/explore/public/application/utils/languages/ppl/default_prepare_ppl_query/default_prepare_ppl_query.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/default_prepare_ppl_query/default_prepare_ppl_query.ts
@@ -5,12 +5,12 @@
 
 import { Query } from '../../../../../../../data/common';
 import { stripStatsFromQuery } from '../strip_stats_from_query';
-import { getQueryWithSource } from '../get_query_string_with_source';
+import { addPPLSourceClause } from '../get_query_string_with_source';
 import { QueryWithQueryAsString } from '../../types';
 
 /**
  * Default PPL query preparation for tabs (removes stats pipe for histogram compatibility)
  */
 export const defaultPreparePplQuery = (query: Query): QueryWithQueryAsString => {
-  return stripStatsFromQuery(getQueryWithSource(query));
+  return stripStatsFromQuery(addPPLSourceClause(query));
 };

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.test.ts
@@ -4,16 +4,16 @@
  */
 
 import { Query } from '../../../../../../../data/common';
-import { getQueryWithSource } from './get_query_with_source';
+import { addPPLSourceClause } from './get_query_with_source';
 
-describe('getQueryWithSource', () => {
+describe('addPPLSourceClause', () => {
   it('should handle undefined query by using empty string', () => {
     const query: Query = {
       query: undefined as any,
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'source = `test-dataset`',
@@ -26,7 +26,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({ ...query, query: 'source=`existing-index` | where field=value' });
   });
 
@@ -36,7 +36,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({ ...query, query: 'SOURCE=`existing-index` | where field=value' });
   });
 
@@ -46,7 +46,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'search source=`existing-index` | where field=value',
@@ -59,7 +59,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'SEARCH SOURCE=`existing-index` | where field=value',
@@ -72,7 +72,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({ ...query, query: 'source   =`existing-index` | where field=value' });
   });
 
@@ -82,7 +82,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({ ...query, query: 'source=`existing-index` | where field=value' });
   });
 
@@ -92,7 +92,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({ ...query, query: 'source=`existing-index`|where field=value' });
   });
 
@@ -102,7 +102,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'search    source   =`existing-index` | where field=value',
@@ -115,7 +115,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'search source=`existing-index` | where field=value',
@@ -128,7 +128,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'source = `test-dataset`',
@@ -141,7 +141,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'source = `test-dataset`',
@@ -154,7 +154,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'source = `test-dataset` | where level="error"',
@@ -167,7 +167,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: 'source = `test-dataset`   | where level="error"',
@@ -180,7 +180,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: ' source = `data_logs_small_time_1*` | where unique_category = "Configuration"',
@@ -193,7 +193,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual({
       ...query,
       query: '  search source=`existing-index` | where field=value',
@@ -206,7 +206,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual(query);
   });
 
@@ -216,7 +216,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual(query);
   });
 
@@ -226,7 +226,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual(query);
   });
 
@@ -236,7 +236,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual(query);
   });
 
@@ -246,7 +246,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual(query);
   });
 
@@ -256,7 +256,7 @@ describe('getQueryWithSource', () => {
       dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
       language: 'ppl',
     };
-    const result = getQueryWithSource(query);
+    const result = addPPLSourceClause(query);
     expect(result).toEqual(query);
   });
 });

--- a/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
+++ b/src/plugins/explore/public/application/utils/languages/ppl/get_query_string_with_source/get_query_with_source.ts
@@ -7,9 +7,10 @@ import { Query } from '../../../../../../../data/common';
 import { QueryWithQueryAsString } from '../../types';
 
 /**
- * Adds a source if query string does not have it
+ * Adds "source = <dataset>" clause to PPL query if not present
+ * Also handles backtick escaping for INDEXES and INDEX_PATTERN dataset types
  */
-export const getQueryWithSource = (query: Query): QueryWithQueryAsString => {
+export const addPPLSourceClause = (query: Query): QueryWithQueryAsString => {
   const queryString = typeof query.query === 'string' ? query.query : '';
   const lowerCaseQuery = queryString.toLowerCase();
   const hasSource = /^[^|]*\bsource\s*=/.test(lowerCaseQuery);

--- a/src/plugins/explore/public/application/utils/languages/prepare_query.test.ts
+++ b/src/plugins/explore/public/application/utils/languages/prepare_query.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Query } from '../../../../../data/common';
+import { prepareQueryForLanguage } from './prepare_query';
+import { addPPLSourceClause } from './ppl';
+
+jest.mock('./ppl', () => ({
+  addPPLSourceClause: jest.fn(),
+}));
+
+describe('prepareQueryForLanguage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('PPL language', () => {
+    it('should call addPPLSourceClause for PPL queries', () => {
+      const query: Query = {
+        query: 'level="error"',
+        dataset: { title: 'test-dataset', id: '123', type: 'INDEX_PATTERN' },
+        language: 'PPL',
+      };
+
+      const expectedResult = {
+        ...query,
+        query: 'source = `test-dataset` level="error"',
+      };
+
+      (addPPLSourceClause as jest.Mock).mockReturnValue(expectedResult);
+
+      const result = prepareQueryForLanguage(query);
+
+      expect(addPPLSourceClause).toHaveBeenCalledWith(query);
+      expect(addPPLSourceClause).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should throw error when query is not a string', () => {
+      const query: Query = {
+        query: { match: { field: 'value' } },
+        language: 'DQL',
+        dataset: { title: 'test', id: '404', type: 'INDEX_PATTERN' },
+      };
+
+      expect(() => prepareQueryForLanguage(query)).toThrow(
+        'Cannot convert query to QueryWithQueryAsString'
+      );
+      expect(addPPLSourceClause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Unknown languages', () => {
+    it('should return query as-is for unknown language', () => {
+      const query: Query = {
+        query: 'some custom query syntax',
+        language: 'custom_lang',
+        dataset: { title: 'test', id: '999', type: 'INDEX_PATTERN' },
+      };
+
+      const result = prepareQueryForLanguage(query);
+
+      expect(addPPLSourceClause).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ...query,
+        query: 'some custom query syntax',
+      });
+    });
+  });
+});

--- a/src/plugins/explore/public/application/utils/languages/prepare_query.ts
+++ b/src/plugins/explore/public/application/utils/languages/prepare_query.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Query } from '../../../../../data/common';
+import { QueryWithQueryAsString } from './types';
+import { addPPLSourceClause } from './ppl';
+
+/**
+ * Prepares a query string based on the query language.
+ *
+ * For PPL queries: Adds "source = <dataset>" clause if not present
+ * For other languages (PromQL, etc.): Returns query as-is
+ *
+ * @param query - The query object containing language, query string, and dataset
+ * @returns Query object with the prepared query string
+ */
+export const prepareQueryForLanguage = (query: Query): QueryWithQueryAsString => {
+  switch (query.language) {
+    case 'PPL':
+      // PPL needs "source = " clause added if not present
+      return addPPLSourceClause(query);
+
+    default:
+      if (typeof query.query !== 'string')
+        throw new Error('Cannot convert query to QueryWithQueryAsString');
+      return { ...query, query: query.query };
+  }
+};

--- a/src/plugins/explore/public/application/utils/state_management/actions/detect_optimal_tab/detect_optimal_tab.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/detect_optimal_tab/detect_optimal_tab.ts
@@ -10,7 +10,7 @@ import { ExploreServices } from '../../../../../types';
 import { defaultPrepareQueryString } from '../query_actions';
 import { normalizeResultRows } from '../../../../../components/visualizations/utils/normalize_result_rows';
 import { visualizationRegistry } from '../../../../../components/visualizations/visualization_registry';
-import { getQueryWithSource } from '../../../languages';
+import { prepareQueryForLanguage } from '../../../languages';
 import { Query } from '../../../../../../../data/common';
 import { QueryExecutionStatus } from '../../types';
 import { EXPLORE_LOGS_TAB_ID, EXPLORE_VISUALIZATION_TAB_ID } from '../../../../../../common';
@@ -71,7 +71,7 @@ export const detectAndSetOptimalTab = createAsyncThunk<
   if (visualizationTab?.prepareQuery) {
     const prepareQuery = visualizationTab.prepareQuery;
     visualizationTabPrepareQuery = (queryParam: Query): string => {
-      return prepareQuery(getQueryWithSource(queryParam));
+      return prepareQuery(queryParam);
     };
   }
   const visualizationTabCacheKey = visualizationTabPrepareQuery(query);

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -91,7 +91,7 @@ import * as fieldCalculatorModule from '../../../../components/fields_selector/l
 
 jest.mock('../../languages', () => ({
   defaultPreparePplQuery: jest.fn(),
-  getQueryWithSource: jest.fn((query) => query),
+  prepareQueryForLanguage: jest.fn((query) => query),
 }));
 
 jest.mock('../../../../../../data/public', () => ({

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -38,7 +38,7 @@ import {
   HistogramDataProcessor,
   ProcessedSearchResults,
 } from '../../interfaces';
-import { defaultPreparePplQuery, getQueryWithSource } from '../../languages';
+import { defaultPreparePplQuery } from '../../languages';
 import {
   HistogramConfig,
   buildPPLHistogramQuery,
@@ -279,7 +279,7 @@ export const executeQueries = createAsyncThunk<
   if (visualizationTab?.prepareQuery) {
     const prepareQuery = visualizationTab.prepareQuery;
     visualizationTabPrepareQuery = (queryParam: Query): string => {
-      return prepareQuery(getQueryWithSource(queryParam));
+      return prepareQuery(queryParam);
     };
   }
   const visualizationTabCacheKey = visualizationTabPrepareQuery(query);
@@ -291,7 +291,7 @@ export const executeQueries = createAsyncThunk<
     if (activeTab?.prepareQuery) {
       const prepareQuery = activeTab.prepareQuery;
       activeTabPrepareQuery = (queryParam: Query): string => {
-        return prepareQuery(getQueryWithSource(queryParam));
+        return prepareQuery(queryParam);
       };
     }
     activeTabCacheKey = activeTabPrepareQuery(query);
@@ -430,7 +430,7 @@ const executeQueryBase = async (
       ...query,
       dataset,
       query:
-        isHistogramQuery && histogramConfig
+        query.language === 'PPL' && isHistogramQuery && histogramConfig
           ? buildPPLHistogramQuery(queryString, histogramConfig)
           : queryString,
     };

--- a/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/query_sync_middleware.ts
@@ -7,7 +7,7 @@ import { Middleware } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
 import { RootState } from '../store';
 import { ExploreServices } from '../../../../types';
-import { getQueryWithSource } from '../../languages';
+import { prepareQueryForLanguage } from '../../languages';
 
 /**
  * Middleware to sync Redux query state with global queryStringManager
@@ -26,13 +26,13 @@ export const createQuerySyncMiddleware = (services: ExploreServices): Middleware
     ) {
       const state = store.getState();
       const query = state.query;
-      const queryWithSource = getQueryWithSource(query);
+      const preparedQuery = prepareQueryForLanguage(query);
 
       if (query.dataset && services.data?.query?.queryString) {
         const queryStringQuery = services.data.query.queryString.getQuery();
 
-        if (!isEqual(queryStringQuery, queryWithSource)) {
-          services.data.query.queryString.setQuery(queryWithSource);
+        if (!isEqual(queryStringQuery, preparedQuery)) {
+          services.data.query.queryString.setQuery(preparedQuery);
         }
 
         // Add to query history only for user-initiated query executions

--- a/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_event_table.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_table_flyout/patterns_flyout_event_table.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../application/utils/state_management/selectors';
 import { ExploreServices } from '../../../types';
 import { SAMPLE_SIZE_SETTING } from '../../../../common';
-import { getQueryWithSource } from '../../../application/utils/languages';
+import { prepareQueryForLanguage } from '../../../application/utils/languages';
 import { createSearchPatternQueryWithSlice } from '../utils/utils';
 
 interface PatternsFlyoutEventTableProps {
@@ -66,7 +66,7 @@ export const PatternsFlyoutEventTable = ({
       const filters = services.data.query.filterManager.getFilters();
       const size = services.uiSettings.get(SAMPLE_SIZE_SETTING);
 
-      const querySource = getQueryWithSource(query);
+      const querySource = prepareQueryForLanguage(query);
 
       const modifiedQuerySource = {
         ...querySource,

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.ts
@@ -18,7 +18,7 @@ import {
 import { defaultPrepareQueryString } from '../../../application/utils/state_management/actions/query_actions';
 import { ExploreServices } from '../../../types';
 import { setPatternsField } from '../../../application/utils/state_management/slices/tab/tab_slice';
-import { getQueryWithSource } from '../../../application/utils/languages';
+import { prepareQueryForLanguage } from '../../../application/utils/languages';
 
 // Small functions returning the two pattern queries
 export const regexPatternQuery = (queryBase: string, patternsField: string) => {
@@ -51,7 +51,7 @@ export const createSearchPatternQuery = (
   usingRegexPatterns: boolean,
   patternString: string
 ) => {
-  const preparedQuery = getQueryWithSource(query);
+  const preparedQuery = prepareQueryForLanguage(query);
   return usingRegexPatterns
     ? regexUpdateSearchPatternQuery(preparedQuery.query, patternsField, patternString)
     : brainUpdateSearchPatternQuery(preparedQuery.query, patternsField, patternString);
@@ -69,7 +69,7 @@ export const createSearchPatternQueryWithSlice = (
   // TODO: switch this logic back to adding onto the createSearchPatternQuery
   // when we don't need a patterns clause to lock in the pattern type
 
-  const preparedQuery = getQueryWithSource(query);
+  const preparedQuery = prepareQueryForLanguage(query);
   return usingRegexPatterns
     ? `${regexUpdateSearchPatternQuery(
         preparedQuery.query,

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/query_panel_actions.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/query_panel_actions.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../../../../application/utils/state_management/selectors', () => ({
 }));
 
 jest.mock('../../../../application/utils/languages', () => ({
-  getQueryWithSource: jest.fn((query) => query),
+  prepareQueryForLanguage: jest.fn((query) => query),
 }));
 
 jest.mock('../../../../application/hooks/editor_hooks/use_editor_text/use_editor_text', () => ({

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/use_query_panel_action_dependencies.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/use_query_panel_action_dependencies.ts
@@ -9,7 +9,7 @@ import {
   selectQuery,
   selectOverallQueryStatus,
 } from '../../../../application/utils/state_management/selectors';
-import { getQueryWithSource } from '../../../../application/utils/languages';
+import { prepareQueryForLanguage } from '../../../../application/utils/languages';
 import { useEditorText } from '../../../../application/hooks/editor_hooks/use_editor_text/use_editor_text';
 
 /**
@@ -19,7 +19,7 @@ import { useEditorText } from '../../../../application/hooks/editor_hooks/use_ed
  * @returns QueryPanelActionDependencies object with 3 fields:
  *   - query: Last executed query (includes query string, language, dataset)
  *   - resultStatus: Query execution status
- *   - queryInEditor: Current query string in the editor with source clause added (ready to execute)
+ *   - queryInEditor: Current query string in the editor prepared for the language
  */
 export const useQueryPanelActionDependencies = (): QueryPanelActionDependencies => {
   // Get query state from Redux
@@ -32,16 +32,16 @@ export const useQueryPanelActionDependencies = (): QueryPanelActionDependencies 
   // Get current editor query text
   const editorQuery = getEditorText();
 
-  // Transform editor query to add source clause (same as executed query)
+  // Prepare editor query based on language (e.g., add "source = " for PPL)
   // This ensures external plugins receive ready-to-execute queries
-  const transformedEditorQuery = getQueryWithSource({
+  const transformedEditorQuery = prepareQueryForLanguage({
     query: editorQuery,
     language: executedQueryState.language,
     dataset: executedQueryState.dataset,
   });
 
   return {
-    query: getQueryWithSource(executedQueryState),
+    query: prepareQueryForLanguage(executedQueryState),
     resultStatus,
     queryInEditor: transformedEditorQuery.query, // Pass the transformed query string
   };

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -48,7 +48,7 @@ import { defaultPrepareQueryString } from '../application/utils/state_management
 import { convertStringsToMappings } from '../components/visualizations/visualization_builder_utils';
 import { normalizeResultRows } from '../components/visualizations/utils/normalize_result_rows';
 import { visualizationRegistry } from '../components/visualizations/visualization_registry';
-import { getQueryWithSource } from '../application/utils/languages';
+import { prepareQueryForLanguage } from '../application/utils/languages';
 
 export interface SearchProps {
   description?: string;
@@ -198,7 +198,7 @@ export class ExploreEmbeddable
       if (activeTab === 'logs') {
         query.query = defaultPrepareQueryString(query);
       } else {
-        query.query = getQueryWithSource(query).query;
+        query.query = prepareQueryForLanguage(query).query;
       }
     }
     searchSource.setFields({


### PR DESCRIPTION
### Description

This PR allows supporting multiple languages in explore, instead of hard coding PPL add source logic.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

added and updated UT

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
