### PR TITLE
Fix saved queries for 3rd-party plugins by honoring wildcard supportedAppName

### DIFF
--- a/src/plugins/data/public/query/saved_query/saved_query_service.ts
+++ b/src/plugins/data/public/query/saved_query/saved_query_service.ts
@@ -149,10 +149,8 @@ export const createSavedQueryService = (
     ) {
       queries = queries.filter((query) => {
         const languageId = query.attributes.query.language;
-        return (
-          languageService?.getLanguage(languageId)?.supportedAppNames?.includes(currentAppId) ??
-          true
-        );
+        const supportedAppNames = languageService?.getLanguage(languageId)?.supportedAppNames;
+        return ['*', currentAppId].some((app) => supportedAppNames?.includes(app)) ?? true;
       });
     }
 


### PR DESCRIPTION
### Description

This PR brings back Saved Queries to 3rd-party plugins 

### Issues Resolved

fixes #10972

## Screenshot

<img width="503" height="371" alt="image" src="https://github.com/user-attachments/assets/e72afeae-85a5-49e1-8d2b-2bc5ada6bc61" />

(after the fix)

## Testing the changes

The fix can be most easily tested by creating a global saved query from a third-party plugin or a plugin that does not explicitly appear in the allowlist at https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/public/query/query_string/language_service/lib/dql_language.ts#L34. Without the fix, the Saved Queries Flyout will remain empty, with the fix applied it will show the saved queries.

## Changelog
- fix: Restore saved queries for 3rd-party plugins by honoring wildcard supportedAppName

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

Tests do not pass, but they also don't pass on `main`.