### PR TITLE
Discover:Trace Red Metric query update

### DIFF
--- a/changelogs/fragments/11063.yml
+++ b/changelogs/fragments/11063.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix RED metric query for Discover:Traces ([#11063](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11063))

--- a/src/plugins/explore/public/application/utils/state_management/actions/trace_aggregation_builder.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/trace_aggregation_builder.test.ts
@@ -47,7 +47,9 @@ describe('TraceAggregationBuilder', () => {
     it('should build a basic request count query', () => {
       const query = buildRequestCountQuery('source=traces', baseConfig);
 
-      expect(query).toBe('source=traces | stats count() by span(endTime, 1m) | sort endTime');
+      expect(query).toBe(
+        'source=traces | stats count() by span(endTime, 1m) | sort `span(endTime,1m)`'
+      );
     });
 
     it('should build a request count query with breakdown field', () => {
@@ -55,7 +57,7 @@ describe('TraceAggregationBuilder', () => {
       const query = buildRequestCountQuery('source=traces', configWithBreakdown);
 
       expect(query).toBe(
-        'source=traces | stats count() by span(endTime, 1m), service.name | sort endTime'
+        'source=traces | stats count() by span(endTime, 1m), service.name | sort `span(endTime,1m)`'
       );
     });
   });
@@ -65,7 +67,7 @@ describe('TraceAggregationBuilder', () => {
       const query = buildErrorCountQuery('source=traces', baseConfig);
 
       expect(query).toBe(
-        'source=traces | where status.code=2 | stats count() as error_count by span(endTime, 1m) | sort endTime'
+        'source=traces | where status.code=2 | stats count() as error_count by span(endTime, 1m) | sort `span(endTime,1m)`'
       );
     });
 
@@ -74,7 +76,7 @@ describe('TraceAggregationBuilder', () => {
       const query = buildErrorCountQuery('source=traces', configWithBreakdown);
 
       expect(query).toBe(
-        'source=traces | where status.code=2 | stats count() as error_count by span(endTime, 1m), service.name | sort endTime'
+        'source=traces | where status.code=2 | stats count() as error_count by span(endTime, 1m), service.name | sort `span(endTime,1m)`'
       );
     });
   });
@@ -84,7 +86,7 @@ describe('TraceAggregationBuilder', () => {
       const query = buildLatencyQuery('source=traces', baseConfig);
 
       expect(query).toBe(
-        'source=traces | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(endTime, 1m) | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort endTime'
+        'source=traces | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(endTime, 1m) | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort `span(endTime,1m)`'
       );
     });
 
@@ -93,7 +95,7 @@ describe('TraceAggregationBuilder', () => {
       const query = buildLatencyQuery('source=traces', configWithBreakdown);
 
       expect(query).toBe(
-        'source=traces | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(endTime, 1m), service.name | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort endTime'
+        'source=traces | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(endTime, 1m), service.name | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort `span(endTime,1m)`'
       );
     });
   });
@@ -103,11 +105,12 @@ describe('TraceAggregationBuilder', () => {
       const queries = buildTraceAggregationQueries('source=traces', baseConfig);
 
       expect(queries).toEqual({
-        requestCountQuery: 'source=traces | stats count() by span(endTime, 1m) | sort endTime',
+        requestCountQuery:
+          'source=traces | stats count() by span(endTime, 1m) | sort `span(endTime,1m)`',
         errorCountQuery:
-          'source=traces | where status.code=2 | stats count() as error_count by span(endTime, 1m) | sort endTime',
+          'source=traces | where status.code=2 | stats count() as error_count by span(endTime, 1m) | sort `span(endTime,1m)`',
         latencyQuery:
-          'source=traces | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(endTime, 1m) | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort endTime',
+          'source=traces | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(endTime, 1m) | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort `span(endTime,1m)`',
       });
     });
   });
@@ -137,7 +140,7 @@ describe('TraceAggregationBuilder', () => {
       const query = buildRequestCountQuery(baseQuery, baseConfig);
 
       expect(query).toBe(
-        'source=`traces-*` | WHERE `service.name` = "frontend" | stats count() by span(endTime, 1m) | sort endTime'
+        'source=`traces-*` | WHERE `service.name` = "frontend" | stats count() by span(endTime, 1m) | sort `span(endTime,1m)`'
       );
     });
 

--- a/src/plugins/explore/public/application/utils/state_management/actions/trace_aggregation_builder.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/trace_aggregation_builder.ts
@@ -22,27 +22,30 @@ export const buildRequestCountQuery = (
   config: TraceAggregationConfig
 ): string => {
   const { timeField, interval, breakdownField } = config;
+  const spanColumn = `span(${timeField},${interval})`;
 
   return breakdownField
-    ? `${baseQuery} | stats count() by span(${timeField}, ${interval}), ${breakdownField} | sort ${timeField}`
-    : `${baseQuery} | stats count() by span(${timeField}, ${interval}) | sort ${timeField}`;
+    ? `${baseQuery} | stats count() by span(${timeField}, ${interval}), ${breakdownField} | sort \`${spanColumn}\``
+    : `${baseQuery} | stats count() by span(${timeField}, ${interval}) | sort \`${spanColumn}\``;
 };
 
 export const buildErrorCountQuery = (baseQuery: string, config: TraceAggregationConfig): string => {
   const { timeField, interval, breakdownField } = config;
   const errorCondition = `status.code=2`;
+  const spanColumn = `span(${timeField},${interval})`;
 
   return breakdownField
-    ? `${baseQuery} | where ${errorCondition} | stats count() as error_count by span(${timeField}, ${interval}), ${breakdownField} | sort ${timeField}`
-    : `${baseQuery} | where ${errorCondition} | stats count() as error_count by span(${timeField}, ${interval}) | sort ${timeField}`;
+    ? `${baseQuery} | where ${errorCondition} | stats count() as error_count by span(${timeField}, ${interval}), ${breakdownField} | sort \`${spanColumn}\``
+    : `${baseQuery} | where ${errorCondition} | stats count() as error_count by span(${timeField}, ${interval}) | sort \`${spanColumn}\``;
 };
 
 export const buildLatencyQuery = (baseQuery: string, config: TraceAggregationConfig): string => {
   const { timeField, interval, breakdownField } = config;
+  const spanColumn = `span(${timeField},${interval})`;
 
   return breakdownField
-    ? `${baseQuery} | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(${timeField}, ${interval}), ${breakdownField} | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort ${timeField}`
-    : `${baseQuery} | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(${timeField}, ${interval}) | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort ${timeField}`;
+    ? `${baseQuery} | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(${timeField}, ${interval}), ${breakdownField} | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort \`${spanColumn}\``
+    : `${baseQuery} | where isnotnull(durationInNanos) | stats avg(durationInNanos) as avg_duration_nanos by span(${timeField}, ${interval}) | eval avg_latency_ms = avg_duration_nanos / 1000000 | sort \`${spanColumn}\``;
 };
 
 export const createTraceAggregationConfig = (


### PR DESCRIPTION
### Description
Update the red metric queries to sort after the buckets are formed.

Before
```
{
POST /_plugins/_ppl
  "query": "source = `otel-v1-apm-span-sample` | WHERE `endTime` >= '2025-12-09 23:08:40.692' AND `endTime` <= '2025-12-11 23:08:40.692' | stats count() by span(`endTime`, 3h) | sort `endTime`"
}

```
After:
```
POST /_plugins/_ppl
{
  "query": "source = `otel-v1-apm-*` | WHERE `endTime` >= '2025-12-09 23:08:40.692' AND `endTime` <= '2025-12-11 23:08:40.692' | stats count() by span(endTime, 3h) | sort `span(endTime,3h)`"
}
```
The previous method 3.1+ PPL moves the sort earlier to account for the name, this fix makes it faster and allows compatibility with older PPL versions

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed RED metric query for Discover:Traces.

* **Tests**
  * Updated trace aggregation query tests for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->