### PR TITLE
Put global styles in layer to allow overriding by oui2

### DIFF
--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -41,11 +41,20 @@ export const Styles: FunctionComponent = () => {
             box-sizing: border-box;
           }
 
-          html, body, div, span, svg {
+          html, body {
             margin: 0;
             padding: 0;
             border: none;
             vertical-align: baseline;
+          }
+
+          @layer theme {
+            div, span, svg {
+              margin: 0;
+              padding: 0;
+              border: none;
+              vertical-align: baseline;
+            }
           }
 
           body, html {


### PR DESCRIPTION
### Description

This just prevents these styles from impacting oui2. There's nothing above this in global css so should be safe. This is just going into the playground branch though so will need to be thorough evaluated later.

### Issues Resolved
N/A

## Screenshot
Before
<img width="3582" height="1688" alt="image" src="https://github.com/user-attachments/assets/f17efc2b-f865-4f6b-bdfa-7df4a24101b0" />

After
<img width="3594" height="1794" alt="image" src="https://github.com/user-attachments/assets/652ea7e7-f8d8-4438-8350-ce71402ec828" />

## Testing the changes
see screenshots

## Changelog
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
