### PR TITLE
Do not force focus styles to oui components

### DIFF
--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -40,8 +40,9 @@ $euiCollapsibleNavWidth: $euiSize * 20;
 // You can also use "osd-resetFocusState" to not apply the default focus
 // state. This is useful when you've already hand crafted your own
 // focus states in OpenSearch Dashboards.
+// NOTE: we also ignore this style for OUI2 classes ("oui:" prefix)
 :focus {
-  &:not([class^="eui"]):not(.osd-resetFocusState) {
+  &:not([class^="eui"]):not([class^="oui\:"]):not(.osd-resetFocusState) {
     @include euiFocusRing;
   }
 }


### PR DESCRIPTION
### Description

This prevents a focus style from being forced on non-eui elements. OUI2 uses an oui: prefix for classes, so using that to include in this selector as the !important makes it hard to workaround otherwise.

Pushing to oui2 playground so not including changelog

### Issues Resolved

N/A

## Screenshot

N/A

## Testing the changes

Tested locally

## Changelog
-skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
