### PR TITLE
chore: remove redundant calls to format already formatted Datetime strings

### DIFF
--- a/src/plugins/query_enhancements/common/utils.test.ts
+++ b/src/plugins/query_enhancements/common/utils.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isPPLSearchQuery, throwFacetError, formatDate } from './utils';
+import { isPPLSearchQuery, throwFacetError } from './utils';
 import { Query } from 'src/plugins/data/common';
 
 describe('throwFacetError', () => {
@@ -110,62 +110,6 @@ describe('throwFacetError', () => {
       expect(err.name).toBeUndefined();
       expect(err.status).toBeUndefined();
     }
-  });
-});
-
-describe('formatDate', () => {
-  it('should format date string with milliseconds', () => {
-    const dateString = '2025-07-30T20:30:31.567Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-07-30 20:30:31.567');
-  });
-
-  it('should format date string with zero milliseconds', () => {
-    const dateString = '2025-07-30T20:30:31.000Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-07-30 20:30:31.000');
-  });
-
-  it('should format date string with single digit milliseconds', () => {
-    const dateString = '2025-07-30T20:30:31.005Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-07-30 20:30:31.005');
-  });
-
-  it('should format date string with double digit milliseconds', () => {
-    const dateString = '2025-07-30T20:30:31.050Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-07-30 20:30:31.050');
-  });
-
-  it('should format date string with maximum milliseconds', () => {
-    const dateString = '2025-07-30T20:30:31.999Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-07-30 20:30:31.999');
-  });
-
-  it('should handle different date formats', () => {
-    const dateString = '2025-01-01T00:00:00.123Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-01-01 00:00:00.123');
-  });
-
-  it('should pad single digit months and days', () => {
-    const dateString = '2025-01-05T09:08:07.456Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-01-05 09:08:07.456');
-  });
-
-  it('should handle leap year dates', () => {
-    const dateString = '2024-02-29T12:34:56.789Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2024-02-29 12:34:56.789');
-  });
-
-  it('should handle end of year dates', () => {
-    const dateString = '2025-12-31T23:59:59.999Z';
-    const result = formatDate(dateString);
-    expect(result).toBe('2025-12-31 23:59:59.999');
   });
 });
 

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -15,25 +15,6 @@ import {
 } from './types';
 import { API } from './constants';
 
-export const formatDate = (dateString: string) => {
-  const date = new Date(dateString);
-  return (
-    date.getFullYear() +
-    '-' +
-    ('0' + (date.getMonth() + 1)).slice(-2) +
-    '-' +
-    ('0' + date.getDate()).slice(-2) +
-    ' ' +
-    ('0' + date.getHours()).slice(-2) +
-    ':' +
-    ('0' + date.getMinutes()).slice(-2) +
-    ':' +
-    ('0' + date.getSeconds()).slice(-2) +
-    '.' +
-    ('00' + date.getMilliseconds()).slice(-3)
-  );
-};
-
 export const getFields = (rawResponse: any) => {
   return rawResponse.data.schema?.map((field: any, index: any) => ({
     ...field,

--- a/src/plugins/query_enhancements/public/search/filters/filter_utils.ts
+++ b/src/plugins/query_enhancements/public/search/filters/filter_utils.ts
@@ -12,7 +12,6 @@ import {
   isFilterDisabled,
   TimeRange,
 } from '../../../../data/common';
-import { formatDate } from '../../../common';
 
 export class FilterUtils {
   /**
@@ -23,9 +22,7 @@ export class FilterUtils {
    */
   public static getTimeFilterWhereClause(timeFieldName: string, timeRange: TimeRange): string {
     const { fromDate, toDate } = formatTimePickerDate(timeRange, 'YYYY-MM-DD HH:mm:ss.SSS');
-    return `WHERE \`${timeFieldName}\` >= '${formatDate(
-      fromDate
-    )}' AND \`${timeFieldName}\` <= '${formatDate(toDate)}'`;
+    return `WHERE \`${timeFieldName}\` >= '${fromDate}' AND \`${timeFieldName}\` <= '${toDate}'`;
   }
 
   /**


### PR DESCRIPTION
### Description

Remove redundant calls to format already formatted Datetime strings
The tests for the now unused removed function also used to fail unless the timezone was set to UTC.
So there's some test flakiness that was reduced.

### Issues Resolved

timezone sensitive tests removed

## Screenshot

no visible change

## Testing the changes

no functional change.
Tests all pass and if manual testing was done with the PPL query builder.

## Changelog

- skip

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (with the exception of `calls reportOptInStatus if reportOptInStatusChange is true`, but that failed on my machine before the changes as well)
  - [x] `yarn test:jest_integration`
- ~~[ ] New functionality includes testing.~~ no new functionatity
- ~~[ ] New functionality has been documented.~~ no new functionatity
- ~~[ ] Update [CHANGELOG.md](./../CHANGELOG.md)~~ no new functionatity
- [x] Commits are signed per the DCO using --signoff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal date handling in the query enhancement plugin by streamlining utility functions and removing unused code dependencies for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->