### PR TITLE
chore: fix missing opensearch-sql depedency when running

### DIFF
--- a/packages/osd-opensearch/src/cluster.js
+++ b/packages/osd-opensearch/src/cluster.js
@@ -232,6 +232,7 @@ exports.Cluster = class Cluster {
    * @property {String} version - version of OpenSearch
    */
   async setupSql(installPath, version) {
+    await this.installSqlPlugin(installPath, version, 'opensearch-job-scheduler');
     await this.installSqlPlugin(installPath, version, 'opensearch-sql');
     await this.installSqlPlugin(installPath, version, 'opensearch-observability');
   }


### PR DESCRIPTION


### Description

Fix missing opensearch-sql depedency when running
`yarn opensearch snapshot --sql`

### Issues Resolved

running `yarn opensearch snapshot --sql` is not loading opensearch-sql successfully

## Screenshot

no visible change

## Testing the changes

run `yarn opensearch snapshot --sql` and look for 

before:
```
   │ info Installing OpenSearch Plugin from the path: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/3.5.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-sql-3.5.0.0.zip
   │ warn Failed to setup: opensearch-sql
```

after:
```
   │ info Installing OpenSearch Plugin from the path: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/3.5.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-sql-3.5.0.0.zip
   │ info Plugin installation complete
```


## Changelog

- skip

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (same ones fail locally that failed before)
  - [x] `yarn test:jest_integration`
- [ ] ~~New functionality includes testing.~~ (no new functionality)
- [ ] ~~New functionality has been documented.~~ (no new functionality)
- [ ] ~~Update [CHANGELOG.md](./../CHANGELOG.md)~~ (no new functionality)
- [x] Commits are signed per the DCO using --signoff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated the OpenSearch Job Scheduler plugin into cluster setup; it is now installed as part of startup, prior to the SQL and observability plugins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->