### PR TITLE
Traces: Auto create bugfix

### DIFF
--- a/changelogs/fragments/11174.yml
+++ b/changelogs/fragments/11174.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix trace automation naming convention ([#11174](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11174))

--- a/src/plugins/explore/public/utils/create_auto_datasets.test.ts
+++ b/src/plugins/explore/public/utils/create_auto_datasets.test.ts
@@ -93,7 +93,7 @@ describe('createAutoDetectedDatasets', () => {
         signalType: 'logs',
         schemaMappings: JSON.stringify({
           otelLogs: {
-            timeField: 'time',
+            timestamp: 'time',
             traceId: 'traceId',
             spanId: 'spanId',
             serviceName: 'resource.attributes.service.name',
@@ -170,7 +170,7 @@ describe('createAutoDetectedDatasets', () => {
         signalType: 'logs',
         schemaMappings: JSON.stringify({
           otelLogs: {
-            timeField: 'time',
+            timestamp: 'time',
             traceId: 'traceId',
             spanId: 'spanId',
             serviceName: 'resource.attributes.service.name',
@@ -282,7 +282,7 @@ describe('createAutoDetectedDatasets', () => {
         signalType: 'logs',
         schemaMappings: JSON.stringify({
           otelLogs: {
-            timeField: 'time',
+            timestamp: 'time',
             traceId: 'traceId',
             spanId: 'spanId',
             serviceName: 'resource.attributes.service.name',
@@ -652,7 +652,7 @@ describe('createAutoDetectedDatasets', () => {
 
     const expectedSchemaMappings = {
       otelLogs: {
-        timeField: 'time',
+        timestamp: 'time',
         traceId: 'traceId',
         spanId: 'spanId',
         serviceName: 'resource.attributes.service.name',
@@ -689,7 +689,7 @@ describe('createAutoDetectedDatasets', () => {
 
     const expectedSchemaMappings = {
       otelLogs: {
-        timeField: 'timestamp',
+        timestamp: 'timestamp',
         traceId: 'traceId',
         spanId: 'spanId',
         serviceName: 'resource.attributes.service.name',

--- a/src/plugins/explore/public/utils/create_auto_datasets.ts
+++ b/src/plugins/explore/public/utils/create_auto_datasets.ts
@@ -132,7 +132,7 @@ export async function createAutoDetectedDatasets(
             signalType: 'logs',
             schemaMappings: JSON.stringify({
               otelLogs: {
-                timeField: detection.logTimeField || 'time',
+                timestamp: detection.logTimeField || 'time',
                 traceId: 'traceId',
                 spanId: 'spanId',
                 serviceName: 'resource.attributes.service.name',
@@ -165,7 +165,7 @@ export async function createAutoDetectedDatasets(
             signalType: 'logs',
             schemaMappings: JSON.stringify({
               otelLogs: {
-                timeField: detection.logTimeField || 'time',
+                timestamp: detection.logTimeField || 'time',
                 traceId: 'traceId',
                 spanId: 'spanId',
                 serviceName: 'resource.attributes.service.name',


### PR DESCRIPTION
### Description
The auto creation was succeeding but the mis-named field was causing the UI not to pick up the registered timefield in the edit menus.
Switched to the correct name and is working correctly now.

<img width="1548" height="797" alt="Screenshot 2026-01-14 at 10 40 24 AM" src="https://github.com/user-attachments/assets/4b31f8dd-05d3-4d18-b674-d11d16c191c5" />


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a naming convention inconsistency in trace automation. Schema mappings for log datasets now correctly use "timestamp" as the field name for referencing time values, replacing the previous naming convention. This improves consistency across all generated dataset schema definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->