### PR TITLE
feat:support semaphore based query for ppl

### DIFF
--- a/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx
@@ -48,6 +48,7 @@ export const useDashboardAppAndGlobalState = ({
   useEffect(() => {
     if (savedDashboardInstance && dashboard) {
       let unsubscribeFromDashboardContainer: () => void;
+      let containerRef: DashboardContainer | undefined;
 
       const {
         dashboardConfig,
@@ -149,6 +150,7 @@ export const useDashboardAppAndGlobalState = ({
           }
         };
 
+        containerRef = dashboardContainer;
         setCurrentContainer(dashboardContainer);
 
         const stopSyncingDashboardContainerOutputs = handleDashboardContainerOutputs(
@@ -221,6 +223,11 @@ export const useDashboardAppAndGlobalState = ({
         stopSyncingAppFilters();
         stopSyncingQueryServiceStateWithUrl();
         unsubscribeFromDashboardContainer?.();
+
+        // Fire signal for each widget when user Navigates away
+        if (containerRef) {
+          containerRef.destroy();
+        }
       };
     }
   }, [dashboard, eventEmitter, savedDashboardInstance, services]);

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -48,6 +48,8 @@ export class QueryEnhancementsPlugin
   private currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
   private appIdSubscription?: Subscription;
 
+  private pplSearchInterceptor?: PPLSearchInterceptor;
+
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<ConfigSchema>();
     this.storage = new DataStorage(window.localStorage, 'discover.queryAssist.');
@@ -64,17 +66,20 @@ export class QueryEnhancementsPlugin
     const pplControls = [pplLanguageReference('PPL')];
     const sqlControls = [sqlLanguageReference('SQL')];
 
+    // Create and store PPLSearchInterceptor instance
+    this.pplSearchInterceptor = new PPLSearchInterceptor({
+      toasts: core.notifications.toasts,
+      http: core.http,
+      uiSettings: core.uiSettings,
+      startServices: core.getStartServices(),
+      usageCollector: data.search.usageCollector,
+    });
+
     // Register PPL language configuration
     const pplLanguageConfig: LanguageConfig = {
       id: 'PPL',
       title: 'PPL',
-      search: new PPLSearchInterceptor({
-        toasts: core.notifications.toasts,
-        http: core.http,
-        uiSettings: core.uiSettings,
-        startServices: core.getStartServices(),
-        usageCollector: data.search.usageCollector,
-      }),
+      search: this.pplSearchInterceptor,
       getQueryString: (currentQuery: Query) => `source = ${currentQuery.dataset?.title}`,
       addFiltersToQuery: PPLFilterUtils.addFiltersToQuery,
       addFiltersToPrompt: NaturalLanguageFilterUtils.addFiltersToPrompt,
@@ -296,6 +301,9 @@ export class QueryEnhancementsPlugin
     data.resourceClientFactory.register('prometheus', (http) => new PrometheusResourceClient(http));
 
     return {
+      registerStrategySemaphore: (strategy: string, limit: number) => {
+        this.pplSearchInterceptor?.registerStrategySemaphore(strategy, limit);
+      },
       isQuerySummaryCollapsed$: this.isQuerySummaryCollapsed$,
       resultSummaryEnabled$: this.resultSummaryEnabled$,
       isSummaryAgentAvailable$: this.isSummaryAgentAvailable$,

--- a/src/plugins/query_enhancements/public/search/utils/semaphore.ts
+++ b/src/plugins/query_enhancements/public/search/utils/semaphore.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Simple semaphore for limiting concurrent operations
+ */
+export class Semaphore {
+  private available: number;
+  private waitQueue: (() => void)[] = [];
+
+  constructor(limit: number) {
+    this.available = limit;
+  }
+
+  /**
+   * Acquire a semaphore slot. Will block if limit reached.
+   */
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+    });
+  }
+
+  /**
+   * Release a semaphore slot, allowing next waiting operation to proceed
+   */
+  release(): void {
+    const next = this.waitQueue.shift();
+    if (next) {
+      next();
+    } else {
+      this.available++;
+    }
+  }
+}

--- a/src/plugins/query_enhancements/public/types.ts
+++ b/src/plugins/query_enhancements/public/types.ts
@@ -12,6 +12,7 @@ import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public'
 import { UsageCollectionSetup } from '../../usage_collection/public';
 
 export interface QueryEnhancementsPluginSetup {
+  registerStrategySemaphore: (strategy: string, limit: number) => void;
   isQuerySummaryCollapsed$: BehaviorSubject<boolean>;
   resultSummaryEnabled$: BehaviorSubject<boolean>;
   isSummaryAgentAvailable$: BehaviorSubject<boolean>;


### PR DESCRIPTION
### Description

Dashboards with multiple widgets querying async data sources fire all queries simultaneously, overwhelming backend services.

Solution
Adds a plugin-level utility to register concurrency limits per search strategy. The PPL search interceptor uses semaphores to batch queries, acquiring slots before submission and releasing on completion.

Changes
Added Semaphore utility class for concurrency control
Exposed registerStrategySemaphore in query enhancements plugin
Implemented batching logic in PPL search interceptor
Added dashboard container cleanup on navigation, this results in abort signal on naviagte away

Usage Example
```
// In a data source plugin's setup method
setup(core, { queryEnhancements }) {
  // Limit CloudWatch Lake queries to 5 concurrent requests
  queryEnhancements.registerStrategySemaphore('STRATERGY_NAME', 5);
}
```
This limits to 5 queries at a time
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

NA

## Testing the changes

Tested Dashboards for PPL based query

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
