### PR TITLE
Explore: Dynamic setting flag Traces + Metrics

### DIFF
--- a/changelogs/fragments/11220.yml
+++ b/changelogs/fragments/11220.yml
@@ -1,0 +1,2 @@
+feat:
+- Add dynamic setting flag for Explore Traces + Metrics ([#11220](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11220))

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -30,7 +30,6 @@ import {
   withNotifyOnErrors,
 } from '../../opensearch_dashboards_utils/public';
 import { ExploreFlavor, PLUGIN_ID, PLUGIN_NAME } from '../common';
-import { ConfigSchema } from '../common/config';
 import { generateDocViewsUrl } from './application/legacy/discover/application/components/doc_views/generate_doc_views_url';
 import { DocViewsLinksRegistry } from './application/legacy/discover/application/doc_views_links/doc_views_links_registry';
 import {
@@ -87,8 +86,6 @@ export class ExplorePlugin
       ExploreSetupDependencies,
       ExploreStartDependencies
     > {
-  // @ts-ignore
-  private config: ConfigSchema;
   private stateUpdaterByApp: Partial<
     Record<ExploreFlavor | 'explore', BehaviorSubject<AppUpdater>>
   > = {
@@ -113,9 +110,7 @@ export class ExplorePlugin
   private queryPanelActionsRegistryService = new QueryPanelActionsRegistryService();
   private slotRegistryService = new SlotRegistryService();
 
-  constructor(private readonly initializerContext: PluginInitializerContext) {
-    this.config = initializerContext.config.get<ConfigSchema>();
-  }
+  constructor(private readonly initializerContext: PluginInitializerContext) {}
 
   public setup(
     core: CoreSetup<ExploreStartDependencies, ExplorePluginStart>,

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -526,7 +526,10 @@ export class ExplorePlugin
     }
 
     // Configure visualization visibility based on workspace
-    this.configureExploreVisualizationVisibility(core, plugins);
+    this.configureExploreVisualizationVisibility(core, plugins).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error('Failed to configure explore visualization visibility', error);
+    });
 
     this.initializeServices = () => {
       if (this.servicesInitialized) {

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -11,6 +11,7 @@ import { filter, map, take } from 'rxjs/operators';
 import {
   App,
   AppMountParameters,
+  AppNavLinkStatus,
   AppUpdater,
   CoreSetup,
   CoreStart,
@@ -125,7 +126,7 @@ export class ExplorePlugin
 
     // Set usage collector
     setUsageCollector(setupDeps.usageCollection);
-    this.registerExploreVisualization(core, setupDeps);
+    this.registerExploreVisualizationAlias(setupDeps);
     const visualizationRegistryService = this.visualizationRegistryService.setup();
 
     this.docViewsRegistry = new DocViewsRegistry();
@@ -379,6 +380,14 @@ export class ExplorePlugin
       };
     };
 
+    // Create updaters for Traces and Metrics to control visibility
+    if (!this.stateUpdaterByApp[ExploreFlavor.Traces]) {
+      this.stateUpdaterByApp[ExploreFlavor.Traces] = new BehaviorSubject<AppUpdater>(() => ({}));
+    }
+    if (!this.stateUpdaterByApp[ExploreFlavor.Metrics]) {
+      this.stateUpdaterByApp[ExploreFlavor.Metrics] = new BehaviorSubject<AppUpdater>(() => ({}));
+    }
+
     // Register applications into the side navigation menu
     core.application.register(
       createExploreApp(ExploreFlavor.Logs, {
@@ -390,16 +399,20 @@ export class ExplorePlugin
       createExploreApp(ExploreFlavor.Traces, {
         id: `${PLUGIN_ID}/${ExploreFlavor.Traces}`,
         title: 'Traces',
+        updater$: this.stateUpdaterByApp[ExploreFlavor.Traces]!.asObservable(),
       })
     );
     core.application.register(
       createExploreApp(ExploreFlavor.Metrics, {
         id: `${PLUGIN_ID}/${ExploreFlavor.Metrics}`,
         title: 'Metrics',
+        updater$: this.stateUpdaterByApp[ExploreFlavor.Metrics]!.asObservable(),
       })
     );
     core.application.register(createExploreApp());
 
+    // Register all nav links during setup
+    // Visibility will be controlled by capabilities in the start lifecycle
     const navLinks = [
       {
         id: PLUGIN_ID,
@@ -412,27 +425,19 @@ export class ExplorePlugin
         order: 300,
         parentNavLinkId: PLUGIN_ID,
       },
-    ];
-
-    // Only add Traces nav link if the discoverTraces feature is enabled
-    if (this.config.discoverTraces?.enabled) {
-      navLinks.push({
+      {
         id: `${PLUGIN_ID}/${ExploreFlavor.Traces}`,
         category: undefined,
         order: 300,
         parentNavLinkId: PLUGIN_ID,
-      });
-    }
-
-    // Only add Metrics nav link if the discoverMetrics feature is enabled
-    if (this.config.discoverMetrics?.enabled) {
-      navLinks.push({
+      },
+      {
         id: `${PLUGIN_ID}/${ExploreFlavor.Metrics}`,
         category: undefined,
         order: 300,
         parentNavLinkId: PLUGIN_ID,
-      });
-    }
+      },
+    ];
 
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, navLinks);
     this.registerEmbeddable(core, setupDeps);
@@ -488,6 +493,40 @@ export class ExplorePlugin
     if (plugins.expressions) {
       setExpressionLoader(plugins.expressions.ExpressionLoader);
     }
+
+    // Control nav link visibility based on dynamic capabilities
+    const capabilities = core.application.capabilities;
+
+    // Update Traces nav link visibility based on dynamic capabilities
+    if (this.stateUpdaterByApp[ExploreFlavor.Traces]) {
+      this.stateUpdaterByApp[ExploreFlavor.Traces]!.next((app) => {
+        if (app.id === `${PLUGIN_ID}/${ExploreFlavor.Traces}`) {
+          return {
+            navLinkStatus: capabilities.explore?.discoverTracesEnabled
+              ? AppNavLinkStatus.visible
+              : AppNavLinkStatus.hidden,
+          };
+        }
+        return {};
+      });
+    }
+
+    // Update Metrics nav link visibility based on dynamic capabilities
+    if (this.stateUpdaterByApp[ExploreFlavor.Metrics]) {
+      this.stateUpdaterByApp[ExploreFlavor.Metrics]!.next((app) => {
+        if (app.id === `${PLUGIN_ID}/${ExploreFlavor.Metrics}`) {
+          return {
+            navLinkStatus: capabilities.explore?.discoverMetricsEnabled
+              ? AppNavLinkStatus.visible
+              : AppNavLinkStatus.hidden,
+          };
+        }
+        return {};
+      });
+    }
+
+    // Configure visualization visibility based on workspace
+    this.configureExploreVisualizationVisibility(core, plugins);
 
     this.initializeServices = () => {
       if (this.servicesInitialized) {
@@ -565,10 +604,7 @@ export class ExplorePlugin
     plugins.embeddable.registerEmbeddableFactory(factory.type, factory);
   }
 
-  private async registerExploreVisualization(
-    core: CoreSetup<ExploreStartDependencies, ExplorePluginStart>,
-    setupDeps: ExploreSetupDependencies
-  ) {
+  private registerExploreVisualizationAlias(setupDeps: ExploreSetupDependencies) {
     const exploreVisDisplayName = i18n.translate('explore.visualization.title', {
       defaultMessage: 'Visualize with Discover',
     });
@@ -623,15 +659,17 @@ export class ExplorePlugin
         },
       },
     });
+  }
 
-    const [coreStart, pluginsStart] = await core.getStartServices();
-    const isExploreEnabledWorkspace = await this.getIsExploreEnabledWorkspace(coreStart);
+  private async configureExploreVisualizationVisibility(
+    core: CoreStart,
+    plugins: ExploreStartDependencies
+  ) {
+    const isExploreEnabledWorkspace = await this.getIsExploreEnabledWorkspace(core);
     if (isExploreEnabledWorkspace) {
-      const dashboardVisActions = pluginsStart.uiActions.getTriggerActions(
-        DASHBOARD_ADD_PANEL_TRIGGER
-      );
-      const visTypes = pluginsStart.visualizations.all();
-      const aliasTypes = pluginsStart.visualizations.getAliases();
+      const dashboardVisActions = plugins.uiActions.getTriggerActions(DASHBOARD_ADD_PANEL_TRIGGER);
+      const visTypes = plugins.visualizations.all();
+      const aliasTypes = plugins.visualizations.getAliases();
       const allVisTypes = [...visTypes, ...aliasTypes];
       dashboardVisActions.forEach((action) => {
         const visOfAction = allVisTypes.find((vis) => action.id === `add_vis_action_${vis.name}`);
@@ -644,7 +682,7 @@ export class ExplorePlugin
         }
       });
     } else {
-      const registeredVisAlias = pluginsStart.visualizations
+      const registeredVisAlias = plugins.visualizations
         .getAliases()
         .find((v) => v.name === this.DISCOVER_VISUALIZATION_NAME);
 


### PR DESCRIPTION
### Description
This PR refactors the Explore plugin to use the DynamicConfigService for managing feature flags (discoverTraces.enabled and discoverMetrics.enabled). 
This enables dynamic configuration of features without requiring restarts, and exposes these flags as capabilities that other plugins can consume. 

[RFC] Dynamic Configuration Service: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7111

  Changes

  Server-Side (src/plugins/explore/server/plugin.ts)

  - Added default capability provider for explore.discoverTracesEnabled and explore.discoverMetricsEnabled (both default to false)
  - Registered capability switcher that fetches dynamic config values via DynamicConfigService
  - Feature flags are now resolved dynamically from config sources with proper fallback handling

  Benefits:
  - Configuration can be updated dynamically without restarts
  - Values fall back gracefully: Dynamic Config Store → opensearch_dashboards.yml → Schema Defaults
  - Other plugins can check these capabilities via request.getCapabilities()

  Browser-Side (src/plugins/explore/public/plugin.ts)

  - Refactored to use AppUpdater pattern for controlling nav link visibility
  - Setup phase registers all nav links (Logs, Traces, Metrics) immediately
  - Start phase reads capabilities and updates nav link visibility dynamically
  - Split registerExploreVisualization into two methods to avoid circular dependencies

  Benefits:
  - No setup lifecycle blocking (resolves 30-second timeout issues)
  - Nav link visibility controlled by server-provided capabilities
  - Proper separation of setup and start lifecycle concerns

  How Other Plugins Can Use Explore Capabilities

  Server-Side Example
  ```
  // In any route handler
  router.post(
    {
      path: '/api/my-plugin/traces',
      validate: { /* ... */ },
    },
    async (context, request, response) => {
      // Get capabilities - includes explore feature flags
      const capabilities = await request.getCapabilities();

      // Check if traces feature is enabled
      if (!capabilities.explore?.discoverTracesEnabled) {
        return response.forbidden({
          body: { message: 'Traces feature is not enabled' },
        });
      }

      // Proceed with traces logic
      return response.ok({ body: { /* traces data */ } });
    }
  );
```
  Browser-Side Example
```
  // In a React component
  import { useCapabilities } from '../../../opensearch-dashboards-react/public';

  export const TracesPanel = () => {
    const capabilities = useCapabilities();

    // Check if traces is enabled
    if (!capabilities.explore?.discoverTracesEnabled) {
      return <EuiEmptyPrompt title="Traces Not Available" />;
    }

    return <div>Traces UI here</div>;
  };
```
  Configuration

  Feature flags are configured via opensearch_dashboards.yml:

  explore:
    discoverTraces:
      enabled: true
    discoverMetrics:
      enabled: false

  Testing

  - Updated src/plugins/explore/public/plugin.test.ts with new tests for:
    - AppUpdater registration for Traces and Metrics
    - All nav links registered during setup
    - Capability-based visibility control in start lifecycle
    - Various enabled/disabled capability combinations
  - Added comprehensive usage documentation in src/plugins/explore/CAPABILITY_USAGE_EXAMPLES.md

  Breaking Changes

  None. The configuration format remains the same (explore.discoverTraces.enabled and explore.discoverMetrics.enabled). This is a refactoring that adds dynamic
   capabilities while maintaining backward compatibility.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
