### PR TITLE
[Explore Vis] Fix show full time range

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -29,6 +29,7 @@ import {
   buildAxisConfigs,
   assembleSpec,
   buildVisMap,
+  applyTimeRange,
 } from '../utils/echarts_spec';
 import {
   createAreaSeries,
@@ -76,6 +77,7 @@ export const createSimpleAreaChart = (
       transform(sortByTime(axisColumnMappings?.x?.column), convertTo2DArray(allColumns)),
       createBaseConfig({ title: `${axisConfig.yAxis?.name} Over Time` }),
       buildAxisConfigs,
+      applyTimeRange,
       createAreaSeries({
         styles,
         categoryField: timeField,
@@ -87,6 +89,7 @@ export const createSimpleAreaChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -254,6 +257,7 @@ export const createMultiAreaChart = (
         }`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       buildVisMap({
         seriesFields: (headers) => (headers ?? []).filter((h) => h !== timeField),
       }),
@@ -264,6 +268,7 @@ export const createMultiAreaChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -451,6 +456,7 @@ export const createFacetedMultiAreaChart = (
         } (Faceted by ${axisColumnMappings?.[AxisRole.FACET]?.name})`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       createFacetAreaSeries({
         styles,
         categoryField: timeField,
@@ -462,6 +468,7 @@ export const createFacetedMultiAreaChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -38,6 +38,7 @@ import {
   buildAxisConfigs,
   assembleSpec,
   buildVisMap,
+  applyTimeRange,
 } from '../utils/echarts_spec';
 import {
   aggregate,
@@ -242,6 +243,7 @@ export const createTimeBarChart = (
       ),
       createBaseConfig({ title: `${axisColumnMappings?.y?.name} Over Time` }),
       buildAxisConfigs,
+      applyTimeRange,
       buildVisMap({
         seriesFields: (headers) => (headers ?? []).filter((h) => h !== timeField),
       }),
@@ -257,6 +259,7 @@ export const createTimeBarChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -409,6 +412,7 @@ export const createGroupedTimeBarChart = (
         title: `${axisColumnMappings?.y?.name} Over Time by ${colorColumn.name}`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       buildVisMap({
         seriesFields: (headers) => (headers ?? []).filter((h) => h !== timeField),
       }),
@@ -426,6 +430,7 @@ export const createGroupedTimeBarChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -592,6 +597,7 @@ export const createFacetedTimeBarChart = (
         title: `${axisColumnMappings.y?.name} Over Time by ${axisColumnMappings.color?.name} (Faceted by ${axisColumnMappings.facet?.name})`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       buildVisMap({
         seriesFields: (headers) => (headers ?? []).filter((h) => h !== timeField),
       }),
@@ -606,6 +612,7 @@ export const createFacetedTimeBarChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
     return result.spec;
   }

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -24,7 +24,13 @@ import {
 } from '../utils/utils';
 import { createCrosshairLayers, createHighlightBarLayers } from '../utils/create_hover_state';
 import { createTimeRangeBrush, createTimeRangeUpdater } from '../utils/time_range_brush';
-import { pipe, createBaseConfig, buildAxisConfigs, assembleSpec } from '../utils/echarts_spec';
+import {
+  pipe,
+  createBaseConfig,
+  buildAxisConfigs,
+  assembleSpec,
+  applyTimeRange,
+} from '../utils/echarts_spec';
 import {
   convertTo2DArray,
   transform,
@@ -63,6 +69,7 @@ export const createSimpleLineChart = (
       transform(sortByTime(axisColumnMappings?.x?.column), convertTo2DArray(allColumns)),
       createBaseConfig({ title: `${axisConfig.yAxis?.name} Over Time` }),
       buildAxisConfigs,
+      applyTimeRange,
       createLineSeries({
         styles,
         categoryField: timeField,
@@ -74,6 +81,7 @@ export const createSimpleLineChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -234,6 +242,7 @@ export const createLineBarChart = (
         title: `${valueField.name} (Bar) and ${value2Field.name} (Line) Over Time`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       createLineBarSeries({ styles, categoryField: timeField, value2Field, valueField }),
       assembleSpec
     )({
@@ -241,6 +250,7 @@ export const createLineBarChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -454,6 +464,7 @@ export const createMultiLineChart = (
         }`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       createLineSeries({
         styles,
         categoryField: timeField,
@@ -465,6 +476,7 @@ export const createMultiLineChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;
@@ -641,6 +653,7 @@ export const createFacetedMultiLineChart = (
         } (Faceted by ${axisColumnMappings?.[AxisRole.FACET]?.name})`,
       }),
       buildAxisConfigs,
+      applyTimeRange,
       createFacetLineSeries({
         styles,
         categoryField: timeField,
@@ -652,6 +665,7 @@ export const createFacetedMultiLineChart = (
       styles,
       axisConfig,
       axisColumnMappings: axisColumnMappings ?? {},
+      timeRange,
     });
 
     return result.spec;

--- a/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
@@ -24,6 +24,7 @@ import {
   VisFieldType,
   Threshold,
   ThresholdOptions,
+  AxisRole,
 } from '../types';
 import { convertThresholds } from './utils';
 
@@ -48,6 +49,7 @@ export interface BaseChartStyle {
   useThresholdColor?: boolean;
   addLegend?: boolean;
   legendPosition?: Positions;
+  showFullTimeRange?: boolean;
 }
 
 interface Axis {
@@ -74,6 +76,7 @@ export interface EChartsSpecInput<T extends BaseChartStyle = BaseChartStyle> {
   styles: T;
   axisConfig?: EChartsAxisConfig;
   axisColumnMappings: AxisColumnMappings;
+  timeRange?: { from: string; to: string };
 }
 
 /**
@@ -411,5 +414,76 @@ export const buildVisMap = ({
   return {
     ...state,
     visualMap,
+  };
+};
+
+/**
+ * Apply time range to axis if showFullTimeRange is enabled
+ */
+export const applyTimeRange = <T extends BaseChartStyle>(
+  state: EChartsSpecState<T>
+): EChartsSpecState<T> => {
+  const { styles, axisColumnMappings, timeRange, xAxisConfig, yAxisConfig } = state;
+
+  if (!styles.showFullTimeRange || !timeRange?.from || !timeRange?.to) {
+    return state;
+  }
+
+  const timeAxisEntry = Object.entries(axisColumnMappings).find(
+    ([, col]) => col?.schema === VisFieldType.Date
+  );
+
+  if (!timeAxisEntry) {
+    return state;
+  }
+
+  const [axisRole] = timeAxisEntry as [AxisRole, any];
+
+  // Process time values
+  const processTimeValue = (iso: string) => {
+    const date = new Date(iso);
+    return isNaN(date.getTime()) ? iso : date;
+  };
+
+  const minTime = processTimeValue(timeRange.from);
+  const maxTime = processTimeValue(timeRange.to);
+
+  let updatedXAxisConfig = xAxisConfig;
+  let updatedYAxisConfig = yAxisConfig;
+
+  if (axisRole === AxisRole.X) {
+    if (Array.isArray(xAxisConfig)) {
+      updatedXAxisConfig = xAxisConfig.map((config) => ({
+        ...config,
+        min: minTime,
+        max: maxTime,
+      }));
+    } else if (xAxisConfig) {
+      updatedXAxisConfig = {
+        ...xAxisConfig,
+        min: minTime,
+        max: maxTime,
+      };
+    }
+  } else if (axisRole === AxisRole.Y) {
+    if (Array.isArray(yAxisConfig)) {
+      updatedYAxisConfig = yAxisConfig.map((config) => ({
+        ...config,
+        min: minTime,
+        max: maxTime,
+      }));
+    } else if (yAxisConfig) {
+      updatedYAxisConfig = {
+        ...yAxisConfig,
+        min: minTime,
+        max: maxTime,
+      };
+    }
+  }
+
+  return {
+    ...state,
+    xAxisConfig: updatedXAxisConfig,
+    yAxisConfig: updatedYAxisConfig,
   };
 };


### PR DESCRIPTION
### Description

This change fixes the "show full time range" toggle functionality when using ECharts renderer instead of Vega-Lite.


## Screenshot
### Area Chart
<img width="2878" height="1308" alt="image" src="https://github.com/user-attachments/assets/b354572c-e741-4f96-aedb-77926810b28f" />
<img width="2908" height="1298" alt="image" src="https://github.com/user-attachments/assets/288c1859-3ef7-482d-8593-90aa74df3d10" />


### Bar Chart
<img width="2874" height="1300" alt="image" src="https://github.com/user-attachments/assets/22ca3a4a-e381-4141-928b-da3599d1afcc" />
<img width="2864" height="1300" alt="image" src="https://github.com/user-attachments/assets/397b02ab-d311-4288-886d-bb9f6eb7a9c0" />


### Line Chart
<img width="2864" height="1302" alt="image" src="https://github.com/user-attachments/assets/76ff95dd-9015-46c7-a770-7ae0f93d232a" />
<img width="2866" height="1302" alt="image" src="https://github.com/user-attachments/assets/dde93647-067b-459e-8e54-5ccd8209a7be" />




<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
- fix: Fix show full time range

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
