### PR TITLE
[Explore] make step more granular for Prometheus range query

### DIFF
--- a/src/plugins/query_enhancements/server/search/prom_utils.test.ts
+++ b/src/plugins/query_enhancements/server/search/prom_utils.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { calculateStep, DEFAULT_RESOLUTION, MIN_STEP_INTERVAL } from './prom_utils';
+
+describe('prom_utils', () => {
+  describe('calculateStep', () => {
+    it('should return minimum step interval when calculated step is smaller', () => {
+      const durationMs = 60000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(MIN_STEP_INTERVAL);
+    });
+
+    it('should calculate step for 1 hour duration', () => {
+      const durationMs = 3600000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(15);
+    });
+
+    it('should calculate step for 24 hour duration', () => {
+      const durationMs = 86400000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(100);
+    });
+
+    it('should calculate step for 7 day duration', () => {
+      const durationMs = 604800000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(500);
+    });
+
+    it('should calculate step for 30 day duration', () => {
+      const durationMs = 2592000000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(2000);
+    });
+
+    it('should respect custom resolution parameter', () => {
+      const durationMs = 3600000;
+      const step = calculateStep(durationMs, 100);
+      expect(step).toBe(50);
+    });
+
+    it('should respect custom minimum interval parameter', () => {
+      const durationMs = 3600000;
+      const step = calculateStep(durationMs, DEFAULT_RESOLUTION, 1);
+      expect(step).toBe(5);
+    });
+
+    it('should handle very large durations (1 year+)', () => {
+      const durationMs = 400 * 24 * 60 * 60 * 1000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(50000);
+    });
+
+    it('should handle very small durations', () => {
+      const durationMs = 1000;
+      const step = calculateStep(durationMs);
+      expect(step).toBe(MIN_STEP_INTERVAL);
+    });
+
+    describe('roundInterval produces 1-2-5 sequence values', () => {
+      it('should round to 1 for intervals <= 1', () => {
+        const durationMs = 1000 * DEFAULT_RESOLUTION;
+        const step = calculateStep(durationMs, DEFAULT_RESOLUTION, 0);
+        expect(step).toBe(1);
+      });
+
+      it('should round to 2 for intervals in (1, 2]', () => {
+        const durationMs = 2000 * DEFAULT_RESOLUTION;
+        const step = calculateStep(durationMs, DEFAULT_RESOLUTION, 0);
+        expect(step).toBe(2);
+      });
+
+      it('should round to 5 for intervals in (2, 5]', () => {
+        const durationMs = 5000 * DEFAULT_RESOLUTION;
+        const step = calculateStep(durationMs, DEFAULT_RESOLUTION, 0);
+        expect(step).toBe(5);
+      });
+
+      it('should round to 10 for intervals in (5, 10]', () => {
+        const durationMs = 10000 * DEFAULT_RESOLUTION;
+        const step = calculateStep(durationMs, DEFAULT_RESOLUTION, 0);
+        expect(step).toBe(10);
+      });
+
+      it('should round to 100 for intervals around 60-100', () => {
+        const durationMs = 60000 * DEFAULT_RESOLUTION;
+        const step = calculateStep(durationMs, DEFAULT_RESOLUTION, 0);
+        expect(step).toBe(100);
+      });
+    });
+  });
+});

--- a/src/plugins/query_enhancements/server/search/prom_utils.ts
+++ b/src/plugins/query_enhancements/server/search/prom_utils.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Default resolution for step calculation
+export const DEFAULT_RESOLUTION = 1440;
+// Minimum step interval in seconds
+export const MIN_STEP_INTERVAL = 15;
+
+function roundInterval(intervalMs: number): number {
+  if (intervalMs <= 1) return 1;
+
+  const magnitude = Math.pow(10, Math.floor(Math.log10(intervalMs)));
+  const normalized = intervalMs / magnitude;
+
+  let nice: number;
+  if (normalized <= 1) nice = 1;
+  else if (normalized <= 2) nice = 2;
+  else if (normalized <= 5) nice = 5;
+  else nice = 10;
+
+  return Math.round(nice * magnitude);
+}
+
+export function calculateStep(
+  durationMs: number,
+  resolution: number = DEFAULT_RESOLUTION,
+  minIntervalSec: number = MIN_STEP_INTERVAL
+): number {
+  const rawIntervalMs = durationMs / resolution;
+  const roundedIntervalMs = roundInterval(rawIntervalMs);
+  const stepSec = roundedIntervalMs / 1000;
+  return Math.max(stepSec, minIntervalSec);
+}

--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
@@ -21,15 +21,14 @@ import {
   PromQLQueryParams,
   PromQLQueryResponse,
 } from '../connections/managers/prometheus_manager';
+import { calculateStep, DEFAULT_RESOLUTION } from './prom_utils';
 
-// This creates an upper bound for data points sent to the frontend (targetSamples * maxSeries)
-const AUTO_STEP_TARGET_SAMPLES = 50;
 // MAX_SERIES_TABLE: Maximum series for table display
 const MAX_SERIES_TABLE = 2000;
 // MAX_SERIES_VIZ: Maximum series for visualization. This should be lower than MAX_SERIES_TABLE
 const MAX_SERIES_VIZ = 100;
 // We'll want to re-evaluate this when we provide an affordance for step configuration
-const MAX_DATAPOINTS = AUTO_STEP_TARGET_SAMPLES * MAX_SERIES_TABLE;
+const MAX_DATAPOINTS = DEFAULT_RESOLUTION * MAX_SERIES_TABLE;
 
 /**
  * Result from executing a single query in a multi-query context
@@ -58,10 +57,8 @@ export const promqlSearchStrategyProvider = (
           start: parsedFrom.unix(),
           end: parsedTo.unix(),
         };
-        const duration = (timeRange.end - timeRange.start) * 1000;
-        const step =
-          requestBody.step ??
-          Math.max(Math.ceil(duration / AUTO_STEP_TARGET_SAMPLES) / 1000, 0.001);
+        const durationMs = (timeRange.end - timeRange.start) * 1000;
+        const step = requestBody.step ?? calculateStep(durationMs);
         const { dataset, query, language }: Query = requestBody.query;
         const datasetId = dataset?.id ?? '';
 


### PR DESCRIPTION
### Description

This PR increases the "resolution" of the chart. Originally step for 15 hours would be 1080 seconds, leaving not many datapoints to see on frontend. After this PR it would be 50 seconds

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

before
<img width="5120" height="2588" alt="image" src="https://github.com/user-attachments/assets/946d65e5-cc0b-46b4-9a3b-3f71baf1ed80" />

after
<img width="5120" height="2588" alt="image" src="https://github.com/user-attachments/assets/11fa1298-72af-4638-a46d-6c7ee49abe7d" />


## Testing the changes

UT

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
