### PR TITLE
[Explore Vis] Fix state timeline legend toggle not working

### DIFF
--- a/src/plugins/explore/public/components/visualizations/state_timeline/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/state_timeline/to_expression.ts
@@ -105,6 +105,7 @@ export const createNumericalStateTimeline = (
       createBaseConfig({
         title: `${colorMapping?.name} by ${axisConfig.yAxis?.name} and ${axisConfig.xAxis?.name}`,
         addTrigger: false,
+        legend: { show: styleOptions.addLegend },
       }),
       buildAxisConfigs,
       createStateTimeLineSpec({ styles: styleOptions, groupField }),
@@ -334,6 +335,7 @@ export const createCategoricalStateTimeline = (
       createBaseConfig({
         title: `${colorMapping?.name} by ${axisConfig.yAxis?.name} and ${axisConfig.xAxis?.name}`,
         addTrigger: false,
+        legend: { show: styleOptions.addLegend },
       }),
       buildAxisConfigs,
       createStateTimeLineSpec({ styles: styleOptions, groupField }),
@@ -565,6 +567,7 @@ export const createSingleCategoricalStateTimeline = (
       createBaseConfig({
         title: `${colorMapping?.name}  by ${axisConfig.xAxis?.name}`,
         addTrigger: false,
+        legend: { show: styleOptions.addLegend },
       }),
       buildAxisConfigs,
       createStateTimeLineSpec({ styles: styleOptions, groupField: undefined }),
@@ -810,6 +813,7 @@ export const createSingleNumericalStateTimeline = (
       createBaseConfig({
         title: `${colorMapping?.name}  by ${axisConfig.xAxis?.name}`,
         addTrigger: false,
+        legend: { show: styleOptions.addLegend },
       }),
       buildAxisConfigs,
       createStateTimeLineSpec({ styles: styleOptions, groupField: undefined }),


### PR DESCRIPTION
### Description

Fixes legend toggle functionality not working in state timeline visualizations.
The legend toggle in state timeline charts was not responding to user interactions. Users could not hide/show the legend using the UI controls, even though the toggle appeared functional in the style panel. 


## Screenshot

<img width="2502" height="1138" alt="image" src="https://github.com/user-attachments/assets/ade6e3c4-7e4d-487e-b12f-3255dcb02ee0" />
<img width="2498" height="1138" alt="image" src="https://github.com/user-attachments/assets/ff34381f-590b-4cb6-851a-fb1b47479571" />


## Changelog
- fix: Fix state timeline legend toggle not working

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
