### PR TITLE
[DataView] support data-connection metadata and pass them in Prometheus

### DIFF
--- a/src/plugins/data/common/data_views/data_views/data_view.test.ts
+++ b/src/plugins/data/common/data_views/data_views/data_view.test.ts
@@ -109,6 +109,23 @@ function createWithDataSource(id: string) {
   });
 }
 
+function createWithDataSourceMeta(id: string) {
+  const {
+    type,
+    version,
+    attributes: { timeFieldName, fields, title },
+  } = stubbedSavedObjectIndexPattern(id);
+
+  const dataSourceMeta = { prometheusUrl: 'http://localhost:9090', customField: 'value' };
+  return new DataView({
+    spec: { id, type, version, timeFieldName, fields, title, dataSourceMeta },
+    savedObjectsClient: {} as any,
+    fieldFormats: fieldFormatsMock,
+    shortDotsEnable: false,
+    metaFields: [],
+  });
+}
+
 describe('DataView', () => {
   let dataView: DataView;
 
@@ -383,6 +400,28 @@ describe('DataViewWithDataSource', () => {
       nestedArrayDataView.flattenHit(hit);
 
       expect(hit).toEqual(hitClone);
+    });
+  });
+});
+
+describe('DataViewWithDataSourceMeta', () => {
+  let dataView: DataView;
+
+  beforeEach(() => {
+    dataView = createWithDataSourceMeta('test-pattern');
+  });
+
+  describe('dataSourceMeta', () => {
+    test('should store dataSourceMeta from spec', () => {
+      expect(dataView.dataSourceMeta).toEqual({
+        prometheusUrl: 'http://localhost:9090',
+        customField: 'value',
+      });
+    });
+
+    test('should be undefined when not provided in spec', () => {
+      const dataViewWithoutMeta = create('test-pattern');
+      expect(dataViewWithoutMeta.dataSourceMeta).toBeUndefined();
     });
   });
 });

--- a/src/plugins/data/common/data_views/data_views/data_view.ts
+++ b/src/plugins/data/common/data_views/data_views/data_view.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SavedObjectsClientCommon, Dataset, DataSource } from '../..';
+import { SavedObjectsClientCommon, Dataset, DataSource, DataStructureCustomMeta } from '../..';
 import { IndexPattern } from '../../index_patterns/index_patterns/index_pattern';
 import { IDataView, DataViewSpec } from '../types';
 import { FieldFormatsStartCommon } from '../../field_formats';
@@ -23,6 +23,7 @@ interface DataViewDeps {
  */
 export class DataView extends IndexPattern implements IDataView {
   public savedObjectsClient: SavedObjectsClientCommon;
+  public dataSourceMeta: DataViewSpec['dataSourceMeta'];
 
   constructor({
     spec = {},
@@ -40,6 +41,7 @@ export class DataView extends IndexPattern implements IDataView {
     });
 
     this.savedObjectsClient = savedObjectsClient;
+    this.dataSourceMeta = spec.dataSourceMeta;
   }
 
   public async initializeDataSourceRef(): Promise<void> {

--- a/src/plugins/data/common/data_views/types.ts
+++ b/src/plugins/data/common/data_views/types.ts
@@ -143,6 +143,8 @@ export type DataViewSavedObjectReference = SavedObjectReference;
  */
 export type DataViewSpec = IndexPatternSpec & {
   dataSourceRef?: DataViewSavedObjectReference;
+  // non OpenSearch data-source may have additional meta properties
+  dataSourceMeta?: Record<string, unknown>;
 };
 
 /**

--- a/src/plugins/data/public/antlr/promql/code_completion.test.ts
+++ b/src/plugins/data/public/antlr/promql/code_completion.test.ts
@@ -45,9 +45,11 @@ const mockParseQuery = sharedUtils.parseQuery as jest.Mock;
 
 describe('promql code_completion', () => {
   describe('getSuggestions', () => {
+    const mockDataSourceMeta = { prometheusUrl: 'http://localhost:9090' };
     const mockIndexPattern = {
       id: 'test-datasource-id',
       title: 'test-index',
+      dataSourceMeta: mockDataSourceMeta,
       fields: [
         { name: 'field1', type: 'string' },
         { name: 'field2', type: 'number' },
@@ -193,11 +195,12 @@ describe('promql code_completion', () => {
       );
     });
 
-    it('should call prometheus client with indexPattern.id and timeRange', async () => {
+    it('should call prometheus client with indexPattern.id, dataSourceMeta and timeRange', async () => {
       await getSimpleSuggestions('');
 
       expect(mockPrometheusClient.getMetrics).toHaveBeenCalledWith(
         mockIndexPattern.id,
+        mockDataSourceMeta,
         mockTimeRange
       );
     });

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
@@ -207,6 +207,53 @@ describe('DatasetService', () => {
     );
   });
 
+  test('cacheDataset passes dataSourceMeta when dataSource has meta', async () => {
+    const mockDataset = {
+      id: 'test-dataset',
+      title: 'Test Dataset',
+      type: mockType.id,
+      dataSource: {
+        id: 'ds-1',
+        title: 'Data Source 1',
+        type: 'OpenSearch',
+        version: '1.0',
+        meta: { prometheusUrl: 'http://localhost:9090', customField: 'value' },
+      },
+    } as Dataset;
+    service.registerType(mockType);
+
+    await service.cacheDataset(mockDataset, mockDataPluginServices);
+    expect(indexPatterns.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSourceMeta: { prometheusUrl: 'http://localhost:9090', customField: 'value' },
+      }),
+      true
+    );
+  });
+
+  test('cacheDataset sets dataSourceMeta to undefined when dataSource has no meta', async () => {
+    const mockDataset = {
+      id: 'test-dataset',
+      title: 'Test Dataset',
+      type: mockType.id,
+      dataSource: {
+        id: 'ds-1',
+        title: 'Data Source 1',
+        type: 'OpenSearch',
+        version: '1.0',
+      },
+    } as Dataset;
+    service.registerType(mockType);
+
+    await service.cacheDataset(mockDataset, mockDataPluginServices);
+    expect(indexPatterns.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSourceMeta: undefined,
+      }),
+      true
+    );
+  });
+
   test('saveDataset creates and saves a new dataset without data source', async () => {
     const mockDataset = {
       id: 'test-dataset',

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -125,6 +125,7 @@ export class DatasetService {
                 version: dataset.dataSource.version,
               }
             : undefined,
+          dataSourceMeta: dataset.dataSource ? dataset.dataSource.meta : undefined,
         } as IndexPatternSpec;
 
         if (defaultCache) {

--- a/src/plugins/explore/public/application/utils/query_assist/promql_generator.test.ts
+++ b/src/plugins/explore/public/application/utils/query_assist/promql_generator.test.ts
@@ -75,6 +75,7 @@ describe('generatePromQLWithAgUi', () => {
     question: 'Show CPU usage',
     dataSourceName: 'prometheus-ds',
     dataSourceId: 'ds-123',
+    dataSourceMeta: { prometheusUrl: 'http://localhost:9090' },
   };
 
   describe('successful query generation', () => {

--- a/src/plugins/explore/public/application/utils/query_assist/promql_generator.ts
+++ b/src/plugins/explore/public/application/utils/query_assist/promql_generator.ts
@@ -25,6 +25,7 @@ interface GeneratePromQLOptions {
   question: string;
   dataSourceName: string;
   dataSourceId?: string;
+  dataSourceMeta?: Record<string, unknown>;
 }
 
 interface GeneratePromQLResult {
@@ -63,9 +64,10 @@ export async function generatePromQLWithAgUi({
   question,
   dataSourceName,
   dataSourceId,
+  dataSourceMeta,
 }: GeneratePromQLOptions): Promise<GeneratePromQLResult> {
   const agent = new AgUiAgent();
-  const toolHandlers = new PromQLToolHandlers(data, dataSourceName);
+  const toolHandlers = new PromQLToolHandlers(data, dataSourceName, dataSourceMeta);
 
   let streamingText = '';
   let query: string | undefined;

--- a/src/plugins/explore/public/application/utils/query_assist/promql_tool_handlers.test.ts
+++ b/src/plugins/explore/public/application/utils/query_assist/promql_tool_handlers.test.ts
@@ -18,6 +18,7 @@ describe('PromQLToolHandlers', () => {
   let mockData: DataPublicPluginStart;
   let handlers: PromQLToolHandlers;
   const testDataSourceName = 'test-datasource';
+  const testDataSourceMeta = { prometheusUrl: 'http://localhost:9090' };
   const mockTimeRange = { from: 'now-15m', to: 'now' };
 
   beforeEach(() => {
@@ -42,7 +43,7 @@ describe('PromQLToolHandlers', () => {
       },
     } as unknown) as DataPublicPluginStart;
 
-    handlers = new PromQLToolHandlers(mockData, testDataSourceName);
+    handlers = new PromQLToolHandlers(mockData, testDataSourceName, testDataSourceMeta);
   });
 
   describe('constructor', () => {
@@ -58,9 +59,14 @@ describe('PromQLToolHandlers', () => {
         },
       } as unknown) as DataPublicPluginStart;
 
-      expect(() => new PromQLToolHandlers(mockDataWithoutClient, testDataSourceName)).toThrow(
-        'Prometheus resource client not found'
-      );
+      expect(
+        () => new PromQLToolHandlers(mockDataWithoutClient, testDataSourceName, testDataSourceMeta)
+      ).toThrow('Prometheus resource client not found');
+    });
+
+    it('should accept optional dataSourceMeta parameter', () => {
+      const handlersWithoutMeta = new PromQLToolHandlers(mockData, testDataSourceName);
+      expect(handlersWithoutMeta).toBeDefined();
     });
   });
 
@@ -415,6 +421,7 @@ describe('PromQLToolHandlers', () => {
       expect(mockPrometheusClient.getSeries).toHaveBeenCalledWith(
         testDataSourceName,
         '{__name__=~"metric1|metric2"}',
+        testDataSourceMeta,
         mockTimeRange
       );
     });
@@ -430,6 +437,7 @@ describe('PromQLToolHandlers', () => {
       expect(mockPrometheusClient.getSeries).toHaveBeenCalledWith(
         testDataSourceName,
         '{__name__=~"metric\\.name|metric\\+plus"}',
+        testDataSourceMeta,
         mockTimeRange
       );
     });
@@ -449,12 +457,14 @@ describe('PromQLToolHandlers', () => {
       expect(mockPrometheusClient.getSeries).toHaveBeenCalledWith(
         testDataSourceName,
         '{__name__=~"metric_0|metric_1|metric_2|metric_3|metric_4|metric_5|metric_6|metric_7|metric_8|metric_9"}',
+        testDataSourceMeta,
         mockTimeRange
       );
       // Second batch: metrics 10-14
       expect(mockPrometheusClient.getSeries).toHaveBeenCalledWith(
         testDataSourceName,
         '{__name__=~"metric_10|metric_11|metric_12|metric_13|metric_14"}',
+        testDataSourceMeta,
         mockTimeRange
       );
     });

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_editor/on_editor_run/call_agent/call_agent.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_editor/on_editor_run/call_agent/call_agent.ts
@@ -66,6 +66,7 @@ export const callAgentActionCreator = createAsyncThunk<
         question: editorText,
         dataSourceName: dataset.title,
         dataSourceId: dataset.dataSource?.id,
+        dataSourceMeta: dataset.dataSource?.meta as Record<string, unknown>,
       });
       dispatch(runQueryActionCreator(services, result.query));
       dispatch(setLastExecutedTranslatedQuery(result.query));

--- a/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
@@ -5,7 +5,6 @@
 
 import {
   CORE_SIGNAL_TYPES,
-  DATA_STRUCTURE_META_TYPES,
   DataStructure,
   DataStructureCustomMeta,
   Dataset,
@@ -33,13 +32,9 @@ export const prometheusTypeConfig: DatasetTypeConfig = {
       language: 'PROMQL',
       timeFieldName: patternMeta?.timeFieldName || 'Time',
       signalType: CORE_SIGNAL_TYPES.METRICS,
-      dataSource: connection.parent
-        ? {
-            id: connection.parent.id,
-            title: connection.parent.title,
-            type: connection.parent.type,
-          }
-        : undefined,
+      dataSource: {
+        meta: connection.meta,
+      },
     } as Dataset;
   },
 
@@ -85,12 +80,6 @@ const fetchConnections = async (services: IDataPluginServices): Promise<DataStru
           id: so.attributes.connectionId,
           title: so.attributes.connectionId,
           type: DATASET.PROMETHEUS,
-          meta: {
-            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
-            language: 'promql',
-            timeFieldName: 'Time',
-            dataSourceId: so.references.find((ref) => ref.type === 'data-source')?.id,
-          },
         }))
     );
   } catch (error) {

--- a/src/plugins/query_enhancements/public/resources/prometheus_resource_client.test.ts
+++ b/src/plugins/query_enhancements/public/resources/prometheus_resource_client.test.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpSetup } from 'opensearch-dashboards/public';
+import dateMath from '@elastic/datemath';
+import { PrometheusResourceClient } from './prometheus_resource_client';
+import { RESOURCE_TYPES } from '../../common/constants';
+
+describe('PrometheusResourceClient', () => {
+  let mockHttp: jest.Mocked<HttpSetup>;
+  let client: PrometheusResourceClient;
+
+  const testDataConnectionId = 'test-connection';
+  const testMeta = { prometheusUrl: 'http://localhost:9090', customField: 'value' };
+
+  // Fixed timestamps for testing
+  const mockFromTime = 1609459200;
+  const mockToTime = 1609460100;
+  const testTimeRange = { from: 'now-15m', to: 'now' };
+
+  beforeEach(() => {
+    mockHttp = ({
+      post: jest.fn().mockResolvedValue({ data: [] }),
+    } as unknown) as jest.Mocked<HttpSetup>;
+
+    client = new PrometheusResourceClient(mockHttp);
+
+    // Mock dateMath.parse
+    jest.spyOn(dateMath, 'parse').mockImplementation((value: string) => {
+      if (value === 'now-15m') {
+        return { unix: () => mockFromTime } as any;
+      }
+      if (value === 'now') {
+        return { unix: () => mockToTime } as any;
+      }
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('getMetrics', () => {
+    it('should call the correct endpoint with meta and time range', async () => {
+      await client.getMetrics(testDataConnectionId, testMeta, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.METRICS,
+            name: undefined,
+          },
+          content: {
+            ...testMeta,
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+
+    it('should pass only meta when no time range provided', async () => {
+      await client.getMetrics(testDataConnectionId, testMeta);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.METRICS,
+            name: undefined,
+          },
+          content: testMeta,
+        }),
+      });
+    });
+
+    it('should work without meta and time range', async () => {
+      await client.getMetrics(testDataConnectionId);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.METRICS,
+            name: undefined,
+          },
+        }),
+      });
+    });
+  });
+
+  describe('getLabels', () => {
+    it('should call the correct endpoint with meta, metric and time range', async () => {
+      const metric = 'http_requests_total';
+      await client.getLabels(testDataConnectionId, testMeta, metric, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.LABELS,
+            name: metric,
+          },
+          content: {
+            ...testMeta,
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+
+    it('should call without metric when not provided', async () => {
+      await client.getLabels(testDataConnectionId, testMeta, undefined, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.LABELS,
+            name: undefined,
+          },
+          content: {
+            ...testMeta,
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+  });
+
+  describe('getLabelValues', () => {
+    it('should call the correct endpoint with meta, label and time range', async () => {
+      const label = 'job';
+      await client.getLabelValues(testDataConnectionId, testMeta, label, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.LABEL_VALUES,
+            name: label,
+          },
+          content: {
+            ...testMeta,
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+  });
+
+  describe('getMetricMetadata', () => {
+    it('should call the correct endpoint with meta, metric and time range', async () => {
+      const metric = 'http_requests_total';
+      await client.getMetricMetadata(testDataConnectionId, testMeta, metric, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.METRIC_METADATA,
+            name: metric,
+          },
+          content: {
+            ...testMeta,
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+  });
+
+  describe('getSeries', () => {
+    it('should call the correct endpoint with match, meta and time range', async () => {
+      const match = '{__name__=~"metric1|metric2"}';
+      await client.getSeries(testDataConnectionId, match, testMeta, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.SERIES,
+            name: match,
+          },
+          content: {
+            ...testMeta,
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+
+    it('should call without meta when not provided', async () => {
+      const match = '{__name__="metric1"}';
+      await client.getSeries(testDataConnectionId, match, undefined, testTimeRange);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/enhancements/resources', {
+        body: JSON.stringify({
+          connection: {
+            id: testDataConnectionId,
+            type: 'prometheus',
+          },
+          resource: {
+            type: RESOURCE_TYPES.PROMETHEUS.SERIES,
+            name: match,
+          },
+          content: {
+            start: mockFromTime,
+            end: mockToTime,
+          },
+        }),
+      });
+    });
+  });
+
+  describe('toContent behavior', () => {
+    it('should merge meta with time range when both provided', async () => {
+      await client.getMetrics(testDataConnectionId, testMeta, testTimeRange);
+
+      const callBody = JSON.parse((mockHttp.post as jest.Mock).mock.calls[0][1].body);
+      expect(callBody.content).toEqual({
+        ...testMeta,
+        start: mockFromTime,
+        end: mockToTime,
+      });
+    });
+
+    it('should return only meta when time range parsing fails', async () => {
+      jest.spyOn(dateMath, 'parse').mockReturnValue(null);
+
+      await client.getMetrics(testDataConnectionId, testMeta, testTimeRange);
+
+      const callBody = JSON.parse((mockHttp.post as jest.Mock).mock.calls[0][1].body);
+      expect(callBody.content).toEqual(testMeta);
+    });
+
+    it('should return meta when no time range provided', async () => {
+      await client.getMetrics(testDataConnectionId, testMeta, undefined);
+
+      const callBody = JSON.parse((mockHttp.post as jest.Mock).mock.calls[0][1].body);
+      expect(callBody.content).toEqual(testMeta);
+    });
+
+    it('should return undefined when neither meta nor time range provided', async () => {
+      await client.getMetrics(testDataConnectionId);
+
+      const callBody = JSON.parse((mockHttp.post as jest.Mock).mock.calls[0][1].body);
+      expect(callBody.content).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/query_enhancements/public/resources/prometheus_resource_client.ts
+++ b/src/plugins/query_enhancements/public/resources/prometheus_resource_client.ts
@@ -27,55 +27,74 @@ export class PrometheusResourceClient extends BaseResourceClient {
   /**
    * Converts a TimeRange to content object with Unix timestamps for Prometheus API
    */
-  private toContent(timeRange?: TimeRange): Record<string, unknown> | undefined {
-    if (!timeRange) return undefined;
+  private toContent(
+    meta?: Record<string, unknown>,
+    timeRange?: TimeRange
+  ): Record<string, unknown> | undefined {
+    if (!timeRange) return meta;
 
     const parsedFrom = dateMath.parse(timeRange.from);
     const parsedTo = dateMath.parse(timeRange.to, { roundUp: true });
 
     if (!parsedFrom || !parsedTo) {
-      return undefined;
+      return meta;
     }
 
     return {
+      ...meta,
       start: parsedFrom.unix(),
       end: parsedTo.unix(),
     };
   }
 
-  getLabels(dataConnectionId: string, metric?: string, timeRange?: TimeRange) {
+  getLabels(
+    dataConnectionId: string,
+    meta?: Record<string, unknown>,
+    metric?: string,
+    timeRange?: TimeRange
+  ) {
     return this.get<string[]>(
       dataConnectionId,
       RESOURCE_TYPES.PROMETHEUS.LABELS,
       metric,
-      this.toContent(timeRange)
+      this.toContent(meta, timeRange)
     );
   }
 
-  getLabelValues(dataConnectionId: string, label: string, timeRange?: TimeRange) {
+  getLabelValues(
+    dataConnectionId: string,
+    meta?: Record<string, unknown>,
+    label?: string,
+    timeRange?: TimeRange
+  ) {
     return this.get<string[]>(
       dataConnectionId,
       RESOURCE_TYPES.PROMETHEUS.LABEL_VALUES,
       label,
-      this.toContent(timeRange)
+      this.toContent(meta, timeRange)
     );
   }
 
-  getMetrics(dataConnectionId: string, timeRange?: TimeRange) {
+  getMetrics(dataConnectionId: string, meta?: Record<string, unknown>, timeRange?: TimeRange) {
     return this.get<string[]>(
       dataConnectionId,
       RESOURCE_TYPES.PROMETHEUS.METRICS,
       undefined,
-      this.toContent(timeRange)
+      this.toContent(meta, timeRange)
     );
   }
 
-  getMetricMetadata(dataConnectionId: string, metric?: string, timeRange?: TimeRange) {
+  getMetricMetadata(
+    dataConnectionId: string,
+    meta?: Record<string, unknown>,
+    metric?: string,
+    timeRange?: TimeRange
+  ) {
     return this.get<PrometheusMetricMetadata>(
       dataConnectionId,
       RESOURCE_TYPES.PROMETHEUS.METRIC_METADATA,
       metric,
-      this.toContent(timeRange)
+      this.toContent(meta, timeRange)
     );
   }
 
@@ -89,13 +108,14 @@ export class PrometheusResourceClient extends BaseResourceClient {
   getSeries(
     dataConnectionId: string,
     match: string,
+    meta?: Record<string, unknown>,
     timeRange?: TimeRange
   ): Promise<Array<Record<string, string>>> {
     return this.get<Array<Record<string, string>>>(
       dataConnectionId,
       RESOURCE_TYPES.PROMETHEUS.SERIES,
       match,
-      this.toContent(timeRange)
+      this.toContent(meta, timeRange)
     );
   }
 }


### PR DESCRIPTION
### Description

Support data-connection metadata and pass them in Prometheus calls. This PR adds a `dataSourceMeta` field in `DataView`. DataView extends index-pattern, and it can hold not just index-pattern but also data-connections. It currently does not do anything, but in the future we may have data-connection specific metadata that we want to send as part of the query or resource request.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

UT

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
