### PR TITLE
CSP Report-Only Policy: Adding blob: to worker-src Directive

### DIFF
--- a/src/core/server/csp_report_only/config.ts
+++ b/src/core/server/csp_report_only/config.ts
@@ -24,7 +24,7 @@ export const config = {
         `style-src-elem 'self'`,
         `style-src-attr 'self' 'unsafe-inline'`,
         `child-src 'none'`,
-        `worker-src 'self'`,
+        `worker-src blob: 'self'`,
         `frame-src 'none'`,
         `object-src 'none'`,
         `manifest-src 'self'`,

--- a/src/core/server/csp_report_only/csp_report_only_config.test.ts
+++ b/src/core/server/csp_report_only/csp_report_only_config.test.ts
@@ -23,7 +23,7 @@ describe('CspReportOnlyConfig', () => {
     test('DEFAULT', () => {
       expect(CspReportOnlyConfig.DEFAULT).toMatchInlineSnapshot(`
         CspReportOnlyConfig {
-          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
+          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
           "endpoint": undefined,
           "endpointName": "csp-endpoint",
           "isEmitting": false,
@@ -39,7 +39,7 @@ describe('CspReportOnlyConfig', () => {
             "style-src-elem 'self'",
             "style-src-attr 'self' 'unsafe-inline'",
             "child-src 'none'",
-            "worker-src 'self'",
+            "worker-src blob: 'self'",
             "frame-src 'none'",
             "object-src 'none'",
             "manifest-src 'self'",
@@ -58,7 +58,7 @@ describe('CspReportOnlyConfig', () => {
     test('defaults from config', () => {
       expect(new CspReportOnlyConfig()).toMatchInlineSnapshot(`
         CspReportOnlyConfig {
-          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
+          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
           "endpoint": undefined,
           "endpointName": "csp-endpoint",
           "isEmitting": false,
@@ -74,7 +74,7 @@ describe('CspReportOnlyConfig', () => {
             "style-src-elem 'self'",
             "style-src-attr 'self' 'unsafe-inline'",
             "child-src 'none'",
-            "worker-src 'self'",
+            "worker-src blob: 'self'",
             "frame-src 'none'",
             "object-src 'none'",
             "manifest-src 'self'",
@@ -93,7 +93,7 @@ describe('CspReportOnlyConfig', () => {
     test('creates from partial config', () => {
       expect(new CspReportOnlyConfig({ isEmitting: true })).toMatchInlineSnapshot(`
         CspReportOnlyConfig {
-          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
+          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
           "endpoint": undefined,
           "endpointName": "csp-endpoint",
           "isEmitting": true,
@@ -109,7 +109,7 @@ describe('CspReportOnlyConfig', () => {
             "style-src-elem 'self'",
             "style-src-attr 'self' 'unsafe-inline'",
             "child-src 'none'",
-            "worker-src 'self'",
+            "worker-src blob: 'self'",
             "frame-src 'none'",
             "object-src 'none'",
             "manifest-src 'self'",
@@ -159,7 +159,7 @@ describe('CspReportOnlyConfig', () => {
 
       expect(config).toMatchInlineSnapshot(`
         CspReportOnlyConfig {
-          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'; report-uri https://opensearch.org/csp-endpoints; report-to csp-endpoint;",
+          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'; report-uri https://opensearch.org/csp-endpoints; report-to csp-endpoint;",
           "endpoint": "https://opensearch.org/csp-endpoints",
           "endpointName": "csp-endpoint",
           "isEmitting": true,
@@ -175,7 +175,7 @@ describe('CspReportOnlyConfig', () => {
             "style-src-elem 'self'",
             "style-src-attr 'self' 'unsafe-inline'",
             "child-src 'none'",
-            "worker-src 'self'",
+            "worker-src blob: 'self'",
             "frame-src 'none'",
             "object-src 'none'",
             "manifest-src 'self'",
@@ -247,7 +247,7 @@ describe('CspReportOnlyConfig', () => {
 
       expect(config).toMatchInlineSnapshot(`
         CspReportOnlyConfig {
-          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'; report-uri https://opensearch.org/csp-endpoints;",
+          "cspReportOnlyHeader": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'; report-uri https://opensearch.org/csp-endpoints;",
           "endpoint": "https://opensearch.org/csp-endpoints",
           "endpointName": "csp-endpoint",
           "isEmitting": true,
@@ -263,7 +263,7 @@ describe('CspReportOnlyConfig', () => {
             "style-src-elem 'self'",
             "style-src-attr 'self' 'unsafe-inline'",
             "child-src 'none'",
-            "worker-src 'self'",
+            "worker-src blob: 'self'",
             "frame-src 'none'",
             "object-src 'none'",
             "manifest-src 'self'",


### PR DESCRIPTION
### Description

OpenSearch Dashboards uses Content Security Policy (CSP) headers to protect against cross-site scripting (XSS) and other code injection attacks. This has two CSP configurations:
1. Enforced CSP [config.ts] -> Actively blocks policy violations
2. Report-Only CSP [config.ts] -> Logs violations without blocking, used for testing stricter policies

The browser console was logging CSP violations:

This warning appeared because:
* The application legitimately creates Web Workers from blob URLs (used by ace editor, syntax highlighters, etc.)
* The enforced CSP already allowed this: worker-src blob: 'self'
* The report-only CSP was stricter: worker-src 'self' (missing blob:)

Updated the report-only CSP to match the enforced CSP by adding `blob`: to the worker-src directive

With worker-src blob: 'self', workers are allowed from:
* Same origin (e.g., /workers/syntax.js)
* Blob URLs (e.g., blob:http://localhost:5601/abc123)
Any other source would be blocked (enforced CSP) or logged (report-only CSP).

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes
 - feat: adding blog to worker src in CSP policies

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
