### PR TITLE
Fix Discover embed mode layout height calculation

### DIFF
--- a/src/plugins/data_explorer/public/components/app_container.scss
+++ b/src/plugins/data_explorer/public/components/app_container.scss
@@ -17,6 +17,10 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
     height: calc(100vh - #{$osdHeaderOffset * 2});
   }
 
+  &--embed {
+    height: 100vh;
+  }
+
   &__canvas {
     height: 100%;
   }

--- a/src/plugins/data_explorer/public/components/app_container.test.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.test.tsx
@@ -43,4 +43,21 @@ describe('DataExplorerApp', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('should render with deLayout--embed class when in embed mode', () => {
+    const view = createView();
+    const embedParams = {
+      ...params,
+      history: {
+        ...params.history,
+        location: {
+          ...params.history.location,
+          search: '?embed=true',
+        },
+      },
+    };
+    const { container } = render(<AppContainer view={view} params={embedParams as any} />);
+
+    expect(container.querySelector('.deLayout--embed')).toBeInTheDocument();
+  });
 });

--- a/src/plugins/data_explorer/public/components/app_container.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.tsx
@@ -28,6 +28,7 @@ import { DISCOVER_LOAD_EVENT, NEW_DISCOVER_LOAD_EVENT, trackUiMetric } from '../
 export const AppContainer = React.memo(
   ({ view, params }: { view?: View; params: AppMountParameters }) => {
     const isMobile = useIsWithinBreakpoints(['xs', 's', 'm']);
+    const isEmbedded = new URLSearchParams(params.history.location.search).has('embed');
 
     const opensearchDashboards = useOpenSearchDashboards<IDataPluginServices>();
     const { uiSettings } = opensearchDashboards.services;
@@ -82,7 +83,8 @@ export const AppContainer = React.memo(
         <EuiPage
           className={classNames(
             'deLayout',
-            isEnhancementsEnabled && !showActionsInGroup ? 'dsc--next' : undefined
+            isEnhancementsEnabled && !showActionsInGroup ? 'dsc--next' : undefined,
+            isEmbedded ? 'deLayout--embed' : undefined
           )}
           paddingSize="none"
           grow={false}


### PR DESCRIPTION
Addresses #11091

## Problem
In embed mode (`?embed`), the Discover panel's main container (`.euiPage.deLayout`) incorrectly calculates its height by subtracting header offsets that don't exist in the embedded context, resulting in a large empty space at the bottom of the page.

## Solution
Detect embed mode and apply a dedicated CSS class that uses full viewport height without header compensation.

## Changes
```diff
+ const isEmbedded = new URLSearchParams(params.history.location.search).has('embed');

  className={classNames(
    'deLayout',
    isEnhancementsEnabled && !showActionsInGroup ? 'dsc--next' : undefined,
+   isEmbedded ? 'deLayout--embed' : undefined
  )}
```

```scss
+ &--embed {
+   height: 100vh;
+ }
```

## Testing
- Navigate to `/app/data-explorer/discover#?embed`
- Verify no empty space at bottom
- Verify content fills viewport correctly
- Test with different screen sizes

## Impact
- Embedded Discover views now use full viewport height
- No impact on standard (non-embedded) UI
- Fixes layout issue reported in #11091