### PR TITLE
Fix duplicate focus_query_bar shortcut ID

### DIFF
--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -123,7 +123,7 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   }, [queryLanguage]);
 
   keyboardShortcut?.useKeyboardShortcut({
-    id: 'focus_query_bar',
+    id: 'focus_explore_query_bar',
     pluginId: 'explore',
     name: i18n.translate('explore.queryPanelEditor.focusQueryBarShortcut', {
       defaultMessage: 'Focus query bar',


### PR DESCRIPTION
Addresses #11070

## Problem
When `explore.enabled: true` is set, both the `data` and `explore` plugins attempt to register a keyboard shortcut with the same ID (`focus_query_bar`), causing an error screen when creating visualizations with filters.

## Root Cause
- `src/plugins/data/public/ui/query_string_input/query_string_input.tsx` registers `focus_query_bar`
- `src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts` also registers `focus_query_bar`

## Solution
Rename the explore plugin's shortcut ID to `focus_explore_query_bar` to avoid collision.

## Changes
```diff
keyboardShortcut?.useKeyboardShortcut({
-   id: 'focus_query_bar',
+   id: 'focus_explore_query_bar',
    pluginId: 'explore',
```

## Testing
1. Set `explore.enabled: true` in config
2. Go to Visualize and create Data Table
3. Add Filter in Bucket
4. Verify no error occurs
5. Test that '/' shortcut still focuses query bar

## Impact
- No functional change - shortcut still works the same
- Fixes error when using explore plugin
- No breaking changes