### PR TITLE
Skip fetch_size when PPL query ends with explicit head command

### DIFF
--- a/src/plugins/query_enhancements/common/utils.test.ts
+++ b/src/plugins/query_enhancements/common/utils.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isPPLSearchQuery, throwFacetError, formatDate } from './utils';
+import { isPPLSearchQuery, queryEndsWithHead, throwFacetError, formatDate } from './utils';
 import { Query } from 'src/plugins/data/common';
 
 describe('throwFacetError', () => {
@@ -166,6 +166,91 @@ describe('formatDate', () => {
     const dateString = '2025-12-31T23:59:59.999Z';
     const result = formatDate(dateString);
     expect(result).toBe('2025-12-31 23:59:59.999');
+  });
+});
+
+describe('queryEndsWithHead', () => {
+  it('should detect head at end of query', () => {
+    expect(queryEndsWithHead('source=t | head 100')).toBe(true);
+  });
+
+  it('should return false when head is followed by other commands', () => {
+    expect(queryEndsWithHead('source=t | head 100 | fields age')).toBe(false);
+    expect(queryEndsWithHead('source=t | head 100 | sort name ASC')).toBe(false);
+  });
+
+  it('should detect head at end after other commands', () => {
+    expect(queryEndsWithHead('source=t | where age > 20 | head 200')).toBe(true);
+  });
+
+  it('should return false when no head is present', () => {
+    expect(queryEndsWithHead('source=t | fields age')).toBe(false);
+  });
+
+  it('should allow trailing where clause (time-range filter)', () => {
+    expect(
+      queryEndsWithHead(
+        "source=t | head 800 | where timestamp >= '2024-01-01' and timestamp <= '2024-12-31'"
+      )
+    ).toBe(true);
+  });
+
+  it('should return false when head is followed by non-where commands then where', () => {
+    expect(
+      queryEndsWithHead("source=t | head 800 | sort name ASC | where timestamp >= '2024-01-01'")
+    ).toBe(false);
+  });
+
+  it('should return false when head is only inside a subquery', () => {
+    expect(queryEndsWithHead('source=t | where id in [source=other | head 10] | fields age')).toBe(
+      false
+    );
+  });
+
+  it('should return false for join query with head only in subquery', () => {
+    expect(
+      queryEndsWithHead(
+        'source=state_country | inner join left=a, right=b ON a.name = b.name' +
+          ' [source=state_country | sort name | head 3] | sort a.name | fields a.name, a.age'
+      )
+    ).toBe(false);
+  });
+
+  it('should detect head at end of join query', () => {
+    expect(
+      queryEndsWithHead(
+        'source=state_country | inner join left=a, right=b ON a.name = b.name' +
+          ' [source=state_country | sort name | head 3] | sort a.name | head 100'
+      )
+    ).toBe(true);
+  });
+
+  it('should be case insensitive', () => {
+    expect(queryEndsWithHead('source=t | HEAD 100')).toBe(true);
+    expect(queryEndsWithHead('source=t | Head 50')).toBe(true);
+  });
+
+  it('should detect head without a number (PPL defaults to 10)', () => {
+    expect(queryEndsWithHead('source=t | head')).toBe(true);
+  });
+
+  it('should not match field names containing head', () => {
+    expect(queryEndsWithHead('source=t | fields header, headline')).toBe(false);
+  });
+
+  it('should detect head with extra whitespace', () => {
+    expect(queryEndsWithHead('source=t |   head   100')).toBe(true);
+  });
+
+  it('should detect head with from offset syntax', () => {
+    expect(queryEndsWithHead('source=t | head 1 from 1')).toBe(true);
+    expect(queryEndsWithHead('source=t | head 600 from 100')).toBe(true);
+  });
+
+  it('should detect head with from offset and trailing where', () => {
+    expect(queryEndsWithHead("source=t | head 100 from 50 | where timestamp >= '2024-01-01'")).toBe(
+      true
+    );
   });
 });
 

--- a/src/plugins/query_enhancements/common/utils.ts
+++ b/src/plugins/query_enhancements/common/utils.ts
@@ -141,6 +141,16 @@ export const buildQueryStatusConfig = (response: any) => {
 };
 
 /**
+ * Detects whether a PPL query ends with a `head` command in the main query,
+ * ignoring any trailing `| where ...` clauses (appended time-range filters)
+ * and any `head` commands inside subquery brackets [...].
+ */
+export const queryEndsWithHead = (queryString: string): boolean => {
+  const masked = queryString.replace(/\[.*?\]/g, (match) => '\0'.repeat(match.length));
+  return /\|\s*head\b(\s+\d+)?(\s+from\s+\d+)?\s*(\|\s*where\b.*)?\s*$/i.test(masked);
+};
+
+/**
  * Test if a PPL query is using search command
  * https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/cmd/search.md
  */

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.test.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.test.ts
@@ -172,6 +172,114 @@ describe('pplSearchStrategyProvider', () => {
     expect(usage.trackError).toHaveBeenCalled();
   });
 
+  it('should not send fetchSize when query ends with head', async () => {
+    const mockResponse = {
+      success: true,
+      data: {
+        schema: [{ name: 'field1', type: 'long' }],
+        datarows: [[1]],
+      },
+      took: 100,
+    };
+    const mockDescribeQuery = jest.fn().mockResolvedValue(mockResponse);
+    const mockFacet = ({
+      describeQuery: mockDescribeQuery,
+    } as unknown) as facet.Facet;
+    jest.spyOn(facet, 'Facet').mockImplementation(() => mockFacet);
+    (utils.getFields as jest.Mock).mockReturnValue([{ name: 'field1', type: 'long' }]);
+
+    const strategy = pplSearchStrategyProvider(config$, logger, client, usage);
+    await strategy.search(
+      mockRequestHandlerContext,
+      ({
+        body: { query: { query: 'source = table | head 600', dataset: { id: 'test-dataset' } } },
+      } as unknown) as IOpenSearchDashboardsSearchRequest<unknown>,
+      {}
+    );
+
+    expect(mockRequestHandlerContext.core.uiSettings.client.get).not.toHaveBeenCalled();
+    const requestArg = mockDescribeQuery.mock.calls[0][1];
+    expect(requestArg.body.fetchSize).toBeUndefined();
+  });
+
+  it('should send fetchSize when head is followed by other commands', async () => {
+    (mockRequestHandlerContext.core.uiSettings.client.get as jest.Mock).mockResolvedValue(500);
+    const mockResponse = {
+      success: true,
+      data: {
+        schema: [{ name: 'field1', type: 'long' }],
+        datarows: [[1]],
+      },
+      took: 100,
+    };
+    const mockDescribeQuery = jest.fn().mockResolvedValue(mockResponse);
+    const mockFacet = ({
+      describeQuery: mockDescribeQuery,
+    } as unknown) as facet.Facet;
+    jest.spyOn(facet, 'Facet').mockImplementation(() => mockFacet);
+    (utils.getFields as jest.Mock).mockReturnValue([{ name: 'field1', type: 'long' }]);
+
+    const strategy = pplSearchStrategyProvider(config$, logger, client, usage);
+    await strategy.search(
+      mockRequestHandlerContext,
+      ({
+        body: {
+          query: {
+            query: 'source = table | head 600 | sort name ASC',
+            dataset: { id: 'test-dataset' },
+          },
+        },
+      } as unknown) as IOpenSearchDashboardsSearchRequest<unknown>,
+      {}
+    );
+
+    expect(mockRequestHandlerContext.core.uiSettings.client.get).toHaveBeenCalledWith(
+      'discover:sampleSize'
+    );
+    const requestArg = mockDescribeQuery.mock.calls[0][1];
+    expect(requestArg.body.fetchSize).toBe(500);
+  });
+
+  it('should send fetchSize when head is only inside a subquery', async () => {
+    (mockRequestHandlerContext.core.uiSettings.client.get as jest.Mock).mockResolvedValue(500);
+    const mockResponse = {
+      success: true,
+      data: {
+        schema: [{ name: 'field1', type: 'long' }],
+        datarows: [[1]],
+      },
+      took: 100,
+    };
+    const mockDescribeQuery = jest.fn().mockResolvedValue(mockResponse);
+    const mockFacet = ({
+      describeQuery: mockDescribeQuery,
+    } as unknown) as facet.Facet;
+    jest.spyOn(facet, 'Facet').mockImplementation(() => mockFacet);
+    (utils.getFields as jest.Mock).mockReturnValue([{ name: 'field1', type: 'long' }]);
+
+    const strategy = pplSearchStrategyProvider(config$, logger, client, usage);
+    await strategy.search(
+      mockRequestHandlerContext,
+      ({
+        body: {
+          query: {
+            query:
+              'source=state_country | inner join left=a, right=b ON a.name = b.name' +
+              ' [source=state_country | sort name | head 3] | sort a.name | fields a.name, a.age',
+            dataset: { id: 'test-dataset' },
+          },
+        },
+      } as unknown) as IOpenSearchDashboardsSearchRequest<unknown>,
+      {}
+    );
+
+    expect(mockRequestHandlerContext.core.uiSettings.client.get).toHaveBeenCalledWith(
+      'discover:sampleSize'
+    );
+    const requestArg = mockDescribeQuery.mock.calls[0][1];
+    expect(requestArg.body.fetchSize).toBe(500);
+  });
+
   it('should read fetchSize from discover:sampleSize UI setting', async () => {
     (mockRequestHandlerContext.core.uiSettings.client.get as jest.Mock).mockResolvedValue(200);
     const mockResponse = {

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
@@ -14,7 +14,7 @@ import {
   Query,
   createDataFrame,
 } from '../../../data/common';
-import { getFields, throwFacetError } from '../../common/utils';
+import { getFields, queryEndsWithHead, throwFacetError } from '../../common/utils';
 import { Facet } from '../utils';
 import { QueryAggConfig } from '../../common';
 
@@ -41,8 +41,11 @@ export const pplSearchStrategyProvider = (
         const query: Query = request.body.query;
         const aggConfig: QueryAggConfig | undefined = request.body.aggConfig;
 
-        const fetchSize = await context.core.uiSettings.client.get<number>(SAMPLE_SIZE_SETTING);
-        request.body = { ...request.body, fetchSize };
+        const hasHead = typeof query.query === 'string' && queryEndsWithHead(query.query);
+        if (!hasHead) {
+          const fetchSize = await context.core.uiSettings.client.get<number>(SAMPLE_SIZE_SETTING);
+          request.body = { ...request.body, fetchSize };
+        }
 
         const rawResponse: any = await pplFacet.describeQuery(context, request);
 


### PR DESCRIPTION
### Description

When a PPL query ends with an explicit `head` command (e.g. `source=t | head 600`), OSD unconditionally injects `fetch_size` (from `discover:sampleSize`, default 500) into the API request. Because the SQL plugin honors the smaller of `fetch_size` and `head`, a query like `| head 600` with `fetch_size=500` silently returns only 500 rows — the user has no way to retrieve the remaining 100.

This PR detects when `head` is the **last command** in the user's query and skips injecting `fetch_size`, letting the user's explicit `head` value be the sole row limiter. Queries without a trailing `head` continue to send `fetch_size` as before.

Key behaviors:
- `source=t | head 800` — skips `fetch_size` (head is the final command)
- `source=t | head 800 | where ts >= ...` — skips `fetch_size` (trailing `where` is an OSD-appended time filter)
- `source=t | head 800 | sort name ASC` — sends `fetch_size` as normal (head is not the final command)
- Join subqueries like `[source=t | head 3]` are masked and do not trigger detection
<img width="2272" height="466" alt="Screenshot 2026-03-03 at 2 52 58 PM" src="https://github.com/user-attachments/assets/7baa574c-1d30-48e3-a3ec-58bac871142e" />
<img width="2281" height="543" alt="Screenshot 2026-03-03 at 2 53 04 PM" src="https://github.com/user-attachments/assets/389c6a2e-4b8a-4c2f-9067-86556049b9e5" />


### Issues Resolved

Fixes https://github.com/opensearch-project/sql/issues/5191 (Bug 2)

## Testing the changes

1. Start OSD with default `discover:sampleSize = 500`
2. Run `source=<index> | head 600` — should return 600 rows (previously capped at 500)
3. Run `source=<index> | head 600 | sort name ASC` — should still send `fetch_size` and return 500 rows
4. Run `source=<index> | fields host` — should still send `fetch_size=500` and return 500 rows
5. Run a join query with `head` only in the subquery — should still send `fetch_size`
6. Run queries with field names like `header`, `headline` — no false positives

## Changelog

- skip

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff