### PR TITLE
Remove zero-width space from field name text

### DIFF
--- a/src/plugins/agent_traces/public/components/fields_selector/discover_field.tsx
+++ b/src/plugins/agent_traces/public/components/fields_selector/discover_field.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   EuiPopover,
   EuiPopoverTitle,
@@ -40,7 +40,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { DiscoverFieldDetails } from './discover_field_details';
-import { FieldIcon } from '../../../../opensearch_dashboards_react/public';
+import { FieldIcon, wrapOnDot } from '../../../../opensearch_dashboards_react/public';
 import { FieldDetails } from './types';
 import { DataViewField, DataView } from '../../../../data/public';
 import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
@@ -111,17 +111,16 @@ export const DiscoverField = ({
 
   const [infoIsOpen, setOpen] = useState(false);
 
-  function wrapOnDot(str?: string) {
-    // u200B is a non-width white-space character, which allows
-    // the browser to efficiently word-wrap right after the dot
-    // without us having to draw a lot of extra DOM elements, etc
-    return str ? str.replace(/\./g, '.\u200B') : '';
-  }
+  const wrappedName = useMemo(
+    () =>
+      useShortDots ? wrapOnDot(shortenDottedString(field.name)) : wrapOnDot(field.displayName),
+    [field.name, field.displayName, useShortDots]
+  );
 
   const fieldName = (
     <EuiToolTip delay="long" content={field.name}>
       <span data-test-subj={`field-${field.name}`} className="agentTracesSidebarField__name">
-        {useShortDots ? wrapOnDot(shortenDottedString(field.name)) : wrapOnDot(field.displayName)}
+        {wrappedName}
       </span>
     </EuiToolTip>
   );

--- a/src/plugins/agent_traces/public/components/fields_selector/facet_value.tsx
+++ b/src/plugins/agent_traces/public/components/fields_selector/facet_value.tsx
@@ -3,21 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiToolTip, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { Bucket } from './types';
 import { DataViewField } from '../../../../data/public';
 import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
+import { wrapOnDot } from '../../../../opensearch_dashboards_react/public';
 import './discover_field.scss';
 import './facet_value.scss';
-
-function wrapOnDot(str?: string) {
-  // u200B is a non-width white-space character, which allows
-  // the browser to efficiently word-wrap right after the dot
-  // without us having to draw a lot of extra DOM elements, etc
-  return str ? str.replace(/\./g, '.\u200B') : '';
-}
 
 export interface FacetValueProps {
   /**
@@ -55,13 +49,19 @@ export const FacetValue = ({ field, bucket, onAddFilter, useShortDots }: FacetVa
     }
   );
 
+  const wrappedDisplay = useMemo(
+    () =>
+      useShortDots ? wrapOnDot(shortenDottedString(bucket.display)) : wrapOnDot(bucket.display),
+    [bucket.display, useShortDots]
+  );
+
   const displayValue = (
     <EuiToolTip delay="long" content={bucket.display}>
       <span
         data-test-subj={`field-${bucket.display}`}
         className="agentTracesSidebarField__name eui-textBreakWord"
       >
-        {useShortDots ? wrapOnDot(shortenDottedString(bucket.display)) : wrapOnDot(bucket.display)}
+        {wrappedDisplay}
       </span>
     </EuiToolTip>
   );

--- a/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   EuiPopover,
   EuiPopoverTitle,
@@ -40,7 +40,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { DiscoverFieldDetails } from './discover_field_details';
-import { FieldIcon } from '../../../../../opensearch_dashboards_react/public';
+import { FieldIcon, wrapOnDot } from '../../../../../opensearch_dashboards_react/public';
 import { FieldDetails } from './types';
 import { IndexPatternField, IndexPattern } from '../../../../../data/public';
 import { shortenDottedString } from '../../helpers';
@@ -125,12 +125,11 @@ export const DiscoverField = ({
     }
   };
 
-  function wrapOnDot(str?: string) {
-    // u200B is a non-width white-space character, which allows
-    // the browser to efficiently word-wrap right after the dot
-    // without us having to draw a lot of extra DOM elements, etc
-    return str ? str.replace(/\./g, '.\u200B') : '';
-  }
+  const wrappedName = useMemo(
+    () =>
+      useShortDots ? wrapOnDot(shortenDottedString(field.name)) : wrapOnDot(field.displayName),
+    [field.name, field.displayName, useShortDots]
+  );
 
   const fieldName = (
     <EuiToolTip delay="long" content={field.name}>
@@ -138,7 +137,7 @@ export const DiscoverField = ({
         data-test-subj={`field-${field.name}`}
         className="dscSidebarField__name eui-textBreakWord"
       >
-        {useShortDots ? wrapOnDot(shortenDottedString(field.name)) : wrapOnDot(field.displayName)}
+        {wrappedName}
       </span>
     </EuiToolTip>
   );

--- a/src/plugins/explore/public/components/fields_selector/discover_field.tsx
+++ b/src/plugins/explore/public/components/fields_selector/discover_field.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   EuiPopover,
   EuiPopoverTitle,
@@ -40,7 +40,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { DiscoverFieldDetails } from './discover_field_details';
-import { FieldIcon } from '../../../../opensearch_dashboards_react/public';
+import { FieldIcon, wrapOnDot } from '../../../../opensearch_dashboards_react/public';
 import { FieldDetails } from './types';
 import { DataViewField, DataView } from '../../../../data/public';
 import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
@@ -136,17 +136,16 @@ export const DiscoverField = ({
     }
   };
 
-  function wrapOnDot(str?: string) {
-    // u200B is a non-width white-space character, which allows
-    // the browser to efficiently word-wrap right after the dot
-    // without us having to draw a lot of extra DOM elements, etc
-    return str ? str.replace(/\./g, '.\u200B') : '';
-  }
+  const wrappedName = useMemo(
+    () =>
+      useShortDots ? wrapOnDot(shortenDottedString(field.name)) : wrapOnDot(field.displayName),
+    [field.name, field.displayName, useShortDots]
+  );
 
   const fieldName = (
     <EuiToolTip delay="long" content={field.name}>
       <span data-test-subj={`field-${field.name}`} className="exploreSidebarField__name">
-        {useShortDots ? wrapOnDot(shortenDottedString(field.name)) : wrapOnDot(field.displayName)}
+        {wrappedName}
       </span>
     </EuiToolTip>
   );

--- a/src/plugins/explore/public/components/fields_selector/facet_value.tsx
+++ b/src/plugins/explore/public/components/fields_selector/facet_value.tsx
@@ -3,21 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiToolTip, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { Bucket } from './types';
 import { DataViewField } from '../../../../data/public';
 import { shortenDottedString } from '../../application/legacy/discover/application/helpers';
+import { wrapOnDot } from '../../../../opensearch_dashboards_react/public';
 import './discover_field.scss';
 import './facet_value.scss';
-
-function wrapOnDot(str?: string) {
-  // u200B is a non-width white-space character, which allows
-  // the browser to efficiently word-wrap right after the dot
-  // without us having to draw a lot of extra DOM elements, etc
-  return str ? str.replace(/\./g, '.\u200B') : '';
-}
 
 export interface FacetValueProps {
   /**
@@ -55,13 +49,19 @@ export const FacetValue = ({ field, bucket, onAddFilter, useShortDots }: FacetVa
     }
   );
 
+  const wrappedDisplay = useMemo(
+    () =>
+      useShortDots ? wrapOnDot(shortenDottedString(bucket.display)) : wrapOnDot(bucket.display),
+    [bucket.display, useShortDots]
+  );
+
   const displayValue = (
     <EuiToolTip delay="long" content={bucket.display}>
       <span
         data-test-subj={`field-${bucket.display}`}
         className="exploreSidebarField__name eui-textBreakWord"
       >
-        {useShortDots ? wrapOnDot(shortenDottedString(bucket.display)) : wrapOnDot(bucket.display)}
+        {wrappedDisplay}
       </span>
     </EuiToolTip>
   );

--- a/src/plugins/opensearch_dashboards_react/public/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/index.ts
@@ -45,7 +45,7 @@ export * from './notifications';
 export { Markdown, MarkdownSimple } from './markdown';
 export { reactToUiComponent, uiToReactComponent } from './adapters';
 export { useUrlTracker } from './use_url_tracker';
-export { toMountPoint, MountPointPortal } from './util';
+export { toMountPoint, MountPointPortal, wrapOnDot } from './util';
 export { RedirectAppLinks } from './app_links';
 import { Branding } from 'opensearch-dashboards/public';
 

--- a/src/plugins/opensearch_dashboards_react/public/util/index.ts
+++ b/src/plugins/opensearch_dashboards_react/public/util/index.ts
@@ -31,3 +31,4 @@
 export { toMountPoint } from './to_mount_point';
 export { MountPointPortal } from './mount_point_portal';
 export { useIfMounted } from './utils';
+export { wrapOnDot } from './wrap_on_dot';

--- a/src/plugins/opensearch_dashboards_react/public/util/wrap_on_dot.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/util/wrap_on_dot.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+/**
+ * Renders a dotted string with <wbr> elements after each dot, allowing the
+ * browser to word-wrap at dot boundaries without affecting the copied text.
+ */
+export function wrapOnDot(str?: string): React.ReactNode {
+  if (!str) return '';
+  const parts = str.split('.');
+  return (
+    <>
+      {parts.map((part, i) => (
+        <React.Fragment key={i}>
+          {i > 0 && (
+            <>
+              .<wbr />
+            </>
+          )}
+          {part}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/plugins/vis_builder/public/application/components/data_tab/field.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/field.tsx
@@ -28,7 +28,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { EuiDraggable, EuiPopover } from '@elastic/eui';
 
 import { IndexPatternField } from '../../../../../data/public';
@@ -36,6 +36,7 @@ import {
   FieldButton,
   FieldButtonProps,
   FieldIcon,
+  wrapOnDot,
 } from '../../../../../opensearch_dashboards_react/public';
 
 import { COUNT_FIELD, useDrag } from '../../utils/drag_drop';
@@ -45,7 +46,6 @@ import './field.scss';
 
 export interface FieldProps {
   field: IndexPatternField;
-  // @ts-expect-error TS7006 TODO(ts-error): fixme
   getDetails: (field) => FieldDetails;
   id: number;
 }
@@ -102,18 +102,13 @@ export const DraggableFieldButton = ({
     value: dragValue ?? name,
   });
 
-  function wrapOnDot(str: string) {
-    // u200B is a non-width white-space character, which allows
-    // the browser to efficiently word-wrap right after the dot
-    // without us having to draw a lot of extra DOM elements, etc
-    return str.replace(/\./g, '.\u200B');
-  }
-
   const defaultIcon = <FieldIcon type={type} scripted={scripted} size="l" />;
+
+  const wrappedDisplayName = useMemo(() => wrapOnDot(displayName), [displayName]);
 
   const defaultFieldName = (
     <span data-test-subj={`field-${name}`} title={name} className="vbFieldButton__name">
-      {wrapOnDot(displayName)}
+      {wrappedDisplayName}
     </span>
   );
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

#### Problem                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                  
  The field name sidebar in Explore, Discover, Vis Builder, and Agent Traces used a `wrapOnDot` helper to allow long dotted field names (e.g. `products.manufacturer.keyword`) to word-wrap at dot boundaries. It did this by inserting a Unicode zero-width space (U+200B) after each dot:                                                                                                                                                                                                                                      
```
str.replace(/\./g, '.\u200B')
```

  Because U+200B is injected directly into the text content, it gets included when a user selects and copies a field name. The invisible character silently corrupts the copied value, causing queries built from copied field names to fail.

####   Fix

  Replace U+200B insertion with <wbr> (Word Break Opportunity) elements. <wbr> is a void DOM element that provides the same word-wrap hint to the browser but contributes nothing to the text content when copied.

  Additionally, wrap the `wrapOnDot `call in `useMemo` in each component to avoid recreating the JSX tree (array allocation + React element creation) on every render.

  Finally, consolidate the previously duplicated wrapOnDot function (copied across 6 files in 4 plugins) into a single shared utility in `opensearch_dashboards_react`, which all affected plugins already depend on via `requiredBundles`.

####   Changes

  - `opensearch_dashboards_react/public/util/wrap_on_dot.tsx` — new shared utility implementing wrapOnDot with <wbr>
  - `opensearch_dashboards_react/public/util/index.ts and public/index.ts` — re-export wrapOnDot
  - explore, discover, agent_traces, vis_builder — remove local `wrapOnDot` copies, import from shared location, wrap call in `useMemo`

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
