### PR TITLE
Fix internal documentation links for developers on Github

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -270,7 +270,7 @@ $ yarn start --run-examples
 
 #### Join the discussion
 
-See the [communication guide](COMMUNICATION.md) for information on how to join our slack workspace, forum, or developer office hours.
+See the [communication guide](COMMUNICATIONS.md) for information on how to join our slack workspace, forum, or developer office hours.
 
 ## Alternative development installations
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OpenSearch Dashboards is an open-source data visualization tool designed to work
 
 We aim to be an exceptional community-driven platform and to foster open participation and collective contribution with all contributors. Stay up to date on what's happening with the OpenSearch Project by tracking GitHub [issues](https://github.com/opensearch-project/OpenSearch-Dashboards/issues) and [pull requests](https://github.com/opensearch-project/OpenSearch-Dashboards/pulls). 
 
-You can [contribute to this project](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/CONTRIBUTING.md) by [opening issues](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose) to give feedback, share ideas, identify bugs, and contribute code.
+You can [contribute to this project](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md) by [opening issues](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/new/choose) to give feedback, share ideas, identify bugs, and contribute code.
 
 Set up your [OpenSearch Dashboards development environment](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/DEVELOPER_GUIDE.md#getting-started-guide) today! The project team looks forward to your contributions.
 


### PR DESCRIPTION
### Description
Fixes broken links when navigating docs on Github.

### Issues Resolved

n/a

## Screenshot

n/a

## Testing the changes

Go to https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/DEVELOPER_GUIDE.md and then click the `see the communication guide` link and you will get an error.

Go to https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/README.md and click the `contribute to this project` link and you will be redirected to the wrong page.



## Changelog
- skip

### Check List
Mostly n/a:

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x ] Commits are signed per the DCO using --signoff
