### PR TITLE
chore: Enable manual workflow runs and fix codecov for forks

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -9,6 +9,7 @@ on:
     branches: ['main', '[0-9]+\.x', '[0-9]+\.[0-9]+'] # Run the functional test on push for only release branches
   pull_request:
     branches: ['**']
+  workflow_dispatch:
 
 env:
   OSD_OPTIMIZER_THEMES: v8light
@@ -106,7 +107,18 @@ jobs:
         id: mocha-tests
         run: yarn test:mocha:coverage
 
+      - name: Check for Codecov token
+        id: check-codecov
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]; then
+            echo "has_token=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_token=false" >> $GITHUB_OUTPUT
+          fi
+      
       - name: Upload Code Coverage
+        if: steps.check-codecov.outputs.has_token == 'true' || github.repository == 'opensearch-project/OpenSearch-Dashboards'
         id: upload-code-coverage
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary
Enables manual workflow runs for the build and test workflow and fixes codecov to only run when the token is configured and the project is opensearch-project/OpenSearch-Dashboards (so forks don't fail on missing codecov token).

- This PR addresses #11487 

## Changes
- [chore] Make manual runs possible for the build and test workflow
- [chore] Don't run codecov if token isn't configured or project isn't opensearch-project/OpenSearch-Dashboards

## Changelog
- skip
