### PR TITLE
[Banner Plugin] Fix text render issue from react-markdown upgrade

### DIFF
--- a/src/plugins/banner/public/components/global_banner.tsx
+++ b/src/plugins/banner/public/components/global_banner.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import React, { Fragment, useEffect, useState, Suspense, useRef, useCallback } from 'react';
+import React, { useEffect, useState, Suspense, useRef, useCallback } from 'react';
 import { EuiCallOut, EuiLoadingSpinner } from '@elastic/eui';
 import { BannerConfig, HIDDEN_BANNER_HEIGHT, DEFAULT_BANNER_CONFIG } from '../../common';
 import { LinkRenderer } from './link_renderer';
@@ -147,13 +147,12 @@ export const GlobalBanner: React.FC<GlobalBannerProps> = ({ http }) => {
           }
         >
           <ReactMarkdownLazy
-            // @ts-expect-error TS2322 TODO(ts-error): fixme
-            renderers={{
-              root: Fragment,
-              link: LinkRenderer,
+            components={{
+              a: LinkRenderer,
             }}
-            source={bannerConfig.content.trim()}
-          />
+          >
+            {bannerConfig.content.trim()}
+          </ReactMarkdownLazy>
         </Suspense>
       );
     }


### PR DESCRIPTION
### Description

This PR fixes the banner plugin to work with React 18 by updating the react-markdown API usage in `global_banner.tsx`. The banner component was using deprecated react-markdown v4/v5 API (`renderers` and `source` props) which are no longer supported in react-markdown v6.x that was upgraded as part of the React 18 migration (#11187).

**Changes:**
- Updated `ReactMarkdownLazy` to use `components` prop instead of deprecated `renderers` prop
- Changed from `source` prop to passing content as children (the new react-markdown v6 API)
- Removed unused `Fragment` import

### Issues Resolved

Fixes banner text not displaying after React 18 upgrade (#11187)

## Screenshot

<img width="1852" height="688" alt="image" src="https://github.com/user-attachments/assets/2f9334ac-e80c-49e1-83fe-7fa591620104" />

## Testing the changes

1. Enable the banner plugin in `opensearch_dashboards.yml`:
   ```yaml
   banner.enabled: true
   banner.content: "This is an important announcement for all users. [Learn more](https://opensearch.org) about OpenSearch."
   ```
2. Start OpenSearch Dashboards: `yarn start`
3. Verify the banner displays at the top of the page with the markdown content rendered correctly
4. Verify the "Learn more" link opens in a new tab
5. Run the banner plugin tests: `yarn test:jest --testPathPattern=src/plugins/banner`

## Changelog

- fix: Update banner plugin react-markdown API for React 18 compatibility

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff