### PR TITLE
[Chat] Show context-aware starter suggestions based on current page

### DIFF
--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -9,6 +9,7 @@ import { ChatMessages } from './chat_messages';
 import { ChatLayoutMode } from './chat_header_button';
 import type { Message, AssistantMessage, ToolMessage, UserMessage } from '../../common/types';
 import { convertTimelineToMessageRows } from './chat_messages';
+import { starterSuggestionsRegistry } from '../services/starter_suggestions_registry';
 
 // Mock the child components
 jest.mock('./message_row', () => ({
@@ -408,8 +409,18 @@ describe('ChatMessages', () => {
 
   describe('context-aware starter suggestions', () => {
     const mockUnsubscribe = jest.fn();
+    const customSuggestions = [
+      {
+        icon: 'visBarVerticalStacked',
+        iconColor: 'primary',
+        text: 'Compare configurations',
+        prompt: 'Compare',
+      },
+      { icon: 'starFilled', iconColor: 'warning', text: 'Evaluate quality', prompt: 'Evaluate' },
+    ];
 
     afterEach(() => {
+      starterSuggestionsRegistry.unregister('testApp');
       delete (window as any).assistantContextStore;
     });
 
@@ -421,9 +432,15 @@ describe('ChatMessages', () => {
       expect(getByText('Explain a concept')).toBeTruthy();
     });
 
-    it('should show default suggestions when context store has no matching appId', () => {
+    it('should show default suggestions when context store has no matching appId in registry', () => {
       (window as any).assistantContextStore = {
-        getContextsByCategory: jest.fn().mockReturnValue([]),
+        getContextsByCategory: jest.fn().mockReturnValue([
+          {
+            description: 'Page context for /app/unknownApp',
+            value: JSON.stringify({ appId: 'unknownApp', breadcrumbs: [] }),
+            label: 'Page: /app/unknownApp',
+          },
+        ]),
         subscribe: jest.fn().mockReturnValue(mockUnsubscribe),
       };
 
@@ -432,13 +449,14 @@ describe('ChatMessages', () => {
       expect(getByText('Ask questions about your data')).toBeTruthy();
     });
 
-    it('should show search relevance suggestions when appId is searchRelevance', () => {
+    it('should show registered suggestions when appId matches a registry entry', () => {
+      starterSuggestionsRegistry.register('testApp', customSuggestions);
       (window as any).assistantContextStore = {
         getContextsByCategory: jest.fn().mockReturnValue([
           {
-            description: 'Page context for /app/searchRelevance',
-            value: JSON.stringify({ appId: 'searchRelevance', breadcrumbs: [] }),
-            label: 'Page: /app/searchRelevance',
+            description: 'Page context for /app/testApp',
+            value: JSON.stringify({ appId: 'testApp', breadcrumbs: [] }),
+            label: 'Page: /app/testApp',
           },
         ]),
         subscribe: jest.fn().mockReturnValue(mockUnsubscribe),
@@ -446,13 +464,14 @@ describe('ChatMessages', () => {
 
       const { getByText, queryByText } = render(<ChatMessages {...defaultProps} />);
 
-      expect(getByText('Compare two search configurations')).toBeTruthy();
-      expect(getByText('Evaluate search quality')).toBeTruthy();
-      expect(getByText('Create a query set')).toBeTruthy();
+      expect(getByText('Compare configurations')).toBeTruthy();
+      expect(getByText('Evaluate quality')).toBeTruthy();
       expect(queryByText('Ask questions about your data')).toBeNull();
     });
 
     it('should update suggestions reactively when context store emits a change', () => {
+      starterSuggestionsRegistry.register('testApp', customSuggestions);
+
       let subscriberCallback: () => void;
       const mockStore = {
         getContextsByCategory: jest.fn().mockReturnValue([]),
@@ -469,9 +488,9 @@ describe('ChatMessages', () => {
 
       mockStore.getContextsByCategory.mockReturnValue([
         {
-          description: 'Page context for /app/searchRelevance',
-          value: JSON.stringify({ appId: 'searchRelevance', breadcrumbs: [] }),
-          label: 'Page: /app/searchRelevance',
+          description: 'Page context for /app/testApp',
+          value: JSON.stringify({ appId: 'testApp', breadcrumbs: [] }),
+          label: 'Page: /app/testApp',
         },
       ]);
 
@@ -479,7 +498,7 @@ describe('ChatMessages', () => {
         subscriberCallback!();
       });
 
-      expect(getByText('Compare two search configurations')).toBeTruthy();
+      expect(getByText('Compare configurations')).toBeTruthy();
       expect(queryByText('Ask questions about your data')).toBeNull();
     });
 

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -15,6 +15,10 @@ import { ChatSuggestions } from './chat_suggestions';
 import { ToolCallGroup } from './tool_call_group';
 import { AssistantActionService } from '../../../context_provider/public';
 import type { AssistantContextStore } from '../../../context_provider/public';
+import {
+  starterSuggestionsRegistry,
+  StarterSuggestionItem,
+} from '../services/starter_suggestions_registry';
 
 /**
  * Determine tool status based on tool call and result
@@ -28,14 +32,7 @@ function getToolStatus(
   return 'completed';
 }
 
-interface SuggestionItem {
-  icon: string;
-  iconColor?: string;
-  text: string;
-  prompt: string;
-}
-
-const STARTER_SUGGESTIONS: SuggestionItem[] = [
+const STARTER_SUGGESTIONS: StarterSuggestionItem[] = [
   {
     icon: 'search',
     iconColor: 'primary',
@@ -56,40 +53,18 @@ const STARTER_SUGGESTIONS: SuggestionItem[] = [
   },
 ];
 
-const SEARCH_RELEVANCE_SUGGESTIONS: SuggestionItem[] = [
-  {
-    icon: 'visBarVerticalStacked',
-    iconColor: 'primary',
-    text: 'Compare two search configurations',
-    prompt: 'Help me set up a query set comparison between two search configurations',
-  },
-  {
-    icon: 'starFilled',
-    iconColor: 'warning',
-    text: 'Evaluate search quality',
-    prompt: 'How do I evaluate my search quality using NDCG or MAP metrics?',
-  },
-  {
-    icon: 'searchProfilerApp',
-    iconColor: 'accent',
-    text: 'Create a query set',
-    prompt: 'Help me create a query set for search relevance evaluation',
-  },
-];
-
-const CONTEXT_SUGGESTIONS: Record<string, SuggestionItem[]> = {
-  searchRelevance: SEARCH_RELEVANCE_SUGGESTIONS,
-};
-
-function getStarterSuggestions(): SuggestionItem[] {
+function getStarterSuggestions(): StarterSuggestionItem[] {
   const contextStore = (window as any).assistantContextStore as AssistantContextStore | undefined;
   if (contextStore) {
     const pageContexts = contextStore.getContextsByCategory('page');
     for (const ctx of pageContexts) {
       try {
         const value = typeof ctx.value === 'string' ? JSON.parse(ctx.value) : ctx.value;
-        if (value?.appId && CONTEXT_SUGGESTIONS[value.appId]) {
-          return CONTEXT_SUGGESTIONS[value.appId];
+        if (value?.appId) {
+          const registered = starterSuggestionsRegistry.getSuggestions(value.appId);
+          if (registered) {
+            return registered;
+          }
         }
       } catch {
         // ignore parse errors
@@ -279,7 +254,7 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
   onFillInput,
   startResponse,
 }) => {
-  const [suggestions, setSuggestions] = useState<SuggestionItem[]>(getStarterSuggestions);
+  const [suggestions, setSuggestions] = useState<StarterSuggestionItem[]>(getStarterSuggestions);
 
   useEffect(() => {
     const contextStore = (window as any).assistantContextStore as AssistantContextStore | undefined;

--- a/src/plugins/chat/public/index.ts
+++ b/src/plugins/chat/public/index.ts
@@ -15,6 +15,6 @@ import { ChatPlugin } from './plugin';
 export function plugin(initializerContext: PluginInitializerContext) {
   return new ChatPlugin(initializerContext);
 }
-export { ChatPluginSetup, ChatPluginStart } from './types';
+export { ChatPluginSetup, ChatPluginStart, StarterSuggestionItem } from './types';
 export { SlashCommand } from './services/slash_commands';
 export { ChatService } from './services/chat_service';

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -23,6 +23,7 @@ import { toMountPoint } from '../../opensearch_dashboards_react/public';
 import { SuggestedActionsService } from './services/suggested_action';
 import { isChatEnabled } from '../common/chat_capabilities';
 import { CommandRegistryService } from './services/command_registry_service';
+import { starterSuggestionsRegistry } from './services/starter_suggestions_registry';
 import { ConfirmationService } from './services/confirmation_service';
 import { AgenticMemoryProvider } from './services/agentic_memory_provider';
 
@@ -100,6 +101,8 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
     return {
       suggestedActionsService: suggestedActionsSetup,
       commandRegistry: commandRegistrySetup,
+      registerStarterSuggestions: (appId, suggestions) =>
+        starterSuggestionsRegistry.register(appId, suggestions),
     };
   }
 

--- a/src/plugins/chat/public/services/starter_suggestions_registry.ts
+++ b/src/plugins/chat/public/services/starter_suggestions_registry.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface StarterSuggestionItem {
+  icon: string;
+  iconColor?: string;
+  text: string;
+  prompt: string;
+}
+
+class StarterSuggestionsRegistry {
+  private registry: Map<string, StarterSuggestionItem[]> = new Map();
+
+  register(appId: string, suggestions: StarterSuggestionItem[]): void {
+    this.registry.set(appId, suggestions);
+  }
+
+  unregister(appId: string): void {
+    this.registry.delete(appId);
+  }
+
+  getSuggestions(appId: string): StarterSuggestionItem[] | undefined {
+    return this.registry.get(appId);
+  }
+}
+
+export const starterSuggestionsRegistry = new StarterSuggestionsRegistry();

--- a/src/plugins/chat/public/types.ts
+++ b/src/plugins/chat/public/types.ts
@@ -9,10 +9,14 @@ import { ChartsPluginStart } from '../../charts/public';
 import { ChatService } from './services/chat_service';
 import { SuggestedActionsServiceSetupContract } from './services/suggested_action';
 import { CommandRegistrySetup } from './services/command_registry_service';
+import { StarterSuggestionItem } from './services/starter_suggestions_registry';
+
+export type { StarterSuggestionItem };
 
 export interface ChatPluginSetup {
   suggestedActionsService: SuggestedActionsServiceSetupContract;
   commandRegistry: CommandRegistrySetup;
+  registerStarterSuggestions: (appId: string, suggestions: StarterSuggestionItem[]) => void;
 }
 
 export interface ChatPluginStart {


### PR DESCRIPTION
### Description

Users opening the AI Assistant (OSD chat) see the same questions wherever they start their conversation.
This PR enables context-sensitive questions in OSD chat and adds questions for the relevance tuning agent (see https://github.com/opensearch-project/opensearch-agent-server).

### Issues Resolved

n/a

## Screenshot

New default questions when user is in the context of the Search Relevance Workbench:
<img width="2275" height="966" alt="image" src="https://github.com/user-attachments/assets/25357756-707f-4e7e-aa3f-04d330097e9b" />

## Testing the changes

Added tests for changes.

## Changelog

- feat: show context-aware starter suggestions based on current page in OpenSearch Dashboards Chat

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
