### PR TITLE
[Agent Traces] fix empty state when switching datasets

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/04/agent_traces.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/04/agent_traces.spec.js
@@ -8,6 +8,7 @@ import { getRandomizedWorkspaceName } from '../../../../../../utils/apps/explore
 import { prepareTestSuite, createWorkspaceWithDatasource } from '../../../../../../utils/helpers';
 
 const AGENT_TRACES_INDEX_PATTERN = 'agent_traces_cy_test*';
+const AGENT_TRACES_INDEX_PATTERN_ALT = 'agent_traces_cy_tes*';
 const AGENT_TRACES_TIME_FIELD = 'startTime';
 const AGENT_TRACES_START = 'Sep 1, 2026 @ 00:00:00.000';
 const AGENT_TRACES_END = 'Oct 1, 2026 @ 00:00:00.000';
@@ -171,6 +172,41 @@ const agentTracesTestSuite = () => {
         'have.length.greaterThan',
         0
       );
+    });
+
+    it('should display traces immediately after switching datasets', () => {
+      // Load the first dataset
+      selectDatasetAndWaitForData();
+
+      cy.get('.agentTracesTable__container .agentTraces-table tbody tr', {
+        timeout: 15000,
+      }).should('have.length.greaterThan', 0);
+
+      // Switch to the second dataset
+      cy.explore.setIndexPatternFromAdvancedSelector(
+        AGENT_TRACES_INDEX_PATTERN_ALT,
+        DATASOURCE_NAME,
+        undefined,
+        AGENT_TRACES_TIME_FIELD
+      );
+
+      cy.getElementByTestId('datasetSelectButton').should(
+        'contain.text',
+        AGENT_TRACES_INDEX_PATTERN_ALT
+      );
+
+      // Traces should appear without needing to click the tab again or the
+      // Update button.  Previously, a race condition in the dataset change
+      // middleware caused "No agent traces found" to flash until the user
+      // manually re-triggered a query.
+      cy.get('.agentTracesTable__container .agentTraces-table tbody tr', {
+        timeout: 15000,
+      }).should('have.length.greaterThan', 0);
+
+      // Verify the Traces tab is still active
+      cy.getElementByTestId('agentTracesTabs')
+        .find('.euiTab-isSelected .euiTab__content')
+        .should('contain.text', 'Traces');
     });
   });
 };

--- a/src/plugins/agent_traces/public/application/utils/state_management/middleware/dataset_change_middleware.test.ts
+++ b/src/plugins/agent_traces/public/application/utils/state_management/middleware/dataset_change_middleware.test.ts
@@ -14,8 +14,13 @@ import {
   clearLastExecutedData,
   setPatternsField,
   setUsingRegexPatterns,
+  setSort,
 } from '../slices';
-import { clearQueryStatusMap } from '../slices/query_editor/query_editor_slice';
+import {
+  clearQueryStatusMap,
+  setOverallQueryStatus,
+} from '../slices/query_editor/query_editor_slice';
+import { QueryExecutionStatus } from '../types';
 import { createMockAgentTracesServices, createMockStore, MockStore } from '../__mocks__';
 import { DEFAULT_DATA } from '../../../../../../data/common';
 import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
@@ -257,5 +262,82 @@ describe('createDatasetChangeMiddleware', () => {
     expect(mockStore.dispatch).not.toHaveBeenCalledWith(setSummaryAgentIsAvailable(true));
     // But should call getSummaryAgentIsAvailable with the correct data source ID
     expect(mockedGetSummaryAgentIsAvailable).toHaveBeenCalledWith(mockServices, 'data-source-id');
+  });
+
+  it('should dispatch LOADING overall query status immediately after clearing', async () => {
+    const newDataset = { id: 'new-dataset', type: 'index_pattern' };
+    mockStore.getState = jest.fn().mockReturnValue({
+      query: { dataset: newDataset },
+      queryEditor: {
+        promptModeIsAvailable: false,
+        summaryAgentIsAvailable: false,
+      },
+    });
+
+    await middleware(setQueryState({ query: 'source=hello', language: 'PPL' }));
+
+    // setOverallQueryStatus(LOADING) must be dispatched right after clearQueryStatusMap
+    // to prevent the UI from flashing "No agent traces found" during the async gap.
+    const dispatchCalls = (mockStore.dispatch as jest.Mock).mock.calls.map((call) => call[0]);
+    const clearIdx = dispatchCalls.findIndex((a: any) => a.type === clearQueryStatusMap.type);
+    const loadingIdx = dispatchCalls.findIndex(
+      (a: any) =>
+        a.type === setOverallQueryStatus.type && a.payload?.status === QueryExecutionStatus.LOADING
+    );
+
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    expect(loadingIdx).toBeGreaterThanOrEqual(0);
+    expect(loadingIdx).toBe(clearIdx + 1);
+  });
+
+  it('should dispatch setSort with default sort before executing queries when dataset has timeFieldName', async () => {
+    const newDataset = {
+      id: 'new-dataset',
+      type: 'INDEXES',
+      timeFieldName: 'startTime',
+      dataSource: { id: 'ds-id' },
+    };
+    mockStore.getState = jest.fn().mockReturnValue({
+      query: { dataset: newDataset },
+      queryEditor: {
+        promptModeIsAvailable: false,
+        summaryAgentIsAvailable: false,
+      },
+    });
+
+    await middleware(setQueryState({ query: 'source=hello', language: 'PPL' }));
+
+    const dispatchCalls = (mockStore.dispatch as jest.Mock).mock.calls.map((call) => call[0]);
+    const setSortIdx = dispatchCalls.findIndex((a: any) => a.type === setSort.type);
+    const execIdx = dispatchCalls.findIndex((a: any) => a.type === 'mock/executeQueries');
+
+    // setSort must be dispatched with the dataset's time field as default sort
+    expect(setSortIdx).toBeGreaterThanOrEqual(0);
+    expect(dispatchCalls[setSortIdx].payload).toEqual([['startTime', 'desc']]);
+
+    // setSort must come before executeQueries so the cache key matches
+    expect(execIdx).toBeGreaterThanOrEqual(0);
+    expect(setSortIdx).toBeLessThan(execIdx);
+  });
+
+  it('should not dispatch setSort when dataset has no timeFieldName', async () => {
+    const newDataset = {
+      id: 'new-dataset',
+      type: 'INDEXES',
+      dataSource: { id: 'ds-id' },
+    };
+    mockStore.getState = jest.fn().mockReturnValue({
+      query: { dataset: newDataset },
+      queryEditor: {
+        promptModeIsAvailable: false,
+        summaryAgentIsAvailable: false,
+      },
+    });
+
+    await middleware(setQueryState({ query: 'source=hello', language: 'PPL' }));
+
+    const dispatchCalls = (mockStore.dispatch as jest.Mock).mock.calls.map((call) => call[0]);
+    const setSortAction = dispatchCalls.find((a: any) => a.type === setSort.type);
+    expect(setSortAction).toBeUndefined();
   });
 });

--- a/src/plugins/agent_traces/public/application/utils/state_management/middleware/dataset_change_middleware.ts
+++ b/src/plugins/agent_traces/public/application/utils/state_management/middleware/dataset_change_middleware.ts
@@ -17,8 +17,14 @@ import {
   setSummaryAgentIsAvailable,
   setPatternsField,
   setUsingRegexPatterns,
+  setSort,
 } from '../slices';
-import { clearQueryStatusMap, setBreakdownField } from '../slices/query_editor/query_editor_slice';
+import {
+  clearQueryStatusMap,
+  setBreakdownField,
+  setOverallQueryStatus,
+} from '../slices/query_editor/query_editor_slice';
+import { QueryExecutionStatus } from '../types';
 import { executeQueries } from '../actions/query_actions';
 import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
 import { getSummaryAgentIsAvailable } from '../../get_summary_agent_is_available';
@@ -56,6 +62,17 @@ export const createDatasetChangeMiddleware = (
       store.dispatch(setActiveTab(''));
       store.dispatch(clearResults());
       store.dispatch(clearQueryStatusMap());
+      // Immediately signal LOADING so the UI shows a spinner instead of the
+      // empty-state ("No agent traces found") during the async gap before
+      // executeQueries dispatches its own LOADING status.
+      store.dispatch(
+        setOverallQueryStatus({
+          status: QueryExecutionStatus.LOADING,
+          startTime: Date.now(),
+          elapsedMs: undefined,
+          error: undefined,
+        })
+      );
       store.dispatch(clearLastExecutedData());
       store.dispatch(setPatternsField(''));
       store.dispatch(setUsingRegexPatterns(false));
@@ -92,6 +109,16 @@ export const createDatasetChangeMiddleware = (
               },
               false
             );
+          }
+
+          // Initialize default sort for the new dataset so the cache key from
+          // executeQueries matches what useTabResults computes in the component.
+          // Without this, resetLegacyStateActionCreator sets sort to [] but the
+          // component may compute its cache key with the dataset's default sort,
+          // causing a cache miss that shows "No agent traces found".
+          const timeFieldName = currentDataset.timeFieldName;
+          if (timeFieldName) {
+            store.dispatch(setSort([[timeFieldName, 'desc']]) as any);
           }
 
           await store.dispatch(executeQueries({ services }) as any);


### PR DESCRIPTION
### Description

There's a bug after introducing sort in UI, that causes cache key to not match and table to be empty when switching dataset. This PR fixes it.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

UT, cypress

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
