### PR TITLE
chore(deps): update fast-xml-parser to 5.5.9 CVE-2026-33036, CVE-2026-33349

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "**/lodash": "4.17.23",
     "**/body-parser": "^2.2.1",
     "**/@tootallnate/once": "^3.0.1",
-    "**/fast-xml-parser": "^5.3.8",
+    "**/fast-xml-parser": "^5.5.9",
     "**/grunt/minimatch": "^3.1.5"
   },
   "workspaces": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13156,7 +13156,7 @@ fast-xml-builder@^1.1.4:
   dependencies:
     path-expression-matcher "^1.1.3"
 
-fast-xml-parser@5.3.6, fast-xml-parser@^5.3.8:
+fast-xml-parser@5.3.6, fast-xml-parser@^5.5.9:
   version "5.5.9"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz#e59637abebec3dbfbb4053b532d787af6ea11527"
   integrity sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==


### PR DESCRIPTION
### Description

Update fast-xml-parser to 5.5.9 to address CVE-2026-33036, CVE-2026-33349

Summary:
Added "**/fast-xml-parser": "^5.5.9" to the resolutions block in package.json

This forces all transitive dependencies to use fast-xml-parser@5.5.9 instead of the vulnerable 5.5.1


### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11558
Closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11544

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->
- fix: use fast-xml-parser 5.5.9 to address CVE-2026-33036
- fix: use fast-xml-parser 5.5.9 to address CVE-2026-33349

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff
