### PR TITLE
added strict back to config with depcrecated flag

### DIFF
--- a/src/core/server/csp/config.ts
+++ b/src/core/server/csp/config.ts
@@ -45,6 +45,8 @@ export const config = {
       defaultValue: LOOSE_CSP_RULES_DEFAULT_VALUE,
     }),
     enable: schema.boolean({ defaultValue: false }),
+    /** @deprecated Use `enable` instead. */
+    strict: schema.boolean({ defaultValue: false }),
     warnLegacyBrowsers: schema.boolean({ defaultValue: true }),
     nonceDirectives: schema.arrayOf(schema.string(), {
       defaultValue: ['style-src-elem'],


### PR DESCRIPTION
### Description

The CSP config key [csp.strict](to better reflect its intent (enabling CSP hardening mode). To avoid a fatal startup crash for deployments that still have [csp.strict]set in their [opensearch_dashboards.yml], both keys are now accepted by the config schema. The [strict]key is marked @deprecated — it will be removed in a future release. The runtime ([CspConfig] already resolves [enable || strict], so behavior is unchanged regardless of which key is used.

## Changelog

- skip

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
