### PR TITLE
feat: introduce query-based tab auto switching to discover

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/10/queries.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/10/queries.spec.js
@@ -140,8 +140,10 @@ const queriesTestSuite = () => {
         cy.osd.waitForLoader(true);
         cy.wait(1000);
 
-        // Logs table is displayed by default
-        cy.getElementByTestId('docTable').should('be.visible');
+        // Statistic tab is selected
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
         // Navigate to visualization
         cy.get('#explore_visualization_tab').click();
         cy.getElementByTestId('exploreVisualizationLoader').should('be.visible');

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/23/auto_tab_detect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/23/auto_tab_detect.spec.js
@@ -1,0 +1,307 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DATASOURCE_NAME,
+  INDEX_WITH_TIME_1,
+  START_TIME,
+  END_TIME,
+} from '../../../../../../utils/apps/constants';
+import {
+  getRandomizedWorkspaceName,
+  getRandomizedDatasetId,
+} from '../../../../../../utils/apps/explore/shared';
+import {
+  prepareTestSuite,
+  createWorkspaceAndDatasetUsingEndpoint,
+} from '../../../../../../utils/helpers';
+
+const workspace = getRandomizedWorkspaceName();
+const datasetId = getRandomizedDatasetId();
+const indexPattern = `${INDEX_WITH_TIME_1}*`;
+
+const autoTabDetectTestSuite = () => {
+  describe('auto tab detection based on query', { scrollBehavior: false }, () => {
+    before(() => {
+      cy.osd.setupEnvAndGetDataSource(DATASOURCE_NAME);
+
+      createWorkspaceAndDatasetUsingEndpoint(
+        DATASOURCE_NAME,
+        workspace,
+        datasetId,
+        indexPattern,
+        'timestamp',
+        'logs',
+        ['use-case-observability']
+      );
+    });
+
+    beforeEach(() => {
+      cy.osd.navigateToWorkSpaceSpecificPage({
+        workspaceName: workspace,
+        page: 'explore/logs',
+        isEnhancement: true,
+      });
+
+      cy.explore.setDataset(indexPattern, DATASOURCE_NAME, 'INDEX_PATTERN');
+      cy.explore.setTopNavDate(START_TIME, END_TIME);
+      cy.osd.waitForLoader(true);
+    });
+
+    after(() => {
+      cy.osd.cleanupWorkspaceAndDataSourceAndIndices(workspace, [INDEX_WITH_TIME_1]);
+    });
+
+    // =========================================================================
+    // Rule 1: Current tab is Logs (default)
+    // =========================================================================
+    describe('Rule 1 - current tab is Logs (default)', () => {
+      it('switches to Statistics tab when query contains stats command', () => {
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('switches to Statistics tab when query contains table command', () => {
+        const tableQuery = `source = ${indexPattern} | table category, bytes_transferred`;
+        cy.explore.setQueryEditor(tableQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('switches to Visualization tab when query contains chart command', () => {
+        const chartQuery = `source = ${indexPattern} | chart count() by category`;
+        cy.explore.setQueryEditor(chartQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('switches to Visualization tab when query contains timechart command', () => {
+        const timechartQuery = `source = ${indexPattern} | timechart count()`;
+        cy.explore.setQueryEditor(timechartQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('remains on Logs tab when query has no special command', () => {
+        const plainQuery = `source = ${indexPattern} | where bytes_transferred > 1000`;
+        cy.explore.setQueryEditor(plainQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-logs')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+    });
+
+    describe('tab preservation on same-query refresh', () => {
+      it('preserves Visualization tab when re-running the same query', () => {
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        // Auto-detected to Statistics tab
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Manually switch to Visualization tab
+        cy.getElementByTestId('exploreTab-explore_visualization_tab').click();
+        cy.wait(500);
+
+        // Re-run the same query via the execution button (time-only refresh)
+        cy.getElementByTestId('exploreQueryExecutionButton').click({ force: true });
+        cy.osd.waitForLoader(true);
+
+        // Visualization tab should remain selected (same query = no tab switch)
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+    });
+
+    describe('Statistics tab hides action bar buttons', () => {
+      it('hides Add to Dashboard and Export CSV buttons on Statistics tab', () => {
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        // Verify we are on Statistics tab
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Add to Dashboard button should not be visible
+        cy.get('[data-test-subj="dscResultsActionBar"]').within(() => {
+          cy.get('[data-test-subj="addToDashboardButton"]').should('not.exist');
+          cy.get('[data-test-subj="downloadCsvButton"]').should('not.exist');
+        });
+      });
+    });
+
+    describe('Statistics tab renders table with results', () => {
+      it('displays a table with data when stats query is executed', () => {
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        // Verify Statistics tab is selected
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Verify the statistics table is rendered with data
+        cy.get('.exploreStatisticTable').should('be.visible');
+        cy.get('.exploreStatisticTable table').should('exist');
+        cy.get('.exploreStatisticTable tbody tr').should('have.length.greaterThan', 0);
+      });
+    });
+
+    // =========================================================================
+    // Rule 2: Current tab is Statistic
+    // =========================================================================
+    describe('Rule 2 - current tab is Statistic', () => {
+      it('stays on Statistics when query contains stats (stats/table → stay)', () => {
+        // Get to Statistics tab via a stats query
+        const statsQuery1 = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery1);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Change to a different stats query — should stay on Statistics
+        const statsQuery2 = `source = ${indexPattern} | stats avg(bytes_transferred) by category`;
+        cy.explore.setQueryEditor(statsQuery2);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('stays on Statistics when query contains chart (chart/timechart → stay)', () => {
+        // Get to Statistics tab via a stats query
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Now change to a chart query — should stay on Statistics (interchangeable)
+        const chartQuery = `source = ${indexPattern} | chart count() by category`;
+        cy.explore.setQueryEditor(chartQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('switches to Logs when query has no special command (other → Logs)', () => {
+        // Get to Statistics tab via a stats query
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_statistics')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Now change to a plain query — should switch to Logs
+        const plainQuery = `source = ${indexPattern} | where bytes_transferred > 500`;
+        cy.explore.setQueryEditor(plainQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-logs')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+    });
+
+    // =========================================================================
+    // Rule 3: Current tab is Visualization
+    // =========================================================================
+    describe('Rule 3 - current tab is Visualization', () => {
+      it('stays on Visualization when query contains stats (stats/table → stay)', () => {
+        // Get to Visualization tab via a chart query
+        const chartQuery = `source = ${indexPattern} | chart count() by category`;
+        cy.explore.setQueryEditor(chartQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Now change to a stats query — should stay on Visualization (interchangeable)
+        const statsQuery = `source = ${indexPattern} | stats count() by category`;
+        cy.explore.setQueryEditor(statsQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('stays on Visualization when query contains chart (chart/timechart → stay)', () => {
+        // Get to Visualization tab via a chart query
+        const chartQuery1 = `source = ${indexPattern} | chart count() by category`;
+        cy.explore.setQueryEditor(chartQuery1);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Change to a timechart query — should stay on Visualization
+        const chartQuery2 = `source = ${indexPattern} | timechart count() by category`;
+        cy.explore.setQueryEditor(chartQuery2);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+
+      it('stays on Visualization when query has no special command (other → stay)', () => {
+        // Get to Visualization tab via a chart query
+        const chartQuery = `source = ${indexPattern} | chart count() by category`;
+        cy.explore.setQueryEditor(chartQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+
+        // Now change to a plain query — should stay on Visualization
+        const plainQuery = `source = ${indexPattern} | where bytes_transferred > 500`;
+        cy.explore.setQueryEditor(plainQuery);
+        cy.osd.waitForLoader(true);
+
+        cy.getElementByTestId('exploreTab-explore_visualization_tab')
+          .should('be.visible')
+          .and('have.attr', 'aria-selected', 'true');
+      });
+    });
+  });
+};
+
+prepareTestSuite('Auto Tab Detect', autoTabDetectTestSuite);

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/23/statistics_tab.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/23/statistics_tab.spec.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DATASOURCE_NAME,
+  INDEX_WITH_TIME_1,
+  START_TIME,
+  END_TIME,
+} from '../../../../../../utils/apps/constants';
+import {
+  getRandomizedWorkspaceName,
+  getRandomizedDatasetId,
+} from '../../../../../../utils/apps/explore/shared';
+import {
+  prepareTestSuite,
+  createWorkspaceAndDatasetUsingEndpoint,
+} from '../../../../../../utils/helpers';
+
+const workspace = getRandomizedWorkspaceName();
+const datasetId = getRandomizedDatasetId();
+const indexPattern = `${INDEX_WITH_TIME_1}*`;
+
+const statisticsTabTestSuite = () => {
+  describe('Statistics tab', { scrollBehavior: false }, () => {
+    before(() => {
+      cy.osd.setupEnvAndGetDataSource(DATASOURCE_NAME);
+
+      createWorkspaceAndDatasetUsingEndpoint(
+        DATASOURCE_NAME,
+        workspace,
+        datasetId,
+        indexPattern,
+        'timestamp',
+        'logs',
+        ['use-case-observability']
+      );
+    });
+
+    beforeEach(() => {
+      cy.osd.navigateToWorkSpaceSpecificPage({
+        workspaceName: workspace,
+        page: 'explore/logs',
+        isEnhancement: true,
+      });
+
+      cy.explore.setDataset(indexPattern, DATASOURCE_NAME, 'INDEX_PATTERN');
+      cy.explore.setTopNavDate(START_TIME, END_TIME);
+      cy.osd.waitForLoader(true);
+    });
+
+    after(() => {
+      cy.osd.cleanupWorkspaceAndDataSourceAndIndices(workspace, [INDEX_WITH_TIME_1]);
+    });
+
+    it('is visible in the tab bar', () => {
+      cy.getElementByTestId('exploreTab-explore_statistics').should('be.visible');
+      cy.getElementByTestId('exploreTab-explore_statistics').should('contain.text', 'Statistics');
+    });
+
+    it('renders a table with columns matching the stats query fields', () => {
+      const statsQuery = `source = ${indexPattern} | stats count() by category`;
+      cy.explore.setQueryEditor(statsQuery);
+      cy.osd.waitForLoader(true);
+
+      // Verify Statistics tab is auto-selected
+      cy.getElementByTestId('exploreTab-explore_statistics')
+        .should('be.visible')
+        .and('have.attr', 'aria-selected', 'true');
+
+      // Verify the table has the expected column headers
+      cy.get('.exploreStatisticTable').should('be.visible');
+      cy.get('.exploreStatisticTable thead th').should('have.length.greaterThan', 1);
+    });
+
+    it('supports row expansion to show JSON details', () => {
+      const statsQuery = `source = ${indexPattern} | stats count() by category`;
+      cy.explore.setQueryEditor(statsQuery);
+      cy.osd.waitForLoader(true);
+
+      // Verify Statistics tab is selected
+      cy.getElementByTestId('exploreTab-explore_statistics')
+        .should('be.visible')
+        .and('have.attr', 'aria-selected', 'true');
+
+      // Click the expand button on the first row
+      cy.get('.exploreStatisticTable tbody tr').first().find('button[aria-label="Expand"]').click();
+
+      // Verify the expanded row shows JSON content
+      cy.get('.exploreStatisticTable .euiCodeBlock').should('be.visible');
+
+      // Click again to collapse
+      cy.get('.exploreStatisticTable tbody tr')
+        .first()
+        .find('button[aria-label="Collapse"]')
+        .click();
+
+      // Verify the expanded row is collapsed
+      cy.get('.exploreStatisticTable .euiCodeBlock').should('not.exist');
+    });
+
+    it('can be manually selected and shows results', () => {
+      // Run a plain query first (stays on Logs tab)
+      const plainQuery = `source = ${indexPattern}`;
+      cy.explore.setQueryEditor(plainQuery);
+      cy.osd.waitForLoader(true);
+
+      // Verify Logs tab is selected
+      cy.getElementByTestId('exploreTab-logs')
+        .should('be.visible')
+        .and('have.attr', 'aria-selected', 'true');
+
+      // Manually click the Statistics tab
+      cy.getElementByTestId('exploreTab-explore_statistics').click();
+      cy.wait(1000);
+
+      // Verify Statistics tab is now selected
+      cy.getElementByTestId('exploreTab-explore_statistics').should(
+        'have.attr',
+        'aria-selected',
+        'true'
+      );
+
+      // Verify the statistics table container is rendered
+      cy.get('.explore-statistic-tab').should('be.visible');
+    });
+
+    it('displays hit count in the action bar', () => {
+      const statsQuery = `source = ${indexPattern} | stats count() by category`;
+      cy.explore.setQueryEditor(statsQuery);
+      cy.osd.waitForLoader(true);
+
+      // Verify Statistics tab is selected
+      cy.getElementByTestId('exploreTab-explore_statistics')
+        .should('be.visible')
+        .and('have.attr', 'aria-selected', 'true');
+
+      // Verify the results action bar shows hit count
+      cy.getElementByTestId('dscResultsActionBar').should('be.visible');
+      cy.getElementByTestId('discoverQueryHits').should('be.visible');
+    });
+  });
+};
+
+prepareTestSuite('Statistics Tab', statisticsTabTestSuite);

--- a/src/plugins/explore/common/index.ts
+++ b/src/plugins/explore/common/index.ts
@@ -21,9 +21,11 @@ export const DEFAULT_LOGS_COLUMNS_SETTING = 'explore:defaultLogsColumns';
 export const ENABLE_EXPERIMENTAL_SETTING = 'explore:experimental';
 export const EXPLORE_DEFAULT_LANGUAGE = 'PPL';
 export const EXPLORE_LOGS_TAB_ID = 'logs';
+export const EXPLORE_STATISTICS_TAB_ID = 'explore_statistics';
 export const EXPLORE_PATTERNS_TAB_ID = 'explore_patterns_tab';
 export const EXPLORE_VISUALIZATION_TAB_ID = 'explore_visualization_tab';
 export const EXPLORE_FIELD_STATS_TAB_ID = 'explore_field_stats_tab';
+export const EXPLORE_NO_TAB_ID = '';
 export const VISUALIZATION_EDITOR_APP_ID = 'visualization-editor';
 export const VISUALIZATION_EDITOR_APP_NAME = 'VisualizationEditor';
 

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -18,6 +18,7 @@ import {
   EXPLORE_PATTERNS_TAB_ID,
   EXPLORE_FIELD_STATS_TAB_ID,
   ENABLE_EXPERIMENTAL_SETTING,
+  EXPLORE_STATISTICS_TAB_ID,
 } from '../../common';
 import { VisTab } from '../components/tabs/vis_tab';
 import { prepareQueryForLanguage } from './utils/languages';
@@ -32,6 +33,7 @@ import { setIndividualQueryStatus } from './utils/state_management/slices/query_
 import { QueryExecutionStatus } from './utils/state_management/types';
 import { PatternsTab } from '../components/tabs/patterns_tab';
 import { BRAIN_QUERY_OLD_ENGINE_ERROR_PREFIX } from '../components/patterns_table/utils/constants';
+import { StatisticsTab } from '../components/tabs/statistics_tab';
 
 /**
  * Registers built-in tabs with the tab registry
@@ -196,12 +198,30 @@ export const registerBuiltInTabs = (
     component: VisTab,
   });
 
+  tabRegistry.registerTab({
+    id: EXPLORE_STATISTICS_TAB_ID,
+    label: i18n.translate('explore.statistics.label', {
+      defaultMessage: 'Statistics',
+    }),
+    flavor: [ExploreFlavor.Logs],
+    order: 17,
+    supportedLanguages: [EXPLORE_DEFAULT_LANGUAGE],
+
+    // Prepare query based on language
+    prepareQuery: (query) => {
+      const preparedQuery = prepareQueryForLanguage(query);
+      return preparedQuery.query;
+    },
+
+    component: StatisticsTab,
+  });
+
   // Register Field Stats Tab
   if (isExperimentalEnabled) {
     tabRegistry.registerTab({
       id: EXPLORE_FIELD_STATS_TAB_ID,
       label: i18n.translate('explore.fieldStatsTab.label', {
-        defaultMessage: 'Field Stats',
+        defaultMessage: 'Fields',
       }),
       flavor: [ExploreFlavor.Logs],
       order: 25,

--- a/src/plugins/explore/public/application/utils/hooks/use_initial_query_execution.test.tsx
+++ b/src/plugins/explore/public/application/utils/hooks/use_initial_query_execution.test.tsx
@@ -19,6 +19,7 @@ import {
 import { metaReducer } from '../state_management/slices/meta/meta_slice';
 import { executeQueries } from '../state_management/actions/query_actions';
 import { clearResults } from '../state_management/slices';
+import { detectAndSetOptimalTab } from '../state_management/actions/detect_optimal_tab';
 import { MockStore } from '../state_management/__mocks__';
 import * as CurrentExploreIdHook from './use_current_explore_id';
 import * as DatasetContextHook from '../../context';
@@ -33,6 +34,10 @@ jest.mock('../state_management/actions/query_actions', () => ({
   executeQueries: jest.fn().mockReturnValue({ type: 'EXECUTE_QUERIES' }),
 }));
 
+jest.mock('../state_management/actions/detect_optimal_tab', () => ({
+  detectAndSetOptimalTab: jest.fn().mockReturnValue({ type: 'DETECT_AND_SET_OPTIMAL_TAB' }),
+}));
+
 jest.mock('../state_management/slices', () => ({
   ...jest.requireActual('../state_management/slices'),
   clearResults: jest.fn().mockReturnValue({ type: 'CLEAR_RESULTS' }),
@@ -41,6 +46,9 @@ jest.mock('../state_management/slices', () => ({
 
 const mockExecuteQueries = executeQueries as jest.MockedFunction<typeof executeQueries>;
 const mockClearResults = clearResults as jest.MockedFunction<typeof clearResults>;
+const mockDetectAndSetOptimalTab = detectAndSetOptimalTab as jest.MockedFunction<
+  typeof detectAndSetOptimalTab
+>;
 
 // Mock store state type
 interface MockRootState {
@@ -197,18 +205,27 @@ describe('useInitialQueryExecution', () => {
 
       expect(mockClearResults).toHaveBeenCalled();
       expect(mockExecuteQueries).toHaveBeenCalledWith({ services: mockServices });
+      expect(mockDetectAndSetOptimalTab).toHaveBeenCalledWith({ services: mockServices });
       expect(result.current.isInitialized).toBe(false); // Still false until Redux state updates
     });
 
-    it('should only initialize once', () => {
-      const { rerender } = renderHookWithProvider(mockServices);
+    it('should only initialize once', async () => {
+      let hookResult: any;
+
+      await act(async () => {
+        hookResult = renderHookWithProvider(mockServices);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
 
       // First render
       expect(mockExecuteQueries).toHaveBeenCalledTimes(1);
       expect(mockServices.data.query.queryString.addToQueryHistory).toHaveBeenCalledTimes(1);
 
       // Re-render should not trigger again
-      rerender();
+      await act(async () => {
+        hookResult.rerender();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
       expect(mockExecuteQueries).toHaveBeenCalledTimes(1);
       expect(mockServices.data.query.queryString.addToQueryHistory).toHaveBeenCalledTimes(1);
     });
@@ -268,6 +285,7 @@ describe('useInitialQueryExecution', () => {
       // But should still execute query (business logic decision)
       expect(mockClearResults).toHaveBeenCalled();
       expect(mockExecuteQueries).toHaveBeenCalledWith({ services: mockServices });
+      expect(mockDetectAndSetOptimalTab).toHaveBeenCalledWith({ services: mockServices });
       // Verify setIsInitialized was dispatched (state update happens asynchronously)
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -345,6 +363,9 @@ describe('useInitialQueryExecution', () => {
       // But should still execute query
       expect(mockClearResults).toHaveBeenCalled();
       expect(mockExecuteQueries).toHaveBeenCalledWith({ services: servicesWithoutTimefilter });
+      expect(mockDetectAndSetOptimalTab).toHaveBeenCalledWith({
+        services: servicesWithoutTimefilter,
+      });
       // Verify setIsInitialized was dispatched (state update happens asynchronously)
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -459,6 +480,7 @@ describe('useInitialQueryExecution', () => {
 
       expect(mockClearResults).toHaveBeenCalled();
       expect(mockExecuteQueries).toHaveBeenCalled();
+      expect(mockDetectAndSetOptimalTab).toHaveBeenCalled();
       // Verify setIsInitialized was dispatched (state update happens asynchronously)
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -487,6 +509,7 @@ describe('useInitialQueryExecution', () => {
       // But should still execute query
       expect(mockClearResults).toHaveBeenCalled();
       expect(mockExecuteQueries).toHaveBeenCalled();
+      expect(mockDetectAndSetOptimalTab).toHaveBeenCalled();
       // Verify setIsInitialized was dispatched (state update happens asynchronously)
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/plugins/explore/public/application/utils/hooks/use_initial_query_execution.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_initial_query_execution.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { ExploreServices } from '../../../types';
 import { RootState } from '../state_management/store';
@@ -11,6 +11,8 @@ import { executeQueries } from '../state_management/actions/query_actions';
 import { clearResults, clearQueryStatusMap, setIsInitialized } from '../state_management/slices';
 import { useCurrentExploreId } from './use_current_explore_id';
 import { useDatasetContext } from '../../context';
+import { selectActiveTabId } from '../state_management/selectors';
+import { detectAndSetOptimalTab } from '../state_management/actions/detect_optimal_tab';
 
 /**
  * Hook to handle initial query execution on page load
@@ -20,8 +22,12 @@ export const useInitialQueryExecution = (services: ExploreServices) => {
   const dispatch = useDispatch();
   const { isInitialized } = useSelector((state: RootState) => state.meta);
   const queryState = useSelector((state: RootState) => state.query);
+  const activeTabId = useSelector(selectActiveTabId);
+  const activeTabIdRef = useRef(activeTabId);
   const exploreId = useCurrentExploreId();
   const { dataset: datasetFromContext, isLoading: datasetLoading } = useDatasetContext();
+
+  activeTabIdRef.current = activeTabId;
 
   const shouldSearchOnPageLoad = useMemo(() => {
     if (queryState.dataset && services?.data?.query?.queryString) {
@@ -55,6 +61,9 @@ export const useInitialQueryExecution = (services: ExploreServices) => {
         dispatch(clearResults());
         dispatch(clearQueryStatusMap());
 
+        if (!activeTabIdRef.current) {
+          await dispatch(detectAndSetOptimalTab({ services }));
+        }
         // @ts-expect-error TS2345 TODO(ts-error): fixme
         await dispatch(executeQueries({ services }));
         dispatch(setIsInitialized(true));

--- a/src/plugins/explore/public/application/utils/hooks/use_tab_results.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_tab_results.ts
@@ -9,7 +9,7 @@ import { RootState } from '../state_management/store';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../../types';
 import { defaultPrepareQueryString } from '../state_management/actions/query_actions';
-import { selectPatternsField } from '../state_management/selectors';
+import { selectActiveTabId, selectPatternsField } from '../state_management/selectors';
 import { selectQueryStatusMapByKey } from '../state_management/selectors/query_editor/query_editor';
 import { resultsCache } from '../state_management/slices';
 
@@ -19,7 +19,7 @@ import { resultsCache } from '../state_management/slices';
 export const useTabResults = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const query = useSelector((state: RootState) => state.query);
-  const activeTabId = useSelector((state: RootState) => state.ui.activeTabId);
+  const activeTabId = useSelector(selectActiveTabId);
   const patternsField = useSelector(selectPatternsField); // for use in updating dependency array of cacheKey
 
   const cacheKey = useMemo(() => {

--- a/src/plugins/explore/public/application/utils/state_management/actions/detect_optimal_tab.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/detect_optimal_tab.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { detectAndSetOptimalTab } from './detect_optimal_tab';
+import {
+  EXPLORE_LOGS_TAB_ID,
+  EXPLORE_STATISTICS_TAB_ID,
+  EXPLORE_VISUALIZATION_TAB_ID,
+} from '../../../../../common';
+
+jest.mock('../slices', () => ({
+  setActiveTab: jest.fn((tabId) => ({ type: 'ui/setActiveTab', payload: tabId })),
+}));
+
+const mockServices = {} as any;
+
+/**
+ * Helper to build a minimal RootState-like object for getState().
+ */
+const buildState = (query: string, activeTabId: string) => ({
+  query: { query },
+  ui: { activeTabId },
+});
+
+/**
+ * Invokes the thunk and returns the tab id that was dispatched via setActiveTab.
+ */
+const runDetect = async (query: string, activeTabId: string): Promise<string> => {
+  const mockDispatch = jest.fn();
+  const mockGetState = jest.fn().mockReturnValue(buildState(query, activeTabId));
+
+  const thunk = detectAndSetOptimalTab({ services: mockServices });
+  await thunk(mockDispatch, mockGetState, undefined);
+
+  // setActiveTab is called inside the thunk via dispatch
+  const setActiveTabCall = mockDispatch.mock.calls.find(
+    (call) => call[0]?.type === 'ui/setActiveTab'
+  );
+  expect(setActiveTabCall).toBeDefined();
+  return setActiveTabCall![0].payload;
+};
+
+describe('detectAndSetOptimalTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Rule 1: Current tab is Logs (default)
+  // =========================================================================
+  describe('Rule 1 — current tab is Logs', () => {
+    it('switches to Statistics when query contains | stats', async () => {
+      const tab = await runDetect('source = idx | stats count() by category', EXPLORE_LOGS_TAB_ID);
+      expect(tab).toBe(EXPLORE_STATISTICS_TAB_ID);
+    });
+
+    it('switches to Statistics when query contains | table', async () => {
+      const tab = await runDetect('source = idx | table col1, col2', EXPLORE_LOGS_TAB_ID);
+      expect(tab).toBe(EXPLORE_STATISTICS_TAB_ID);
+    });
+
+    it('switches to Visualization when query contains | chart', async () => {
+      const tab = await runDetect('source = idx | chart count() by cat', EXPLORE_LOGS_TAB_ID);
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('switches to Visualization when query contains | timechart', async () => {
+      const tab = await runDetect('source = idx | timechart count()', EXPLORE_LOGS_TAB_ID);
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('stays on Logs when query has no special command', async () => {
+      const tab = await runDetect('source = idx | where x > 1', EXPLORE_LOGS_TAB_ID);
+      expect(tab).toBe(EXPLORE_LOGS_TAB_ID);
+    });
+
+    it('stays on Logs when query is empty', async () => {
+      const tab = await runDetect('', EXPLORE_LOGS_TAB_ID);
+      expect(tab).toBe(EXPLORE_LOGS_TAB_ID);
+    });
+  });
+
+  // =========================================================================
+  // Rule 2: Current tab is Statistic
+  // =========================================================================
+  describe('Rule 2 — current tab is Statistic', () => {
+    it('stays on Statistics when query contains | stats', async () => {
+      const tab = await runDetect(
+        'source = idx | stats count() by category',
+        EXPLORE_STATISTICS_TAB_ID
+      );
+      expect(tab).toBe(EXPLORE_STATISTICS_TAB_ID);
+    });
+
+    it('stays on Statistics when query contains | table', async () => {
+      const tab = await runDetect('source = idx | table col1', EXPLORE_STATISTICS_TAB_ID);
+      expect(tab).toBe(EXPLORE_STATISTICS_TAB_ID);
+    });
+
+    it('stays on Statistics when query contains | chart (interchangeable)', async () => {
+      const tab = await runDetect('source = idx | chart count() by cat', EXPLORE_STATISTICS_TAB_ID);
+      expect(tab).toBe(EXPLORE_STATISTICS_TAB_ID);
+    });
+
+    it('stays on Statistics when query contains | timechart (interchangeable)', async () => {
+      const tab = await runDetect('source = idx | timechart count()', EXPLORE_STATISTICS_TAB_ID);
+      expect(tab).toBe(EXPLORE_STATISTICS_TAB_ID);
+    });
+
+    it('switches to Logs when query has no special command', async () => {
+      const tab = await runDetect('source = idx | where x > 1', EXPLORE_STATISTICS_TAB_ID);
+      expect(tab).toBe(EXPLORE_LOGS_TAB_ID);
+    });
+
+    it('switches to Logs when query is empty', async () => {
+      const tab = await runDetect('', EXPLORE_STATISTICS_TAB_ID);
+      expect(tab).toBe(EXPLORE_LOGS_TAB_ID);
+    });
+  });
+
+  // =========================================================================
+  // Rule 3: Current tab is Visualization
+  // =========================================================================
+  describe('Rule 3 — current tab is Visualization', () => {
+    it('stays on Visualization when query contains | stats (interchangeable)', async () => {
+      const tab = await runDetect(
+        'source = idx | stats count() by category',
+        EXPLORE_VISUALIZATION_TAB_ID
+      );
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('stays on Visualization when query contains | table (interchangeable)', async () => {
+      const tab = await runDetect('source = idx | table col1', EXPLORE_VISUALIZATION_TAB_ID);
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('stays on Visualization when query contains | chart', async () => {
+      const tab = await runDetect(
+        'source = idx | chart count() by cat',
+        EXPLORE_VISUALIZATION_TAB_ID
+      );
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('stays on Visualization when query contains | timechart', async () => {
+      const tab = await runDetect('source = idx | timechart count()', EXPLORE_VISUALIZATION_TAB_ID);
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('stays on Visualization when query has no special command', async () => {
+      const tab = await runDetect('source = idx | where x > 1', EXPLORE_VISUALIZATION_TAB_ID);
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+
+    it('stays on Visualization when query is empty', async () => {
+      const tab = await runDetect('', EXPLORE_VISUALIZATION_TAB_ID);
+      expect(tab).toBe(EXPLORE_VISUALIZATION_TAB_ID);
+    });
+  });
+});

--- a/src/plugins/explore/public/application/utils/state_management/actions/detect_optimal_tab.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/detect_optimal_tab.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { RootState } from '../store';
+import { setActiveTab } from '../slices';
+import { ExploreServices } from '../../../../types';
+import {
+  EXPLORE_LOGS_TAB_ID,
+  EXPLORE_STATISTICS_TAB_ID,
+  EXPLORE_VISUALIZATION_TAB_ID,
+} from '../../../../../common';
+
+const hasStatsOrTable = (q: string) => /\|\s*(stats|table)\b/i.test(q);
+const hasChartOrTimechart = (q: string) => /\|\s*(chart|timechart)\b/i.test(q);
+
+/**
+ * Determines the optimal tab based on the current query and the user's
+ * current tab selection, then dispatches setActiveTab once.
+ *
+ * Decision matrix:
+ *
+ * | Current Tab ↓ \ Query →  | stats/table    | chart/timechart  | No command      |
+ * |--------------------------|----------------|------------------|-----------------|
+ * | Logs (default)           | → Statistic    | → Visualization  | → Logs (stay)   |
+ * | Statistic                | → Statistic    | → Statistic      | → Logs          |
+ * | Visualization            | → Visualization| → Visualization  | → Visualization |
+ */
+export const detectAndSetOptimalTab = createAsyncThunk<
+  void,
+  { services: ExploreServices },
+  { state: RootState }
+>('ui/detectAndSetOptimalTab', async (_args, { getState, dispatch }) => {
+  const state = getState();
+  const queryString = typeof state.query.query === 'string' ? state.query.query : '';
+  const currentTab = state.ui.activeTabId || EXPLORE_LOGS_TAB_ID;
+
+  let targetTab: string;
+
+  switch (currentTab) {
+    case EXPLORE_LOGS_TAB_ID:
+      if (hasStatsOrTable(queryString)) {
+        targetTab = EXPLORE_STATISTICS_TAB_ID;
+      } else if (hasChartOrTimechart(queryString)) {
+        targetTab = EXPLORE_VISUALIZATION_TAB_ID;
+      } else {
+        targetTab = EXPLORE_LOGS_TAB_ID;
+      }
+      break;
+
+    case EXPLORE_STATISTICS_TAB_ID:
+      if (hasStatsOrTable(queryString) || hasChartOrTimechart(queryString)) {
+        targetTab = EXPLORE_STATISTICS_TAB_ID;
+      } else {
+        targetTab = EXPLORE_LOGS_TAB_ID;
+      }
+      break;
+
+    case EXPLORE_VISUALIZATION_TAB_ID:
+      targetTab = EXPLORE_VISUALIZATION_TAB_ID;
+      break;
+
+    default:
+      targetTab = currentTab;
+  }
+
+  dispatch(setActiveTab(targetTab));
+});

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_editor/run_query/run_query.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_editor/run_query/run_query.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../slices';
 import { clearQueryStatusMap } from '../../../slices/query_editor/query_editor_slice';
 import { executeQueries } from '../../query_actions';
+import { detectAndSetOptimalTab } from '../../detect_optimal_tab';
 
 jest.mock('../../../slices', () => ({
   setQueryStringWithHistory: jest.fn((query) => ({
@@ -40,22 +41,32 @@ jest.mock('../../query_actions', () => ({
   executeQueries: jest.fn((args) => ({ type: 'executeQueries', payload: args })),
 }));
 
+jest.mock('../../detect_optimal_tab', () => ({
+  detectAndSetOptimalTab: jest.fn((args) => ({
+    type: 'detectAndSetOptimalTab',
+    payload: args,
+  })),
+}));
+
 describe('runQueryActionCreator', () => {
   const mockDispatch = jest.fn();
   const mockGetState = jest.fn();
   const mockServices = { some: 'service' } as any;
   const query = 'this is some query';
+  const previousQuery = 'previous query';
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetState.mockReturnValue({ query: { query: previousQuery } });
   });
 
-  it('dispatches setQueryStringWithHistory, clearResults, clearQueryStatusMap, executeQueries, and setQueryExecutionButtonStatus when query is provided', async () => {
+  it('dispatches detectAndSetOptimalTab when query differs from previous query', async () => {
     await runQueryActionCreator(mockServices, query)(mockDispatch, mockGetState);
 
     expect(setQueryStringWithHistory).toHaveBeenCalledWith(query);
     expect(clearResults).toHaveBeenCalled();
     expect(clearQueryStatusMap).toHaveBeenCalled();
+    expect(detectAndSetOptimalTab).toHaveBeenCalledWith({ services: mockServices });
     expect(executeQueries).toHaveBeenCalledWith({ services: mockServices });
     expect(setQueryExecutionButtonStatus).toHaveBeenCalledWith('REFRESH');
 
@@ -73,6 +84,43 @@ describe('runQueryActionCreator', () => {
       payload: false,
     });
     expect(mockDispatch).toHaveBeenNthCalledWith(5, {
+      type: 'detectAndSetOptimalTab',
+      payload: { services: mockServices },
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(6, {
+      type: 'executeQueries',
+      payload: { services: mockServices },
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(7, {
+      type: 'queryEditor/setQueryExecutionButtonStatus',
+      payload: 'REFRESH',
+    });
+  });
+
+  it('dispatches detectAndSetOptimalTab when no query is provided (undefined differs from previous)', async () => {
+    await runQueryActionCreator(mockServices)(mockDispatch, mockGetState);
+
+    expect(setQueryStringWithHistory).not.toHaveBeenCalled();
+    expect(clearResults).toHaveBeenCalled();
+    expect(clearQueryStatusMap).toHaveBeenCalled();
+    expect(detectAndSetOptimalTab).toHaveBeenCalledWith({ services: mockServices });
+    expect(executeQueries).toHaveBeenCalledWith({ services: mockServices });
+    expect(setQueryExecutionButtonStatus).toHaveBeenCalledWith('REFRESH');
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, { type: 'clearResults' });
+    expect(mockDispatch).toHaveBeenNthCalledWith(2, {
+      type: 'queryEditor/clearQueryStatusMap',
+      payload: undefined,
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(3, {
+      type: 'queryEditor/setIsQueryEditorDirty',
+      payload: false,
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(4, {
+      type: 'detectAndSetOptimalTab',
+      payload: { services: mockServices },
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(5, {
       type: 'executeQueries',
       payload: { services: mockServices },
     });
@@ -82,40 +130,13 @@ describe('runQueryActionCreator', () => {
     });
   });
 
-  it('dispatches clearResults, clearQueryStatusMap, setIsQueryEditorDirty, executeQueries, and setQueryExecutionButtonStatus when no query is provided', async () => {
-    await runQueryActionCreator(mockServices)(mockDispatch, mockGetState);
-
-    expect(setQueryStringWithHistory).not.toHaveBeenCalled();
-    expect(clearResults).toHaveBeenCalled();
-    expect(clearQueryStatusMap).toHaveBeenCalled();
-    expect(executeQueries).toHaveBeenCalledWith({ services: mockServices });
-    expect(setQueryExecutionButtonStatus).toHaveBeenCalledWith('REFRESH');
-
-    expect(mockDispatch).toHaveBeenNthCalledWith(1, { type: 'clearResults' });
-    expect(mockDispatch).toHaveBeenNthCalledWith(2, {
-      type: 'queryEditor/clearQueryStatusMap',
-      payload: undefined,
-    });
-    expect(mockDispatch).toHaveBeenNthCalledWith(3, {
-      type: 'queryEditor/setIsQueryEditorDirty',
-      payload: false,
-    });
-    expect(mockDispatch).toHaveBeenNthCalledWith(4, {
-      type: 'executeQueries',
-      payload: { services: mockServices },
-    });
-    expect(mockDispatch).toHaveBeenNthCalledWith(5, {
-      type: 'queryEditor/setQueryExecutionButtonStatus',
-      payload: 'REFRESH',
-    });
-  });
-
-  it('dispatches clearResults, clearQueryStatusMap, setIsQueryEditorDirty, executeQueries, and setQueryExecutionButtonStatus when query is undefined', async () => {
+  it('dispatches detectAndSetOptimalTab when query is explicitly undefined (differs from previous)', async () => {
     await runQueryActionCreator(mockServices, undefined)(mockDispatch, mockGetState);
 
     expect(setQueryStringWithHistory).not.toHaveBeenCalled();
     expect(clearResults).toHaveBeenCalled();
     expect(clearQueryStatusMap).toHaveBeenCalled();
+    expect(detectAndSetOptimalTab).toHaveBeenCalledWith({ services: mockServices });
     expect(executeQueries).toHaveBeenCalledWith({ services: mockServices });
     expect(setQueryExecutionButtonStatus).toHaveBeenCalledWith('REFRESH');
 
@@ -129,28 +150,70 @@ describe('runQueryActionCreator', () => {
       payload: false,
     });
     expect(mockDispatch).toHaveBeenNthCalledWith(4, {
-      type: 'executeQueries',
+      type: 'detectAndSetOptimalTab',
       payload: { services: mockServices },
     });
     expect(mockDispatch).toHaveBeenNthCalledWith(5, {
+      type: 'executeQueries',
+      payload: { services: mockServices },
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(6, {
       type: 'queryEditor/setQueryExecutionButtonStatus',
       payload: 'REFRESH',
     });
   });
 
-  it('dispatches setQueryStringWithHistory, clearResults, clearQueryStatusMap, setIsQueryEditorDirty, executeQueries, and setQueryExecutionButtonStatus when query is an empty string', async () => {
+  it('dispatches detectAndSetOptimalTab when query is an empty string (differs from previous)', async () => {
     const emptyQuery = '';
     await runQueryActionCreator(mockServices, emptyQuery)(mockDispatch, mockGetState);
 
     expect(setQueryStringWithHistory).toHaveBeenCalledWith(emptyQuery);
     expect(clearResults).toHaveBeenCalled();
     expect(clearQueryStatusMap).toHaveBeenCalled();
+    expect(detectAndSetOptimalTab).toHaveBeenCalledWith({ services: mockServices });
     expect(executeQueries).toHaveBeenCalledWith({ services: mockServices });
     expect(setQueryExecutionButtonStatus).toHaveBeenCalledWith('REFRESH');
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'setQueryStringWithHistory',
       payload: emptyQuery,
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(2, { type: 'clearResults' });
+    expect(mockDispatch).toHaveBeenNthCalledWith(3, {
+      type: 'queryEditor/clearQueryStatusMap',
+      payload: undefined,
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(4, {
+      type: 'queryEditor/setIsQueryEditorDirty',
+      payload: false,
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(5, {
+      type: 'detectAndSetOptimalTab',
+      payload: { services: mockServices },
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(6, {
+      type: 'executeQueries',
+      payload: { services: mockServices },
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(7, {
+      type: 'queryEditor/setQueryExecutionButtonStatus',
+      payload: 'REFRESH',
+    });
+  });
+
+  it('skips detectAndSetOptimalTab when query matches previous query (same-query refresh)', async () => {
+    await runQueryActionCreator(mockServices, previousQuery)(mockDispatch, mockGetState);
+
+    expect(setQueryStringWithHistory).toHaveBeenCalledWith(previousQuery);
+    expect(clearResults).toHaveBeenCalled();
+    expect(clearQueryStatusMap).toHaveBeenCalled();
+    expect(detectAndSetOptimalTab).not.toHaveBeenCalled();
+    expect(executeQueries).toHaveBeenCalledWith({ services: mockServices });
+    expect(setQueryExecutionButtonStatus).toHaveBeenCalledWith('REFRESH');
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'setQueryStringWithHistory',
+      payload: previousQuery,
     });
     expect(mockDispatch).toHaveBeenNthCalledWith(2, { type: 'clearResults' });
     expect(mockDispatch).toHaveBeenNthCalledWith(3, {

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_editor/run_query/run_query.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_editor/run_query/run_query.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../slices/query_editor/query_editor_slice';
 import { executeQueries } from '../../query_actions';
 import { ExploreServices } from '../../../../../../types';
+import { detectAndSetOptimalTab } from '../../detect_optimal_tab';
 
 /**
  * This is called when you want to run the query
@@ -23,12 +24,21 @@ export const runQueryActionCreator = (services: ExploreServices, query?: string)
   dispatch: AppDispatch,
   getState: () => RootState
 ) => {
+  const previousQuery = getState().query.query;
+
   if (typeof query === 'string') {
     dispatch(setQueryStringWithHistory(query));
   }
   dispatch(clearResults());
   dispatch(clearQueryStatusMap());
   dispatch(setIsQueryEditorDirty(false));
+
+  // Only re-detect the optimal tab when the query text actually changed.
+  // Time-only refreshes (no query param or same query) should preserve the
+  // current tab choice.
+  if (query !== previousQuery) {
+    await dispatch(detectAndSetOptimalTab({ services }));
+  }
 
   await dispatch(executeQueries({ services }));
 

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_explore_state/reset_explore_state.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_explore_state/reset_explore_state.test.ts
@@ -14,10 +14,12 @@ import {
 } from '../../slices';
 import { getPreloadedState } from '../../utils/redux_persistence';
 import { executeQueries } from '../query_actions';
+import { detectAndSetOptimalTab } from '../detect_optimal_tab';
 
 jest.mock('../../utils/redux_persistence');
 jest.mock('../../slices');
 jest.mock('../query_actions');
+jest.mock('../detect_optimal_tab');
 
 describe('resetExploreStateActionCreator', () => {
   const services = {} as any;
@@ -43,6 +45,9 @@ describe('resetExploreStateActionCreator', () => {
     ((setQueryState as unknown) as jest.Mock).mockReturnValue({ type: 'SET_QUERY' });
     ((setQueryEditorState as unknown) as jest.Mock).mockReturnValue({ type: 'SET_QUERY_EDITOR' });
     ((executeQueries as unknown) as jest.Mock).mockReturnValue({ type: 'EXECUTE_QUERIES' });
+    ((detectAndSetOptimalTab as unknown) as jest.Mock).mockReturnValue({
+      type: 'DETECT_OPTIMAL_TAB',
+    });
   });
 
   it('dispatches actions in correct order with preloaded state', async () => {
@@ -56,6 +61,7 @@ describe('resetExploreStateActionCreator', () => {
     expect(mockDispatch).toHaveBeenNthCalledWith(4, { type: 'SET_LEGACY' });
     expect(mockDispatch).toHaveBeenNthCalledWith(5, { type: 'SET_QUERY' });
     expect(mockDispatch).toHaveBeenNthCalledWith(6, { type: 'SET_QUERY_EDITOR' });
-    expect(mockDispatch).toHaveBeenNthCalledWith(7, { type: 'EXECUTE_QUERIES' });
+    expect(mockDispatch).toHaveBeenNthCalledWith(7, { type: 'DETECT_OPTIMAL_TAB' });
+    expect(mockDispatch).toHaveBeenNthCalledWith(8, { type: 'EXECUTE_QUERIES' });
   });
 });

--- a/src/plugins/explore/public/application/utils/state_management/actions/reset_explore_state/reset_explore_state.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/reset_explore_state/reset_explore_state.ts
@@ -16,6 +16,7 @@ import { ExploreServices } from '../../../../../types';
 import { executeQueries } from '../query_actions';
 import { AppDispatch } from '../../store';
 import { useClearEditors } from '../../../../hooks';
+import { detectAndSetOptimalTab } from '../detect_optimal_tab';
 
 /**
  * Redux Thunk for resetting the Explore state to its preloaded state.
@@ -34,5 +35,6 @@ export const resetExploreStateActionCreator = (
   dispatch(setLegacyState(state.legacy));
   dispatch(setQueryState(state.query));
   dispatch(setQueryEditorState(state.queryEditor));
+  await dispatch(detectAndSetOptimalTab({ services }));
   await dispatch(executeQueries({ services }));
 };

--- a/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.ts
+++ b/src/plugins/explore/public/application/utils/state_management/middleware/dataset_change_middleware.ts
@@ -16,12 +16,14 @@ import {
   setSummaryAgentIsAvailable,
   setPatternsField,
   setUsingRegexPatterns,
+  setActiveTab,
 } from '../slices';
 import { clearQueryStatusMap, setBreakdownField } from '../slices/query_editor/query_editor_slice';
 import { executeQueries } from '../actions/query_actions';
 import { getPromptModeIsAvailable } from '../../get_prompt_mode_is_available';
 import { getSummaryAgentIsAvailable } from '../../get_summary_agent_is_available';
 import { resetLegacyStateActionCreator } from '../actions/reset_legacy_state';
+import { EXPLORE_NO_TAB_ID } from '../../../../../common';
 
 /**
  * Middleware to handle dataset changes and trigger necessary side effects
@@ -51,6 +53,7 @@ export const createDatasetChangeMiddleware = (
 
       currentDataset = dataset;
 
+      store.dispatch(setActiveTab(EXPLORE_NO_TAB_ID));
       store.dispatch(clearResults());
       store.dispatch(clearQueryStatusMap());
       store.dispatch(clearLastExecutedData());

--- a/src/plugins/explore/public/components/container/bottom_container/bottom_right_container/resizable_vis_control_and_tabs.tsx
+++ b/src/plugins/explore/public/components/container/bottom_container/bottom_right_container/resizable_vis_control_and_tabs.tsx
@@ -20,11 +20,11 @@ import { PanelDirection } from '@elastic/eui/src/components/resizable_container/
 
 import { getVisualizationBuilder } from '../../../visualizations/visualization_builder';
 import { ExploreTabs } from '../../../tabs/tabs';
-import { selectActiveTab } from '../../../../application/utils/state_management/selectors';
 import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
 import { useTabError } from '../../../../application/utils/hooks/use_tab_error';
 import { ExploreServices } from '../../../../types';
 import { EXPLORE_VISUALIZATION_TAB_ID } from '../../../../../common';
+import { selectActiveTab } from '../../../../application/utils/state_management/selectors';
 
 export const ResizableVisControlAndTabs = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();

--- a/src/plugins/explore/public/components/tabs/action_bar/results_action_bar/results_action_bar.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/results_action_bar/results_action_bar.tsx
@@ -20,7 +20,11 @@ import {
   selectWrapCellText,
 } from '../../../../application/utils/state_management/selectors';
 import { setWrapCellText } from '../../../../application/utils/state_management/slices';
-import { EXPLORE_LOGS_TAB_ID } from '../../../../../common';
+import {
+  EXPLORE_LOGS_TAB_ID,
+  EXPLORE_PATTERNS_TAB_ID,
+  EXPLORE_STATISTICS_TAB_ID,
+} from '../../../../../common';
 import { PatternsSettingsPopoverButton } from '../patterns_settings/patterns_settings_popover_button';
 import { getVisualizationBuilder } from '../../../visualizations/visualization_builder';
 import { SlotItemsForType } from '../../../../services/slot_registry';
@@ -52,9 +56,11 @@ export const DiscoverResultsActionBar = ({
   const currentTab = useSelector(selectActiveTabId);
   const wrapCellText = useSelector(selectWrapCellText);
   const isLogsTab = currentTab === EXPLORE_LOGS_TAB_ID;
-  const shouldShowAddToDashboardButton = currentTab !== 'explore_patterns_tab';
-  const shouldShowExportButton = currentTab !== 'explore_patterns_tab';
-  const showTabSpecificSettings = currentTab === 'explore_patterns_tab';
+  const shouldShowAddToDashboardButton =
+    currentTab !== EXPLORE_PATTERNS_TAB_ID && currentTab !== EXPLORE_STATISTICS_TAB_ID;
+  const shouldShowExportButton =
+    currentTab !== EXPLORE_PATTERNS_TAB_ID && currentTab !== EXPLORE_STATISTICS_TAB_ID;
+  const showTabSpecificSettings = currentTab === EXPLORE_PATTERNS_TAB_ID;
   const visualizationBuilder = getVisualizationBuilder();
   const visConfig = useObservable(visualizationBuilder.visConfig$);
   const showRawTable = useObservable(visualizationBuilder.showRawTable$);

--- a/src/plugins/explore/public/components/tabs/statistics_tab.test.tsx
+++ b/src/plugins/explore/public/components/tabs/statistics_tab.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { StatisticsTab } from './statistics_tab';
+import { EXPLORE_ACTION_BAR_SLOT_ID } from './tabs';
+
+const mockUseTabResults = jest.fn();
+
+jest.mock('./action_bar/action_bar', () => ({
+  ActionBar: () => <div data-testid="mocked-action-bar" />,
+}));
+
+jest.mock('../../application/utils/hooks/use_tab_results', () => ({
+  useTabResults: () => mockUseTabResults(),
+}));
+
+const createResults = (
+  hits: Array<Record<string, any>> = [],
+  fieldSchema: Array<{ name: string }> = []
+) => ({
+  hits: {
+    hits: hits.map((source) => ({ _source: source })),
+  },
+  fieldSchema,
+});
+
+describe('StatisticsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTabResults.mockReturnValue({ results: null, status: undefined });
+  });
+
+  const renderWithSlot = (ui: React.ReactElement = <StatisticsTab />) => {
+    return render(
+      <div>
+        <div id={EXPLORE_ACTION_BAR_SLOT_ID} />
+        {ui}
+      </div>
+    );
+  };
+
+  it('renders the main container with correct class names', () => {
+    const { container } = renderWithSlot();
+
+    expect(container.querySelector('.explore-statistic-tab')).toBeInTheDocument();
+    expect(container.querySelector('.tab-container')).toBeInTheDocument();
+    expect(container.querySelector('.exploreStatisticTable')).toBeInTheDocument();
+  });
+
+  it('renders ActionBar into the portal slot', () => {
+    const { container } = renderWithSlot();
+
+    const slot = container.querySelector(`#${EXPLORE_ACTION_BAR_SLOT_ID}`);
+    expect(slot).toBeInTheDocument();
+    expect(slot!.querySelector('[data-testid="mocked-action-bar"]')).toBeInTheDocument();
+  });
+
+  it('renders columns from fieldSchema and row data from hits', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults(
+        [
+          { city: 'Seattle', temp: 55 },
+          { city: 'Portland', temp: 50 },
+        ],
+        [{ name: 'city' }, { name: 'temp' }]
+      ),
+    });
+
+    renderWithSlot();
+
+    expect(screen.getByText('Seattle')).toBeInTheDocument();
+    expect(screen.getByText('Portland')).toBeInTheDocument();
+    expect(screen.getByText('55')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+
+  it('skips schema entries with falsy name', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults([{ valid: 'data' }], [{ name: 'valid' }, { name: '' }]),
+    });
+
+    renderWithSlot();
+
+    // 'valid' should appear as both column header and cell value
+    expect(screen.getAllByText('valid').length).toBeGreaterThanOrEqual(1);
+    // 'data' should appear as cell value, confirming the valid column rendered
+    expect(screen.getByText('data')).toBeInTheDocument();
+  });
+
+  it('expands a row to show JSON details on click', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults([{ field: 'value1' }], [{ name: 'field' }]),
+    });
+
+    renderWithSlot();
+
+    fireEvent.click(screen.getByLabelText('Expand'));
+
+    expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
+    expect(screen.getByText(/"field": "value1"/)).toBeInTheDocument();
+  });
+
+  it('collapses an expanded row on second click', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults([{ field: 'value1' }], [{ name: 'field' }]),
+    });
+
+    renderWithSlot();
+
+    fireEvent.click(screen.getByLabelText('Expand'));
+    expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
+    expect(screen.queryByText(/"field": "value1"/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Collapse'));
+    expect(screen.getByLabelText('Expand')).toBeInTheDocument();
+    expect(screen.queryByText(/"field": "value1"/)).not.toBeInTheDocument();
+  });
+
+  it('excludes the synthetic id field from expanded JSON', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults([{ name: 'Alice', age: 30 }], [{ name: 'name' }, { name: 'age' }]),
+    });
+
+    renderWithSlot();
+
+    fireEvent.click(screen.getByLabelText('Expand'));
+
+    expect(screen.getByText(/"name": "Alice"/)).toBeInTheDocument();
+    expect(screen.queryByText(/"id":/)).not.toBeInTheDocument();
+  });
+
+  it('toggles expansion when clicking a row', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults([{ field: 'value1' }], [{ name: 'field' }]),
+    });
+
+    renderWithSlot();
+
+    // Click the row itself (not the expand button)
+    fireEvent.click(screen.getByText('value1'));
+
+    expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
+    expect(screen.getByText(/"field": "value1"/)).toBeInTheDocument();
+
+    // Click again to collapse
+    fireEvent.click(screen.getByText('value1'));
+
+    expect(screen.getByLabelText('Expand')).toBeInTheDocument();
+    expect(screen.queryByText(/"field": "value1"/)).not.toBeInTheDocument();
+  });
+
+  it('supports multiple rows expanded simultaneously', () => {
+    mockUseTabResults.mockReturnValue({
+      results: createResults([{ field: 'value1' }, { field: 'value2' }], [{ name: 'field' }]),
+    });
+
+    renderWithSlot();
+
+    const expandButtons = screen.getAllByLabelText('Expand');
+    fireEvent.click(expandButtons[0]);
+    fireEvent.click(screen.getAllByLabelText('Expand')[0]);
+
+    expect(screen.getAllByLabelText('Collapse')).toHaveLength(2);
+  });
+});

--- a/src/plugins/explore/public/components/tabs/statistics_tab.tsx
+++ b/src/plugins/explore/public/components/tabs/statistics_tab.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CriteriaWithPagination,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiButtonIcon,
+  EuiCodeBlock,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
+import { createPortal } from 'react-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { EXPLORE_ACTION_BAR_SLOT_ID } from './tabs';
+import { ActionBar } from './action_bar/action_bar';
+import { useTabResults } from '../../application/utils/hooks/use_tab_results';
+
+const STATISTICS_PAGE_SIZE = 100;
+
+export const StatisticsTab = React.memo(() => {
+  const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<Record<string, JSX.Element>>(
+    {}
+  );
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+  const [pageIndex, setPageIndex] = useState(0);
+  const { results } = useTabResults();
+
+  useEffect(() => {
+    setSlot(document.getElementById(EXPLORE_ACTION_BAR_SLOT_ID));
+  }, []);
+
+  const onTableChange = useCallback(({ page }: CriteriaWithPagination<Record<string, any>>) => {
+    const { index } = page;
+    setPageIndex(index);
+  }, []);
+
+  const toggleDetails = useCallback((item: { id: string }) => {
+    const { id, ...rest } = item;
+    setItemIdToExpandedRowMap((prev) => {
+      const next = { ...prev };
+      if (next[id]) {
+        delete next[id];
+      } else {
+        next[id] = (
+          <EuiCodeBlock language="json">{JSON.stringify(rest, undefined, 2)}</EuiCodeBlock>
+        );
+      }
+      return next;
+    });
+  }, []);
+
+  const columns = useMemo(() => {
+    const cols: Array<EuiBasicTableColumn<Record<string, any>>> = [];
+    if (results) {
+      const schema = results.fieldSchema || [];
+
+      for (const { name } of schema) {
+        if (name) {
+          cols.push({
+            name,
+            field: name,
+            truncateText: true,
+          });
+        }
+      }
+      cols.push({
+        align: RIGHT_ALIGNMENT,
+        width: '40px',
+        isExpander: true,
+        render: (item: any) => (
+          <EuiButtonIcon
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              toggleDetails(item);
+            }}
+            aria-label={itemIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
+            iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
+          />
+        ),
+      });
+    }
+    return cols;
+  }, [itemIdToExpandedRowMap, results, toggleDetails]);
+
+  const rows = useMemo(() => {
+    if (results) {
+      const hits = results.hits?.hits || [];
+      const schema = results.fieldSchema || [];
+
+      const transformedData = hits.map((row, i) => {
+        const transformedRow: Record<string, any> = {};
+        transformedRow.id = i;
+        for (const { name } of schema) {
+          const source = row._source as Record<string, any>;
+          if (name) {
+            transformedRow[name] = source[name];
+          }
+        }
+        return transformedRow;
+      });
+      return transformedData;
+    }
+    return [];
+  }, [results]);
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize: STATISTICS_PAGE_SIZE,
+      totalItemCount: rows.length,
+      hidePerPageOptions: true,
+    }),
+    [pageIndex, rows.length]
+  );
+
+  const pageOfItems = useMemo(
+    () =>
+      rows.slice(
+        pageIndex * STATISTICS_PAGE_SIZE,
+        pageIndex * STATISTICS_PAGE_SIZE + STATISTICS_PAGE_SIZE
+      ),
+    [pageIndex, rows]
+  );
+
+  const getRowProps = useCallback(
+    (item: { id: string }) => ({
+      onClick: () => toggleDetails(item),
+      style: { cursor: 'pointer' },
+    }),
+    [toggleDetails]
+  );
+
+  return (
+    <div className="explore-statistic-tab tab-container">
+      {slot && createPortal(<ActionBar />, slot)}
+      <EuiBasicTable
+        className="exploreStatisticTable"
+        items={pageOfItems}
+        itemId="id"
+        columns={columns}
+        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+        isExpandable={true}
+        tableLayout="auto"
+        cellProps={{ style: { whiteSpace: 'nowrap', maxWidth: '200px' } }}
+        pagination={pagination}
+        onChange={onTableChange}
+        rowProps={getRowProps}
+      />
+    </div>
+  );
+});

--- a/src/plugins/explore/public/components/tabs/tabs.scss
+++ b/src/plugins/explore/public/components/tabs/tabs.scss
@@ -37,4 +37,16 @@
   .euiTabs:not(.euiTabs--condensed)::before {
     height: 0;
   }
+
+  .explore-statistic-tab {
+    .exploreStatisticTable {
+      display: flex;
+      flex-direction: column;
+      overflow: auto;
+
+      > div:first-of-type {
+        overflow: auto;
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Description
This PR introduced a new "Statistic" tab for dedicated tabular query results.

#### Tab Selection Rules
When a user runs a query, the tab behavior depends on two factors: the currently selected tab and the query content.

#### Rule 1 — Current tab is Logs (or no manual selection)

Logs is the default tab. When the user is on Logs (whether by default or manual selection), the system applies query-based auto-selection:

|Query Pattern	|Result	|
|---	|---	|
|Contains `stats` or `table`	|→ Switch to **Statistic**	|
|Contains `chart` or `timechart`	|→ Switch to **Visualization**	|
|None of the above	|→ Stay on **Logs**	|

#### Rule 2 — Current tab is Statistic

The user has expressed interest in tabular/aggregated data. Respect that intent:

|Query Pattern	|Result	|
|---	|---	|
|Contains `stats` or `table`	|→ Stay on **Statistic**	|
|Contains `chart` or `timechart`	|→ Stay on **Statistic** (interchangeable)	|
|None of the above	|→ Switch to **Logs**	|

#### Rule 3 — Current tab is Visualization

The user has expressed interest in visual/analytical data. Respect that intent:

|Query Pattern	|Result	|
|---	|---	|
|Contains `stats` or `table`	|→ Stay on **Visualization** (interchangeable)	|
|Contains `chart` or `timechart`	|→ Stay on **Visualization**	|
|None of the above	|→ Stay on **Visualization** (data-driven viz is valid without explicit commands)	|

### Decision Matrix

|Current Tab ↓ \ Query →	|stats / table	|chart / timechart	|Other cases	|
|---	|---	|---	|---	|
|**Logs**	|→ Statistic	|→ Visualization	|→ Logs (stay)	|
|**Statistic**	|→ Statistic (stay)	|→ Statistic (stay)	|→ Logs	|
|**Visualization**	|→ Visualization (stay)	|→ Visualization (stay)	|→ Visualization (stay)	|

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


https://github.com/user-attachments/assets/c52f96cd-f112-4267-953a-e9acc166a290


https://github.com/user-attachments/assets/7359cdfb-1d9a-4525-a450-f72808517819



<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
