### PR TITLE
[Backport 3.6] fix: vis editor empty state (#11613)

### DIFF
--- a/changelogs/fragments/11613.yml
+++ b/changelogs/fragments/11613.yml
@@ -1,0 +1,2 @@
+fix:
+- Vis editor should not import empty state component from legacy discover ([#11613](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11613))

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/in_context_bottom_left_container.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/in_context_bottom_left_container.tsx
@@ -14,12 +14,10 @@ import {
   EuiIcon,
 } from '@elastic/eui';
 import { TimeRange } from 'src/plugins/data/common';
-import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { ExploreServices } from '../../../types';
 import { QueryExecutionStatus } from '../../utils/state_management/types';
-import { DiscoverNoResults } from '../../../application/legacy/discover/application/components/no_results/no_results';
-import { DiscoverUninitialized } from '../../../application/legacy/discover/application/components/uninitialized/uninitialized';
-import { LoadingSpinner } from '../../../application/legacy/discover/application/components/loading_spinner/loading_spinner';
+import { VisEditorUninitialized } from './vis_editor_uninitialized';
+import { VisEditorNoResults } from './vis_editor_no_results';
+import { VisEditorLoadingState } from './vis_editor_loading_state';
 import { useSearchContext } from '../../../components/query_panel/utils/use_search_context';
 import { QueryPanel } from './in_context_query_panel';
 import { useQueryBuilderState } from '../hooks/use_query_builder_state';
@@ -39,28 +37,15 @@ const typeText = i18n.translate('explore.errorPanel.type', {
 });
 
 export const ResizableQueryPanelAndVisualization = () => {
-  const { services } = useOpenSearchDashboards<ExploreServices>();
-
   const { queryBuilder, queryEditorState } = useQueryBuilderState();
 
   const queryStatus = queryEditorState.queryStatus;
-
-  const dataview = queryBuilder.getDataView();
-
-  const onRefresh = () => {
-    queryBuilder.executeQuery();
-  };
 
   const renderVis = () => {
     if (queryStatus.status === QueryExecutionStatus.NO_RESULTS) {
       return (
         <EditorPanel>
-          <DiscoverNoResults
-            queryString={services?.data?.query?.queryString}
-            query={services?.data?.query?.queryString?.getQuery()}
-            savedQuery={services?.data?.query?.savedQueries}
-            timeFieldName={dataview?.timeFieldName}
-          />
+          <VisEditorNoResults />
         </EditorPanel>
       );
     }
@@ -68,9 +53,7 @@ export const ResizableQueryPanelAndVisualization = () => {
     if (queryStatus.status === QueryExecutionStatus.UNINITIALIZED) {
       return (
         <EditorPanel>
-          <div style={{ height: '100%' }}>
-            <DiscoverUninitialized onRefresh={onRefresh} />
-          </div>
+          <VisEditorUninitialized />
         </EditorPanel>
       );
     }
@@ -78,7 +61,7 @@ export const ResizableQueryPanelAndVisualization = () => {
     if (queryStatus.status === QueryExecutionStatus.LOADING) {
       return (
         <EditorPanel>
-          <LoadingSpinner />
+          <VisEditorLoadingState />
         </EditorPanel>
       );
     }

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/vis_editor_loading_state.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/vis_editor_loading_state.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
+
+export const VisEditorLoadingState = () => {
+  return (
+    <EuiEmptyPrompt
+      className="visEditorEmptyPrompt"
+      data-test-subj="visEditorLoading"
+      icon={<EuiLoadingSpinner size="xl" data-test-subj="visEditorLoadingSpinner" />}
+      title={
+        <h2>
+          {i18n.translate('explore.visEditor.loading.title', {
+            defaultMessage: 'Running query',
+          })}
+        </h2>
+      }
+    />
+  );
+};

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/vis_editor_no_results.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/vis_editor_no_results.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { EuiEmptyPrompt, EuiIcon } from '@elastic/eui';
+
+export const VisEditorNoResults = () => {
+  return (
+    <EuiEmptyPrompt
+      className="visEditorEmptyPrompt"
+      data-test-subj="visEditorNoResults"
+      icon={<EuiIcon type="visualizeApp" size="xl" />}
+      title={
+        <h2>
+          {i18n.translate('explore.visEditor.noResults.title', {
+            defaultMessage: 'No results',
+          })}
+        </h2>
+      }
+      body={
+        <p>
+          {i18n.translate('explore.visEditor.noResults.body', {
+            defaultMessage: 'Try adjusting your query, expanding the time range',
+          })}
+        </p>
+      }
+    />
+  );
+};

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/vis_editor_uninitialized.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/vis_editor_uninitialized.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { EuiEmptyPrompt, EuiIcon } from '@elastic/eui';
+
+export const VisEditorUninitialized = () => {
+  return (
+    <EuiEmptyPrompt
+      className="visEditorEmptyPrompt"
+      data-test-subj="visEditorUninitialized"
+      icon={<EuiIcon type="visualizeApp" size="xl" />}
+      title={
+        <h2>
+          {i18n.translate('explore.visEditor.uninitialized.title', {
+            defaultMessage: 'Run a query to visualize your data',
+          })}
+        </h2>
+      }
+      body={
+        <p>
+          {i18n.translate('explore.visEditor.uninitialized.body', {
+            defaultMessage:
+              'Write a query in the editor below, then run it to see your data visualized.',
+          })}
+        </p>
+      }
+    />
+  );
+};

--- a/src/plugins/explore/public/application/in_context_vis_editor/in_context_editor.scss
+++ b/src/plugins/explore/public/application/in_context_vis_editor/in_context_editor.scss
@@ -121,5 +121,13 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
     container-type: inline-size; // containment context
     /* stylelint-disable-next-line */
     container-name: canvas;
+
+    .visEditorEmptyPrompt {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
   }
 }


### PR DESCRIPTION
### Description
Backport [e11799f](https://github.com/opensearch-project/OpenSearch-Dashboards/commit/e11799fff92a9187c71c224d26f0c5203d793379) from #11613
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
