### PR TITLE
[Bug] Discover:Traces: Span fly-out

### DIFF
--- a/changelogs/fragments/11654.yml
+++ b/changelogs/fragments/11654.yml
@@ -1,0 +1,2 @@
+fix:
+- Fix span flyout race condition in Explore trace details ([#11654](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11654))

--- a/src/plugins/explore/public/application/pages/traces/trace_details/state/trace_app_state.test.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/state/trace_app_state.test.ts
@@ -653,4 +653,109 @@ describe('TraceAppState', () => {
       expect(state.dataset.title).toBe('');
     });
   });
+
+  describe('disableUrlSync option', () => {
+    it('disables URL sync when disableUrlSync is true', () => {
+      mockOsdUrlStateStorage.get.mockReturnValue(null);
+
+      const stateDefaults = {
+        traceId: 'test-trace-id',
+        dataset: createMockDataset(),
+        spanId: 'test-span-id',
+      };
+
+      createTraceAppState({
+        stateDefaults,
+        osdUrlStateStorage: mockOsdUrlStateStorage,
+        disableUrlSync: true,
+      });
+
+      // Should not attempt to read from URL
+      expect(mockOsdUrlStateStorage.get).not.toHaveBeenCalled();
+      // Should not attempt to write to URL
+      expect(mockOsdUrlStateStorage.set).not.toHaveBeenCalled();
+      // Should not set up sync
+      expect(syncState).not.toHaveBeenCalled();
+    });
+
+    it('uses only defaults when disableUrlSync is true, ignoring URL state', () => {
+      const urlState = {
+        traceId: 'url-trace-id',
+        spanId: 'url-span-id',
+        dataset: createMockDataset(),
+      };
+      mockOsdUrlStateStorage.get.mockReturnValue(urlState);
+
+      const stateDefaults = {
+        traceId: 'default-trace-id',
+        dataset: createMockDataset(),
+        spanId: 'default-span-id',
+      };
+
+      createTraceAppState({
+        stateDefaults,
+        osdUrlStateStorage: mockOsdUrlStateStorage,
+        disableUrlSync: true,
+      });
+
+      // Should use defaults, not URL state
+      expect(createStateContainer).toHaveBeenCalledWith(stateDefaults, expect.any(Object));
+    });
+
+    it('returns no-op stopStateSync when disableUrlSync is true', () => {
+      const stateDefaults = {
+        traceId: 'test-trace-id',
+        dataset: createMockDataset(),
+        spanId: undefined,
+      };
+
+      const { stopStateSync } = createTraceAppState({
+        stateDefaults,
+        osdUrlStateStorage: mockOsdUrlStateStorage,
+        disableUrlSync: true,
+      });
+
+      // Should not throw when called
+      expect(() => stopStateSync()).not.toThrow();
+      // syncState should not have been called
+      expect(syncState).not.toHaveBeenCalled();
+    });
+
+    it('enables URL sync by default when disableUrlSync is not provided', () => {
+      mockOsdUrlStateStorage.get.mockReturnValue(null);
+
+      const stateDefaults = {
+        traceId: 'test-trace-id',
+        dataset: createMockDataset(),
+        spanId: undefined,
+      };
+
+      createTraceAppState({
+        stateDefaults,
+        osdUrlStateStorage: mockOsdUrlStateStorage,
+      });
+
+      // Should set up sync when disableUrlSync is not provided
+      expect(syncState).toHaveBeenCalled();
+    });
+
+    it('enables URL sync when disableUrlSync is explicitly false', () => {
+      mockOsdUrlStateStorage.get.mockReturnValue(null);
+
+      const stateDefaults = {
+        traceId: 'test-trace-id',
+        dataset: createMockDataset(),
+        spanId: undefined,
+      };
+
+      createTraceAppState({
+        stateDefaults,
+        osdUrlStateStorage: mockOsdUrlStateStorage,
+        disableUrlSync: false,
+      });
+
+      // Should set up sync when disableUrlSync is false
+      expect(syncState).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/plugins/explore/public/application/pages/traces/trace_details/state/trace_app_state.ts
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/state/trace_app_state.ts
@@ -21,14 +21,18 @@ const STATE_STORAGE_KEY = '_a';
 export const createTraceAppState = ({
   stateDefaults,
   osdUrlStateStorage,
+  disableUrlSync = false,
 }: {
   stateDefaults: TraceAppState;
   osdUrlStateStorage: IOsdUrlStateStorage;
+  disableUrlSync?: boolean;
 }) => {
-  const initialStateFromUrl = osdUrlStateStorage.get<TraceAppState>(STATE_STORAGE_KEY);
+  const initialStateFromUrl = disableUrlSync
+    ? null
+    : osdUrlStateStorage.get<TraceAppState>(STATE_STORAGE_KEY);
   const initialState: TraceAppState = {
     ...stateDefaults,
-    ...initialStateFromUrl,
+    ...(initialStateFromUrl || {}),
   };
 
   const stateContainer = createStateContainer(initialState, {
@@ -50,29 +54,38 @@ export const createTraceAppState = ({
     }),
   });
 
-  if (!initialStateFromUrl) {
-    osdUrlStateStorage.set<TraceAppState>(STATE_STORAGE_KEY, initialState, {
-      replace: true,
+  // Only sync with URL if not disabled
+  if (!disableUrlSync) {
+    if (!initialStateFromUrl) {
+      osdUrlStateStorage.set<TraceAppState>(STATE_STORAGE_KEY, initialState, {
+        replace: true,
+      });
+    }
+
+    const { start: startStateSync, stop: stopStateSync } = syncState({
+      stateStorage: osdUrlStateStorage,
+      stateContainer: {
+        ...stateContainer,
+        set: (state: TraceAppState | null) => {
+          if (state) {
+            stateContainer.set(state);
+          }
+        },
+      },
+      storageKey: STATE_STORAGE_KEY,
     });
+
+    startStateSync();
+
+    return {
+      stateContainer,
+      stopStateSync,
+    };
   }
 
-  const { start: startStateSync, stop: stopStateSync } = syncState({
-    stateStorage: osdUrlStateStorage,
-    stateContainer: {
-      ...stateContainer,
-      set: (state: TraceAppState | null) => {
-        if (state) {
-          stateContainer.set(state);
-        }
-      },
-    },
-    storageKey: STATE_STORAGE_KEY,
-  });
-
-  startStateSync();
-
+  // Return no-op stopStateSync when URL sync is disabled
   return {
     stateContainer,
-    stopStateSync,
+    stopStateSync: () => {},
   };
 };

--- a/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
@@ -90,18 +90,24 @@ export const TraceDetails: React.FC<TraceDetailsProps> = ({
   const { stateContainer, stopStateSync } = useMemo(() => {
     // Convert DataView to Dataset format if needed
     const getDatasetFromDataView = (dataView: DataView): Dataset => {
+      // Check if already a Dataset with dataSource (not DataView with dataSourceRef)
+      const existingDataSource = (dataView as any).dataSource;
+      const dataSourceRef = (dataView as any).dataSourceRef;
+
       return {
         id: dataView.id || 'default-dataset-id',
         title: dataView.title,
         type: dataView.type || 'INDEX_PATTERN',
         timeFieldName: dataView.timeFieldName,
-        dataSource: dataView.dataSourceRef
-          ? {
-              id: dataView.dataSourceRef.id,
-              title: dataView.dataSourceRef.name || dataView.dataSourceRef.id,
-              type: dataView.dataSourceRef.type || 'OpenSearch',
-            }
-          : undefined,
+        dataSource:
+          existingDataSource ||
+          (dataSourceRef
+            ? {
+                id: dataSourceRef.id,
+                title: dataSourceRef.name || dataSourceRef.id,
+                type: dataSourceRef.type || 'OpenSearch',
+              }
+            : undefined),
       };
     };
 

--- a/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
@@ -119,9 +119,10 @@ export const TraceDetails: React.FC<TraceDetailsProps> = ({
         spanId: defaultSpanId,
       },
       osdUrlStateStorage: osdUrlStateStorage!,
+      disableUrlSync: isFlyout,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [osdUrlStateStorage]);
+  }, [osdUrlStateStorage, isFlyout]);
 
   // Get current state values and subscribe to changes
   const [appState, setAppState] = useState(() => stateContainer.get());

--- a/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/trace_view.tsx
@@ -68,6 +68,8 @@ export interface TraceDetailsProps {
   isEmbedded?: boolean;
   isFlyout?: boolean;
   defaultDataset?: DataView;
+  defaultTraceId?: string;
+  defaultSpanId?: string;
 }
 // Displaying only 10 logs in the tab
 export const LOGS_DATA = 10;
@@ -77,6 +79,8 @@ export const TraceDetails: React.FC<TraceDetailsProps> = ({
   isEmbedded = false,
   isFlyout = false,
   defaultDataset,
+  defaultTraceId,
+  defaultSpanId,
 }) => {
   const {
     services: { chrome, data, osdUrlStateStorage, savedObjects, uiSettings },
@@ -103,7 +107,7 @@ export const TraceDetails: React.FC<TraceDetailsProps> = ({
 
     return createTraceAppState({
       stateDefaults: {
-        traceId: '',
+        traceId: defaultTraceId || '',
         dataset: defaultDataset
           ? getDatasetFromDataView(defaultDataset)
           : {
@@ -112,7 +116,7 @@ export const TraceDetails: React.FC<TraceDetailsProps> = ({
               type: 'INDEX_PATTERN',
               timeFieldName: 'endTime',
             },
-        spanId: undefined,
+        spanId: defaultSpanId,
       },
       osdUrlStateStorage: osdUrlStateStorage!,
     });

--- a/src/plugins/explore/public/application/pages/traces/trace_flyout/trace_flyout.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_flyout/trace_flyout.tsx
@@ -22,7 +22,12 @@ export const TraceFlyout: React.FC = () => {
 
   return (
     <EuiFlyout data-test-subj="traceFlyout" onClose={closeTraceFlyout} ownFocus={false}>
-      <TraceDetails isFlyout={true} defaultDataset={dataset} />
+      <TraceDetails
+        isFlyout={true}
+        defaultDataset={dataset}
+        defaultTraceId={flyoutData.traceId}
+        defaultSpanId={flyoutData.spanId}
+      />
     </EuiFlyout>
   );
 };


### PR DESCRIPTION
### Description
Fixed the span flyout race condition by modifying 2 files:

  Files Changed:

  1. trace_view.tsx - Added props to accept defaultTraceId and defaultSpanId
  2. trace_flyout.tsx - Pass traceId and spanId directly as props when rendering TraceDetails

  The Problem:

  When clicking a date cell to open the span flyout, it would show "Please select a span to view details" error. Console logs showed traceId: '' and
  spanId: undefined even though the data was being passed correctly to the flyout.

  Root Cause:

  TraceDetails uses osdUrlStateStorage to manage state in the URL (_a parameter). When the flyout opened:
  1. TraceFlyout calls osdUrlStateStorage.set() to write traceId/spanId to URL (asynchronous)
  2. TraceDetails immediately mounts and calls osdUrlStateStorage.get() to read from URL
  3. Race condition: The read happens before the write completes → empty values

  The Solution:

  Bypass URL state entirely for the flyout by passing critical data as props:
  - Added defaultTraceId and defaultSpanId props to TraceDetails interface
  - Modified state initialization to use props as defaults: traceId: defaultTraceId || ''
  - TraceFlyout now passes data directly: <TraceDetails defaultTraceId={flyoutData.traceId} defaultSpanId={flyoutData.spanId} />

  Why It Works:

  Props are synchronous - when TraceDetails mounts, the props are guaranteed to be available immediately. No waiting for URL state to sync. The flyout
   always has the correct traceId and spanId from the start, eliminating the race condition entirely.

## Additional fix for CI failure

  The Cypress test "Clicking a span entry opens the trace flyout" was failing with an "Unknown Trace" error.

  Root cause: When the flyout opened, it was reading stale URL state (_a parameter) from the traces listing page, which overwrote the correct
  trace/span IDs you were passing as props. This created a race condition where the flyout would sometimes render with corrupted data from the page
  URL instead of the row data you clicked.

Changed

  Added disableUrlSync parameter to completely isolate flyout state from page URL:

  1. trace_app_state.ts - Skip reading/writing URL state when disableUrlSync: true
  2. trace_view.tsx - Pass disableUrlSync: isFlyout to disable URL sync for flyouts
  3. trace_app_state.test.ts - Added tests for the new behavior

  Now the flyout uses only the props you pass, never touching the page URL state. This eliminates the race condition.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11648


## Screenshot
Before:

https://github.com/user-attachments/assets/8c7b6b37-3127-432b-8d5f-c78fb39068a8


After:

https://github.com/user-attachments/assets/cfa64387-ca27-4834-96a8-f5ba9e30afd1




## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

## Changelog
<!--
Add a short but concise sentence about the impact of this pull request. Prefix an entry with the type of change they correspond to: breaking, chore, deprecate, doc, feat, fix, infra, refactor, test.
- fix: Update the graph
- feat: Add a new feature

If this change does not need to added to the changelog, just add a single `skip` line e.g.
- skip

Descriptions following the prefixes must be 100 characters long or less
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
