### PR TITLE
[Explore] Add resizable query panel with drag handle

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -419,9 +419,9 @@
 
 # @experimental Set the enabled value to true and provide an AG-UI agent to enable chat
 # chat:
-# enabled: true
-# agUiUrl: "http://your-ai-agent-url:port"
-# mlCommonsAgentId: "olly-chat-agent-id"
+  # enabled: true
+  # agUiUrl: "http://your-ai-agent-url:port"
+  # mlCommonsAgentId: "olly-chat-agent-id"
 
 # @experimental Set the value to true to enable context provider
 # contextProvider:

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -384,7 +384,7 @@
 # opensearchDashboards.dashboardAdmin.users: ["dashboard_admin"]
 
 # Set the value to true to enable the new UI for savedQueries in Discover
-data.savedQueriesNewUI.enabled: true
+# data.savedQueriesNewUI.enabled: true
 
 # Set the value to true to enable the banner plugin
 # banner.enabled: true
@@ -396,24 +396,27 @@ data.savedQueriesNewUI.enabled: true
 # opensearchDashboards.keyboardShortcuts.enabled: false
 
 # set the value to true to enable dataset management
-datasetManagement.enabled: true
+# datasetManagement.enabled: true
 
 # The new OpenSearch Dashboards Experience
 # Enable the following three flags together for the new OpenSearch Dashboards discover features
 # ===========================================
 
 # Set the value of this setting to true to enable multiple data source feature.
-data_source.enabled: true
+# data_source.enabled: true
 
 # Set the value to true to enable workspace feature
 # Please note, workspace will not work with multi-tenancy. To enable workspace feature, you need to disable multi-tenancy first with `opensearch_security.multitenancy.enabled: false`
-workspace.enabled: true
+# workspace.enabled: true
 
-explore.enabled: true
+# explore.enabled: true
+
 # @experimental Set the value to true to enable discover traces
-explore.discoverTraces.enabled: true
+# explore.discoverTraces.enabled: true
+
 # @experimental Set the value to true to enable discover metrics
-explore.discoverMetrics.enabled: true
+# explore.discoverMetrics.enabled: true
+
 # @experimental Set the enabled value to true and provide an AG-UI agent to enable chat
 # chat:
 # enabled: true

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -384,7 +384,7 @@
 # opensearchDashboards.dashboardAdmin.users: ["dashboard_admin"]
 
 # Set the value to true to enable the new UI for savedQueries in Discover
-# data.savedQueriesNewUI.enabled: true
+data.savedQueriesNewUI.enabled: true
 
 # Set the value to true to enable the banner plugin
 # banner.enabled: true
@@ -396,32 +396,29 @@
 # opensearchDashboards.keyboardShortcuts.enabled: false
 
 # set the value to true to enable dataset management
-# datasetManagement.enabled: true
+datasetManagement.enabled: true
 
 # The new OpenSearch Dashboards Experience
 # Enable the following three flags together for the new OpenSearch Dashboards discover features
 # ===========================================
 
 # Set the value of this setting to true to enable multiple data source feature.
-# data_source.enabled: true
+data_source.enabled: true
 
 # Set the value to true to enable workspace feature
 # Please note, workspace will not work with multi-tenancy. To enable workspace feature, you need to disable multi-tenancy first with `opensearch_security.multitenancy.enabled: false`
-# workspace.enabled: true
+workspace.enabled: true
 
-# explore.enabled: true
-
+explore.enabled: true
 # @experimental Set the value to true to enable discover traces
-# explore.discoverTraces.enabled: true
-
+explore.discoverTraces.enabled: true
 # @experimental Set the value to true to enable discover metrics
-# explore.discoverMetrics.enabled: true
-
+explore.discoverMetrics.enabled: true
 # @experimental Set the enabled value to true and provide an AG-UI agent to enable chat
 # chat:
-  # enabled: true
-  # agUiUrl: "http://your-ai-agent-url:port"
-  # mlCommonsAgentId: "olly-chat-agent-id"
+# enabled: true
+# agUiUrl: "http://your-ai-agent-url:port"
+# mlCommonsAgentId: "olly-chat-agent-id"
 
 # @experimental Set the value to true to enable context provider
 # contextProvider:

--- a/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -165,6 +165,7 @@ describe('useQueryPanelEditor', () => {
       trigger: jest.fn(),
       focus: jest.fn(),
       getContentHeight: jest.fn(() => 50),
+      getDomNode: jest.fn(() => ({ parentElement: { clientHeight: 100 } })),
       getLayoutInfo: jest.fn(() => ({ width: 800 })),
       layout: jest.fn(),
       updateOptions: jest.fn(),

--- a/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -165,7 +165,10 @@ describe('useQueryPanelEditor', () => {
       trigger: jest.fn(),
       focus: jest.fn(),
       getContentHeight: jest.fn(() => 50),
-      getDomNode: jest.fn(() => ({ parentElement: { clientHeight: 100 } })),
+      getDomNode: jest.fn(() => ({
+        parentElement: { clientHeight: 100 },
+        closest: jest.fn(() => ({ clientHeight: 100 })),
+      })),
       getLayoutInfo: jest.fn(() => ({ width: 800 })),
       layout: jest.fn(),
       updateOptions: jest.fn(),

--- a/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -307,9 +307,11 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
 
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
-        const containerEl = editor.getDomNode()?.parentElement;
-        const containerHeight = containerEl?.clientHeight || 100;
-        // Use the container height as the max, falling back to 100px
+        // Read the resizable panel's allocated height rather than the editor's
+        // immediate parent, which may have been pushed taller by content.
+        const panelEl = editor.getDomNode()?.closest('.exploreResizableQueryContainer__queryPanel');
+        const containerHeight =
+          panelEl?.clientHeight || editor.getDomNode()?.parentElement?.clientHeight || 100;
         const maxHeight = Math.max(containerHeight, 36);
         const finalHeight = Math.min(contentHeight, maxHeight);
 

--- a/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/agent_traces/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -307,7 +307,10 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
 
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
-        const maxHeight = 100;
+        const containerEl = editor.getDomNode()?.parentElement;
+        const containerHeight = containerEl?.clientHeight || 100;
+        // Use the container height as the max, falling back to 100px
+        const maxHeight = Math.max(containerHeight, 36);
         const finalHeight = Math.min(contentHeight, maxHeight);
 
         editor.layout({

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -19,6 +19,7 @@ import { useTimefilterSubscription } from '../../utils/hooks/use_timefilter_subs
 import { useHeaderVariants } from '../../utils/hooks/use_header_variants';
 import { NewExperienceBanner } from '../../../components/experience_banners/new_experience_banner';
 import { BottomContainer } from '../../../components/container/bottom_container';
+import { ResizableQueryContainer } from '../../../components/container/resizable_query_container';
 import { TopNav } from '../../../components/top_nav/top_nav';
 import { useInitPage } from '../../../application/utils/hooks/use_page_initialization';
 import {
@@ -91,12 +92,10 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
             <TopNav setHeaderActionMenu={setHeaderActionMenu} savedExplore={savedExplore} />
             <NewExperienceBanner />
 
-            <div className="dscCanvas__queryPanel">
-              <QueryPanel />
-            </div>
-
-            {/* Main content area with resizable panels under QueryPanel */}
-            <BottomContainer />
+            <ResizableQueryContainer queryPanel={<QueryPanel />}>
+              {/* Main content area with resizable panels under QueryPanel */}
+              <BottomContainer />
+            </ResizableQueryContainer>
           </EuiPageBody>
         </EuiPage>
       </div>

--- a/src/plugins/explore/public/application/pages/metrics/metrics_page.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_page.tsx
@@ -20,6 +20,7 @@ import { NewExperienceBanner } from '../../../components/experience_banners/new_
 import { TopNav } from '../../../components/top_nav/top_nav';
 import { useInitPage } from '../../../application/utils/hooks/use_page_initialization';
 import { BottomRightContainer } from './metrics_bottom_container/bottom_right_container';
+import { ResizableQueryContainer } from '../../../components/container/resizable_query_container';
 
 /**
  * Main application component for the Explore plugin
@@ -44,14 +45,12 @@ export const MetricsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAc
             <TopNav setHeaderActionMenu={setHeaderActionMenu} savedExplore={savedExplore} />
             <NewExperienceBanner />
 
-            <div className="dscCanvas__queryPanel">
-              <QueryPanel />
-            </div>
-
-            {/* Main content area with resizable panels under QueryPanel */}
-            <EuiPageBody className="explore-layout__canvas">
-              <BottomRightContainer />
-            </EuiPageBody>
+            <ResizableQueryContainer queryPanel={<QueryPanel />}>
+              {/* Main content area with resizable panels under QueryPanel */}
+              <EuiPageBody className="explore-layout__canvas">
+                <BottomRightContainer />
+              </EuiPageBody>
+            </ResizableQueryContainer>
           </EuiPageBody>
         </EuiPage>
       </div>

--- a/src/plugins/explore/public/application/pages/traces/traces_page.tsx
+++ b/src/plugins/explore/public/application/pages/traces/traces_page.tsx
@@ -19,6 +19,7 @@ import { useTimefilterSubscription } from '../../utils/hooks/use_timefilter_subs
 import { useHeaderVariants } from '../../utils/hooks/use_header_variants';
 import { NewExperienceBanner } from '../../../components/experience_banners/new_experience_banner';
 import { BottomContainer } from '../../../components/container/bottom_container';
+import { ResizableQueryContainer } from '../../../components/container/resizable_query_container';
 import { TopNav } from '../../../components/top_nav/top_nav';
 import { useInitPage } from '../../../application/utils/hooks/use_page_initialization';
 import { EXPLORE_PATTERNS_TAB_ID, EXPLORE_VISUALIZATION_TAB_ID } from '../../../../common';
@@ -77,12 +78,10 @@ export const TracesPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderAct
               <TopNav setHeaderActionMenu={setHeaderActionMenu} savedExplore={savedExplore} />
               <NewExperienceBanner />
 
-              <div className="dscCanvas__queryPanel">
-                <QueryPanel />
-              </div>
-
-              {/* Main content area with resizable panels under QueryPanel */}
-              <BottomContainer />
+              <ResizableQueryContainer queryPanel={<QueryPanel />}>
+                {/* Main content area with resizable panels under QueryPanel */}
+                <BottomContainer />
+              </ResizableQueryContainer>
             </EuiPageBody>
           </EuiPage>
         </div>

--- a/src/plugins/explore/public/components/container/resizable_query_container/index.ts
+++ b/src/plugins/explore/public/components/container/resizable_query_container/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { ResizableQueryContainer } from './resizable_query_container';

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
@@ -7,8 +7,16 @@
     flex: 1;
     min-height: 0;
 
+    &__wrapper {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
     &__queryPanel {
         overflow: hidden;
+        margin-bottom: 10px;
     }
 
     &__queryPanelInner {
@@ -57,6 +65,7 @@
         border-bottom: 1px solid $ouiBorderColor;
         padding: 0;
         width: 100%;
+        margin-top: 10px;
 
         &::before,
         &::after {
@@ -125,5 +134,6 @@
 
     &__contentPanel {
         min-height: 0;
+        margin-top: 10px;
     }
 }

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
@@ -6,32 +6,33 @@
 .exploreResizableQueryContainer {
   flex: 1;
   min-height: 0;
-
-  &__wrapper {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-  }
+  gap: $ouiSizeXS;
 
   &__queryPanel {
-    overflow: auto;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
+    position: relative;
+
+    // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+    >.euiResizablePanel__content {
+      overflow: hidden;
+      position: relative;
+    }
   }
 
   &__queryPanelInner {
-    height: 100%;
+    position: absolute;
+    inset: 0;
     display: flex;
     flex-direction: column;
-    min-height: 0;
-    overflow: hidden;
 
     .exploreQueryPanel {
       flex: 1;
       display: flex;
       flex-direction: column;
       min-height: 0;
+      overflow: hidden;
     }
 
     .exploreQueryPanel__editorsWrapper {

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
@@ -6,6 +6,7 @@
 .exploreResizableQueryContainer {
     flex: 1;
     min-height: 0;
+    gap: $ouiSizeXS;
 
     &__wrapper {
         flex: 1;
@@ -16,7 +17,6 @@
 
     &__queryPanel {
         overflow: hidden;
-        margin-bottom: 10px;
     }
 
     &__queryPanelInner {
@@ -59,13 +59,10 @@
         z-index: $ouiZLevel1;
         cursor: row-resize;
         height: $ouiSize;
-        background-color: $ouiColorLightestShade;
+        background: none;
         border: none;
-        border-top: 1px solid $ouiBorderColor;
-        border-bottom: 1px solid $ouiBorderColor;
         padding: 0;
         width: 100%;
-        margin-top: 10px;
 
         &::before,
         &::after {
@@ -134,6 +131,5 @@
 
     &__contentPanel {
         min-height: 0;
-        margin-top: 10px;
     }
 }

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
@@ -4,132 +4,59 @@
  */
 
 .exploreResizableQueryContainer {
-    flex: 1;
-    min-height: 0;
-    gap: $ouiSizeXS;
+  flex: 1;
+  min-height: 0;
 
-    &__wrapper {
+  &__queryPanel {
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__queryPanelInner {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .exploreQueryPanel {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .exploreQueryPanel__editorsWrapper {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .exploreQueryPanelEditor {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+
+      .react-monaco-editor-container {
         flex: 1;
         min-height: 0;
-        display: flex;
-        flex-direction: column;
+      }
     }
+  }
 
-    &__queryPanel {
-        overflow: hidden;
+  &__resizeHandle {
+    z-index: 1;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &::before,
+    &::after {
+      width: $ouiSize * 2;
     }
+  }
 
-    &__queryPanelInner {
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-
-        // Allow the query panel editor to fill the available space
-        .exploreQueryPanel {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            min-height: 0;
-        }
-
-        .exploreQueryPanel__editorsWrapper {
-            flex: 1;
-            min-height: 0;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .exploreQueryPanelEditor {
-            flex: 1;
-            min-height: 0;
-            display: flex;
-            flex-direction: column;
-
-            // Let the Monaco editor fill the available height
-            .react-monaco-editor-container {
-                flex: 1;
-                min-height: 0;
-            }
-        }
-    }
-
-    &__resizeHandle {
-        position: relative;
-        flex-shrink: 0;
-        z-index: $ouiZLevel1;
-        cursor: row-resize;
-        height: $ouiSize;
-        background: none;
-        border: none;
-        padding: 0;
-        width: 100%;
-
-        &::before,
-        &::after {
-            content: '';
-            display: block;
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            background-color: $ouiColorDarkestShade;
-            width: $ouiSizeM;
-            height: 1px;
-            transition: width $ouiAnimSpeedFast ease,
-                height $ouiAnimSpeedFast ease,
-                transform $ouiAnimSpeedFast ease,
-                background-color $ouiAnimSpeedFast ease;
-        }
-
-        &::before {
-            transform: translate(-50%, -2px);
-        }
-
-        &::after {
-            transform: translate(-50%, 1px);
-        }
-
-        &:hover:not(:disabled) {
-
-            &::before,
-            &::after {
-                background-color: $ouiColorMediumShade;
-                transition-delay: $ouiAnimSpeedFast;
-            }
-        }
-
-        &:focus:not(:disabled) {
-            background-color: transparentize($ouiColorPrimary, 0.9);
-            outline: none;
-
-            &::before,
-            &::after {
-                background-color: $ouiColorPrimary;
-                transition: width $ouiAnimSpeedFast ease,
-                    height $ouiAnimSpeedFast ease,
-                    transform $ouiAnimSpeedFast ease;
-                transition-delay: calc($ouiAnimSpeedFast / 2);
-            }
-        }
-
-        &:hover:not(:disabled),
-        &:focus:not(:disabled) {
-
-            &::before,
-            &::after {
-                width: 100%;
-            }
-
-            &::before {
-                transform: translate(-50%, -1px);
-            }
-
-            &::after {
-                transform: translate(-50%, 0);
-            }
-        }
-    }
-
-    &__contentPanel {
-        min-height: 0;
-    }
+  &__contentPanel {
+    min-height: 0;
+  }
 }

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.exploreResizableQueryContainer {
+    flex: 1;
+    min-height: 0;
+
+    &__queryPanel {
+        overflow: hidden;
+    }
+
+    &__queryPanelInner {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+
+        // Allow the query panel editor to fill the available space
+        .exploreQueryPanel {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+
+        .exploreQueryPanel__editorsWrapper {
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .exploreQueryPanelEditor {
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+
+            // Let the Monaco editor fill the available height
+            .react-monaco-editor-container {
+                flex: 1;
+                min-height: 0;
+            }
+        }
+    }
+
+    &__resizeHandle {
+        position: relative;
+        flex-shrink: 0;
+        z-index: $ouiZLevel1;
+        cursor: row-resize;
+        height: $ouiSize;
+        background-color: $ouiColorLightestShade;
+        border: none;
+        border-top: 1px solid $ouiBorderColor;
+        border-bottom: 1px solid $ouiBorderColor;
+        padding: 0;
+        width: 100%;
+
+        &::before,
+        &::after {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            background-color: $ouiColorDarkestShade;
+            width: $ouiSizeM;
+            height: 1px;
+            transition: width $ouiAnimSpeedFast ease,
+                height $ouiAnimSpeedFast ease,
+                transform $ouiAnimSpeedFast ease,
+                background-color $ouiAnimSpeedFast ease;
+        }
+
+        &::before {
+            transform: translate(-50%, -2px);
+        }
+
+        &::after {
+            transform: translate(-50%, 1px);
+        }
+
+        &:hover:not(:disabled) {
+
+            &::before,
+            &::after {
+                background-color: $ouiColorMediumShade;
+                transition-delay: $ouiAnimSpeedFast;
+            }
+        }
+
+        &:focus:not(:disabled) {
+            background-color: transparentize($ouiColorPrimary, 0.9);
+            outline: none;
+
+            &::before,
+            &::after {
+                background-color: $ouiColorPrimary;
+                transition: width $ouiAnimSpeedFast ease,
+                    height $ouiAnimSpeedFast ease,
+                    transform $ouiAnimSpeedFast ease;
+                transition-delay: calc($ouiAnimSpeedFast / 2);
+            }
+        }
+
+        &:hover:not(:disabled),
+        &:focus:not(:disabled) {
+
+            &::before,
+            &::after {
+                width: 100%;
+            }
+
+            &::before {
+                transform: translate(-50%, -1px);
+            }
+
+            &::after {
+                transform: translate(-50%, 0);
+            }
+        }
+    }
+
+    &__contentPanel {
+        min-height: 0;
+    }
+}

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.scss
@@ -7,8 +7,15 @@
   flex: 1;
   min-height: 0;
 
+  &__wrapper {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
   &__queryPanel {
-    overflow: hidden;
+    overflow: auto;
     display: flex;
     flex-direction: column;
   }
@@ -17,6 +24,8 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
 
     .exploreQueryPanel {
       flex: 1;

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.test.tsx
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { ResizableQueryContainer } from './resizable_query_container';
+
+// Mock the scss import
+jest.mock('./resizable_query_container.scss', () => ({}));
+
+// Track resize events
+const resizeEvents: Event[] = [];
+const originalDispatchEvent = window.dispatchEvent;
+
+describe('ResizableQueryContainer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resizeEvents.length = 0;
+    window.dispatchEvent = jest.fn((event: Event) => {
+      resizeEvents.push(event);
+      return originalDispatchEvent.call(window, event);
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    window.dispatchEvent = originalDispatchEvent;
+  });
+
+  const queryPanel = <div data-test-subj="query-panel">Query Panel</div>;
+  const content = <div data-test-subj="content-panel">Content</div>;
+
+  const renderComponent = () => {
+    return render(
+      <ResizableQueryContainer queryPanel={queryPanel}>{content}</ResizableQueryContainer>
+    );
+  };
+
+  it('renders the query panel and content', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('query-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('content-panel')).toBeInTheDocument();
+  });
+
+  it('renders the wrapper element', () => {
+    renderComponent();
+
+    const wrapper = document.querySelector('.exploreResizableQueryContainer__wrapper');
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  it('renders the resizable container with vertical direction', () => {
+    renderComponent();
+
+    const container = document.querySelector('.exploreResizableQueryContainer');
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders the query panel inner wrapper', () => {
+    renderComponent();
+
+    const inner = document.querySelector('.exploreResizableQueryContainer__queryPanelInner');
+    expect(inner).toBeInTheDocument();
+  });
+
+  it('renders the resize handle', () => {
+    renderComponent();
+
+    const handle = document.querySelector('.exploreResizableQueryContainer__resizeHandle');
+    expect(handle).toBeInTheDocument();
+  });
+
+  it('dispatches resize event on mount for Monaco layout', () => {
+    renderComponent();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    const resizeDispatched = resizeEvents.some((e) => e.type === 'resize');
+    expect(resizeDispatched).toBe(true);
+  });
+
+  it('uses fallback size before measurement', () => {
+    renderComponent();
+
+    // Before the measurement timer fires, the container should render
+    // with the fallback size (key="default")
+    const container = document.querySelector('.exploreResizableQueryContainer');
+    expect(container).toBeInTheDocument();
+  });
+
+  it('attempts measurement after timeout', () => {
+    renderComponent();
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    // Component should still be rendered after measurement attempt
+    expect(screen.getByTestId('query-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('content-panel')).toBeInTheDocument();
+  });
+
+  it('dispatches resize event on panel width change', () => {
+    renderComponent();
+
+    // Clear events from mount
+    resizeEvents.length = 0;
+
+    // Trigger a resize by dispatching a resize event (simulating panel change)
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(resizeEvents.length).toBeGreaterThan(0);
+  });
+});

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.test.tsx
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.test.tsx
@@ -45,13 +45,6 @@ describe('ResizableQueryContainer', () => {
     expect(screen.getByTestId('content-panel')).toBeInTheDocument();
   });
 
-  it('renders the wrapper element', () => {
-    renderComponent();
-
-    const wrapper = document.querySelector('.exploreResizableQueryContainer__wrapper');
-    expect(wrapper).toBeInTheDocument();
-  });
-
   it('renders the resizable container with vertical direction', () => {
     renderComponent();
 
@@ -84,23 +77,14 @@ describe('ResizableQueryContainer', () => {
     expect(resizeDispatched).toBe(true);
   });
 
-  it('uses fallback size before measurement', () => {
+  it('computes initial size based on viewport height', () => {
+    // window.innerHeight defaults to 768 in jsdom
+    // 72 / 768 * 100 ≈ 9.375%, clamped between 5-15%
     renderComponent();
 
-    // Before the measurement timer fires, the container should render
-    // with the fallback size (key="default")
     const container = document.querySelector('.exploreResizableQueryContainer');
     expect(container).toBeInTheDocument();
-  });
-
-  it('attempts measurement after timeout', () => {
-    renderComponent();
-
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
-
-    // Component should still be rendered after measurement attempt
+    // Panel should render with computed size
     expect(screen.getByTestId('query-panel')).toBeInTheDocument();
     expect(screen.getByTestId('content-panel')).toBeInTheDocument();
   });
@@ -111,7 +95,6 @@ describe('ResizableQueryContainer', () => {
     // Clear events from mount
     resizeEvents.length = 0;
 
-    // Trigger a resize by dispatching a resize event (simulating panel change)
     act(() => {
       window.dispatchEvent(new Event('resize'));
     });

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
@@ -63,12 +63,12 @@ export const ResizableQueryContainer: React.FC<ResizableQueryContainerProps> = (
     return () => clearTimeout(timer);
   }, []);
 
-  console.log(queryPanelSize, 'queryPanelSize');
+  // console.log(queryPanelSize, 'queryPanelSize');
 
   const size = queryPanelSize ?? QUERY_PANEL_FALLBACK_SIZE;
   const minSize = queryPanelSize != null ? `${queryPanelSize}%` : '5%';
 
-  console.log(size, minSize, 'size', 'minSize');
+  // console.log(size, minSize, 'size', 'minSize');
 
   return (
     <div ref={containerRef} className="exploreResizableQueryContainer__wrapper">

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useEffect } from 'react';
+import { EuiResizableContainer } from '@elastic/eui';
+import './resizable_query_container.scss';
+
+const QUERY_PANEL_MIN_SIZE = '5%';
+const QUERY_PANEL_INITIAL_SIZE = 10;
+const CONTENT_PANEL_INITIAL_SIZE = 90;
+const STORAGE_KEY = 'explore:queryPanelSize';
+
+interface ResizableQueryContainerProps {
+  queryPanel: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const ResizableQueryContainer: React.FC<ResizableQueryContainerProps> = ({
+  queryPanel,
+  children,
+}) => {
+  const getInitialSize = useCallback((): number => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = parseFloat(stored);
+        if (!isNaN(parsed) && parsed >= 5 && parsed <= 60) return parsed;
+      }
+    } catch {
+      // Ignore localStorage errors
+    }
+    return QUERY_PANEL_INITIAL_SIZE;
+  }, []);
+
+  const handlePanelWidthChange = useCallback((newSizes: Record<string, number>) => {
+    const querySize = newSizes.queryPanel;
+    if (querySize != null) {
+      try {
+        localStorage.setItem(STORAGE_KEY, String(querySize));
+      } catch {
+        // Ignore localStorage errors
+      }
+    }
+
+    // Trigger Monaco editor relayout after resize
+    window.dispatchEvent(new Event('resize'));
+  }, []);
+
+  // Dispatch resize on mount so Monaco calculates its layout correctly
+  useEffect(() => {
+    const timer = setTimeout(() => window.dispatchEvent(new Event('resize')), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const initialQuerySize = getInitialSize();
+  const initialContentSize = 100 - initialQuerySize;
+
+  console.log('-------------------drga');
+  return (
+    <EuiResizableContainer
+      direction="vertical"
+      className="exploreResizableQueryContainer"
+      onPanelWidthChange={handlePanelWidthChange}
+    >
+      {(EuiResizablePanel, EuiResizableButton) => (
+        <>
+          <EuiResizablePanel
+            id="queryPanel"
+            initialSize={initialQuerySize}
+            minSize={QUERY_PANEL_MIN_SIZE}
+            paddingSize="none"
+            className="exploreResizableQueryContainer__queryPanel"
+          >
+            <div className="exploreResizableQueryContainer__queryPanelInner">{queryPanel}</div>
+          </EuiResizablePanel>
+          <EuiResizableButton className="exploreResizableQueryContainer__resizeHandle" />
+          <EuiResizablePanel
+            id="contentPanel"
+            initialSize={initialContentSize}
+            minSize="40%"
+            paddingSize="none"
+            className="exploreResizableQueryContainer__contentPanel"
+          >
+            {children}
+          </EuiResizablePanel>
+        </>
+      )}
+    </EuiResizableContainer>
+  );
+};

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { EuiResizableContainer } from '@elastic/eui';
 import './resizable_query_container.scss';
 
-const QUERY_PANEL_MIN_SIZE = '5%';
-const QUERY_PANEL_INITIAL_SIZE = 10;
-const CONTENT_PANEL_INITIAL_SIZE = 90;
-const STORAGE_KEY = 'explore:queryPanelSize';
+// Fallback used only until the real measurement is available.
+const QUERY_PANEL_FALLBACK_SIZE = 10;
 
 interface ResizableQueryContainerProps {
   queryPanel: React.ReactNode;
@@ -21,30 +19,41 @@ export const ResizableQueryContainer: React.FC<ResizableQueryContainerProps> = (
   queryPanel,
   children,
 }) => {
-  const getInitialSize = useCallback((): number => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        const parsed = parseFloat(stored);
-        if (!isNaN(parsed) && parsed >= 5 && parsed <= 60) return parsed;
-      }
-    } catch {
-      // Ignore localStorage errors
-    }
-    return QUERY_PANEL_INITIAL_SIZE;
+  const editorRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [queryPanelSize, setQueryPanelSize] = useState<number | null>(null);
+
+  // Measure the query panel's natural content height by targeting the
+  // innermost Monaco container, the widgets bar, and panel/editor padding.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const container = containerRef.current;
+      const panel = editorRef.current;
+      if (!container || !panel) return;
+
+      const containerHeight = container.clientHeight;
+      if (containerHeight <= 0) return;
+
+      // Widgets bar
+      const widgetsEl = panel.querySelector('.exploreQueryPanelWidgets') as HTMLElement | null;
+      const widgetsHeight = widgetsEl?.offsetHeight ?? 0;
+
+      // Monaco's actual rendered content area
+      const monacoContainer = panel.querySelector(
+        '.react-monaco-editor-container'
+      ) as HTMLElement | null;
+      const monacoEl = monacoContainer?.querySelector('.monaco-editor') as HTMLElement | null;
+      const viewLines = monacoEl?.querySelector('.view-lines') as HTMLElement | null;
+      const monacoContentHeight = viewLines?.offsetHeight ?? 18; // fallback to single lineHeight
+
+      const totalHeight = widgetsHeight + monacoContentHeight;
+      const pct = Math.min(Math.max((totalHeight / containerHeight) * 100, 3), 60);
+      setQueryPanelSize(pct);
+    }, 200);
+    return () => clearTimeout(timer);
   }, []);
 
-  const handlePanelWidthChange = useCallback((newSizes: Record<string, number>) => {
-    const querySize = newSizes.queryPanel;
-    if (querySize != null) {
-      try {
-        localStorage.setItem(STORAGE_KEY, String(querySize));
-      } catch {
-        // Ignore localStorage errors
-      }
-    }
-
-    // Trigger Monaco editor relayout after resize
+  const handlePanelWidthChange = useCallback(() => {
     window.dispatchEvent(new Event('resize'));
   }, []);
 
@@ -54,39 +63,47 @@ export const ResizableQueryContainer: React.FC<ResizableQueryContainerProps> = (
     return () => clearTimeout(timer);
   }, []);
 
-  const initialQuerySize = getInitialSize();
-  const initialContentSize = 100 - initialQuerySize;
+  console.log(queryPanelSize, 'queryPanelSize');
 
-  console.log('-------------------drga');
+  const size = queryPanelSize ?? QUERY_PANEL_FALLBACK_SIZE;
+  const minSize = queryPanelSize != null ? `${queryPanelSize}%` : '5%';
+
+  console.log(size, minSize, 'size', 'minSize');
+
   return (
-    <EuiResizableContainer
-      direction="vertical"
-      className="exploreResizableQueryContainer"
-      onPanelWidthChange={handlePanelWidthChange}
-    >
-      {(EuiResizablePanel, EuiResizableButton) => (
-        <>
-          <EuiResizablePanel
-            id="queryPanel"
-            initialSize={initialQuerySize}
-            minSize={QUERY_PANEL_MIN_SIZE}
-            paddingSize="none"
-            className="exploreResizableQueryContainer__queryPanel"
-          >
-            <div className="exploreResizableQueryContainer__queryPanelInner">{queryPanel}</div>
-          </EuiResizablePanel>
-          <EuiResizableButton className="exploreResizableQueryContainer__resizeHandle" />
-          <EuiResizablePanel
-            id="contentPanel"
-            initialSize={initialContentSize}
-            minSize="40%"
-            paddingSize="none"
-            className="exploreResizableQueryContainer__contentPanel"
-          >
-            {children}
-          </EuiResizablePanel>
-        </>
-      )}
-    </EuiResizableContainer>
+    <div ref={containerRef} className="exploreResizableQueryContainer__wrapper">
+      <EuiResizableContainer
+        key={queryPanelSize != null ? 'measured' : 'default'}
+        direction="vertical"
+        className="exploreResizableQueryContainer"
+        onPanelWidthChange={handlePanelWidthChange}
+      >
+        {(EuiResizablePanel, EuiResizableButton) => (
+          <>
+            <EuiResizablePanel
+              id="queryPanel"
+              initialSize={size}
+              minSize={minSize}
+              paddingSize="none"
+              className="exploreResizableQueryContainer__queryPanel"
+            >
+              <div ref={editorRef} className="exploreResizableQueryContainer__queryPanelInner">
+                {queryPanel}
+              </div>
+            </EuiResizablePanel>
+            <EuiResizableButton className="exploreResizableQueryContainer__resizeHandle" />
+            <EuiResizablePanel
+              id="contentPanel"
+              initialSize={100 - size}
+              minSize="40%"
+              paddingSize="none"
+              className="exploreResizableQueryContainer__contentPanel"
+            >
+              {children}
+            </EuiResizablePanel>
+          </>
+        )}
+      </EuiResizableContainer>
+    </div>
   );
 };

--- a/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
+++ b/src/plugins/explore/public/components/container/resizable_query_container/resizable_query_container.tsx
@@ -3,12 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { EuiResizableContainer } from '@elastic/eui';
 import './resizable_query_container.scss';
 
-// Fallback used only until the real measurement is available.
-const QUERY_PANEL_FALLBACK_SIZE = 10;
+// Approximate pixel height needed for the query panel to show one line:
+// widgets bar (~32px) + editor line (~18px) + editor padding/border (~22px)
+const QUERY_PANEL_SINGLE_LINE_PX = 72;
+const QUERY_PANEL_MIN_SIZE = '3%';
+
+// Compute initial size as a percentage of the viewport so the panel
+// always fits at least one editor line regardless of screen height.
+function getInitialQueryPanelSize(): number {
+  const viewportHeight = window.innerHeight || 800;
+  const pct = (QUERY_PANEL_SINGLE_LINE_PX / viewportHeight) * 100;
+  // Clamp between 5% and 15% to stay reasonable on all screen sizes
+  return Math.min(Math.max(pct, 5), 15);
+}
 
 interface ResizableQueryContainerProps {
   queryPanel: React.ReactNode;
@@ -20,38 +31,7 @@ export const ResizableQueryContainer: React.FC<ResizableQueryContainerProps> = (
   children,
 }) => {
   const editorRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [queryPanelSize, setQueryPanelSize] = useState<number | null>(null);
-
-  // Measure the query panel's natural content height by targeting the
-  // innermost Monaco container, the widgets bar, and panel/editor padding.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      const container = containerRef.current;
-      const panel = editorRef.current;
-      if (!container || !panel) return;
-
-      const containerHeight = container.clientHeight;
-      if (containerHeight <= 0) return;
-
-      // Widgets bar
-      const widgetsEl = panel.querySelector('.exploreQueryPanelWidgets') as HTMLElement | null;
-      const widgetsHeight = widgetsEl?.offsetHeight ?? 0;
-
-      // Monaco's actual rendered content area
-      const monacoContainer = panel.querySelector(
-        '.react-monaco-editor-container'
-      ) as HTMLElement | null;
-      const monacoEl = monacoContainer?.querySelector('.monaco-editor') as HTMLElement | null;
-      const viewLines = monacoEl?.querySelector('.view-lines') as HTMLElement | null;
-      const monacoContentHeight = viewLines?.offsetHeight ?? 18; // fallback to single lineHeight
-
-      const totalHeight = widgetsHeight + monacoContentHeight;
-      const pct = Math.min(Math.max((totalHeight / containerHeight) * 100, 3), 60);
-      setQueryPanelSize(pct);
-    }, 200);
-    return () => clearTimeout(timer);
-  }, []);
+  const initialSize = useMemo(() => getInitialQueryPanelSize(), []);
 
   const handlePanelWidthChange = useCallback(() => {
     window.dispatchEvent(new Event('resize'));
@@ -63,47 +43,37 @@ export const ResizableQueryContainer: React.FC<ResizableQueryContainerProps> = (
     return () => clearTimeout(timer);
   }, []);
 
-  // console.log(queryPanelSize, 'queryPanelSize');
-
-  const size = queryPanelSize ?? QUERY_PANEL_FALLBACK_SIZE;
-  const minSize = queryPanelSize != null ? `${queryPanelSize}%` : '5%';
-
-  // console.log(size, minSize, 'size', 'minSize');
-
   return (
-    <div ref={containerRef} className="exploreResizableQueryContainer__wrapper">
-      <EuiResizableContainer
-        key={queryPanelSize != null ? 'measured' : 'default'}
-        direction="vertical"
-        className="exploreResizableQueryContainer"
-        onPanelWidthChange={handlePanelWidthChange}
-      >
-        {(EuiResizablePanel, EuiResizableButton) => (
-          <>
-            <EuiResizablePanel
-              id="queryPanel"
-              initialSize={size}
-              minSize={minSize}
-              paddingSize="none"
-              className="exploreResizableQueryContainer__queryPanel"
-            >
-              <div ref={editorRef} className="exploreResizableQueryContainer__queryPanelInner">
-                {queryPanel}
-              </div>
-            </EuiResizablePanel>
-            <EuiResizableButton className="exploreResizableQueryContainer__resizeHandle" />
-            <EuiResizablePanel
-              id="contentPanel"
-              initialSize={100 - size}
-              minSize="40%"
-              paddingSize="none"
-              className="exploreResizableQueryContainer__contentPanel"
-            >
-              {children}
-            </EuiResizablePanel>
-          </>
-        )}
-      </EuiResizableContainer>
-    </div>
+    <EuiResizableContainer
+      direction="vertical"
+      className="exploreResizableQueryContainer"
+      onPanelWidthChange={handlePanelWidthChange}
+    >
+      {(EuiResizablePanel, EuiResizableButton) => (
+        <>
+          <EuiResizablePanel
+            id="queryPanel"
+            initialSize={initialSize}
+            minSize={QUERY_PANEL_MIN_SIZE}
+            paddingSize="none"
+            className="exploreResizableQueryContainer__queryPanel"
+          >
+            <div ref={editorRef} className="exploreResizableQueryContainer__queryPanelInner">
+              {queryPanel}
+            </div>
+          </EuiResizablePanel>
+          <EuiResizableButton className="exploreResizableQueryContainer__resizeHandle" />
+          <EuiResizablePanel
+            id="contentPanel"
+            initialSize={100 - initialSize}
+            minSize="40%"
+            paddingSize="none"
+            className="exploreResizableQueryContainer__contentPanel"
+          >
+            {children}
+          </EuiResizablePanel>
+        </>
+      )}
+    </EuiResizableContainer>
   );
 };

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -153,6 +153,7 @@ import {
   selectQueryLanguage,
   selectQueryString,
   selectIsQueryEditorDirty,
+  selectDataset,
 } from '../../../../application/utils/state_management/selectors';
 
 const mockUseSelector = jest.mocked(useSelector);

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -56,19 +56,7 @@ jest.mock('../../../../application/hooks', () => ({
 }));
 
 jest.mock('../../../../application/context');
-jest.mock('../../../../../../data/public', () => {
-  const actual = jest.createMockFromModule<any>('../../../../../../data/public');
-  return {
-    ...actual,
-    attachPPLValidationContext: jest.fn(() => jest.fn()),
-    attachPPLGrammarRefresh: jest.fn(() => jest.fn()),
-    syncPPLValidationContext: jest.fn(),
-    shouldUseRuntimeGrammar: jest.fn(() => false),
-    pplGrammarCache: {
-      subscribeToGrammarUpdates: jest.fn(() => jest.fn()),
-    },
-  };
-});
+jest.mock('../../../../../../data/public');
 jest.mock('../../../../application/utils/state_management/actions/query_editor');
 jest.mock('../../../../application/utils/state_management/slices');
 jest.mock('../../../../application/utils/state_management/selectors', () => ({
@@ -76,7 +64,6 @@ jest.mock('../../../../application/utils/state_management/selectors', () => ({
   selectPromptModeIsAvailable: jest.fn((state) => state.promptModeIsAvailable),
   selectQueryLanguage: jest.fn((state) => state.queryLanguage),
   selectQueryString: jest.fn((state) => state.queryString),
-  selectDataset: jest.fn((state) => state.dataset),
 }));
 jest.mock('../../../../application/utils/state_management/types', () => ({
   EditorMode: {
@@ -128,9 +115,6 @@ jest.mock('@osd/monaco', () => ({
       },
     },
   },
-  setPPLValidationContext: jest.fn(),
-  clearPPLValidationContext: jest.fn(),
-  revalidatePPLModel: jest.fn(),
 }));
 
 // Now import after mocking
@@ -153,7 +137,6 @@ import {
   selectQueryLanguage,
   selectQueryString,
   selectIsQueryEditorDirty,
-  selectDataset,
 } from '../../../../application/utils/state_management/selectors';
 
 const mockUseSelector = jest.mocked(useSelector);
@@ -187,7 +170,10 @@ describe('useQueryPanelEditor', () => {
       trigger: jest.fn(),
       focus: jest.fn(),
       getContentHeight: jest.fn(() => 50),
-      getDomNode: jest.fn(() => ({ parentElement: { clientHeight: 100 } })),
+      getDomNode: jest.fn(() => ({
+        parentElement: { clientHeight: 100 },
+        closest: jest.fn(() => ({ clientHeight: 100 })),
+      })),
       getLayoutInfo: jest.fn(() => ({ width: 800 })),
       layout: jest.fn(),
       updateOptions: jest.fn(),
@@ -273,7 +259,6 @@ describe('useQueryPanelEditor', () => {
       if (selectorString.includes('selectIsPromptEditorMode')) return false;
       if (selectorString.includes('selectQueryString')) return '';
       if (selectorString.includes('selectIsQueryEditorDirty')) return false;
-      if (selectorString.includes('selectDataset')) return undefined;
       return '';
     });
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -187,6 +187,7 @@ describe('useQueryPanelEditor', () => {
       trigger: jest.fn(),
       focus: jest.fn(),
       getContentHeight: jest.fn(() => 50),
+      getDomNode: jest.fn(() => ({ parentElement: { clientHeight: 100 } })),
       getLayoutInfo: jest.fn(() => ({ width: 800 })),
       layout: jest.fn(),
       updateOptions: jest.fn(),

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -770,7 +770,6 @@ describe('useQueryPanelEditor', () => {
         await result.current.suggestionProvider.provideCompletionItems(
           mockModel,
           mockPosition,
-          // @ts-expect-error TS2345 TODO(ts-error): fixme
           {},
           { isCancellationRequested: false }
         );
@@ -813,7 +812,6 @@ describe('useQueryPanelEditor', () => {
         await result.current.suggestionProvider.provideCompletionItems(
           mockModel,
           mockPosition,
-          // @ts-expect-error TS2345 TODO(ts-error): fixme
           {},
           { isCancellationRequested: false }
         );

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -56,7 +56,19 @@ jest.mock('../../../../application/hooks', () => ({
 }));
 
 jest.mock('../../../../application/context');
-jest.mock('../../../../../../data/public');
+jest.mock('../../../../../../data/public', () => {
+  const actual = jest.createMockFromModule<any>('../../../../../../data/public');
+  return {
+    ...actual,
+    attachPPLValidationContext: jest.fn(() => jest.fn()),
+    attachPPLGrammarRefresh: jest.fn(() => jest.fn()),
+    syncPPLValidationContext: jest.fn(),
+    shouldUseRuntimeGrammar: jest.fn(() => false),
+    pplGrammarCache: {
+      subscribeToGrammarUpdates: jest.fn(() => jest.fn()),
+    },
+  };
+});
 jest.mock('../../../../application/utils/state_management/actions/query_editor');
 jest.mock('../../../../application/utils/state_management/slices');
 jest.mock('../../../../application/utils/state_management/selectors', () => ({
@@ -64,6 +76,7 @@ jest.mock('../../../../application/utils/state_management/selectors', () => ({
   selectPromptModeIsAvailable: jest.fn((state) => state.promptModeIsAvailable),
   selectQueryLanguage: jest.fn((state) => state.queryLanguage),
   selectQueryString: jest.fn((state) => state.queryString),
+  selectDataset: jest.fn((state) => state.dataset),
 }));
 jest.mock('../../../../application/utils/state_management/types', () => ({
   EditorMode: {
@@ -115,6 +128,9 @@ jest.mock('@osd/monaco', () => ({
       },
     },
   },
+  setPPLValidationContext: jest.fn(),
+  clearPPLValidationContext: jest.fn(),
+  revalidatePPLModel: jest.fn(),
 }));
 
 // Now import after mocking
@@ -259,6 +275,7 @@ describe('useQueryPanelEditor', () => {
       if (selectorString.includes('selectIsPromptEditorMode')) return false;
       if (selectorString.includes('selectQueryString')) return '';
       if (selectorString.includes('selectIsQueryEditorDirty')) return false;
+      if (selectorString.includes('selectDataset')) return undefined;
       return '';
     });
 
@@ -753,6 +770,7 @@ describe('useQueryPanelEditor', () => {
         await result.current.suggestionProvider.provideCompletionItems(
           mockModel,
           mockPosition,
+          // @ts-expect-error TS2345 TODO(ts-error): fixme
           {},
           { isCancellationRequested: false }
         );
@@ -795,6 +813,7 @@ describe('useQueryPanelEditor', () => {
         await result.current.suggestionProvider.provideCompletionItems(
           mockModel,
           mockPosition,
+          // @ts-expect-error TS2345 TODO(ts-error): fixme
           {},
           { isCancellationRequested: false }
         );

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -4,7 +4,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { monaco, PPLValidationContext, revalidatePPLModel } from '@osd/monaco';
+import { monaco } from '@osd/monaco';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
 import { DEFAULT_DATA } from '../../../../../../data/common';
@@ -14,7 +14,6 @@ import {
   selectQueryLanguage,
   selectQueryString,
   selectIsQueryEditorDirty,
-  selectDataset,
 } from '../../../../application/utils/state_management/selectors';
 import { promptEditorOptions, queryEditorOptions } from './editor_options';
 
@@ -35,21 +34,14 @@ import { usePromptIsTyping } from './use_prompt_is_typing';
 import { EditorMode } from '../../../../application/utils/state_management/types';
 import { useMultiQueryDecorations } from './use_multi_query_decorations';
 import { getAutocompleteContext } from '../../../../application/utils/multi_query_utils';
-import {
-  attachPPLValidationContext,
-  attachPPLGrammarRefresh,
-  syncPPLValidationContext,
-  pplGrammarCache,
-  shouldUseRuntimeGrammar,
-} from '../../../../../../data/public';
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 type LanguageConfiguration = monaco.languages.LanguageConfiguration;
 type IEditorConstructionOptions = monaco.editor.IEditorConstructionOptions;
 
-export const DEFAULT_TRIGGER_CHARACTERS = [' ', '=', "'", '"', '`'];
+const DEFAULT_TRIGGER_CHARACTERS = [' ', '=', "'", '"', '`'];
 
-export const languageConfiguration: LanguageConfiguration = {
+const languageConfiguration: LanguageConfiguration = {
   autoClosingPairs: [
     { open: '(', close: ')' },
     { open: '[', close: ']' },
@@ -113,20 +105,6 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   const promptModeIsAvailableRef = useRef(promptModeIsAvailable);
   const queryLanguageRef = useRef(queryLanguage);
   const isQueryEditorDirty = useSelector(selectIsQueryEditorDirty);
-  const dataset = useSelector(selectDataset);
-  const detachValidationContextRef = useRef<(() => void) | undefined>();
-  const detachGrammarRefreshRef = useRef<(() => void) | undefined>();
-
-  const getValidationContext = useCallback((): PPLValidationContext => {
-    const currentQuery = queryString.getQuery();
-    const dsId = currentQuery.dataset?.dataSource?.id;
-    const dsVersion = currentQuery.dataset?.dataSource?.version;
-    return {
-      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
-      dataSourceId: dsId,
-      dataSourceVersion: dsVersion,
-    };
-  }, [queryString]);
 
   const switchEditorMode = useLanguageSwitch();
 
@@ -143,32 +121,6 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   useEffect(() => {
     queryLanguageRef.current = queryLanguage;
   }, [queryLanguage]);
-
-  // Sync PPL validation context when datasource changes
-  useEffect(() => {
-    const dsId = dataset?.dataSource?.id;
-    const dsVersion = dataset?.dataSource?.version;
-    syncPPLValidationContext(editorRef.current, {
-      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
-      dataSourceId: dsId,
-      dataSourceVersion: dsVersion,
-    });
-    const model = editorRef.current?.getModel();
-    if (model) {
-      void revalidatePPLModel(model);
-    }
-  }, [dataset?.dataSource?.id, dataset?.dataSource?.version, editorRef]);
-
-  // Cleanup validation context on unmount
-  useEffect(
-    () => () => {
-      detachValidationContextRef.current?.();
-      detachValidationContextRef.current = undefined;
-      detachGrammarRefreshRef.current?.();
-      detachGrammarRefreshRef.current = undefined;
-    },
-    []
-  );
 
   keyboardShortcut?.useKeyboardShortcut({
     id: 'focus_query_bar',
@@ -319,24 +271,6 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
     (editor: IStandaloneCodeEditor) => {
       setEditorRef(editor);
 
-      // Attach PPL runtime validation context
-      detachValidationContextRef.current?.();
-      detachGrammarRefreshRef.current?.();
-      detachValidationContextRef.current = attachPPLValidationContext(editor, getValidationContext);
-      detachGrammarRefreshRef.current = attachPPLGrammarRefresh(
-        editor,
-        getValidationContext,
-        (listener) => pplGrammarCache.subscribeToGrammarUpdates(listener),
-        revalidatePPLModel
-      );
-
-      // Revalidate immediately so any initial content that was validated before
-      // the context was attached gets re-checked with the runtime grammar.
-      const model = editor.getModel();
-      if (model) {
-        void revalidatePPLModel(model);
-      }
-
       const focusDisposable = editor.onDidFocusEditorText(() => {
         setEditorIsFocused(true);
       });
@@ -373,7 +307,10 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
 
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
-        const maxHeight = 100;
+        const containerEl = editor.getDomNode()?.parentElement;
+        const containerHeight = containerEl?.clientHeight || 100;
+        // Use the container height as the max, falling back to 100px
+        const maxHeight = Math.max(containerHeight, 36);
         const finalHeight = Math.min(contentHeight, maxHeight);
 
         editor.layout({
@@ -421,7 +358,6 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
       setEditorIsFocused,
       updateDecorations,
       clearDecorations,
-      getValidationContext,
     ]
   );
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -373,9 +373,11 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
 
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
-        const containerEl = editor.getDomNode()?.parentElement;
-        const containerHeight = containerEl?.clientHeight || 100;
-        // Use the container height as the max, falling back to 100px
+        // Read the resizable panel's allocated height rather than the editor's
+        // immediate parent, which may have been pushed taller by content.
+        const panelEl = editor.getDomNode()?.closest('.exploreResizableQueryContainer__queryPanel');
+        const containerHeight =
+          panelEl?.clientHeight || editor.getDomNode()?.parentElement?.clientHeight || 100;
         const maxHeight = Math.max(containerHeight, 36);
         const finalHeight = Math.min(contentHeight, maxHeight);
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -4,7 +4,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { monaco } from '@osd/monaco';
+import { monaco, PPLValidationContext, revalidatePPLModel } from '@osd/monaco';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
 import { DEFAULT_DATA } from '../../../../../../data/common';
@@ -14,6 +14,7 @@ import {
   selectQueryLanguage,
   selectQueryString,
   selectIsQueryEditorDirty,
+  selectDataset,
 } from '../../../../application/utils/state_management/selectors';
 import { promptEditorOptions, queryEditorOptions } from './editor_options';
 
@@ -34,14 +35,21 @@ import { usePromptIsTyping } from './use_prompt_is_typing';
 import { EditorMode } from '../../../../application/utils/state_management/types';
 import { useMultiQueryDecorations } from './use_multi_query_decorations';
 import { getAutocompleteContext } from '../../../../application/utils/multi_query_utils';
+import {
+  attachPPLValidationContext,
+  attachPPLGrammarRefresh,
+  syncPPLValidationContext,
+  pplGrammarCache,
+  shouldUseRuntimeGrammar,
+} from '../../../../../../data/public';
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 type LanguageConfiguration = monaco.languages.LanguageConfiguration;
 type IEditorConstructionOptions = monaco.editor.IEditorConstructionOptions;
 
-const DEFAULT_TRIGGER_CHARACTERS = [' ', '=', "'", '"', '`'];
+export const DEFAULT_TRIGGER_CHARACTERS = [' ', '=', "'", '"', '`'];
 
-const languageConfiguration: LanguageConfiguration = {
+export const languageConfiguration: LanguageConfiguration = {
   autoClosingPairs: [
     { open: '(', close: ')' },
     { open: '[', close: ']' },
@@ -105,6 +113,20 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   const promptModeIsAvailableRef = useRef(promptModeIsAvailable);
   const queryLanguageRef = useRef(queryLanguage);
   const isQueryEditorDirty = useSelector(selectIsQueryEditorDirty);
+  const dataset = useSelector(selectDataset);
+  const detachValidationContextRef = useRef<(() => void) | undefined>();
+  const detachGrammarRefreshRef = useRef<(() => void) | undefined>();
+
+  const getValidationContext = useCallback((): PPLValidationContext => {
+    const currentQuery = queryString.getQuery();
+    const dsId = currentQuery.dataset?.dataSource?.id;
+    const dsVersion = currentQuery.dataset?.dataSource?.version;
+    return {
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      dataSourceId: dsId,
+      dataSourceVersion: dsVersion,
+    };
+  }, [queryString]);
 
   const switchEditorMode = useLanguageSwitch();
 
@@ -121,6 +143,32 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   useEffect(() => {
     queryLanguageRef.current = queryLanguage;
   }, [queryLanguage]);
+
+  // Sync PPL validation context when datasource changes
+  useEffect(() => {
+    const dsId = dataset?.dataSource?.id;
+    const dsVersion = dataset?.dataSource?.version;
+    syncPPLValidationContext(editorRef.current, {
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      dataSourceId: dsId,
+      dataSourceVersion: dsVersion,
+    });
+    const model = editorRef.current?.getModel();
+    if (model) {
+      void revalidatePPLModel(model);
+    }
+  }, [dataset?.dataSource?.id, dataset?.dataSource?.version, editorRef]);
+
+  // Cleanup validation context on unmount
+  useEffect(
+    () => () => {
+      detachValidationContextRef.current?.();
+      detachValidationContextRef.current = undefined;
+      detachGrammarRefreshRef.current?.();
+      detachGrammarRefreshRef.current = undefined;
+    },
+    []
+  );
 
   keyboardShortcut?.useKeyboardShortcut({
     id: 'focus_query_bar',
@@ -271,6 +319,24 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
     (editor: IStandaloneCodeEditor) => {
       setEditorRef(editor);
 
+      // Attach PPL runtime validation context
+      detachValidationContextRef.current?.();
+      detachGrammarRefreshRef.current?.();
+      detachValidationContextRef.current = attachPPLValidationContext(editor, getValidationContext);
+      detachGrammarRefreshRef.current = attachPPLGrammarRefresh(
+        editor,
+        getValidationContext,
+        (listener) => pplGrammarCache.subscribeToGrammarUpdates(listener),
+        revalidatePPLModel
+      );
+
+      // Revalidate immediately so any initial content that was validated before
+      // the context was attached gets re-checked with the runtime grammar.
+      const model = editor.getModel();
+      if (model) {
+        void revalidatePPLModel(model);
+      }
+
       const focusDisposable = editor.onDidFocusEditorText(() => {
         setEditorIsFocused(true);
       });
@@ -358,6 +424,7 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
       setEditorIsFocused,
       updateDecorations,
       clearDecorations,
+      getValidationContext,
     ]
   );
 


### PR DESCRIPTION
### Description

Adds a resizable vertical split between the query panel and the content area in the Explore plugin (Logs, Metrics, Traces pages). Users can now drag to resize the query editor panel height.

###  Changes
ResizableQueryContainer component (resizable_query_container.tsx)

- Wraps the query panel and content area in an EuiResizableContainer with direction="vertical"
- Dynamically measures the query panel's initial height from Monaco's rendered .view-lines height plus the widgets bar, so the panel starts with single line height
-  Initial panel size is computed from the viewport height to always fit one editor line (~72px) regardless of screen size, clamped between 5-15
- Dispatches resize events on panel change and mount so Monaco recalculates its layout
- Resize handle styles (resizable_query_container.scss)
- `onDidContentSizeChange` in both explore and agent_traces `use_query_panel_editor.ts` now reads the resizable panel's allocated height via `closest()` instead of the editor's immediate parent, preventing multi-line queries from locking the panel height on page reload

- Custom styles for the EuiResizableButton to work around an oui/eui CSS class prefix mismatch where the default OUI styles don't apply to the EUI-prefixed button element
- Matches the existing OUI resizable button pattern: transparent background, two centered grab indicator lines, full-width line expansion on hover/focus with primary color highlight

### Screenshot

https://github.com/user-attachments/assets/adbf9f80-91a5-432d-9de5-f82d8708a314





###  Testing

- Verified on Logs, Metrics, and Traces pages
- Empty query: panel starts at single-line editor height
- Pre-filled query: panel starts at multi-line height
- Drag handle visible and functional, consistent with bottom container's resize handle
- Monaco editor relayouts correctly after resize

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
