### PR TITLE
[AI] Update PR description skill and add unit test skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -7,13 +7,22 @@ This directory contains Claude Code skills for OpenSearch Dashboards development
 ## Available Skills
 
 ### `create_pr_description` ([create_pr_description/](create_pr_description/))
-Generate comprehensive PR descriptions by analyzing code changes and adhering to the project's pull request template.
+Generate concise, one-screen PR descriptions optimized for quick reviewer comprehension.
 
 - **Skill Definition**: [create_pr_description/SKILL.md](create_pr_description/SKILL.md)
 - **Documentation**: [create_pr_description/README.md](create_pr_description/README.md)
-- **Claude Usage**: `/create_pr_description [--pr_number 123] [--include_diff] [--auto_commit_message]`
+- **Claude Usage**: `/create_pr_description [--pr_number 123]`
 - **Kiro Usage**: Also available as Kiro prompt at [.kiro/prompts/create_pr_description.md](../../.kiro/prompts/create_pr_description.md)
-- **Purpose**: Analyzes code changes, commit history, and project context to generate template-compliant, comprehensive PR descriptions
+- **Purpose**: Generates brief, engineer-style PR descriptions that fit on one screen for typical changes
+
+### `test_changes` ([test_changes/](test_changes/))
+Run Jest unit tests for files changed in the current branch.
+
+- **Skill Definition**: [test_changes/SKILL.md](test_changes/SKILL.md)
+- **Documentation**: [test_changes/README.md](test_changes/README.md)
+- **Claude Usage**: `/test_changes [--scope branch|staged|unstaged|all-local] [--base origin/main]`
+- **Kiro Usage**: Also available as Kiro prompt at [.kiro/prompts/test_changes.md](../../.kiro/prompts/test_changes.md)
+- **Purpose**: Finds changed files, maps them to test files, warns about missing tests, and runs `yarn test:jest`
 
 ### `resolve_cve` ([resolve_cve/](resolve_cve/))
 Automatically identify and resolve security vulnerabilities (CVEs) in project dependencies.

--- a/.claude/skills/create_pr_description/README.md
+++ b/.claude/skills/create_pr_description/README.md
@@ -1,321 +1,35 @@
-# Create PR Description Skill
+# create_pr_description Skill
 
-Automatically generate comprehensive, template-compliant PR descriptions by analyzing code changes, commit history, and project context. This skill transforms the tedious process of writing PR descriptions into an intelligent, automated workflow.
+Generate concise, template-compliant PR descriptions by analyzing code changes.
 
-## Overview
+## What it does
 
-Writing good PR descriptions is time-consuming but critical for code review quality and project documentation. This skill analyzes your changes and generates detailed, structured descriptions that follow your project's PR template, saving time while improving consistency and thoroughness.
+Analyzes your code changes (local or from an existing PR) and generates a PR description that follows `.github/pull_request_template.md`. Optimized for brevity — descriptions fit on one screen for typical PRs.
 
-## Quick Start
+## Usage
 
-### For Local Changes (Most Common)
 ```bash
-# Analyze your uncommitted changes and generate PR description  
+# Analyze local changes
 /create_pr_description
 
-# Include detailed code diff analysis
-/create_pr_description --include_diff
-
-# Use commit messages for additional context
-/create_pr_description --auto_commit_message
-```
-
-### For Existing PRs
-```bash
-# Analyze and improve an existing PR description
+# Analyze an existing PR
 /create_pr_description --pr_number 11659
-
-# Generate comprehensive description with full analysis
-/create_pr_description --pr_number 11659 --include_diff --auto_commit_message
 ```
 
-## Features
+Also available as a Kiro prompt: `/create_pr_description` or `@create_pr_description`.
 
-### 🎯 **Template Compliance**
-- Automatically reads `.github/pull_request_template.md`
-- Intelligently fills every template section
-- Preserves template structure and formatting
-- Future-proof against template changes
+## Parameters
 
-### 🧠 **Intelligent Analysis** 
-- **Change Classification**: Identifies features, bugs fixes, refactoring, breaking changes
-- **Impact Assessment**: Determines scope (frontend, backend, core, security)
-- **File Categorization**: Separates source code, tests, documentation, config files
-- **Context Extraction**: Pulls intent from commit messages and branch names
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--pr_number` | No | PR number to analyze. If omitted, analyzes local changes |
+| `--output_file` | No | Output path (defaults to `tmp/pr-description.md`) |
 
-### 🔗 **Auto-Detection**
-- **Issue Linking**: Finds GitHub issues from commits (`fixes #123`) and branch names
-- **Test Files**: Identifies new/modified tests and suggests test commands
-- **Breaking Changes**: Detects API changes, removed exports, config modifications
-- **Security Impact**: Flags auth, permission, and data access changes
+## Style
 
-### ✅ **Smart Automation**
-- **Checklist Completion**: Auto-checks items based on actual changes
-- **Changelog Generation**: Creates appropriate changelog entries
-- **Testing Recommendations**: Suggests specific test commands and manual steps
-- **Review Guidance**: Highlights areas needing special attention
-
-## Use Cases
-
-### 🚀 **New Feature PRs**
-Perfect for feature branches that add new functionality:
-```bash
-# Branch: feat/new-visualization-component
-/create_pr_description --auto_commit_message
-```
-**Generated content includes:**
-- Feature overview and capabilities
-- UI component documentation  
-- Usage examples and API docs
-- Comprehensive testing plan
-
-### 🐛 **Bug Fix PRs**
-Ideal for bug fixes with clear issue references:
-```bash
-# Branch: fix/issue-1234-login-redirect  
-/create_pr_description --include_diff
-```
-**Generated content includes:**
-- Root cause analysis
-- Fix implementation details
-- Regression prevention measures
-- Specific test cases for the bug
-
-### 🔧 **Refactoring PRs**
-Excellent for code cleanup and restructuring:
-```bash
-/create_pr_description --include_diff --auto_commit_message
-```
-**Generated content includes:**
-- Refactoring motivation and benefits
-- Before/after code structure comparison
-- Backward compatibility assurance
-- Performance impact assessment
-
-### 🔒 **Security PRs** 
-Critical for security-related changes:
-```bash
-/create_pr_description --include_diff
-```
-**Generated content includes:**
-- Security vulnerability details
-- Fix implementation approach  
-- Security review requirements
-- Additional testing recommendations
-
-## Arguments Reference
-
-| Argument | Description | Example |
-|----------|-------------|---------|
-| `pr_number` | Analyze existing PR instead of local changes | `--pr_number 11659` |
-| `include_diff` | Include detailed code diff analysis | `--include_diff` |
-| `auto_commit_message` | Use commit messages for context | `--auto_commit_message` |
-| `output_file` | Custom output file path | `--output_file my-pr.md` |
-
-## Output Structure
-
-The skill generates a complete PR description with these sections:
-
-### 📋 **Summary Section**
-```markdown
-## Summary
-This PR adds a new data visualization component that enables users to create
-interactive bar charts with customizable aggregation options.
-
-### Key Changes  
-- Add BarChartVisualization React component with D3.js integration
-- Implement data aggregation service for chart data processing
-- Create comprehensive test suite covering edge cases and interactions
-- Update visualization registry to include new chart type
-
-### Technical Details
-The implementation uses a modular architecture with separate concerns for
-data processing, rendering, and user interaction...
-```
-
-### 🔗 **Issues Resolved**
-```markdown
-## Issues Resolved
-- closes #1234
-- fixes #5678  
-```
-
-### 🧪 **Testing Plan**
-```markdown
-## Testing
-### Unit Tests
-yarn test:jest src/plugins/vis_type_bar_chart/public/components/bar_chart.test.tsx
-
-### Integration Tests  
-yarn test:jest_integration test/functional/apps/visualizations/bar_chart.ts
-
-### Manual Testing
-1. Navigate to Visualizations → Create new visualization
-2. Select "Bar Chart" from visualization types
-3. Configure data source and aggregation options
-4. Verify chart renders correctly with sample data
-5. Test responsive behavior and interaction features
-```
-
-### 📝 **Changelog Entry**
-```markdown
-## Changelog
-- [FEATURE] Add interactive bar chart visualization with D3.js integration and customizable aggregation options
-```
-
-### ✅ **Smart Checklist**
-```markdown
-## Checklist
-- [x] Added unit tests (12 new test files)
-- [x] Updated documentation (README.md, plugin docs)
-- [x] Added changelog entry  
-- [x] Tested in multiple browsers
-- [ ] Requires security review (no security-related changes)
-- [x] Breaking changes documented (no breaking changes)
-```
-
-## Integration Examples
-
-### Pre-commit Hook Integration
-```bash
-# Add to .git/hooks/pre-commit
-#!/bin/sh
-echo "Generating PR description..."
-/create_pr_description --auto_commit_message --output_file pr-description.md
-echo "✅ PR description ready in pr-description.md"
-```
-
-### VS Code Task Integration
-```json
-{
-    "label": "Generate PR Description",
-    "type": "shell", 
-    "command": "/create_pr_description",
-    "args": ["--include_diff", "--auto_commit_message"],
-    "group": "build",
-    "presentation": {
-        "echo": true,
-        "reveal": "always"
-    }
-}
-```
-
-### GitHub Actions Integration
-```yaml
-name: Auto PR Description
-on:
-  pull_request:
-    types: [opened, synchronize]
-jobs:
-  generate-description:
-    if: github.event.pull_request.body == ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Generate PR Description
-        run: /create_pr_description --pr_number ${{ github.event.number }}
-```
-
-## Tips and Best Practices
-
-### 🎯 **Getting the Best Results**
-
-1. **Use descriptive commit messages**: The skill extracts context from commit messages
-   ```bash
-   git commit -m "feat(visualizations): add interactive bar chart with D3.js integration"
-   ```
-
-2. **Follow branch naming conventions**: Branch names provide additional context
-   ```bash
-   feat/issue-1234-bar-chart-visualization
-   fix/login-redirect-bug  
-   refactor/data-views-service
-   ```
-
-3. **Stage changes thoughtfully**: The skill analyzes staged vs unstaged changes
-   ```bash
-   git add src/plugins/  # Add main changes
-   git add test/         # Add related tests
-   # Leave unrelated changes unstaged
-   ```
-
-4. **Include issue references**: Link to GitHub issues in commits or branch names
-   ```bash
-   git commit -m "fix: resolve login redirect issue (closes #1234)"
-   ```
-
-### ⚡ **Workflow Optimization**
-
-**Recommended workflow:**
-1. Complete your feature/fix development
-2. Stage all related changes (`git add` relevant files)
-3. Run `/create_pr_description --auto_commit_message --include_diff`
-4. Review and customize the generated description
-5. Create your PR with the generated description
-6. Make final edits if needed
-
-**For large PRs:**
-```bash
-# Break down analysis by including specific context
-/create_pr_description --include_diff --auto_commit_message --output_file detailed-pr.md
-```
-
-**For quick fixes:**
-```bash
-# Generate basic description for simple changes
-/create_pr_description
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**No changes detected:**
-```bash
-# Ensure you have staged or committed changes
-git status
-git add <files>
-/create_pr_description
-```
-
-**Template not found:**
-```bash
-# Skill will generate basic structure if no template exists
-# Consider adding .github/pull_request_template.md to your project
-```
-
-**Output file permissions:**
-```bash
-# Default output is tmp/pr-description.md (gitignored)
-# Use custom path if needed: --output_file my-description.md
-```
-
-### Getting Help
-
-- **Skill not working?** Check that you have staged changes or specify a PR number
-- **Want different output format?** Customize the output using the generated file as a base
-- **Need more context?** Use `--include_diff` and `--auto_commit_message` for maximum detail
-
-## Examples in Action
-
-See the skill in action with these real-world scenarios:
-
-### Example 1: Feature Addition
-**Input:** New React component with tests
-**Generated:** Comprehensive description with component API docs, usage examples, and testing plan
-
-### Example 2: Bug Fix  
-**Input:** Fix for authentication redirect issue
-**Generated:** Root cause analysis, fix details, and regression prevention measures
-
-### Example 3: Refactoring
-**Input:** Service layer restructuring 
-**Generated:** Motivation, architectural changes, and backward compatibility notes
-
-### Example 4: Security Update
-**Input:** Fix for session handling vulnerability
-**Generated:** Security impact assessment, fix approach, and additional review requirements
-
----
-
-This skill transforms PR descriptions from an afterthought into a comprehensive, professional documentation process that improves code review quality and project maintainability! 🚀
+The skill enforces concise, engineer-style writing:
+- No emojis, no hype words, no filler
+- 1-4 sentence descriptions for typical changes
+- Concrete test commands, not generic advice
+- Checklist items checked based on actual diff content
+- Small/medium PRs fit in ~30-40 lines of markdown

--- a/.claude/skills/create_pr_description/SKILL.md
+++ b/.claude/skills/create_pr_description/SKILL.md
@@ -1,313 +1,100 @@
 ---
 name: create_pr_description
-description: Generate comprehensive PR descriptions by analyzing code changes and adhering to the project's pull request template
+description: Generate a concise PR description from code changes, following the repo's PR template
 arguments:
   - name: pr_number
-    description: PR number to analyze. If not provided, will analyze local uncommitted changes
-    required: false
-  - name: include_diff
-    description: Include detailed code diff analysis in the description
-    required: false
-  - name: auto_commit_message
-    description: Use commit messages to enhance context and change explanations
+    description: PR number to analyze. If not provided, analyzes local uncommitted/committed changes
     required: false
   - name: output_file
     description: File path to save the generated PR description (defaults to tmp/pr-description.md)
     required: false
 ---
 
-# Create PR Description Skill
+# Generate PR Description
 
-Generate comprehensive, template-compliant PR descriptions by intelligently analyzing code changes, commit history, and project context. Transforms rushed, incomplete PR descriptions into thorough, reviewer-friendly documentation.
+Analyze code changes and produce a PR description that follows `.github/pull_request_template.md`. The output should be concise enough that a reviewer can understand the PR in under 30 seconds.
 
-## Usage
+## Writing Style Rules
 
-```bash
-/create_pr_description [--pr_number 123] [--include_diff] [--auto_commit_message] [--output_file path/to/output.md]
-```
+- Write like a senior engineer, not a marketing team. No emojis, no hype words ("revolutionizes", "powerful", "comprehensive"), no filler.
+- Every sentence must convey information a reviewer needs. If removing a sentence loses nothing, remove it.
+- Description section: 1-4 sentences max for typical changes. Use bullet points only when listing multiple distinct changes.
+- Testing section: List concrete commands or steps. Skip generic advice like "verify functionality works as expected".
+- Checklist: Check boxes that are actually true based on the diff. Leave unchecked items alone — don't add explanatory sub-bullets unless the template already has them.
+- For small/medium PRs (< ~300 lines changed), the entire description should fit on one screen (~30-40 lines of markdown).
+- For large PRs (features, designs), more detail is warranted — but still prefer structured brevity over prose.
 
-## Key Features
+## Good Example
 
-- **Template Compliance**: Automatically reads and fills `.github/pull_request_template.md`
-- **Dual Mode Analysis**: Works with existing PRs or local uncommitted changes
-- **Smart Content Generation**: AI-powered analysis of code changes and impact
-- **Auto-Issue Detection**: Finds and links related GitHub issues from commits/branch names
-- **Testing Recommendations**: Suggests specific test commands based on changed files
-- **Changelog Generation**: Creates appropriate changelog entries following project conventions
-- **Checklist Intelligence**: Auto-completes checklist items based on actual changes
+This is the style to emulate (from a real CVE fix PR):
 
-## Process
-
-### Step 1: Determine Analysis Mode
-
-**If `--pr_number` provided:**
-```bash
-# Analyze existing PR
-gh pr view {pr_number} --json number,title,body,headRefName,baseRefName,files
-gh pr diff {pr_number} --name-only
-```
-
-**If no PR number (local changes mode):**
-```bash
-# Analyze local changes
-git status --porcelain
-git diff --name-only
-git diff --staged --name-only
-git log --oneline -10  # Recent commit context
-```
-
-### Step 2: Load and Parse PR Template
-
-**Read current template dynamically:**
-```bash
-# Always use current template (future-proof)
-template_path=".github/pull_request_template.md"
-if [[ -f "$template_path" ]]; then
-    # Parse template structure
-    # Identify sections: Description, Issues Resolved, Testing, Changelog, etc.
-    # Extract placeholders and instructions
-fi
-```
-
-**Template Section Detection:**
-- Parse markdown headers (`## Description`, `## Testing`, etc.)
-- Identify comment placeholders (`<!-- Describe your changes -->`)
-- Detect checklists (`- [ ] Added unit tests`)
-- Extract existing content to preserve manual additions
-
-### Step 3: Analyze Code Changes
-
-**File Analysis:**
-```bash
-# Categorize changed files
-changed_files=()
-test_files=()
-doc_files=()
-config_files=()
-
-for file in $(git diff --name-only); do
-    case "$file" in
-        *.test.* | *spec.* | cypress/**) test_files+=("$file") ;;
-        *.md | docs/**) doc_files+=("$file") ;;
-        package.json | yarn.lock | *.config.*) config_files+=("$file") ;;
-        *) changed_files+=("$file") ;;
-    esac
-done
-```
-
-**Change Impact Assessment:**
-- **Frontend changes**: React components, UI files, stylesheets
-- **Backend changes**: Server plugins, APIs, saved objects
-- **Core changes**: Platform code, shared utilities
-- **Security impact**: Authentication, authorization, data access
-- **Breaking changes**: API modifications, config changes, deprecations
-
-### Step 4: Extract Context and Intent
-
-**From Commit Messages (if `--auto_commit_message`):**
-```bash
-# Get recent commit messages for context
-git log --oneline --no-merges -10 --pretty=format:"%s"
-# Parse for:
-# - Issue references (fixes #123, closes #456)
-# - Change type keywords (feat:, fix:, refactor:, etc.)
-# - Scope information ((plugin), (core), (ui))
-```
-
-**From Branch Names:**
-```bash
-current_branch=$(git branch --show-current)
-# Extract patterns:
-# - Issue numbers: feature/issue-123, fix-1234
-# - Change type: feat/new-feature, bugfix/auth-error
-# - Scope: plugin/data-views, core/saved-objects
-```
-
-**From File Content (if `--include_diff`):**
-```bash
-# Analyze actual code changes
-git diff HEAD~1 --unified=3
-# Look for:
-# - New functions/classes added
-# - Deprecated code removed  
-# - Configuration changes
-# - Test additions/modifications
-# - Documentation updates
-```
-
-### Step 5: Generate Template Content
-
-**Description Section:**
 ```markdown
-## Summary
-{Generated summary based on change analysis}
+### Description
 
-This PR {change_type} {main_functionality} in {affected_components}.
+Resolves security vulnerabilities in project dependencies:
+* **CVE-2026-4800** (High): lodash vulnerable to Code Injection via `_.template` imports key names
+* **Package**: lodash@4.17.23 → lodash@4.18.1
+* **Resolution Strategy**: Direct Package Update - Updated all lodash dependencies and yarn resolutions to safe versions
 
-### Key Changes
-- {List of major changes with file context}
-- {Impact on existing functionality}
-- {New features or capabilities added}
+### Issues Resolved
+* closes #11658
 
-### Technical Details
-{Detailed explanation of implementation approach}
+## Screenshot
+
+## Testing the changes
+
+**CVE Resolution Verification:**
+1. Run `yarn osd bootstrap` - Should complete successfully
+2. Run `yarn audit --level high` - Should not show CVE-2026-4800 or lodash vulnerabilities
+3. Check `yarn.lock` - Should show lodash@4.18.1 (safe version)
+
+**Build Verification:**
+* Ensure project builds and starts successfully
+* No functional regressions expected as this is a security patch update
+
+### Check List
+- [x] All tests pass
+  - [x] `yarn test:jest`
+  - [x] `yarn test:jest_integration`
+- [ ] New functionality includes testing.
+- [ ] New functionality has been documented.
+- [x] Commits are signed per the DCO using --signoff
 ```
 
-**Issues Resolved Section:**
+## Steps
+
+### Step 1: Read the PR template
+
 ```bash
-# Auto-extract from commits and branch name
-issue_refs=$(git log --grep="fixes\|closes\|resolves" --oneline -10 | grep -oE "#[0-9]+")
-branch_issue=$(echo "$current_branch" | grep -oE "[0-9]+")
-
-# Generate closes statements
-for issue in $issue_refs; do
-    echo "- closes $issue"
-done
+cat .github/pull_request_template.md
 ```
 
-**Testing Section:**
+Use this as the skeleton. Preserve its structure exactly.
+
+### Step 2: Gather change context
+
+For local changes:
 ```bash
-# Generate test commands based on changed files
-if [[ ${#test_files[@]} -gt 0 ]]; then
-    echo "### Unit Tests"
-    for test_file in "${test_files[@]}"; do
-        echo "yarn test:jest $test_file"
-    done
-fi
-
-if [[ -n $(find . -name "*.cy.ts" -newer HEAD~1) ]]; then
-    echo "### Cypress Tests"  
-    echo "yarn cypress:run --spec path/to/new/spec.cy.ts"
-fi
-
-# Manual testing recommendations
-echo "### Manual Testing"
-echo "1. Navigate to affected UI components"
-echo "2. Verify functionality works as expected"
-echo "3. Test edge cases and error conditions"
+git diff --name-only HEAD
+git diff --stat HEAD
+git log --oneline -5
+git branch --show-current
 ```
 
-**Changelog Section:**
+For an existing PR (if a PR number is provided):
 ```bash
-# Generate appropriate changelog entry
-change_type="FEATURE"  # or FIX, BREAKING, CHORE based on analysis
-
-case "$change_type" in
-    "FEATURE") echo "[$change_type] Add {functionality_description}" ;;
-    "FIX") echo "[$change_type] Resolve {issue_description}" ;;  
-    "BREAKING") echo "[$change_type] Remove deprecated {component_name}" ;;
-    "CHORE") echo "[$change_type] Update {dependency/tooling}" ;;
-esac
+gh pr view {pr_number} --json title,body,headRefName,files
+gh pr diff {pr_number} --stat
 ```
 
-**Smart Checklist Completion:**
-```bash
-# Auto-check based on actual changes
-checklist_items=(
-    "Added unit tests:${#test_files[@]} -gt 0"
-    "Updated documentation:${#doc_files[@]} -gt 0"  
-    "Added changelog entry:always_required"
-    "Requires security review:security_files_changed"
-)
+### Step 3: Fill in the template
 
-for item in "${checklist_items[@]}"; do
-    condition="${item#*:}"
-    text="${item%:*}"
-    if eval "$condition"; then
-        echo "- [x] $text"
-    else  
-        echo "- [ ] $text"
-    fi
-done
-```
+- **Description**: State what changed and why in 1-4 sentences. If there are multiple distinct changes, use a short bullet list. Include the specific files/components affected only when it helps the reviewer navigate.
+- **Issues Resolved**: Extract from branch name or commit messages. Use `closes #N` format.
+- **Screenshot**: Leave empty unless UI changes are present, in which case note that a screenshot should be attached.
+- **Testing**: List the specific test commands relevant to the changed files. Include manual steps only if automated tests don't cover the change.
+- **Checklist**: Check items based on what the diff actually contains (test files present → check test box, docs changed → check docs box, etc.).
 
-### Step 6: Output Generation
+### Step 4: Output
 
-**Create final PR description:**
-```bash
-output_file="${output_file:-tmp/pr-description.md}"
-mkdir -p "$(dirname "$output_file")"
-
-# Clean existing file
-rm -f "$output_file"
-
-# Use current template as base
-cp .github/pull_request_template.md "$output_file"
-
-# Replace template sections with generated content
-# Use intelligent placeholder replacement
-sed -i 's/<!-- Describe what this change achieves-->/{generated_description}/g' "$output_file"
-sed -i 's/<!-- List any issues this PR will resolve -->/{generated_issues}/g' "$output_file"
-# ... continue for all template sections
-```
-
-**Success output:**
-```bash
-echo "✅ PR description generated successfully!"
-echo "📄 Output: $output_file"
-echo ""
-echo "📋 Generated content includes:"
-echo "  - Comprehensive change summary"
-echo "  - Auto-detected issue references" 
-echo "  - Specific testing recommendations"
-echo "  - Appropriate changelog entry"
-echo "  - Smart checklist completion"
-echo ""
-echo "📂 Ready to copy-paste into your PR description!"
-```
-
-## Advanced Features
-
-### **Intelligent Change Classification:**
-- **New Features**: New files, exported functions, UI components
-- **Bug Fixes**: Changes to existing logic, error handling additions
-- **Refactoring**: Code restructuring without functional changes
-- **Breaking Changes**: Removed exports, changed APIs, config modifications
-- **Security Updates**: Authentication, authorization, data validation changes
-
-### **Context-Aware Recommendations:**
-- **Core Platform Changes**: Recommend additional reviewer assignment
-- **Plugin Changes**: Suggest plugin-specific testing
-- **UI Changes**: Include screenshot recommendations
-- **API Changes**: Highlight backward compatibility impact
-- **Database Changes**: Note migration requirements
-
-### **Template Customization:**
-- Adapts to any project's PR template format
-- Preserves existing template structure and styling
-- Maintains project-specific sections and requirements
-- Future-proof against template updates
-
-## Error Handling
-
-- **No template found**: Generate basic structured description
-- **Git errors**: Fall back to file system analysis
-- **Empty changes**: Provide template with guidance prompts
-- **Permission issues**: Clear error messages with resolution steps
-
-## Integration Patterns
-
-**Pre-commit hook usage:**
-```bash
-# Add to .git/hooks/pre-commit
-/create_pr_description --auto_commit_message --output_file pr-description.md
-echo "PR description ready in pr-description.md"
-```
-
-**CI/CD integration:**
-```bash
-# Auto-generate for draft PRs
-if [[ "$PR_STATUS" == "draft" ]]; then
-    /create_pr_description --pr_number "$PR_NUMBER" 
-fi
-```
-
-**Branch naming convention support:**
-```bash
-# Extract context from standardized branch names
-# feat/OSD-123-add-visualization -> Feature for issue OSD-123
-# fix/login-redirect-bug -> Bug fix for login redirect
-# refactor/data-views-service -> Refactoring data views service
-```
-
-This skill transforms the tedious PR description process into an automated, intelligent workflow that produces consistent, high-quality documentation every time! 🚀
+Write the filled template to `tmp/pr-description.md` (or a specified output path) and print it to the terminal.

--- a/.claude/skills/resolve_cve/README.md
+++ b/.claude/skills/resolve_cve/README.md
@@ -137,9 +137,6 @@ Resolves security vulnerability in project dependencies:
 
 ## Testing the changes
 [CVE-specific verification commands]
-
-## Changelog
-- fix: Resolve CVE-2025-54798 in tmp dependency
 ```
 
 **Failure Reports: `tmp/cve-failure-report.md`** - Detailed analysis if resolution fails

--- a/.claude/skills/resolve_cve/SKILL.md
+++ b/.claude/skills/resolve_cve/SKILL.md
@@ -94,7 +94,7 @@ After each remediation attempt:
 Create a PR-ready description in `tmp/cve-pr-description.md` by **dynamically using the current GitHub PR template**:
 
 1. **Read the current PR template**: Load `.github/pull_request_template.md` to get the latest format
-2. **Parse template structure**: Identify sections like Description, Issues Resolved, Testing, Changelog, etc.
+2. **Parse template structure**: Identify sections like Description, Issues Resolved, Testing, etc.
 3. **Fill in CVE-specific content**: Replace template placeholders with actual CVE resolution details
 4. **Auto-extract GitHub Issue Numbers**: Parse CVE issue URLs and add `closes #[number]` entries
 
@@ -103,7 +103,6 @@ Create a PR-ready description in `tmp/cve-pr-description.md` by **dynamically us
 - **Description section**: Fill with CVE summary, affected packages, resolution strategy
 - **Issues Resolved section**: Auto-populate with `closes #[issue-number]` from found CVE issues
 - **Testing section**: Add CVE-specific verification commands
-- **Changelog section**: Generate appropriate changelog entry for security fixes
 - **Checklist section**: Mark relevant items as completed based on resolution results
 
 **Dynamic Template Approach**:
@@ -116,7 +115,6 @@ cp .github/pull_request_template.md tmp/cve-pr-description.md
 # - Replace "<!-- Describe what this change achieves-->" with CVE details
 # - Replace "<!-- List any issues this PR will resolve -->" with closes #123
 # - Fill testing section with CVE verification steps
-# - Add appropriate changelog entry
 ```
 
 This ensures the skill **always respects the current PR template format**, even if it changes in the future - no manual skill updates required!
@@ -160,8 +158,6 @@ cp .github/pull_request_template.md tmp/cve-pr-description.md
    ```
 
 3. **Testing section**: Replace `<!-- Please provide detailed steps... -->` with CVE-specific validation steps
-
-4. **Changelog section**: Add appropriate security fix entry following existing format
 
 This approach ensures the skill **automatically adapts** to any future PR template changes without requiring skill updates.
 

--- a/.claude/skills/test_changes/README.md
+++ b/.claude/skills/test_changes/README.md
@@ -1,0 +1,39 @@
+# test_changes Skill
+
+Run Jest unit tests for files you've changed locally.
+
+## Usage
+
+```bash
+# Run tests for all changes on your branch (vs base branch)
+/test_changes
+
+# Only staged changes
+/test_changes --scope staged
+
+# Only unstaged changes
+/test_changes --scope unstaged
+
+# All uncommitted changes (staged + unstaged)
+/test_changes --scope all-local
+
+# Diff against a specific base
+/test_changes --base origin/feature-branch
+```
+
+Also available as a Kiro prompt: `@test_changes`.
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `--scope` | No | `branch` | `branch`, `staged`, `unstaged`, or `all-local` |
+| `--base` | No | auto-detect | Base ref for branch scope (auto-detects `origin/main` or `origin/mainline`) |
+
+## What it does
+
+1. Finds changed `.ts`/`.tsx`/`.js` files based on scope
+2. Maps source files to their `*.test.*` counterparts
+3. Includes any directly changed test files
+4. Warns (non-blocking) about source files with no matching test
+5. Runs `yarn test:jest` with the discovered test files

--- a/.claude/skills/test_changes/SKILL.md
+++ b/.claude/skills/test_changes/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: test_changes
+description: Run Jest unit tests for files changed in the current branch
+arguments:
+  - name: scope
+    description: "What to diff against: 'branch' (vs base branch, default), 'staged' (staged only), 'unstaged' (unstaged only), 'all-local' (staged + unstaged)"
+    required: false
+  - name: base
+    description: "Base ref to diff against when scope=branch (default: auto-detects remote main/mainline)"
+    required: false
+---
+
+# Run Changed Tests
+
+Find and run Jest tests relevant to locally changed files.
+
+## Process
+
+### Step 1: Determine changed files
+
+Based on the `scope` argument (default: `branch`):
+
+```bash
+# scope=branch (default): all changes since diverging from base branch
+# Auto-detect base: use origin/main or origin/mainline, whichever exists
+base="${base:-$(git rev-parse --verify origin/main 2>/dev/null && echo origin/main || echo origin/mainline)}"
+git diff --name-only --diff-filter=ACMR "$base"...HEAD
+# Also include uncommitted changes on top
+git diff --name-only --diff-filter=ACMR HEAD
+
+# scope=staged
+git diff --cached --name-only --diff-filter=ACMR
+
+# scope=unstaged
+git diff --name-only --diff-filter=ACMR
+
+# scope=all-local
+git diff --name-only --diff-filter=ACMR HEAD
+```
+
+Filter to only `.ts`, `.tsx`, `.js`, `.jsx` files. Exclude files under `target/`, `build/`, `node_modules/`.
+
+### Step 2: Separate source files and test files
+
+From the changed file list:
+- **Test files**: any file matching `*.test.ts`, `*.test.tsx`, `*.test.js`, `*.test.jsx` → run directly.
+- **Source files**: everything else → look for a corresponding test file.
+
+### Step 3: Find test files for changed source files
+
+For each changed source file (e.g., `src/plugins/foo/bar.ts`), check if any of these exist:
+1. `src/plugins/foo/bar.test.ts`
+2. `src/plugins/foo/bar.test.tsx`
+3. `src/plugins/foo/bar.test.js`
+
+Use the first match found.
+
+### Step 4: Warn about missing tests
+
+For any changed source file with no matching test file, print a warning:
+```
+⚠ No test file found for: src/plugins/foo/bar.ts
+```
+
+This is informational only — do not fail or block.
+
+### Step 5: Run tests
+
+Combine all discovered test files (from changed test files + matched test files for source changes), deduplicate, then run:
+
+```bash
+yarn test:jest path/to/test1.test.ts path/to/test2.test.tsx ...
+```
+
+If no test files are found at all, report that and exit cleanly.
+
+### Step 6: Report results
+
+Summarize:
+- How many test files were run
+- Which changed source files had no tests (the warnings from step 4)
+- Pass/fail status from Jest

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ selenium
 package-lock.json
 .yo-rc.json
 .vscode
-.kiro/
+.kiro/*
 !.kiro/prompts/
 *.sublime-*
 npm-debug.log*

--- a/.kiro/prompts/create_pr_description.md
+++ b/.kiro/prompts/create_pr_description.md
@@ -1,0 +1,10 @@
+Generate a concise PR description for ${1} following .github/pull_request_template.md.
+
+Rules:
+- Write like a senior engineer. No emojis, no hype words, no filler.
+- Description: 1-4 sentences for typical changes. Bullet points only for multiple distinct changes.
+- Testing: Concrete commands and steps only.
+- Checklist: Check boxes based on actual diff content.
+- Small/medium PRs (< ~300 lines): entire description fits on one screen (~30-40 lines).
+
+Read the PR template first, then analyze the changes, then fill in each section.

--- a/.kiro/prompts/test_changes.md
+++ b/.kiro/prompts/test_changes.md
@@ -1,0 +1,12 @@
+Run Jest unit tests for files changed in the current branch.
+
+Scope: ${1:-branch} (options: branch, staged, unstaged, all-local)
+Base ref: ${2:-auto-detect origin/main or origin/mainline}
+
+Steps:
+1. Find changed .ts/.tsx/.js files based on scope
+2. For test files (*.test.*) in the diff, run them directly
+3. For source files, find matching *.test.ts / *.test.tsx / *.test.js
+4. Warn about source files with no matching test (non-blocking)
+5. Run: yarn test:jest <all discovered test files>
+6. Summarize results: files run, missing tests, pass/fail

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -213,6 +213,7 @@
     - [Opensearch dashboards.release notes 3.3.0](../release-notes/opensearch-dashboards.release-notes-3.3.0.md)
     - [Opensearch dashboards.release notes 3.4.0](../release-notes/opensearch-dashboards.release-notes-3.4.0.md)
     - [Opensearch dashboards.release notes 3.5.0](../release-notes/opensearch-dashboards.release-notes-3.5.0.md)
+    - [Opensearch dashboards.release notes 3.6.0](../release-notes/opensearch-dashboards.release-notes-3.6.0.md)
   - scripts
     - [README](../scripts/README.md)
   - [DOCS_README](DOCS_README.md)


### PR DESCRIPTION
As an actual usecase, the descriptions of this PR and #11665 were both generated using the updated skill.

### Description

Replaces the verbose `create_pr_description` skill with a concise version optimized for quick reviewer comprehension, adds a new `test_changes` skill for running Jest tests on changed files, and removes stale changelog references from existing skills.

Key changes:
* **create_pr_description**: Rewritten to enforce one-screen PR descriptions with no filler — SKILL.md, README.md, and a new Kiro prompt (was missing)
* **test_changes**: New skill that diffs changed files, maps them to `*.test.*` counterparts, warns about missing tests, and runs `yarn test:jest`
* **resolve_cve**: Removed changelog section references (changelog infrastructure was removed in #11563)
* **.gitignore**: Fixed `.kiro/` → `.kiro/*` so the `!.kiro/prompts/` negation pattern works

### Issues Resolved

### Screenshot

### Testing the changes

These are AI skill/prompt definitions (markdown files only) — no runtime code changes.

1. Verify skill files are well-formed: check that SKILL.md files have valid frontmatter and README.md files render correctly
2. Verify `.kiro/prompts/` files are tracked by git after the `.gitignore` fix:
   ```bash
   git ls-files .kiro/prompts/
   ```
3. Verify no stale changelog references remain:
   ```bash
   grep -ri "changelog" .claude/ .kiro/prompts/
   ```

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
