### PR TITLE
[DaC] Add RFC and requirements for Dashboards-as-Code

### DIFF
--- a/docs/requirements/RFC.md
+++ b/docs/requirements/RFC.md
@@ -1,0 +1,1014 @@
+# RFC: Dashboards-as-Code for OpenSearch Dashboards
+
+|               |                                                     |
+|---------------|-----------------------------------------------------|
+| **Proposal**  | [RFC] Dashboards-as-Code for OpenSearch Dashboards  |
+| **Status**    | Draft                                               |
+| **Authors**   | OpenSearch Dashboards Team                          |
+| **Created**   | 2026-03-23                                          |
+| **Updated**   | 2026-03-23                                          |
+| **Issue**     | _To be created_                                     |
+
+## Summary
+
+This RFC proposes adding Dashboards-as-Code (DaC) capabilities to OpenSearch Dashboards, enabling users to define, validate, version-control, and deploy dashboards programmatically. The design extends the existing Saved Objects API with typed schemas, validation endpoints, and a diff mechanism, then layers multi-language SDKs and a CLI on top.
+
+## Motivation
+
+### The Problem
+
+Organizations managing OpenSearch Dashboards at scale face these challenges today:
+
+1. **No programmatic dashboard definition.** Dashboards are created exclusively through the UI. Teams with 50-500+ dashboards cannot apply consistent standards, reuse components, or generate dashboards from templates.
+
+2. **No version control integration.** Dashboard changes are not tracked in Git. There is no peer-review workflow, no rollback capability, and no audit trail of who changed what.
+
+3. **Fragile migration/backup story.** The only bulk mechanism is ndjson export/import, which produces opaque blobs unsuitable for code review or meaningful diffs.
+
+4. **No CI/CD pipeline support.** Dashboard deployment cannot be automated. Promoting dashboards across dev/staging/prod environments is manual and error-prone.
+
+### Why Now
+
+Every major observability platform has shipped or is actively building as-code capabilities:
+
+- **Grafana 12** (2025): Foundation SDK (5 languages), grafanactl CLI, Git Sync, Dashboard Schema v2, Terraform provider updates
+- **Perses** (CNCF): CUE + Go SDKs, percli CLI with build/diff/preview/lint, GitHub Actions, Kubernetes Operator
+- **Datadog**: Official SDKs (6 languages), mature Terraform provider (2,755+ commits), Kubernetes Operator
+- **Dynatrace**: Monaco CLI for config-as-code across observability + security
+
+OpenSearch Dashboards risks becoming uncompetitive for teams that expect GitOps-style workflows for their observability stack.
+
+### Goals
+
+1. Enable programmatic dashboard definition in TypeScript, Python, Go, and Java
+2. Extend the Saved Objects API with typed schemas, validation, and diff capabilities
+3. Ship a CLI (`osdctl`) for build, validate, diff, apply, and pull workflows
+4. Provide CI/CD integration (GitHub Actions, generic pipeline support)
+5. Keep all features fully open-source
+
+### Non-Goals (this RFC)
+
+- Git Sync (bi-directional UI-to-Git synchronization) — deferred to a follow-up RFC
+- Alerting-as-code, SLO-as-code — deferred to Phase 4
+- Terraform/Pulumi providers — deferred to Phase 3
+- Kubernetes Operator / CRDs — out of scope
+
+---
+
+## Design
+
+### Architecture Overview
+
+```
+                                                  OpenSearch Dashboards Server
+                                                 +---------------------------------+
+                                                 |                                 |
++------------------+     +------------------+    |  +---------------------------+  |
+| SDK (TS/Py/Go/   | --> | JSON/YAML files  | -->|  | Saved Objects API         |  |
+| Java)            |     | (git-tracked)    |    |  | (extended)                |  |
++------------------+     +------------------+    |  |                           |  |
+        |                        |               |  |  +-- _validate endpoint   |  |
+        v                        v               |  |  +-- _diff endpoint       |  |
++------------------+     +------------------+    |  |  +-- _bulk_apply endpoint |  |
+| osdctl CLI       | --> | CI/CD Pipeline   | -->|  |  +-- labels/annotations  |  |
+| (build/validate/ |     | (GitHub Actions, |    |  |  +-- version counter     |  |
+|  diff/apply/pull)|     |  GitLab CI, etc) |    |  +---------------------------+  |
++------------------+     +------------------+    |              |                   |
+                                                 |              v                   |
+                                                 |  +---------------------------+  |
+                                                 |  | Saved Objects Store       |  |
+                                                 |  | (.kibana index)           |  |
+                                                 |  +---------------------------+  |
+                                                 +---------------------------------+
+```
+
+The design has four layers:
+
+1. **API Layer** — Extensions to the Saved Objects API (server-side)
+2. **Schema Layer** — Typed, versioned JSON Schema definitions for each resource
+3. **SDK Layer** — Multi-language builder libraries that compile to JSON/YAML
+4. **CLI Layer** — Developer tool that orchestrates build, validate, diff, apply
+
+Each layer builds on the one below it. The SDK and CLI are external tools; only the API and schema layers require changes to the OpenSearch Dashboards server.
+
+---
+
+### Layer 1: Saved Objects API Extensions
+
+#### Design Principle
+
+**Extend, don't replace.** The Saved Objects API is battle-tested. We add new endpoints alongside existing ones. Existing integrations (ndjson export, UI, programmatic CRUD) continue to work unchanged.
+
+#### 1.1 Typed Schema Registry
+
+Each Saved Object type gets a formal JSON Schema definition, registered at server startup.
+
+```
+src/core/server/saved_objects/schemas/
+  dashboard.v1.json
+  visualization.v1.json
+  index-pattern.v1.json
+  search.v1.json
+```
+
+**Schema structure** (example for dashboard):
+
+```jsonc
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opensearch-dashboards://saved-objects/dashboard/v1",
+  "type": "object",
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "panelsJSON": {
+      "description": "Panel layout and configuration",
+      "type": "array",
+      "items": { "$ref": "#/$defs/panel" }
+    },
+    "optionsJSON": {
+      "type": "object",
+      "properties": {
+        "useMargins": { "type": "boolean", "default": true },
+        "hidePanelTitles": { "type": "boolean", "default": false }
+      }
+    },
+    "timeRestore": { "type": "boolean" },
+    "timeTo": { "type": "string" },
+    "timeFrom": { "type": "string" },
+    "refreshInterval": { "$ref": "#/$defs/refreshInterval" }
+  },
+  "required": ["title", "panelsJSON"]
+}
+```
+
+**Schema versioning:** Schemas use `<type>/v<N>` versioning. The server exposes a `GET /api/saved_objects/_schemas` endpoint that returns all registered schemas, enabling SDK auto-generation.
+
+```
+GET /api/saved_objects/_schemas
+GET /api/saved_objects/_schemas/dashboard/v1
+```
+
+#### 1.2 Validation Endpoint
+
+```
+POST /api/saved_objects/_validate
+Content-Type: application/json
+
+{
+  "type": "dashboard",
+  "attributes": { ... }
+}
+```
+
+**Response (success):**
+```json
+{
+  "valid": true,
+  "warnings": []
+}
+```
+
+**Response (failure):**
+```json
+{
+  "valid": false,
+  "errors": [
+    {
+      "path": "attributes.panelsJSON[2].gridData.w",
+      "message": "must be >= 1",
+      "schemaPath": "#/$defs/panel/properties/gridData/properties/w/minimum"
+    }
+  ]
+}
+```
+
+**Validation modes** (via query parameter):
+- `?mode=schema` — Validate against JSON Schema only (fast, offline-capable)
+- `?mode=full` — Schema + server-side checks (data source existence, index pattern validity, plugin availability)
+
+#### 1.3 Diff Endpoint
+
+```
+POST /api/saved_objects/_diff
+Content-Type: application/json
+
+{
+  "type": "dashboard",
+  "id": "my-dashboard-id",
+  "attributes": { ... }
+}
+```
+
+**Response:**
+```json
+{
+  "status": "updated",
+  "diff": [
+    {
+      "op": "replace",
+      "path": "/attributes/title",
+      "oldValue": "Old Title",
+      "newValue": "New Title"
+    },
+    {
+      "op": "add",
+      "path": "/attributes/panelsJSON/3",
+      "newValue": { "...": "new panel definition" }
+    }
+  ]
+}
+```
+
+**Status values:** `new` (object doesn't exist yet), `updated` (changes detected), `unchanged` (identical), `error`.
+
+#### 1.4 Labels and Annotations
+
+Extend the Saved Object document structure:
+
+```json
+{
+  "type": "dashboard",
+  "id": "cpu-monitoring",
+  "attributes": { "...": "..." },
+  "labels": {
+    "env": "production",
+    "team": "platform",
+    "managed-by": "osdctl"
+  },
+  "annotations": {
+    "owner": "jane@company.com",
+    "source-repo": "github.com/acme/dashboards",
+    "last-applied-hash": "sha256:abc123..."
+  }
+}
+```
+
+**Query support:** Extend the existing `GET /api/saved_objects/_find` endpoint:
+
+```
+GET /api/saved_objects/_find?type=dashboard&labels=env:production,team:platform
+```
+
+**Behavioral notes:**
+- `labels` are indexed and queryable. Keys and values are strings. Max 64 labels per object.
+- `annotations` are stored but not indexed. Free-form metadata for tooling.
+- The `managed-by` label identifies objects managed by as-code tooling. The UI shows a badge/indicator for these objects to prevent accidental manual edits.
+- `last-applied-hash` annotation enables client-side drift detection.
+
+#### 1.5 Optimistic Concurrency
+
+Add a `version` field to Saved Objects (distinct from the existing internal `_version`):
+
+```
+PUT /api/saved_objects/dashboard/cpu-monitoring
+If-Match: "5"
+
+{ "attributes": { ... } }
+```
+
+**Behavior:**
+- Every create/update increments `version` (integer, starting at 1).
+- Update/delete requests with `If-Match` header are rejected with `409 Conflict` if the version doesn't match.
+- `If-Match` is optional for backward compatibility — omitting it skips the check (existing behavior).
+- The `version` is returned in all GET/find responses.
+
+#### 1.6 Git-Diff-Friendly Export Format
+
+New endpoint for clean, deterministic export:
+
+```
+GET /api/saved_objects/_export_clean?type=dashboard&id=cpu-monitoring
+Accept: application/json  # or application/yaml
+```
+
+**Output design principles:**
+- Sorted keys (deterministic JSON)
+- No server-generated fields in the body (id, version, timestamps go in a separate `metadata` block)
+- Panels as a flat array with named references (not deeply nested)
+- Human-readable field names (not `panelsJSON` containing a stringified JSON blob)
+
+**Example output:**
+
+```yaml
+apiVersion: dashboard/v1
+metadata:
+  name: cpu-monitoring
+  project: my-workspace
+  labels:
+    env: production
+    team: platform
+  annotations:
+    owner: jane@company.com
+spec:
+  title: "CPU Monitoring"
+  description: "Production CPU metrics across all clusters"
+  timeRange:
+    from: "now-1h"
+    to: "now"
+  refreshInterval: "30s"
+  panels:
+    - name: cpu-usage
+      type: visualization
+      visualization: line
+      gridPosition: { x: 0, y: 0, w: 24, h: 12 }
+      query:
+        language: PPL
+        query: "source = metrics | where name = 'cpu.usage' | stats avg(value) by host"
+      options:
+        showLegend: true
+    - name: cpu-by-host
+      type: visualization
+      visualization: heatmap
+      gridPosition: { x: 0, y: 12, w: 24, h: 12 }
+      query:
+        language: DQL
+        query: "cpu.usage:*"
+  dataSources:
+    - name: metrics-cluster
+      type: opensearch
+      default: true
+```
+
+**Compatibility:** The existing ndjson export continues to work unchanged. The clean format is opt-in.
+
+#### 1.7 Bulk Apply Endpoint
+
+```
+POST /api/saved_objects/_bulk_apply
+Content-Type: application/json
+
+{
+  "resources": [
+    { "type": "dashboard", "id": "cpu-monitoring", "attributes": { ... } },
+    { "type": "visualization", "id": "cpu-line-chart", "attributes": { ... } }
+  ],
+  "options": {
+    "dryRun": false,
+    "overwrite": true,
+    "createMissing": true
+  }
+}
+```
+
+**Behavior:**
+- Creates objects that don't exist, updates those that do (upsert semantics).
+- `dryRun: true` — validates all resources and reports what would change, without persisting.
+- If any resource fails validation, the entire batch is rejected (transactional).
+- Response includes per-resource status: `created`, `updated`, `unchanged`, `error`.
+
+---
+
+### Layer 2: Schema-Driven SDK Generation
+
+#### Approach
+
+SDKs are **auto-generated from the JSON Schema definitions** exposed by `GET /api/saved_objects/_schemas`. This ensures:
+- SDKs stay in sync with the server without manual maintenance
+- New resource types or schema versions automatically get SDK support
+- Type safety is guaranteed by the schema
+
+#### Generation Pipeline
+
+```
+JSON Schema files  -->  Code Generator  -->  TypeScript SDK
+(dashboard/v1.json)     (openapi-generator      Python SDK
+                         or custom)              Go SDK
+                                                 Java SDK
+```
+
+The generator produces:
+1. **Type definitions** — Interfaces/structs matching the schema
+2. **Builder classes** — Fluent API for constructing resources
+3. **Validators** — Client-side validation using the schema
+4. **Serializers** — Output to JSON or YAML in the clean export format
+
+#### TypeScript SDK Example
+
+```typescript
+import { Dashboard, Panel, Query } from '@opensearch-dashboards/sdk';
+
+const cpuDashboard = Dashboard.create('cpu-monitoring')
+  .title('CPU Monitoring')
+  .description('Production CPU metrics across all clusters')
+  .labels({ env: 'production', team: 'platform' })
+  .annotation('owner', 'jane@company.com')
+  .timeRange('now-1h', 'now')
+  .refreshInterval('30s')
+  .addPanel(
+    Panel.create('cpu-usage')
+      .visualization('line')
+      .gridPosition({ x: 0, y: 0, w: 24, h: 12 })
+      .query(
+        Query.ppl("source = metrics | where name = 'cpu.usage' | stats avg(value) by host")
+      )
+      .option('showLegend', true)
+  )
+  .addPanel(
+    Panel.create('cpu-by-host')
+      .visualization('heatmap')
+      .gridPosition({ x: 0, y: 12, w: 24, h: 12 })
+      .query(
+        Query.dql('cpu.usage:*')
+      )
+  )
+  .addDataSource('metrics-cluster', { type: 'opensearch', default: true })
+  .build();
+
+// Output to file
+cpuDashboard.toYAML('dashboards/cpu-monitoring.yaml');
+cpuDashboard.toJSON('dashboards/cpu-monitoring.json');
+```
+
+#### Python SDK Example
+
+```python
+from opensearch_dashboards_sdk import Dashboard, Panel, Query
+
+cpu_dashboard = (
+    Dashboard("cpu-monitoring")
+    .title("CPU Monitoring")
+    .description("Production CPU metrics across all clusters")
+    .labels(env="production", team="platform")
+    .time_range("now-1h", "now")
+    .refresh_interval("30s")
+    .add_panel(
+        Panel("cpu-usage")
+        .visualization("line")
+        .grid_position(x=0, y=0, w=24, h=12)
+        .query(Query.ppl("source = metrics | where name = 'cpu.usage' | stats avg(value) by host"))
+        .option("showLegend", True)
+    )
+    .add_data_source("metrics-cluster", type="opensearch", default=True)
+    .build()
+)
+
+cpu_dashboard.to_yaml("dashboards/cpu-monitoring.yaml")
+```
+
+#### Go SDK Example
+
+```go
+package main
+
+import (
+    "github.com/opensearch-project/osd-sdk-go/dashboard"
+    "github.com/opensearch-project/osd-sdk-go/panel"
+    "github.com/opensearch-project/osd-sdk-go/query"
+)
+
+func main() {
+    d, err := dashboard.New("cpu-monitoring",
+        dashboard.Title("CPU Monitoring"),
+        dashboard.Labels(map[string]string{"env": "production", "team": "platform"}),
+        dashboard.TimeRange("now-1h", "now"),
+        dashboard.RefreshInterval("30s"),
+        dashboard.AddPanel("cpu-usage",
+            panel.Visualization("line"),
+            panel.GridPosition(0, 0, 24, 12),
+            panel.Query(query.PPL("source = metrics | where name = 'cpu.usage' | stats avg(value) by host")),
+        ),
+        dashboard.AddDataSource("metrics-cluster", datasource.OpenSearch(datasource.Default(true))),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    d.ToYAML("dashboards/cpu-monitoring.yaml")
+}
+```
+
+#### Reusable Components
+
+SDKs support composable fragments for DRY dashboard definitions:
+
+```typescript
+// shared/standard-panels.ts
+import { Panel, Query } from '@opensearch-dashboards/sdk';
+
+export const cpuPanel = (host: string) =>
+  Panel.create(`cpu-${host}`)
+    .visualization('line')
+    .gridPosition({ x: 0, y: 0, w: 24, h: 12 })
+    .query(Query.ppl(`source = metrics | where host = '${host}' | stats avg(cpu) by timestamp`));
+
+// dashboards/per-host.ts
+import { Dashboard } from '@opensearch-dashboards/sdk';
+import { cpuPanel } from '../shared/standard-panels';
+
+const hosts = ['web-1', 'web-2', 'api-1'];
+for (const host of hosts) {
+  Dashboard.create(`monitoring-${host}`)
+    .addPanel(cpuPanel(host))
+    .build()
+    .toYAML(`dashboards/monitoring-${host}.yaml`);
+}
+```
+
+---
+
+### Layer 3: CLI Design (`osdctl`)
+
+#### Overview
+
+`osdctl` is a standalone binary (Node.js-based, distributed via npm, Homebrew, and direct download) that orchestrates the DaC workflow.
+
+#### Configuration
+
+```yaml
+# ~/.osdctl/config.yaml
+profiles:
+  dev:
+    url: https://dashboards-dev.internal:5601
+    auth:
+      type: basic
+      username: admin
+      # password read from OSD_PASSWORD env var or keychain
+  staging:
+    url: https://dashboards-staging.internal:5601
+    auth:
+      type: saml
+      token_command: "aws sso get-role-credentials ..."
+  prod:
+    url: https://dashboards.company.com:5601
+    auth:
+      type: basic
+
+default_profile: dev
+output_dir: ./built
+```
+
+#### Command Reference
+
+##### `osdctl init`
+
+Scaffold a new DaC project.
+
+```bash
+$ osdctl init --language typescript my-dashboards
+Creating project my-dashboards/
+  my-dashboards/package.json
+  my-dashboards/tsconfig.json
+  my-dashboards/dashboards/example.ts
+  my-dashboards/.osdctl.yaml
+  my-dashboards/.github/workflows/deploy.yaml
+  my-dashboards/.gitignore
+
+Project created. Run:
+  cd my-dashboards
+  npm install
+  osdctl build
+```
+
+Supported: `--language typescript|python|go|java`
+
+##### `osdctl build`
+
+Compile SDK source into JSON/YAML dashboard definitions.
+
+```bash
+# Build a single file
+$ osdctl build -f dashboards/cpu-monitoring.ts -o yaml
+
+# Build all files in a directory
+$ osdctl build -d dashboards/ -o json
+
+# Output to stdout instead of files
+$ osdctl build -f dashboards/cpu-monitoring.ts --stdout
+```
+
+**How it works:**
+1. Detects language from file extension or project config
+2. Executes the source file (e.g., `npx tsx`, `python`, `go run`)
+3. Captures the SDK output (JSON/YAML)
+4. Writes results to `./built/` directory (one file per dashboard)
+
+##### `osdctl validate`
+
+Validate dashboard definitions against the schema.
+
+```bash
+# Local-only validation (no server needed)
+$ osdctl validate -d built/
+Validating 5 dashboards...
+  cpu-monitoring.yaml          VALID
+  memory-overview.yaml         VALID
+  disk-usage.yaml              ERROR  panelsJSON[2].gridData.w must be >= 1
+  network-traffic.yaml         VALID
+  application-errors.yaml      VALID
+
+4/5 valid, 1 error
+
+# Server-side validation (checks data sources, plugins)
+$ osdctl validate -d built/ --server --profile staging
+```
+
+##### `osdctl diff`
+
+Compare local definitions against a running instance.
+
+```bash
+$ osdctl diff -d built/ --profile prod
+Comparing 5 dashboards against prod...
+
+  cpu-monitoring               UPDATED
+    ~ title: "CPU Metrics" -> "CPU Monitoring"
+    + panels[3]: new panel "cpu-p99-latency"
+
+  memory-overview              UNCHANGED
+  disk-usage                   NEW
+  network-traffic              UPDATED
+    ~ refreshInterval: "1m" -> "30s"
+  application-errors           UNCHANGED
+
+2 updated, 1 new, 2 unchanged
+```
+
+**How it works:**
+1. For each local definition, calls `POST /api/saved_objects/_diff`
+2. Renders diffs with colorized, human-readable output
+3. Optionally writes `.diff` files to output directory
+
+##### `osdctl apply`
+
+Deploy dashboard definitions to a running instance.
+
+```bash
+# Apply all dashboards
+$ osdctl apply -d built/ --profile prod
+Applying 5 dashboards to prod...
+  cpu-monitoring               UPDATED  (v5 -> v6)
+  memory-overview              UNCHANGED
+  disk-usage                   CREATED  (v1)
+  network-traffic              UPDATED  (v3 -> v4)
+  application-errors           UNCHANGED
+
+3 changes applied, 2 unchanged
+
+# Dry-run mode
+$ osdctl apply -d built/ --profile prod --dry-run
+
+# Apply with confirmation prompt
+$ osdctl apply -d built/ --profile prod --confirm
+```
+
+**How it works:**
+1. Calls `POST /api/saved_objects/_bulk_apply` with all resources
+2. Uses optimistic concurrency (`If-Match`) to prevent overwriting concurrent changes
+3. Stamps `managed-by: osdctl` label and `last-applied-hash` annotation on applied objects
+
+##### `osdctl pull`
+
+Export dashboards from a running instance to local files.
+
+```bash
+# Pull all dashboards
+$ osdctl pull --profile prod -o yaml
+Pulling dashboards from prod...
+  Wrote dashboards/cpu-monitoring.yaml
+  Wrote dashboards/memory-overview.yaml
+  ... (12 dashboards)
+
+# Pull specific dashboards by label
+$ osdctl pull --profile prod --label team=platform -o yaml
+
+# Pull into SDK code (TypeScript)
+$ osdctl pull --profile prod --language typescript
+  Wrote dashboards/cpu-monitoring.ts
+```
+
+**How it works:**
+1. Calls `GET /api/saved_objects/_export_clean` for the clean format
+2. Writes individual files per dashboard (one dashboard per file)
+3. `--language` mode reverse-generates SDK code from the JSON/YAML definition
+
+##### `osdctl lint`
+
+Check dashboards against organizational policies.
+
+```bash
+$ osdctl lint -d built/
+Linting 5 dashboards...
+  cpu-monitoring.yaml
+    WARN  no "owner" annotation set
+    WARN  no description provided
+  disk-usage.yaml
+    ERROR missing required label "env"
+
+2 warnings, 1 error
+```
+
+**Lint rules** configured via `.osdctl.yaml`:
+
+```yaml
+lint:
+  rules:
+    require-labels: ["env", "team"]
+    require-annotations: ["owner"]
+    require-description: warn
+    max-panels-per-dashboard: 30
+    naming-convention: kebab-case
+    allowed-data-sources: ["metrics-*", "logs-*"]
+```
+
+##### `osdctl preview`
+
+Create an ephemeral dashboard for testing.
+
+```bash
+$ osdctl preview -f built/cpu-monitoring.yaml --profile dev
+Preview dashboard created at:
+  https://dashboards-dev.internal:5601/app/dashboards#/preview/tmp-abc123
+
+Preview expires in 1 hour. Press Ctrl+C to delete early.
+```
+
+---
+
+### Layer 4: CI/CD Integration
+
+#### GitHub Actions
+
+Official actions published to `opensearch-project/osdctl-actions`:
+
+```yaml
+# .github/workflows/dashboards.yaml
+name: Deploy Dashboards
+
+on:
+  push:
+    branches: [main]
+    paths: ['dashboards/**']
+  pull_request:
+    paths: ['dashboards/**']
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: opensearch-project/osdctl-actions/setup@v1
+
+      - name: Build dashboards
+        run: osdctl build -d dashboards/ -o yaml
+
+      - name: Validate
+        run: osdctl validate -d built/
+
+      - name: Diff (on PRs)
+        if: github.event_name == 'pull_request'
+        run: osdctl diff -d built/ --profile staging
+        env:
+          OSD_URL: ${{ secrets.OSD_STAGING_URL }}
+          OSD_TOKEN: ${{ secrets.OSD_STAGING_TOKEN }}
+
+  deploy:
+    needs: validate
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: opensearch-project/osdctl-actions/setup@v1
+
+      - name: Build
+        run: osdctl build -d dashboards/ -o yaml
+
+      - name: Deploy to production
+        run: osdctl apply -d built/ --profile prod
+        env:
+          OSD_URL: ${{ secrets.OSD_PROD_URL }}
+          OSD_TOKEN: ${{ secrets.OSD_PROD_TOKEN }}
+```
+
+#### Generic CI/CD
+
+Docker image for use in any pipeline:
+
+```dockerfile
+FROM opensearchproject/osdctl:latest
+# Contains osdctl + Node.js + Python + Go runtimes for SDK execution
+```
+
+```bash
+# Works in any CI system
+docker run --rm -v $(pwd):/workspace opensearchproject/osdctl \
+  osdctl build -d /workspace/dashboards/ -o yaml && \
+  osdctl validate -d /workspace/built/ && \
+  osdctl apply -d /workspace/built/ --url $OSD_URL --token $OSD_TOKEN
+```
+
+---
+
+## Data Flow
+
+### Write Path (SDK to Deployed Dashboard)
+
+```
+1. Developer writes dashboard code (TypeScript/Python/Go/Java)
+        |
+        v
+2. `osdctl build` executes SDK code, produces JSON/YAML files
+        |
+        v
+3. Files committed to Git, PR opened
+        |
+        v
+4. CI runs `osdctl validate` (schema check) + `osdctl diff` (change preview)
+        |
+        v
+5. PR merged to main
+        |
+        v
+6. CD runs `osdctl apply`, calls POST /api/saved_objects/_bulk_apply
+        |
+        v
+7. Saved Objects API validates, applies, increments version
+        |
+        v
+8. Dashboard live in OpenSearch Dashboards
+```
+
+### Read Path (Deployed Dashboard to Code)
+
+```
+1. `osdctl pull --profile prod`
+        |
+        v
+2. GET /api/saved_objects/_export_clean (deterministic YAML)
+        |
+        v
+3. Files written to local directory
+        |
+        v
+4. (Optional) `osdctl pull --language typescript` reverse-generates SDK code
+        |
+        v
+5. Developer commits to Git, continues as-code workflow
+```
+
+### Drift Detection
+
+```
+1. Scheduled CI job runs `osdctl diff -d built/ --profile prod`
+        |
+        v
+2. Diff endpoint compares local definitions against deployed state
+        |
+        v
+3. If drift detected:
+   - CI job fails / posts alert
+   - Team decides: update code (accept drift) or re-apply (reject drift)
+```
+
+---
+
+## Schema Migration Strategy
+
+### Backward Compatibility
+
+The typed schema layer is **additive** — it does not change the underlying Saved Objects storage format. Existing dashboards created via the UI continue to work without modification.
+
+### Schema Versioning
+
+```
+dashboard/v1      <-- initial typed schema (covers current attributes)
+dashboard/v1beta2 <-- future schema with layout decoupled from panels
+dashboard/v2      <-- stable release of the decoupled schema
+```
+
+**Migration path:**
+1. `v1` matches the current Saved Objects structure exactly — zero migration needed
+2. `v1beta2` introduces the cleaner structure (layout/panels decoupled) as opt-in
+3. `osdctl convert --from v1 --to v2` migrates definitions forward
+4. Server accepts both `v1` and `v2` simultaneously during transition
+
+### Impact on Existing Features
+
+| Feature | Impact |
+|---|---|
+| Dashboard UI (create/edit) | No change. UI continues writing to Saved Objects as today. |
+| Saved Objects API (existing endpoints) | No change. All existing endpoints work identically. |
+| ndjson Export/Import | No change. Existing format preserved. |
+| Saved Objects Management UI | Enhanced: shows `managed-by` badge, labels, version counter. |
+| Dashboard listing | Enhanced: filter by labels (e.g., show only `team: platform` dashboards). |
+
+---
+
+## Security Considerations
+
+### Authentication
+
+`osdctl` supports multiple auth methods:
+- **Basic auth** — username/password (for dev/test environments)
+- **Token-based** — API token or bearer token
+- **SAML/OIDC** — via `token_command` that shells out to an identity provider CLI
+- **Environment variables** — `OSD_URL`, `OSD_TOKEN`, `OSD_USERNAME`, `OSD_PASSWORD`
+
+Credentials are **never** stored in config files. Passwords are read from environment variables, keychains, or interactive prompts.
+
+### Authorization
+
+The `_validate`, `_diff`, `_bulk_apply`, and `_export_clean` endpoints respect existing OpenSearch Dashboards security:
+- Workspace/tenant isolation applies to all new endpoints
+- Users can only validate/diff/apply resources they have permission to access
+- The `managed-by` label is informational — it does not bypass access control
+
+### Managed Object Protection
+
+When a Saved Object has `labels.managed-by: osdctl`:
+- The UI shows a visual indicator ("Managed by code — edits may be overwritten")
+- The UI **does not** block editing (users may need emergency manual changes)
+- The `last-applied-hash` annotation enables the CLI to detect if someone manually changed a managed object
+
+---
+
+## Rejected Alternatives
+
+### 1. Build a completely new API from scratch
+
+**Why rejected:** The Saved Objects API already handles CRUD, references, multi-tenancy, and bulk operations. Building parallel endpoints duplicates effort, creates confusion about which API to use, and forces migration of all existing integrations. Extending the existing API is faster to ship and preserves backward compatibility.
+
+### 2. Use CUE as the primary schema/SDK language
+
+**Why rejected:** CUE is powerful for validation but has a steep learning curve, limited ecosystem, and niche adoption. Perses uses CUE, but even they added a Go SDK because CUE's dependency management and integration story are weak. General-purpose languages (TypeScript, Python, Go, Java) reach more users and integrate with existing tooling.
+
+### 3. Embed Git operations in the server (Grafana Git Sync model)
+
+**Why rejected for Phase 1:** Git Sync requires significant server-side complexity (Git client, webhook handling, conflict resolution, branch management). The CLI + CI/CD approach delivers the same GitOps outcome with less server complexity and more flexibility (works with any Git provider, any CI system). Git Sync is a candidate for a future RFC.
+
+### 4. Use Jsonnet as the templating language
+
+**Why rejected:** Jsonnet is a single-purpose templating language with limited IDE support and no type system. Multi-language SDKs using general-purpose languages provide better DX (type checking, autocompletion, testing, debugging) and reach the widest possible audience.
+
+### 5. Terraform provider as the primary interface
+
+**Why rejected for Phase 1:** Terraform adds a dependency on HCL and the Terraform ecosystem. Many teams want as-code workflows without Terraform. The SDK + CLI approach serves a broader audience. A Terraform provider is planned for Phase 3, built on top of the same API extensions.
+
+---
+
+## Rollout Plan
+
+### Phase 1 — Foundation (Target: Q2-Q3 2026)
+
+**Server-side:**
+- [ ] JSON Schema definitions for dashboard, visualization, index-pattern, search
+- [ ] `GET /api/saved_objects/_schemas` endpoint
+- [ ] `POST /api/saved_objects/_validate` endpoint
+- [ ] `POST /api/saved_objects/_diff` endpoint
+- [ ] `POST /api/saved_objects/_bulk_apply` endpoint
+- [ ] Labels and annotations on Saved Objects
+- [ ] Optimistic concurrency control (`version` + `If-Match`)
+- [ ] `GET /api/saved_objects/_export_clean` endpoint
+- [ ] `managed-by` badge in Saved Objects Management UI
+
+**Client-side:**
+- [ ] TypeScript SDK (`@opensearch-dashboards/sdk`) published to npm
+- [ ] `osdctl` CLI: `init`, `build`, `validate`, `diff`, `apply`, `pull`
+- [ ] GitHub Actions: `setup-osdctl` action
+- [ ] Documentation: getting-started guide, SDK API reference, CLI reference
+- [ ] Example repository with TypeScript DaC project
+
+### Phase 2 — Multi-Language & CI/CD (Target: Q3-Q4 2026)
+
+- [ ] Python SDK published to PyPI
+- [ ] Go SDK published as Go module
+- [ ] SDK auto-generation pipeline from JSON Schema
+- [ ] `osdctl lint` with configurable rules
+- [ ] `osdctl convert` (Grafana JSON import)
+- [ ] `osdctl preview` (ephemeral dashboards)
+- [ ] GitHub Actions: composite deploy workflow
+- [ ] Docker image for generic CI/CD
+- [ ] Dashboard template gallery (Kubernetes, application, security starter kits)
+
+### Phase 3 — IaC Providers (Target: Q1 2027)
+
+- [ ] Terraform provider for OpenSearch Dashboards
+- [ ] Pulumi provider (bridged from Terraform)
+- [ ] Java SDK published to Maven Central
+- [ ] GitLab CI templates, Jenkins shared library
+
+---
+
+## Open Questions
+
+1. **Schema granularity:** Should the typed schema cover the full panel visualization config (chart type, axes, thresholds), or stop at the panel boundary and treat visualization config as opaque JSON? Full typing enables richer validation and SDK autocompletion but couples the schema to visualization plugin internals.
+
+2. **Plugin SDK extension point:** Should visualization plugins be able to register their own JSON Schema fragments and SDK builders (like Perses' plugin-per-language model)? This grows the ecosystem but adds complexity.
+
+3. **`osdctl pull --language` feasibility:** Reverse-generating idiomatic SDK code from JSON/YAML is hard to do well. Should we defer this to a later phase or ship a simpler "scaffold from JSON" that generates less-polished but functional code?
+
+4. **Multi-workspace support:** How does `osdctl apply` handle dashboards across multiple workspaces? Should workspace be a field in the resource definition, a CLI flag, or both?
+
+5. **ndjson migration:** Should we provide `osdctl convert --from ndjson` to help teams migrate existing ndjson-based automation to the new clean format?
+
+---
+
+## References
+
+- [Requirements Document](./dashboards-as-code-requirements.md) — Full competitive analysis and prioritized requirements
+- [Grafana 12 Observability-as-Code](https://grafana.com/blog/observability-as-code-grafana-12/)
+- [Perses Dashboard-as-Code](https://perses.dev/perses/docs/concepts/dashboard-as-code/)
+- [Perses Go SDK](https://github.com/perses/perses/tree/main/go-sdk)
+- [Perses CLI Actions](https://github.com/perses/cli-actions)
+- [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)
+- [Grafonnet (Jsonnet)](https://github.com/grafana/grafonnet)
+- [Dynatrace Monaco](https://github.com/Dynatrace/dynatrace-configuration-as-code)

--- a/docs/requirements/dashboards-as-code-requirements.md
+++ b/docs/requirements/dashboards-as-code-requirements.md
@@ -1,0 +1,416 @@
+# Dashboards-as-Code & Observability-as-Code for OpenSearch Dashboards
+
+## Product Requirements Document
+
+**Status:** Draft
+**Date:** 2026-03-23
+**Author:** Engineering
+**Classification:** Internal / Customer-Facing Strategy
+
+---
+
+## 1. Executive Summary
+
+The observability industry is rapidly converging on **"as-code" workflows** as the standard for managing dashboards, alerts, SLOs, and data source configurations. Grafana 12, Perses, Datadog, Dynatrace, and New Relic have all shipped — or are actively shipping — first-class tooling that treats observability resources as version-controlled, reviewable, testable code artifacts.
+
+**OpenSearch Dashboards currently has no native as-code story.** Customers managing dashboards at scale rely on manual UI operations, fragile ndjson import/export, or custom scripts against the Saved Objects API. This document defines the requirements for a competitive, customer-centric Dashboards-as-Code capability for OpenSearch Dashboards.
+
+---
+
+## 2. Market Context & Competitive Landscape
+
+### 2.1 Grafana 12 — Observability-as-Code (Released 2025)
+
+Grafana has made the most aggressive push, building a full-stack as-code platform:
+
+| Capability | Status | Details |
+|---|---|---|
+| **Kubernetes-style Resource APIs** | Experimental | Versioned `/apis/...` endpoints (`v1beta1`) alongside legacy `/api/...`. Consistent, resource-oriented design. |
+| **Dashboard Schema v2** | Experimental | Decouples layout from panel config. Cleaner JSON, optimized for Git diffs. |
+| **Git Sync** | Experimental (OSS), Private Preview (Cloud) | Bi-directional GitHub sync from the UI. Save to `main` or feature branches. PR creation from save modal. Dashboard image previews in PRs. Planned: GitLab, Bitbucket, plain Git. |
+| **Foundation SDK** | Public Preview | Multi-language: **Go, Java, PHP, Python, TypeScript**. Strongly-typed builders. Synced with Grafana release cycles. |
+| **grafanactl CLI** | Public Preview | Get, pull, push, validate resources. SDK integration for local previews. Multi-instance sync. |
+| **Terraform Provider** | Public Preview | Auto-generated resources from App Platform APIs. Schema-based validation. Drift detection via Terraform state. |
+| **Grafonnet (Jsonnet)** | Stable (community) | Auto-generated Jsonnet library from OpenAPI specs. 30+ panel types. Prometheus, Loki, Elasticsearch query builders. |
+
+**Key Insight:** Grafana is betting on a **Kubernetes-style API foundation** that all tooling (SDKs, CLI, Terraform, Git Sync) builds on top of. This is architecturally sound and creates a flywheel effect.
+
+### 2.2 Perses — Dashboard-as-Code (CNCF Project)
+
+Perses is a CNCF-sandbox project purpose-built for dashboard-as-code:
+
+| Capability | Details |
+|---|---|
+| **CUE SDK** | First-class CUE language support. Schema validation, IDE support, plugin integration. Uses CUE modules for dependency management. |
+| **Go SDK** | Builder-pattern API for programmatic dashboard construction. Functional options pattern (`dashboard.New("name", options...)`). |
+| **percli CLI** | `dac setup` (scaffold), `dac build` (compile to JSON/YAML), `dac diff` (compare local vs. server), `dac preview` (ephemeral dashboards), `apply` (deploy), `lint` (validate with custom rules). |
+| **GitHub Actions** | Official `perses/cli-actions` library with pre-configured workflows and individual actions for build, validate, deploy. |
+| **Plugin Architecture** | Plugins provide SDK pieces per language. Official plugins fully support CUE + Go. Third-party plugins may vary. Plugins: Prometheus, TimeSeries, Table, Loki, Pyroscope, Tempo, ClickHouse. |
+| **Kubernetes Operator** | `perses-operator` enables dashboard definitions as Kubernetes CRDs in application namespaces. Full GitOps via ArgoCD/Flux. |
+| **Validation** | Multi-level: offline schema validation, online server validation, custom lint rules (YAML-configured organizational policies). |
+| **Output Formats** | JSON and YAML. One dashboard per file convention. Batch builds via directory option. |
+
+**Key Insight:** Perses demonstrates that a focused, open-source DaC tool with **CUE + Go SDKs and a purpose-built CLI** can deliver an excellent developer experience. Their `dac diff` (compare local vs. deployed) and `dac preview` (ephemeral test dashboards) commands are particularly strong UX patterns to emulate. The plugin-per-SDK-language model is elegant.
+
+### 2.3 Datadog
+
+| Capability | Details |
+|---|---|
+| **Dashboard API** | Full REST API for CRUD operations on dashboards, monitors, SLOs, synthetics, incidents. JSON definitions. |
+| **Official SDKs** | Python, Go, Java, Ruby, TypeScript API clients with sync/async support, pagination, retry logic, proxy config. **Broadest SDK language coverage among observability vendors.** |
+| **Terraform Provider** | Mature, officially maintained by Datadog (2,755+ commits, 420+ forks). Resources for dashboards, monitors, SLOs, synthetics, downtimes, log configs. |
+| **Pulumi Provider** | Multi-language support (TypeScript, Python, Go, C#, Java) for all Datadog resources. Community-maintained (pulumiverse). |
+| **Datadog Operator** | Kubernetes-native CRDs for managing monitors and SLOs as Kubernetes resources. |
+
+### 2.4 Dynatrace — Monaco
+
+| Capability | Details |
+|---|---|
+| **Monaco CLI** | Official configuration-as-code tool. Go-based binary (98.8% Go). Apache 2.0 license. Active release cadence (v2.28+, 91+ releases). |
+| **Scope** | Dashboards, alerting profiles, management zones, auto-tagging, request attributes, calculated metrics, SLOs, synthetic monitors. Branded as **"Observability as Code and Security as Code."** |
+| **Multi-Environment** | Purpose-built for deploying standardized + customized configs across many Dynatrace environments. Per-environment overrides. |
+| **GitOps** | Designed for Git-based workflows. Environment-specific overrides. Dry-run support. |
+| **CI/CD** | Built-in support for Jenkins, GitHub Actions, GitLab CI. CLI-first design for pipeline automation. |
+| **Coexistence** | Official guidance helps users choose between Monaco and Terraform Dynatrace provider based on use case. |
+
+### 2.5 New Relic
+
+| Capability | Details |
+|---|---|
+| **NerdGraph API** | GraphQL API for dashboards, alerts, SLOs. Programmatic CRUD. |
+| **Terraform Provider** | Officially maintained. Resources for dashboards, alert policies, NRQL conditions, synthetics. |
+| **NR CLI (newrelic-cli)** | Command-line tool for entity management and deployment markers. |
+
+### 2.6 Grafonnet (Jsonnet for Grafana)
+
+| Capability | Details |
+|---|---|
+| **What it is** | Auto-generated Jsonnet library from Grafana's OpenAPI specs (grafana-foundation-sdk). Successor to grafonnet-lib. |
+| **Panel types** | 30+ panels: TimeSeries, Bar, Pie, Heatmap, Gauge, Table, Logs, Geomap, Canvas, Candlestick, etc. |
+| **Query builders** | Prometheus, Loki, CloudWatch, Elasticsearch, Azure Monitor integrations. |
+| **Status** | Experimental. Performance-optimized (avoids builder pattern that was slow at scale in grafonnet-lib). |
+| **Key value** | Eliminates duplication via parameterized, reusable dashboard components. Compiles to standard Grafana JSON. |
+
+### 2.7 Infrastructure-as-Code Ecosystem
+
+| Tool | Languages | Observability Support |
+|---|---|---|
+| **Terraform** | HCL | Grafana, Datadog, New Relic, Dynatrace, PagerDuty, Elastic providers. State-based drift detection. `plan` shows drift. |
+| **Pulumi** | TypeScript, Python, Go, C#, Java, YAML | Grafana, Datadog providers. Full programming language power. Native unit + integration testing. |
+| **Crossplane** | YAML (Kubernetes CRDs) | Kubernetes-native IaC. Provider model extensible to observability. |
+
+### 2.8 Key Competitive Takeaways
+
+1. **Terraform dominates multi-vendor IaC** — both Grafana and Datadog have official, actively maintained providers. This is the most common path for teams already using Terraform.
+2. **Grafana has the richest native as-code ecosystem** — JSON provisioning, Grafonnet/Jsonnet, Foundation SDK, Terraform, Kubernetes Operator. More options than any other vendor.
+3. **Drift detection is a key differentiator for IaC tools** (Terraform, Pulumi) over native APIs/SDKs that require custom drift implementation.
+4. **Datadog's SDK breadth** (6+ languages) makes programmatic management accessible without IaC tooling.
+5. **Dynatrace Monaco is unique** in combining observability + security configuration in a single multi-environment CLI.
+
+---
+
+## 3. Current State of OpenSearch Dashboards
+
+### What exists today:
+
+- **Saved Objects API**: CRUD for dashboards, visualizations, index patterns, saved searches. Supports find/search with filtering and reference tracking between objects. Battle-tested and deployed in production across the OpenSearch ecosystem.
+- **ndjson Import/Export**: Bulk export/import via UI or API (`_export` / `_import` endpoints). Used widely for backup and migration.
+- **Saved Objects Management UI**: Manual point-and-click management for individual resources.
+
+### What the Saved Objects API already provides (and should be reused):
+
+| Capability | Status |
+|---|---|
+| CRUD for all dashboard resource types | Stable, production-ready |
+| Bulk export/import (ndjson) | Stable |
+| Find/search with filtering | Stable |
+| Object reference tracking | Stable |
+| Multi-tenant/workspace support | Stable |
+
+### Gaps that need to be addressed on top of the existing API:
+
+| Gap | Impact |
+|---|---|
+| No validation-only mode (dry-run) | Cannot validate dashboard definitions before persisting — forces trial-and-error deployment |
+| No diff endpoint | Cannot compare local definitions against deployed state server-side |
+| No resource metadata (labels, annotations) | Cannot organize/filter dashboards at scale; no support for ownership, environment tags, or policy labels |
+| Untyped `attributes` blob | Schema is not documented as a stable contract; SDK generation and validation are impossible without a formal schema |
+| Not Git-diff-friendly | IDs, references, and deep nesting make JSON diffs noisy and hard to review |
+| No optimistic concurrency | No version/generation counter — concurrent edits can silently overwrite each other |
+| No multi-language SDK | Customers cannot programmatically define dashboards in their language of choice |
+| No purpose-built CLI | No `build`, `validate`, `diff`, `apply` workflow for dashboards |
+| No Git-native workflow | No bi-directional sync, no PR previews, no branch-based editing |
+| No Terraform/Pulumi provider | Cannot manage OpenSearch Dashboards resources alongside other infrastructure |
+| No CI/CD tooling | No GitHub Actions, no pipeline integrations for dashboard deployment |
+| No alerting/SLO-as-code | Monitor and alert definitions are UI-only |
+
+---
+
+## 4. Requirements
+
+### 4.1 Saved Objects API Extensions (P0 — Must Have)
+
+**Rationale:** The existing Saved Objects API provides solid CRUD foundations. Rather than building a parallel API from scratch, we extend it with the capabilities needed for as-code workflows. This mirrors Grafana's approach — their new `/apis/...` endpoints coexist with legacy `/api/...` during a transition period.
+
+**Approach:** Build a **versioned schema layer and as-code endpoints on top of the Saved Objects API**, not a replacement.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| API-1 | **Typed, versioned schema for each resource type** | Publish formal JSON Schema / OpenAPI specs for dashboards, visualizations, index patterns, saved searches. The existing `attributes` blob gets a documented, stable schema contract. Schema versions tracked (e.g., `dashboard/v1`). SDKs and validation are generated from these schemas. |
+| API-2 | **Dry-run / validation endpoint** | New endpoint (e.g., `POST /api/saved_objects/_validate`) or `?dryRun=true` query parameter on existing endpoints. Validates resource definitions against the typed schema without persisting. Returns detailed, field-level validation errors. Supports both local (schema-only) and server-side (plugin-aware) validation modes. |
+| API-3 | **Git-diff-friendly export format** | New export mode that produces deterministic, human-readable JSON/YAML: sorted keys, stable IDs, layout decoupled from panel config (Grafana Schema v2 pattern), minimal nesting. Available alongside existing ndjson export. |
+| API-4 | **Resource metadata: labels & annotations** | Extend Saved Objects with user-defined `labels` (key-value for filtering/selection, e.g., `env: prod`, `team: platform`) and `annotations` (free-form metadata, e.g., `owner: jane@company.com`). Queryable via the existing find/search API. |
+| API-5 | **Optimistic concurrency control** | Add `version` or `generation` counter to Saved Objects. Update/delete operations require the current version — returns `409 Conflict` on mismatch. Prevents silent overwrites from concurrent edits (UI + as-code). |
+| API-6 | **Diff endpoint** | New endpoint (e.g., `POST /api/saved_objects/_diff`) accepts a resource definition and returns a structured diff against the currently deployed version. Powers the CLI `diff` command server-side. |
+| API-7 | **Bulk operations enhancement** | Extend existing `_export` / `_import` with transactional semantics: all-or-nothing apply, rollback on failure. Add `_bulk_apply` for create-or-update in a single call. |
+
+### 4.2 Multi-Language SDK (P0 — Must Have)
+
+**Rationale:** Grafana supports 5 languages. Perses supports CUE + Go. Customers expect to define dashboards in their stack's language.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| SDK-1 | **TypeScript/JavaScript SDK** | Builder-pattern API for dashboards, panels, visualizations, queries, variables. Strongly typed. Published to npm. |
+| SDK-2 | **Python SDK** | Builder-pattern API. Published to PyPI. First-class support for data engineering / ML teams. |
+| SDK-3 | **Go SDK** | Builder-pattern API. Published as Go module. Enables infrastructure-team adoption. |
+| SDK-4 | **Java SDK** | Builder-pattern API. Published to Maven Central. Enterprise customer requirement. |
+| SDK-5 | **SDK auto-generation from schema** | SDKs generated from OpenAPI/JSON Schema specs (Grafana Foundation SDK pattern). Synchronized with release cycles. |
+| SDK-6 | **Composable, reusable components** | SDK supports defining reusable panel templates, variable sets, and dashboard fragments that can be shared across dashboards. |
+| SDK-7 | **Output to JSON/YAML** | SDKs compile dashboard definitions to validated JSON or YAML files suitable for version control. |
+
+### 4.3 CLI Tool — `opensearch-dashboards-cli` or `osdctl` (P0 — Must Have)
+
+**Rationale:** Both Perses (`percli`) and Grafana (`grafanactl`) ship dedicated CLIs. This is the primary developer interface.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| CLI-1 | **`init` / `setup`** | Scaffold a new DaC project with SDK dependencies, folder structure, and example dashboard. Language selection flag. |
+| CLI-2 | **`build`** | Compile SDK source files (TS, Python, Go, Java) into validated JSON/YAML dashboard definitions. Single file and directory modes. |
+| CLI-3 | **`validate`** | Validate dashboard definitions against the schema. Local-only validation and server-side validation modes. Detailed error reporting. |
+| CLI-4 | **`diff`** | Show differences between local dashboard definitions and deployed state. Colorized, human-readable output. |
+| CLI-5 | **`apply`** | Deploy dashboard definitions to an OpenSearch Dashboards instance. Support for create, update, and delete operations. Dry-run mode. |
+| CLI-6 | **`pull`** | Export deployed dashboards from a running instance into local SDK-compatible or JSON/YAML format. |
+| CLI-7 | **`push`** | Push local definitions to a remote instance. Conflict detection and resolution options. |
+| CLI-8 | **`lint`** | Check dashboard definitions against best practices and organizational policies (naming conventions, required labels, data source restrictions). Configurable rule sets. |
+| CLI-9 | **Multi-instance support** | Named connection profiles for managing dashboards across dev/staging/prod environments. |
+| CLI-10 | **`convert`** | Convert between formats: Grafana JSON to OpenSearch Dashboards format, ndjson to new schema, legacy to v2 schema. Migration aid. (Perses has `migrate` for Grafana-to-Perses conversion.) |
+| CLI-11 | **`preview`** | Create ephemeral/temporary dashboards on a running instance for testing before full deployment. (Mirrors Perses `dac preview`.) |
+
+### 4.4 Git-Native Workflows (P1 — High Priority)
+
+**Rationale:** Grafana Git Sync is a headline feature. Customers managing 100+ dashboards need version control.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| GIT-1 | **Git Sync** | Bi-directional synchronization between OpenSearch Dashboards and a Git repository (GitHub, GitLab, Bitbucket). Configurable sync branch. |
+| GIT-2 | **Branch-based editing** | Save dashboard changes to feature branches from the UI. Create PRs/MRs directly. |
+| GIT-3 | **PR preview rendering** | Generate dashboard preview images or links for pull request reviews. Integrate with GitHub/GitLab PR comments. |
+| GIT-4 | **Webhook-driven sync** | Automatic deployment on merge to main branch via webhook. Configurable per repository. |
+| GIT-5 | **Conflict resolution** | Detect and surface conflicts when UI changes and Git changes diverge. Three-way merge support or clear override policy. |
+| GIT-6 | **Audit trail** | Full history of who changed what, when, with Git commit references. Queryable via API. |
+
+### 4.5 CI/CD Integration (P1 — High Priority)
+
+**Rationale:** Perses ships GitHub Actions. Grafana's CLI is designed for pipeline integration. This is table-stakes for enterprise adoption.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| CI-1 | **GitHub Actions** | Official action library: `setup-osdctl`, `build-dashboards`, `validate-dashboards`, `deploy-dashboards`. Composite workflow for common patterns. |
+| CI-2 | **GitLab CI templates** | Official `.gitlab-ci.yml` templates for build, validate, deploy pipeline stages. |
+| CI-3 | **Jenkins shared library** | Reusable pipeline steps for Jenkins-based organizations. |
+| CI-4 | **Generic CI support** | CLI-based workflow that works with any CI/CD system (CircleCI, Azure DevOps, Buildkite, etc.). Docker image with pre-installed CLI. |
+| CI-5 | **Deployment environments** | Support for environment-specific variable overrides (dev, staging, prod). Environment promotion workflows. |
+| CI-6 | **Rollback support** | Ability to revert to a previous dashboard version via CLI or API. Version history queryable. |
+
+### 4.6 Terraform & Pulumi Providers (P1 — High Priority)
+
+**Rationale:** Terraform is the de facto standard for infrastructure management. Every major observability vendor has a provider.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| TF-1 | **Terraform provider for OpenSearch Dashboards** | Resources: `opensearch_dashboard`, `opensearch_visualization`, `opensearch_index_pattern`, `opensearch_saved_search`. Data sources for reading existing resources. |
+| TF-2 | **Drift detection** | Terraform plan correctly identifies differences between state and deployed resources. |
+| TF-3 | **Import support** | `terraform import` for existing dashboards to bring them under Terraform management. |
+| TF-4 | **Schema-based validation** | Terraform validates resource attributes at plan time using the published schema. |
+| TF-5 | **Pulumi provider** | Multi-language Pulumi provider (TypeScript, Python, Go, C#, Java) bridged from Terraform provider or native. |
+
+### 4.7 Observability-as-Code — Beyond Dashboards (P2 — Medium Priority)
+
+**Rationale:** Grafana is expanding to alerting-as-code and SLO-as-code. Datadog and Dynatrace already manage alerts, SLOs, and synthetics as code. This is the direction the market is heading.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| OAC-1 | **Alerting-as-code** | Define monitor and alert rules as code (SDK, CLI, Terraform). Includes conditions, thresholds, notification channels. |
+| OAC-2 | **Anomaly detection-as-code** | Programmatically configure anomaly detection rules for OpenSearch metrics. |
+| OAC-3 | **Data source configuration-as-code** | Define and manage data source connections (OpenSearch clusters, Prometheus endpoints, etc.) as code resources. |
+| OAC-4 | **Index pattern management-as-code** | Create and manage index patterns, field mappings, and scripted fields programmatically. |
+| OAC-5 | **Saved query / saved search-as-code** | Define reusable queries and saved searches as code artifacts. |
+| OAC-6 | **Access control-as-code** | Manage workspace permissions, tenant configurations, and resource-level access as code (integrates with OpenSearch Security plugin). |
+
+### 4.8 Developer Experience (P0 — Must Have)
+
+**Rationale:** The DaC workflow must be delightful. Poor DX will drive customers to competitors.
+
+| ID | Requirement | Acceptance Criteria |
+|---|---|---|
+| DX-1 | **Comprehensive documentation** | Getting-started guide, SDK API reference, CLI reference, cookbook with common patterns, migration guide from manual workflows. |
+| DX-2 | **Example repository** | Public GitHub repo with example DaC projects in each supported language. CI/CD pipeline examples. |
+| DX-3 | **IDE support** | JSON Schema for IDE autocompletion in VS Code, IntelliJ. SDK type definitions provide inline documentation. |
+| DX-4 | **Local preview** | `osdctl preview` command renders a dashboard locally without deploying. Hot-reload on file changes. |
+| DX-5 | **Error messages** | Actionable, human-readable error messages with file/line references and fix suggestions. |
+| DX-6 | **Dashboard template gallery** | Curated library of reusable dashboard templates (Kubernetes monitoring, application performance, log analysis, security) available as SDK packages. |
+| DX-7 | **Migration tooling** | Automated conversion from existing manual dashboards to SDK code in the user's chosen language. `osdctl convert --from-instance --language python`. |
+
+---
+
+## 5. Prioritized Roadmap (Recommended)
+
+### Phase 1 — Foundation (Q2-Q3 2026)
+
+**Goal:** Extend the Saved Objects API and ship the TypeScript SDK. Enable early adopters.
+
+- Typed schemas and validation endpoint on Saved Objects API (API-1, API-2)
+- Git-diff-friendly export format (API-3)
+- Optimistic concurrency control (API-5)
+- TypeScript SDK with builder pattern (SDK-1)
+- CLI: `build`, `validate`, `apply`, `pull` commands (CLI-1 through CLI-7)
+- Documentation and example repo (DX-1, DX-2)
+
+### Phase 2 — Multi-Language & GitOps (Q3-Q4 2026)
+
+**Goal:** Reach parity with Perses. Ship Python + Go SDKs and Git workflows.
+
+- Python SDK (SDK-2)
+- Go SDK (SDK-3)
+- SDK auto-generation pipeline (SDK-5)
+- Git Sync — bi-directional GitHub integration (GIT-1, GIT-2)
+- GitHub Actions library (CI-1)
+- CLI: `diff`, `lint`, `convert` commands (CLI-4, CLI-8, CLI-10)
+- Local preview (DX-4)
+
+### Phase 3 — Infrastructure-as-Code (Q1 2027)
+
+**Goal:** Reach parity with Grafana/Datadog on IaC. Ship Terraform provider.
+
+- Terraform provider (TF-1 through TF-4)
+- Pulumi provider (TF-5)
+- Java SDK (SDK-4)
+- GitLab CI / Jenkins templates (CI-2, CI-3)
+- PR preview rendering (GIT-3)
+- Dashboard template gallery (DX-6)
+
+### Phase 4 — Full Observability-as-Code (Q2-Q3 2027)
+
+**Goal:** Differentiate. Go beyond dashboards to full observability lifecycle management.
+
+- Alerting-as-code (OAC-1)
+- Data source configuration-as-code (OAC-3)
+- Access control-as-code (OAC-6)
+- Anomaly detection-as-code (OAC-2)
+- Migration tooling: instance-to-code conversion (DX-7)
+- Webhook-driven GitOps (GIT-4)
+
+---
+
+## 6. Competitive Differentiation Opportunities
+
+### 6.1 Open-Source First, No Lock-In
+
+Unlike Grafana (which gates Git Sync and advanced features behind Cloud/Enterprise), OpenSearch Dashboards can ship **all DaC features in the open-source distribution**. This is a massive differentiator for cost-conscious organizations and the open-source community.
+
+### 6.2 OpenSearch-Native Query Integration
+
+SDKs should provide **first-class OpenSearch query builders** — DQL, PPL, and SQL query construction with autocompletion and validation. No competitor offers deep query-language integration in their DaC SDKs.
+
+### 6.3 Multi-Format Dashboard Compatibility
+
+Ship a `convert` command that imports **Grafana JSON dashboards** into OpenSearch Dashboards format. Lower the migration barrier for organizations moving from Grafana to OpenSearch. Also support Perses format import for CNCF ecosystem alignment.
+
+### 6.4 Security-as-Code Integration
+
+Leverage OpenSearch's security plugin to offer **fine-grained access control-as-code** — define who can view/edit which dashboards, tenants, and workspaces via the same as-code workflow. No competitor integrates security policies this deeply into their DaC story.
+
+### 6.5 AI-Assisted Dashboard Generation
+
+Integrate with LLMs to offer `osdctl generate --prompt "Create a Kubernetes pod monitoring dashboard for my production cluster"`. Generate SDK code, not just JSON — giving customers a starting point they can version-control and iterate on.
+
+### 6.6 Plugin SDK for Community Extensions
+
+Follow Perses' model: provide an **SDK extension point** so visualization plugin authors can ship typed builders for their plugins. Grows the ecosystem without central bottleneck.
+
+---
+
+## 7. Success Metrics
+
+| Metric | Target (12 months post-launch) |
+|---|---|
+| SDK downloads (npm + PyPI + Go modules) | 10,000+ monthly |
+| CLI installs | 5,000+ monthly |
+| Terraform provider installs | 2,000+ monthly |
+| Dashboards managed via as-code workflows | 20% of new dashboards in active deployments |
+| GitHub Actions workflow runs | 1,000+ monthly |
+| Customer NPS for DaC feature | 50+ |
+| Grafana-to-OpenSearch dashboard conversions | 500+ monthly |
+
+---
+
+## 8. Key Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Schema instability delays SDK adoption | High | Build typed schemas incrementally on top of existing Saved Objects structure. Use `v1beta1` for early feedback before stabilizing. Existing API continues to work unchanged. |
+| Low community contribution to SDKs | Medium | Auto-generate SDKs from schema to reduce maintenance burden. Start with TypeScript (largest user base). |
+| Grafana Git Sync moves to GA before our launch | Medium | Differentiate on open-source availability and OpenSearch-native features rather than racing on Git Sync. |
+| Terraform provider maintenance burden | Medium | Use Terraform Plugin Framework for auto-generation. Align resources with versioned API for consistency. |
+| Enterprise customers need features faster than roadmap | Medium | Prioritize CLI + TypeScript SDK in Phase 1 to unblock immediate automation needs. |
+
+---
+
+## 9. Open Questions
+
+1. **Schema evolution**: How do we version the typed schemas layered on top of Saved Objects? Do we use path-based versioning (`dashboard/v1`) or header-based? How do we handle schema migrations when the underlying Saved Objects structure changes?
+
+2. **CUE support**: Perses uses CUE as their primary schema language. Should we support CUE as an SDK language, or focus on general-purpose languages (TS, Python, Go, Java)?
+
+3. **Saved Objects API surface**: Which new endpoints (validation, diff, bulk_apply) should be added as extensions to the existing Saved Objects API vs. as a separate API namespace? How do we keep the Saved Objects API backward-compatible while adding these capabilities?
+
+4. **CNCF alignment**: Should we contribute to / build on Perses rather than building from scratch? Perses is CNCF-sandbox and vendor-neutral by design.
+
+5. **Multi-tenancy**: How should as-code workflows interact with OpenSearch Dashboards workspaces and multi-tenant configurations? Should labels/annotations be workspace-scoped?
+
+6. **ndjson compatibility**: The new Git-diff-friendly format will differ from existing ndjson exports. What is the migration path for customers with existing ndjson-based automation?
+
+---
+
+## Appendix A: Competitive Feature Matrix
+
+| Feature | OpenSearch (Current) | OpenSearch (Proposed) | Grafana 12 | Perses | Datadog | Dynatrace |
+|---|---|---|---|---|---|---|
+| Typed Resource API | Saved Objects (untyped) | P0 (extend Saved Objects) | v1beta1 (new API) | Yes | Yes | Yes |
+| Multi-Language SDK | None | P0 (TS, Py, Go, Java) | Go, Java, PHP, Py, TS | CUE, Go | None (API-only) | None (YAML) |
+| CLI Tool | None | P0 | grafanactl | percli | datadog-ci | Monaco |
+| Git Sync (native) | None | P1 | Experimental | No (GitOps via CI) | No | No |
+| Terraform Provider | None | P1 | Yes (mature) | No | Yes (mature) | Yes |
+| Pulumi Provider | None | P1 | Yes | No | Yes | No |
+| GitHub Actions | None | P1 | Via CLI | Yes (official) | Yes | Via Monaco |
+| Dashboard Schema v2 | None | P0 | Experimental | N/A (native) | N/A | N/A |
+| Alerting-as-Code | None | P2 | Planned | No | Yes | Yes |
+| SLO-as-Code | None | P2 | Planned | No | Yes | Yes |
+| Validation/Linting | None | P0 | Via CLI | Via percli | Via API | Via Monaco |
+| Local Preview | None | P1 | Via SDK | No | No | No |
+| Dashboard Conversion | None | P1 | N/A | No | No | No |
+| Open Source (full) | Yes | Yes | Partial (gated) | Yes | No | No |
+
+---
+
+## Appendix B: Reference Implementations
+
+- **Perses CLI Actions**: https://github.com/perses/cli-actions
+- **Perses Go SDK**: `github.com/perses/perses/go-sdk`
+- **Perses CUE SDK**: `github.com/perses/perses/cue/dac-utils`
+- **Grafana Foundation SDK**: https://github.com/grafana/grafana-foundation-sdk
+- **Grafana grafanactl**: Part of Grafana 12 distribution
+- **Grafonnet (Jsonnet)**: https://github.com/grafana/grafonnet
+- **Terraform Grafana Provider**: https://registry.terraform.io/providers/grafana/grafana
+- **Terraform Datadog Provider**: https://registry.terraform.io/providers/DataDog/datadog
+- **Dynatrace Monaco**: https://github.com/Dynatrace/dynatrace-configuration-as-code


### PR DESCRIPTION
## Summary
- Introduces the design RFC for Dashboards-as-Code (DaC)
- Adds detailed requirements document covering API endpoints, SDK, CLI, managed lock enforcement, and CI/CD integration

This is PR 1 of 8 in the DaC series. It ships design context first so reviewers of subsequent code PRs have the full rationale.

## Test Plan
- [ ] Documentation renders correctly
- [ ] No code changes — docs only

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)