### PR TITLE
[Chat] Fix unfinished frontend tool calls not being restored when loading a conversation

### DIFF
--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -333,14 +333,17 @@ describe('ChatWindow', () => {
 
   describe('persistence integration', () => {
     it('should restore timeline from persisted messages on mount', async () => {
-      const persistedMessages = [
-        { id: '1', role: 'user' as const, content: 'Hello' },
-        { id: '2', role: 'assistant' as const, content: 'Hi there!' },
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [
+            { id: '1', role: 'user' as const, content: 'Hello' },
+            { id: '2', role: 'assistant' as const, content: 'Hi there!' },
+          ],
+          timestamp: Date.now(),
+        },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages: persistedMessages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue(mockEvents);
 
       renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -436,7 +439,6 @@ describe('ChatWindow', () => {
         await ref.current?.sendMessage({ content: 'test message' });
       });
 
-      // Wait for message processing
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 20));
       });
@@ -445,7 +447,7 @@ describe('ChatWindow', () => {
       expect(mockChatService.saveConversation).toHaveBeenCalled();
     });
 
-    it('should show timeline early when restoring conversation with unfinished tool calls', async () => {
+    it('should replay events including synthetic tool call events when restoring with unfinished tool calls', async () => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const { ChatEventHandler } = require('../services/chat_event_handler');
       const mockHandleEvent = jest.fn();
@@ -454,91 +456,77 @@ describe('ChatWindow', () => {
         clearState: jest.fn(),
       }));
 
-      // Create messages with an unfinished tool call (no corresponding tool result)
-      const messagesWithUnfinishedToolCall = [
-        { id: 'user-1', role: 'user' as const, content: 'Run a command' },
+      // The service returns events with synthetic TOOL_CALL_* events already injected
+      const mockEvents = [
         {
-          id: 'assistant-1',
-          role: 'assistant' as const,
-          content: '',
-          toolCalls: [
-            {
-              id: 'tool-call-1',
-              function: {
-                name: 'execute_command',
-                arguments: '{"command": "ls -la"}',
-              },
-            },
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [
+            { id: 'user-1', role: 'user' as const, content: 'Run a command' },
+            { id: 'assistant-1', role: 'assistant' as const, content: '', toolCalls: [] },
           ],
+          timestamp: Date.now(),
         },
-        // No tool result message - this tool call is unfinished
+        {
+          type: 'TOOL_CALL_START',
+          toolCallId: 'tool-call-1',
+          toolCallName: 'execute_command',
+          parentMessageId: 'assistant-1',
+          timestamp: Date.now(),
+        },
+        {
+          type: 'TOOL_CALL_ARGS',
+          toolCallId: 'tool-call-1',
+          delta: '{"command": "ls -la"}',
+          timestamp: Date.now(),
+        },
+        { type: 'TOOL_CALL_END', toolCallId: 'tool-call-1', timestamp: Date.now() },
       ];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages: messagesWithUnfinishedToolCall,
-      });
-
-      const { queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for restoration to complete
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      });
-
-      // Loading should be hidden early so users can see and interact with confirmation dialogs
-      expect(queryByText('Loading conversation...')).toBeNull();
-
-      // Event handler should be called to re-trigger the unfinished tool calls
-      expect(mockHandleEvent).toHaveBeenCalled();
-    });
-
-    it('should not overwrite timeline when unfinished tool calls exist', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { ChatEventHandler } = require('../services/chat_event_handler');
-      const mockHandleEvent = jest.fn();
-      ChatEventHandler.mockImplementation(() => ({
-        handleEvent: mockHandleEvent,
-        clearState: jest.fn(),
-      }));
-
-      // Create messages with an unfinished tool call
-      const messagesWithUnfinishedToolCall = [
-        { id: 'user-1', role: 'user' as const, content: 'Run a command' },
-        {
-          id: 'assistant-1',
-          role: 'assistant' as const,
-          content: '',
-          toolCalls: [
-            {
-              id: 'tool-call-1',
-              function: {
-                name: 'execute_command',
-                arguments: '{"command": "ls -la"}',
-              },
-            },
-          ],
-        },
-      ];
-
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages: messagesWithUnfinishedToolCall,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue(mockEvents);
 
       renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
-      // Wait for restoration to complete
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
-      // Verify that tool call events were triggered for the unfinished tool call
-      // The handleEvent should be called with TOOL_CALL_START, TOOL_CALL_ARGS, and TOOL_CALL_END
-      const toolCallStartEvents = mockHandleEvent.mock.calls.filter(
-        (call: any) => call[0]?.type === 'TOOL_CALL_START'
-      );
-      expect(toolCallStartEvents.length).toBeGreaterThan(0);
+      expect(mockHandleEvent).toHaveBeenCalledTimes(mockEvents.length);
+      const calledTypes = mockHandleEvent.mock.calls.map((call: any) => call[0]?.type);
+      expect(calledTypes).toContain('TOOL_CALL_START');
+      expect(calledTypes).toContain('TOOL_CALL_ARGS');
+      expect(calledTypes).toContain('TOOL_CALL_END');
+    });
+
+    it('should replay all events through eventHandler when restoring', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      const mockHandleEvent = jest.fn();
+      ChatEventHandler.mockImplementation(() => ({
+        handleEvent: mockHandleEvent,
+        clearState: jest.fn(),
+      }));
+
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [
+            { id: 'user-1', role: 'user' as const, content: 'Hello' },
+            { id: 'assistant-1', role: 'assistant' as const, content: 'Hi' },
+          ],
+          timestamp: Date.now(),
+        },
+      ];
+
+      mockChatService.restoreLatestConversation.mockResolvedValue(mockEvents);
+
+      renderWithContext(<ChatWindow onClose={jest.fn()} />);
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      expect(mockHandleEvent).toHaveBeenCalledTimes(1);
+      expect(mockHandleEvent.mock.calls[0][0].type).toBe('MESSAGES_SNAPSHOT');
     });
   });
 
@@ -587,10 +575,9 @@ describe('ChatWindow', () => {
         { id: 'assistant-2', role: 'assistant' as const, content: 'Second response' },
       ];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages: initialTimeline,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'MESSAGES_SNAPSHOT', messages: initialTimeline, timestamp: Date.now() },
+      ]);
 
       const ref = React.createRef<ChatWindowInstance>();
       renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
@@ -603,10 +590,8 @@ describe('ChatWindow', () => {
       // Mock resend observable
       const resendObservable = {
         subscribe: jest.fn((callbacks) => {
-          setTimeout(() => {
-            callbacks.next({ type: 'message', content: 'Resent response' });
-            callbacks.complete();
-          }, 10);
+          callbacks.next({ type: 'message', content: 'Resent response' });
+          callbacks.complete();
           return { unsubscribe: jest.fn() };
         }),
       };
@@ -641,10 +626,9 @@ describe('ChatWindow', () => {
         { id: 'assistant-1', role: 'assistant' as const, content: 'Assistant message' },
       ];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages: initialTimeline,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'MESSAGES_SNAPSHOT', messages: initialTimeline, timestamp: Date.now() },
+      ]);
 
       const ref = React.createRef<ChatWindowInstance>();
       renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
@@ -887,10 +871,13 @@ describe('ChatWindow', () => {
     });
 
     it('should hide loading screen after successful restoration', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread',
-        messages: [{ id: '1', role: 'user', content: 'Hello' }],
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: '1', role: 'user', content: 'Hello' }],
+          timestamp: Date.now(),
+        },
+      ]);
 
       const { queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -939,10 +926,13 @@ describe('ChatWindow', () => {
     it('should retry restoration when retry button is clicked and clear error on success', async () => {
       mockChatService.restoreLatestConversation
         .mockRejectedValueOnce(new Error('First attempt failed'))
-        .mockResolvedValueOnce({
-          threadId: 'test-thread',
-          messages: [{ id: '1', role: 'user', content: 'Hello' }],
-        });
+        .mockResolvedValueOnce([
+          {
+            type: 'MESSAGES_SNAPSHOT',
+            messages: [{ id: '1', role: 'user', content: 'Hello' }],
+            timestamp: Date.now(),
+          },
+        ]);
 
       const { getByText, queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -1271,6 +1261,132 @@ describe('ChatWindow', () => {
 
       // Verify no error toast was shown (since loading was aborted)
       expect(mockCore.notifications.toasts.addWarning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSelectConversation', () => {
+    beforeEach(() => {
+      mockChatService.restoreLatestConversation.mockResolvedValue(null);
+      mockChatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
+        conversations: [
+          {
+            id: 'conv-1',
+            threadId: 'thread-1',
+            name: 'Test conversation',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 10,
+      });
+    });
+
+    it('should call eventHandler.clearState before replaying events to prevent state bleed', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      const callOrder: string[] = [];
+      const mockHandleEvent = jest.fn().mockImplementation(() => {
+        callOrder.push('handleEvent');
+      });
+      const mockClearState = jest.fn().mockImplementation(() => {
+        callOrder.push('clearState');
+      });
+      ChatEventHandler.mockImplementation(() => ({
+        handleEvent: mockHandleEvent,
+        clearState: mockClearState,
+      }));
+
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: 'u1', role: 'user', content: 'Hi' }],
+          timestamp: Date.now(),
+        },
+      ];
+      mockChatService.loadConversation.mockResolvedValue(mockEvents);
+
+      const { getByLabelText, getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      const historyButton = getByLabelText('Show conversation history');
+      await act(async () => {
+        historyButton.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      const conversationItem = getByText('Test conversation');
+      await act(async () => {
+        conversationItem.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // clearState must come before any handleEvent call
+      const clearIndex = callOrder.indexOf('clearState');
+      const firstHandleIndex = callOrder.indexOf('handleEvent');
+      expect(clearIndex).toBeGreaterThanOrEqual(0);
+      expect(firstHandleIndex).toBeGreaterThan(clearIndex);
+    });
+
+    it('should replay all events through eventHandler when selecting a conversation', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      const mockHandleEvent = jest.fn();
+      const mockClearState = jest.fn();
+      ChatEventHandler.mockImplementation(() => ({
+        handleEvent: mockHandleEvent,
+        clearState: mockClearState,
+      }));
+
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: 'u1', role: 'user', content: 'Hi' }],
+          timestamp: Date.now(),
+        },
+        {
+          type: 'TOOL_CALL_START',
+          toolCallId: 'tc-1',
+          toolCallName: 'my_tool',
+          timestamp: Date.now(),
+        },
+      ];
+      mockChatService.loadConversation.mockResolvedValue(mockEvents);
+
+      const { getByLabelText, getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      const historyButton = getByLabelText('Show conversation history');
+      await act(async () => {
+        historyButton.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      const conversationItem = getByText('Test conversation');
+      await act(async () => {
+        conversationItem.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      expect(mockHandleEvent).toHaveBeenCalledTimes(mockEvents.length);
+      const calledTypes = mockHandleEvent.mock.calls.map((call: any) => call[0]?.type);
+      expect(calledTypes).toContain('MESSAGES_SNAPSHOT');
+      expect(calledTypes).toContain('TOOL_CALL_START');
     });
   });
 

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -6,7 +6,7 @@
 /* eslint-disable no-console */
 
 import React, { useState, useEffect, useMemo, useImperativeHandle, useCallback, useRef } from 'react';
-import { useUnmount } from 'react-use';
+import { useUnmount, useMount } from 'react-use';
 import moment from "moment";
 import { i18n } from '@osd/i18n';
 import { EuiButton, EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
@@ -17,7 +17,6 @@ import { ConfirmationRequest } from '../services/confirmation_service';
 import {
   // eslint-disable-next-line prettier/prettier
   type Event as ChatEvent,
-  EventType,
 } from '../../common/events';
 import type {
   Message,
@@ -151,83 +150,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     };
   }, [eventHandler]);
 
-  // Restore unfinished tool calls by re-triggering their events
-  const restoreUnfinishedToolCalls = useCallback(async (
-    messages: Message[],
-    abortController: AbortController
-  ): Promise<boolean> => {
-    const lastMessage = messages[messages.length - 1];
-    if (lastMessage.role !== 'assistant' || !lastMessage.toolCalls) {
-      return false;
-    }
-
-    // Find tool calls without corresponding tool result messages
-    const unfinishedToolCalls = lastMessage.toolCalls.filter(toolCall => {
-      const hasToolResult = messages.some(msg =>
-        msg.role === 'tool' && msg.toolCallId === toolCall.id
-      );
-      return !hasToolResult;
-    });
-
-    if (unfinishedToolCalls.length === 0) {
-      return false;
-    }
-
-    // Remove unfinished tool calls from the last message to show a clean timeline.
-    // The unfinished tools will be re-triggered below and may require user confirmation
-    // (e.g., clicking approve/reject buttons), so we need to show the UI early.
-    const lastMessageWithoutUnfinishedTools = {
-      ...lastMessage,
-      toolCalls: lastMessage.toolCalls.filter((toolCall) => !unfinishedToolCalls.includes(toolCall))
-    };
-
-    // Set loading to false early so users can see and interact with confirmation dialogs
-    setIsLoading(false);
-    setTimeline([...messages.slice(0, -1), lastMessageWithoutUnfinishedTools]);
-
-    // Helper to apply event only if not aborted
-    const applyEventHandler = async (event: ChatEvent): Promise<void> => {
-      if (abortController.signal.aborted) {
-        return;
-      }
-      await eventHandler.handleEvent(event);
-    };
-
-    // Trigger tool call events for unfinished tool calls
-    for (const toolCall of unfinishedToolCalls) {
-      if (abortController.signal.aborted) {
-        return true;
-      }
-
-      try {
-        await applyEventHandler({
-          type: EventType.TOOL_CALL_START,
-          toolCallId: toolCall.id,
-          toolCallName: toolCall.function.name,
-          parentMessageId: lastMessage.id,
-          timestamp: Date.now(),
-        });
-
-        await applyEventHandler({
-          type: EventType.TOOL_CALL_ARGS,
-          toolCallId: toolCall.id,
-          delta: toolCall.function.arguments,
-          timestamp: Date.now(),
-        });
-
-        await applyEventHandler({
-          type: EventType.TOOL_CALL_END,
-          toolCallId: toolCall.id,
-          timestamp: Date.now(),
-        });
-      } catch (error: any) {
-        console.error(`Error restoring tool call for ${toolCall.function.name}:`, error);
-      }
-    }
-
-    return true;
-  }, [eventHandler]);
-
   // Extracted restoration logic to avoid duplication
   const restoreConversationTimeline = useCallback(async () => {
     // Create abort controller for this loading operation
@@ -239,30 +161,20 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     try {
       // Check if aborted before starting
-      if (abortController.signal.aborted) {
-        return;
-      }
+      if (abortController.signal.aborted) return;
 
-      const result = await chatService.restoreLatestConversation();
+      const events = await chatService.restoreLatestConversation();
 
       // Check if aborted after async operation
-      if (abortController.signal.aborted) {
-        return;
-      }
+      if (abortController.signal.aborted) return;
+      
+      eventHandler.clearState();
+      setIsLoading(false);
 
-      if (result && result.messages.length > 0) {
-        const { messages } = result;
-
-        // Restore unfinished tool calls if any exist
-        const timelineUpdated = await restoreUnfinishedToolCalls(messages, abortController);
-
-        // Check if aborted before setting timeline
-        if (abortController.signal.aborted) {
-          return;
-        }
-
-        if (!timelineUpdated) {
-          setTimeline(messages);
+      if (events) {
+        for (const event of events) {
+          if (abortController.signal.aborted) return;
+          await eventHandler.handleEvent(event);
         }
       }
     } catch (error: any) {
@@ -281,12 +193,12 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         loadingAbortControllerRef.current = null;
       }
     }
-  }, [chatService, restoreUnfinishedToolCalls]);
+  }, [chatService, eventHandler]);
 
   // Restore timeline from latest conversation on component mount
-  useEffect(() => {
+  useMount(() => {
     restoreConversationTimeline();
-  }, [restoreConversationTimeline]);
+  });
 
   // Save conversation to history whenever timeline changes
   useEffect(() => {
@@ -563,29 +475,28 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     try {
       // Check if aborted before starting
-      if (abortController.signal.aborted) {
-        return;
-      }
+      if (abortController.signal.aborted) return;
 
       // Load the conversation and get AG-UI event array
       const events = await chatService.loadConversation(conversation.threadId);
 
       // Check if aborted after async operation
-      if (abortController.signal.aborted) {
-        return;
-      }
+      if (abortController.signal.aborted) return;
 
       if (events) {
-        // Process each event through the event handler for proper state restoration
-        for (const event of events) {
-          await eventHandler.handleEvent(event);
-        }
-
         // Reset UI state
+        eventHandler.clearState();
         setCurrentRunId(null);
         setIsStreaming(false);
         setPendingConfirmation(null);
+        confirmationService.cleanAll();
         setShowHistory(false);
+        setIsLoading(false);
+
+        for (const event of events) {
+          if (abortController.signal.aborted) return;
+          await eventHandler.handleEvent(event);
+        }
       }
     } catch (error: any) {
       // Don't show error if aborted
@@ -612,13 +523,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         loadingAbortControllerRef.current = null;
       }
     }
-  }, [chatService, eventHandler, toasts]);
+  }, [chatService, eventHandler, confirmationService, toasts]);
 
-  const handleRetryRestore = useCallback(() => {
-    restoreConversationTimeline();
-  }, [restoreConversationTimeline]);
-
-  // Build window instance object
   const windowInstance = useMemo<ChatWindowInstance>(() => ({
     startNewChat: () => handleNewChat(),
     sendMessage: async ({content, messages}) => (await handleSendRef.current?.({input:content, messages}))
@@ -669,7 +575,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             <p>{restoreError}</p>
           </EuiText>
           <EuiButton
-            onClick={handleRetryRestore}
+            onClick={restoreConversationTimeline}
             iconType="refresh"
           >
             {i18n.translate('chat.window.retryButton', {

--- a/src/plugins/chat/public/components/chat_window_conversation_name.test.tsx
+++ b/src/plugins/chat/public/components/chat_window_conversation_name.test.tsx
@@ -32,8 +32,12 @@ jest.mock('../../../context_provider/public', () => {
 });
 
 jest.mock('../services/chat_event_handler', () => ({
-  ChatEventHandler: jest.fn().mockImplementation(() => ({
-    handleEvent: jest.fn(),
+  ChatEventHandler: jest.fn().mockImplementation((config) => ({
+    handleEvent: jest.fn().mockImplementation(async (event) => {
+      if (event.type === 'MESSAGES_SNAPSHOT' && event.messages) {
+        config.callbacks.onTimelineUpdate(() => event.messages);
+      }
+    }),
     clearState: jest.fn(),
   })),
 }));
@@ -129,10 +133,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '1', role: 'user' as const, content: 'How can I find the largest index?' },
         { id: '2', role: 'assistant' as const, content: 'You can use...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -156,10 +161,11 @@ describe('ChatWindow - Conversation Name', () => {
         },
         { id: '2', role: 'assistant' as const, content: 'The weather is...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -184,10 +190,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '3', role: 'user' as const, content: 'Can you describe this image?' },
         { id: '4', role: 'assistant' as const, content: 'Sure...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -211,10 +218,11 @@ describe('ChatWindow - Conversation Name', () => {
         },
         { id: '2', role: 'assistant' as const, content: 'I see an image...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -232,10 +240,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '2', role: 'user' as const, content: 'Tell me about TypeScript' },
         { id: '3', role: 'assistant' as const, content: 'TypeScript is...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -254,10 +263,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '3', role: 'user' as const, content: 'How do I debug my code?' },
         { id: '4', role: 'assistant' as const, content: 'You can use...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -276,10 +286,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '1', role: 'user' as const, content: longMessage },
         { id: '2', role: 'assistant' as const, content: 'Response' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -302,10 +313,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '2', role: 'assistant' as const, content: 'Initial response' },
       ];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'test-thread-id',
-        messages: initialMessages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages: initialMessages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -320,10 +332,11 @@ describe('ChatWindow - Conversation Name', () => {
       // Now test with a different conversation
       const newMessages = [{ id: '3', role: 'user' as const, content: 'New conversation started' }];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue({
-        threadId: 'new-thread-id',
-        messages: newMessages,
-      });
+      mockChatService.restoreLatestConversation.mockResolvedValue([
+        { type: 'RUN_STARTED', threadId: 'new-thread-id', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages: newMessages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
 
       // Unmount and remount to simulate loading a different conversation
       const { container: newContainer } = renderWithContext(<ChatWindow onClose={jest.fn()} />);

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -9,9 +9,22 @@ import { Observable, BehaviorSubject } from 'rxjs';
 import { Message } from '../../common/types';
 import { ToolDefinition } from '../../../context_provider/public';
 import { ChatServiceStart } from '../../../../core/public';
+import { AssistantActionService } from '../../../context_provider/public';
 
 // Mock AgUiAgent
 jest.mock('./ag_ui_agent');
+
+// Mock AssistantActionService singleton
+jest.mock('../../../context_provider/public', () => ({
+  AssistantActionService: {
+    getInstance: jest.fn().mockReturnValue({
+      getState$: jest
+        .fn()
+        .mockReturnValue({ subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }) }),
+      hasAction: jest.fn().mockReturnValue(false),
+    }),
+  },
+}));
 
 // Mock data source management
 jest.mock('../../../data_source_management/public', () => ({
@@ -1305,45 +1318,37 @@ describe('ChatService', () => {
   });
 
   describe('restoreLatestConversation', () => {
-    it('should restore the latest conversation with messages', async () => {
-      const mockMessages = [
-        { id: 'msg-1', role: 'user', content: 'Hello' },
-        { id: 'msg-2', role: 'assistant', content: 'Hi there!' },
-      ];
+    const mockMessages = [
+      { id: 'msg-1', role: 'user', content: 'Hello' },
+      { id: 'msg-2', role: 'assistant', content: 'Hi there!' },
+    ];
+    const mockThreadId = 'thread-12345';
+    const mockSnapshotEvent = {
+      type: 'MESSAGES_SNAPSHOT',
+      messages: mockMessages,
+      timestamp: Date.now(),
+    };
 
-      const mockThreadId = 'thread-12345';
-
-      // Mock the conversation history service
+    it('should return events array including MESSAGES_SNAPSHOT for the latest conversation', async () => {
       chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
-        conversations: [
-          {
-            threadId: mockThreadId,
-            title: 'Test Conversation',
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          },
-        ],
+        conversations: [{ threadId: mockThreadId, title: 'Test', createdAt: 0, updatedAt: 0 }],
         total: 1,
       });
-
-      chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue([
-        {
-          type: 'MESSAGES_SNAPSHOT',
-          messages: mockMessages,
-          timestamp: Date.now(),
-        },
-      ]);
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([mockSnapshotEvent]);
 
       const result = await chatService.restoreLatestConversation();
 
       expect(result).not.toBeNull();
-      expect(result?.threadId).toBe(mockThreadId);
-      expect(result?.messages).toEqual(mockMessages);
+      expect(Array.isArray(result)).toBe(true);
+      const snapshot = result!.find((e: any) => e.type === 'MESSAGES_SNAPSHOT');
+      expect(snapshot).toBeDefined();
+      expect((snapshot as any).messages).toEqual(mockMessages);
       expect(mockCoreChatService.setThreadId).toHaveBeenCalledWith(mockThreadId);
     });
 
     it('should return null and generate new thread when no conversations exist', async () => {
-      // Mock empty conversation list
       chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
         conversations: [],
         total: 0,
@@ -1352,88 +1357,284 @@ describe('ChatService', () => {
       const result = await chatService.restoreLatestConversation();
 
       expect(result).toBeNull();
-      // Should generate a new thread
-      expect(mockCoreChatService.newThread).toHaveBeenCalled();
-    });
-
-    it('should return null and generate new thread when conversation has no MESSAGES_SNAPSHOT event', async () => {
-      const mockThreadId = 'thread-12345';
-
-      chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
-        conversations: [
-          {
-            threadId: mockThreadId,
-            title: 'Test Conversation',
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          },
-        ],
-        total: 1,
-      });
-
-      // Return events without MESSAGES_SNAPSHOT
-      chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue([
-        {
-          type: 'OTHER_EVENT',
-          timestamp: Date.now(),
-        },
-      ]);
-
-      const result = await chatService.restoreLatestConversation();
-
-      expect(result).toBeNull();
-      // Should generate a new thread
       expect(mockCoreChatService.newThread).toHaveBeenCalled();
     });
 
     it('should return null and generate new thread when getConversation returns null', async () => {
-      const mockThreadId = 'thread-12345';
-
       chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
-        conversations: [
-          {
-            threadId: mockThreadId,
-            title: 'Test Conversation',
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          },
-        ],
+        conversations: [{ threadId: mockThreadId, title: 'Test', createdAt: 0, updatedAt: 0 }],
         total: 1,
       });
-
       chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue(null);
 
       const result = await chatService.restoreLatestConversation();
 
       expect(result).toBeNull();
-      // Should generate a new thread
       expect(mockCoreChatService.newThread).toHaveBeenCalled();
     });
 
     it('should return null and skip restore when thread ID is already set', async () => {
-      // Mock that thread ID is already set
       mockCoreChatService.getThreadId.mockReturnValue('existing-thread-id');
-
-      // Mock conversation history (should not be called)
-      chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
-        conversations: [
-          {
-            threadId: 'thread-12345',
-            title: 'Test Conversation',
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          },
-        ],
-        total: 1,
-      });
+      chatService.conversationHistoryService.getConversations = jest.fn();
 
       const result = await chatService.restoreLatestConversation();
 
       expect(result).toBeNull();
-      // Should not call getConversations since thread is already set
       expect(chatService.conversationHistoryService.getConversations).not.toHaveBeenCalled();
-      // Should NOT generate a new thread - use existing one
       expect(mockCoreChatService.newThread).not.toHaveBeenCalled();
+    });
+
+    it('should inject synthetic tool call events for unfinished tool calls', async () => {
+      const mockHasAction = jest.fn((name: string) => name === 'run_cmd');
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        mockHasAction
+      );
+
+      const messagesWithUnfinished = [
+        { id: 'user-1', role: 'user', content: 'Run it' },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            {
+              id: 'tc-1',
+              type: 'function',
+              function: { name: 'run_cmd', arguments: '{"cmd":"ls"}' },
+            },
+          ],
+        },
+      ];
+
+      chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
+        conversations: [{ threadId: mockThreadId, title: 'Test', createdAt: 0, updatedAt: 0 }],
+        total: 1,
+      });
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([
+          { type: 'MESSAGES_SNAPSHOT', messages: messagesWithUnfinished, timestamp: Date.now() },
+        ]);
+
+      const result = await chatService.restoreLatestConversation();
+
+      expect(result).not.toBeNull();
+      const types = result!.map((e: any) => e.type);
+      expect(types).toContain('TOOL_CALL_START');
+      expect(types).toContain('TOOL_CALL_ARGS');
+      expect(types).toContain('TOOL_CALL_END');
+
+      const snapshot = result!.find((e: any) => e.type === 'MESSAGES_SNAPSHOT') as any;
+      const lastMsg = snapshot.messages[snapshot.messages.length - 1];
+      expect(lastMsg.toolCalls).toHaveLength(0);
+    });
+
+    it('should not inject synthetic events for non-frontend tool calls', async () => {
+      const mockHasAction = jest.fn().mockReturnValue(false);
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        mockHasAction
+      );
+
+      const messagesWithServerTool = [
+        { id: 'user-1', role: 'user', content: 'Run it' },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'tc-1', type: 'function', function: { name: 'server_tool', arguments: '{}' } },
+          ],
+        },
+      ];
+
+      chatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
+        conversations: [{ threadId: mockThreadId, title: 'Test', createdAt: 0, updatedAt: 0 }],
+        total: 1,
+      });
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([
+          { type: 'MESSAGES_SNAPSHOT', messages: messagesWithServerTool, timestamp: Date.now() },
+        ]);
+
+      const result = await chatService.restoreLatestConversation();
+
+      expect(result).not.toBeNull();
+      const types = result!.map((e: any) => e.type);
+      expect(types).not.toContain('TOOL_CALL_START');
+    });
+  });
+
+  describe('loadConversation', () => {
+    const mockThreadId = 'thread-load-123';
+    const mockMessages = [
+      { id: 'msg-1', role: 'user', content: 'Hello' },
+      { id: 'msg-2', role: 'assistant', content: 'Hi!' },
+    ];
+
+    it('should return events array and set thread ID', async () => {
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([
+          { type: 'MESSAGES_SNAPSHOT', messages: mockMessages, timestamp: Date.now() },
+        ]);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      expect(result).not.toBeNull();
+      expect(Array.isArray(result)).toBe(true);
+      expect(mockCoreChatService.setThreadId).toHaveBeenCalledWith(mockThreadId);
+    });
+
+    it('should return null when getConversation returns null', async () => {
+      chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue(null);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      expect(result).toBeNull();
+    });
+
+    it('should inject synthetic tool call events for unfinished tool calls', async () => {
+      const mockHasAction = jest.fn((name: string) => name === 'run_cmd');
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        mockHasAction
+      );
+
+      const messagesWithUnfinished = [
+        { id: 'user-1', role: 'user', content: 'Run it' },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            {
+              id: 'tc-1',
+              type: 'function',
+              function: { name: 'run_cmd', arguments: '{"cmd":"ls"}' },
+            },
+          ],
+        },
+      ];
+
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([
+          { type: 'MESSAGES_SNAPSHOT', messages: messagesWithUnfinished, timestamp: Date.now() },
+        ]);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      expect(result).not.toBeNull();
+      const types = result!.map((e: any) => e.type);
+      expect(types).toContain('TOOL_CALL_START');
+      expect(types).toContain('TOOL_CALL_ARGS');
+      expect(types).toContain('TOOL_CALL_END');
+    });
+
+    it('should inject synthetic events for each of multiple unfinished tool calls', async () => {
+      const mockHasAction = jest.fn((name: string) => name === 'cmd_a' || name === 'cmd_b');
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        mockHasAction
+      );
+
+      const messagesWithMultipleUnfinished = [
+        { id: 'user-1', role: 'user', content: 'Run two commands' },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'tc-1', type: 'function', function: { name: 'cmd_a', arguments: '{"a":1}' } },
+            { id: 'tc-2', type: 'function', function: { name: 'cmd_b', arguments: '{"b":2}' } },
+          ],
+        },
+      ];
+
+      chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue([
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: messagesWithMultipleUnfinished,
+          timestamp: Date.now(),
+        },
+      ]);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      expect(result).not.toBeNull();
+      const startEvents = result!.filter((e: any) => e.type === 'TOOL_CALL_START');
+      const argsEvents = result!.filter((e: any) => e.type === 'TOOL_CALL_ARGS');
+      const endEvents = result!.filter((e: any) => e.type === 'TOOL_CALL_END');
+
+      expect(startEvents).toHaveLength(2);
+      expect(argsEvents).toHaveLength(2);
+      expect(endEvents).toHaveLength(2);
+
+      const startIds = startEvents.map((e: any) => e.toolCallId);
+      expect(startIds).toContain('tc-1');
+      expect(startIds).toContain('tc-2');
+    });
+
+    it('should not inject tool call events when all tool calls have results', async () => {
+      const mockHasAction = jest.fn((name: string) => name === 'run_cmd');
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        mockHasAction
+      );
+
+      const messagesWithFinished = [
+        { id: 'user-1', role: 'user', content: 'Run it' },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'tc-1', type: 'function', function: { name: 'run_cmd', arguments: '{}' } },
+          ],
+        },
+        { id: 'tool-1', role: 'tool', content: 'done', toolCallId: 'tc-1' },
+      ];
+
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([
+          { type: 'MESSAGES_SNAPSHOT', messages: messagesWithFinished, timestamp: Date.now() },
+        ]);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      expect(result).not.toBeNull();
+      const types = result!.map((e: any) => e.type);
+      expect(types).not.toContain('TOOL_CALL_START');
+    });
+
+    it('should not inject synthetic events for non-frontend tool calls', async () => {
+      const mockHasAction = jest.fn().mockReturnValue(false);
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        mockHasAction
+      );
+
+      const messagesWithServerTool = [
+        { id: 'user-1', role: 'user', content: 'Run it' },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'tc-1', type: 'function', function: { name: 'server_tool', arguments: '{}' } },
+          ],
+        },
+      ];
+
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue([
+          { type: 'MESSAGES_SNAPSHOT', messages: messagesWithServerTool, timestamp: Date.now() },
+        ]);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      expect(result).not.toBeNull();
+      const types = result!.map((e: any) => e.type);
+      expect(types).not.toContain('TOOL_CALL_START');
     });
   });
 

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -8,16 +8,18 @@ import { AgUiAgent } from './ag_ui_agent';
 import { RunAgentInput, Message, UserMessage, ToolMessage } from '../../common/types';
 import type { ToolDefinition } from '../../../context_provider/public';
 import { AssistantActionService } from '../../../context_provider/public';
-import { ChatLayoutMode } from '../types';
 import type { ChatWindowInstance } from '../components/chat_window';
 import {
   IUiSettingsClient,
   UiSettingScope,
   ChatServiceStart,
-  ChatWindowState,
   WorkspacesStart,
   Event,
   EventType,
+  MessagesSnapshotEvent,
+  ToolCallStartEvent,
+  ToolCallArgsEvent,
+  ToolCallEndEvent,
 } from '../../../../core/public';
 import { getDefaultDataSourceId } from '../../../data_source_management/public';
 import { ConversationHistoryService } from './conversation_history_service';
@@ -404,6 +406,7 @@ export class ChatService {
     intervalMs: number = 1000
   ): Promise<void> {
     const threadId = this.getThreadId();
+    if (!threadId) return;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
@@ -581,15 +584,103 @@ export class ChatService {
   }
 
   /**
-   * Restore the latest conversation from agentic memory
-   * Returns the messages and thread ID
-   * If thread ID is already set, skip restore (use existing thread)
-   * If no conversation can be restored, generate a new thread
+   * Preprocess a conversation's event array before replay.
+   *
+   * Finds the MESSAGES_SNAPSHOT event and checks whether the last assistant message
+   * contains tool calls that have no corresponding tool result messages (i.e. the
+   * frontend tool execution never completed). When such "unfinished" tool calls are
+   * found the method:
+   *   1. Rewrites the MESSAGES_SNAPSHOT so the last assistant message only contains
+   *      the *finished* tool calls — giving the event handler a clean baseline.
+   *   2. Appends synthetic TOOL_CALL_START → TOOL_CALL_ARGS → TOOL_CALL_END events
+   *      for every unfinished tool call so the event handler re-executes them exactly
+   *      as if they had just arrived from the agent.
+   *
+   * If there are no unfinished tool calls the original array is returned unchanged.
    */
-  public async restoreLatestConversation(): Promise<{
-    threadId: string;
-    messages: Message[];
-  } | null> {
+  private injectUnfinishedToolCallEvents(events: Event[]): Event[] {
+    const snapshotIndex = events.findIndex((e) => e.type === EventType.MESSAGES_SNAPSHOT);
+    if (snapshotIndex === -1) return events;
+
+    const snapshot = events[snapshotIndex] as MessagesSnapshotEvent;
+    const messages = snapshot.messages;
+    if (!messages || messages.length === 0) return events;
+
+    const lastMessage = messages[messages.length - 1];
+    if (
+      lastMessage.role !== 'assistant' ||
+      !('toolCalls' in lastMessage) ||
+      !lastMessage.toolCalls
+    ) {
+      return events;
+    }
+
+    const toolResultIds = new Set(
+      messages
+        .filter((m) => m.role === 'tool' && 'toolCallId' in m)
+        .map((m) => (m as any).toolCallId as string)
+    );
+
+    const assistantActionService = AssistantActionService.getInstance();
+
+    const unfinished = lastMessage.toolCalls.filter(
+      (tc) => assistantActionService.hasAction(tc.function.name) && !toolResultIds.has(tc.id)
+    );
+
+    if (unfinished.length === 0) return events;
+
+    const unfinishedIds = new Set(unfinished.map((tc) => tc.id));
+
+    // Rewrite the snapshot: strip unfinished tool calls from the last assistant message
+    const patchedLastMessage = {
+      ...lastMessage,
+      toolCalls: lastMessage.toolCalls.filter((tc) => !unfinishedIds.has(tc.id)),
+    };
+    const patchedSnapshot: MessagesSnapshotEvent = {
+      ...snapshot,
+      messages: [...messages.slice(0, -1), patchedLastMessage],
+    };
+
+    // Build synthetic tool call events for each unfinished tool call
+    const syntheticEvents: Event[] = [];
+    for (const toolCall of unfinished) {
+      syntheticEvents.push({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: toolCall.id,
+        toolCallName: toolCall.function.name,
+        parentMessageId: lastMessage.id,
+        timestamp: Date.now(),
+      } as ToolCallStartEvent);
+
+      syntheticEvents.push({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: toolCall.id,
+        delta: toolCall.function.arguments,
+        timestamp: Date.now(),
+      } as ToolCallArgsEvent);
+
+      syntheticEvents.push({
+        type: EventType.TOOL_CALL_END,
+        toolCallId: toolCall.id,
+        timestamp: Date.now(),
+      } as ToolCallEndEvent);
+    }
+
+    // Return: events before snapshot + patched snapshot + events after snapshot + synthetic events
+    return [
+      ...events.slice(0, snapshotIndex),
+      patchedSnapshot,
+      ...events.slice(snapshotIndex + 1),
+      ...syntheticEvents,
+    ];
+  }
+
+  /**
+   * Restore the latest conversation from agentic memory.
+   * Returns the AG-UI event array (with unfinished tool calls injected) for replay,
+   * or null if no conversation exists or a thread is already active.
+   */
+  public async restoreLatestConversation(): Promise<Event[] | null> {
     // Check if thread ID is already set - if so, skip restore and use existing thread
     const currentThreadId = this.coreChatService?.getThreadId();
     if (currentThreadId) {
@@ -606,7 +697,6 @@ export class ChatService {
     if (result.conversations.length > 0) {
       // Found a latest conversation - get full details
       const latestConversationSummary = result.conversations[0];
-
       // Get the full conversation with all events
       const events = await this.conversationHistoryService.getConversation(
         latestConversationSummary.threadId
@@ -618,28 +708,22 @@ export class ChatService {
         return null;
       }
 
-      // Extract messages from MESSAGES_SNAPSHOT event
-      const snapshotEvent = events.find((e) => e.type === EventType.MESSAGES_SNAPSHOT);
-      if (snapshotEvent && 'messages' in snapshotEvent) {
-        // Set the thread ID in core service
-        if (this.coreChatService) {
-          this.coreChatService.setThreadId(latestConversationSummary.threadId);
-        }
-        return {
-          threadId: latestConversationSummary.threadId,
-          messages: snapshotEvent.messages,
-        };
+      // Set the thread ID in core service
+      if (this.coreChatService) {
+        this.coreChatService.setThreadId(latestConversationSummary.threadId);
       }
+
+      return this.injectUnfinishedToolCallEvents(events);
     }
 
-    // No conversation found or no snapshot event, generate a new thread
+    // No conversation found, generate a new thread
     this.newThread();
     return null;
   }
 
   /**
-   * Load a conversation from history
-   * Returns AG-UI event array for proper state restoration
+   * Load a specific conversation from history by thread ID.
+   * Returns the AG-UI event array (with unfinished tool calls injected) for replay.
    */
   public async loadConversation(threadId: string): Promise<Event[] | null> {
     const events = await this.conversationHistoryService.getConversation(threadId);
@@ -652,7 +736,7 @@ export class ChatService {
       this.coreChatService.setThreadId(threadId);
     }
 
-    return events;
+    return this.injectUnfinishedToolCallEvents(events);
   }
 
   /**


### PR DESCRIPTION
### Description

When a conversation is restored (on mount or when switching from history), any unfinished frontend tool calls were not replayed correctly. This PR fixes that by moving the unfinished tool call detection and injection logic into `ChatService`, so both `restoreLatestConversation` and `loadConversation` return a complete AG-UI event array ready for replay. Only frontend tools registered via `AssistantActionService` (including disabled ones) are treated as unfinished.

As part of this change, `restoreLatestConversation` now returns `Event[] | null` instead of `{ threadId, messages }`, and the chat window replays all events through `eventHandler` rather than setting the timeline directly. This also fixes a state bleed issue where tool call states from a previous session could leak into a newly loaded one.

### Testing the changes

**Setup:** Load sample data (e.g. OpenSearch Dashboards sample web logs) and open the Explore page with the chat assistant available.

**Reproduce the bug (before this fix):**
1. Open the chat window on the Explore page and ask: "use execute_ppl_query to show me the top 5 source IPs from opensearch_dashboards_sample_data_logs"
2. While the query is still running, **refresh the page**
3. Reopen the chat window
4. **Before fix:** the conversation is restored but the `execute_ppl_query` tool call is missing — the assistant never gets a result and the conversation is stuck
5. **After fix:** the `execute_ppl_query` tool call is re-triggered automatically, the query runs again, and the assistant receives the result and continues normally

**Also verify switching conversations:**
1. Repeat steps 1–2 above but instead of refreshing, open conversation history and switch to a different conversation, then switch back
2. **After fix:** the unfinished tool call is re-triggered when switching back to the original conversation

### Check List
- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff