### PR TITLE
[Explore] Restrict field stats tab to only OpenSearch datasets

### DIFF
--- a/src/plugins/explore/public/components/tabs/tabs.tsx
+++ b/src/plugins/explore/public/components/tabs/tabs.tsx
@@ -19,7 +19,7 @@ import { ExploreServices } from '../../types';
 import { RootState } from '../../application/utils/state_management/store';
 import { useFlavorId } from '../../helpers/use_flavor_id';
 import { ErrorGuard } from './error_guard/error_guard';
-import { EXPLORE_PATTERNS_TAB_ID } from '../../../common';
+import { EXPLORE_PATTERNS_TAB_ID, EXPLORE_FIELD_STATS_TAB_ID } from '../../../common';
 import { DEFAULT_DATA } from '../../../../data/common';
 
 export const EXPLORE_ACTION_BAR_SLOT_ID = 'explore-action-bar-slot';
@@ -62,11 +62,12 @@ export const ExploreTabs = () => {
     return registryTabs.filter((registryTab) => {
       const registeredFlavor = registryTab.flavor.includes(flavorId);
       const isPatternsTab = registryTab.id === EXPLORE_PATTERNS_TAB_ID;
+      const isFieldStatsTab = registryTab.id === EXPLORE_FIELD_STATS_TAB_ID;
       const isDefaultDataset =
         query?.dataset &&
         (query.dataset.type === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN ||
           query.dataset.type === DEFAULT_DATA.SET_TYPES.INDEX);
-      if (isPatternsTab) {
+      if (isPatternsTab || isFieldStatsTab) {
         return registeredFlavor && isDefaultDataset;
       }
       return registeredFlavor;


### PR DESCRIPTION
### Description

Restrict the Field Stats tab to only appear for OpenSearch-backed datasets (index patterns and indices), matching the existing behavior of the Patterns tab. Non-OpenSearch datasets like S3 don't support the field stats queries, so the tab should not be shown.

### Issues Resolved

N/A

## Testing the changes

1. Start OpenSearch Dashboards with Explore enabled: `yarn start:explore`
2. Enable experimental features: set `explore:experimental` to `true` in Advanced Settings
3. Select an index pattern dataset → verify both Patterns and Field Stats tabs appear
4. Select an S3 dataset → verify neither Patterns nor Field Stats tabs appear
5. Select an index (non-pattern) dataset → verify both tabs appear

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff