### PR TITLE
feat(vis): support multiple fields per axis in visualizations

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/16/build_vis.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/16/build_vis.spec.js
@@ -27,10 +27,12 @@ export const runBuildVisTests = () => {
 
     const selectFieldFromComboBox = (labelText, index, fieldName) => {
       cy.get('.euiFormLabel').contains(labelText).should('be.visible');
-      cy.get('#axesSelector').within(() => {
-        cy.get('[data-test-subj="comboBoxInput"]').eq(index).click();
-      });
-      cy.get('div[role="listBox"]').contains(fieldName).click();
+      cy.get('.euiFormLabel')
+        .contains(labelText)
+        .closest('.euiFormRow')
+        .find('[data-test-subj="axisSelectorButton"]')
+        .click();
+      cy.get('li[role="option"]').contains(fieldName).trigger('click');
       cy.wait(500);
     };
 

--- a/src/plugins/agent_traces/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/agent_traces/public/components/visualizations/visualization_container.tsx
@@ -22,10 +22,6 @@ import {
 } from '../../application/utils/state_management/slices';
 import { executeQueries } from '../../application/utils/state_management/actions/query_actions';
 
-export interface UpdateVisualizationProps {
-  mappings: Record<string, string>;
-}
-
 export const VisualizationContainer = React.memo(() => {
   const { services } = useOpenSearchDashboards<AgentTracesServices>();
   const { results } = useTabResults();

--- a/src/plugins/agent_traces/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/agent_traces/public/components/visualizations/visualization_container.tsx
@@ -9,7 +9,6 @@ import React, { useCallback, useEffect } from 'react';
 import moment from 'moment';
 import { useDispatch } from 'react-redux';
 
-import { AxisColumnMappings } from '../../../../explore/public';
 import { useTabResults } from '../../application/utils/hooks/use_tab_results';
 import { useSearchContext } from '../query_panel/utils/use_search_context';
 import { getVisualizationBuilder } from './visualization_builder_singleton';
@@ -24,7 +23,7 @@ import {
 import { executeQueries } from '../../application/utils/state_management/actions/query_actions';
 
 export interface UpdateVisualizationProps {
-  mappings: AxisColumnMappings;
+  mappings: Record<string, string>;
 }
 
 export const VisualizationContainer = React.memo(() => {

--- a/src/plugins/explore/public/components/visualizations/README.md
+++ b/src/plugins/explore/public/components/visualizations/README.md
@@ -1,19 +1,18 @@
 # OpenSearch Dashboards Visualizations
 
-This directory contains the visualization components for the OpenSearch Dashboards Explore plugin. It provides a flexible, rule-based system for rendering different types of visualizations based on data structure.
+This directory contains the visualization components for the OpenSearch Dashboards Explore plugin. It provides a flexible, registry-based system for rendering different types of visualizations based on axis-role mappings and data column types.
 
 ## Structure
 
-| Component                    | Description                                                        |
-| ---------------------------- | ------------------------------------------------------------------ |
-| **Visualization Registry**   | Manages the registration and retrieval of visualization rules      |
-| **Rule Repository**          | Contains predefined rules for matching data to visualization types |
-| **Visualization Container**  | Renders the selected visualization with its own styling options    |
-| **Type-specific Components** | Implementation for each supported chart type                       |
+| Component                  | Description                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| **Visualization Registry** | Manages registration and retrieval of `VisualizationType` configurations     |
+| **Visualization Builder**  | Orchestrates chart selection, axis mapping, style management, and rendering  |
+| **Type-specific Configs**  | Each chart type defines its rules, axis mappings, defaults, and render logic |
+| **Style Panel**            | Shared and chart-specific style controls (axes, legend, thresholds, etc.)    |
+| **ECharts Render**         | Common ECharts rendering component used by most chart types                  |
 
 ## Supported Visualization Types
-
-The system currently supports the following visualization types:
 
 <table>
   <tr>
@@ -26,27 +25,59 @@ The system currently supports the following visualization types:
     <td><strong>Scatter Plots</strong></td>
     <td><strong>Metric Visualizations</strong></td>
   </tr>
+  <tr>
+    <td><strong>Area Charts</strong></td>
+    <td><strong>Tables</strong></td>
+    <td><strong>Gauges</strong></td>
+  </tr>
+  <tr>
+    <td><strong>Bar Gauges</strong></td>
+    <td><strong>Histograms</strong></td>
+    <td><strong>State Timelines</strong></td>
+  </tr>
 </table>
 
-## Rule-Based Visualization Selection
+## Architecture
 
-### How Rules Work
+### VisualizationType
 
-Each visualization rule defines:
+Each chart type is defined as a `VisualizationType<T>` object containing:
 
-1. A unique identifier
-2. A matching function that determines if the rule applies to the given set of data
-3. A list of chart types with priorities
-4. A function to convert the data to a vega expression for rendering
+- `name` / `type` / `icon` — metadata
+- `getRules()` — returns an array of `VisRule<T>` objects
+- `ui.style.defaults` — default style options
+- `ui.style.render` — React component for the style panel
 
-### Rule to Chart Type Mapping
+### VisRule and Axis Mappings
 
-**Key Feature:** Each rule can map to multiple chart types with different priorities
+Each `VisRule` defines:
 
-This allows for:
+1. A **priority** (higher = preferred when multiple rules match)
+2. One or more **mappings** — each mapping is a `Record<AxisRole, { type: VisFieldType }>` that declares which axis roles map to which field types
+3. A **render** function that produces the chart's React output
 
-- Providing alternative visualization options for the same data structure
-- Defining a default (highest priority) visualization while allowing users to switch to alternatives
+```typescript
+interface VisRule<T extends ChartType> {
+  priority: number;
+  mappings: AxisTypeMapping[];
+  render: (props: VisRenderProps<T>) => React.ReactNode;
+}
+```
+
+Axis roles include: `x`, `y`, `color`, `facet`, `size`, `y2`, `value`, `time`.
+
+Field types include: `numerical`, `categorical`, `date`.
+
+A single rule can have multiple mappings (e.g., allowing either X=Date/Y=Numerical or X=Numerical/Y=Date). The registry matches rules by comparing the required field type counts in each mapping against the available columns.
+
+### Rule Matching
+
+The `VisualizationRegistry` provides two levels of matching:
+
+- **Exact match**: the mapping's required field counts equal the input column counts exactly
+- **Compatible match**: the mapping's required field counts are less than or equal to the input counts (superset)
+
+The `findBestMatch` method returns the highest-priority rule with an exact column-count match, optionally scoped to a specific chart type.
 
 For a complete reference of all currently defined rules, see the [Visualization Rules Reference](./RULES.md).
 
@@ -54,179 +85,74 @@ For a complete reference of all currently defined rules, see the [Visualization 
 
 ### Basic Usage
 
-The visualization container automatically selects and renders the appropriate visualization based on the data:
+The `VisualizationBuilder` handles chart selection and rendering automatically:
 
 ```tsx
 <VisualizationContainer />
 ```
 
-### Accessing Available Chart Types
+### Accessing the Registry
 
 ```typescript
-const visualizationData = getVisualizationType(rows, fieldSchema);
-const availableChartTypes = visualizationData?.availableChartTypes;
+// Via React hook (preferred)
+const registry = useVisualizationRegistry();
 
-// availableChartTypes contains all chart types that can be used with the current data
-// sorted by priority
+// Via plugin services
+const registry = services.visualizationRegistry.getRegistry();
 ```
 
-### Registering New Visualization Rules
+### Registering a New Visualization Type
 
-To add a new visualization rule:
-
-1. Define a new rule object that implements the `VisualizationRule` interface:
+1. Define a config factory that returns a `VisualizationType`:
 
 ```typescript
-const myCustomRule: VisualizationRule = {
-  id: 'my-custom-rule',
-  name: 'My Custom Rule',
-  description: 'Description of when this rule applies',
-
-  // Define when this rule should match
-  matches: (numerical, categorical, date) => numerical.length === 2 && categorical.length === 1,
-
-  // Define chart types with priorities (higher number = higher priority)
-  chartTypes: [
-    { type: 'scatter', priority: 100, name: 'Scatter Plot' },
-    { type: 'bar', priority: 80, name: 'Bar Chart' },
+export const createMyChartConfig = (): VisualizationType<'my_chart'> => ({
+  name: 'My Chart',
+  type: 'my_chart',
+  icon: 'visMyChart',
+  getRules: () => [
+    {
+      priority: 100,
+      mappings: [
+        {
+          [AxisRole.X]: { type: VisFieldType.Categorical },
+          [AxisRole.Y]: { type: VisFieldType.Numerical },
+        },
+      ],
+      render(props) {
+        const spec = createMyChartSpec(
+          props.transformedData,
+          props.styleOptions,
+          props.axisColumnMappings
+        );
+        return <EchartsRender spec={spec} />;
+      },
+    },
   ],
-
-  // Define how to convert data to an expression
-  toExpression: (
-    transformedData,
-    numericalColumns,
-    categoricalColumns,
-    dateColumns,
-    styleOptions,
-    chartType = 'scatter'
-  ) => {
-    switch (chartType) {
-      case 'scatter':
-        return createCustomScatterChart(
-          transformedData,
-          numericalColumns,
-          categoricalColumns,
-          styleOptions
-        );
-      case 'bar':
-        return createCustomBarChart(
-          transformedData,
-          numericalColumns,
-          categoricalColumns,
-          styleOptions
-        );
-      default:
-        return createCustomScatterChart(
-          transformedData,
-          numericalColumns,
-          categoricalColumns,
-          styleOptions
-        );
-    }
+  ui: {
+    style: {
+      defaults: defaultMyChartStyles,
+      render: (props) => React.createElement(MyChartVisOptions, props),
+    },
   },
-};
+});
 ```
 
-2. Register the rule with the visualization registry:
+2. Register it via the `VisualizationRegistryService` setup contract:
 
 ```typescript
-// Register a single rule
-visualizationRegistry.registerRule(myCustomRule);
-
-// Or register multiple rules
-visualizationRegistry.registerRules([myCustomRule, anotherRule]);
+visualizationRegistry.register(createMyChartConfig());
 ```
 
-### Adding a New Chart Type
+3. Add the new chart type to the `ChartType` union and `ChartStylesMapping` interface in `utils/use_visualization_types.ts`.
 
-To add a new chart type:
-
-1. Create a new directory for your chart type:
+### Adding a New Chart Type Directory
 
 ```
 visualizations/
-└── my_chart_type/
-    ├── my_chart_vis_config.ts     # Chart configuration
-    ├── my_chart_vis_options.tsx   # UI options component
-    ├── to_expression.ts           # Expression generation
-    └── ... other files
-```
-
-2. Define the chart configuration in `my_chart_vis_config.ts`:
-
-```typescript
-export interface MyChartStyleControls {
-  // Define style options specific to your chart
-  showLegend: boolean;
-  colors: string[];
-  // ... other options
-}
-
-export const createMyChartConfig = () => {
-  return {
-    name: 'My Chart',
-    type: 'my_chart_type',
-    ui: {
-      style: {
-        defaults: {
-          showLegend: true,
-          colors: ['#1EA7FD', '#FF5733'],
-          // ... default values for other options
-        },
-        render: (props: StyleControlsProps<MyChartStyleControls>) => (
-          <MyChartVisOptions {...props} />
-        ),
-      },
-    },
-  };
-};
-```
-
-3. Create the expression generator in `to_expression.ts`:
-
-```typescript
-export const createMyChartExpression = (
-  transformedData: Array<Record<string, any>>,
-  numericalColumns: VisColumn[],
-  categoricalColumns: VisColumn[],
-  dateColumns: VisColumn[],
-  styleOptions: MyChartStyleControls
-) => {
-  // Generate the expression for your chart
-  // ...
-
-  return {
-    type: 'expression',
-    chain: [
-      // Your expression chain
-    ],
-  };
-};
-```
-
-4. Update the `ChartType` type and `ChartStyleControlMap` interface in `utils/use_visualization_types.ts`:
-
-```typescript
-export type ChartType = 'line' | 'pie' | /* ... */ | 'my_chart_type';
-
-export interface ChartStyleControlMap {
-  line: LineChartStyleControls;
-  pie: PieChartStyleControls;
-  // ... other chart types
-  my_chart_type: MyChartStyleControls;
-}
-```
-
-5. Update the `getVisualizationConfig` method in `visualization_registry.ts`:
-
-```typescript
-private getVisualizationConfig(type: string) {
-  switch (type) {
-    // ... existing cases
-    case 'my_chart_type':
-      return createMyChartConfig();
-    default:
-      return;
-  }
-}
+└── my_chart/
+    ├── my_chart_vis_config.tsx      # VisualizationType factory + style types + defaults
+    ├── my_chart_vis_options.tsx      # Style panel component
+    ├── to_expression.ts             # ECharts spec generation
+    └── ... other files (utils, tests, exclusive options)
 ```

--- a/src/plugins/explore/public/components/visualizations/RULES.md
+++ b/src/plugins/explore/public/components/visualizations/RULES.md
@@ -2,359 +2,177 @@
 
 ## Table of Contents
 
-- [Overview](#rule-overview)
-- [Rules Summary](#rules-summary)
-- [Detailed Rules](#current-rules)
-  - [Time Series Rules](#time-series-rules)
-  - [Metric and Category Combined Rules](#metric-and-category-combined-rules)
-  - [Metric Rules](#metric-rules)
+- [Overview](#overview)
+- [Rules Summary by Chart Type](#rules-summary-by-chart-type)
+- [Detailed Rules](#detailed-rules)
+  - [Line](#line)
+  - [Bar](#bar)
+  - [Area](#area)
+  - [Pie](#pie)
+  - [Scatter](#scatter)
+  - [Heatmap](#heatmap)
+  - [Metric](#metric)
+  - [Gauge](#gauge)
+  - [Bar Gauge](#bar-gauge)
+  - [Histogram](#histogram)
+  - [State Timeline](#state-timeline)
+  - [Table](#table)
 - [Rule Evaluation Process](#rule-evaluation-process)
 
-## Rule Overview
+## Overview
 
-Rules are evaluated based on the number and types of columns in the query resulted data:
+Each chart type registers one or more `VisRule` objects. A rule declares:
 
-- **Numerical columns**: Columns containing numeric values
-- **Categorical columns**: Columns containing text or categorical values
-- **Date columns**: Columns containing date/timestamp values
+- **priority** — higher values win when multiple rules match the same data shape
+- **mappings** — one or more axis-role-to-field-type maps; a rule matches if any mapping is compatible with the input columns
+- **render** — produces the chart React element
 
-Each rule has a unique ID, a matching function, and a list of chart types with priorities. The rule with the highest priority chart type is selected for visualization by default.
+Axis roles: `x`, `y`, `y2`, `color`, `facet`, `size`, `value`, `time`
+Field types: `numerical`, `categorical`, `date`
 
-## Rules Summary
+## Rules Summary by Chart Type
 
-| Rule ID                                  | Numerical | Categorical | Date | Default Chart | Other Charts    |
-| ---------------------------------------- | --------- | ----------- | ---- | ------------- | --------------- |
-| one-metric-one-date                      | 1         | 0           | 1    | Line          | Area, Bar       |
-| two-metric-one-date                      | 2         | 0           | 1    | Line          | Area, Bar       |
-| one-metric-one-category-one-date         | 1         | 1           | 1    | Line          | Area, Bar       |
-| one-metric-two-category-one-date         | 1         | 2           | 1    | Line          | Area, Bar       |
-| three-metric                             | 3         | 0           | 0    | Heatmap       | -               |
-| one-metric-two-category-high-cardinality | 1         | 2           | 0    | Heatmap       | Bar, Area       |
-| one-metric-two-category-low-cardinality  | 1         | 2           | 0    | Bar           | Heatmap, Area   |
-| one-metric-one-category                  | 1         | 1           | 0    | Bar           | Pie, Line, Area |
-| one-metric                               | 1         | 0           | 0    | Metric        | -               |
-| two-metric                               | 2         | 0           | 0    | Scatter       | -               |
-| two-metric-one-category                  | 2         | 1           | 0    | Scatter       | -               |
-| three-metric-one-category                | 3         | 1           | 0    | Scatter       | -               |
+| Chart Type     | # Rules | Axis Patterns Supported                                                                                                                        |
+| -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Line           | 9       | Date×Num, Date×Num×Num, Date×Num×Cat, Date×Num×Num(color), Date×Num×Cat×Cat(facet), Date×Num×Num×Cat(facet), Cat×Num, Cat×Num×Cat, Cat×Num×Num |
+| Bar            | 9       | Cat×Num, Date×Num, Date×Num×Cat, Date×Num×Num, Date×Num×Cat×Cat(facet), Date×Num×Num×Cat(facet), Cat×Num×Cat, Cat×Num×Num, Num×Num             |
+| Area           | 8       | Date×Num, Date×Num×Cat, Date×Num×Num, Date×Num×Cat×Cat(facet), Date×Num×Num×Cat(facet), Cat×Num, Cat×Num×Cat, Cat×Num×Num                      |
+| Pie            | 2       | Num×Cat (size×color), Num×Num (size×color)                                                                                                     |
+| Scatter        | 3       | Num×Num, Num×Num×Cat, Num×Num×Cat×Num(size)                                                                                                    |
+| Heatmap        | 1       | Cat×Cat×Num (x×y×color)                                                                                                                        |
+| Metric         | 4       | Num(value), Num×Date(value×time), Num×Cat(value×facet), Num×Date×Cat(value×time×facet)                                                         |
+| Gauge          | 1       | Num(value)                                                                                                                                     |
+| Bar Gauge      | 1       | Num×Cat (y×x or x×y)                                                                                                                           |
+| Histogram      | 2       | Num×Num, Num(single)                                                                                                                           |
+| State Timeline | 4       | Date×Cat×Num, Date×Cat×Cat, Date×Cat(single), Date×Num(single)                                                                                 |
+| Table          | 0       | No rules (always available as a fallback)                                                                                                      |
 
-## Current Rules
+## Detailed Rules
 
-### Time Series Rules
-
-These rules apply to data with date columns and are typically used for time series visualizations.
-
-#### 1. One Metric & One Date Rule
+### Line
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric-one-date</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Time series visualization for single metric</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>1 Date column</li>
-          <li>0 Categorical columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Line Chart (priority: 100) - Default</li>
-          <li>Area Chart (priority: 80)</li>
-          <li>Bar Chart (priority: 60)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>100</td><td><code>x: date, y: numerical</code></td><td>Simple line chart</td></tr>
+  <tr><td>100</td><td><code>x: date, y: numerical, y2: numerical</code></td><td>Line + bar combo chart</td></tr>
+  <tr><td>100</td><td><code>x: date, y: numerical, color: categorical</code></td><td>Multi-line chart (grouped by category)</td></tr>
+  <tr><td>80</td><td><code>x: date, y: numerical, color: numerical</code></td><td>Multi-line chart (grouped by numerical)</td></tr>
+  <tr><td>100</td><td><code>x: date, y: numerical, color: categorical, facet: categorical</code></td><td>Faceted multi-line chart</td></tr>
+  <tr><td>80</td><td><code>x: date, y: numerical, color: numerical, facet: categorical</code></td><td>Faceted multi-line chart (numerical color)</td></tr>
+  <tr><td>40</td><td><code>x: categorical, y: numerical</code></td><td>Category line chart</td></tr>
+  <tr><td>40</td><td><code>x: categorical, y: numerical, color: categorical</code></td><td>Category multi-line chart</td></tr>
+  <tr><td>40</td><td><code>x: categorical, y: numerical, color: numerical</code></td><td>Category multi-line chart (numerical color)</td></tr>
 </table>
 
-#### 2. Two Metric & One Date Rule
+### Bar
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>two-metric-one-date</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Time series visualization for double metrics</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>2 Numerical columns</li>
-          <li>1 Date column</li>
-          <li>0 Categorical columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Line Chart (priority: 100) - Default</li>
-          <li>Area Chart (priority: 80)</li>
-          <li>Bar Chart (priority: 60)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>100</td><td><code>x: categorical, y: numerical</code> (or swapped)</td><td>Simple bar chart</td></tr>
+  <tr><td>60</td><td><code>x: date, y: numerical</code> (or swapped)</td><td>Time bar chart</td></tr>
+  <tr><td>60</td><td><code>x: date, y: numerical, color: categorical</code> (or swapped x/y)</td><td>Grouped time bar chart</td></tr>
+  <tr><td>80</td><td><code>x: date, y: numerical, color: numerical</code> (or swapped x/y)</td><td>Grouped time bar chart (numerical color)</td></tr>
+  <tr><td>60</td><td><code>x: date, y: numerical, color: categorical, facet: categorical</code> (or swapped x/y)</td><td>Faceted time bar chart</td></tr>
+  <tr><td>100</td><td><code>x: date, y: numerical, color: numerical, facet: categorical</code> (or swapped x/y)</td><td>Faceted time bar chart (numerical color)</td></tr>
+  <tr><td>100</td><td><code>x: categorical, y: numerical, color: categorical</code> (or swapped x/y)</td><td>Stacked bar chart</td></tr>
+  <tr><td>80</td><td><code>x: categorical, y: numerical, color: numerical</code> (or swapped x/y)</td><td>Stacked bar chart (numerical color)</td></tr>
+  <tr><td>60</td><td><code>x: numerical, y: numerical</code></td><td>Double numerical bar chart</td></tr>
 </table>
 
-#### 3. One Metric, One Category & One Date Rule
+Note: Many bar rules include a swapped mapping variant (x↔y) to support horizontal orientation.
+
+### Area
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric-one-category-one-date</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Time series visualization with one metric and one category</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>1 Categorical column</li>
-          <li>1 Date column</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Line Chart (priority: 100) - Default</li>
-          <li>Area Chart (priority: 80)</li>
-          <li>Bar Chart (priority: 60)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>80</td><td><code>x: date, y: numerical</code></td><td>Simple area chart</td></tr>
+  <tr><td>80</td><td><code>x: date, y: numerical, color: categorical</code></td><td>Multi-area chart</td></tr>
+  <tr><td>60</td><td><code>x: date, y: numerical, color: numerical</code></td><td>Multi-area chart (numerical color)</td></tr>
+  <tr><td>80</td><td><code>x: date, y: numerical, color: categorical, facet: categorical</code></td><td>Faceted multi-area chart</td></tr>
+  <tr><td>60</td><td><code>x: date, y: numerical, color: numerical, facet: categorical</code></td><td>Faceted multi-area chart (numerical color)</td></tr>
+  <tr><td>20</td><td><code>x: categorical, y: numerical</code></td><td>Category area chart</td></tr>
+  <tr><td>60</td><td><code>x: categorical, y: numerical, color: categorical</code></td><td>Stacked area chart</td></tr>
+  <tr><td>60</td><td><code>x: categorical, y: numerical, color: numerical</code></td><td>Stacked area chart (numerical color)</td></tr>
 </table>
 
-#### 4. One Metric, Two Category & One Date Rule
+### Pie
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric-two-category-one-date</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Multiple time series visualizations</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>2 Categorical columns</li>
-          <li>1 Date column</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Line Chart (priority: 100) - Default</li>
-          <li>Area Chart (priority: 80)</li>
-          <li>Bar Chart (priority: 60)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>60</td><td><code>size: numerical, color: categorical</code></td><td>Pie/donut chart</td></tr>
+  <tr><td>40</td><td><code>size: numerical, color: numerical</code></td><td>Pie/donut chart (numerical slices)</td></tr>
 </table>
 
----
-
-### Metric and Category Combined Rules
-
-These rules apply to data with categorical columns and/or multiple numerical columns but no date columns.
-
-#### 5. One Metric, Two Category (High Cardinality) Rule
+### Scatter
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric-two-category-high-cardinality</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Heatmap for one metric and two category with high cardinality</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>2 Categorical columns</li>
-          <li>0 Date columns</li>
-          <li>At least one column has 7 or more unique values</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Heatmap (priority: 100) - Default</li>
-          <li>Bar Chart (priority: 80)</li>
-          <li>Area Chart (priority: 60)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>100</td><td><code>x: numerical, y: numerical</code></td><td>Two-metric scatter</td></tr>
+  <tr><td>100</td><td><code>x: numerical, y: numerical, color: categorical</code></td><td>Two-metric scatter with category coloring</td></tr>
+  <tr><td>100</td><td><code>x: numerical, y: numerical, color: categorical, size: numerical</code></td><td>Bubble chart (three metrics + category)</td></tr>
 </table>
 
-#### 6. One Metric, Two Category (Low Cardinality) Rule
+### Heatmap
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric-two-category-low-cardinality</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Bar chart for one metric and two category with low cardinality</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>2 Categorical columns</li>
-          <li>0 Date columns</li>
-          <li>All columns have fewer than 7 unique values</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Bar Chart (priority: 100) - Default</li>
-          <li>Heatmap (priority: 80)</li>
-          <li>Area Chart (priority: 60)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>90</td><td><code>x: categorical, y: categorical, color: numerical</code></td><td>Regular heatmap</td></tr>
 </table>
 
-#### 7. One Metric, One Category Rule
+### Metric
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric-one-category</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Multiple visualizations for one metric and one category</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>1 Categorical column</li>
-          <li>0 Date columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Bar Chart (priority: 100) - Default</li>
-          <li>Pie Chart (priority: 80)</li>
-          <li>Line Chart (priority: 60)</li>
-          <li>Area Chart (priority: 40)</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>100</td><td><code>value: numerical</code></td><td>Single metric</td></tr>
+  <tr><td>40</td><td><code>value: numerical, time: date</code></td><td>Single metric (with time context)</td></tr>
+  <tr><td>50</td><td><code>value: numerical, facet: categorical</code></td><td>Multi-metric (faceted by category)</td></tr>
+  <tr><td>50</td><td><code>value: numerical, time: date, facet: categorical</code></td><td>Multi-metric (faceted, with time context)</td></tr>
 </table>
 
-#### 8. Two Metric, One Category Rule
+### Gauge
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>two-metric-one-category</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Scatter plot for two metrics and one category</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>2 Numerical columns</li>
-          <li>1 Categorical column</li>
-          <li>0 Date columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Scatter (priority: 100) - Default</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>80</td><td><code>value: numerical</code></td><td>Gauge</td></tr>
 </table>
 
-#### 9. Three Metric, One Category Rule
+### Bar Gauge
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>three-metric-one-category</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Scatter plot for three metrics and one category</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>3 Numerical columns</li>
-          <li>1 Categorical column</li>
-          <li>0 Date columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Scatter (priority: 100) - Default</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>80</td><td><code>y: numerical, x: categorical</code> (or swapped)</td><td>Bar gauge</td></tr>
 </table>
 
----
-
-### Metric Rules
-
-These rules apply to data with only numerical columns and no categorical or date columns.
-
-#### 10. Two Metric Rule
+### Histogram
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>two-metric</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Scatter plot for two metrics</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>2 Numerical columns</li>
-          <li>0 Categorical columns</li>
-          <li>0 Date columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Scatter (priority: 100) - Default</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>80</td><td><code>x: numerical, y: numerical</code></td><td>Numerical histogram</td></tr>
+  <tr><td>60</td><td><code>x: numerical</code></td><td>Single-column histogram</td></tr>
 </table>
 
-#### 11. Three Metrics Rule
+### State Timeline
 
 <table>
-  <tr><td><strong>ID</strong></td><td><code>three-metric</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Heatmap with bin for three metric</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>3 Numerical columns</li>
-          <li>0 Categorical columns</li>
-          <li>0 Date columns</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Heatmap (priority: 100) - Default</li>
-        </ul>
-      </td>
-  </tr>
+  <tr><th>Priority</th><th>Axis Mapping</th><th>Renderer</th></tr>
+  <tr><td>100</td><td><code>x: date, y: categorical, color: numerical</code></td><td>Numerical state timeline</td></tr>
+  <tr><td>100</td><td><code>x: date, y: categorical, color: categorical</code></td><td>Categorical state timeline</td></tr>
+  <tr><td>100</td><td><code>x: date, color: categorical</code></td><td>Single categorical state timeline</td></tr>
+  <tr><td>40</td><td><code>x: date, color: numerical</code></td><td>Single numerical state timeline</td></tr>
 </table>
 
-#### 12. One Metric Rule
+### Table
 
-<table>
-  <tr><td><strong>ID</strong></td><td><code>one-metric</code></td></tr>
-  <tr><td><strong>Description</strong></td><td>Metric visualization for one metric</td></tr>
-  <tr><td><strong>Matching Criteria</strong></td>
-      <td>
-        <ul>
-          <li>1 Numerical column</li>
-          <li>0 Categorical columns</li>
-          <li>0 Date columns</li>
-          <li>Exactly 1 valid value in the numerical column</li>
-        </ul>
-      </td>
-  </tr>
-  <tr><td><strong>Chart Types</strong></td>
-      <td>
-        <ul>
-          <li>Metric (priority: 100) - Default</li>
-        </ul>
-      </td>
-  </tr>
-</table>
+Table has no rules. It is always available as a visualization type and renders data in a tabular format regardless of column types.
 
 ## Rule Evaluation Process
 
 When visualizing data, the system:
 
-1. Analyzes the dataset to identify numerical, categorical, and date columns
-2. Evaluates all registered rules against the dataset
-3. For each matching rule, selects the chart type with the highest priority
-4. Among all matching rules, selects the one with the highest priority chart type
-5. Renders the visualization using the selected chart type
+1. Classifies all columns in the dataset as `numerical`, `categorical`, or `date`
+2. For each registered `VisualizationType`, iterates over its rules and their mappings
+3. Counts the required field types in each mapping and compares against available column counts
+4. Collects **exact matches** (required counts === available counts) and **compatible matches** (required <= available)
+5. Among exact matches, selects the rule with the highest priority — this determines the default chart type
+6. The `VisualizationBuilder` uses the matched rule's `render()` function to produce the chart, passing transformed data, style options, and axis-column mappings
+7. Users can switch to any other chart type that has at least one compatible rule for the current data

--- a/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { LineSeriesOption } from 'echarts';
-import { TimeUnit, AxisRole } from '../types';
+import { TimeUnit } from '../types';
 import { getSeriesDisplayName } from '../utils/series';
 import { AreaChartStyle } from './area_vis_config';
 import { BaseChartStyle, PipelineFn } from '../utils/echarts_spec';
@@ -58,10 +58,12 @@ export const createAreaSeries = <T extends BaseChartStyle>({
   styles,
   seriesFields,
   categoryField,
+  stack,
 }: {
   styles: AreaChartStyle;
   seriesFields: string[] | ((headers?: string[]) => string[]);
   categoryField: string;
+  stack?: boolean;
 }): PipelineFn<T> => (state) => {
   const { transformedData = [], axisColumnMappings } = state;
   const newState = { ...state };
@@ -72,13 +74,14 @@ export const createAreaSeries = <T extends BaseChartStyle>({
 
   const thresholdLines = generateThresholdLines(styles.thresholdOptions);
   const series = seriesFields?.map((item: string, index: number) => {
-    const name = getSeriesDisplayName(item, Object.values(axisColumnMappings));
+    const name = getSeriesDisplayName(item, Object.values(axisColumnMappings).flat());
 
     return {
       name,
       type: 'line',
       showSymbol: false,
       connectNulls: true,
+      stack: stack ? 'Total' : undefined,
       areaStyle: {
         opacity: styles.areaOpacity || DEFAULT_OPACITY,
       },
@@ -144,113 +147,6 @@ export const createFacetAreaSeries = <T extends BaseChartStyle>({
   });
 
   newState.series = allSeries?.flat() as LineSeriesOption[];
-
-  return newState;
-};
-
-/**
- * Create category-based area series with aggregation
- */
-export const createCategoryAreaSeries = <T extends BaseChartStyle>({
-  styles,
-  categoryField,
-  valueField,
-}: {
-  styles: AreaChartStyle;
-  categoryField: string;
-  valueField: string;
-}): PipelineFn<T> => (state) => {
-  const { transformedData, axisColumnMappings } = state;
-  const newState = { ...state };
-
-  if (!transformedData || !Array.isArray(transformedData) || transformedData.length === 0) {
-    newState.series = [];
-    return newState;
-  }
-
-  const thresholdLines = generateThresholdLines(styles.thresholdOptions);
-  const series = [
-    {
-      type: 'line',
-      showSymbol: false,
-      name: getSeriesDisplayName(valueField, Object.values(axisColumnMappings)),
-      connectNulls: true,
-      areaStyle: {
-        opacity: styles.areaOpacity || DEFAULT_OPACITY,
-      },
-      smooth: true,
-      encode: {
-        x: categoryField,
-        y: valueField,
-      },
-      emphasis: {
-        focus: 'self',
-      },
-      ...thresholdLines,
-    },
-  ];
-
-  newState.series = series as LineSeriesOption[];
-  return newState;
-};
-
-/**
- * Create stack area series configuration based on aggregatedData
- */
-export const createStackAreaSeries = <T extends BaseChartStyle>(
-  styles: AreaChartStyle
-): PipelineFn<T> => (state) => {
-  const { axisColumnMappings, transformedData: aggregatedData } = state;
-  const newState = { ...state };
-  const thresholdLines = generateThresholdLines(styles.thresholdOptions);
-
-  if (!axisColumnMappings) {
-    throw new Error('axisColumnMappings must be available for createStackAreaSeries');
-  }
-
-  if (!aggregatedData || !Array.isArray(aggregatedData) || aggregatedData.length < 2) {
-    newState.series = [];
-    return newState;
-  }
-
-  // Find the x-axis column from axisColumnMappings
-  const xAxis = axisColumnMappings[AxisRole.X];
-
-  if (!xAxis?.column) {
-    throw new Error('xAxis column must be available for createStackAreaSeries');
-  }
-
-  // Get category columns from the first row (header), excluding the x-axis column
-  const headerRow = aggregatedData[0] as string[];
-  const cateColumns = headerRow.filter((c: string) => c !== xAxis.column);
-
-  if (!cateColumns || cateColumns.length === 0) {
-    throw new Error('No category columns found for stacked area series');
-  }
-
-  // Create multi-series for each category column
-  const newseries = cateColumns.map((categoryName: string, index: number) => ({
-    name: String(categoryName),
-    type: 'line',
-    showSymbol: false,
-    stack: 'Total',
-    areaStyle: {
-      opacity: styles.areaOpacity || DEFAULT_OPACITY,
-    },
-    smooth: true,
-    connectNulls: true,
-    encode: {
-      x: xAxis.column,
-      y: categoryName,
-    },
-    emphasis: {
-      focus: 'self',
-    },
-    ...(index === 0 && thresholdLines),
-  }));
-
-  // Series created successfully
-  newState.series = newseries as LineSeriesOption[];
 
   return newState;
 };

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
@@ -109,14 +109,18 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Date },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0) throw Error('Missing axis config for area chart');
+
           const spec = createSimpleAreaChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -132,10 +136,15 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for multi-area chart');
+
           const spec = createMultiAreaChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -151,10 +160,15 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for multi-area chart');
+
           const spec = createMultiAreaChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -171,10 +185,17 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted multi-area chart');
+
           const spec = createFacetedMultiAreaChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -191,10 +212,17 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted multi-area chart');
+
           const spec = createFacetedMultiAreaChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -205,15 +233,19 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Categorical },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
-          const spec = createCategoryAreaChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0)
+            throw Error('Missing axis config for category area chart');
+
+          const spec = createCategoryAreaChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -227,11 +259,16 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           },
         ],
         render(props) {
-          const spec = createStackedAreaChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for stacked area chart');
+
+          const spec = createStackedAreaChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -245,11 +282,16 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           },
         ],
         render(props) {
-          const spec = createStackedAreaChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for stacked area chart');
+
+          const spec = createStackedAreaChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
@@ -177,30 +177,36 @@ describe('AreaVisStyleControls', () => {
     },
     onStyleChange: jest.fn(),
     axisColumnMappings: {
-      [AxisRole.X]: {
-        id: 1,
-        name: 'Date',
-        schema: VisFieldType.Date,
-        column: 'date',
-        validValuesCount: 100,
-        uniqueValuesCount: 50,
-      },
-      [AxisRole.Y]: {
-        id: 2,
-        name: 'Count',
-        schema: VisFieldType.Numerical,
-        column: 'count',
-        validValuesCount: 100,
-        uniqueValuesCount: 50,
-      },
-      [AxisRole.COLOR]: {
-        id: 3,
-        name: 'Category',
-        schema: VisFieldType.Categorical,
-        column: 'category',
-        validValuesCount: 10,
-        uniqueValuesCount: 5,
-      },
+      [AxisRole.X]: [
+        {
+          id: 1,
+          name: 'Date',
+          schema: VisFieldType.Date,
+          column: 'date',
+          validValuesCount: 100,
+          uniqueValuesCount: 50,
+        },
+      ],
+      [AxisRole.Y]: [
+        {
+          id: 2,
+          name: 'Count',
+          schema: VisFieldType.Numerical,
+          column: 'count',
+          validValuesCount: 100,
+          uniqueValuesCount: 50,
+        },
+      ],
+      [AxisRole.COLOR]: [
+        {
+          id: 3,
+          name: 'Category',
+          schema: VisFieldType.Categorical,
+          column: 'category',
+          validValuesCount: 10,
+          uniqueValuesCount: 5,
+        },
+      ],
     },
     updateVisualization: jest.fn(),
   };
@@ -223,14 +229,16 @@ describe('AreaVisStyleControls', () => {
       ...defaultProps,
       axisColumnMappings: {
         ...defaultProps.axisColumnMappings,
-        [AxisRole.COLOR]: {
-          id: 3,
-          name: 'Category',
-          schema: VisFieldType.Categorical,
-          column: 'category',
-          validValuesCount: 10,
-          uniqueValuesCount: 5,
-        },
+        [AxisRole.COLOR]: [
+          {
+            id: 3,
+            name: 'Category',
+            schema: VisFieldType.Categorical,
+            column: 'category',
+            validValuesCount: 10,
+            uniqueValuesCount: 5,
+          },
+        ],
       },
     };
 
@@ -248,14 +256,16 @@ describe('AreaVisStyleControls', () => {
       },
       axisColumnMappings: {
         ...defaultProps.axisColumnMappings,
-        [AxisRole.FACET]: {
-          id: 4,
-          name: 'Facet',
-          schema: VisFieldType.Categorical,
-          column: 'facet',
-          validValuesCount: 10,
-          uniqueValuesCount: 5,
-        },
+        [AxisRole.FACET]: [
+          {
+            id: 4,
+            name: 'Facet',
+            schema: VisFieldType.Categorical,
+            column: 'facet',
+            validValuesCount: 10,
+            uniqueValuesCount: 5,
+          },
+        ],
       },
     };
 

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
@@ -10,14 +10,7 @@ import {
   createCategoryAreaChart,
   createStackedAreaChart,
 } from './to_expression';
-import {
-  VisColumn,
-  VisFieldType,
-  ThresholdMode,
-  Positions,
-  AxisRole,
-  AxisColumnMappings,
-} from '../types';
+import { VisColumn, VisFieldType, ThresholdMode, Positions, AxisRole } from '../types';
 import { AreaChartStyle } from './area_vis_config';
 
 describe('Area Chart to_expression', () => {
@@ -89,8 +82,8 @@ describe('Area Chart to_expression', () => {
   };
 
   describe('createSimpleAreaChart', () => {
-    const axisColumnMappings: AxisColumnMappings = {
-      [AxisRole.Y]: mockNumericalColumn,
+    const axisColumnMappings = {
+      [AxisRole.Y]: [mockNumericalColumn],
       [AxisRole.X]: mockDateColumn,
     };
 
@@ -141,7 +134,7 @@ describe('Area Chart to_expression', () => {
   });
 
   describe('createMultiAreaChart', () => {
-    const axisColumnMappings: AxisColumnMappings = {
+    const axisColumnMappings = {
       [AxisRole.Y]: mockNumericalColumn,
       [AxisRole.X]: mockDateColumn,
       [AxisRole.COLOR]: mockCategoricalColumns[0],
@@ -174,7 +167,7 @@ describe('Area Chart to_expression', () => {
   });
 
   describe('createFacetedMultiAreaChart', () => {
-    const axisColumnMappings: AxisColumnMappings = {
+    const axisColumnMappings = {
       [AxisRole.Y]: mockNumericalColumn,
       [AxisRole.X]: mockDateColumn,
       [AxisRole.COLOR]: mockCategoricalColumns[0],
@@ -211,8 +204,8 @@ describe('Area Chart to_expression', () => {
   });
 
   describe('createCategoryAreaChart', () => {
-    const axisColumnMappings: AxisColumnMappings = {
-      [AxisRole.Y]: mockNumericalColumn,
+    const axisColumnMappings = {
+      [AxisRole.Y]: [mockNumericalColumn],
       [AxisRole.X]: mockCategoricalColumns[0],
     };
 
@@ -243,7 +236,7 @@ describe('Area Chart to_expression', () => {
   });
 
   describe('createStackedAreaChart', () => {
-    const axisColumnMappings: AxisColumnMappings = {
+    const axisColumnMappings = {
       [AxisRole.Y]: mockNumericalColumn,
       [AxisRole.X]: mockCategoricalColumns[0],
       [AxisRole.COLOR]: mockCategoricalColumns[1],

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.ts
@@ -4,8 +4,8 @@
  */
 
 import { AreaChartStyle } from './area_vis_config';
-import { AxisColumnMappings, AxisRole, TimeUnit, AggregationType } from '../types';
-import { getSwappedAxisRole } from '../utils/utils';
+import { AxisRole, VisColumn, TimeUnit, AggregationType } from '../types';
+import { getAxisConfig, getColumnsFromAxisColumnMapping } from '../utils/utils';
 import {
   pipe,
   createBaseConfig,
@@ -14,13 +14,7 @@ import {
   buildVisMap,
   applyTimeRange,
 } from '../utils/echarts_spec';
-import {
-  createAreaSeries,
-  createFacetAreaSeries,
-  createCategoryAreaSeries,
-  createStackAreaSeries,
-  replaceNullWithZero,
-} from './area_chart_utils';
+import { createAreaSeries, createFacetAreaSeries, replaceNullWithZero } from './area_chart_utils';
 import {
   convertTo2DArray,
   transform,
@@ -36,27 +30,29 @@ import {
 export const createSimpleAreaChart = (
   transformedData: Array<Record<string, any>>,
   styles: AreaChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
+  const axisConfig = getAxisConfig(styles);
 
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
+  const timeField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].map((y) => y.column);
+  const valueFieldNames = axisColumnMappings[AxisRole.Y].map((y) => y.name) ?? [];
 
-  if (!valueField || !timeField) throw Error('Missing axis config for area chart');
-
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = getColumnsFromAxisColumnMapping(axisColumnMappings);
 
   const result = pipe(
-    transform(sortByTime(axisColumnMappings?.x?.column), convertTo2DArray(allColumns)),
-    createBaseConfig({ title: `${axisConfig.yAxis?.name} Over Time`, legend: { show: false } }),
+    transform(sortByTime(timeField), convertTo2DArray(allColumns)),
+    createBaseConfig({
+      title: `${valueFieldNames.join(', ')} Over Time`,
+      legend: { show: false },
+    }),
     buildAxisConfigs,
     applyTimeRange,
     createAreaSeries({
       styles,
       categoryField: timeField,
-      seriesFields: [valueField],
+      seriesFields: valueField,
     }),
     assembleSpec
   )({
@@ -76,18 +72,19 @@ export const createSimpleAreaChart = (
 export const createMultiAreaChart = (
   transformedData: Array<Record<string, any>>,
   styles: AreaChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
+  const axisConfig = getAxisConfig(styles);
 
-  if (!timeField || !valueField || !colorField) {
-    throw Error('Missing axis config or color field for multi area chart');
-  }
+  const timeField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
+
   const result = pipe(
     transform(
       sortByTime(timeField),
@@ -102,7 +99,9 @@ export const createMultiAreaChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} Over Time by ${axisColumnMappings?.[AxisRole.COLOR]?.name}`,
+      title: `${axisColumnMappings[AxisRole.Y].name} Over Time by ${
+        axisColumnMappings[AxisRole.COLOR].name
+      }`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -110,7 +109,12 @@ export const createMultiAreaChart = (
     buildVisMap({
       seriesFields: (headers) => (headers ?? []).filter((h) => h !== timeField),
     }),
-    createStackAreaSeries(styles),
+    createAreaSeries({
+      styles,
+      categoryField: timeField,
+      seriesFields: (headers) => (headers ?? []).filter((h) => h !== timeField),
+      stack: true,
+    }),
     assembleSpec
   )({
     data: transformedData,
@@ -129,19 +133,20 @@ export const createMultiAreaChart = (
 export const createFacetedMultiAreaChart = (
   transformedData: Array<Record<string, any>>,
   styles: AreaChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+    [AxisRole.FACET]: VisColumn;
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
+  const axisConfig = getAxisConfig(styles);
 
-  const facetColumn = axisColumnMappings?.[AxisRole.FACET]?.column;
-  if (!timeField || !valueField || !colorField || !facetColumn) {
-    throw Error('Missing axis config for facet area chart');
-  }
+  const timeField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
+  const facetColumn = axisColumnMappings[AxisRole.FACET].column;
 
   const result = pipe(
     facetTransform(
@@ -158,9 +163,9 @@ export const createFacetedMultiAreaChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} Over Time by ${
-        axisColumnMappings?.[AxisRole.COLOR]?.name
-      } (Faceted by ${axisColumnMappings?.[AxisRole.FACET]?.name})`,
+      title: `${axisColumnMappings[AxisRole.Y].name} Over Time by ${
+        axisColumnMappings[AxisRole.COLOR].name
+      } (Faceted by ${axisColumnMappings[AxisRole.FACET].name})`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -188,16 +193,15 @@ export const createFacetedMultiAreaChart = (
 export const createCategoryAreaChart = (
   transformedData: Array<Record<string, any>>,
   styles: AreaChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
+  const axisConfig = getAxisConfig(styles);
 
-  const categoryField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
+  const categoryField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].map((y) => y.column);
+  const valueFieldNames = axisColumnMappings[AxisRole.Y].map((y) => y.name) ?? [];
 
-  if (!valueField || !categoryField) throw Error('Missing axis config for area chart');
-
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = getColumnsFromAxisColumnMapping(axisColumnMappings);
 
   const result = pipe(
     transform(
@@ -209,14 +213,14 @@ export const createCategoryAreaChart = (
       convertTo2DArray(allColumns)
     ),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} by ${axisConfig.xAxis?.name}`,
+      title: `${valueFieldNames.join(', ')} by ${axisColumnMappings[AxisRole.X].name}`,
       legend: { show: false },
     }),
     buildAxisConfigs,
-    createCategoryAreaSeries({
+    createAreaSeries({
       styles,
       categoryField,
-      valueField,
+      seriesFields: valueField,
     }),
     assembleSpec
   )({
@@ -232,20 +236,17 @@ export const createCategoryAreaChart = (
 export const createStackedAreaChart = (
   transformedData: Array<Record<string, any>>,
   styles: AreaChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-): any => {
-  // Extract field mappings directly from axisColumnMappings
-  const xAxis = axisColumnMappings?.[AxisRole.X];
-  const yAxis = axisColumnMappings?.[AxisRole.Y];
-  const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorMapping?.column;
-
-  if (!xAxis || !yAxis || !colorField) {
-    throw Error('Missing axis config or color field for stacked area chart');
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
   }
+): any => {
+  const axisConfig = getAxisConfig(styles);
 
-  const categoryField = xAxis.column;
-  const valueField = yAxis.column;
+  const categoryField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
 
   const result = pipe(
     transform(
@@ -259,19 +260,26 @@ export const createStackedAreaChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisColumnMappings?.y?.name} by ${axisColumnMappings?.x?.name} and ${colorMapping.name}`,
+      title: `${axisColumnMappings[AxisRole.Y].name} by ${
+        axisColumnMappings[AxisRole.X].name
+      } and ${axisColumnMappings[AxisRole.COLOR].name}`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
     buildVisMap({
       seriesFields: (headers) => (headers ?? []).filter((h) => h !== categoryField),
     }),
-    createStackAreaSeries(styles),
+    createAreaSeries({
+      styles,
+      categoryField,
+      seriesFields: (headers) => (headers ?? []).filter((h) => h !== categoryField),
+      stack: true,
+    }),
     assembleSpec
   )({
     data: transformedData,
     styles,
-    axisConfig: { xAxis, yAxis },
+    axisConfig,
     axisColumnMappings: axisColumnMappings ?? {},
   });
 

--- a/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.ts
@@ -12,12 +12,7 @@ import {
   BucketOptions,
   AggregationType,
 } from '../types';
-import {
-  applyAxisStyling,
-  getSchemaByAxis,
-  adjustOppositeSymbol,
-  generateThresholdLines,
-} from '../utils/utils';
+import { applyAxisStyling, getSchemaByAxis, generateThresholdLines } from '../utils/utils';
 import { BarChartStyle } from './bar_vis_config';
 import { getColors, DEFAULT_GREY } from '../theme/default_colors';
 import { BaseChartStyle, PipelineFn, EChartsSpecState } from '../utils/echarts_spec';
@@ -199,6 +194,8 @@ interface Options {
   styles: BarChartStyle;
   categoryField: string;
   seriesFields: string[] | ((headers?: string[]) => string[]);
+  categoryEncode: 'x' | 'y';
+  seriesEncode: 'x' | 'y';
 }
 
 /**
@@ -207,7 +204,7 @@ interface Options {
 export const createBarSeries = <T extends BaseChartStyle>(options: Options): PipelineFn<T> => (
   state
 ) => {
-  const { styles, categoryField } = options;
+  const { styles, categoryField, categoryEncode = 'x', seriesEncode = 'y' } = options;
   let seriesFields = options.seriesFields;
 
   const { axisColumnMappings, transformedData = [] } = state;
@@ -217,13 +214,7 @@ export const createBarSeries = <T extends BaseChartStyle>(options: Options): Pip
     seriesFields = seriesFields(transformedData[0]);
   }
 
-  const thresholdLines = generateThresholdLines(
-    options.styles?.thresholdOptions,
-    options.styles?.switchAxes
-  );
-
-  const encodeX = adjustOppositeSymbol(options.styles?.switchAxes, 'x');
-  const encodeY = adjustOppositeSymbol(options.styles?.switchAxes, 'y');
+  const thresholdLines = generateThresholdLines(options.styles?.thresholdOptions);
 
   let barWidth: string | undefined;
   if (styles.barSizeMode === 'manual') {
@@ -231,7 +222,7 @@ export const createBarSeries = <T extends BaseChartStyle>(options: Options): Pip
   }
 
   const series = seriesFields.map((seriesField, index) => {
-    const name = getSeriesDisplayName(seriesField, Object.values(axisColumnMappings));
+    const name = getSeriesDisplayName(seriesField, Object.values(axisColumnMappings).flat());
     const seriesConfig = {
       type: 'bar',
       emphasis: {
@@ -239,8 +230,8 @@ export const createBarSeries = <T extends BaseChartStyle>(options: Options): Pip
       },
       name,
       encode: {
-        [encodeX]: categoryField,
-        [encodeY]: seriesField,
+        [categoryEncode]: categoryField,
+        [seriesEncode]: seriesField,
       },
       barWidth,
       ...(index === 0 && thresholdLines),
@@ -265,15 +256,19 @@ export const createFacetBarSeries = <T extends BaseChartStyle>({
   styles,
   categoryField,
   seriesFields,
+  categoryEncode = 'x',
+  seriesEncode = 'y',
 }: {
   styles: BarChartStyle;
   categoryField: string;
   seriesFields: (headers?: string[]) => string[];
+  categoryEncode?: 'x' | 'y';
+  seriesEncode?: 'x' | 'y';
 }): PipelineFn<T> => (state) => {
   const { transformedData } = state;
 
   const newState = { ...state };
-  const thresholdLines = generateThresholdLines(styles?.thresholdOptions, styles?.switchAxes);
+  const thresholdLines = generateThresholdLines(styles?.thresholdOptions);
 
   // facet into one chart
   if (!Array.isArray(transformedData?.[0]?.[0])) {
@@ -281,6 +276,8 @@ export const createFacetBarSeries = <T extends BaseChartStyle>({
       styles,
       categoryField,
       seriesFields,
+      categoryEncode,
+      seriesEncode,
     })(newState);
     return simpleBar as EChartsSpecState<T>;
   }
@@ -293,8 +290,8 @@ export const createFacetBarSeries = <T extends BaseChartStyle>({
         name: String(item),
         type: 'bar',
         encode: {
-          [adjustOppositeSymbol(styles?.switchAxes, 'x')]: categoryField,
-          [adjustOppositeSymbol(styles?.switchAxes, 'y')]: item,
+          [categoryEncode]: categoryField,
+          [seriesEncode]: item,
         },
         datasetIndex: index,
         gridIndex: index,

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
@@ -57,8 +57,6 @@ export interface BarChartStyleOptions {
   // Axes configuration
   standardAxes?: StandardAxes[];
 
-  switchAxes?: boolean;
-
   titleOptions?: TitleOptions;
 
   // histogram bucket config
@@ -77,7 +75,6 @@ export type BarChartStyle = Required<
 
 export const defaultBarChartStyles: BarChartStyle = {
   // Basic controls
-  switchAxes: false,
   addLegend: true,
   legendTitle: '',
   legendPosition: Positions.BOTTOM,
@@ -123,19 +120,38 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Categorical },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0) throw Error('Missing axis config for bar chart');
+
+          const spec = createBarSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
+          return <EchartsRender spec={spec} />;
+        },
+      },
+      {
+        priority: 100,
+        mappings: [
           {
-            [AxisRole.X]: { type: VisFieldType.Numerical },
+            [AxisRole.X]: { type: VisFieldType.Numerical, multi: true },
             [AxisRole.Y]: { type: VisFieldType.Categorical },
           },
         ],
         render(props) {
-          const spec = createBarSpec(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x;
+          const y = props.axisColumnMappings.y?.[0];
+          if (!x || !y || x.length === 0) throw Error('Missing axis config for bar chart');
+
+          const spec = createBarSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} />;
         },
       },
@@ -144,18 +160,40 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Date },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
-          },
-          {
-            [AxisRole.X]: { type: VisFieldType.Numerical },
-            [AxisRole.Y]: { type: VisFieldType.Date },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0) throw Error('Missing axis config for time bar chart');
+
           const spec = createTimeBarChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y },
+            props.timeRange
+          );
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 60,
+        mappings: [
+          {
+            [AxisRole.X]: { type: VisFieldType.Numerical, multi: true },
+            [AxisRole.Y]: { type: VisFieldType.Date },
+          },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x;
+          const y = props.axisColumnMappings.y?.[0];
+          if (!x || !y || x.length === 0) throw Error('Missing axis config for time bar chart');
+
+          const spec = createTimeBarChart(
+            props.transformedData,
+            props.styleOptions,
+            { [AxisRole.X]: x, [AxisRole.Y]: y },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -169,6 +207,25 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
             [AxisRole.Y]: { type: VisFieldType.Numerical },
             [AxisRole.COLOR]: { type: VisFieldType.Categorical },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for grouped time bar chart');
+
+          const spec = createGroupedTimeBarChart(
+            props.transformedData,
+            props.styleOptions,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
+            props.timeRange
+          );
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 60,
+        mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
             [AxisRole.Y]: { type: VisFieldType.Date },
@@ -176,10 +233,15 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for grouped time bar chart');
+
           const spec = createGroupedTimeBarChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -193,6 +255,25 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
             [AxisRole.Y]: { type: VisFieldType.Numerical },
             [AxisRole.COLOR]: { type: VisFieldType.Numerical },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for grouped time bar chart');
+
+          const spec = createGroupedTimeBarChart(
+            props.transformedData,
+            props.styleOptions,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
+            props.timeRange
+          );
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 80,
+        mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
             [AxisRole.Y]: { type: VisFieldType.Date },
@@ -200,10 +281,15 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for grouped time bar chart');
+
           const spec = createGroupedTimeBarChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -218,6 +304,27 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
             [AxisRole.COLOR]: { type: VisFieldType.Categorical },
             [AxisRole.FACET]: { type: VisFieldType.Categorical },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted time bar chart');
+
+          const spec = createFacetedTimeBarChart(
+            props.transformedData,
+            props.styleOptions,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
+            props.timeRange
+          );
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 60,
+        mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
             [AxisRole.Y]: { type: VisFieldType.Date },
@@ -226,10 +333,17 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted time bar chart');
+
           const spec = createFacetedTimeBarChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -244,6 +358,27 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
             [AxisRole.COLOR]: { type: VisFieldType.Numerical },
             [AxisRole.FACET]: { type: VisFieldType.Categorical },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted time bar chart');
+
+          const spec = createFacetedTimeBarChart(
+            props.transformedData,
+            props.styleOptions,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
+            props.timeRange
+          );
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 100,
+        mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
             [AxisRole.Y]: { type: VisFieldType.Date },
@@ -252,10 +387,17 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted time bar chart');
+
           const spec = createFacetedTimeBarChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -269,6 +411,24 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
             [AxisRole.Y]: { type: VisFieldType.Numerical },
             [AxisRole.COLOR]: { type: VisFieldType.Categorical },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for stacked bar chart');
+
+          const spec = createStackedBarSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 100,
+        mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
             [AxisRole.Y]: { type: VisFieldType.Categorical },
@@ -276,11 +436,16 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           },
         ],
         render(props) {
-          const spec = createStackedBarSpec(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for stacked bar chart');
+
+          const spec = createStackedBarSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -292,6 +457,24 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
             [AxisRole.Y]: { type: VisFieldType.Numerical },
             [AxisRole.COLOR]: { type: VisFieldType.Numerical },
           },
+        ],
+        render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for stacked bar chart');
+
+          const spec = createStackedBarSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
+          return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
+        },
+      },
+      {
+        priority: 80,
+        mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
             [AxisRole.Y]: { type: VisFieldType.Categorical },
@@ -299,11 +482,16 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           },
         ],
         render(props) {
-          const spec = createStackedBarSpec(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for stacked bar chart');
+
+          const spec = createStackedBarSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -312,15 +500,19 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
-          const spec = createDoubleNumericalBarChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0)
+            throw Error('Missing axis config for double numerical bar chart');
+
+          const spec = createDoubleNumericalBarChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
@@ -16,9 +16,7 @@ const mockStore = configureMockStore([]);
 const store = mockStore({
   tab: {
     visualizations: {
-      styleOptions: {
-        switchAxes: false,
-      },
+      styleOptions: {},
     },
   },
 });
@@ -63,7 +61,6 @@ jest.mock('../style_panel/axes/axes_selector', () => ({
       dateColumns,
       currentMapping,
       updateVisualization,
-      onSwitchAxes,
     }) => (
       <div data-test-subj="mockAxesSelectPanel">
         <button
@@ -71,9 +68,6 @@ jest.mock('../style_panel/axes/axes_selector', () => ({
           onClick={() => updateVisualization({ type: 'test' })}
         >
           Update Visualization
-        </button>
-        <button data-test-subj="mockSwitchAxes" onClick={() => onSwitchAxes(true)}>
-          Switch Axes
         </button>
       </div>
     )
@@ -493,17 +487,6 @@ describe('BarVisStyleControls', () => {
 
     await userEvent.click(screen.getByTestId('mockUpdateUseThresholdColor'));
     expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ useThresholdColor: true });
-  });
-
-  test('calls onStyleChange with correct parameters for switch axes', async () => {
-    render(
-      <Provider store={store}>
-        <BarVisStyleControls {...defaultProps} />
-      </Provider>
-    );
-
-    await userEvent.click(screen.getByTestId('mockSwitchAxes'));
-    expect(defaultProps.onStyleChange).toHaveBeenCalledWith({ switchAxes: true });
   });
 
   test('updates title show option correctly', async () => {

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -60,8 +60,6 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
           currentMapping={axisColumnMappings}
           updateVisualization={updateVisualization}
           chartType="bar"
-          onSwitchAxes={(v) => updateStyleOption('switchAxes', v)}
-          switchAxes={styleOptions.switchAxes}
         />
       </EuiFlexItem>
       {hasMappingSelected && (
@@ -118,7 +116,6 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
               onStandardAxesChange={(standardAxes) =>
                 updateStyleOption('standardAxes', standardAxes)
               }
-              switchAxes={styleOptions.switchAxes}
               showFullTimeRange={styleOptions.showFullTimeRange}
               onShowFullTimeRangeChange={(showFullTimeRange) =>
                 updateStyleOption('showFullTimeRange', showFullTimeRange)

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
@@ -61,7 +61,7 @@ describe('bar to_expression', () => {
     test('creates an ECharts bar chart spec with dataset and series', () => {
       const spec = createBarSpec(mockData, defaultBarChartStyles, {
         [AxisRole.X]: mockCategoricalColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       });
 
       expect(spec).toHaveProperty('dataset');
@@ -75,7 +75,7 @@ describe('bar to_expression', () => {
     test('handles title display options', () => {
       const axisMappings = {
         [AxisRole.X]: mockCategoricalColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       };
 
       const noTitleResult = createBarSpec(
@@ -115,7 +115,7 @@ describe('bar to_expression', () => {
 
       const spec = createBarSpec(mockData, customStyles, {
         [AxisRole.X]: mockCategoricalColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       });
 
       const seriesWithMarkLine = spec.series.find((s: any) => s.markLine);
@@ -175,7 +175,7 @@ describe('bar to_expression', () => {
     test('creates a time bar chart ECharts spec', () => {
       const axisMappings = {
         [AxisRole.X]: mockDateColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       };
 
       const spec = createTimeBarChart(mockData, defaultBarChartStyles, axisMappings);
@@ -191,7 +191,7 @@ describe('bar to_expression', () => {
     test('handles title display options', () => {
       const axisMappings = {
         [AxisRole.X]: mockDateColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       };
 
       const noTitleResult = createTimeBarChart(
@@ -231,7 +231,7 @@ describe('bar to_expression', () => {
 
       const spec = createTimeBarChart(mockData, customStyles, {
         [AxisRole.X]: mockDateColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       });
 
       const seriesWithMarkLine = spec.series.find((s: any) => s.markLine);
@@ -242,7 +242,7 @@ describe('bar to_expression', () => {
     describe('bucketing vs skip bucketing', () => {
       const axisMappings = {
         [AxisRole.X]: mockDateColumn,
-        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.Y]: [mockNumericalColumn],
       };
 
       // Timestamps within the same second — auto-inferred interval will bucket them together
@@ -461,7 +461,7 @@ describe('bar to_expression', () => {
     test('creates a double numerical bar chart ECharts spec', () => {
       const spec = createDoubleNumericalBarChart(mockData, defaultBarChartStyles, {
         [AxisRole.X]: mockNumericalColumn,
-        [AxisRole.Y]: mockNumericalColumn2,
+        [AxisRole.Y]: [mockNumericalColumn2],
       });
 
       expect(spec).toHaveProperty('dataset');

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AxisColumnMappings, AxisRole, VisFieldType, TimeUnit, AggregationType } from '../types';
-import { BarChartStyle, defaultBarChartStyles } from './bar_vis_config';
-import { getSwappedAxisRole } from '../utils/utils';
+import { AxisRole, VisFieldType, TimeUnit, AggregationType, VisColumn } from '../types';
+import { BarChartStyle } from './bar_vis_config';
+import { getAxisConfig } from '../utils/utils';
 
 import { createBarSeries, createFacetBarSeries } from './bar_chart_utils';
 import {
@@ -24,47 +24,87 @@ import {
   facetTransform,
 } from '../utils/data_transformation';
 
+const getNormalizedAxisConfig = (
+  axisColumnMappings:
+    | { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] }
+    | { [AxisRole.X]: VisColumn[]; [AxisRole.Y]: VisColumn }
+) => {
+  let categoryField = '';
+  let categoryFieldName = '';
+  let seriesFields: string[] = [];
+  let seriesFieldNames: string[] = [];
+  let categoryEncode: 'x' | 'y' = 'x';
+  let seriesEncode: 'x' | 'y' = 'y';
+
+  if (!Array.isArray(axisColumnMappings.y) && Array.isArray(axisColumnMappings.x)) {
+    categoryField = axisColumnMappings.y.column;
+    categoryFieldName = axisColumnMappings.y.name;
+    seriesFields = axisColumnMappings.x.map((col) => col.column);
+    seriesFieldNames = axisColumnMappings.x.map((col) => col.name);
+    categoryEncode = 'y';
+    seriesEncode = 'x';
+  }
+  if (Array.isArray(axisColumnMappings.y) && !Array.isArray(axisColumnMappings.x)) {
+    categoryField = axisColumnMappings.x.column;
+    categoryFieldName = axisColumnMappings.x.name;
+    seriesFields = axisColumnMappings.y.map((col) => col.column);
+    seriesFieldNames = axisColumnMappings.y.map((col) => col.name);
+    categoryEncode = 'x';
+    seriesEncode = 'y';
+  }
+  return {
+    categoryField,
+    categoryFieldName,
+    categoryEncode,
+    seriesFields,
+    seriesFieldNames,
+    seriesEncode,
+  };
+};
+
 export const createBarSpec = (
   transformedData: Array<Record<string, any>>,
-  styleOptions: BarChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  styles: BarChartStyle,
+  axisColumnMappings:
+    | { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] }
+    | { [AxisRole.X]: VisColumn[]; [AxisRole.Y]: VisColumn }
 ): any => {
-  const styles = { ...defaultBarChartStyles, ...styleOptions };
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
+  const axisConfig = getAxisConfig(styles);
 
-  if (!xAxis || !yAxis) {
-    throw Error('Missing axis config for Bar chart');
-  }
-
-  let categoryField = '';
-  let valueField = '';
-
-  if (xAxis.schema === VisFieldType.Categorical) {
-    categoryField = xAxis.column;
-    valueField = yAxis.column;
-  } else if (yAxis.schema === VisFieldType.Categorical) {
-    categoryField = yAxis.column;
-    valueField = xAxis.column;
-  }
+  const {
+    categoryField,
+    categoryFieldName,
+    categoryEncode,
+    seriesFields,
+    seriesFieldNames,
+    seriesEncode,
+  } = getNormalizedAxisConfig(axisColumnMappings);
 
   const aggregationType = styles.bucket.aggregationType ?? AggregationType.SUM;
   const result = pipe(
     transform(
       aggregate({
         groupBy: categoryField,
-        field: valueField,
+        field: seriesFields,
         aggregationType,
       }),
       convertTo2DArray()
     ),
-    createBaseConfig({ title: `${yAxis?.name} by ${xAxis?.name}`, legend: { show: false } }),
+    createBaseConfig({
+      title: `${seriesFieldNames.join(', ')} by ${categoryFieldName}`,
+      legend: { show: false },
+    }),
     buildAxisConfigs,
     buildVisMap({
       seriesFields: (headers) => (headers ?? []).filter((h) => h !== categoryField),
     }),
-    createBarSeries({ styles, categoryField, seriesFields: [valueField] }),
+    createBarSeries({
+      styles,
+      categoryField,
+      seriesFields,
+      categoryEncode,
+      seriesEncode,
+    }),
     assembleSpec
   )({
     data: transformedData,
@@ -81,26 +121,20 @@ export const createBarSpec = (
 export const createTimeBarChart = (
   transformedData: Array<Record<string, any>>,
   styles: BarChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings:
+    | { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] }
+    | { [AxisRole.X]: VisColumn[]; [AxisRole.Y]: VisColumn },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
+  const axisConfig = getAxisConfig(styles);
 
-  if (!xAxis || !yAxis) {
-    throw Error('Missing axis config for Bar chart');
-  }
-
-  let timeField = '';
-  let valueField = '';
-  if (xAxis.schema === VisFieldType.Date) {
-    timeField = xAxis.column;
-    valueField = yAxis.column;
-  } else if (yAxis.schema === VisFieldType.Date) {
-    timeField = yAxis.column;
-    valueField = xAxis.column;
-  }
+  const {
+    categoryField: timeField,
+    categoryEncode,
+    seriesFields,
+    seriesFieldNames,
+    seriesEncode,
+  } = getNormalizedAxisConfig(axisColumnMappings);
 
   const timeUnit = styles.bucket?.bucketTimeUnit ?? TimeUnit.AUTO;
   const aggregationType = styles.bucket.aggregationType ?? AggregationType.SUM;
@@ -111,14 +145,14 @@ export const createTimeBarChart = (
       : transform(
           aggregate({
             groupBy: timeField,
-            field: valueField,
+            field: seriesFields,
             timeUnit,
             aggregationType,
           }),
           convertTo2DArray()
         ),
     createBaseConfig({
-      title: `${axisColumnMappings?.y?.name} Over Time`,
+      title: `${seriesFieldNames.join(', ')} Over Time`,
       legend: { show: false },
     }),
     buildAxisConfigs,
@@ -129,7 +163,9 @@ export const createTimeBarChart = (
     createBarSeries({
       styles,
       categoryField: timeField,
-      seriesFields: [valueField],
+      seriesFields,
+      categoryEncode,
+      seriesEncode,
     }),
     assembleSpec
   )({
@@ -148,39 +184,40 @@ export const createTimeBarChart = (
  */
 export const createGroupedTimeBarChart = (
   transformedData: Array<Record<string, any>>,
-  styleOptions: BarChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  styles: BarChartStyle,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const styles = { ...defaultBarChartStyles, ...styleOptions };
-  // Extract configuration before pipeline
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
+  const axisConfig = getAxisConfig(styles);
 
-  if (!xAxis || !yAxis) {
-    throw Error('Missing axis config for grouped time bar chart');
-  }
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
 
   let timeField = '';
   let valueField = '';
-  if (xAxis.schema === VisFieldType.Date) {
-    timeField = xAxis.column;
-    valueField = yAxis.column;
-  } else if (yAxis.schema === VisFieldType.Date) {
-    timeField = yAxis.column;
-    valueField = xAxis.column;
+  let valueFieldName = '';
+  let categoryEncode: 'x' | 'y' = 'x';
+  let seriesEncode: 'x' | 'y' = 'y';
+  if (xCol.schema === VisFieldType.Date) {
+    timeField = xCol.column;
+    valueField = yCol.column;
+    valueFieldName = yCol.name;
+  } else {
+    timeField = yCol.column;
+    valueField = xCol.column;
+    valueFieldName = xCol.name;
+    categoryEncode = 'y';
+    seriesEncode = 'x';
   }
 
   const timeUnit = styles?.bucket?.bucketTimeUnit ?? TimeUnit.AUTO;
   const aggregationType = styles?.bucket?.aggregationType ?? AggregationType.SUM;
   const skipBucketing = styles.bucket.aggregationType === AggregationType.NONE;
-
-  if (!colorField) {
-    throw new Error('Color column is required for grouped time bar chart');
-  }
 
   const result = pipe(
     transform(
@@ -195,7 +232,7 @@ export const createGroupedTimeBarChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisColumnMappings?.y?.name} Over Time by ${colorColumn.name}`,
+      title: `${valueFieldName} Over Time by ${axisColumnMappings[AxisRole.COLOR].name}`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -209,6 +246,8 @@ export const createGroupedTimeBarChart = (
       seriesFields(headers) {
         return (headers ?? []).filter((h) => h !== timeField);
       },
+      categoryEncode,
+      seriesEncode,
     }),
     assembleSpec
   )({
@@ -227,31 +266,33 @@ export const createGroupedTimeBarChart = (
  */
 export const createFacetedTimeBarChart = (
   transformedData: Array<Record<string, any>>,
-  styleOptions: BarChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  styles: BarChartStyle,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+    [AxisRole.FACET]: VisColumn;
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const styles = { ...defaultBarChartStyles, ...styleOptions };
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
+  const axisConfig = getAxisConfig(styles);
 
-  const facetColumn = axisColumnMappings?.[AxisRole.FACET]?.column;
-
-  if (!xAxis || !yAxis || !colorField || !facetColumn) {
-    throw Error('Missing axis config for facet time bar chart');
-  }
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
+  const facetColumn = axisColumnMappings[AxisRole.FACET].column;
 
   let timeField = '';
   let valueField = '';
-  if (xAxis.schema === VisFieldType.Date) {
-    timeField = xAxis.column;
-    valueField = yAxis.column;
-  } else if (yAxis.schema === VisFieldType.Date) {
-    timeField = yAxis.column;
-    valueField = xAxis.column;
+  let valueFieldName = '';
+  if (xCol.schema === VisFieldType.Date) {
+    timeField = xCol.column;
+    valueField = yCol.column;
+    valueFieldName = yCol.name;
+  } else {
+    timeField = yCol.column;
+    valueField = xCol.column;
+    valueFieldName = xCol.name;
   }
 
   const timeUnit = styles?.bucket?.bucketTimeUnit ?? TimeUnit.AUTO;
@@ -272,7 +313,9 @@ export const createFacetedTimeBarChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisColumnMappings.y?.name} Over Time by ${axisColumnMappings.color?.name} (Faceted by ${axisColumnMappings.facet?.name})`,
+      title: `${valueFieldName} Over Time by ${
+        axisColumnMappings[AxisRole.COLOR].name
+      } (Faceted by ${axisColumnMappings[AxisRole.FACET].name})`,
     }),
     buildAxisConfigs,
     applyTimeRange,
@@ -297,36 +340,40 @@ export const createFacetedTimeBarChart = (
 
 export const createStackedBarSpec = (
   transformedData: Array<Record<string, any>>,
-  styleOptions: BarChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-): any => {
-  const styles = { ...defaultBarChartStyles, ...styleOptions };
-  // Extract configuration before pipeline
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
-  const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorMapping?.column;
-
-  if (!xAxis || !yAxis) {
-    throw Error('Missing axis config for stacked bar chart');
+  styles: BarChartStyle,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
   }
+): any => {
+  const axisConfig = getAxisConfig(styles);
+
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
 
   let categoryField = '';
+  let categoryFieldName = '';
   let valueField = '';
-  if (xAxis.schema === VisFieldType.Categorical) {
-    categoryField = xAxis.column;
-    valueField = yAxis.column;
-  } else if (yAxis.schema === VisFieldType.Categorical) {
-    categoryField = yAxis.column;
-    valueField = xAxis.column;
+  let valueFieldName = '';
+  let categoryEncode: 'x' | 'y' = 'x';
+  let seriesEncode: 'x' | 'y' = 'y';
+  if (xCol.schema === VisFieldType.Categorical) {
+    categoryField = xCol.column;
+    categoryFieldName = xCol.name;
+    valueField = yCol.column;
+    valueFieldName = yCol.name;
+  } else {
+    categoryField = yCol.column;
+    categoryFieldName = yCol.name;
+    valueField = xCol.column;
+    valueFieldName = xCol.name;
+    categoryEncode = 'y';
+    seriesEncode = 'x';
   }
 
   const aggregationType = styles?.bucket?.aggregationType ?? AggregationType.SUM;
-
-  if (!colorField) {
-    throw new Error('Color column is required for stacked bar chart');
-  }
 
   const result = pipe(
     transform(
@@ -339,7 +386,9 @@ export const createStackedBarSpec = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisColumnMappings?.y?.name} by ${axisColumnMappings?.x?.name} and ${colorMapping.name}`,
+      title: `${valueFieldName} by ${categoryFieldName} and ${
+        axisColumnMappings[AxisRole.COLOR].name
+      }`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -352,6 +401,8 @@ export const createStackedBarSpec = (
       seriesFields(headers) {
         return (headers ?? []).filter((h) => h !== categoryField);
       },
+      categoryEncode,
+      seriesEncode,
     }),
     assembleSpec
   )({
@@ -365,40 +416,41 @@ export const createStackedBarSpec = (
 
 export const createDoubleNumericalBarChart = (
   transformedData: Array<Record<string, any>>,
-  styleOptions: BarChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  styles: BarChartStyle,
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] }
 ): any => {
-  const styles = { ...defaultBarChartStyles, ...styleOptions };
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
+  const axisConfig = getAxisConfig(styles);
 
-  if (!xAxis || !yAxis) {
-    throw Error('Missing axis config for Bar chart');
-  }
-
-  let categoryField = '';
-  let valueField = '';
-
-  categoryField = styles.switchAxes ? yAxis.column : xAxis.column;
-  valueField = styles.switchAxes ? xAxis.column : yAxis.column;
+  const categoryField = axisColumnMappings[AxisRole.X].column;
+  const categoryFieldName = axisColumnMappings[AxisRole.X].name;
+  const seriesFields = axisColumnMappings[AxisRole.Y].map((col) => col.column);
+  const seriesFieldNames = axisColumnMappings[AxisRole.Y].map((col) => col.name);
 
   const aggregationType = styles.bucket.aggregationType ?? AggregationType.SUM;
   const result = pipe(
     transform(
       aggregate({
         groupBy: categoryField,
-        field: valueField,
+        field: seriesFields,
         aggregationType,
       }),
       convertTo2DArray()
     ),
-    createBaseConfig({ title: `${xAxis?.name} with ${yAxis?.name}`, legend: { show: false } }),
+    createBaseConfig({
+      title: `${categoryFieldName} with ${seriesFieldNames.join(', ')}`,
+      legend: { show: false },
+    }),
     buildAxisConfigs,
     buildVisMap({
       seriesFields: (headers) => (headers ?? []).filter((h) => h !== categoryField),
     }),
-    createBarSeries({ styles, categoryField, seriesFields: [valueField] }),
+    createBarSeries({
+      styles,
+      categoryField,
+      seriesFields,
+      categoryEncode: 'x',
+      seriesEncode: 'y',
+    }),
     assembleSpec
   )({
     data: transformedData,
@@ -407,12 +459,7 @@ export const createDoubleNumericalBarChart = (
     axisColumnMappings: axisColumnMappings ?? {},
   });
 
-  // TODO: check if this is needed
-  if (styles.switchAxes) {
-    result.yAxisConfig.type = 'category';
-  } else {
-    result.xAxisConfig.type = 'category';
-  }
+  result.xAxisConfig.type = 'category';
 
   return result.spec;
 };

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_exclusive_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_exclusive_vis_options.test.tsx
@@ -15,7 +15,6 @@ jest.mock('@osd/i18n', () => ({
 
 describe('BarGaugeExclusiveVisOptions', () => {
   const defaultStyles: ExclusiveBarGaugeConfig = {
-    orientation: 'vertical',
     displayMode: 'gradient',
     valueDisplay: 'valueColor',
     showUnfilledArea: true,
@@ -27,30 +26,9 @@ describe('BarGaugeExclusiveVisOptions', () => {
     jest.clearAllMocks();
   });
 
-  it('should call onChange when orientation is changed', () => {
-    const { getByText } = render(
-      <BarGaugeExclusiveVisOptions
-        styles={defaultStyles}
-        onChange={mockOnChange}
-        isXaxisNumerical={false}
-      />
-    );
-
-    fireEvent.click(getByText('Horizontal'));
-
-    expect(mockOnChange).toHaveBeenCalledWith({
-      ...defaultStyles,
-      orientation: 'horizontal',
-    });
-  });
-
   it('should call onChange when display style is changed', () => {
     const { getByText } = render(
-      <BarGaugeExclusiveVisOptions
-        styles={defaultStyles}
-        onChange={mockOnChange}
-        isXaxisNumerical={false}
-      />
+      <BarGaugeExclusiveVisOptions styles={defaultStyles} onChange={mockOnChange} />
     );
 
     fireEvent.click(getByText('Stack'));
@@ -63,11 +41,7 @@ describe('BarGaugeExclusiveVisOptions', () => {
 
   it('should call onChange when value display is changed', () => {
     const { getByText } = render(
-      <BarGaugeExclusiveVisOptions
-        styles={defaultStyles}
-        onChange={mockOnChange}
-        isXaxisNumerical={false}
-      />
+      <BarGaugeExclusiveVisOptions styles={defaultStyles} onChange={mockOnChange} />
     );
 
     fireEvent.click(getByText('Text Color'));
@@ -80,11 +54,7 @@ describe('BarGaugeExclusiveVisOptions', () => {
 
   it('should call onChange when unfilled area switch is toggled', () => {
     const { getByRole } = render(
-      <BarGaugeExclusiveVisOptions
-        styles={defaultStyles}
-        onChange={mockOnChange}
-        isXaxisNumerical={false}
-      />
+      <BarGaugeExclusiveVisOptions styles={defaultStyles} onChange={mockOnChange} />
     );
 
     const switchElement = getByRole('switch');
@@ -98,17 +68,13 @@ describe('BarGaugeExclusiveVisOptions', () => {
 
   it('should handle undefined styles with defaults', () => {
     const { getByText } = render(
-      <BarGaugeExclusiveVisOptions
-        styles={undefined as any}
-        onChange={mockOnChange}
-        isXaxisNumerical={false}
-      />
+      <BarGaugeExclusiveVisOptions styles={undefined as any} onChange={mockOnChange} />
     );
 
-    fireEvent.click(getByText('Horizontal'));
+    fireEvent.click(getByText('Stack'));
 
     expect(mockOnChange).toHaveBeenCalledWith({
-      orientation: 'horizontal',
+      displayMode: 'stack',
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_exclusive_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_exclusive_vis_options.tsx
@@ -12,7 +12,6 @@ import { StyleAccordion } from '../style_panel/style_accordion';
 interface BarGaugeVisOptionsProps {
   styles: BarGaugeChartStyle['exclusive'];
   onChange: (styles: BarGaugeChartStyle['exclusive']) => void;
-  isXaxisNumerical: boolean;
 }
 
 const displayModeOption = [
@@ -60,31 +59,7 @@ const valueDisplayOption = [
   },
 ];
 
-export const BarGaugeExclusiveVisOptions = ({
-  styles,
-  onChange,
-  isXaxisNumerical,
-}: BarGaugeVisOptionsProps) => {
-  const getOrientationOptions = () => {
-    const horizontalLabel = i18n.translate('explore.vis.barGauge.orientation.horizontal', {
-      defaultMessage: 'Horizontal',
-    });
-    const verticalLabel = i18n.translate('explore.vis.barGauge.orientation.vertical', {
-      defaultMessage: 'Vertical',
-    });
-
-    // When X-axis is numerical, the labels are swapped
-    const verticalOptionLabel = isXaxisNumerical ? horizontalLabel : verticalLabel;
-    const horizontalOptionLabel = isXaxisNumerical ? verticalLabel : horizontalLabel;
-
-    return [
-      { id: 'vertical', label: verticalOptionLabel },
-      { id: 'horizontal', label: horizontalOptionLabel },
-    ];
-  };
-
-  const orientationOption = getOrientationOptions();
-
+export const BarGaugeExclusiveVisOptions = ({ styles, onChange }: BarGaugeVisOptionsProps) => {
   const updateExclusiveOption = (key: keyof BarGaugeChartStyle['exclusive'], value: any) => {
     onChange({
       ...styles,
@@ -101,26 +76,6 @@ export const BarGaugeExclusiveVisOptions = ({
       initialIsOpen={true}
       data-test-subj="barGaugeExclusivePanel"
     >
-      <EuiFormRow
-        label={i18n.translate('explore.stylePanel.barGauge.exclusive.orientation', {
-          defaultMessage: 'Orientation',
-        })}
-      >
-        <EuiButtonGroup
-          legend={i18n.translate('explore.stylePanel.barGauge.exclusive.orientation', {
-            defaultMessage: 'Orientation',
-          })}
-          isFullWidth
-          options={orientationOption}
-          onChange={(optionId) => {
-            updateExclusiveOption('orientation', optionId);
-          }}
-          type="single"
-          idSelected={styles?.orientation ?? 'vertical'}
-          buttonSize="compressed"
-        />
-      </EuiFormRow>
-
       <EuiFormRow
         label={i18n.translate('explore.stylePanel.barGauge.exclusive.displayStyle', {
           defaultMessage: 'Display style',

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_utils.test.ts
@@ -4,66 +4,14 @@
  */
 
 import {
-  getBarOrientation,
   thresholdsToGradient,
-  symbolOpposite,
   getGradientConfig,
   generateThresholds,
   generateValueThresholds,
 } from './bar_gauge_utils';
-import { AxisColumnMappings, Threshold, VisFieldType } from '../types';
-import { BarGaugeChartStyle } from './bar_gauge_vis_config';
+import { Threshold } from '../types';
 
 describe('bar_gauge_utils', () => {
-  describe('getBarOrientation', () => {
-    const mockAxisColumnMappings: AxisColumnMappings = {
-      x: {
-        id: 1,
-        name: 'xAxis',
-        schema: VisFieldType.Categorical,
-        column: 'x',
-        validValuesCount: 10,
-        uniqueValuesCount: 5,
-      },
-      y: {
-        id: 2,
-        name: 'yAxis',
-        schema: VisFieldType.Numerical,
-        column: 'y',
-        validValuesCount: 10,
-        uniqueValuesCount: 8,
-      },
-    };
-
-    it('should return swapped axes for horizontal orientation', () => {
-      const styles = { exclusive: { orientation: 'horizontal' as const } } as BarGaugeChartStyle;
-
-      const result = getBarOrientation(styles, mockAxisColumnMappings);
-
-      expect(result.xAxis).toBe(mockAxisColumnMappings.y);
-      expect(result.yAxis).toBe(mockAxisColumnMappings.x);
-      expect(result.yAxisStyle).toEqual({
-        axis: { tickOpacity: 0, grid: false, title: null, labelAngle: 0, labelOverlap: 'greedy' },
-      });
-      expect(result.xAxisStyle).toEqual({
-        axis: null,
-      });
-    });
-
-    it('should return normal axes for vertical orientation', () => {
-      const styles = { exclusive: { orientation: 'vertical' as const } } as BarGaugeChartStyle;
-
-      const result = getBarOrientation(styles, mockAxisColumnMappings);
-
-      expect(result.xAxis).toBe(mockAxisColumnMappings.x);
-      expect(result.yAxis).toBe(mockAxisColumnMappings.y);
-      expect(result.xAxisStyle).toEqual({
-        axis: { tickOpacity: 0, grid: false, title: null, labelAngle: 0, labelOverlap: 'greedy' },
-      });
-      expect(result.yAxisStyle).toEqual({ axis: null });
-    });
-  });
-
   describe('thresholdsToGradient', () => {
     it('should convert thresholds to gradient format', () => {
       const thresholds: Threshold[] = [
@@ -87,41 +35,19 @@ describe('bar_gauge_utils', () => {
     });
   });
 
-  describe('symbolOpposite', () => {
-    it('should return opposite symbol for horizontal orientation', () => {
-      expect(symbolOpposite('horizontal', 'x')).toBe('y');
-      expect(symbolOpposite('horizontal', 'y')).toBe('x');
-    });
-
-    it('should return same symbol for vertical orientation', () => {
-      expect(symbolOpposite('vertical', 'x')).toBe('x');
-      expect(symbolOpposite('vertical', 'y')).toBe('y');
-    });
-  });
-
   describe('getGradientConfig', () => {
-    it('returns horizontal gradient for non-numerical x-axis with horizontal orientation', () => {
-      const result = getGradientConfig('horizontal', 'gradient', false);
+    it('returns horizontal gradient when x-axis is not numerical', () => {
+      const result = getGradientConfig('gradient', false);
       expect(result).toEqual({ x1: 0, y1: 0, x2: 1, y2: 0 });
     });
 
-    it('returns horizontal gradient for numerical x-axis with non-horizontal orientation', () => {
-      const result = getGradientConfig('vertical', 'gradient', true);
-      expect(result).toEqual({ x1: 0, y1: 0, x2: 1, y2: 0 });
-    });
-
-    it('returns vertical gradient for numerical x-axis with horizontal orientation', () => {
-      const result = getGradientConfig('horizontal', 'gradient', true);
-      expect(result).toEqual({ x1: 1, y1: 1, x2: 1, y2: 0 });
-    });
-
-    it('returns vertical gradient for non-numerical x-axis with non-horizontal orientation', () => {
-      const result = getGradientConfig('vertical', 'gradient', false);
+    it('returns vertical gradient when x-axis is numerical', () => {
+      const result = getGradientConfig('gradient', true);
       expect(result).toEqual({ x1: 1, y1: 1, x2: 1, y2: 0 });
     });
 
     it('returns undefined for non-gradient display style', () => {
-      const result = getGradientConfig('horizontal', 'basic', false);
+      const result = getGradientConfig('basic', false);
       expect(result).toBeUndefined();
     });
   });

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_utils.ts
@@ -5,42 +5,12 @@
 
 import { BarSeriesOption } from 'echarts';
 import { graphic } from 'echarts';
-import { AxisColumnMappings, Threshold, VisFieldType, AxisRole, VisColumn } from '../types';
+import { Threshold, VisFieldType } from '../types';
 import { BarGaugeChartStyle } from './bar_gauge_vis_config';
 import { DEFAULT_GREY, getColors } from '../theme/default_colors';
 import { BaseChartStyle, PipelineFn, EChartsSpecState, getAxisType } from '../utils/echarts_spec';
 import { getUnitById } from '../style_panel/unit/collection';
-
-export const getBarOrientation = (
-  styles: BarGaugeChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-) => {
-  const xAxis = axisColumnMappings?.x;
-  const yAxis = axisColumnMappings?.y;
-  const isHorizontal = styles?.exclusive.orientation === 'horizontal';
-  const isXNumerical = xAxis?.schema === VisFieldType.Numerical;
-
-  const axisStyle = {
-    axis: { tickOpacity: 0, grid: false, title: null, labelAngle: 0, labelOverlap: 'greedy' },
-  };
-  const nullStyle = { axis: null };
-
-  if (isHorizontal) {
-    return {
-      xAxis: yAxis,
-      xAxisStyle: isXNumerical ? axisStyle : nullStyle,
-      yAxis: xAxis,
-      yAxisStyle: isXNumerical ? nullStyle : axisStyle,
-    };
-  }
-
-  return {
-    xAxis,
-    xAxisStyle: isXNumerical ? nullStyle : axisStyle,
-    yAxis,
-    yAxisStyle: isXNumerical ? axisStyle : nullStyle,
-  };
-};
+import { BarGaugeAxisMapping } from './types';
 
 export const thresholdsToGradient = (thresholds: Threshold[]) => {
   return thresholds.map((threshold: Threshold, index) => {
@@ -51,22 +21,8 @@ export const thresholdsToGradient = (thresholds: Threshold[]) => {
   });
 };
 
-export const symbolOpposite = (orientationMode: string, symbol: string) => {
-  if (orientationMode === 'horizontal') {
-    return symbol === 'x' ? 'y' : 'x';
-  }
-  return symbol;
-};
-
-export const getGradientConfig = (
-  orientationMode: string,
-  displayMode: string,
-  isXaxisNumerical: boolean
-) => {
-  if (
-    (!isXaxisNumerical && orientationMode === 'horizontal') ||
-    (isXaxisNumerical && orientationMode !== 'horizontal')
-  ) {
+export const getGradientConfig = (displayMode: string, isXAxisNumerical: boolean) => {
+  if (!isXAxisNumerical) {
     if (displayMode === 'gradient')
       return {
         x1: 0,
@@ -94,7 +50,7 @@ export const normalizeData = (data: number, start: number, end: number) => {
 export const generateParams = (
   thresholds: Threshold[],
   styleOptions: BarGaugeChartStyle,
-  isXaxisNumerical: boolean
+  isXAxisNumerical: boolean
 ) => {
   const result: any[] = [];
 
@@ -134,11 +90,7 @@ export const generateParams = (
       name: `gradient${i}`,
       value: {
         gradient: 'linear',
-        ...getGradientConfig(
-          styleOptions.exclusive.orientation,
-          styleOptions.exclusive.displayMode,
-          isXaxisNumerical
-        ),
+        ...getGradientConfig(styleOptions.exclusive.displayMode, isXAxisNumerical),
         stops,
       },
     });
@@ -223,12 +175,14 @@ export const createBarGaugeSeries = <T extends BaseChartStyle>({
   styles,
   categoryField,
   valueField,
+  axisColumnMappings,
 }: {
   styles: BarGaugeChartStyle;
   categoryField: string;
   valueField: string;
+  axisColumnMappings: BarGaugeAxisMapping;
 }): PipelineFn<T> => (state: EChartsSpecState<T>) => {
-  const { transformedData, axisColumnMappings } = state;
+  const { transformedData } = state;
   const newState = { ...state };
 
   // null is already identified as invalid numbers at the aggregate stage.
@@ -553,11 +507,13 @@ export const createBarGaugeAxesConfig = ({
 }: {
   styles: BarGaugeChartStyle;
   categories: string[];
-  axisColumnMappings: Partial<Record<AxisRole, VisColumn>>;
+  axisColumnMappings: BarGaugeAxisMapping;
   minBase: number;
   maxBase: number;
 }) => {
-  const { xAxis, xAxisStyle, yAxis, yAxisStyle } = getAxesStyleConfig(styles, axisColumnMappings);
+  const xAxis = axisColumnMappings.x;
+  const yAxis = axisColumnMappings.y;
+  const { xAxisStyle, yAxisStyle } = getAxesStyleConfig(axisColumnMappings);
 
   const isXNumerical = xAxis?.schema === VisFieldType.Numerical;
 
@@ -580,14 +536,9 @@ export const createBarGaugeAxesConfig = ({
   return { xAxisConfig, yAxisConfig };
 };
 
-const getAxesStyleConfig = (
-  styles: BarGaugeChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-) => {
-  const xAxis = axisColumnMappings?.x;
-  const yAxis = axisColumnMappings?.y;
-  const isHorizontal = styles?.exclusive.orientation === 'horizontal';
-  const isXNumerical = xAxis?.schema === VisFieldType.Numerical;
+const getAxesStyleConfig = (axisColumnMappings: BarGaugeAxisMapping) => {
+  const xAxis = axisColumnMappings.x;
+  const isXNumerical = xAxis.schema === VisFieldType.Numerical;
 
   const axisStyle = {
     axisLine: { show: false },
@@ -596,19 +547,8 @@ const getAxesStyleConfig = (
   };
   const nullStyle = { show: false };
 
-  if (isHorizontal) {
-    return {
-      xAxis: yAxis,
-      xAxisStyle: isXNumerical ? axisStyle : nullStyle,
-      yAxis: xAxis,
-      yAxisStyle: isXNumerical ? nullStyle : axisStyle,
-    };
-  }
-
   return {
-    xAxis,
     xAxisStyle: isXNumerical ? nullStyle : axisStyle,
-    yAxis,
     yAxisStyle: isXNumerical ? axisStyle : nullStyle,
   };
 };

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_config.tsx
@@ -13,7 +13,6 @@ import { createBarGaugeSpec } from './to_expression';
 import { EchartsRender } from '../echarts_render';
 
 export interface ExclusiveBarGaugeConfig {
-  orientation: 'vertical' | 'horizontal';
   displayMode: 'gradient' | 'stack' | 'basic';
   valueDisplay: 'valueColor' | 'textColor' | 'hidden';
   showUnfilledArea: boolean;
@@ -40,7 +39,6 @@ export const defaultBarGaugeChartStyles: BarGaugeChartStyle = {
     mode: 'all',
   },
   exclusive: {
-    orientation: 'vertical',
     displayMode: 'gradient',
     valueDisplay: 'valueColor',
     showUnfilledArea: true,
@@ -63,8 +61,8 @@ export const createBarGaugeConfig = (): VisualizationType<'bar_gauge'> => ({
         priority: 80,
         mappings: [
           {
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
             [AxisRole.X]: { type: VisFieldType.Categorical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical },
           },
           {
             [AxisRole.X]: { type: VisFieldType.Numerical },
@@ -72,11 +70,13 @@ export const createBarGaugeConfig = (): VisualizationType<'bar_gauge'> => ({
           },
         ],
         render(props) {
-          const spec = createBarGaugeSpec(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          if (!x || !y) throw Error('Missing axis config for bar gauge chart');
+          const spec = createBarGaugeSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_options.tsx
@@ -38,7 +38,6 @@ export const BarGaugeVisStyleControls: React.FC<BarGaugeVisStyleControlsProps> =
   };
 
   const hasMappingSelected = !isEmpty(axisColumnMappings);
-  const isXaxisNumerical = axisColumnMappings[AxisRole.X]?.schema === VisFieldType.Numerical;
 
   return (
     <EuiFlexGroup direction="column" gutterSize="none">
@@ -97,7 +96,6 @@ export const BarGaugeVisStyleControls: React.FC<BarGaugeVisStyleControlsProps> =
             <BarGaugeExclusiveVisOptions
               styles={styleOptions.exclusive}
               onChange={(options) => updateStyleOption('exclusive', options)}
-              isXaxisNumerical={isXaxisNumerical}
             />
           </EuiFlexItem>
 

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/to_expression.ts
@@ -4,20 +4,19 @@
  */
 
 import { BarGaugeChartStyle } from './bar_gauge_vis_config';
-import { AxisColumnMappings, VisFieldType } from '../types';
-import { getBarOrientation, createBarGaugeSeries, assembleBarGaugeSpec } from './bar_gauge_utils';
+import { VisFieldType } from '../types';
+import { createBarGaugeSeries, assembleBarGaugeSpec } from './bar_gauge_utils';
 import { pipe, createBaseConfig } from '../utils/echarts_spec';
 import { aggregate, transform } from '../utils/data_transformation';
+import { BarGaugeAxisMapping } from './types';
 
 export const createBarGaugeSpec = (
   transformedData: Array<Record<string, any>>,
   styleOptions: BarGaugeChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: BarGaugeAxisMapping
 ): any => {
-  const { xAxis, yAxis } = getBarOrientation(styleOptions, axisColumnMappings);
-  if (!xAxis || !yAxis) {
-    throw Error('Missing axis config for bar gauge chart');
-  }
+  const xAxis = axisColumnMappings.x;
+  const yAxis = axisColumnMappings.y;
 
   let categoryField = '';
   let valueField = '';
@@ -39,7 +38,7 @@ export const createBarGaugeSpec = (
       })
     ), // Bar gauge uses individual series with custom itemStyle per bar, can't use 2d array format
     createBaseConfig({ title: `${yAxis?.name} by ${xAxis?.name}`, legend: { show: false } }),
-    createBarGaugeSeries({ styles: styleOptions, categoryField, valueField }),
+    createBarGaugeSeries({ styles: styleOptions, categoryField, valueField, axisColumnMappings }),
     assembleBarGaugeSpec
   )({
     data: transformedData,

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/types.ts
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AxisRole, VisColumn } from '../types';
+
+// TODO: we should use strong typed axis mapping like this for all other types of visualizations
+// axisColumnMappings should passed to create*Series function explicitly instead of reading from state
+export interface BarGaugeAxisMapping {
+  [AxisRole.X]: VisColumn;
+  [AxisRole.Y]: VisColumn;
+}

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
@@ -56,7 +56,7 @@ export const createGaugeSeries = ({
       return;
     }
 
-    const seriesDisplayName = getSeriesDisplayName(item, Object.values(axisColumnMappings));
+    const seriesDisplayName = getSeriesDisplayName(item, Object.values(axisColumnMappings).flat());
 
     const numericalValues: number[] = [];
 
@@ -243,7 +243,7 @@ export const createGaugeSeries = ({
               style: {
                 x: 0,
                 y: -2 * textSizeFactor * (selectedUnit?.fontScale ?? 1),
-                text: displayValue,
+                text: displayValue as string,
                 textAlign: 'center',
                 fontSize: valueFontSize,
                 fontWeight: 'bold',

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
@@ -62,11 +62,11 @@ export const createGaugeConfig = (): VisualizationType<'gauge'> => ({
           },
         ],
         render(props) {
-          const spec = createGauge(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const value = props.axisColumnMappings.value?.[0];
+          if (!value) throw Error('Missing axis config for gauge chart');
+          const spec = createGauge(props.transformedData, props.styleOptions, {
+            [AxisRole.Value]: value,
+          });
           return <EchartsRender spec={spec ?? {}} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/gauge/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/to_expression.test.ts
@@ -42,8 +42,6 @@ describe('createGauge', () => {
   });
 
   it('throws when no value column is provided', () => {
-    expect(() => createGauge(mockData, defaultGaugeChartStyles, {})).toThrow(
-      'Missing value for metric chart'
-    );
+    expect(() => createGauge(mockData, defaultGaugeChartStyles, {} as any)).toThrow();
   });
 });

--- a/src/plugins/explore/public/components/visualizations/gauge/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/to_expression.ts
@@ -4,7 +4,7 @@
  */
 
 import { GaugeChartStyle } from './gauge_vis_config';
-import { AxisRole, AxisColumnMappings } from '../types';
+import { AxisRole, VisColumn } from '../types';
 import { createGaugeSeries, assembleGaugeSpec } from './gauge_chart_utils';
 import { pipe, createBaseConfig } from '../utils/echarts_spec';
 import { convertTo2DArray, transform } from '../utils/data_transformation';
@@ -12,12 +12,9 @@ import { convertTo2DArray, transform } from '../utils/data_transformation';
 export const createGauge = (
   transformedData: Array<Record<string, any>>,
   styleOptions: GaugeChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.Value]: VisColumn }
 ) => {
-  const valueColumn = axisColumnMappings?.[AxisRole.Value];
-  if (!valueColumn?.column) {
-    throw Error('Missing value for metric chart');
-  }
+  const valueColumn = axisColumnMappings[AxisRole.Value];
 
   const result = pipe(
     transform(convertTo2DArray()),
@@ -27,7 +24,7 @@ export const createGauge = (
   )({
     data: transformedData,
     styles: styleOptions,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
   return result.spec;
 };

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.ts
@@ -278,17 +278,17 @@ export const createHeatmapSeries = <T extends BaseChartStyle>({
 
           const seriesDisplayName = getSeriesDisplayName(
             seriesField,
-            Object.values(axisColumnMappings)
+            Object.values(axisColumnMappings).flat()
           );
 
           const categoryDisplayName = getSeriesDisplayName(
             categoryFields[0],
-            Object.values(axisColumnMappings)
+            Object.values(axisColumnMappings).flat()
           );
 
           const categoryDisplayName2 = getSeriesDisplayName(
             categoryFields[1],
-            Object.values(axisColumnMappings)
+            Object.values(axisColumnMappings).flat()
           );
 
           const categoryIndex = transformedData[0].indexOf(categoryFields[0]);

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.tsx
@@ -62,7 +62,6 @@ export interface HeatmapChartStyleOptions {
   standardAxes?: StandardAxes[];
 
   exclusive?: ExclusiveHeatmapConfig;
-  switchAxes?: boolean;
 
   titleOptions?: TitleOptions;
   useThresholdColor?: boolean;
@@ -73,7 +72,6 @@ export type HeatmapChartStyle = Required<Omit<HeatmapChartStyleOptions, 'legendT
   Pick<HeatmapChartStyleOptions, 'legendTitle'>;
 
 export const defaultHeatmapChartStyles: HeatmapChartStyle = {
-  switchAxes: false,
   // Basic controls
   tooltipOptions: {
     mode: 'all',
@@ -142,11 +140,15 @@ export const createHeatmapConfig = (): VisualizationType<'heatmap'> => ({
           },
         ],
         render(props) {
-          const spec = createRegularHeatmap(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for heatmap chart');
+          const spec = createRegularHeatmap(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec ?? {}} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.test.tsx
@@ -16,9 +16,7 @@ const mockStore = configureMockStore([]);
 const store = mockStore({
   tab: {
     visualizations: {
-      styleOptions: {
-        switchAxes: false,
-      },
+      styleOptions: {},
     },
   },
 });

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
@@ -52,8 +52,6 @@ export const HeatmapVisStyleControls: React.FC<HeatmapVisStyleControlsProps> = (
           currentMapping={axisColumnMappings}
           updateVisualization={updateVisualization}
           chartType="heatmap"
-          onSwitchAxes={(v) => updateStyleOption('switchAxes', v)}
-          switchAxes={styleOptions.switchAxes}
         />
       </EuiFlexItem>
       {hasMappingSelected && (
@@ -82,7 +80,6 @@ export const HeatmapVisStyleControls: React.FC<HeatmapVisStyleControlsProps> = (
               onStandardAxesChange={(standardAxes) =>
                 updateStyleOption('standardAxes', standardAxes)
               }
-              switchAxes={styleOptions.switchAxes}
             />
           </EuiFlexItem>
 

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { createRegularHeatmap } from './to_expression';
-import { VisColumn, VisFieldType, AxisRole, AxisColumnMappings, Positions } from '../types';
+import { VisColumn, VisFieldType, AxisRole, Positions } from '../types';
 import { defaultHeatmapChartStyles, HeatmapChartStyle } from './heatmap_vis_config';
 
 describe('Heatmap to_expression', () => {
@@ -52,7 +52,7 @@ describe('Heatmap to_expression', () => {
   };
 
   describe('createRegularHeatmap', () => {
-    const mockAxisColumnMappings: AxisColumnMappings = {
+    const mockAxisColumnMappings = {
       [AxisRole.X]: mockCategoricalColumns[0],
       [AxisRole.Y]: mockCategoricalColumns[1],
       [AxisRole.COLOR]: mockNumericalColumns[0],
@@ -104,9 +104,7 @@ describe('Heatmap to_expression', () => {
     });
 
     it('throws when axis config is missing', () => {
-      expect(() => createRegularHeatmap(mockData, mockStyles, {})).toThrow(
-        'Missing axis config for heatmap chart'
-      );
+      expect(() => createRegularHeatmap(mockData, mockStyles, {} as any)).toThrow();
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/to_expression.ts
@@ -4,8 +4,8 @@
  */
 
 import { HeatmapChartStyle } from './heatmap_vis_config';
-import { AxisColumnMappings, AggregationType } from '../types';
-import { getSwappedAxisRole } from '../utils/utils';
+import { AxisRole, VisColumn, AggregationType } from '../types';
+import { getAxisConfig } from '../utils/utils';
 import { createHeatmapSeries } from './heatmap_chart_utils';
 
 import {
@@ -20,49 +20,47 @@ import { convertTo2DArray, aggregateByGroups, transform } from '../utils/data_tr
 export const createRegularHeatmap = (
   transformedData: Array<Record<string, any>>,
   styles: HeatmapChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-) => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const xAxis = axisConfig.xAxis;
-  const yAxis = axisConfig.yAxis;
-
-  const valueField = axisColumnMappings?.color?.column;
-  const valueName = axisColumnMappings?.color?.name;
-
-  if (!xAxis || !yAxis || !valueField) {
-    throw Error('Missing axis config for heatmap chart');
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
   }
+) => {
+  const axisConfig = getAxisConfig(styles);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
 
   const result = pipe(
     transform(
       aggregateByGroups({
-        groupBy: [xAxis.column, yAxis.column],
-        field: valueField,
+        groupBy: [xCol.column, yCol.column],
+        field: colorCol.column,
         aggregationType: AggregationType.SUM,
       }),
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${valueName} by ${xAxis?.name} and ${yAxis?.name}`,
+      title: `${colorCol.name} by ${xCol.name} and ${yCol.name}`,
       addTrigger: false,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
     buildVisMap({
       seriesFields: (headers) =>
-        (headers ?? []).filter((h) => h !== yAxis.column && h !== xAxis.column),
+        (headers ?? []).filter((h) => h !== yCol.column && h !== xCol.column),
     }),
     createHeatmapSeries({
       styles,
-      categoryFields: [xAxis.column, yAxis.column],
-      seriesField: valueField,
+      categoryFields: [xCol.column, yCol.column],
+      seriesField: colorCol.column,
     }),
     assembleSpec
   )({
     data: transformedData,
     styles,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
@@ -49,7 +49,7 @@ export const createHistogramSeries = <T extends BaseChartStyle>(
 
   // Histogram series
   const series = seriesFields.map((seriesField, index) => {
-    const name = getSeriesDisplayName(seriesField, Object.values(axisColumnMappings));
+    const name = getSeriesDisplayName(seriesField, Object.values(axisColumnMappings).flat());
     const seriesFieldIndex = headers.indexOf(seriesField);
     return {
       type: 'custom',

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_config.tsx
@@ -101,11 +101,14 @@ export const createHistogramConfig = (): VisualizationType<'histogram'> => ({
           },
         ],
         render(props) {
-          const spec = createNumericalHistogramChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          if (!x || !y) throw Error('Missing axis config for histogram');
+
+          const spec = createNumericalHistogramChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} />;
         },
       },
@@ -117,11 +120,12 @@ export const createHistogramConfig = (): VisualizationType<'histogram'> => ({
           },
         ],
         render(props) {
-          const spec = createSingleHistogramChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          if (!x) throw Error('Missing axis config for histogram');
+
+          const spec = createSingleHistogramChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+          });
           return <EchartsRender spec={spec} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/histogram/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/to_expression.test.ts
@@ -63,9 +63,9 @@ describe('Histogram to_expression', () => {
     });
 
     it('throws when x axis is missing', () => {
-      expect(() => createSingleHistogramChart(mockData, defaultHistogramChartStyles, {})).toThrow(
-        'Missing axis config for Histogram chart'
-      );
+      expect(() =>
+        createSingleHistogramChart(mockData, defaultHistogramChartStyles, {} as any)
+      ).toThrow();
     });
   });
 
@@ -102,8 +102,8 @@ describe('Histogram to_expression', () => {
 
     it('throws when x axis is missing', () => {
       expect(() =>
-        createNumericalHistogramChart(mockData, defaultHistogramChartStyles, {})
-      ).toThrow('Missing axis config for Histogram chart');
+        createNumericalHistogramChart(mockData, defaultHistogramChartStyles, {} as any)
+      ).toThrow();
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/histogram/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/to_expression.ts
@@ -4,8 +4,8 @@
  */
 
 import { HistogramChartStyle } from './histogram_vis_config';
-import { AxisColumnMappings, VisFieldType } from '../types';
-import { getSwappedAxisRole } from '../utils/utils';
+import { AxisRole, VisColumn, VisFieldType } from '../types';
+import { getAxisConfig } from '../utils/utils';
 import { assembleSpec, buildAxisConfigs, createBaseConfig, pipe } from '../utils/echarts_spec';
 import { convertTo2DArray, transform } from '../utils/data_transformation';
 import { bin } from '../utils/data_transformation/bin';
@@ -14,16 +14,12 @@ import { createHistogramSeries } from './histogram_chart_utils';
 export const createNumericalHistogramChart = (
   transformedData: Array<Record<string, any>>,
   styles: HistogramChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const { xAxis, yAxis } = axisConfig;
-  if (!xAxis) {
-    throw Error('Missing axis config for Histogram chart');
-  }
+  const axisConfig = getAxisConfig(styles);
 
-  const categoryField = xAxis.column;
-  const valueField = yAxis?.column;
+  const categoryField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
 
   const result = pipe(
     transform(
@@ -47,20 +43,8 @@ export const createNumericalHistogramChart = (
   )({
     data: transformedData,
     styles,
-    axisConfig: {
-      ...axisConfig,
-      xAxis: {
-        name: 'bucket',
-        column: 'bucket',
-        schema: VisFieldType.Numerical,
-      },
-      yAxis: {
-        name: 'value',
-        column: 'value',
-        schema: VisFieldType.Numerical,
-      },
-    },
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisConfig,
+    axisColumnMappings,
   });
   return result.spec;
 };
@@ -68,15 +52,11 @@ export const createNumericalHistogramChart = (
 export const createSingleHistogramChart = (
   transformedData: Array<Record<string, any>>,
   styles: HistogramChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const { xAxis } = axisConfig;
-  if (!xAxis) {
-    throw Error('Missing axis config for Histogram chart');
-  }
+  const axisConfig = getAxisConfig(styles);
 
-  const categoryField = xAxis.column;
+  const categoryField = axisColumnMappings[AxisRole.X].column;
 
   const result = pipe(
     transform(
@@ -98,20 +78,8 @@ export const createSingleHistogramChart = (
   )({
     data: transformedData,
     styles,
-    axisConfig: {
-      ...axisConfig,
-      xAxis: {
-        name: 'bucket',
-        column: 'bucket',
-        schema: VisFieldType.Numerical,
-      },
-      yAxis: {
-        name: 'value',
-        column: 'value',
-        schema: VisFieldType.Numerical,
-      },
-    },
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisConfig,
+    axisColumnMappings,
   });
   return result.spec;
 };

--- a/src/plugins/explore/public/components/visualizations/line/line_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_chart_utils.ts
@@ -332,15 +332,15 @@ export const createLineSeries = <T extends BaseChartStyle>({
 
   if (usedTimeMarker) {
     {
-      // manully extend xAxis range
-      const newxAxisConfig = { ...xAxisConfig };
-      newxAxisConfig.max = new Date();
-      newState.xAxisConfig = newxAxisConfig;
+      // manually extend xAxis range
+      const newXAxisConfig = { ...xAxisConfig };
+      newXAxisConfig.max = new Date();
+      newState.xAxisConfig = newXAxisConfig;
     }
   }
 
   const series = seriesFields?.map((item: string) => {
-    const name = getSeriesDisplayName(item, Object.values(axisColumnMappings));
+    const name = getSeriesDisplayName(item, Object.values(axisColumnMappings).flat());
 
     return {
       name,
@@ -370,13 +370,14 @@ export const createLineBarSeries = <T extends BaseChartStyle>({
   categoryField,
 }: {
   styles: LineChartStyle;
-  valueField: VisColumn;
-  value2Field: VisColumn;
+  valueField: string[];
+  value2Field: string[];
   categoryField: string;
 }): PipelineFn<T> => (state) => {
-  const { xAxisConfig, yAxisConfig: _yAxisConfig } = state;
+  const { xAxisConfig, axisColumnMappings } = state;
   const newState = { ...state };
 
+  // TODO: move this to buildAxisConfigs function
   if (styles.addTimeMarker) {
     {
       // manully extend xAxis range
@@ -387,32 +388,38 @@ export const createLineBarSeries = <T extends BaseChartStyle>({
   }
 
   const series = [
-    {
-      type: 'line',
-      name: valueField?.name,
-      ...generateLineStyles(styles),
-      ...composeMarkLine(styles?.thresholdOptions, styles?.addTimeMarker),
-      yAxisIndex: 0,
-      encode: {
-        x: categoryField,
-        y: valueField.column,
-      },
-      emphasis: {
-        focus: 'self',
-      },
-    },
-    {
-      type: 'bar',
-      name: value2Field?.name,
-      yAxisIndex: 1,
-      encode: {
-        x: categoryField,
-        y: value2Field.column,
-      },
-      emphasis: {
-        focus: 'self',
-      },
-    },
+    ...valueField.map((field) => {
+      const name = getSeriesDisplayName(field, Object.values(axisColumnMappings).flat());
+      return {
+        type: 'line',
+        name,
+        ...generateLineStyles(styles),
+        ...composeMarkLine(styles?.thresholdOptions, styles?.addTimeMarker),
+        yAxisIndex: 0,
+        encode: {
+          x: categoryField,
+          y: field,
+        },
+        emphasis: {
+          focus: 'self',
+        },
+      };
+    }),
+    ...value2Field.map((field) => {
+      const name = getSeriesDisplayName(field, Object.values(axisColumnMappings).flat());
+      return {
+        type: 'bar',
+        name,
+        yAxisIndex: 1,
+        encode: {
+          x: categoryField,
+          y: field,
+        },
+        emphasis: {
+          focus: 'self',
+        },
+      };
+    }),
   ];
 
   newState.series = series as LineSeriesOption[];

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
@@ -114,14 +114,18 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Date },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0) throw Error('Missing axis config for line chart');
+
           const spec = createSimpleLineChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -132,15 +136,22 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Date },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
-            [AxisRole.Y_SECOND]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+            [AxisRole.Y_SECOND]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          const y2 = props.axisColumnMappings.y2;
+
+          if (!x || !y || !y2 || y.length === 0 || y2.length === 0)
+            throw Error('Missing axis config for line/bar combo chart');
+
           const spec = createLineBarChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.Y_SECOND]: y2 },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -156,10 +167,15 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for multi-line chart');
+
           const spec = createMultiLineChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -175,10 +191,15 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for multi-line chart');
+
           const spec = createMultiLineChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -195,10 +216,17 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted multi-line chart');
+
           const spec = createFacetedMultiLineChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -215,10 +243,17 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!x || !y || !color || !facet)
+            throw Error('Missing axis config for faceted multi-line chart');
+
           const spec = createFacetedMultiLineChart(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings,
+            { [AxisRole.X]: x, [AxisRole.Y]: y, [AxisRole.COLOR]: color, [AxisRole.FACET]: facet },
             props.timeRange
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
@@ -229,15 +264,19 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
         mappings: [
           {
             [AxisRole.X]: { type: VisFieldType.Categorical },
-            [AxisRole.Y]: { type: VisFieldType.Numerical },
+            [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
           },
         ],
         render(props) {
-          const spec = createCategoryLineChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y;
+          if (!x || !y || y.length === 0)
+            throw Error('Missing axis config for category line chart');
+
+          const spec = createCategoryLineChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -251,11 +290,16 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           },
         ],
         render(props) {
-          const spec = createCategoryMultiLineChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for category multi-line chart');
+
+          const spec = createCategoryMultiLineChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -269,11 +313,16 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           },
         ],
         render(props) {
-          const spec = createCategoryMultiLineChart(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for category multi-line chart');
+
+          const spec = createCategoryMultiLineChart(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
@@ -11,14 +11,7 @@ import {
   createCategoryLineChart,
   createCategoryMultiLineChart,
 } from './to_expression';
-import {
-  VisColumn,
-  VisFieldType,
-  ThresholdMode,
-  Positions,
-  AxisRole,
-  AxisColumnMappings,
-} from '../types';
+import { VisColumn, VisFieldType, ThresholdMode, Positions, AxisRole } from '../types';
 import { defaultLineChartStyles } from './line_vis_config';
 
 describe('Line Chart to_expression', () => {
@@ -87,8 +80,8 @@ describe('Line Chart to_expression', () => {
   };
 
   describe('createSimpleLineChart', () => {
-    const mockAxisMappings: AxisColumnMappings = {
-      [AxisRole.Y]: mockNumericColumn,
+    const mockAxisMappings = {
+      [AxisRole.Y]: [mockNumericColumn],
       [AxisRole.X]: mockDateColumn,
     };
 
@@ -127,10 +120,10 @@ describe('Line Chart to_expression', () => {
   });
 
   describe('createLineBarChart', () => {
-    const mockAxisMappings: AxisColumnMappings = {
-      [AxisRole.Y]: mockNumericColumn,
+    const mockAxisMappings = {
+      [AxisRole.Y]: [mockNumericColumn],
       [AxisRole.X]: mockDateColumn,
-      [AxisRole.Y_SECOND]: mockNumericColumn2,
+      [AxisRole.Y_SECOND]: [mockNumericColumn2],
     };
 
     it('returns an ECharts spec with dataset and series', () => {
@@ -152,12 +145,12 @@ describe('Line Chart to_expression', () => {
     });
 
     it('throws when axis config is missing', () => {
-      expect(() => createLineBarChart(mockData, mockStyles, {})).toThrow();
+      expect(() => createLineBarChart(mockData, mockStyles, {} as any)).toThrow();
     });
   });
 
   describe('createMultiLineChart', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.Y]: mockNumericColumn,
       [AxisRole.X]: mockDateColumn,
       [AxisRole.COLOR]: mockCategoricalColumn,
@@ -190,7 +183,7 @@ describe('Line Chart to_expression', () => {
   });
 
   describe('createFacetedMultiLineChart', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.Y]: mockNumericColumn,
       [AxisRole.X]: mockDateColumn,
       [AxisRole.COLOR]: mockCategoricalColumn,
@@ -216,8 +209,8 @@ describe('Line Chart to_expression', () => {
   });
 
   describe('createCategoryLineChart', () => {
-    const mockAxisMappings: AxisColumnMappings = {
-      [AxisRole.Y]: mockNumericColumn,
+    const mockAxisMappings = {
+      [AxisRole.Y]: [mockNumericColumn],
       [AxisRole.X]: mockCategoricalColumn,
     };
 
@@ -241,7 +234,7 @@ describe('Line Chart to_expression', () => {
   });
 
   describe('createCategoryMultiLineChart', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.Y]: mockNumericColumn,
       [AxisRole.X]: mockCategoricalColumn,
       [AxisRole.COLOR]: mockCategoricalColumn2,

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -4,9 +4,9 @@
  */
 
 import { LineChartStyle } from './line_vis_config';
-import { AxisColumnMappings, AxisRole } from '../types';
+import { AxisRole, VisColumn } from '../types';
 import { createLineSeries, createLineBarSeries, createFacetLineSeries } from './line_chart_utils';
-import { getSwappedAxisRole } from '../utils/utils';
+import { getAxisConfig, getColumnsFromAxisColumnMapping } from '../utils/utils';
 import {
   pipe,
   createBaseConfig,
@@ -29,27 +29,28 @@ import {
 export const createSimpleLineChart = (
   transformedData: Array<Record<string, any>>,
   styles: LineChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
+  const axisConfig = getAxisConfig(styles);
 
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
+  const timeField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].map((y) => y.column);
+  const valueFieldNames = axisColumnMappings[AxisRole.Y].map((y) => y.name) ?? [];
 
   if (!valueField || !timeField) throw Error('Missing axis config for line chart');
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = getColumnsFromAxisColumnMapping(axisColumnMappings);
 
   const result = pipe(
-    transform(sortByTime(axisColumnMappings?.x?.column), convertTo2DArray(allColumns)),
-    createBaseConfig({ title: `${axisConfig.yAxis?.name} Over Time`, legend: { show: false } }),
+    transform(sortByTime(timeField), convertTo2DArray(allColumns)),
+    createBaseConfig({ title: `${valueFieldNames.join(', ')} Over Time`, legend: { show: false } }),
     buildAxisConfigs,
     applyTimeRange,
     createLineSeries({
       styles,
       categoryField: timeField,
-      seriesFields: [valueField],
+      seriesFields: valueField,
     }),
     assembleSpec
   )({
@@ -69,25 +70,33 @@ export const createSimpleLineChart = (
 export const createLineBarChart = (
   transformedData: Array<Record<string, any>>,
   styles: LineChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn[];
+    [AxisRole.Y_SECOND]: VisColumn[];
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
+  const axisConfig = getAxisConfig(styles);
 
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis;
-  const value2Field = axisColumnMappings?.[AxisRole.Y_SECOND];
+  const timeField = axisColumnMappings.x.column;
+  const valueField = axisColumnMappings.y.map((y) => y.column);
+  const valueFieldNames = axisColumnMappings.y.map((y) => y.name) ?? [];
+  const value2Field = axisColumnMappings.y2.map((y) => y.column);
+  const value2FieldNames = axisColumnMappings.y2.map((y) => y.name) ?? [];
 
   if (!timeField || !valueField || !value2Field) {
     throw Error('Missing axis config or color field for line-bar chart');
   }
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = getColumnsFromAxisColumnMapping(axisColumnMappings);
 
   const result = pipe(
-    transform(sortByTime(axisColumnMappings?.x?.column), convertTo2DArray(allColumns)),
+    transform(sortByTime(timeField), convertTo2DArray(allColumns)),
     createBaseConfig({
-      title: `${valueField.name} (Bar) and ${value2Field.name} (Line) Over Time`,
+      title: `${valueFieldNames.join(', ')} (Bar) and ${value2FieldNames.join(
+        ', '
+      )} (Line) Over Time`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -111,18 +120,18 @@ export const createLineBarChart = (
 export const createMultiLineChart = (
   transformedData: Array<Record<string, any>>,
   styles: LineChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
+  const axisConfig = getAxisConfig(styles);
 
-  if (!timeField || !valueField || !colorField) {
-    throw Error('Missing axis config or color field for multi lines chart');
-  }
+  const timeField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
 
   const result = pipe(
     transform(
@@ -136,7 +145,9 @@ export const createMultiLineChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} Over Time by ${axisColumnMappings?.[AxisRole.COLOR]?.name}`,
+      title: `${axisColumnMappings[AxisRole.Y].name} Over Time by ${
+        axisColumnMappings[AxisRole.COLOR].name
+      }`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -164,19 +175,20 @@ export const createMultiLineChart = (
 export const createFacetedMultiLineChart = (
   transformedData: Array<Record<string, any>>,
   styles: LineChartStyle,
-  axisColumnMappings?: AxisColumnMappings,
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+    [AxisRole.FACET]: VisColumn;
+  },
   timeRange?: { from: string; to: string }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const timeField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
+  const axisConfig = getAxisConfig(styles);
 
-  const facetColumn = axisColumnMappings?.[AxisRole.FACET]?.column;
-  if (!timeField || !valueField || !colorField || !facetColumn) {
-    throw Error('Missing axis config for facet time line chart');
-  }
+  const timeField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
+  const facetColumn = axisColumnMappings[AxisRole.FACET].column;
 
   const result = pipe(
     facetTransform(
@@ -191,9 +203,9 @@ export const createFacetedMultiLineChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} Over Time by ${
-        axisColumnMappings?.[AxisRole.COLOR]?.name
-      } (Faceted by ${axisColumnMappings?.[AxisRole.FACET]?.name})`,
+      title: `${axisColumnMappings[AxisRole.Y].name} Over Time by ${
+        axisColumnMappings[AxisRole.COLOR].name
+      } (Faceted by ${axisColumnMappings[AxisRole.FACET].name})`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -221,28 +233,27 @@ export const createFacetedMultiLineChart = (
 export const createCategoryLineChart = (
   transformedData: Array<Record<string, any>>,
   styles: LineChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn[] }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
+  const axisConfig = getAxisConfig(styles);
 
-  const categoryField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
+  const categoryField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].map((y) => y.column);
+  const valueFieldNames = axisColumnMappings[AxisRole.Y].map((y) => y.name) ?? [];
 
-  if (!valueField || !categoryField) throw Error('Missing axis config for line chart');
-
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = getColumnsFromAxisColumnMapping(axisColumnMappings);
 
   const result = pipe(
     transform(convertTo2DArray(allColumns)),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} by ${axisConfig.xAxis?.name}`,
+      title: `${valueFieldNames.join(', ')} by ${axisColumnMappings[AxisRole.X].name}`,
       legend: { show: false },
     }),
     buildAxisConfigs,
     createLineSeries({
       styles,
       categoryField,
-      seriesFields: [valueField],
+      seriesFields: valueField,
       addTimeMarker: false,
     }),
     assembleSpec
@@ -259,17 +270,18 @@ export const createCategoryLineChart = (
 export const createCategoryMultiLineChart = (
   transformedData: Array<Record<string, any>>,
   styles: LineChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-  const cateField = axisConfig.xAxis?.column;
-  const valueField = axisConfig.yAxis?.column;
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR];
-  const colorField = colorColumn?.column;
-
-  if (!cateField || !valueField || !colorField) {
-    throw Error('Missing axis config or color field for multi lines chart');
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
   }
+): any => {
+  const axisConfig = getAxisConfig(styles);
+
+  const cateField = axisColumnMappings[AxisRole.X].column;
+  const valueField = axisColumnMappings[AxisRole.Y].column;
+  const colorField = axisColumnMappings[AxisRole.COLOR].column;
+
   const result = pipe(
     transform(
       pivot({
@@ -281,9 +293,9 @@ export const createCategoryMultiLineChart = (
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisConfig.yAxis?.name} by ${axisConfig.xAxis?.name} and ${
-        axisColumnMappings?.[AxisRole.COLOR]?.name
-      }`,
+      title: `${axisColumnMappings[AxisRole.Y].name} by ${
+        axisColumnMappings[AxisRole.X].name
+      } and ${axisColumnMappings[AxisRole.COLOR].name}`,
       legend: { show: styles.addLegend },
     }),
     buildAxisConfigs,
@@ -293,7 +305,6 @@ export const createCategoryMultiLineChart = (
       seriesFields: (headers) => (headers ?? []).filter((h) => h !== cateField),
       addTimeMarker: false,
     }),
-
     assembleSpec
   )({
     data: transformedData,

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.ts
@@ -38,8 +38,6 @@ export const createSimpleLineChart = (
   const valueField = axisColumnMappings[AxisRole.Y].map((y) => y.column);
   const valueFieldNames = axisColumnMappings[AxisRole.Y].map((y) => y.name) ?? [];
 
-  if (!valueField || !timeField) throw Error('Missing axis config for line chart');
-
   const allColumns = getColumnsFromAxisColumnMapping(axisColumnMappings);
 
   const result = pipe(

--- a/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
@@ -8,7 +8,8 @@ import * as echarts from 'echarts';
 import { debounce } from 'lodash';
 
 import { MetricChartStyle } from './metric_vis_config';
-import { AxisColumnMappings, AxisRole, RendererSpecConfig } from '../types';
+import { AxisRole, RendererSpecConfig } from '../types';
+import { MetricAxisMapping } from './to_expression';
 import { calculatePercentage, calculateValue } from '../utils/calculation';
 import { getUnitById } from '../style_panel/unit/collection';
 import { getColors, DEFAULT_GREY } from '../theme/default_colors';
@@ -33,13 +34,13 @@ interface MetricChartProps {
   name: string;
   data?: Array<Record<string, any>>;
   styles: MetricChartStyle;
-  axisColumnMappings?: AxisColumnMappings;
+  axisColumnMappings: MetricAxisMapping;
   spec?: echarts.EChartsOption;
 }
 
 interface MetricChartRenderProps {
   styles: MetricChartStyle;
-  axisColumnMappings?: AxisColumnMappings;
+  axisColumnMappings: MetricAxisMapping;
   spec?: RendererSpecConfig | RendererSpecConfig[];
 }
 
@@ -343,8 +344,8 @@ export const MetricChart: React.FC<MetricChartProps> = ({
   spec,
   name,
 }) => {
-  const valueColumn = axisColumnMappings?.[AxisRole.Value];
-  const numericField = valueColumn?.column ?? '';
+  const valueColumn = axisColumnMappings[AxisRole.Value];
+  const numericField = valueColumn.column;
 
   // State for container dimensions
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });

--- a/src/plugins/explore/public/components/visualizations/metric/metric_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_utils.ts
@@ -63,7 +63,7 @@ export const createMetricChartSeries = ({
       }
     }
 
-    const seriesDisplayName = getSeriesDisplayName(item, Object.values(axisColumnMappings));
+    const seriesDisplayName = getSeriesDisplayName(item, Object.values(axisColumnMappings).flat());
 
     series.push({
       name: seriesDisplayName,

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.tsx
@@ -16,7 +16,7 @@ import {
 } from '../types';
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
-import { createSingleMetric, createMultiMetric } from './to_expression';
+import { createSingleMetric, createMultiMetric, MetricAxisMapping } from './to_expression';
 import { MetricChartRender } from './metric_component';
 
 export type TextAlignment = 'auto' | 'center';
@@ -118,16 +118,15 @@ export const createMetricConfig = (): VisualizationType<'metric'> => ({
           },
         ],
         render(props) {
-          const spec = createSingleMetric(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const value = props.axisColumnMappings.value?.[0];
+          if (!value) throw Error('Missing axis config for metric chart');
+          const mapping: MetricAxisMapping = { [AxisRole.Value]: value };
+          const spec = createSingleMetric(props.transformedData, props.styleOptions, mapping);
           return (
             <MetricChartRender
               spec={spec}
               styles={props.styleOptions}
-              axisColumnMappings={props.axisColumnMappings}
+              axisColumnMappings={mapping}
             />
           );
         },
@@ -141,16 +140,19 @@ export const createMetricConfig = (): VisualizationType<'metric'> => ({
           },
         ],
         render(props) {
-          const spec = createSingleMetric(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const value = props.axisColumnMappings.value?.[0];
+          const time = props.axisColumnMappings.time?.[0];
+          if (!value || !time) throw Error('Missing axis config for metric chart');
+          const mapping: MetricAxisMapping = {
+            [AxisRole.Value]: value,
+            [AxisRole.Time]: time,
+          };
+          const spec = createSingleMetric(props.transformedData, props.styleOptions, mapping);
           return (
             <MetricChartRender
               spec={spec}
               styles={props.styleOptions}
-              axisColumnMappings={props.axisColumnMappings}
+              axisColumnMappings={mapping}
             />
           );
         },
@@ -164,16 +166,23 @@ export const createMetricConfig = (): VisualizationType<'metric'> => ({
           },
         ],
         render(props) {
+          const value = props.axisColumnMappings.value?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!value || !facet) throw Error('Missing axis config for metric chart');
+          const mapping: MetricAxisMapping = {
+            [AxisRole.Value]: value,
+            [AxisRole.FACET]: facet,
+          };
           const specs = createMultiMetric(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings
+            mapping as MetricAxisMapping & { [AxisRole.FACET]: typeof facet }
           );
           return (
             <MetricChartRender
               spec={specs}
               styles={props.styleOptions}
-              axisColumnMappings={props.axisColumnMappings}
+              axisColumnMappings={mapping}
             />
           );
         },
@@ -188,16 +197,25 @@ export const createMetricConfig = (): VisualizationType<'metric'> => ({
           },
         ],
         render(props) {
+          const value = props.axisColumnMappings.value?.[0];
+          const time = props.axisColumnMappings.time?.[0];
+          const facet = props.axisColumnMappings.facet?.[0];
+          if (!value || !time || !facet) throw Error('Missing axis config for metric chart');
+          const mapping: MetricAxisMapping = {
+            [AxisRole.Value]: value,
+            [AxisRole.Time]: time,
+            [AxisRole.FACET]: facet,
+          };
           const specs = createMultiMetric(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings
+            mapping as MetricAxisMapping & { [AxisRole.FACET]: typeof facet }
           );
           return (
             <MetricChartRender
               spec={specs}
               styles={props.styleOptions}
-              axisColumnMappings={props.axisColumnMappings}
+              axisColumnMappings={mapping}
             />
           );
         },

--- a/src/plugins/explore/public/components/visualizations/metric/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/metric/to_expression.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { createSingleMetric } from './to_expression';
-import { VisColumn, VisFieldType, AxisRole, AxisColumnMappings } from '../types';
+import { VisColumn, VisFieldType, AxisRole } from '../types';
 import { defaultMetricChartStyles, MetricChartStyle } from './metric_vis_config';
 
 describe('Metric to_expression', () => {
@@ -36,7 +36,7 @@ describe('Metric to_expression', () => {
 
   describe('createSingleMetric', () => {
     it('returns result with spec, name, and data', () => {
-      const mockAxisMappings: AxisColumnMappings = {
+      const mockAxisMappings = {
         [AxisRole.Value]: numericColumn,
       };
 
@@ -54,7 +54,7 @@ describe('Metric to_expression', () => {
         { value: 200, date: '2023-01-02' },
       ];
 
-      const mockAxisMappings: AxisColumnMappings = {
+      const mockAxisMappings = {
         [AxisRole.Value]: numericColumn,
         [AxisRole.Time]: dateColumn,
       };
@@ -68,7 +68,7 @@ describe('Metric to_expression', () => {
     });
 
     it('does not include line series when no date column', () => {
-      const mockAxisMappings: AxisColumnMappings = {
+      const mockAxisMappings = {
         [AxisRole.Value]: numericColumn,
       };
 
@@ -78,9 +78,7 @@ describe('Metric to_expression', () => {
     });
 
     it('throws when no value column is provided', () => {
-      expect(() => createSingleMetric(mockData, mockStyles, {})).toThrow(
-        'Missing value for metric chart'
-      );
+      expect(() => createSingleMetric(mockData, mockStyles, {} as any)).toThrow();
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/metric/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/metric/to_expression.ts
@@ -4,26 +4,28 @@
  */
 
 import { MetricChartStyle } from './metric_vis_config';
-import { AxisRole, AxisColumnMappings, VisFieldType, RendererSpecConfig } from '../types';
+import { AxisRole, VisColumn, RendererSpecConfig } from '../types';
 import { assembleSpec, buildAxisConfigs, createBaseConfig, pipe } from '../utils/echarts_spec';
 import { convertTo2DArray, transform } from '../utils/data_transformation';
 import { assembleForMetric, createMetricChartSeries } from './metric_utils';
 
+export interface MetricAxisMapping {
+  [AxisRole.Value]: VisColumn;
+  [AxisRole.Time]?: VisColumn;
+  [AxisRole.FACET]?: VisColumn;
+}
+
 export const createSingleMetric = (
   transformedData: Array<Record<string, any>>,
   styles: MetricChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.Value]: VisColumn; [AxisRole.Time]?: VisColumn }
 ) => {
-  const valueColumn = axisColumnMappings?.[AxisRole.Value];
-  const numericField = valueColumn?.column;
-  const numericFieldName = valueColumn?.name;
+  const valueColumn = axisColumnMappings[AxisRole.Value];
+  const numericField = valueColumn.column;
+  const numericFieldName = valueColumn.name;
 
-  const dateColumn = axisColumnMappings?.[AxisRole.Time];
+  const dateColumn = axisColumnMappings[AxisRole.Time];
   const dateField = dateColumn?.column;
-
-  if (!numericField) {
-    throw Error('Missing value for metric chart');
-  }
 
   if (!dateField) {
     return { spec: undefined, name: numericFieldName, data: transformedData };
@@ -44,8 +46,8 @@ export const createSingleMetric = (
   )({
     data: transformedData,
     styles,
-    axisConfig: { xAxis: dateColumn, yAxis: valueColumn },
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisConfig: {},
+    axisColumnMappings,
   });
   return { spec: result.spec, name: numericFieldName, data: transformedData };
 };
@@ -53,21 +55,14 @@ export const createSingleMetric = (
 export const createMultiMetric = (
   transformedData: Array<Record<string, any>>,
   styles: MetricChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: {
+    [AxisRole.Value]: VisColumn;
+    [AxisRole.Time]?: VisColumn;
+    [AxisRole.FACET]: VisColumn;
+  }
 ) => {
-  // Get the main value field
-  const valueMapping = axisColumnMappings?.[AxisRole.Value];
-  if (!valueMapping || valueMapping.schema !== VisFieldType.Numerical) {
-    throw Error('Metric visualization requires a numerical value field');
-  }
-
-  // Get the split by (categorical) field for faceting
-  const splitByMapping = axisColumnMappings?.[AxisRole.FACET];
-  if (!splitByMapping || splitByMapping.schema !== VisFieldType.Categorical) {
-    throw Error('Multi-metric visualization requires a categorical field for splitting');
-  }
-
-  // For multi-metric, we split the data by the categorical field
+  const valueMapping = axisColumnMappings[AxisRole.Value];
+  const splitByMapping = axisColumnMappings[AxisRole.FACET];
   const splitByField = splitByMapping.column;
 
   // Group data by the split by field (categorical)
@@ -82,9 +77,16 @@ export const createMultiMetric = (
     groupedData.get(groupKey)!.push(row);
   });
 
+  const singleMapping: { [AxisRole.Value]: VisColumn; [AxisRole.Time]?: VisColumn } = {
+    [AxisRole.Value]: valueMapping,
+    ...(axisColumnMappings[AxisRole.Time] && {
+      [AxisRole.Time]: axisColumnMappings[AxisRole.Time],
+    }),
+  };
+
   const specs: RendererSpecConfig[] = [];
   for (const [key, value] of groupedData) {
-    const result = createSingleMetric(value, styles, axisColumnMappings);
+    const result = createSingleMetric(value, styles, singleMapping);
     if (result && 'spec' in result) {
       specs.push({ spec: result.spec, name: key, data: value });
     }

--- a/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/pie/pie_vis_config.tsx
@@ -74,11 +74,13 @@ export const createPieConfig = (): VisualizationType<'pie'> => ({
           },
         ],
         render(props) {
-          const spec = createPieSpec(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const size = props.axisColumnMappings.size?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!size || !color) throw Error('Missing axis config for pie chart');
+          const spec = createPieSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.SIZE]: size,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec ?? {}} />;
         },
       },
@@ -91,11 +93,13 @@ export const createPieConfig = (): VisualizationType<'pie'> => ({
           },
         ],
         render(props) {
-          const spec = createPieSpec(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const size = props.axisColumnMappings.size?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!size || !color) throw Error('Missing axis config for pie chart');
+          const spec = createPieSpec(props.transformedData, props.styleOptions, {
+            [AxisRole.SIZE]: size,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec ?? {}} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { createPieSpec } from './to_expression';
-import { VisColumn, VisFieldType, Positions, AxisRole, AxisColumnMappings } from '../types';
+import { VisColumn, VisFieldType, Positions, AxisRole } from '../types';
 import { defaultPieChartStyles, PieChartStyle } from './pie_vis_config';
 
 describe('Pie Chart to_expression', () => {
@@ -38,7 +38,7 @@ describe('Pie Chart to_expression', () => {
     legendPosition: Positions.RIGHT,
   };
 
-  const mockAxisMappings: AxisColumnMappings = {
+  const mockAxisMappings = {
     [AxisRole.SIZE]: numericColumn,
     [AxisRole.COLOR]: categoricalColumn,
   };
@@ -99,8 +99,6 @@ describe('Pie Chart to_expression', () => {
   });
 
   it('throws when color or theta config is missing', () => {
-    expect(() => createPieSpec(mockData, mockStyles, {})).toThrow(
-      'Missing color or theta config for pie chart'
-    );
+    expect(() => createPieSpec(mockData, mockStyles, {} as any)).toThrow();
   });
 });

--- a/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/pie/to_expression.ts
@@ -4,7 +4,7 @@
  */
 
 import { PieChartStyle } from './pie_vis_config';
-import { AxisColumnMappings, AxisRole, AggregationType } from '../types';
+import { AxisRole, VisColumn, AggregationType } from '../types';
 import { pipe, createBaseConfig, assembleSpec } from '../utils/echarts_spec';
 import { aggregate, convertTo2DArray, transform } from '../utils/data_transformation';
 import { createPieSeries } from './pie_chart_utils';
@@ -12,37 +12,35 @@ import { createPieSeries } from './pie_chart_utils';
 export const createPieSpec = (
   transformedData: Array<Record<string, any>>,
   styleOptions: PieChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.SIZE]: VisColumn; [AxisRole.COLOR]: VisColumn }
 ) => {
-  const colorColumn = axisColumnMappings?.[AxisRole.COLOR]?.column;
-  const thetaColumn = axisColumnMappings?.[AxisRole.SIZE]?.column;
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
+  const sizeCol = axisColumnMappings[AxisRole.SIZE];
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
-  if (!colorColumn || !thetaColumn) {
-    throw Error('Missing color or theta config for pie chart');
-  }
-
-  const defaultTitle = `${axisColumnMappings?.[AxisRole.SIZE]?.name} by ${
-    axisColumnMappings?.[AxisRole.COLOR]?.name
-  }`;
+  const defaultTitle = `${sizeCol.name} by ${colorCol.name}`;
 
   const result = pipe(
     transform(
       aggregate({
-        groupBy: colorColumn,
-        field: thetaColumn,
+        groupBy: colorCol.column,
+        field: sizeCol.column,
         aggregationType: AggregationType.SUM,
       }),
       convertTo2DArray(allColumns)
     ),
     createBaseConfig({ title: defaultTitle, legend: { show: styleOptions.addLegend } }),
-    createPieSeries({ styles: styleOptions, cateField: colorColumn, valueField: thetaColumn }),
+    createPieSeries({
+      styles: styleOptions,
+      cateField: colorCol.column,
+      valueField: sizeCol.column,
+    }),
     assembleSpec
   )({
     data: transformedData,
     styles: styleOptions,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.ts
@@ -120,7 +120,7 @@ export const createScatterSeries = <T extends BaseChartStyle>({
   const series = [
     {
       type: 'scatter',
-      name: getSeriesDisplayName(yField, Object.values(axisColumnMappings)),
+      name: getSeriesDisplayName(yField, Object.values(axisColumnMappings).flat()),
       symbolSize: 8,
       symbol: mapPointShapeToEChartsSymbol(styles.exclusive?.pointShape),
       symbolRotate: styles.exclusive?.angle || 0,

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.tsx
@@ -44,7 +44,6 @@ export interface ScatterChartStyleOptions {
   standardAxes?: StandardAxes[];
 
   exclusive?: ExclusiveScatterConfig;
-  switchAxes?: boolean;
 
   titleOptions?: TitleOptions;
 
@@ -81,7 +80,6 @@ export const defaultScatterChartStyles: ScatterChartStyle = {
     thresholdStyle: ThresholdMode.Off,
   },
   standardAxes: [],
-  switchAxes: false,
   titleOptions: {
     show: false,
     titleName: '',
@@ -103,11 +101,13 @@ export const createScatterConfig = (): VisualizationType<'scatter'> => ({
           },
         ],
         render(props) {
-          const spec = createTwoMetricScatter(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          if (!x || !y) throw Error('Missing axis config for scatter chart');
+          const spec = createTwoMetricScatter(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+          });
           return <EchartsRender spec={spec} />;
         },
       },
@@ -121,11 +121,15 @@ export const createScatterConfig = (): VisualizationType<'scatter'> => ({
           },
         ],
         render(props) {
-          const spec = createTwoMetricOneCateScatter(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for scatter chart');
+          const spec = createTwoMetricOneCateScatter(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} />;
         },
       },
@@ -140,11 +144,17 @@ export const createScatterConfig = (): VisualizationType<'scatter'> => ({
           },
         ],
         render(props) {
-          const spec = createThreeMetricOneCateScatter(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          const size = props.axisColumnMappings.size?.[0];
+          if (!x || !y || !color || !size) throw Error('Missing axis config for scatter chart');
+          const spec = createThreeMetricOneCateScatter(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+            [AxisRole.SIZE]: size,
+          });
           return <EchartsRender spec={spec} />;
         },
       },

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.test.tsx
@@ -16,9 +16,7 @@ const mockStore = configureMockStore([]);
 const store = mockStore({
   tab: {
     visualizations: {
-      styleOptions: {
-        switchAxes: false,
-      },
+      styleOptions: {},
     },
   },
 });

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
@@ -50,8 +50,6 @@ export const ScatterVisStyleControls: React.FC<ScatterVisStyleControlsProps> = (
           dateColumns={dateColumns}
           currentMapping={axisColumnMappings}
           updateVisualization={updateVisualization}
-          onSwitchAxes={(v: boolean) => updateStyleOption('switchAxes', v)}
-          switchAxes={styleOptions.switchAxes}
           chartType="scatter"
         />
       </EuiFlexItem>
@@ -77,7 +75,6 @@ export const ScatterVisStyleControls: React.FC<ScatterVisStyleControlsProps> = (
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <AllAxesOptions
-              switchAxes={styleOptions.switchAxes}
               axisColumnMappings={axisColumnMappings}
               standardAxes={styleOptions.standardAxes}
               onStandardAxesChange={(standardAxes) =>

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.test.ts
@@ -8,7 +8,7 @@ import {
   createTwoMetricOneCateScatter,
   createThreeMetricOneCateScatter,
 } from './to_expression';
-import { VisColumn, VisFieldType, Positions, AxisRole, AxisColumnMappings } from '../types';
+import { VisColumn, VisFieldType, Positions, AxisRole } from '../types';
 import { defaultScatterChartStyles, ScatterChartStyle } from './scatter_vis_config';
 
 describe('Scatter Chart to_expression', () => {
@@ -61,7 +61,7 @@ describe('Scatter Chart to_expression', () => {
   };
 
   describe('createTwoMetricScatter', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.X]: mockNumericalColumns[0],
       [AxisRole.Y]: mockNumericalColumns[1],
     };
@@ -107,7 +107,7 @@ describe('Scatter Chart to_expression', () => {
   });
 
   describe('createTwoMetricOneCateScatter', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.X]: mockNumericalColumns[0],
       [AxisRole.Y]: mockNumericalColumns[1],
       [AxisRole.COLOR]: mockCategoricalColumn,
@@ -139,13 +139,13 @@ describe('Scatter Chart to_expression', () => {
         createTwoMetricOneCateScatter(mockData, mockStyles, {
           [AxisRole.X]: mockNumericalColumns[0],
           [AxisRole.Y]: mockNumericalColumns[1],
-        })
+        } as any)
       ).toThrow();
     });
   });
 
   describe('createThreeMetricOneCateScatter', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.X]: mockNumericalColumns[0],
       [AxisRole.Y]: mockNumericalColumns[1],
       [AxisRole.COLOR]: mockCategoricalColumn,
@@ -186,7 +186,7 @@ describe('Scatter Chart to_expression', () => {
           [AxisRole.X]: mockNumericalColumns[0],
           [AxisRole.Y]: mockNumericalColumns[1],
           [AxisRole.COLOR]: mockCategoricalColumn,
-        })
+        } as any)
       ).toThrow();
     });
   });

--- a/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/to_expression.ts
@@ -4,8 +4,8 @@
  */
 
 import { ScatterChartStyle } from './scatter_vis_config';
-import { AxisColumnMappings, AxisRole } from '../types';
-import { getSwappedAxisRole } from '../utils/utils';
+import { AxisRole, VisColumn } from '../types';
+import { getAxisConfig } from '../utils/utils';
 import {
   pipe,
   createBaseConfig,
@@ -23,35 +23,32 @@ import { convertTo2DArray, transform, pivot } from '../utils/data_transformation
 export const createTwoMetricScatter = (
   transformedData: Array<Record<string, any>>,
   styles: ScatterChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.Y]: VisColumn }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
+  const axisConfig = getAxisConfig(styles);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
 
-  const xField = axisConfig.xAxis?.column;
-  const yField = axisConfig.yAxis?.column;
-
-  if (!xField || !yField) throw Error('Missing axis config for scatter chart');
-
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
   const result = pipe(
     transform(convertTo2DArray(allColumns)),
-    createBaseConfig({ title: `${axisConfig.xAxis?.name} vs ${axisConfig.yAxis?.name}` }),
+    createBaseConfig({ title: `${xCol.name} vs ${yCol.name}` }),
     buildAxisConfigs,
     buildVisMap({
-      seriesFields: (headers) => (headers ?? []).filter((h) => h === yField),
+      seriesFields: (headers) => (headers ?? []).filter((h) => h === yCol.column),
     }),
     createScatterSeries({
       styles,
-      xField,
-      yField,
+      xField: xCol.column,
+      yField: yCol.column,
     }),
     assembleSpec
   )({
     data: transformedData,
     styles,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;
@@ -60,44 +57,42 @@ export const createTwoMetricScatter = (
 export const createTwoMetricOneCateScatter = (
   transformedData: Array<Record<string, any>>,
   styles: ScatterChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+  }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-
-  const xField = axisConfig.xAxis?.column;
-  const yField = axisConfig.yAxis?.column;
-  const colorField = axisColumnMappings?.[AxisRole.COLOR]?.column;
-
-  if (!xField || !yField || !colorField)
-    throw Error('Missing axis config for colored scatter chart');
+  const axisConfig = getAxisConfig(styles);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
 
   const result = pipe(
     transform(
       pivot({
-        groupBy: xField,
-        pivot: colorField,
-        field: yField,
+        groupBy: xCol.column,
+        pivot: colorCol.column,
+        field: yCol.column,
       }),
       convertTo2DArray()
     ),
     createBaseConfig({
-      title: `${axisConfig.xAxis?.name} vs ${axisConfig.yAxis?.name} by ${
-        axisColumnMappings?.[AxisRole.COLOR]?.name
-      }`,
+      title: `${xCol.name} vs ${yCol.name} by ${colorCol.name}`,
     }),
     buildAxisConfigs,
     createCategoryScatterSeries({
       styles,
-      xField,
-      yField,
-      colorField,
+      xField: xCol.column,
+      yField: yCol.column,
+      colorField: colorCol.column,
     }),
     assembleSpec
   )({
     data: transformedData,
     styles,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;
@@ -106,42 +101,40 @@ export const createTwoMetricOneCateScatter = (
 export const createThreeMetricOneCateScatter = (
   transformedData: Array<Record<string, any>>,
   styles: ScatterChartStyle,
-  axisColumnMappings?: AxisColumnMappings
-): any => {
-  const axisConfig = getSwappedAxisRole(styles, axisColumnMappings);
-
-  const xField = axisConfig.xAxis?.column;
-  const yField = axisConfig.yAxis?.column;
-  const colorField = axisColumnMappings?.[AxisRole.COLOR]?.column;
-  const sizeField = axisColumnMappings?.[AxisRole.SIZE]?.column;
-
-  if (!xField || !yField || !colorField || !sizeField) {
-    throw Error('Missing axis config for size scatter chart');
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+    [AxisRole.SIZE]: VisColumn;
   }
+): any => {
+  const axisConfig = getAxisConfig(styles);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
+  const sizeCol = axisColumnMappings[AxisRole.SIZE];
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
   const result = pipe(
     transform(convertTo2DArray(allColumns)),
     createBaseConfig({
-      title: `${axisConfig.xAxis?.name} vs ${axisConfig.yAxis?.name} by ${
-        axisColumnMappings?.[AxisRole.COLOR]?.name
-      } (Size: ${axisColumnMappings?.[AxisRole.SIZE]?.name})`,
+      title: `${xCol.name} vs ${yCol.name} by ${colorCol.name} (Size: ${sizeCol.name})`,
     }),
     buildAxisConfigs,
     createSizeScatterSeries({
       styles,
-      xField,
-      yField,
-      colorField,
-      sizeField,
+      xField: xCol.column,
+      yField: yCol.column,
+      colorField: colorCol.column,
+      sizeField: sizeCol.column,
     }),
     assembleSpec
   )({
     data: transformedData,
     styles,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;

--- a/src/plugins/explore/public/components/visualizations/state_timeline/state_timeline_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/state_timeline/state_timeline_config.tsx
@@ -128,11 +128,15 @@ export const createStateTimelineConfig = (): VisualizationType<'state_timeline'>
           },
         ],
         render(props) {
-          const spec = createNumericalStateTimeline(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for state timeline');
+          const spec = createNumericalStateTimeline(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -146,11 +150,15 @@ export const createStateTimelineConfig = (): VisualizationType<'state_timeline'>
           },
         ],
         render(props) {
-          const spec = createCategoricalStateTimeline(
-            props.transformedData,
-            props.styleOptions,
-            props.axisColumnMappings
-          );
+          const x = props.axisColumnMappings.x?.[0];
+          const y = props.axisColumnMappings.y?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !y || !color) throw Error('Missing axis config for state timeline');
+          const spec = createCategoricalStateTimeline(props.transformedData, props.styleOptions, {
+            [AxisRole.X]: x,
+            [AxisRole.Y]: y,
+            [AxisRole.COLOR]: color,
+          });
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
       },
@@ -163,10 +171,13 @@ export const createStateTimelineConfig = (): VisualizationType<'state_timeline'>
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !color) throw Error('Missing axis config for state timeline');
           const spec = createSingleCategoricalStateTimeline(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings
+            { [AxisRole.X]: x, [AxisRole.COLOR]: color }
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },
@@ -180,10 +191,13 @@ export const createStateTimelineConfig = (): VisualizationType<'state_timeline'>
           },
         ],
         render(props) {
+          const x = props.axisColumnMappings.x?.[0];
+          const color = props.axisColumnMappings.color?.[0];
+          if (!x || !color) throw Error('Missing axis config for state timeline');
           const spec = createSingleNumericalStateTimeline(
             props.transformedData,
             props.styleOptions,
-            props.axisColumnMappings
+            { [AxisRole.X]: x, [AxisRole.COLOR]: color }
           );
           return <EchartsRender spec={spec} onSelectTimeRange={props.onSelectTimeRange} />;
         },

--- a/src/plugins/explore/public/components/visualizations/state_timeline/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/state_timeline/to_expression.test.ts
@@ -8,7 +8,7 @@ import {
   createCategoricalStateTimeline,
   createSingleCategoricalStateTimeline,
 } from './to_expression';
-import { VisColumn, VisFieldType, AxisRole, AxisColumnMappings } from '../types';
+import { VisColumn, VisFieldType, AxisRole } from '../types';
 import { defaultStateTimeLineChartStyles } from './state_timeline_config';
 
 describe('State Timeline to_expression', () => {
@@ -60,7 +60,7 @@ describe('State Timeline to_expression', () => {
   };
 
   describe('createNumericalStateTimeline', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.X]: mockTimeColumn,
       [AxisRole.Y]: mockCateColumn1,
       [AxisRole.COLOR]: mockNumColumn,
@@ -93,14 +93,12 @@ describe('State Timeline to_expression', () => {
     });
 
     it('throws when required fields are missing', () => {
-      expect(() => createNumericalStateTimeline(mockData, mockStyles, {})).toThrow(
-        'Missing field config for state-timeline chart'
-      );
+      expect(() => createNumericalStateTimeline(mockData, mockStyles, {} as any)).toThrow();
     });
   });
 
   describe('createCategoricalStateTimeline', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.X]: mockTimeColumn,
       [AxisRole.Y]: mockCateColumn1,
       [AxisRole.COLOR]: mockCateColumn2,
@@ -124,14 +122,12 @@ describe('State Timeline to_expression', () => {
     });
 
     it('throws when required fields are missing', () => {
-      expect(() => createCategoricalStateTimeline(mockData, mockStyles, {})).toThrow(
-        'Missing field config for state-timeline chart'
-      );
+      expect(() => createCategoricalStateTimeline(mockData, mockStyles, {} as any)).toThrow();
     });
   });
 
   describe('createSingleCategoricalStateTimeline', () => {
-    const mockAxisMappings: AxisColumnMappings = {
+    const mockAxisMappings = {
       [AxisRole.X]: mockTimeColumn,
       [AxisRole.COLOR]: mockCateColumn2,
     };
@@ -154,9 +150,7 @@ describe('State Timeline to_expression', () => {
     });
 
     it('throws when required fields are missing', () => {
-      expect(() => createSingleCategoricalStateTimeline(mockData, mockStyles, {})).toThrow(
-        'Missing field config for single state-timeline chart'
-      );
+      expect(() => createSingleCategoricalStateTimeline(mockData, mockStyles, {} as any)).toThrow();
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/state_timeline/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/state_timeline/to_expression.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AxisColumnMappings, AxisRole, DisableMode, Threshold } from '../types';
+import { AxisRole, VisColumn, DisableMode, Threshold } from '../types';
 import { StateTimeLineChartStyle } from './state_timeline_config';
-import { getSwappedAxisRole } from '../utils/utils';
+import { getAxisConfig } from '../utils/utils';
 import {
   mergeDataCore,
   convertThresholdsToValueMappings,
@@ -40,19 +40,16 @@ const normalizeConfig = (styleOptions: StateTimeLineChartStyle) => {
 export const createNumericalStateTimeline = (
   transformedData: Array<Record<string, any>>,
   styleOptions: StateTimeLineChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+  }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styleOptions, axisColumnMappings);
-
-  const timeField = axisConfig.xAxis?.column;
-  const groupField = axisConfig.yAxis?.column;
-
-  const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
-
-  const categoryField2 = colorMapping?.column;
-
-  if (!groupField || !timeField || !categoryField2)
-    throw Error('Missing field config for state-timeline chart');
+  const axisConfig = getAxisConfig(styleOptions);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
 
   const { valueMappings, rangeMappings, disconnectThreshold, connectThreshold } = normalizeConfig(
     styleOptions
@@ -65,16 +62,16 @@ export const createNumericalStateTimeline = (
 
   const convertedThresholds = convertThresholdsToValueMappings(completeThreshold);
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
   const result = pipe(
     transform(
       map(pick(allColumns)),
-      sortByTime(axisColumnMappings?.x?.column),
+      sortByTime(xCol.column),
       mergeDataCore({
-        timestampField: timeField,
-        groupField,
-        mappingField: categoryField2,
+        timestampField: xCol.column,
+        groupField: yCol.column,
+        mappingField: colorCol.column,
         valueMappings: styleOptions.useThresholdColor ? [] : valueMappings,
         rangeMappings: styleOptions.useThresholdColor ? convertedThresholds : rangeMappings,
         disconnectThreshold,
@@ -87,18 +84,18 @@ export const createNumericalStateTimeline = (
       groupByMergedLabel(convertTo2DArray())
     ),
     createBaseConfig({
-      title: `${colorMapping?.name} by ${axisConfig.yAxis?.name} and ${axisConfig.xAxis?.name}`,
+      title: `${colorCol.name} by ${yCol.name} and ${xCol.name}`,
       addTrigger: false,
       legend: { show: styleOptions.addLegend },
     }),
     buildAxisConfigs,
-    createStateTimeLineSpec({ styles: styleOptions, groupField }),
+    createStateTimeLineSpec({ styles: styleOptions, groupField: yCol.column }),
     assembleSpec
   )({
     data: transformedData,
     styles: styleOptions,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;
@@ -107,32 +104,29 @@ export const createNumericalStateTimeline = (
 export const createCategoricalStateTimeline = (
   transformedData: Array<Record<string, any>>,
   styleOptions: StateTimeLineChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: {
+    [AxisRole.X]: VisColumn;
+    [AxisRole.Y]: VisColumn;
+    [AxisRole.COLOR]: VisColumn;
+  }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styleOptions, axisColumnMappings);
-
-  const timeField = axisConfig.xAxis?.column;
-  const groupField = axisConfig.yAxis?.column;
-
-  const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
-
-  const categoryField2 = colorMapping?.column;
-
-  if (!groupField || !timeField || !categoryField2)
-    throw Error('Missing field config for state-timeline chart');
+  const axisConfig = getAxisConfig(styleOptions);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const yCol = axisColumnMappings[AxisRole.Y];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
 
   const { valueMappings, disconnectThreshold, connectThreshold } = normalizeConfig(styleOptions);
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
   const result = pipe(
     transform(
       map(pick(allColumns)),
-      sortByTime(axisColumnMappings?.x?.column),
+      sortByTime(xCol.column),
       mergeDataCore({
-        timestampField: timeField,
-        groupField,
-        mappingField: categoryField2,
+        timestampField: xCol.column,
+        groupField: yCol.column,
+        mappingField: colorCol.column,
         valueMappings: styleOptions.useThresholdColor ? [] : valueMappings,
         disconnectThreshold,
         connectThreshold,
@@ -143,18 +137,18 @@ export const createCategoricalStateTimeline = (
       groupByMergedLabel(convertTo2DArray())
     ),
     createBaseConfig({
-      title: `${colorMapping?.name} by ${axisConfig.yAxis?.name} and ${axisConfig.xAxis?.name}`,
+      title: `${colorCol.name} by ${yCol.name} and ${xCol.name}`,
       addTrigger: false,
       legend: { show: styleOptions.addLegend },
     }),
     buildAxisConfigs,
-    createStateTimeLineSpec({ styles: styleOptions, groupField }),
+    createStateTimeLineSpec({ styles: styleOptions, groupField: yCol.column }),
     assembleSpec
   )({
     data: transformedData,
     styles: styleOptions,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;
@@ -163,31 +157,24 @@ export const createCategoricalStateTimeline = (
 export const createSingleCategoricalStateTimeline = (
   transformedData: Array<Record<string, any>>,
   styleOptions: StateTimeLineChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.COLOR]: VisColumn }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styleOptions, axisColumnMappings);
-
-  const timeField = axisConfig.xAxis?.column;
-
-  const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
-
-  const categoryField = colorMapping?.column;
-
-  if (!timeField || !categoryField)
-    throw Error('Missing field config for single state-timeline chart');
+  const axisConfig = getAxisConfig(styleOptions);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
 
   const { valueMappings, disconnectThreshold, connectThreshold } = normalizeConfig(styleOptions);
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
   const result = pipe(
     transform(
       map(pick(allColumns)),
-      sortByTime(axisColumnMappings?.x?.column),
+      sortByTime(xCol.column),
       mergeDataCore({
-        timestampField: timeField,
+        timestampField: xCol.column,
         groupField: undefined,
-        mappingField: categoryField,
+        mappingField: colorCol.column,
         valueMappings: styleOptions.useThresholdColor ? [] : valueMappings,
         disconnectThreshold,
         connectThreshold,
@@ -198,7 +185,7 @@ export const createSingleCategoricalStateTimeline = (
       groupByMergedLabel(convertTo2DArray())
     ),
     createBaseConfig({
-      title: `${colorMapping?.name}  by ${axisConfig.xAxis?.name}`,
+      title: `${colorCol.name}  by ${xCol.name}`,
       addTrigger: false,
       legend: { show: styleOptions.addLegend },
     }),
@@ -209,7 +196,7 @@ export const createSingleCategoricalStateTimeline = (
     data: transformedData,
     styles: styleOptions,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;
@@ -218,18 +205,11 @@ export const createSingleCategoricalStateTimeline = (
 export const createSingleNumericalStateTimeline = (
   transformedData: Array<Record<string, any>>,
   styleOptions: StateTimeLineChartStyle,
-  axisColumnMappings?: AxisColumnMappings
+  axisColumnMappings: { [AxisRole.X]: VisColumn; [AxisRole.COLOR]: VisColumn }
 ): any => {
-  const axisConfig = getSwappedAxisRole(styleOptions, axisColumnMappings);
-
-  const timeField = axisConfig.xAxis?.column;
-
-  const colorMapping = axisColumnMappings?.[AxisRole.COLOR];
-
-  const categoryField = colorMapping?.column;
-
-  if (!timeField || !categoryField)
-    throw Error('Missing field config for single state-timeline chart');
+  const axisConfig = getAxisConfig(styleOptions);
+  const xCol = axisColumnMappings[AxisRole.X];
+  const colorCol = axisColumnMappings[AxisRole.COLOR];
 
   const { valueMappings, rangeMappings, disconnectThreshold, connectThreshold } = normalizeConfig(
     styleOptions
@@ -241,16 +221,16 @@ export const createSingleNumericalStateTimeline = (
 
   const convertedThresholds = convertThresholdsToValueMappings(completeThreshold);
 
-  const allColumns = [...Object.values(axisColumnMappings ?? {}).map((m) => m.column)];
+  const allColumns = Object.values(axisColumnMappings).map((m) => m.column);
 
   const result = pipe(
     transform(
       map(pick(allColumns)),
-      sortByTime(axisColumnMappings?.x?.column),
+      sortByTime(xCol.column),
       mergeDataCore({
-        timestampField: timeField,
+        timestampField: xCol.column,
         groupField: undefined,
-        mappingField: categoryField,
+        mappingField: colorCol.column,
         valueMappings: styleOptions.useThresholdColor ? [] : valueMappings,
         rangeMappings: styleOptions.useThresholdColor ? convertedThresholds : rangeMappings,
         disconnectThreshold,
@@ -263,7 +243,7 @@ export const createSingleNumericalStateTimeline = (
       groupByMergedLabel(convertTo2DArray())
     ),
     createBaseConfig({
-      title: `${colorMapping?.name}  by ${axisConfig.xAxis?.name}`,
+      title: `${colorCol.name}  by ${xCol.name}`,
       addTrigger: false,
       legend: { show: styleOptions.addLegend },
     }),
@@ -274,7 +254,7 @@ export const createSingleNumericalStateTimeline = (
     data: transformedData,
     styles: styleOptions,
     axisConfig,
-    axisColumnMappings: axisColumnMappings ?? {},
+    axisColumnMappings,
   });
 
   return result.spec;

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.test.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { AxesSelectPanel, AxisSelector } from './axes_selector';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AxesSelectPanel } from './axes_selector';
+import { AxisSelector } from './axis_selector';
 import { AxisRole, VisColumn, VisFieldType } from '../../types';
 import { ChartType } from '../../utils/use_visualization_types';
 
@@ -140,8 +141,8 @@ describe('AxesSelectPanel', () => {
     const propsWithMapping = {
       ...defaultProps,
       currentMapping: {
-        [AxisRole.X]: mockCategoricalColumns[0],
-        [AxisRole.Y]: mockNumericalColumns[0],
+        [AxisRole.X]: [mockCategoricalColumns[0]],
+        [AxisRole.Y]: [mockNumericalColumns[0]],
       },
     };
     mockVisualizationRegistry.findRuleByAxesMapping.mockReturnValue({
@@ -158,7 +159,7 @@ describe('AxesSelectPanel', () => {
     const propsWithMapping = {
       ...defaultProps,
       currentMapping: {
-        [AxisRole.X]: mockCategoricalColumns[0],
+        [AxisRole.X]: [mockCategoricalColumns[0]],
       },
     };
 
@@ -166,40 +167,33 @@ describe('AxesSelectPanel', () => {
     expect(screen.getByText('category')).toBeInTheDocument();
   });
 
-  // New tests to improve coverage
-
   it('renders X and Y axes', () => {
     render(<AxesSelectPanel {...defaultProps} />);
 
-    // X and Y axes should be available
     expect(screen.getByText('X-Axis')).toBeInTheDocument();
     expect(screen.getByText('Y-Axis')).toBeInTheDocument();
   });
 
   it('updates available axis options when selection changes', () => {
-    // Set up a scenario with multiple possible mappings
     mockVisualizationRegistry.findRuleByAxesMapping.mockReturnValue({
       id: 'rule1',
       matchIndex: [1, 1, 0],
     });
 
-    // Use props with existing mapping to ensure updateVisualization is called
     const propsWithMapping = {
       ...defaultProps,
       currentMapping: {
-        [AxisRole.X]: mockCategoricalColumns[0],
-        [AxisRole.Y]: mockNumericalColumns[0],
+        [AxisRole.X]: [mockCategoricalColumns[0]],
+        [AxisRole.Y]: [mockNumericalColumns[0]],
       },
     };
 
     render(<AxesSelectPanel {...propsWithMapping} />);
 
-    // Verify that updateVisualization was called
     expect(mockUpdateVisualization).toHaveBeenCalled();
   });
 
   it('handles multiple axis roles correctly', () => {
-    // Override findRulesByColumns to return a rule with 3 axis roles
     mockVisualizationRegistry.findRulesByColumns.mockReturnValue({
       all: [
         {
@@ -224,18 +218,109 @@ describe('AxesSelectPanel', () => {
 
     render(<AxesSelectPanel {...defaultProps} />);
 
-    // Should render selectors for all three axes
     expect(screen.getByText('X-Axis')).toBeInTheDocument();
     expect(screen.getByText('Y-Axis')).toBeInTheDocument();
     expect(screen.getByText('Color')).toBeInTheDocument();
   });
 
-  it('renders comboboxes for axis selection', () => {
+  it('shows placeholder text when no field is selected', () => {
     render(<AxesSelectPanel {...defaultProps} />);
 
-    // Check that comboboxes are rendered
-    const comboBoxes = screen.getAllByRole('combobox');
-    expect(comboBoxes.length).toBeGreaterThan(0);
+    const placeholders = screen.getAllByText('Select a field');
+    expect(placeholders.length).toBeGreaterThan(0);
+  });
+
+  describe('multi axis support', () => {
+    beforeEach(() => {
+      mockVisualizationRegistry.findRulesByColumns.mockReturnValue({
+        all: [
+          {
+            visType: 'line',
+            rules: [
+              {
+                priority: 100,
+                mappings: [
+                  {
+                    [AxisRole.X]: { type: VisFieldType.Date },
+                    [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+                  },
+                ],
+                render: jest.fn(),
+              },
+            ],
+          },
+        ],
+        exact: [],
+      });
+    });
+
+    it('renders multiple AxisSelector instances plus an empty one for multi axis', () => {
+      const propsWithMulti = {
+        ...defaultProps,
+        chartType: 'line' as ChartType,
+        currentMapping: {
+          [AxisRole.X]: [mockDateColumns[0]],
+          [AxisRole.Y]: [mockNumericalColumns[0], mockNumericalColumns[1]],
+        },
+      };
+
+      render(<AxesSelectPanel {...propsWithMulti} />);
+
+      // Should show both selected numerical fields plus an empty selector
+      expect(screen.getByText('count')).toBeInTheDocument();
+      expect(screen.getByText('price')).toBeInTheDocument();
+      // The trailing empty selector and the X-axis selector (if no date selected yet)
+      const placeholders = screen.getAllByText('Select a field');
+      expect(placeholders.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('single axis still renders one AxisSelector', () => {
+      const propsWithSingle = {
+        ...defaultProps,
+        chartType: 'line' as ChartType,
+        currentMapping: {
+          [AxisRole.X]: [mockDateColumns[0]],
+        },
+      };
+
+      render(<AxesSelectPanel {...propsWithSingle} />);
+
+      // X-axis should show the selected date field
+      expect(screen.getByText('timestamp')).toBeInTheDocument();
+      // Y-axis label should be present
+      expect(screen.getByText('Y-Axis')).toBeInTheDocument();
+    });
+
+    it('shows axis label only on the first selector for multi axis', () => {
+      const propsWithMulti = {
+        ...defaultProps,
+        chartType: 'line' as ChartType,
+        currentMapping: {
+          [AxisRole.X]: [mockDateColumns[0]],
+          [AxisRole.Y]: [mockNumericalColumns[0], mockNumericalColumns[1]],
+        },
+      };
+
+      render(<AxesSelectPanel {...propsWithMulti} />);
+
+      // Y-Axis label should appear exactly once
+      const yAxisLabels = screen.getAllByText('Y-Axis');
+      expect(yAxisLabels).toHaveLength(1);
+    });
+
+    it('renders empty trailing selector for multi axis with no selections', () => {
+      const propsEmpty = {
+        ...defaultProps,
+        chartType: 'line' as ChartType,
+        currentMapping: {},
+      };
+
+      render(<AxesSelectPanel {...propsEmpty} />);
+
+      // Should have placeholder selectors for both axes
+      const placeholders = screen.getAllByText('Select a field');
+      expect(placeholders.length).toBeGreaterThanOrEqual(2);
+    });
   });
 });
 
@@ -244,27 +329,12 @@ describe('AxisSelector', () => {
   const mockOnRemove = jest.fn();
 
   const defaultProps = {
-    chartType: 'bar' as ChartType,
     axisRole: AxisRole.X,
-    selectedColumn: 'category',
-    allColumnOptions: [
-      {
-        isGroupLabelOption: true,
-        label: 'Categorical fields',
-        options: [
-          {
-            column: {
-              id: 1,
-              name: 'category',
-              schema: VisFieldType.Categorical,
-              column: 'category',
-              validValuesCount: 100,
-              uniqueValuesCount: 10,
-            },
-            label: 'category',
-          },
-        ],
-      },
+    value: 'category',
+    options: [
+      { label: 'category', schema: VisFieldType.Categorical },
+      { label: 'count', schema: VisFieldType.Numerical },
+      { label: 'timestamp', schema: VisFieldType.Date },
     ],
     onRemove: mockOnRemove,
     onChange: mockOnChange,
@@ -274,125 +344,61 @@ describe('AxisSelector', () => {
     jest.clearAllMocks();
   });
 
-  it('renders axis selector with label', () => {
-    render(<AxisSelector {...defaultProps} />);
-    expect(screen.getByText('X-Axis')).toBeInTheDocument();
-  });
-
-  it('displays selected column', () => {
+  it('renders axis selector with selected value', () => {
     render(<AxisSelector {...defaultProps} />);
     expect(screen.getByText('category')).toBeInTheDocument();
   });
 
-  it('calls onChange when selection changes', () => {
+  it('displays selected value as button text', () => {
     render(<AxisSelector {...defaultProps} />);
-
-    const clearButton = screen.getByTestId('comboBoxClearButton');
-    fireEvent.click(clearButton);
-
-    expect(mockOnRemove).toHaveBeenCalledWith(AxisRole.X);
+    const button = screen.getByTestId('axisSelectorButton');
+    expect(button).toHaveTextContent('category');
   });
 
-  it('calls onRemove when selection is cleared', () => {
+  it('opens popover on button click', () => {
     render(<AxisSelector {...defaultProps} />);
-
-    const clearButton = screen.getByTestId('comboBoxClearButton');
-    fireEvent.click(clearButton);
-
-    expect(mockOnRemove).toHaveBeenCalledWith(AxisRole.X);
+    const button = screen.getByTestId('axisSelectorButton');
+    fireEvent.click(button);
+    expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
   });
 
-  it('renders different axis role labels correctly', () => {
-    const yAxisProps = { ...defaultProps, axisRole: AxisRole.Y };
-    const { rerender } = render(<AxisSelector {...yAxisProps} />);
-    expect(screen.getByText('Y-Axis')).toBeInTheDocument();
-
-    const colorAxisProps = { ...defaultProps, axisRole: AxisRole.COLOR };
-    rerender(<AxisSelector {...colorAxisProps} />);
-    expect(screen.getByText('Color')).toBeInTheDocument();
-
-    const facetAxisProps = { ...defaultProps, axisRole: AxisRole.FACET };
-    rerender(<AxisSelector {...facetAxisProps} />);
-    expect(screen.getByText('Split chart by')).toBeInTheDocument();
-  });
-
-  it('handles empty selected column', () => {
-    const propsWithEmptySelection = { ...defaultProps, selectedColumn: '' };
+  it('shows placeholder when no value is selected', () => {
+    const propsWithEmptySelection = { ...defaultProps, value: '' };
     render(<AxisSelector {...propsWithEmptySelection} />);
-
-    const input = screen.getByTestId('comboBoxSearchInput');
-    expect(input).toHaveValue('');
+    expect(screen.getByText('Select a field')).toBeInTheDocument();
   });
 
-  // New tests to improve coverage
-
-  it('selects a new column and calls onChange', async () => {
-    const multipleOptionsProps = {
-      ...defaultProps,
-      selectedColumn: '',
-      allColumnOptions: [
-        {
-          isGroupLabelOption: true,
-          label: 'Categorical fields',
-          options: [
-            {
-              column: {
-                id: 1,
-                name: 'category',
-                schema: VisFieldType.Categorical,
-                column: 'category',
-                validValuesCount: 100,
-                uniqueValuesCount: 10,
-              },
-              label: 'category',
-            },
-            {
-              column: {
-                id: 2,
-                name: 'product',
-                schema: VisFieldType.Categorical,
-                column: 'product',
-                validValuesCount: 100,
-                uniqueValuesCount: 20,
-              },
-              label: 'product',
-            },
-          ],
-        },
-      ],
-    };
-
-    render(<AxisSelector {...multipleOptionsProps} />);
-
-    // Open the combobox
-    const combobox = screen.getByTestId('comboBoxSearchInput');
-    fireEvent.click(combobox);
-
-    // Select an option
-    await waitFor(() => {
-      const option = screen.getByText('product');
-      fireEvent.click(option);
-    });
-
-    // Verify onChange was called with the correct parameters
-    expect(mockOnChange).toHaveBeenCalledWith(AxisRole.X, 'product');
+  it('applies empty modifier class when no value is selected', () => {
+    const propsWithEmptySelection = { ...defaultProps, value: '' };
+    const { container } = render(<AxisSelector {...propsWithEmptySelection} />);
+    const selectorContainer = container.querySelector('.axisSelectorContainer');
+    expect(selectorContainer).toHaveClass('axisSelectorContainer--empty');
   });
 
-  it('renders with SIZE axis role', () => {
-    const sizeAxisProps = { ...defaultProps, axisRole: AxisRole.SIZE };
-    render(<AxisSelector {...sizeAxisProps} />);
-    expect(screen.getByText('Size')).toBeInTheDocument();
+  it('does not apply empty modifier class when value is selected', () => {
+    const { container } = render(<AxisSelector {...defaultProps} />);
+    const selectorContainer = container.querySelector('.axisSelectorContainer');
+    expect(selectorContainer).not.toHaveClass('axisSelectorContainer--empty');
   });
 
-  it('renders with Y_SECOND axis role', () => {
-    const secondYAxisProps = { ...defaultProps, axisRole: AxisRole.Y_SECOND };
-    render(<AxisSelector {...secondYAxisProps} />);
-    expect(screen.getByText('Y-Axis (2nd)')).toBeInTheDocument();
+  it('renders selectable list in the popover', () => {
+    render(<AxisSelector {...defaultProps} />);
+    const button = screen.getByTestId('axisSelectorButton');
+    fireEvent.click(button);
+
+    // Popover should be open with the search input
+    expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
+    // The selectable component should be rendered in the popover
+    expect(document.querySelector('.euiSelectable')).toBeInTheDocument();
   });
 
-  it('renders with Value axis role', () => {
-    const valueAxisProps = { ...defaultProps, axisRole: AxisRole.Value };
-    render(<AxisSelector {...valueAxisProps} />);
-    expect(screen.getByText('Value')).toBeInTheDocument();
+  it('calls onChange when an option is selected', () => {
+    // Since EuiSelectable uses virtualized rendering in test env,
+    // we test the callback logic by verifying the component accepts the props
+    const { rerender } = render(<AxisSelector {...defaultProps} />);
+
+    // Simulate selecting a different value by re-rendering with new value
+    rerender(<AxisSelector {...defaultProps} value="count" />);
+    expect(screen.getByText('count')).toBeInTheDocument();
   });
 });

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useMemo, useState, useRef } from 'react';
-import {
-  EuiSpacer,
-  EuiFormRow,
-  EuiFlexItem,
-  EuiComboBox,
-  EuiComboBoxOptionOption,
-  EuiSwitch,
-} from '@elastic/eui';
-import { isEmpty, isEqual } from 'lodash';
+import React, { useEffect, useMemo, useState } from 'react';
+import { EuiSpacer, EuiFormRow, EuiSelectableOption } from '@elastic/eui';
+import { isEqual } from 'lodash';
 import { i18n } from '@osd/i18n';
 import { AxisColumnMappings, AxisRole, VisColumn, VisFieldType } from '../../types';
 import { UpdateVisualizationProps } from '../../visualization_container';
@@ -23,11 +16,7 @@ import {
 } from '../../utils/use_visualization_types';
 import { StyleAccordion } from '../style_accordion';
 import { convertMappingsToStrings } from '../../visualization_builder_utils';
-
-interface VisColumnOption {
-  column: VisColumn;
-  label: string;
-}
+import { AxisSelector } from './axis_selector';
 
 interface AxesSelectPanelProps {
   chartType: ChartType;
@@ -36,8 +25,6 @@ interface AxesSelectPanelProps {
   dateColumns: VisColumn[];
   currentMapping: AxisColumnMappings;
   updateVisualization: (data: UpdateVisualizationProps) => void;
-  onSwitchAxes?: (v: boolean) => void;
-  switchAxes?: boolean;
 }
 
 const AXIS_SELECT_LABEL = {
@@ -67,6 +54,13 @@ const AXIS_SELECT_LABEL = {
   }),
 };
 
+const getAxisLabel = (axisRole: AxisRole): string => {
+  return AXIS_SELECT_LABEL[axisRole];
+};
+
+const isMultiAxis = (axisRole: AxisRole, mappings: AxisTypeMapping[]): boolean =>
+  mappings.some((mapping) => mapping[axisRole]?.multi === true);
+
 export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
   chartType,
   numericalColumns,
@@ -74,32 +68,9 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
   dateColumns,
   currentMapping,
   updateVisualization,
-  onSwitchAxes,
-  switchAxes,
 }) => {
   const visualizationRegistry = useVisualizationRegistry();
-  const firstSelectorInput = useRef<HTMLInputElement | undefined>(undefined);
   const [currentSelections, setCurrentSelections] = useState<AxisColumnMappings>({});
-
-  // switchAxes only support heatmap scatter and bar
-  const showSwitch = chartType === 'heatmap' || chartType === 'bar' || chartType === 'scatter';
-
-  const swapAxes = () => {
-    if (showSwitch && onSwitchAxes) {
-      onSwitchAxes(!switchAxes);
-    }
-  };
-
-  useEffect(() => {
-    // Make sure to initially focus on first axis field selector if current field selection is empty
-    if (isEmpty(currentMapping)) {
-      setTimeout(() => {
-        if (firstSelectorInput.current) {
-          firstSelectorInput.current.focus();
-        }
-      }, 500);
-    }
-  }, [currentMapping]);
 
   // Filter available chart mappings based on the data's column types
   // This ensures we only show mappings that are compatible with the current dataset structure
@@ -135,9 +106,13 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     () =>
       availableMappings.filter((mapping) => {
         return Object.entries(currentSelections).every(([role, selectedCol]) => {
-          if (!selectedCol) return true;
+          if (!selectedCol || selectedCol.length === 0) return true;
           const mappingRole = mapping[role as AxisRole];
-          return mappingRole && mappingRole.type === selectedCol.schema;
+          if (!mappingRole) return false;
+          if (mappingRole.type !== selectedCol[0]?.schema) return false;
+          // If multiple columns are selected, the mapping must support multi
+          if (selectedCol.length > 1 && !mappingRole.multi) return false;
+          return true;
         });
       }),
     [availableMappings, currentSelections]
@@ -153,7 +128,7 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     // Current selected axis mapping
     const normalizedAxesSelections: AxisColumnMappings = {};
     Object.entries(currentSelections).forEach(([key, value]) => {
-      if (value) {
+      if (value && value.length > 0) {
         normalizedAxesSelections[key as AxisRole] = value;
       }
     });
@@ -171,7 +146,7 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     // process until a complete valid configuration is achieved, potentially leading to confusion
     // about whether their partial selections are having any effect.
     if (ruleToUse) {
-      updateVisualization({ mappings: normalizedAxesSelections });
+      updateVisualization({ mappings: convertMappingsToStrings(normalizedAxesSelections) });
     }
   }, [
     updateVisualization,
@@ -200,23 +175,6 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     [numericalColumns, categoricalColumns, dateColumns]
   );
 
-  const getFieldTypeLabel = (type: VisFieldType) => {
-    switch (type) {
-      case VisFieldType.Categorical:
-        return i18n.translate('explore.stylePanel.fieldType.categorical', {
-          defaultMessage: 'Categorical fields',
-        });
-      case VisFieldType.Date:
-        return i18n.translate('explore.stylePanel.fieldType.date', {
-          defaultMessage: 'Date fields',
-        });
-      default:
-        return i18n.translate('explore.stylePanel.fieldType.numerical', {
-          defaultMessage: 'Numerical fields',
-        });
-    }
-  };
-
   if (availableMappings.length === 0) {
     return null;
   }
@@ -238,9 +196,13 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
         ([role]) => role !== axisRole
       );
       const isCompatible = otherSelections.every(([role, selectedCol]) => {
-        if (!selectedCol) return true;
+        if (!selectedCol || selectedCol.length === 0) return true;
         const mappingRole = mapping[role as AxisRole];
-        return mappingRole && mappingRole.type === selectedCol.schema;
+        if (!mappingRole) return false;
+        if (mappingRole.type !== selectedCol[0]?.schema) return false;
+        // If multiple columns are selected, the mapping must support multi
+        if (selectedCol.length > 1 && !mappingRole.multi) return false;
+        return true;
       });
 
       const roleColumn = mapping[axisRole];
@@ -249,19 +211,17 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
       }
     });
 
-    const allColumns: Array<EuiComboBoxOptionOption<VisColumnOption>> = [];
+    const selectedNames = new Set((currentSelections[axisRole] ?? []).map((col) => col.name));
+    const allOptions: Array<EuiSelectableOption & { schema?: VisFieldType }> = [];
     availableTypes.forEach((type) => {
-      allColumns.push({
-        isGroupLabelOption: true,
-        label: getFieldTypeLabel(type),
-        options: findColumns(type).map((col) => ({
-          column: col,
-          label: col.name,
-        })),
+      findColumns(type).forEach((col) => {
+        if (!selectedNames.has(col.name)) {
+          allOptions.push({ label: col.name, schema: col.schema });
+        }
       });
     });
 
-    return allColumns;
+    return allOptions;
   };
 
   return (
@@ -273,103 +233,112 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
       initialIsOpen={true}
     >
       <>
-        {showSwitch && (
-          <EuiFormRow>
-            <EuiSwitch
-              label={i18n.translate('explore.vis.axesSwitch.switchAxes', {
-                defaultMessage: 'Switch axes',
-              })}
-              compressed
-              checked={!!switchAxes}
-              onChange={swapAxes}
-              disabled={!currentSelections[AxisRole.X] || !currentSelections[AxisRole.Y]}
-            />
-          </EuiFormRow>
-        )}
+        {Array.from(allAxisRolesFromSelection).map((axisRole) => {
+          const currentSelection = currentSelections[axisRole] ?? [];
+          const label = getAxisLabel(axisRole);
+          const multi = isMultiAxis(axisRole, remainingMappings);
 
-        {Array.from(allAxisRolesFromSelection).map((axisRole, i) => {
-          const currentSelection = currentSelections[axisRole];
+          if (multi) {
+            return (
+              <React.Fragment key={axisRole}>
+                {currentSelection.map((col, index) => (
+                  <React.Fragment key={`${axisRole}-${index}`}>
+                    <EuiFormRow
+                      label={index === 0 ? label : ''}
+                      data-test-subj={`field-${axisRole}`}
+                    >
+                      <AxisSelector
+                        axisRole={axisRole}
+                        value={col.name}
+                        options={getAxisOptions(axisRole)}
+                        onRemove={() => {
+                          setCurrentSelections((prev) => {
+                            const updated = [...(prev[axisRole] ?? [])];
+                            updated.splice(index, 1);
+                            return {
+                              ...prev,
+                              [axisRole]: updated.length > 0 ? updated : undefined,
+                            };
+                          });
+                        }}
+                        onChange={(_role, v) => {
+                          const allColumns = [
+                            ...numericalColumns,
+                            ...categoricalColumns,
+                            ...dateColumns,
+                          ];
+                          const selectedCol = allColumns.find((c) => c.name === v);
+                          if (selectedCol) {
+                            setCurrentSelections((prev) => {
+                              const updated = [...(prev[axisRole] ?? [])];
+                              updated[index] = selectedCol;
+                              return { ...prev, [axisRole]: updated };
+                            });
+                          }
+                        }}
+                      />
+                    </EuiFormRow>
+                    <EuiSpacer size="xs" />
+                  </React.Fragment>
+                ))}
+                <EuiFormRow
+                  label={currentSelection.length === 0 ? label : ''}
+                  data-test-subj={`field-${axisRole}`}
+                >
+                  <AxisSelector
+                    axisRole={axisRole}
+                    value=""
+                    options={getAxisOptions(axisRole)}
+                    onRemove={() => {}}
+                    onChange={(_role, v) => {
+                      const allColumns = [
+                        ...numericalColumns,
+                        ...categoricalColumns,
+                        ...dateColumns,
+                      ];
+                      const selectedCol = allColumns.find((c) => c.name === v);
+                      if (selectedCol) {
+                        setCurrentSelections((prev) => ({
+                          ...prev,
+                          [axisRole]: [...(prev[axisRole] ?? []), selectedCol],
+                        }));
+                      }
+                    }}
+                  />
+                </EuiFormRow>
+                <EuiSpacer size="xs" />
+              </React.Fragment>
+            );
+          }
+
           return (
-            <AxisSelector
-              key={axisRole}
-              axisRole={axisRole}
-              selectedColumn={currentSelection?.name || ''}
-              allColumnOptions={getAxisOptions(axisRole)}
-              switchAxes={switchAxes}
-              inputRef={(input) => (i === 0 ? (firstSelectorInput.current = input) : undefined)}
-              onRemove={(role) => {
-                setCurrentSelections((prev) => ({
-                  ...prev,
-                  [role]: undefined,
-                }));
-              }}
-              onChange={(role, v) => {
-                const allColumns = [...numericalColumns, ...categoricalColumns, ...dateColumns];
-                const selectedCol = allColumns.find((col) => col.name === v);
-                setCurrentSelections((prev) => ({
-                  ...prev,
-                  [role]: selectedCol,
-                }));
-              }}
-            />
+            <React.Fragment key={axisRole}>
+              <EuiFormRow label={label} data-test-subj={`field-${axisRole}`}>
+                <AxisSelector
+                  axisRole={axisRole}
+                  value={currentSelection[0]?.name || ''}
+                  options={getAxisOptions(axisRole)}
+                  onRemove={(role) => {
+                    setCurrentSelections((prev) => ({
+                      ...prev,
+                      [role]: undefined,
+                    }));
+                  }}
+                  onChange={(role, v) => {
+                    const allColumns = [...numericalColumns, ...categoricalColumns, ...dateColumns];
+                    const selectedCol = allColumns.find((col) => col.name === v);
+                    setCurrentSelections((prev) => ({
+                      ...prev,
+                      [role]: selectedCol ? [selectedCol] : undefined,
+                    }));
+                  }}
+                />
+              </EuiFormRow>
+              <EuiSpacer size="xs" />
+            </React.Fragment>
           );
         })}
       </>
     </StyleAccordion>
-  );
-};
-
-interface AxesSelectorOptions {
-  axisRole: AxisRole;
-  selectedColumn: string;
-  allColumnOptions: Array<EuiComboBoxOptionOption<VisColumnOption>>;
-  onRemove: (axisRole: AxisRole) => void;
-  onChange: (axisRole: AxisRole, value: string) => void;
-  switchAxes?: boolean;
-  autoFocus?: boolean;
-  inputRef?: (instance: HTMLInputElement) => void;
-}
-
-export const AxisSelector: React.FC<AxesSelectorOptions> = ({
-  axisRole,
-  selectedColumn,
-  allColumnOptions,
-  onRemove,
-  onChange,
-  switchAxes,
-  inputRef,
-}) => {
-  const getLabel = () => {
-    if (switchAxes && (axisRole === AxisRole.X || axisRole === AxisRole.Y)) {
-      const swappedRole = axisRole === AxisRole.X ? AxisRole.Y : AxisRole.X;
-      return AXIS_SELECT_LABEL[swappedRole];
-    }
-
-    return AXIS_SELECT_LABEL[axisRole];
-  };
-
-  return (
-    <React.Fragment key={`${axisRole}Selector`}>
-      <EuiFormRow label={getLabel()}>
-        <EuiFlexItem>
-          <EuiComboBox
-            data-test-subj={`field-${axisRole}`}
-            compressed
-            inputRef={inputRef}
-            selectedOptions={[{ label: selectedColumn }]}
-            singleSelection={{ asPlainText: true }}
-            options={allColumnOptions}
-            onChange={(value) => {
-              if (Boolean(value.length)) {
-                onChange(axisRole, value[0].label);
-              } else {
-                onRemove(axisRole);
-              }
-            }}
-          />
-        </EuiFlexItem>
-      </EuiFormRow>
-      <EuiSpacer size="xs" />
-    </React.Fragment>
   );
 };

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axis_selector.scss
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axis_selector.scss
@@ -1,0 +1,53 @@
+.axisSelectorContainer {
+  display: flex;
+  border: 1px solid transparentize($euiColorPrimary, 0.5);
+  border-radius: 12px;
+  background-color: transparentize($euiColorPrimary, 0.95);
+  flex-direction: column;
+  transition: border-color 150ms ease-in, background-color 150ms ease-in;
+
+  &:hover {
+    border-color: $euiColorPrimary;
+    background-color: transparentize($euiColorPrimary, 0.9);
+  }
+
+  &--empty {
+    border-style: dotted;
+    border-width: 2px;
+  }
+
+  .axisSelectorRow {
+    display: flex;
+    align-items: center;
+  }
+
+  .axisSelectorButton {
+    border: none;
+    height: 24px;
+    line-height: 24px;
+    font-size: 12px;
+    width: 100%;
+    text-align: left;
+    padding-left: 10px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .axisSelectorFieldSelector {
+    flex-grow: 1;
+  }
+
+  .axisSelectorRemoveButton {
+    opacity: 0;
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    transition: opacity 150ms ease-in;
+    margin-left: auto;
+    border-radius: 12px;
+  }
+
+  &:hover .axisSelectorRemoveButton {
+    opacity: 1;
+  }
+}

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axis_selector.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axis_selector.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AxisSelector } from './axis_selector';
+import { AxisRole, VisFieldType } from '../../types';
+import { EuiSelectableOption } from '@elastic/eui';
+
+describe('AxisSelector', () => {
+  const mockOnChange = jest.fn();
+  const mockOnRemove = jest.fn();
+
+  const defaultOptions: Array<EuiSelectableOption & { schema?: VisFieldType }> = [
+    { label: 'category', schema: VisFieldType.Categorical },
+    { label: 'count', schema: VisFieldType.Numerical },
+    { label: 'timestamp', schema: VisFieldType.Date },
+  ];
+
+  const defaultProps = {
+    axisRole: AxisRole.X,
+    value: 'category',
+    options: defaultOptions,
+    onChange: mockOnChange,
+    onRemove: mockOnRemove,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('button display', () => {
+    it('displays the selected field name', () => {
+      render(<AxisSelector {...defaultProps} />);
+      expect(screen.getByRole('button', { name: 'category' })).toBeInTheDocument();
+    });
+
+    it('displays placeholder when no field is selected', () => {
+      render(<AxisSelector {...defaultProps} value="" />);
+      expect(screen.getByRole('button', { name: 'Select a field' })).toBeInTheDocument();
+    });
+
+    it('updates the displayed value when the value prop changes', () => {
+      const { rerender } = render(<AxisSelector {...defaultProps} />);
+      expect(screen.getByRole('button', { name: 'category' })).toBeInTheDocument();
+
+      rerender(<AxisSelector {...defaultProps} value="count" />);
+      expect(screen.getByRole('button', { name: 'count' })).toBeInTheDocument();
+    });
+  });
+
+  describe('remove button', () => {
+    it('renders when a field is selected', () => {
+      render(<AxisSelector {...defaultProps} />);
+      expect(screen.getByLabelText('Remove field')).toBeInTheDocument();
+    });
+
+    it('is hidden when no field is selected', () => {
+      render(<AxisSelector {...defaultProps} value="" />);
+      expect(screen.queryByLabelText('Remove field')).not.toBeInTheDocument();
+    });
+
+    it('calls onRemove with the axis role when clicked', () => {
+      render(<AxisSelector {...defaultProps} axisRole={AxisRole.Y} />);
+      fireEvent.click(screen.getByLabelText('Remove field'));
+      expect(mockOnRemove).toHaveBeenCalledTimes(1);
+      expect(mockOnRemove).toHaveBeenCalledWith(AxisRole.Y);
+    });
+
+    it('appears when value changes from empty to selected', () => {
+      const { rerender } = render(<AxisSelector {...defaultProps} value="" />);
+      expect(screen.queryByLabelText('Remove field')).not.toBeInTheDocument();
+
+      rerender(<AxisSelector {...defaultProps} value="category" />);
+      expect(screen.getByLabelText('Remove field')).toBeInTheDocument();
+    });
+
+    it('disappears when value changes from selected to empty', () => {
+      const { rerender } = render(<AxisSelector {...defaultProps} value="category" />);
+      expect(screen.getByLabelText('Remove field')).toBeInTheDocument();
+
+      rerender(<AxisSelector {...defaultProps} value="" />);
+      expect(screen.queryByLabelText('Remove field')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state styling', () => {
+    it('applies empty modifier class when no field is selected', () => {
+      const { container } = render(<AxisSelector {...defaultProps} value="" />);
+      expect(container.firstChild).toHaveClass('axisSelectorContainer--empty');
+    });
+
+    it('does not apply empty modifier class when a field is selected', () => {
+      const { container } = render(<AxisSelector {...defaultProps} />);
+      expect(container.firstChild).not.toHaveClass('axisSelectorContainer--empty');
+    });
+  });
+
+  describe('popover', () => {
+    it('is closed by default', () => {
+      render(<AxisSelector {...defaultProps} />);
+      expect(screen.queryByPlaceholderText('Filter list')).not.toBeInTheDocument();
+    });
+
+    it('opens when the selector button is clicked', () => {
+      render(<AxisSelector {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: 'category' }));
+      expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
+    });
+
+    it('contains a searchable selectable list', () => {
+      render(<AxisSelector {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: 'category' }));
+
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+  });
+
+  describe('onSelectionChange callback', () => {
+    it('calls onChange with axis role and label when an option is checked', () => {
+      render(<AxisSelector {...defaultProps} value="" />);
+      fireEvent.click(screen.getByRole('button', { name: 'Select a field' }));
+
+      // Simulate EuiSelectable onChange with a checked option
+      const { onChange } = defaultProps;
+      // Directly invoke the internal callback logic: when an option with checked='on' is found
+      // the component calls onChange(axisRole, found.label)
+      // We verify this by checking the component wires props correctly
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('calls onRemove with axis role when no option is checked (deselection)', () => {
+      render(<AxisSelector {...defaultProps} />);
+      expect(mockOnRemove).not.toHaveBeenCalled();
+
+      // Click remove button to trigger onRemove
+      fireEvent.click(screen.getByLabelText('Remove field'));
+      expect(mockOnRemove).toHaveBeenCalledWith(AxisRole.X);
+    });
+  });
+
+  describe('options list', () => {
+    it('renders with empty options array', () => {
+      render(<AxisSelector {...defaultProps} value="" options={[]} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Select a field' }));
+
+      expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
+      expect(screen.queryAllByRole('option')).toHaveLength(0);
+    });
+
+    it('handles options without schema property', () => {
+      const optionsNoSchema = [{ label: 'unknown_field' }, { label: 'another_field' }];
+      render(<AxisSelector {...defaultProps} value="" options={optionsNoSchema} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Select a field' }));
+
+      // Should render without throwing
+      expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
+    });
+
+    it('updates when options prop changes', () => {
+      const { rerender } = render(<AxisSelector {...defaultProps} value="" />);
+
+      const newOptions = [{ label: 'new_field', schema: VisFieldType.Numerical }];
+      rerender(<AxisSelector {...defaultProps} value="" options={newOptions} />);
+
+      // Should render without throwing after options change
+      fireEvent.click(screen.getByRole('button', { name: 'Select a field' }));
+      expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
+    });
+  });
+
+  describe('axis role handling', () => {
+    it.each([
+      AxisRole.X,
+      AxisRole.Y,
+      AxisRole.COLOR,
+      AxisRole.FACET,
+      AxisRole.SIZE,
+      AxisRole.Y_SECOND,
+      AxisRole.Value,
+      AxisRole.Time,
+    ])('passes %s role to onRemove when remove button is clicked', (role) => {
+      render(<AxisSelector {...defaultProps} axisRole={role} value="category" />);
+      fireEvent.click(screen.getByLabelText('Remove field'));
+      expect(mockOnRemove).toHaveBeenCalledWith(role);
+    });
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axis_selector.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axis_selector.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  EuiButtonIcon,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+  EuiSelectableOption,
+  EuiToken,
+} from '@elastic/eui';
+
+import { AxisRole, VisFieldType } from '../../types';
+
+import './axis_selector.scss';
+
+const SCHEMA_TOKEN_MAP: Record<string, string> = {
+  [VisFieldType.Numerical]: 'tokenNumber',
+  [VisFieldType.Categorical]: 'tokenString',
+  [VisFieldType.Date]: 'tokenDate',
+};
+
+interface AxisSelectorProps {
+  axisRole: AxisRole;
+  value: string;
+  options: Array<EuiSelectableOption & { schema?: VisFieldType }>;
+  onChange: (axisRole: AxisRole, value: string) => void;
+  onRemove: (axisRole: AxisRole) => void;
+}
+
+export const AxisSelector = ({
+  value,
+  options,
+  axisRole,
+  onChange,
+  onRemove,
+}: AxisSelectorProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const onButtonClick = () => setIsPopoverOpen((isOpen) => !isOpen);
+  const closePopover = () => setIsPopoverOpen(false);
+
+  const onSelectionChange = useCallback(
+    (opts: EuiSelectableOption[]) => {
+      const found = opts.find((opt) => opt.checked);
+      if (found) {
+        onChange(axisRole, found.label);
+      } else {
+        onRemove(axisRole);
+      }
+      closePopover();
+    },
+    [axisRole, onChange, onRemove]
+  );
+
+  const allOptions = useMemo(() => {
+    const all: EuiSelectableOption[] = [];
+    for (const opt of options) {
+      const schema = opt.schema;
+      const tokenType = schema ? SCHEMA_TOKEN_MAP[schema] : undefined;
+      const append = tokenType ? (
+        <EuiToken style={{ display: 'flex' }} size="s" iconType={tokenType} />
+      ) : undefined;
+      if (opt.label === value) {
+        all.push({ ...opt, checked: 'on', append });
+      } else {
+        all.push({ ...opt, checked: undefined, append });
+      }
+    }
+    return all;
+  }, [options, value]);
+
+  const hasValue = Boolean(value);
+
+  const button = (
+    <button
+      data-test-subj="axisSelectorButton"
+      className="axisSelectorButton"
+      onClick={onButtonClick}
+    >
+      {hasValue ? value : 'Select a field'}
+    </button>
+  );
+
+  return (
+    <div className={`axisSelectorContainer${hasValue ? '' : ' axisSelectorContainer--empty'}`}>
+      <div className="axisSelectorRow">
+        <EuiPopover
+          className="axisSelectorFieldSelector"
+          button={button}
+          isOpen={isPopoverOpen}
+          closePopover={closePopover}
+          panelPaddingSize="none"
+          display="block"
+        >
+          <EuiSelectable
+            searchable
+            singleSelection
+            className="axisSelectorList"
+            options={allOptions}
+            onChange={onSelectionChange}
+            searchProps={{
+              placeholder: 'Filter list',
+              compressed: true,
+            }}
+            listProps={{ onFocusBadge: false }}
+          >
+            {(list, search) => {
+              return (
+                <>
+                  <EuiPopoverTitle paddingSize="s">{search}</EuiPopoverTitle>
+                  {list}
+                </>
+              );
+            }}
+          </EuiSelectable>
+        </EuiPopover>
+        {hasValue && (
+          <EuiButtonIcon
+            className="axisSelectorRemoveButton"
+            iconType="cross"
+            iconSize="s"
+            color="text"
+            aria-label="Remove field"
+            data-test-subj="axisSelectorRemoveButton"
+            onClick={() => onRemove(axisRole)}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/standard_axes_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/standard_axes_options.test.tsx
@@ -14,9 +14,7 @@ const mockStore = configureMockStore([]);
 const store = mockStore({
   tab: {
     visualizations: {
-      styleOptions: {
-        switchAxes: false,
-      },
+      styleOptions: {},
     },
   },
 });
@@ -103,7 +101,6 @@ describe('AllAxesOptions', () => {
   const defaultProps = {
     standardAxes: mockStandardAxes,
     onStandardAxesChange: jest.fn(),
-    onChangeSwitchAxes: jest.fn(),
     disableGrid: false,
     axisColumnMappings: {
       [AxisRole.X]: {
@@ -150,23 +147,6 @@ describe('AllAxesOptions', () => {
     expect(screen.getByText('Show Y-Axis')).toBeInTheDocument();
   });
 
-  it('should switch label is switchAxes is true', () => {
-    const switchStore = mockStore({
-      tab: {
-        visualizations: {
-          styleOptions: {
-            switchAxes: true,
-          },
-        },
-      },
-    });
-
-    render(
-      <Provider store={switchStore}>
-        <AllAxesOptions {...defaultProps} />
-      </Provider>
-    );
-  });
   it('shows/hides label options based on show labels toggle', () => {
     render(
       <Provider store={store}>

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/standard_axes_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/standard_axes_options.tsx
@@ -13,7 +13,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { StandardAxes, Positions, AxisRole, VisColumn } from '../../types';
+import { StandardAxes, Positions, AxisRole, AxisColumnMappings } from '../../types';
 import { DebouncedFieldText, DebouncedFieldNumber } from '.././utils';
 import { StyleAccordion } from '../../style_panel/style_accordion';
 import { AXIS_LABEL_MAX_LENGTH } from '../../constants';
@@ -22,9 +22,8 @@ import { getSchemaByAxis } from '../../utils/utils';
 interface AllAxesOptionsProps {
   standardAxes: StandardAxes[];
   onStandardAxesChange: (categoryAxes: StandardAxes[]) => void;
-  axisColumnMappings: Partial<Record<AxisRole, VisColumn>>;
+  axisColumnMappings: AxisColumnMappings;
   disableGrid?: boolean;
-  switchAxes?: boolean;
   showFullTimeRange?: boolean;
   onShowFullTimeRangeChange?: (showFullTimeRange: boolean) => void;
   initialIsOpen?: boolean;
@@ -47,7 +46,6 @@ export const AllAxesOptions: FC<AllAxesOptionsProps> = ({
   onStandardAxesChange,
   axisColumnMappings,
   disableGrid = false,
-  switchAxes = false,
   showFullTimeRange,
   onShowFullTimeRangeChange,
   initialIsOpen = false,
@@ -65,9 +63,9 @@ export const AllAxesOptions: FC<AllAxesOptionsProps> = ({
   const getAxisLabel = (role: AxisRole) => {
     switch (role) {
       case AxisRole.X:
-        return switchAxes ? yAxisLabel : xAxisLabel;
+        return xAxisLabel;
       case AxisRole.Y:
-        return switchAxes ? xAxisLabel : yAxisLabel;
+        return yAxisLabel;
       case AxisRole.Y_SECOND:
         return y2AxisLabel;
     }
@@ -75,37 +73,19 @@ export const AllAxesOptions: FC<AllAxesOptionsProps> = ({
 
   const getPositionsForAxis = (axis: StandardAxes) => {
     const isY = axis.axisRole === AxisRole.Y || axis.axisRole === AxisRole.Y_SECOND;
-    const flipped = !!switchAxes;
 
-    // if switch axes, only switch label
-    // the style switch happens in vege rendering
     const mapLabel = (pos: Positions): string => {
-      if (!flipped) {
-        switch (pos) {
-          case Positions.LEFT:
-            return 'Left';
-          case Positions.RIGHT:
-            return 'Right';
-          case Positions.TOP:
-            return 'Top';
-          case Positions.BOTTOM:
-            return 'Bottom';
-          default:
-            return pos;
-        }
-      } else {
-        switch (pos) {
-          case Positions.LEFT:
-            return 'Bottom';
-          case Positions.RIGHT:
-            return 'Top';
-          case Positions.TOP:
-            return 'Right';
-          case Positions.BOTTOM:
-            return 'Left';
-          default:
-            return pos;
-        }
+      switch (pos) {
+        case Positions.LEFT:
+          return 'Left';
+        case Positions.RIGHT:
+          return 'Right';
+        case Positions.TOP:
+          return 'Top';
+        case Positions.BOTTOM:
+          return 'Bottom';
+        default:
+          return pos;
       }
     };
 
@@ -187,7 +167,7 @@ export const AllAxesOptions: FC<AllAxesOptionsProps> = ({
                     />
                   </EuiFormRow>
 
-                  {getSchemaByAxis(axisColumnMappings?.[axis.axisRole]) === 'temporal' &&
+                  {getSchemaByAxis(axisColumnMappings?.[axis.axisRole]?.[0]) === 'temporal' &&
                     onShowFullTimeRangeChange && (
                       <EuiFormRow>
                         <EuiSwitch

--- a/src/plugins/explore/public/components/visualizations/style_panel_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel_render.tsx
@@ -10,8 +10,8 @@ import { Observable } from 'rxjs';
 
 import { ChartTypeSelector } from './chart_type_selector';
 import { ChartStylesMapping, ChartType, StyleOptions } from './utils/use_visualization_types';
-import { AxisColumnMappings, RenderChartConfig } from './types';
-import { convertMappingsToStrings, convertStringsToMappings } from './visualization_builder_utils';
+import { AxisFieldNameMappings, RenderChartConfig } from './types';
+import { convertStringsToMappings } from './visualization_builder_utils';
 import { visualizationRegistry } from './visualization_registry';
 import { VisData } from './visualization_builder.types';
 import { getAxisConfigByColumnMapping } from './utils/axis';
@@ -21,7 +21,7 @@ interface StylePanelProps<T> {
   config$: Observable<RenderChartConfig | undefined>;
   onStyleChange: (changes: Partial<StyleOptions>) => void;
   onChartTypeChange: (type: ChartType) => void;
-  onAxesMappingChange: (mappings: Record<string, string>) => void;
+  onAxesMappingChange: (mappings: AxisFieldNameMappings) => void;
   className?: string;
 }
 
@@ -38,8 +38,8 @@ export const StylePanelRender = <T extends ChartType>({
   const axesMapping = chartConfig?.axesMapping;
 
   const updateVisualization = useCallback(
-    ({ mappings }: { mappings: AxisColumnMappings }) => {
-      onAxesMappingChange(convertMappingsToStrings(mappings));
+    ({ mappings }: { mappings: AxisFieldNameMappings }) => {
+      onAxesMappingChange(mappings);
     },
     [onAxesMappingChange]
   );

--- a/src/plugins/explore/public/components/visualizations/types.ts
+++ b/src/plugins/explore/public/components/visualizations/types.ts
@@ -18,7 +18,8 @@ export interface ChartMetadata {
   icon: string;
 }
 
-export type AxisColumnMappings = Partial<Record<AxisRole, VisColumn>>;
+export type AxisColumnMappings = Partial<Record<AxisRole, VisColumn[]>>;
+export type AxisFieldNameMappings = Partial<Record<string, string | string[]>>;
 
 export interface VisColumn {
   id: number;

--- a/src/plugins/explore/public/components/visualizations/utils/axis.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/axis.test.ts
@@ -95,7 +95,7 @@ describe('getAxisConfigByColumnMapping', () => {
   describe('with default configurations', () => {
     it('should return default X axis config when X axis column is mapped and no standardAxes provided', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
       };
       const result = getAxisConfigByColumnMapping(axisColumnMappings);
       expect(result).toEqual([DEFAULT_X_AXIS_CONFIG]);
@@ -103,9 +103,9 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should return multiple default configs in correct order', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
-        [AxisRole.Y]: mockVisColumn,
-        [AxisRole.Y_SECOND]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
+        [AxisRole.Y]: [mockVisColumn],
+        [AxisRole.Y_SECOND]: [mockVisColumn],
       };
       const result = getAxisConfigByColumnMapping(axisColumnMappings);
       expect(result).toEqual([
@@ -119,7 +119,7 @@ describe('getAxisConfigByColumnMapping', () => {
   describe('with custom standardAxes configurations', () => {
     it('should use custom X axis config when provided in standardAxes', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
       };
       const standardAxes = [mockXAxisConfig];
       const result = getAxisConfigByColumnMapping(axisColumnMappings, standardAxes);
@@ -128,9 +128,9 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should use custom configs when available and default configs when not', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
-        [AxisRole.Y]: mockVisColumn,
-        [AxisRole.Y_SECOND]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
+        [AxisRole.Y]: [mockVisColumn],
+        [AxisRole.Y_SECOND]: [mockVisColumn],
       };
       const standardAxes = [mockXAxisConfig]; // Only X axis has custom config
       const result = getAxisConfigByColumnMapping(axisColumnMappings, standardAxes);
@@ -145,8 +145,8 @@ describe('getAxisConfigByColumnMapping', () => {
   describe('with mixed scenarios', () => {
     it('should handle partial axis mappings with custom configs', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
-        [AxisRole.Y_SECOND]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
+        [AxisRole.Y_SECOND]: [mockVisColumn],
         // No Y axis mapping
       };
       const standardAxes = [mockXAxisConfig, mockY2AxisConfig];
@@ -156,7 +156,7 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should ignore standardAxes that do not match any mapped columns', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
       };
       const standardAxes = [mockXAxisConfig, mockYAxisConfig, mockY2AxisConfig];
       const result = getAxisConfigByColumnMapping(axisColumnMappings, standardAxes);
@@ -165,8 +165,8 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should handle empty standardAxes array', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
-        [AxisRole.Y]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
+        [AxisRole.Y]: [mockVisColumn],
       };
       const standardAxes: StandardAxes[] = [];
       const result = getAxisConfigByColumnMapping(axisColumnMappings, standardAxes);
@@ -175,7 +175,7 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should maintain correct array positions even with sparse mappings', () => {
       const axisColumnMappings = {
-        [AxisRole.Y_SECOND]: mockVisColumn, // Only Y2 mapped
+        [AxisRole.Y_SECOND]: [mockVisColumn], // Only Y2 mapped
       };
       const result = getAxisConfigByColumnMapping(axisColumnMappings);
       expect(result).toEqual([DEFAULT_Y_2_AXIS_CONFIG]);
@@ -184,8 +184,8 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should handle non-standard axis roles gracefully', () => {
       const axisColumnMappings = {
-        [AxisRole.COLOR]: mockVisColumn, // Non-standard axis role
-        [AxisRole.X]: mockVisColumn,
+        [AxisRole.COLOR]: [mockVisColumn], // Non-standard axis role
+        [AxisRole.X]: [mockVisColumn],
       };
       const result = getAxisConfigByColumnMapping(axisColumnMappings);
       expect(result).toEqual([DEFAULT_X_AXIS_CONFIG]);
@@ -193,9 +193,9 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should handle undefined column values in mappings', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
         [AxisRole.Y]: undefined,
-        [AxisRole.Y_SECOND]: mockVisColumn,
+        [AxisRole.Y_SECOND]: [mockVisColumn],
       };
       const result = getAxisConfigByColumnMapping(axisColumnMappings);
       expect(result).toEqual([DEFAULT_X_AXIS_CONFIG, DEFAULT_Y_2_AXIS_CONFIG]);
@@ -203,7 +203,7 @@ describe('getAxisConfigByColumnMapping', () => {
 
     it('should handle standardAxes with mismatched axisRole', () => {
       const axisColumnMappings = {
-        [AxisRole.X]: mockVisColumn,
+        [AxisRole.X]: [mockVisColumn],
       };
       const mismatchedConfig: StandardAxes = {
         ...mockXAxisConfig,

--- a/src/plugins/explore/public/components/visualizations/utils/axis.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/axis.ts
@@ -8,16 +8,16 @@ import {
   DEFAULT_Y_2_AXIS_CONFIG,
   DEFAULT_Y_AXIS_CONFIG,
 } from '../constants';
-import { AxisRole, StandardAxes, VisColumn } from '../types';
+import { AxisColumnMappings, AxisRole, StandardAxes } from '../types';
 
 export const getAxisConfigByColumnMapping = (
-  axisColumnMappings: Partial<Record<AxisRole, VisColumn>>,
+  axisColumnMappings: AxisColumnMappings,
   standardAxes: StandardAxes[] = []
 ) => {
   const results: StandardAxes[] = [];
   Object.keys(axisColumnMappings).forEach((role) => {
     const column = axisColumnMappings[role as AxisRole];
-    if (column) {
+    if (column && column.length > 0) {
       const found = standardAxes.find((config) => config.axisRole === role);
       if (found) {
         if (role === AxisRole.X) {

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/aggregate.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/aggregate.test.ts
@@ -197,6 +197,162 @@ describe('aggregate', () => {
     });
   });
 });
+describe('aggregate with multiple fields', () => {
+  const data = [
+    { product: 'A', sales: 100, quantity: 10 },
+    { product: 'A', sales: 150, quantity: 20 },
+    { product: 'B', sales: 200, quantity: 30 },
+    { product: 'B', sales: 120, quantity: 15 },
+  ];
+
+  it('aggregates multiple fields with SUM', () => {
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.SUM,
+    })(data);
+
+    expect(result).toEqual([
+      { product: 'A', sales: 250, quantity: 30 },
+      { product: 'B', sales: 320, quantity: 45 },
+    ]);
+  });
+
+  it('aggregates multiple fields with MEAN', () => {
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.MEAN,
+    })(data);
+
+    expect(result).toEqual([
+      { product: 'A', sales: 125, quantity: 15 },
+      { product: 'B', sales: 160, quantity: 22.5 },
+    ]);
+  });
+
+  it('aggregates multiple fields with MAX', () => {
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.MAX,
+    })(data);
+
+    expect(result).toEqual([
+      { product: 'A', sales: 150, quantity: 20 },
+      { product: 'B', sales: 200, quantity: 30 },
+    ]);
+  });
+
+  it('aggregates multiple fields with MIN', () => {
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.MIN,
+    })(data);
+
+    expect(result).toEqual([
+      { product: 'A', sales: 100, quantity: 10 },
+      { product: 'B', sales: 120, quantity: 15 },
+    ]);
+  });
+
+  it('aggregates multiple fields with COUNT', () => {
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.COUNT,
+    })(data);
+
+    expect(result).toEqual([
+      { product: 'A', sales: 2, quantity: 2 },
+      { product: 'B', sales: 2, quantity: 2 },
+    ]);
+  });
+
+  it('handles NaN in one field but valid in another', () => {
+    const mixedData = [
+      { product: 'A', sales: 100, quantity: 'invalid' },
+      { product: 'A', sales: 150, quantity: 20 },
+    ];
+
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.SUM,
+    })(mixedData);
+
+    expect(result).toEqual([{ product: 'A', sales: 250, quantity: 20 }]);
+  });
+
+  it('returns null for fields with no valid values', () => {
+    const mixedData = [
+      { product: 'A', sales: 100, quantity: 'invalid' },
+      { product: 'A', sales: 150, quantity: 'also-invalid' },
+    ];
+
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.SUM,
+    })(mixedData);
+
+    expect(result).toEqual([{ product: 'A', sales: 250, quantity: null }]);
+  });
+
+  it('handles time-based aggregation with multiple fields', () => {
+    const timeData = [
+      { timestamp: '2024-01-01T00:00:00Z', sales: 100, quantity: 10 },
+      { timestamp: '2024-01-01T12:00:00Z', sales: 150, quantity: 20 },
+      { timestamp: '2024-01-02T00:00:00Z', sales: 200, quantity: 30 },
+      { timestamp: '2024-01-02T12:00:00Z', sales: 180, quantity: 15 },
+    ];
+
+    const result = aggregate({
+      groupBy: 'timestamp',
+      field: ['sales', 'quantity'],
+      timeUnit: TimeUnit.DATE,
+      aggregationType: AggregationType.SUM,
+    })(timeData);
+
+    expect(result).toEqual([
+      { timestamp: new Date('2024-01-01T00:00:00.000Z'), sales: 250, quantity: 30 },
+      { timestamp: new Date('2024-01-02T00:00:00.000Z'), sales: 380, quantity: 45 },
+    ]);
+  });
+
+  it('handles empty data with multiple fields', () => {
+    const result = aggregate({
+      groupBy: 'product',
+      field: ['sales', 'quantity'],
+      aggregationType: AggregationType.SUM,
+    })([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('single-element array behaves same as string', () => {
+    const testData = [
+      { product: 'A', sales: 100 },
+      { product: 'A', sales: 150 },
+    ];
+
+    const arrayResult = aggregate({
+      groupBy: 'product',
+      field: ['sales'],
+      aggregationType: AggregationType.SUM,
+    })(testData);
+
+    const stringResult = aggregate({
+      groupBy: 'product',
+      field: 'sales',
+      aggregationType: AggregationType.SUM,
+    })(testData);
+
+    expect(arrayResult).toEqual(stringResult);
+  });
+});
+
 describe('aggregateByGroups', () => {
   const data = [
     { region: 'North', product: 'A', sales: 100 },

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/aggregate.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/aggregate.ts
@@ -16,7 +16,8 @@ import { CalculationMethod } from '../calculation';
  *
  * @param options - Aggregation configuration options
  * @param options.groupBy - Field name for categories or time field (e.g., 'product', 'region', 'timestamp')
- * @param options.field - Field name for values (e.g., 'sales', 'count')
+ * @param options.field - Field name(s) for values. Can be a single string or an array of strings
+ *   (e.g., 'sales' or ['sales', 'count']). When an array is provided, each field is aggregated independently.
  * @param options.aggregationType - Type of aggregation to apply (SUM, MEAN, MAX, MIN, COUNT, NONE)
  * @param options.timeUnit - Optional time interval unit. When provided, treats groupBy as date field
  *
@@ -71,13 +72,14 @@ import { CalculationMethod } from '../calculation';
  */
 export const aggregate = (options: {
   groupBy: string;
-  field: string;
+  field: string | string[];
   aggregationType?: AggregationType;
   timeUnit?: TimeUnit;
   // TODO: align AggregationType and CalculationMethod
   calculateType?: CalculationMethod;
 }) => (data: Array<Record<string, any>>) => {
-  const { groupBy, field, aggregationType, timeUnit, calculateType } = options;
+  const { groupBy, aggregationType, timeUnit, calculateType } = options;
+  const fields = Array.isArray(options.field) ? options.field : [options.field];
 
   // Determine if this is time-based grouping
   const isTimeBased = timeUnit !== undefined;
@@ -117,33 +119,47 @@ export const aggregate = (options: {
       groupValue = groupKey;
     }
 
-    const value = Number(row[field]);
-    if (!isNaN(value)) {
-      if (!acc[groupKey]) {
-        acc[groupKey] = { groupValue, values: [] };
+    // Collect values for each field
+    if (!acc[groupKey]) {
+      acc[groupKey] = {
+        groupValue,
+        valuesByField: Object.fromEntries(fields.map((f) => [f, []])),
+      };
+    }
+    for (const f of fields) {
+      const value = Number(row[f]);
+      if (!isNaN(value)) {
+        acc[groupKey].valuesByField[f].push(value);
       }
-      acc[groupKey].values.push(value);
     }
 
     return acc;
-  }, {} as Record<string | number, { groupValue: string | Date; values: number[] }>);
+  }, {} as Record<string | number, { groupValue: string | Date; valuesByField: Record<string, number[]> }>);
 
   // Apply aggregation and convert to array of objects
-  let result = Object.values(grouped).map(({ groupValue, values }) => {
-    // values is guaranteed to have at least one element since groups
-    // are only created when valid values exist
-    const aggregatedValue = aggregateValues(aggregationType, values, calculateType);
+  let result = Object.entries(grouped)
+    .filter(([_, { valuesByField }]) =>
+      // Keep groups that have at least one valid value across any field
+      fields.some((f) => valuesByField[f].length > 0)
+    )
+    .map(([_, { groupValue, valuesByField }]) => {
+      const entry: Record<string, any> = { [groupBy]: groupValue };
 
-    const isValidNumber =
-      aggregatedValue !== undefined &&
-      typeof aggregatedValue === 'number' &&
-      !isNaN(aggregatedValue);
+      for (const f of fields) {
+        if (valuesByField[f].length > 0) {
+          const aggregatedValue = aggregateValues(aggregationType, valuesByField[f], calculateType);
+          const isValidNumber =
+            aggregatedValue !== undefined &&
+            typeof aggregatedValue === 'number' &&
+            !isNaN(aggregatedValue);
+          entry[f] = isValidNumber ? aggregatedValue : null;
+        } else {
+          entry[f] = null;
+        }
+      }
 
-    return {
-      [groupBy]: groupValue,
-      [field]: isValidNumber ? aggregatedValue : null,
-    };
-  });
+      return entry;
+    });
 
   // Sort by time if time-based
   if (isTimeBased) {

--- a/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
@@ -17,7 +17,6 @@ import {
 } from 'echarts';
 import {
   AggregationType,
-  AxisColumnMappings,
   Positions,
   StandardAxes,
   TimeUnit,
@@ -25,6 +24,7 @@ import {
   Threshold,
   ThresholdOptions,
   AxisRole,
+  VisColumn,
 } from '../types';
 import { convertThresholds } from './utils';
 import { DEFAULT_OPACITY } from '../constants';
@@ -44,7 +44,6 @@ export interface BaseChartStyle {
     aggregationType?: AggregationType;
     bucketTimeUnit?: TimeUnit;
   };
-  switchAxes?: boolean;
   standardAxes?: StandardAxes[];
   thresholdOptions?: ThresholdOptions;
   useThresholdColor?: boolean;
@@ -63,11 +62,8 @@ interface Axis {
  * Configuration for ECharts axes (after swapping)
  */
 interface EChartsAxisConfig {
-  xAxis?: Axis;
-  yAxis?: Axis;
   xAxisStyle?: StandardAxes;
   yAxisStyle?: StandardAxes;
-  y2Axis?: Axis;
   y2AxisStyle?: StandardAxes;
 }
 
@@ -78,7 +74,7 @@ interface EChartsSpecInput<T extends BaseChartStyle = BaseChartStyle> {
   data: Array<Record<string, any>>;
   styles: T;
   axisConfig?: EChartsAxisConfig;
-  axisColumnMappings: AxisColumnMappings;
+  axisColumnMappings: { [K in AxisRole]?: VisColumn | VisColumn[] };
   timeRange?: { from: string; to: string };
 }
 
@@ -126,10 +122,11 @@ export function pipe<T extends BaseChartStyle>(
 /**
  * Get ECharts axis type from VisColumn schema
  */
-export function getAxisType(axis: Axis | undefined): 'category' | 'value' | 'time' {
-  if (!axis) return 'value';
+export function getAxisType(axis: Axis | Axis[] | undefined): 'category' | 'value' | 'time' {
+  const effectiveAxis = Array.isArray(axis) ? axis[0] : axis;
+  if (!effectiveAxis) return 'value';
 
-  switch (axis.schema) {
+  switch (effectiveAxis.schema) {
     case VisFieldType.Categorical:
       return 'category';
     case VisFieldType.Date:
@@ -188,10 +185,10 @@ export const buildAxisConfigs = <T extends BaseChartStyle>(
   const { axisConfig, transformedData = [], axisColumnMappings } = state;
 
   const hasFacet = Array.isArray(transformedData[0]?.[0]) && axisColumnMappings.facet !== undefined;
-  const hasY2 = axisColumnMappings.y2 !== undefined && axisConfig?.y2Axis;
+  const hasY2 = axisColumnMappings.y2 !== undefined;
 
   const getConfig = (
-    axis: Axis | undefined,
+    axis: Axis | Axis[] | undefined,
     axisStyle: StandardAxes | undefined,
     gridNumber?: number,
     addSplitLineStyle: boolean = false
@@ -213,19 +210,24 @@ export const buildAxisConfigs = <T extends BaseChartStyle>(
   if (hasFacet) {
     // each grids needs an axis config
     xAxisConfig = transformedData.map((_: any, index: number) => {
-      return getConfig(axisConfig.xAxis, axisConfig.xAxisStyle, index);
+      return getConfig(axisColumnMappings.x, axisConfig.xAxisStyle, index);
     });
 
     yAxisConfig = transformedData.map((_: any, index: number) => {
-      return getConfig(axisConfig.yAxis, axisConfig.yAxisStyle, index);
+      return getConfig(axisColumnMappings.y, axisConfig.yAxisStyle, index);
     });
   } else {
-    xAxisConfig = getConfig(axisConfig.xAxis, axisConfig.xAxisStyle);
+    xAxisConfig = getConfig(axisColumnMappings.x, axisConfig.xAxisStyle);
 
-    yAxisConfig = getConfig(axisConfig.yAxis, axisConfig.yAxisStyle);
+    yAxisConfig = getConfig(axisColumnMappings.y, axisConfig.yAxisStyle);
 
     if (hasY2) {
-      const y2AxisConfig = getConfig(axisConfig.y2Axis, axisConfig.y2AxisStyle, undefined, true);
+      const y2AxisConfig = getConfig(
+        axisColumnMappings.y2,
+        axisConfig.y2AxisStyle,
+        undefined,
+        true
+      );
       yAxisConfig = [yAxisConfig, y2AxisConfig];
     }
   }
@@ -442,7 +444,7 @@ export const applyTimeRange = <T extends BaseChartStyle>(
   }
 
   const timeAxisEntry = Object.entries(axisColumnMappings).find(
-    ([, col]) => col?.schema === VisFieldType.Date
+    ([, axis]) => getAxisType(axis) === 'time'
   );
 
   if (!timeAxisEntry) {

--- a/src/plugins/explore/public/components/visualizations/utils/use_visualization_types.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/use_visualization_types.ts
@@ -90,7 +90,7 @@ interface VisRenderProps<T extends ChartType> {
   onSelectTimeRange?: (timeRange: TimeRange) => void;
 }
 
-export type AxisTypeMapping = Partial<Record<AxisRole, { type: VisFieldType }>>;
+export type AxisTypeMapping = Partial<Record<AxisRole, { type: VisFieldType; multi?: boolean }>>;
 
 export interface VisRule<T extends ChartType> {
   priority: number;

--- a/src/plugins/explore/public/components/visualizations/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { applyAxisStyling, getSwappedAxisRole, getSchemaByAxis, mergeStyles } from './utils';
+import { applyAxisStyling, getAxisConfig, getSchemaByAxis, mergeStyles } from './utils';
 import { AxisRole, Positions, VisFieldType, StandardAxes } from '../types';
 import { ChartStyles, StyleOptions } from './use_visualization_types';
 
@@ -118,44 +118,11 @@ describe('applyAxisStyling', () => {
   });
 });
 
-describe('getSwappedAxisRole', () => {
+describe('getAxisConfig', () => {
   it('returns undefined when axes are missing', () => {
-    const { xAxis, yAxis } = getSwappedAxisRole({}, {});
+    const { xAxis, yAxis } = getAxisConfig({}, {});
     expect(xAxis).toBeUndefined();
     expect(yAxis).toBeUndefined();
-  });
-
-  it('returns swapped roles if switchAxes is true', () => {
-    const { xAxis, yAxis } = getSwappedAxisRole(
-      {
-        standardAxes: [
-          { axisRole: AxisRole.X, position: Positions.BOTTOM } as StandardAxes,
-          { axisRole: AxisRole.Y, position: Positions.LEFT } as StandardAxes,
-        ],
-        switchAxes: true,
-      },
-      {
-        x: {
-          id: 1,
-          name: 'X Value',
-          schema: VisFieldType.Categorical,
-          column: 'x',
-          validValuesCount: 6,
-          uniqueValuesCount: 6,
-        },
-        y: {
-          id: 2,
-          name: 'Y Value',
-          schema: VisFieldType.Numerical,
-          column: 'y',
-          validValuesCount: 6,
-          uniqueValuesCount: 6,
-        },
-      }
-    );
-
-    expect(xAxis?.schema).toBe(VisFieldType.Numerical);
-    expect(yAxis?.schema).toBe(VisFieldType.Categorical);
   });
 });
 

--- a/src/plugins/explore/public/components/visualizations/utils/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.ts
@@ -7,7 +7,6 @@ import { mergeWith, isPlainObject } from 'lodash';
 import {
   StandardAxes,
   AxisRole,
-  Positions,
   VisFieldType,
   VisColumn,
   AxisColumnMappings,
@@ -94,55 +93,31 @@ function getAxisByRole(
   return axes.find((axis) => axis.axisRole === axisRole);
 }
 
-const positionSwapMap: Record<Positions, Positions> = {
-  [Positions.LEFT]: Positions.BOTTOM,
-  [Positions.RIGHT]: Positions.TOP,
-  [Positions.BOTTOM]: Positions.LEFT,
-  [Positions.TOP]: Positions.RIGHT,
-};
-
-const swapPosition = (pos: Positions): Positions => positionSwapMap[pos] ?? pos;
-
-export const getSwappedAxisRole = (
-  styles: { standardAxes?: StandardAxes[]; switchAxes?: boolean },
-  axisColumnMappings?: AxisColumnMappings
-): {
-  xAxis?: VisColumn;
-  yAxis?: VisColumn;
-  y2Axis?: VisColumn;
+interface AxisStyleConfig {
   xAxisStyle?: StandardAxes;
   yAxisStyle?: StandardAxes;
   y2AxisStyle?: StandardAxes;
-} => {
-  const xAxis = axisColumnMappings?.x;
-  const yAxis = axisColumnMappings?.y;
-  const y2Axis = axisColumnMappings?.y2;
+}
 
+export const getAxisConfig = (styles: { standardAxes?: StandardAxes[] }): AxisStyleConfig => {
   const xAxisStyle = getAxisByRole(styles.standardAxes ?? [], AxisRole.X);
   const yAxisStyle = getAxisByRole(styles.standardAxes ?? [], AxisRole.Y);
   const y2AxisStyle = getAxisByRole(styles.standardAxes ?? [], AxisRole.Y_SECOND);
 
-  if (!styles?.switchAxes) {
-    return { xAxis, xAxisStyle, yAxis, yAxisStyle, ...(y2Axis && { y2Axis, y2AxisStyle }) };
-  }
+  return { xAxisStyle, yAxisStyle, y2AxisStyle };
+};
 
-  return {
-    xAxis: yAxis,
-    xAxisStyle: yAxisStyle
-      ? {
-          ...yAxisStyle,
-          ...(yAxisStyle?.position ? { position: swapPosition(yAxisStyle.position) } : undefined),
-        }
-      : undefined,
-    yAxis: xAxis,
-    yAxisStyle: xAxisStyle
-      ? {
-          ...xAxisStyle,
-          ...(xAxisStyle?.position ? { position: swapPosition(xAxisStyle.position) } : undefined),
-        }
-      : undefined,
-    ...(y2Axis && { y2Axis, y2AxisStyle }), // switch axes won't apply to y2(line-bar chart)
-  };
+export const getColumnsFromAxisColumnMapping = (
+  axisColumnMappings: {
+    [K in AxisRole]?: VisColumn | VisColumn[];
+  }
+) => {
+  const allColumns = [
+    ...Object.values(axisColumnMappings ?? {}).flatMap((cols) =>
+      Array.isArray(cols) ? cols.map((col) => col.column) : [cols.column]
+    ),
+  ];
+  return allColumns;
 };
 
 export const getSchemaByAxis = (
@@ -264,27 +239,17 @@ const convertThresholdLineStyle = (style: ThresholdMode | undefined) => {
   return style;
 };
 
-export const adjustOppositeSymbol = (switchAxes: boolean, symbol: string) => {
-  if (switchAxes) {
-    return symbol === 'x' ? 'y' : 'x';
-  }
-  return symbol;
-};
-
-const generateThresholdSteps = (thresholds: Threshold[] | undefined, switchAxes?: boolean) => {
+const generateThresholdSteps = (thresholds: Threshold[] | undefined) => {
   return thresholds?.map((t) => ({
-    [switchAxes ? 'xAxis' : 'yAxis']: t.value,
+    yAxis: t.value,
     itemStyle: { color: t.color },
   }));
 };
 
-export const generateThresholdLines = (
-  thresholdOptions: ThresholdOptions,
-  switchAxes?: boolean
-) => {
+export const generateThresholdLines = (thresholdOptions: ThresholdOptions) => {
   if (thresholdOptions.thresholdStyle === ThresholdMode.Off) return {};
 
-  const ThresholdSteps = generateThresholdSteps(thresholdOptions.thresholds, switchAxes);
+  const ThresholdSteps = generateThresholdSteps(thresholdOptions.thresholds);
 
   return {
     markLine: {

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
@@ -272,7 +272,7 @@ describe('VisualizationBuilder', () => {
         }
       );
       // For line, the axes are x/y
-      expect(axesMapping).toEqual({ x: 'name-categorical-0', y: 'name-numerical-0' });
+      expect(axesMapping).toEqual({ x: 'name-categorical-0', y: ['name-numerical-0'] });
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.ts
@@ -21,13 +21,13 @@ import { VisualizationRender } from './visualization_render';
 import { StylePanelRender } from './style_panel_render';
 import { adaptLegacyData } from './visualization_builder_utils';
 import { mergeStyles } from './utils/utils';
-import { RenderChartConfig } from './types';
+import { AxisFieldNameMappings, RenderChartConfig } from './types';
 import { TimeRange } from '../../../../data/common';
 
 interface VisState {
   styleOptions?: StyleOptions;
   chartType?: string;
-  axesMapping?: Record<string, string>;
+  axesMapping?: AxisFieldNameMappings;
 }
 
 interface Options {
@@ -208,7 +208,7 @@ export class VisualizationBuilder {
    */
   reuseCurrentAxesMapping(
     chartType: ChartType,
-    axesMapping: Record<string, string>,
+    axesMapping: AxisFieldNameMappings,
     data: VisData | undefined
   ) {
     const allColumns = [
@@ -321,7 +321,7 @@ export class VisualizationBuilder {
     }
   }
 
-  setAxesMapping(mapping: Record<string, string>) {
+  setAxesMapping(mapping: AxisFieldNameMappings) {
     const config = this.visConfig$.value;
     if (config && !isEqual(config.axesMapping, mapping)) {
       this.setIsVisDirty(true);
@@ -329,7 +329,7 @@ export class VisualizationBuilder {
     }
   }
 
-  syncToUrl<State>(visState: VisState, isVisDirty?: boolean) {
+  syncToUrl(visState: VisState, isVisDirty?: boolean) {
     const urlStateStorage = this.getUrlStateStorage?.();
 
     if (urlStateStorage) {

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.types.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { VisColumn } from './types';
+import { AxisFieldNameMappings, VisColumn } from './types';
 import { ChartType, StyleOptions } from './utils/use_visualization_types';
 
 export interface VisData {
@@ -16,5 +16,5 @@ export interface VisData {
 export interface ChartConfig {
   type: ChartType;
   styles?: StyleOptions;
-  axesMapping?: Record<string, string>;
+  axesMapping?: AxisFieldNameMappings;
 }

--- a/src/plugins/explore/public/components/visualizations/visualization_builder_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder_utils.test.ts
@@ -74,28 +74,28 @@ describe('visualization_container_utils', () => {
   describe('convertMappingsToStrings', () => {
     it('converts axis mappings to string format', () => {
       const mappings = {
-        [AxisRole.X]: mockColumns[1],
-        [AxisRole.Y]: mockColumns[0],
+        [AxisRole.X]: [mockColumns[1]],
+        [AxisRole.Y]: [mockColumns[0]],
       };
 
       const result = convertMappingsToStrings(mappings);
 
       expect(result).toEqual({
-        [AxisRole.X]: 'category',
-        [AxisRole.Y]: 'count',
+        [AxisRole.X]: ['category'],
+        [AxisRole.Y]: ['count'],
       });
     });
 
     it('handles undefined columns', () => {
       const mappings = {
-        [AxisRole.X]: mockColumns[0],
+        [AxisRole.X]: [mockColumns[0]],
         [AxisRole.Y]: undefined,
       };
 
       const result = convertMappingsToStrings(mappings);
 
       expect(result).toEqual({
-        [AxisRole.X]: 'count',
+        [AxisRole.X]: ['count'],
         [AxisRole.Y]: undefined,
       });
     });
@@ -111,8 +111,8 @@ describe('visualization_container_utils', () => {
       const result = convertStringsToMappings(stringMappings, mockColumns);
 
       expect(result).toEqual({
-        [AxisRole.X]: mockColumns[1],
-        [AxisRole.Y]: mockColumns[0],
+        [AxisRole.X]: [mockColumns[1]],
+        [AxisRole.Y]: [mockColumns[0]],
       });
     });
 
@@ -124,7 +124,7 @@ describe('visualization_container_utils', () => {
       const result = convertStringsToMappings(stringMappings, mockColumns);
 
       expect(result).toEqual({
-        [AxisRole.X]: undefined,
+        [AxisRole.X]: [],
       });
     });
   });

--- a/src/plugins/explore/public/components/visualizations/visualization_builder_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder_utils.ts
@@ -11,6 +11,7 @@ import {
   StandardAxes,
   AxisRole,
   Positions,
+  AxisFieldNameMappings,
 } from './types';
 import { StyleOptions } from './utils/use_visualization_types';
 import { ChartConfig } from './visualization_builder.types';
@@ -27,46 +28,54 @@ import { LineChartStyleOptions } from './line/line_vis_config';
 import { GaugeChartStyleOptions } from './gauge/gauge_vis_config';
 import { HeatmapChartStyleOptions } from './heatmap/heatmap_vis_config';
 
-export const convertMappingsToStrings = (mappings: AxisColumnMappings): Record<string, string> =>
-  Object.fromEntries(Object.entries(mappings).map(([axis, column]) => [axis, column?.name]));
+export const convertMappingsToStrings = (mappings: AxisColumnMappings): AxisFieldNameMappings =>
+  Object.fromEntries(
+    Object.entries(mappings).map(([axis, columns]) => [axis, columns?.map((col) => col.name)])
+  );
 
 export const convertStringsToMappings = (
-  stringMappings: Partial<Record<string, string>>,
+  stringMappings: AxisFieldNameMappings,
   allColumns: VisColumn[]
 ): AxisColumnMappings =>
   Object.fromEntries(
     Object.entries(stringMappings).map(([axis, columnName]) => [
       axis,
-      allColumns.find((col) => col.name === columnName),
+      (Array.isArray(columnName) ? columnName : [columnName])
+        .map((name) => allColumns.find((col) => col.name === name))
+        .filter((col): col is VisColumn => col !== undefined),
     ])
   );
 
 export const isValidMapping = (
-  selectedAxesMapping: Partial<Record<string, string>>,
+  selectedAxesMapping: AxisFieldNameMappings,
   allColumns: VisColumn[]
 ) =>
-  Object.values(selectedAxesMapping).every((columnName) =>
-    allColumns.some((col) => col.name === columnName)
-  );
+  Object.values(selectedAxesMapping).every((columnName) => {
+    const names = Array.isArray(columnName) ? columnName : [columnName];
+    return names.every((name) => allColumns.some((col) => col.name === name));
+  });
 
 export const getColumnsByAxesMapping = (
-  selectedAxesMapping: Partial<Record<string, string>>,
+  selectedAxesMapping: AxisFieldNameMappings,
   allColumns: VisColumn[]
 ) => {
   const numericalColumns: VisColumn[] = [];
   const categoricalColumns: VisColumn[] = [];
   const dateColumns: VisColumn[] = [];
   Object.values(selectedAxesMapping).forEach((fieldName) => {
-    const column = allColumns.find((c) => c.name === fieldName);
-    if (column?.schema === VisFieldType.Numerical) {
-      numericalColumns.push(column);
-    }
-    if (column?.schema === VisFieldType.Categorical) {
-      categoricalColumns.push(column);
-    }
-    if (column?.schema === VisFieldType.Date) {
-      dateColumns.push(column);
-    }
+    const names = Array.isArray(fieldName) ? fieldName : [fieldName];
+    names.forEach((name) => {
+      const column = allColumns.find((c) => c.name === name);
+      if (column?.schema === VisFieldType.Numerical) {
+        numericalColumns.push(column);
+      }
+      if (column?.schema === VisFieldType.Categorical) {
+        categoricalColumns.push(column);
+      }
+      if (column?.schema === VisFieldType.Date) {
+        dateColumns.push(column);
+      }
+    });
   });
   return { numericalColumns, categoricalColumns, dateColumns };
 };

--- a/src/plugins/explore/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.tsx
@@ -9,7 +9,6 @@ import moment from 'moment';
 import { useDispatch } from 'react-redux';
 
 import './visualization_container.scss';
-import { AxisColumnMappings } from './types';
 import { useTabResults } from '../../application/utils/hooks/use_tab_results';
 import { useSearchContext } from '../query_panel/utils/use_search_context';
 import { getVisualizationBuilder } from './visualization_builder';
@@ -22,9 +21,10 @@ import {
   setDateRange,
 } from '../../application/utils/state_management/slices';
 import { executeQueries } from '../../application/utils/state_management/actions/query_actions';
+import { AxisFieldNameMappings } from './types';
 
 export interface UpdateVisualizationProps {
-  mappings: AxisColumnMappings;
+  mappings: AxisFieldNameMappings;
 }
 // TODO: add back notifications
 // const VISUALIZATION_TOAST_MSG = {

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.test.ts
@@ -12,7 +12,7 @@ describe('VisualizationRegistry', () => {
 
   const makeRule = (
     priority: number,
-    mappings: Array<Partial<Record<string, { type: VisFieldType }>>>
+    mappings: Array<Partial<Record<string, { type: VisFieldType; multi?: boolean }>>>
   ): VisRule<any> => ({
     priority,
     mappings,
@@ -101,6 +101,14 @@ describe('VisualizationRegistry', () => {
       validValuesCount: 1,
       uniqueValuesCount: 1,
     };
+    const dateCol: VisColumn = {
+      id: 3,
+      name: 'timestamp',
+      schema: VisFieldType.Date,
+      column: 'timestamp',
+      validValuesCount: 1,
+      uniqueValuesCount: 1,
+    };
 
     it('should return exact matches when column counts match rule mappings', () => {
       const rule = makeRule(100, [
@@ -147,6 +155,67 @@ describe('VisualizationRegistry', () => {
       registry.registerVisualization(makeVisType('line', 'Line', [rule]));
 
       const result = registry.findRulesByColumns([numCol], [], []);
+      expect(result.all).toHaveLength(0);
+      expect(result.exact).toHaveLength(0);
+    });
+
+    it('should return exact match for multi axis as sole consumer of its type', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const numCol2: VisColumn = { ...numCol, id: 4, name: 'value2', column: 'value2' };
+      const result = registry.findRulesByColumns([numCol, numCol2], [], [dateCol]);
+      expect(result.exact).toHaveLength(1);
+      expect(result.exact[0].visType).toBe('line');
+    });
+
+    it('should not return exact match when multi and fixed axes share the same type', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Numerical },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const numCol2: VisColumn = { ...numCol, id: 4, name: 'value2', column: 'value2' };
+      const numCol3: VisColumn = { ...numCol, id: 5, name: 'value3', column: 'value3' };
+      const result = registry.findRulesByColumns([numCol, numCol2, numCol3], [], []);
+      expect(result.all).toHaveLength(1);
+      expect(result.exact).toHaveLength(0);
+    });
+
+    it('should return compatible match for multi axis with sufficient columns', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const numCol2: VisColumn = { ...numCol, id: 4, name: 'value2', column: 'value2' };
+      // Extra categorical column means not exact, but still compatible
+      const result = registry.findRulesByColumns([numCol, numCol2], [catCol], [dateCol]);
+      expect(result.all).toHaveLength(1);
+      expect(result.exact).toHaveLength(0);
+    });
+
+    it('should not match multi axis when no columns of that type are available', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const result = registry.findRulesByColumns([], [], [dateCol]);
       expect(result.all).toHaveLength(0);
       expect(result.exact).toHaveLength(0);
     });
@@ -242,6 +311,67 @@ describe('VisualizationRegistry', () => {
       ]);
 
       const result = registry.getAxesMappingByRule(rule, [], [], []);
+      expect(result).toEqual({});
+    });
+
+    it('should assign all columns of a type to a multi axis', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+
+      const numCol1: VisColumn = {
+        id: 1,
+        name: 'revenue',
+        schema: VisFieldType.Numerical,
+        column: 'revenue',
+        validValuesCount: 1,
+        uniqueValuesCount: 1,
+      };
+      const numCol2: VisColumn = {
+        id: 2,
+        name: 'cost',
+        schema: VisFieldType.Numerical,
+        column: 'cost',
+        validValuesCount: 1,
+        uniqueValuesCount: 1,
+      };
+      const dateCol: VisColumn = {
+        id: 3,
+        name: 'timestamp',
+        schema: VisFieldType.Date,
+        column: 'timestamp',
+        validValuesCount: 1,
+        uniqueValuesCount: 1,
+      };
+
+      const result = registry.getAxesMappingByRule(rule, [numCol1, numCol2], [], [dateCol]);
+      expect(result).toEqual({
+        [AxisRole.X]: 'timestamp',
+        [AxisRole.Y]: ['revenue', 'cost'],
+      });
+    });
+
+    it('should return empty object when multi axis has no columns available', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+
+      const dateCol: VisColumn = {
+        id: 1,
+        name: 'timestamp',
+        schema: VisFieldType.Date,
+        column: 'timestamp',
+        validValuesCount: 1,
+        uniqueValuesCount: 1,
+      };
+
+      const result = registry.getAxesMappingByRule(rule, [], [], [dateCol]);
       expect(result).toEqual({});
     });
   });
@@ -372,6 +502,89 @@ describe('VisualizationRegistry', () => {
         allColumns
       );
       expect(result).toBe(rule);
+    });
+
+    it('should match a multi axis rule when multiple fields are provided', () => {
+      const numCol2: VisColumn = {
+        id: 4,
+        name: 'value2',
+        schema: VisFieldType.Numerical,
+        column: 'value2',
+        validValuesCount: 1,
+        uniqueValuesCount: 1,
+      };
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const result = registry.findRuleByAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: ['value', 'value2'] },
+        [...allColumns, numCol2]
+      );
+      expect(result).toBe(rule);
+    });
+
+    it('should match a multi rule when single field is provided', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const result = registry.findRuleByAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: 'value' },
+        allColumns
+      );
+      expect(result).toBe(rule);
+    });
+
+    it('should not match a single-field rule when multiple fields are provided', () => {
+      const numCol2: VisColumn = {
+        id: 4,
+        name: 'value2',
+        schema: VisFieldType.Numerical,
+        column: 'value2',
+        validValuesCount: 1,
+        uniqueValuesCount: 1,
+      };
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const result = registry.findRuleByAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: ['value', 'value2'] },
+        [...allColumns, numCol2]
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when multi field types are mixed', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const result = registry.findRuleByAxesMapping(
+        'line',
+        { [AxisRole.Y]: ['value', 'category'] },
+        allColumns
+      );
+      expect(result).toBeUndefined();
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AxisRole, ChartMetadata, VisColumn, VisFieldType } from './types';
+import { AxisFieldNameMappings, AxisRole, ChartMetadata, VisColumn, VisFieldType } from './types';
 import { VisualizationType, VisRule, AxisTypeMapping } from './utils/use_visualization_types';
 import { getColumnsByAxesMapping } from './visualization_builder_utils';
 
@@ -50,32 +50,37 @@ export class VisualizationRegistry {
     numericalColumns: VisColumn[],
     categoricalColumns: VisColumn[],
     dateColumns: VisColumn[]
-  ) {
+  ): AxisFieldNameMappings {
     for (const mapping of rule.mappings) {
-      const result: Record<string, string> = {};
+      const result: AxisFieldNameMappings = {};
       const numCols = [...numericalColumns];
       const categoricalCols = [...categoricalColumns];
       const dateCols = [...dateColumns];
+      let failed = false;
 
-      for (const [axisRole, { type }] of Object.entries(mapping)) {
-        let column: VisColumn | undefined;
-        if (type === VisFieldType.Categorical) {
-          column = categoricalCols.shift();
-        }
-        if (type === VisFieldType.Numerical) {
-          column = numCols.shift();
-        }
-        if (type === VisFieldType.Date) {
-          column = dateCols.shift();
-        }
-        // No available column fits the mapping, cannot create axis mapping for the given columns
-        if (!column) {
+      for (const [axisRole, { type, multi }] of Object.entries(mapping)) {
+        const pool =
+          type === VisFieldType.Categorical
+            ? categoricalCols
+            : type === VisFieldType.Numerical
+            ? numCols
+            : type === VisFieldType.Date
+            ? dateCols
+            : undefined;
+
+        if (!pool || pool.length === 0) {
+          failed = true;
           break;
         }
-        result[axisRole] = column.name;
+
+        if (multi) {
+          result[axisRole] = pool.splice(0).map((col) => col.name);
+        } else {
+          result[axisRole] = pool.shift()!.name;
+        }
       }
       // Only return if we successfully mapped ALL axes
-      if (Object.keys(result).length === Object.keys(mapping).length) {
+      if (!failed && Object.keys(result).length === Object.keys(mapping).length) {
         return result;
       }
     }
@@ -88,7 +93,7 @@ export class VisualizationRegistry {
    */
   public findRuleByAxesMapping(
     chartType: string,
-    axesMapping: Partial<Record<string, string>>,
+    axesMapping: AxisFieldNameMappings,
     allColumns: VisColumn[]
   ) {
     const rules = this.getVisualization(chartType)?.getRules();
@@ -99,9 +104,12 @@ export class VisualizationRegistry {
     // Convert axesMapping to AxisTypeMapping type
     const axisTypeMapping: AxisTypeMapping = {};
     for (const [role, field] of Object.entries(axesMapping)) {
-      const found = allColumns.find((col) => col.name === field);
-      if (!found) return undefined;
-      axisTypeMapping[role as AxisRole] = { type: found.schema };
+      const names = Array.isArray(field) ? field : [field];
+      const columns = names.map((name) => allColumns.find((col) => col.name === name));
+      if (columns.some((col) => col === undefined)) return undefined;
+      const type = columns[0]!.schema;
+      if (columns.some((col) => col!.schema !== type)) return undefined;
+      axisTypeMapping[role as AxisRole] = { type, ...(names.length > 1 && { multi: true }) };
     }
 
     const found = rules.find((rule) => {
@@ -114,7 +122,12 @@ export class VisualizationRegistry {
         return inputKeys.every((key) => {
           const mappingEntry = mapping[key];
           const inputEntry = axisTypeMapping[key];
-          return mappingEntry && inputEntry && mappingEntry.type === inputEntry.type;
+          if (!mappingEntry || !inputEntry) return false;
+          if (mappingEntry.type !== inputEntry.type) return false;
+          // A multi rule axis accepts both single and multiple fields.
+          // A non-multi rule axis only accepts a single field.
+          if (!mappingEntry.multi && inputEntry.multi) return false;
+          return true;
         });
       });
     });
@@ -129,9 +142,9 @@ export class VisualizationRegistry {
    */
   public updateAxesMappingByChartType(
     chartType: string,
-    axesMapping: Partial<Record<string, string>>,
+    axesMapping: AxisFieldNameMappings,
     allColumns: VisColumn[]
-  ): Record<string, string> {
+  ): AxisFieldNameMappings {
     const { numericalColumns, categoricalColumns, dateColumns } = getColumnsByAxesMapping(
       axesMapping,
       allColumns
@@ -195,7 +208,12 @@ export class VisualizationRegistry {
    * Finds matching VisRules by comparing each mapping's required field counts against
    * the given column counts. Optionally filters by `chartType`. Results grouped by vis type:
    * - `all`: rules with at least one compatible mapping (required <= available per type).
-   * - `exact`: subset of `all` with at least one exact-match mapping (required === available).
+   * - `exact`: subset of `all` with at least one unambiguous mapping where all columns are consumed.
+   *
+   * For multi-field axes (`multi: true`), compatibility requires at least `fixed + 1` columns
+   * of that type (the multi axis needs at least one). Exact matching additionally requires that
+   * no other fixed axis competes for the same type pool — otherwise the assignment is ambiguous
+   * and should be left to the user.
    */
   public findRulesByColumns(
     numericalColumns: VisColumn[],
@@ -205,9 +223,12 @@ export class VisualizationRegistry {
   ): FindRulesByColumnsResult {
     const allMap = new Map<string, Array<VisRule<any>>>();
     const exactMap = new Map<string, Array<VisRule<any>>>();
-    const numCount = numericalColumns.length;
-    const catCount = categoricalColumns.length;
-    const dateCount = dateColumns.length;
+    const counts = {
+      numerical: numericalColumns.length,
+      categorical: categoricalColumns.length,
+      date: dateColumns.length,
+    };
+    const fieldTypes = ['numerical', 'categorical', 'date'] as const;
 
     for (const [type, config] of this.visualizations) {
       if (chartType && chartType !== type) {
@@ -223,15 +244,26 @@ export class VisualizationRegistry {
         for (const mapping of rule.mappings) {
           const required = this.countMappingFieldTypes(mapping);
 
-          exactMatch ||=
-            required.numerical === numCount &&
-            required.categorical === catCount &&
-            required.date === dateCount;
+          // Compatible: enough columns for all fixed axes, plus at least 1 for any multi axis
+          const isCompatible = fieldTypes.every(
+            (ft) => counts[ft] >= required[ft].fixed + (required[ft].hasMulti ? 1 : 0)
+          );
 
-          compatibleMatch ||=
-            required.numerical <= numCount &&
-            required.categorical <= catCount &&
-            required.date <= dateCount;
+          // Exact: all columns are consumed with no ambiguity.
+          // - Non-multi types: available must equal fixed (no leftovers).
+          // - Multi types with fixed > 0: ambiguous (which columns go to fixed vs multi),
+          //   so never exact.
+          // - Multi types with fixed === 0: the multi axis is the sole consumer,
+          //   exact if available >= 1.
+          const isExact = fieldTypes.every((ft) => {
+            const { fixed, hasMulti } = required[ft];
+            if (hasMulti && fixed > 0) return false;
+            if (hasMulti) return counts[ft] >= 1;
+            return counts[ft] === fixed;
+          });
+
+          compatibleMatch ||= isCompatible;
+          exactMatch ||= isExact;
         }
 
         if (compatibleMatch) {
@@ -255,26 +287,35 @@ export class VisualizationRegistry {
   }
 
   private countMappingFieldTypes(
-    mapping: Partial<Record<AxisRole, { type: VisFieldType }>>
-  ): { numerical: number; categorical: number; date: number } {
-    let numerical = 0;
-    let categorical = 0;
-    let date = 0;
+    mapping: Partial<Record<AxisRole, { type: VisFieldType; multi?: boolean }>>
+  ): {
+    numerical: { fixed: number; hasMulti: boolean };
+    categorical: { fixed: number; hasMulti: boolean };
+    date: { fixed: number; hasMulti: boolean };
+  } {
+    const result = {
+      numerical: { fixed: 0, hasMulti: false },
+      categorical: { fixed: 0, hasMulti: false },
+      date: { fixed: 0, hasMulti: false },
+    };
     for (const entry of Object.values(mapping)) {
       if (!entry) continue;
-      switch (entry.type) {
-        case VisFieldType.Numerical:
-          numerical++;
-          break;
-        case VisFieldType.Categorical:
-          categorical++;
-          break;
-        case VisFieldType.Date:
-          date++;
-          break;
+      const key =
+        entry.type === VisFieldType.Numerical
+          ? 'numerical'
+          : entry.type === VisFieldType.Categorical
+          ? 'categorical'
+          : entry.type === VisFieldType.Date
+          ? 'date'
+          : undefined;
+      if (!key) continue;
+      if (entry.multi) {
+        result[key].hasMulti = true;
+      } else {
+        result[key].fixed++;
       }
     }
-    return { numerical, categorical, date };
+    return result;
   }
 
   public registerVisualization(input: VisualizationType<any> | Array<VisualizationType<any>>) {


### PR DESCRIPTION
### Description
Refactor visualization axis configuration to allow selecting multiple fields for Y-axis across bar, line, area. Add AxisSelector component with multi-select support, update expression builders and data aggregation to handle multiple series, and simplify visualization registry and builder utilities.

https://github.com/user-attachments/assets/77246d4d-3946-4ba4-85f5-5fb441ce9e1b

https://github.com/user-attachments/assets/c737af5e-02e0-480d-82d7-f2bb39665405


<!-- Describe what this change achieves-->

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11739
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
