### PR TITLE
[Metrics] Add Prometheus detector/forecaster/monitor flows and previe…

### DIFF
--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_helpers.ts
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_helpers.ts
@@ -1,0 +1,380 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  PROMETHEUS_DETECTOR_MODES,
+  PrometheusDetectorMode,
+} from '../../../../utils/metrics_feature_constants';
+
+const DEFAULT_MONITOR_INTERVAL_MINUTES = 1;
+const DEFAULT_ANOMALY_THRESHOLD = 0.7;
+const DEFAULT_TRIGGER_SEVERITY = '1';
+const DEFAULT_AD_RESULT_INDEX = '.opendistro-anomaly-results*';
+
+const PROMQL_RANGE_SELECTOR_REGEX = /\[\s*([^\]:]+?)\s*(?::[^\]]*)?\]/;
+const PROMQL_DURATION_SEGMENT_REGEX = /(\d+(?:\.\d+)?)(ms|s|m|h|d|w|y)/g;
+
+const DURATION_UNIT_SECONDS: Record<string, number> = {
+  ms: 0.001,
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+  w: 604800,
+  y: 31536000,
+};
+
+const PROMQL_RESERVED_WORDS = new Set([
+  'bool',
+  'by',
+  'without',
+  'on',
+  'ignoring',
+  'group_left',
+  'group_right',
+  'and',
+  'or',
+  'unless',
+  'sum',
+  'avg',
+  'min',
+  'max',
+  'count',
+  'stddev',
+  'stdvar',
+  'topk',
+  'bottomk',
+  'quantile',
+  'rate',
+  'irate',
+  'increase',
+  'delta',
+  'idelta',
+]);
+
+export interface MetricsAlertFormValues {
+  monitorName: string;
+  scheduleIntervalMinutes: number;
+  triggerName: string;
+  severity: string;
+  anomalyGradeThreshold: number;
+  anomalyConfidenceThreshold: number;
+  detectorMode: PrometheusDetectorMode;
+  selectedSeriesId: string;
+  selectedEntityField: string;
+}
+
+export interface MetricsAlertMonitorMetadata {
+  detectorId: string;
+  detectorName: string;
+  promqlQuery: string;
+  dataConnectionId: string;
+  dataSourceId?: string;
+  detectorMode?: PrometheusDetectorMode;
+  selectedSeriesId?: string;
+  selectedEntityField?: string;
+  selectedSeriesLabels?: Record<string, string>;
+}
+
+const sanitizeNamePart = (rawName: string): string =>
+  (rawName || '')
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+const parsePromqlDurationToSeconds = (durationText: string): number | undefined => {
+  const trimmed = (durationText || '').trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  let totalSeconds = 0;
+  let matchedLength = 0;
+  PROMQL_DURATION_SEGMENT_REGEX.lastIndex = 0;
+  let matchedSegment = PROMQL_DURATION_SEGMENT_REGEX.exec(trimmed);
+
+  while (matchedSegment) {
+    if (matchedSegment.index !== matchedLength) {
+      return undefined;
+    }
+
+    const value = Number(matchedSegment[1]);
+    const unit = matchedSegment[2];
+    if (!Number.isFinite(value) || !DURATION_UNIT_SECONDS[unit]) {
+      return undefined;
+    }
+
+    totalSeconds += value * DURATION_UNIT_SECONDS[unit];
+    matchedLength += matchedSegment[0].length;
+    matchedSegment = PROMQL_DURATION_SEGMENT_REGEX.exec(trimmed);
+  }
+
+  if (matchedLength !== trimmed.length || totalSeconds <= 0) {
+    return undefined;
+  }
+
+  return totalSeconds;
+};
+
+export const extractPromqlMetricName = (queryText: string): string | undefined => {
+  const query = (queryText || '').trim();
+  if (!query) {
+    return undefined;
+  }
+
+  const metricSelectorRegex = /([a-zA-Z_:][a-zA-Z0-9_:]*)\s*(?=\{|\[)/;
+  const selectorMatch = metricSelectorRegex.exec(query);
+  if (selectorMatch && selectorMatch[1]) {
+    return selectorMatch[1];
+  }
+
+  const tokenRegex = /\b([a-zA-Z_:][a-zA-Z0-9_:]*)\b/g;
+  let tokenMatch = tokenRegex.exec(query);
+  while (tokenMatch) {
+    const token = tokenMatch[1];
+    const nextChar = query.slice(tokenMatch.index + token.length).trimStart()[0];
+    const isFunction = nextChar === '(';
+    if (!isFunction && !PROMQL_RESERVED_WORDS.has(token.toLowerCase())) {
+      return token;
+    }
+    tokenMatch = tokenRegex.exec(query);
+  }
+
+  return undefined;
+};
+
+export const getPromqlRangeIntervalMinutes = (queryText: string): number | undefined => {
+  const match = PROMQL_RANGE_SELECTOR_REGEX.exec(queryText || '');
+  if (!match || !match[1]) {
+    return undefined;
+  }
+
+  const durationSeconds = parsePromqlDurationToSeconds(match[1]);
+  if (!durationSeconds || durationSeconds <= 0) {
+    return undefined;
+  }
+
+  return Math.max(1, Math.ceil(durationSeconds / 60));
+};
+
+export const toMonitorIntervalMinutes = (detectionInterval: any): number => {
+  const period = detectionInterval?.period ?? detectionInterval;
+  const interval = Number(period?.interval);
+  const rawUnit = String(period?.unit || '').toLowerCase();
+
+  if (!Number.isFinite(interval) || interval <= 0) {
+    return DEFAULT_MONITOR_INTERVAL_MINUTES;
+  }
+
+  if (rawUnit.startsWith('second')) {
+    return Math.max(1, Math.ceil(interval / 60));
+  }
+  if (rawUnit.startsWith('hour')) {
+    return Math.max(1, Math.round(interval * 60));
+  }
+  if (rawUnit.startsWith('day')) {
+    return Math.max(1, Math.round(interval * 24 * 60));
+  }
+
+  return Math.max(1, Math.round(interval));
+};
+
+export const buildDefaultMetricsAlertFormValues = (
+  promqlQuery: string,
+  detectorDefaults?: {
+    detectorMode?: PrometheusDetectorMode;
+    selectedSeriesId?: string;
+    selectedEntityField?: string;
+  }
+): MetricsAlertFormValues => {
+  const metricName = extractPromqlMetricName(promqlQuery);
+  const compactMetricName = sanitizeNamePart(metricName || 'promql');
+  const suffix = Date.now().toString(36).slice(-4);
+  const monitorBase = compactMetricName || 'promql';
+
+  return {
+    monitorName: `metrics-${monitorBase}-monitor-${suffix}`,
+    scheduleIntervalMinutes:
+      getPromqlRangeIntervalMinutes(promqlQuery) || DEFAULT_MONITOR_INTERVAL_MINUTES,
+    triggerName: `${monitorBase}-anomaly-trigger`,
+    severity: DEFAULT_TRIGGER_SEVERITY,
+    anomalyGradeThreshold: DEFAULT_ANOMALY_THRESHOLD,
+    anomalyConfidenceThreshold: DEFAULT_ANOMALY_THRESHOLD,
+    detectorMode: detectorDefaults?.detectorMode || PROMETHEUS_DETECTOR_MODES.singleStream,
+    selectedSeriesId: detectorDefaults?.selectedSeriesId || '',
+    selectedEntityField: detectorDefaults?.selectedEntityField || '',
+  };
+};
+
+export const validateMetricsAlertFormValues = (
+  values: MetricsAlertFormValues
+): string | undefined => {
+  if (!values.monitorName.trim()) {
+    return 'Monitor name is required.';
+  }
+  if (!values.triggerName.trim()) {
+    return 'Trigger name is required.';
+  }
+  if (!Number.isFinite(values.scheduleIntervalMinutes) || values.scheduleIntervalMinutes <= 0) {
+    return 'Monitor schedule must be a positive number of minutes.';
+  }
+  if (
+    !Number.isFinite(values.anomalyGradeThreshold) ||
+    values.anomalyGradeThreshold < 0 ||
+    values.anomalyGradeThreshold > 1
+  ) {
+    return 'Anomaly grade threshold must be between 0 and 1.';
+  }
+  if (
+    !Number.isFinite(values.anomalyConfidenceThreshold) ||
+    values.anomalyConfidenceThreshold < 0 ||
+    values.anomalyConfidenceThreshold > 1
+  ) {
+    return 'Confidence threshold must be between 0 and 1.';
+  }
+  return undefined;
+};
+
+export const buildAlertingMonitorPayload = ({
+  detectorId,
+  exploreMetrics,
+  monitorName,
+  scheduleIntervalMinutes,
+  triggerName,
+  severity,
+  anomalyGradeThreshold,
+  anomalyConfidenceThreshold,
+  adResultIndex = DEFAULT_AD_RESULT_INDEX,
+}: MetricsAlertFormValues & {
+  detectorId: string;
+  exploreMetrics?: MetricsAlertMonitorMetadata;
+  adResultIndex?: string;
+}) => {
+  const intervalMinutes = Math.max(1, Math.round(scheduleIntervalMinutes));
+
+  return {
+    name: monitorName.trim(),
+    type: 'monitor',
+    monitor_type: 'query_level_monitor',
+    enabled: true,
+    schedule: {
+      period: {
+        interval: intervalMinutes,
+        unit: 'MINUTES',
+      },
+    },
+    inputs: [
+      {
+        search: {
+          indices: [adResultIndex],
+          query: {
+            size: 1,
+            sort: [{ anomaly_grade: 'desc' }, { confidence: 'desc' }],
+            query: {
+              bool: {
+                filter: [
+                  {
+                    range: {
+                      execution_end_time: {
+                        from: `{{period_end}}||-${intervalMinutes}m`,
+                        to: '{{period_end}}',
+                        include_lower: true,
+                        include_upper: true,
+                      },
+                    },
+                  },
+                  {
+                    term: {
+                      detector_id: {
+                        value: detectorId,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            aggregations: {
+              max_anomaly_grade: {
+                max: {
+                  field: 'anomaly_grade',
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+    triggers: [
+      {
+        name: triggerName.trim(),
+        severity,
+        condition: {
+          script: {
+            lang: 'painless',
+            source:
+              'return ctx.results != null && ctx.results.length > 0 && ctx.results[0].aggregations != null && ctx.results[0].aggregations.max_anomaly_grade != null && ctx.results[0].hits.total.value > 0 && ctx.results[0].hits.hits[0]._source != null && ctx.results[0].hits.hits[0]._source.confidence != null && ctx.results[0].aggregations.max_anomaly_grade.value != null && ctx.results[0].aggregations.max_anomaly_grade.value >=' +
+              ` ${anomalyGradeThreshold}` +
+              ` && ctx.results[0].hits.hits[0]._source.confidence >= ${anomalyConfidenceThreshold}`,
+          },
+        },
+        actions: [],
+        min_time_between_executions: null,
+        rolling_window_size: null,
+      },
+    ],
+    ui_metadata: {
+      schedule: {
+        period: {
+          interval: intervalMinutes,
+          unit: 'MINUTES',
+        },
+      },
+      monitor_type: 'query_level_monitor',
+      search: {
+        searchType: 'ad',
+        timeField: '',
+        aggregations: [],
+        groupBy: [],
+        bucketValue: 1,
+        bucketUnitOfTime: 'h',
+        filters: [],
+      },
+      ...(exploreMetrics
+        ? {
+            explore_metrics: {
+              created_by: 'explore_metrics',
+              detector_id: exploreMetrics.detectorId,
+              detector_name: exploreMetrics.detectorName,
+              promql_query: exploreMetrics.promqlQuery,
+              data_connection_id: exploreMetrics.dataConnectionId,
+              data_source_id: exploreMetrics.dataSourceId,
+              detector_mode: exploreMetrics.detectorMode,
+              selected_series_id: exploreMetrics.selectedSeriesId,
+              selected_entity_field: exploreMetrics.selectedEntityField,
+              selected_series_labels: exploreMetrics.selectedSeriesLabels,
+            },
+          }
+        : {}),
+      triggers: {
+        [triggerName.trim()]: {
+          value: 10000,
+          enum: 'ABOVE',
+          adTriggerMetadata: {
+            triggerType: 'anomaly_detector_trigger',
+            anomalyGrade: {
+              value: anomalyGradeThreshold,
+              enum: 'ABOVE',
+            },
+            anomalyConfidence: {
+              value: anomalyConfidenceThreshold,
+              enum: 'ABOVE',
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.test.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.test.tsx
@@ -490,6 +490,96 @@ describe('MetricsAlertsPanel', () => {
     );
   });
 
+  test('uses the default data source when local cluster is visible and the metric has no data source id', async () => {
+    mockUseOpenSearchDashboards.mockReturnValue({
+      services: {
+        http: {
+          post: mockHttpPost,
+          get: mockHttpGet,
+          delete: mockHttpDelete,
+        },
+        notifications: {
+          toasts: {
+            addSuccess: mockAddSuccess,
+            addDanger: mockAddDanger,
+            addWarning: mockAddWarning,
+          },
+        },
+        core: {
+          application: {
+            applications$: mockApplications$,
+            getUrlForApp: mockGetUrlForApp.mockImplementation(
+              (appId: string, options?: { path?: string }) =>
+                `/app/${appId}${options?.path ? options.path : ''}`
+            ),
+            navigateToUrl: mockNavigateToUrl,
+          },
+        },
+        store: {
+          getState: () => mockStoreState,
+          dispatch: mockStoreDispatch.mockImplementation((action: any) => action),
+        },
+        dataSourceEnabled: true,
+        hideLocalCluster: false,
+        uiSettings: {},
+        dataSourceManagement: {
+          getDefaultDataSourceId: mockGetDefaultDataSourceId.mockResolvedValue('ds-default'),
+        },
+      },
+    } as any);
+    mockUseQueryPanelActionDependencies.mockReturnValue({
+      query: {
+        language: 'PROMQL',
+        query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+        dataset: {
+          id: 'local',
+          type: 'PROMETHEUS',
+          dataSource: {},
+        },
+      },
+      queryInEditor: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      resultStatus: {
+        status: QueryExecutionStatus.READY,
+      },
+    } as any);
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        detectorId: 'det-visible-default',
+        detectorName: 'metrics-go_gc_heap_allocs_bytes_total-abcd',
+        detectionInterval: { period: { interval: 5, unit: 'Minutes' } },
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        resp: { _id: 'mon-visible-default' },
+      });
+
+    render(<MetricsAlertsPanel />);
+
+    await waitFor(() => expect(mockGetDefaultDataSourceId).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId('metricsCreateAlertMonitorButton'));
+
+    await waitFor(() => expect(mockHttpPost).toHaveBeenCalledTimes(3));
+
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      1,
+      '/api/anomaly_detectors/detectors/_create_from_prometheus_query/ds-default',
+      expect.anything()
+    );
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      2,
+      '/api/anomaly_detectors/detectors/det-visible-default/start/ds-default'
+    );
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      3,
+      '/api/alerting/monitors',
+      expect.objectContaining({
+        query: { dataSourceId: 'ds-default' },
+      })
+    );
+  });
+
   test('creates a high-cardinality detector for multi-series Prometheus queries by default', async () => {
     mockHttpPost
       .mockResolvedValueOnce({

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.test.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.test.tsx
@@ -1,0 +1,571 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { BehaviorSubject } from 'rxjs';
+import { useSelector } from 'react-redux';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MetricsAlertsPanel } from './metrics_alerts_panel';
+import { useOpenSearchDashboards } from '../../../../../../../opensearch_dashboards_react/public';
+import { useQueryPanelActionDependencies } from '../../../../../components/query_panel/query_panel_widgets/query_panel_actions/use_query_panel_action_dependencies';
+import { getVisualizationBuilder } from '../../../../../components/visualizations/visualization_builder';
+import { QueryExecutionStatus } from '../../../../utils/state_management/types';
+
+jest.mock('../../../../../../../opensearch_dashboards_react/public', () => ({
+  useOpenSearchDashboards: jest.fn(),
+  withOpenSearchDashboards: jest.fn((component) => component),
+}));
+
+jest.mock(
+  '../../../../../components/query_panel/query_panel_widgets/query_panel_actions/use_query_panel_action_dependencies',
+  () => ({
+    useQueryPanelActionDependencies: jest.fn(),
+  })
+);
+jest.mock('../../../../../components/visualizations/visualization_builder', () => ({
+  getVisualizationBuilder: jest.fn(),
+}));
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockUseOpenSearchDashboards = useOpenSearchDashboards as jest.MockedFunction<
+  typeof useOpenSearchDashboards
+>;
+const mockUseQueryPanelActionDependencies = useQueryPanelActionDependencies as jest.MockedFunction<
+  typeof useQueryPanelActionDependencies
+>;
+const mockGetVisualizationBuilder = getVisualizationBuilder as jest.MockedFunction<
+  typeof getVisualizationBuilder
+>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+describe('MetricsAlertsPanel', () => {
+  const mockHttpPost = jest.fn();
+  const mockHttpGet = jest.fn();
+  const mockHttpDelete = jest.fn();
+  const mockAddSuccess = jest.fn();
+  const mockAddDanger = jest.fn();
+  const mockAddWarning = jest.fn();
+  const mockGetUrlForApp = jest.fn();
+  const mockNavigateToUrl = jest.fn();
+  const mockStoreDispatch = jest.fn();
+  const mockGetDefaultDataSourceId = jest.fn();
+  let mockApplications$: BehaviorSubject<Map<string, any>>;
+  let mockVisData$: BehaviorSubject<any>;
+  let mockVisConfig$: BehaviorSubject<any>;
+  let mockStoreState: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    mockStoreState = {
+      ui: {},
+    };
+    mockApplications$ = new BehaviorSubject(
+      new Map([
+        ['monitors', { id: 'monitors' }],
+        ['anomaly-detection-dashboards', { id: 'anomaly-detection-dashboards' }],
+      ])
+    );
+    mockUseSelector.mockImplementation((selector: any) => selector(mockStoreState));
+    mockVisData$ = new BehaviorSubject(undefined);
+    mockVisConfig$ = new BehaviorSubject(undefined);
+    mockGetVisualizationBuilder.mockReturnValue({
+      data$: mockVisData$,
+      visConfig$: mockVisConfig$,
+    } as any);
+
+    mockUseOpenSearchDashboards.mockReturnValue({
+      services: {
+        http: {
+          post: mockHttpPost,
+          get: mockHttpGet,
+          delete: mockHttpDelete,
+        },
+        notifications: {
+          toasts: {
+            addSuccess: mockAddSuccess,
+            addDanger: mockAddDanger,
+            addWarning: mockAddWarning,
+          },
+        },
+        core: {
+          application: {
+            applications$: mockApplications$,
+            getUrlForApp: mockGetUrlForApp.mockImplementation(
+              (appId: string, options?: { path?: string }) =>
+                `/app/${appId}${options?.path ? options.path : ''}`
+            ),
+            navigateToUrl: mockNavigateToUrl,
+          },
+        },
+        store: {
+          getState: () => mockStoreState,
+          dispatch: mockStoreDispatch.mockImplementation((action: any) => {
+            if (action.type === 'ui/setMetricsAlertAssociation') {
+              mockStoreState = {
+                ...mockStoreState,
+                ui: {
+                  ...mockStoreState.ui,
+                  metricsAlertAssociation: action.payload,
+                },
+              };
+            }
+            return action;
+          }),
+        },
+        dataSourceEnabled: true,
+        hideLocalCluster: false,
+        uiSettings: {},
+        dataSourceManagement: {
+          getDefaultDataSourceId: mockGetDefaultDataSourceId.mockResolvedValue(''),
+        },
+      },
+    } as any);
+
+    mockUseQueryPanelActionDependencies.mockReturnValue({
+      query: {
+        language: 'PROMQL',
+        query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+        dataset: {
+          id: 'local',
+          type: 'PROMETHEUS',
+          dataSource: {
+            id: 'ds-1',
+          },
+        },
+      },
+      queryInEditor: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      resultStatus: {
+        status: QueryExecutionStatus.READY,
+      },
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('creates detector, starts it, creates monitor inline, and shows success state', async () => {
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        detectorId: 'det-1',
+        detectorName: 'metrics-go_gc_heap_allocs_bytes_total-abcd',
+        detectionInterval: { period: { interval: 5, unit: 'Minutes' } },
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        resp: { _id: 'mon-1' },
+      });
+
+    render(<MetricsAlertsPanel />);
+
+    fireEvent.click(screen.getByTestId('metricsCreateAlertMonitorButton'));
+
+    await waitFor(() => expect(mockHttpPost).toHaveBeenCalledTimes(3));
+
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      1,
+      '/api/anomaly_detectors/detectors/_create_from_prometheus_query/ds-1',
+      expect.objectContaining({ body: expect.any(String) })
+    );
+    expect(JSON.parse(mockHttpPost.mock.calls[0][1].body)).toEqual({
+      query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      dataConnectionId: 'local',
+      description: 'Auto-created from Explore Metrics alerts flow.',
+      detectorMode: 'single_stream',
+    });
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      2,
+      '/api/anomaly_detectors/detectors/det-1/start/ds-1'
+    );
+
+    const monitorCreateCall = mockHttpPost.mock.calls[2];
+    expect(monitorCreateCall[0]).toBe('/api/alerting/monitors');
+    expect(monitorCreateCall[1].query).toEqual({ dataSourceId: 'ds-1' });
+
+    const monitorPayload = JSON.parse(monitorCreateCall[1].body);
+    expect(monitorPayload.name).toContain('metrics-go_gc_heap_allocs_bytes_total-monitor');
+    expect(monitorPayload.schedule.period).toEqual({ interval: 5, unit: 'MINUTES' });
+    expect(monitorPayload.inputs[0].search.query.query.bool.filter[1].term.detector_id.value).toBe(
+      'det-1'
+    );
+    expect(
+      monitorPayload.ui_metadata.triggers[monitorPayload.triggers[0].name].adTriggerMetadata
+    ).toEqual({
+      triggerType: 'anomaly_detector_trigger',
+      anomalyGrade: { value: 0.7, enum: 'ABOVE' },
+      anomalyConfidence: { value: 0.7, enum: 'ABOVE' },
+    });
+
+    await waitFor(() =>
+      expect(mockAddSuccess).toHaveBeenCalledWith(expect.stringContaining('successfully created'))
+    );
+
+    expect(screen.getByText('Monitor available')).toBeInTheDocument();
+    expect(screen.getByTestId('metricsAlertsViewMonitorButton')).toHaveAttribute(
+      'href',
+      '/app/monitors#/monitors/mon-1?type=monitor&mode=classic&dataSourceId=ds-1'
+    );
+    expect(screen.getByTestId('metricsAlertsViewDetectorButton')).toHaveAttribute(
+      'href',
+      '/app/anomaly-detection-dashboards#/detectors/det-1/results?dataSourceId=ds-1'
+    );
+  });
+
+  test('passes the local-cluster sentinel in the monitor deep link when data sources are enabled', async () => {
+    mockUseQueryPanelActionDependencies.mockReturnValue({
+      query: {
+        language: 'PROMQL',
+        query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+        dataset: {
+          id: 'local',
+          type: 'PROMETHEUS',
+          dataSource: {},
+        },
+      },
+      queryInEditor: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      resultStatus: {
+        status: QueryExecutionStatus.READY,
+      },
+    } as any);
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        detectorId: 'det-local',
+        detectorName: 'metrics-go_gc_heap_allocs_bytes_total-local',
+        detectionInterval: { period: { interval: 5, unit: 'Minutes' } },
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        resp: { _id: 'mon-local' },
+      });
+
+    render(<MetricsAlertsPanel />);
+
+    fireEvent.click(screen.getByTestId('metricsCreateAlertMonitorButton'));
+
+    await waitFor(() => expect(mockHttpPost).toHaveBeenCalledTimes(3));
+    expect(screen.getByTestId('metricsAlertsViewMonitorButton')).toHaveAttribute(
+      'href',
+      '/app/monitors#/monitors/mon-local?type=monitor&mode=classic&dataSourceId='
+    );
+  });
+
+  test('shows persisted monitor association instead of the create form', async () => {
+    mockStoreState = {
+      ui: {
+        metricsAlertAssociation: {
+          detectorId: 'det-existing',
+          detectorName: 'detector-existing',
+          monitorId: 'mon-existing',
+          monitorName: 'monitor-existing',
+          promqlQuery: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+          dataConnectionId: 'local',
+          dataSourceId: 'ds-1',
+        },
+      },
+    };
+    mockHttpGet
+      .mockResolvedValueOnce({ ok: true, resp: { name: 'monitor-existing' } })
+      .mockResolvedValueOnce({ name: 'detector-existing' });
+
+    render(<MetricsAlertsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Monitor available')).toBeInTheDocument());
+    expect(screen.queryByTestId('metricsCreateAlertMonitorButton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('metricsAlertsViewMonitorButton')).toHaveAttribute(
+      'href',
+      '/app/monitors#/monitors/mon-existing?type=monitor&mode=classic&dataSourceId=ds-1'
+    );
+  });
+
+  test('rediscovers an existing monitor association for the same metric query', async () => {
+    mockVisData$.next({
+      transformedData: [
+        {
+          timestamp: '2026-04-05T00:00:00.000Z',
+          value: 1,
+          series: '{instance="localhost:9090"}',
+        },
+      ],
+      numericalColumns: [{ id: 1, name: 'Value', column: 'value' }],
+      categoricalColumns: [{ id: 2, name: 'Series', column: 'series' }],
+      dateColumns: [{ id: 3, name: 'Time', column: 'timestamp' }],
+    });
+    mockVisConfig$.next({
+      axesMapping: {
+        x: 'Time',
+        y: 'Value',
+        color: 'Series',
+      },
+    });
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        response: {
+          detectors: [
+            {
+              id: 'det-found',
+              name: 'detector-found',
+              prometheusSource: {
+                query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+                dataConnectionId: 'local',
+              },
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        resp: {
+          hits: {
+            hits: [
+              {
+                _id: 'mon-found',
+                _source: {
+                  monitor: {
+                    name: 'monitor-found',
+                    inputs: [
+                      {
+                        search: {
+                          query: {
+                            query: {
+                              bool: {
+                                filter: [
+                                  {
+                                    term: {
+                                      detector_id: {
+                                        value: 'det-found',
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+    render(<MetricsAlertsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Monitor available')).toBeInTheDocument());
+    expect(screen.queryByTestId('metricsCreateAlertMonitorButton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('metricsAlertsViewMonitorButton')).toHaveAttribute(
+      'href',
+      '/app/monitors#/monitors/mon-found?type=monitor&mode=classic&dataSourceId=ds-1'
+    );
+  });
+
+  test('rolls back detector creation when monitor creation fails', async () => {
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        detectorId: 'det-rollback',
+        detectorName: 'metrics-go_gc_heap_allocs_bytes_total-abcd',
+        detectionInterval: { period: { interval: 5, unit: 'Minutes' } },
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: 'Monitor creation failed.',
+      });
+    mockHttpDelete.mockResolvedValue({ ok: true });
+
+    render(<MetricsAlertsPanel />);
+
+    fireEvent.click(screen.getByTestId('metricsCreateAlertMonitorButton'));
+
+    await waitFor(() =>
+      expect(mockHttpDelete).toHaveBeenCalledWith(
+        '/api/anomaly_detectors/detectors/det-rollback/ds-1'
+      )
+    );
+    expect(mockAddDanger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Failed to create alert monitor',
+      })
+    );
+    expect(screen.getByText('Unable to create monitor')).toBeInTheDocument();
+  });
+
+  test('falls back to the default data source when local cluster is hidden and the metric has no data source id', async () => {
+    mockUseOpenSearchDashboards.mockReturnValue({
+      services: {
+        http: {
+          post: mockHttpPost,
+          get: mockHttpGet,
+          delete: mockHttpDelete,
+        },
+        notifications: {
+          toasts: {
+            addSuccess: mockAddSuccess,
+            addDanger: mockAddDanger,
+            addWarning: mockAddWarning,
+          },
+        },
+        core: {
+          application: {
+            applications$: mockApplications$,
+            getUrlForApp: mockGetUrlForApp.mockImplementation(
+              (appId: string, options?: { path?: string }) =>
+                `/app/${appId}${options?.path ? options.path : ''}`
+            ),
+            navigateToUrl: mockNavigateToUrl,
+          },
+        },
+        store: {
+          getState: () => mockStoreState,
+          dispatch: mockStoreDispatch.mockImplementation((action: any) => action),
+        },
+        dataSourceEnabled: true,
+        hideLocalCluster: true,
+        uiSettings: {},
+        dataSourceManagement: {
+          getDefaultDataSourceId: mockGetDefaultDataSourceId.mockResolvedValue('ds-default'),
+        },
+      },
+    } as any);
+    mockUseQueryPanelActionDependencies.mockReturnValue({
+      query: {
+        language: 'PROMQL',
+        query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+        dataset: {
+          id: 'local',
+          type: 'PROMETHEUS',
+          dataSource: {},
+        },
+      },
+      queryInEditor: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      resultStatus: {
+        status: QueryExecutionStatus.READY,
+      },
+    } as any);
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        detectorId: 'det-fallback',
+        detectorName: 'metrics-go_gc_heap_allocs_bytes_total-abcd',
+        detectionInterval: { period: { interval: 5, unit: 'Minutes' } },
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        resp: { _id: 'mon-fallback' },
+      });
+
+    render(<MetricsAlertsPanel />);
+
+    await waitFor(() => expect(mockGetDefaultDataSourceId).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId('metricsCreateAlertMonitorButton'));
+
+    await waitFor(() => expect(mockHttpPost).toHaveBeenCalledTimes(3));
+
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      1,
+      '/api/anomaly_detectors/detectors/_create_from_prometheus_query/ds-default',
+      expect.anything()
+    );
+    expect(mockHttpPost).toHaveBeenNthCalledWith(
+      2,
+      '/api/anomaly_detectors/detectors/det-fallback/start/ds-default'
+    );
+    expect(screen.getByTestId('metricsAlertsViewMonitorButton')).toHaveAttribute(
+      'href',
+      '/app/monitors#/monitors/mon-fallback?type=monitor&mode=classic&dataSourceId=ds-default'
+    );
+  });
+
+  test('creates a high-cardinality detector for multi-series Prometheus queries by default', async () => {
+    mockHttpPost
+      .mockResolvedValueOnce({
+        ok: true,
+        response: {
+          detectors: [],
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        detectorId: 'det-series',
+        detectorName: 'metrics-go_gc_heap_allocs_bytes_total-prometheus-a-9090-abcd',
+        detectionInterval: { period: { interval: 5, unit: 'Minutes' } },
+      })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: true,
+        resp: { _id: 'mon-series' },
+      });
+    mockVisData$.next({
+      transformedData: [
+        {
+          timestamp: '2026-04-05T00:00:00.000Z',
+          value: 1,
+          series: '{instance="prometheus-a:9090", job="leaf-prometheus"}',
+        },
+        {
+          timestamp: '2026-04-05T00:00:00.000Z',
+          value: 2,
+          series: '{instance="prometheus-b:9090", job="leaf-prometheus"}',
+        },
+      ],
+      numericalColumns: [{ id: 1, name: 'Value', column: 'value' }],
+      categoricalColumns: [{ id: 2, name: 'Series', column: 'series' }],
+      dateColumns: [{ id: 3, name: 'Time', column: 'timestamp' }],
+    });
+    mockVisConfig$.next({
+      axesMapping: {
+        x: 'Time',
+        y: 'Value',
+        color: 'Series',
+      },
+    });
+
+    render(<MetricsAlertsPanel />);
+
+    expect(screen.getByText('Multi-series Prometheus query detected')).toBeInTheDocument();
+    expect(screen.getByTestId('metricsAlertsDetectorModeField')).toHaveValue('high_cardinality');
+    expect(screen.getByTestId('metricsAlertsEntityField')).toHaveValue('instance');
+
+    await waitFor(() => expect(mockHttpPost).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('metricsCreateAlertMonitorButton')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('metricsCreateAlertMonitorButton'));
+
+    await waitFor(() => expect(mockHttpPost).toHaveBeenCalledTimes(4));
+    expect(JSON.parse(mockHttpPost.mock.calls[1][1].body)).toEqual({
+      query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      dataConnectionId: 'local',
+      description: 'Auto-created from Explore Metrics alerts flow.',
+      detectorMode: 'high_cardinality',
+      entityField: 'instance',
+    });
+  });
+
+  test('shows a dependency callout and disables creation when required dashboard apps are unavailable', async () => {
+    mockApplications$.next(new Map());
+
+    render(<MetricsAlertsPanel />);
+
+    expect(screen.getByText('Required alerting dependencies are unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This Metrics alert flow needs the following OpenSearch Dashboards apps to be available: Alerting dashboards plugin, Anomaly Detection dashboards plugin.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('metricsCreateAlertMonitorButton')).toBeDisabled();
+  });
+});

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.tsx
@@ -19,11 +19,11 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import { UiSettingScope } from 'opensearch-dashboards/public';
 import { useObservable } from 'react-use';
 import { useOpenSearchDashboards } from '../../../../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../../../../types';
 import { RootState } from '../../../../utils/state_management/store';
+import { useResolvedOpenSearchDataSourceId } from '../../../../utils/hooks/use_resolved_opensearch_data_source_id';
 import { useQueryPanelActionDependencies } from '../../../../../components/query_panel/query_panel_widgets/query_panel_actions/use_query_panel_action_dependencies';
 import { getVisualizationBuilder } from '../../../../../components/visualizations/visualization_builder';
 import { QueryExecutionStatus } from '../../../../utils/state_management/types';
@@ -77,14 +77,10 @@ const getDependencyAwareErrorMessage = (
   const responseStatus =
     error?.response?.status || error?.statusCode || error?.body?.statusCode || error?.body?.status;
   const serializedError =
-    typeof error === 'string'
-      ? error
-      : typeof error?.body === 'string'
+    typeof error?.body === 'string'
       ? error.body
-      : error?.body
+      : error?.body && typeof error.body === 'object'
       ? JSON.stringify(error.body)
-      : error
-      ? JSON.stringify(error)
       : '';
   const normalized = `${rawMessage} ${serializedError}`.toLowerCase();
   const looksLikeMissingDependency =
@@ -329,8 +325,6 @@ export const MetricsAlertsPanel = () => {
   const [existingAssociationError, setExistingAssociationError] = useState('');
   const [isLoadingExistingAssociation, setIsLoadingExistingAssociation] = useState(false);
   const [createdMonitor, setCreatedMonitor] = useState<CreatedMonitorInfo | null>(null);
-  const [fallbackDataSourceId, setFallbackDataSourceId] = useState('');
-  const [isResolvingDataSourceId, setIsResolvingDataSourceId] = useState(false);
   const persistedAssociation = useSelector((state: RootState) => state.ui.metricsAlertAssociation);
 
   const supportsPrometheusAlerts = useMemo(() => isPrometheusQuery(actionDeps), [actionDeps]);
@@ -380,7 +374,10 @@ export const MetricsAlertsPanel = () => {
     () => String((actionDeps.query as any)?.dataset?.dataSource?.id || '').trim(),
     [actionDeps.query]
   );
-  const currentWorkspaceId = (services.core as any)?.workspaces?.currentWorkspaceId$?.getValue?.();
+  const { dataSourceId, isResolvingDataSourceId } = useResolvedOpenSearchDataSourceId(
+    services,
+    explicitDataSourceId
+  );
   const seriesInference = useMemo(() => inferPrometheusSeries(visData, chartConfig), [
     chartConfig,
     visData,
@@ -395,63 +392,6 @@ export const MetricsAlertsPanel = () => {
     [seriesInference.suggestedEntityFields]
   );
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const resolveFallbackDataSourceId = async () => {
-      const shouldResolveFallback =
-        services.dataSourceEnabled &&
-        services.hideLocalCluster &&
-        !explicitDataSourceId &&
-        !!services.dataSourceManagement?.getDefaultDataSourceId;
-
-      if (!shouldResolveFallback) {
-        setFallbackDataSourceId('');
-        setIsResolvingDataSourceId(false);
-        return;
-      }
-
-      setIsResolvingDataSourceId(true);
-      try {
-        const uiSettingsScope = currentWorkspaceId
-          ? UiSettingScope.WORKSPACE
-          : UiSettingScope.GLOBAL;
-        const defaultDataSourceId = await services.dataSourceManagement!.getDefaultDataSourceId(
-          services.uiSettings,
-          uiSettingsScope
-        );
-        if (!cancelled) {
-          setFallbackDataSourceId(String(defaultDataSourceId || '').trim());
-        }
-      } catch {
-        if (!cancelled) {
-          setFallbackDataSourceId('');
-        }
-      } finally {
-        if (!cancelled) {
-          setIsResolvingDataSourceId(false);
-        }
-      }
-    };
-
-    resolveFallbackDataSourceId();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    explicitDataSourceId,
-    currentWorkspaceId,
-    services.dataSourceEnabled,
-    services.dataSourceManagement,
-    services.hideLocalCluster,
-    services.uiSettings,
-  ]);
-
-  const dataSourceId = useMemo(() => explicitDataSourceId || fallbackDataSourceId, [
-    explicitDataSourceId,
-    fallbackDataSourceId,
-  ]);
   const requiresManagedDataSource = services.dataSourceEnabled && services.hideLocalCluster;
   const missingManagedDataSource =
     requiresManagedDataSource && !isResolvingDataSourceId && !dataSourceId;

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/metrics_alerts_panel.tsx
@@ -1,0 +1,1556 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { i18n } from '@osd/i18n';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
+  EuiCompressedSelect,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { UiSettingScope } from 'opensearch-dashboards/public';
+import { useObservable } from 'react-use';
+import { useOpenSearchDashboards } from '../../../../../../../opensearch_dashboards_react/public';
+import { ExploreServices } from '../../../../../types';
+import { RootState } from '../../../../utils/state_management/store';
+import { useQueryPanelActionDependencies } from '../../../../../components/query_panel/query_panel_widgets/query_panel_actions/use_query_panel_action_dependencies';
+import { getVisualizationBuilder } from '../../../../../components/visualizations/visualization_builder';
+import { QueryExecutionStatus } from '../../../../utils/state_management/types';
+import {
+  MetricsAlertAssociationState,
+  setMetricsAlertAssociation,
+} from '../../../../utils/state_management/slices/ui/ui_slice';
+import {
+  buildAlertingMonitorPayload,
+  buildDefaultMetricsAlertFormValues,
+  MetricsAlertFormValues,
+  toMonitorIntervalMinutes,
+  validateMetricsAlertFormValues,
+} from './metrics_alerts_helpers';
+import { inferPrometheusSeries } from './prometheus_series_inference';
+import {
+  METRICS_ALERTING_APP_ID,
+  METRICS_ANOMALY_DETECTION_APP_ID,
+  PROMETHEUS_DETECTOR_MODES,
+} from '../../../../utils/metrics_feature_constants';
+
+const PROMETHEUS_QUERY_LANGUAGE = 'PROMQL';
+const PROMETHEUS_SOURCE_TYPE = 'PROMETHEUS';
+
+const MONITOR_SEVERITY_OPTIONS = [
+  { value: '1', text: '1 (Highest)' },
+  { value: '2', text: '2 (High)' },
+  { value: '3', text: '3 (Medium)' },
+  { value: '4', text: '4 (Low)' },
+  { value: '5', text: '5 (Lowest)' },
+];
+
+const isPrometheusQuery = (deps: any): boolean => {
+  const language = String(deps?.query?.language || '').toUpperCase();
+  const datasetType = String(deps?.query?.dataset?.type || '').toUpperCase();
+  return language === PROMETHEUS_QUERY_LANGUAGE && datasetType === PROMETHEUS_SOURCE_TYPE;
+};
+
+const getErrorMessage = (error: any): string =>
+  error?.body?.message ||
+  error?.body?.error?.reason ||
+  error?.body?.error ||
+  error?.message ||
+  'Unexpected error';
+
+const getDependencyAwareErrorMessage = (
+  error: any,
+  dependency: 'alerting' | 'anomaly_detection'
+): string => {
+  const rawMessage = getErrorMessage(error);
+  const responseStatus =
+    error?.response?.status || error?.statusCode || error?.body?.statusCode || error?.body?.status;
+  const serializedError =
+    typeof error === 'string'
+      ? error
+      : typeof error?.body === 'string'
+      ? error.body
+      : error?.body
+      ? JSON.stringify(error.body)
+      : error
+      ? JSON.stringify(error)
+      : '';
+  const normalized = `${rawMessage} ${serializedError}`.toLowerCase();
+  const looksLikeMissingDependency =
+    responseStatus === 404 ||
+    normalized.includes('no handler found for uri') ||
+    normalized.includes('endpoint not found') ||
+    normalized.includes('contains unrecognized parameter') ||
+    normalized.includes('not found');
+
+  if (!looksLikeMissingDependency) {
+    return rawMessage;
+  }
+
+  return dependency === 'alerting'
+    ? i18n.translate('explore.metrics.alerts.tab.missingAlertingDependencyError', {
+        defaultMessage:
+          'Alerting is not available for monitor creation. Ensure the Alerting dashboards plugin is installed in OpenSearch Dashboards and the Alerting plugin is installed/enabled on the target OpenSearch cluster.',
+      })
+    : i18n.translate('explore.metrics.alerts.tab.missingAnomalyDetectionDependencyError', {
+        defaultMessage:
+          'Anomaly Detection is not available for detector creation. Ensure the Anomaly Detection dashboards plugin is installed in OpenSearch Dashboards and the AD plugin is installed/enabled on the target OpenSearch cluster.',
+      });
+};
+
+interface CreatedMonitorInfo {
+  detectorId: string;
+  detectorName: string;
+  monitorId: string;
+  monitorName: string;
+}
+
+const normalizePromqlText = (value: string | undefined) => String(value || '').trim();
+
+const toCreatedMonitorInfo = (association: MetricsAlertAssociationState): CreatedMonitorInfo => ({
+  detectorId: association.detectorId,
+  detectorName: association.detectorName,
+  monitorId: association.monitorId,
+  monitorName: association.monitorName,
+});
+
+const matchesMetricsAlertAssociation = (
+  association: MetricsAlertAssociationState | undefined,
+  promqlQuery: string,
+  dataConnectionId: string,
+  dataSourceId?: string,
+  detectorMode?: string,
+  selectedSeriesId?: string,
+  selectedEntityField?: string
+): association is MetricsAlertAssociationState => {
+  if (!association) {
+    return false;
+  }
+
+  const expectedDetectorMode = String(detectorMode || '').trim();
+  const associationDetectorMode = String(association.detectorMode || '').trim();
+
+  return (
+    normalizePromqlText(association.promqlQuery) === normalizePromqlText(promqlQuery) &&
+    String(association.dataConnectionId || '').trim() === String(dataConnectionId || '').trim() &&
+    String(association.dataSourceId || '').trim() === String(dataSourceId || '').trim() &&
+    (!expectedDetectorMode ||
+      !associationDetectorMode ||
+      associationDetectorMode === expectedDetectorMode) &&
+    String(association.selectedSeriesId || '').trim() === String(selectedSeriesId || '').trim() &&
+    String(association.selectedEntityField || '').trim() ===
+      String(selectedEntityField || '').trim()
+  );
+};
+
+const buildAppUrl = (
+  getUrlForApp: (appId: string, options?: { path?: string }) => string,
+  appId: string,
+  path: string
+): string | undefined => {
+  const url = getUrlForApp(appId, { path });
+  if (!url) {
+    return undefined;
+  }
+  return url;
+};
+
+const getDetectorPrometheusSource = (detector: any) =>
+  detector?.prometheusSource || detector?.prometheus_source || {};
+
+const getDetectorCategoryFields = (detector: any): string[] =>
+  (detector?.categoryField || detector?.category_field || [])
+    .map((field: unknown) => String(field || '').trim())
+    .filter(Boolean);
+
+const getDetectorSeriesFilter = (detector: any): Record<string, string> => {
+  const prometheusSource = getDetectorPrometheusSource(detector);
+  const rawSeriesFilter = prometheusSource?.seriesFilter || prometheusSource?.series_filter || {};
+  if (!rawSeriesFilter || typeof rawSeriesFilter !== 'object') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(rawSeriesFilter)
+      .map(([key, value]) => [String(key).trim(), String(value).trim()])
+      .filter(([key, value]) => key && value)
+  );
+};
+
+const doLabelSetsMatch = (
+  expectedLabels: Record<string, string> | undefined,
+  actualLabels: Record<string, string>
+): boolean => {
+  const expectedEntries = Object.entries(expectedLabels || {});
+  if (expectedEntries.length === 0) {
+    return true;
+  }
+
+  return expectedEntries.every(
+    ([key, value]) => String(actualLabels[key] || '').trim() === String(value || '').trim()
+  );
+};
+
+const doesDetectorMatchMetric = ({
+  detector,
+  promqlQuery,
+  dataConnectionId,
+  detectorMode,
+  selectedEntityField,
+  selectedSeriesLabels,
+}: {
+  detector: any;
+  promqlQuery: string;
+  dataConnectionId: string;
+  detectorMode?: string;
+  selectedEntityField?: string;
+  selectedSeriesLabels?: Record<string, string>;
+}): boolean => {
+  const prometheusSource = getDetectorPrometheusSource(detector);
+  const detectorQuery = normalizePromqlText(prometheusSource?.query);
+  const detectorDataConnectionId = String(
+    prometheusSource?.dataConnectionId || prometheusSource?.data_connection_id || ''
+  ).trim();
+
+  if (
+    detectorQuery !== normalizePromqlText(promqlQuery) ||
+    detectorDataConnectionId !== String(dataConnectionId || '').trim()
+  ) {
+    return false;
+  }
+
+  if (detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality) {
+    return getDetectorCategoryFields(detector).includes(String(selectedEntityField || '').trim());
+  }
+
+  if (detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream) {
+    return doLabelSetsMatch(selectedSeriesLabels, getDetectorSeriesFilter(detector));
+  }
+
+  return true;
+};
+
+const extractDetectorIdFromValue = (value: any): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    return String(value.value || value.term || '').trim() || undefined;
+  }
+
+  return String(value).trim() || undefined;
+};
+
+const findDetectorIdInMonitor = (value: any): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const detectorId = findDetectorIdInMonitor(item);
+      if (detectorId) {
+        return detectorId;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value !== 'object') {
+    return undefined;
+  }
+
+  const explicitDetectorId = extractDetectorIdFromValue(value.detector_id || value.detectorId);
+  if (explicitDetectorId) {
+    return explicitDetectorId;
+  }
+
+  for (const childValue of Object.values(value)) {
+    const detectorId = findDetectorIdInMonitor(childValue);
+    if (detectorId) {
+      return detectorId;
+    }
+  }
+
+  return undefined;
+};
+
+const getMonitorFromSearchHit = (hit: any) => {
+  const source = hit?._source || {};
+  const monitor = source.monitor || source;
+  const monitorId = String(hit?._id || monitor?.id || '').trim();
+  if (!monitorId || !monitor) {
+    return undefined;
+  }
+
+  return {
+    id: monitorId,
+    monitor,
+  };
+};
+
+const getMonitorExploreMetricsMetadata = (monitor: any) =>
+  monitor?.ui_metadata?.explore_metrics || monitor?.uiMetadata?.exploreMetrics;
+
+const doesMonitorReferenceDetector = (monitor: any, detectorId: string): boolean => {
+  const metadata = getMonitorExploreMetricsMetadata(monitor);
+  const metadataDetectorId = String(metadata?.detector_id || metadata?.detectorId || '').trim();
+  return metadataDetectorId === detectorId || findDetectorIdInMonitor(monitor) === detectorId;
+};
+
+export const MetricsAlertsPanel = () => {
+  const { services } = useOpenSearchDashboards<ExploreServices>();
+  const actionDeps = useQueryPanelActionDependencies();
+  const visualizationBuilder = getVisualizationBuilder();
+  const visData = useObservable(visualizationBuilder.data$);
+  const chartConfig = useObservable(visualizationBuilder.visConfig$);
+  const availableApplications = useObservable(
+    services.core.application.applications$,
+    new Map<string, unknown>()
+  ) as ReadonlyMap<string, unknown>;
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState('');
+  const [existingAssociationError, setExistingAssociationError] = useState('');
+  const [isLoadingExistingAssociation, setIsLoadingExistingAssociation] = useState(false);
+  const [createdMonitor, setCreatedMonitor] = useState<CreatedMonitorInfo | null>(null);
+  const [fallbackDataSourceId, setFallbackDataSourceId] = useState('');
+  const [isResolvingDataSourceId, setIsResolvingDataSourceId] = useState(false);
+  const persistedAssociation = useSelector((state: RootState) => state.ui.metricsAlertAssociation);
+
+  const supportsPrometheusAlerts = useMemo(() => isPrometheusQuery(actionDeps), [actionDeps]);
+  const isAlertingUiAvailable = useMemo(() => availableApplications.has(METRICS_ALERTING_APP_ID), [
+    availableApplications,
+  ]);
+  const isAnomalyDetectionUiAvailable = useMemo(
+    () => availableApplications.has(METRICS_ANOMALY_DETECTION_APP_ID),
+    [availableApplications]
+  );
+  const missingUiDependencies = useMemo(() => {
+    const missing: string[] = [];
+    if (!isAlertingUiAvailable) {
+      missing.push(
+        i18n.translate('explore.metrics.alerts.tab.missingAlertingUiDependencyLabel', {
+          defaultMessage: 'Alerting dashboards plugin',
+        })
+      );
+    }
+    if (!isAnomalyDetectionUiAvailable) {
+      missing.push(
+        i18n.translate('explore.metrics.alerts.tab.missingAdUiDependencyLabel', {
+          defaultMessage: 'Anomaly Detection dashboards plugin',
+        })
+      );
+    }
+    return missing;
+  }, [isAlertingUiAvailable, isAnomalyDetectionUiAvailable]);
+  const isAOSSCollection = actionDeps.query?.dataset?.dataSource?.type === 'OpenSearch Serverless';
+  const allowedStatuses = [
+    QueryExecutionStatus.READY,
+    QueryExecutionStatus.NO_RESULTS,
+    QueryExecutionStatus.ERROR,
+  ];
+  const isStatusAllowed = allowedStatuses.includes(actionDeps.resultStatus.status);
+
+  const promqlQuery = useMemo(
+    () =>
+      String((actionDeps as any)?.queryInEditor ?? (actionDeps.query as any)?.query ?? '').trim(),
+    [actionDeps]
+  );
+  const dataConnectionId = useMemo(
+    () => String((actionDeps.query as any)?.dataset?.id || '').trim(),
+    [actionDeps.query]
+  );
+  const explicitDataSourceId = useMemo(
+    () => String((actionDeps.query as any)?.dataset?.dataSource?.id || '').trim(),
+    [actionDeps.query]
+  );
+  const currentWorkspaceId = (services.core as any)?.workspaces?.currentWorkspaceId$?.getValue?.();
+  const seriesInference = useMemo(() => inferPrometheusSeries(visData, chartConfig), [
+    chartConfig,
+    visData,
+  ]);
+  const multiSeriesUnsupported = seriesInference.seriesCount > 1;
+  const entityFieldOptions = useMemo(
+    () =>
+      seriesInference.suggestedEntityFields.map((field) => ({
+        value: field,
+        text: field,
+      })),
+    [seriesInference.suggestedEntityFields]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveFallbackDataSourceId = async () => {
+      const shouldResolveFallback =
+        services.dataSourceEnabled &&
+        services.hideLocalCluster &&
+        !explicitDataSourceId &&
+        !!services.dataSourceManagement?.getDefaultDataSourceId;
+
+      if (!shouldResolveFallback) {
+        setFallbackDataSourceId('');
+        setIsResolvingDataSourceId(false);
+        return;
+      }
+
+      setIsResolvingDataSourceId(true);
+      try {
+        const uiSettingsScope = currentWorkspaceId
+          ? UiSettingScope.WORKSPACE
+          : UiSettingScope.GLOBAL;
+        const defaultDataSourceId = await services.dataSourceManagement!.getDefaultDataSourceId(
+          services.uiSettings,
+          uiSettingsScope
+        );
+        if (!cancelled) {
+          setFallbackDataSourceId(String(defaultDataSourceId || '').trim());
+        }
+      } catch {
+        if (!cancelled) {
+          setFallbackDataSourceId('');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsResolvingDataSourceId(false);
+        }
+      }
+    };
+
+    resolveFallbackDataSourceId();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    explicitDataSourceId,
+    currentWorkspaceId,
+    services.dataSourceEnabled,
+    services.dataSourceManagement,
+    services.hideLocalCluster,
+    services.uiSettings,
+  ]);
+
+  const dataSourceId = useMemo(() => explicitDataSourceId || fallbackDataSourceId, [
+    explicitDataSourceId,
+    fallbackDataSourceId,
+  ]);
+  const requiresManagedDataSource = services.dataSourceEnabled && services.hideLocalCluster;
+  const missingManagedDataSource =
+    requiresManagedDataSource && !isResolvingDataSourceId && !dataSourceId;
+  const isActionAvailable =
+    supportsPrometheusAlerts &&
+    isStatusAllowed &&
+    !isAOSSCollection &&
+    missingUiDependencies.length === 0 &&
+    !isResolvingDataSourceId &&
+    !missingManagedDataSource;
+
+  const defaultDetectorFormValues = useMemo(
+    () =>
+      buildDefaultMetricsAlertFormValues(promqlQuery, {
+        detectorMode: seriesInference.defaultDetectorMode,
+        selectedSeriesId: seriesInference.defaultSeriesId,
+        selectedEntityField: seriesInference.defaultEntityField,
+      }),
+    [
+      promqlQuery,
+      seriesInference.defaultDetectorMode,
+      seriesInference.defaultEntityField,
+      seriesInference.defaultSeriesId,
+    ]
+  );
+  const defaultFormSignature = useMemo(
+    () =>
+      [
+        promqlQuery,
+        dataConnectionId,
+        dataSourceId,
+        defaultDetectorFormValues.monitorName,
+        defaultDetectorFormValues.scheduleIntervalMinutes,
+        defaultDetectorFormValues.triggerName,
+        defaultDetectorFormValues.detectorMode,
+        defaultDetectorFormValues.selectedSeriesId,
+        defaultDetectorFormValues.selectedEntityField,
+      ].join('|'),
+    [dataConnectionId, dataSourceId, defaultDetectorFormValues, promqlQuery]
+  );
+
+  const [formValues, setFormValues] = useState<MetricsAlertFormValues>(defaultDetectorFormValues);
+  const selectedSeriesOption = useMemo(
+    () => seriesInference.seriesOptions.find((option) => option.id === formValues.selectedSeriesId),
+    [formValues.selectedSeriesId, seriesInference.seriesOptions]
+  );
+  const matchingAssociation = useMemo(
+    () =>
+      matchesMetricsAlertAssociation(
+        persistedAssociation,
+        promqlQuery,
+        dataConnectionId,
+        dataSourceId,
+        multiSeriesUnsupported ? formValues.detectorMode : undefined,
+        multiSeriesUnsupported && formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+          ? formValues.selectedSeriesId
+          : undefined,
+        multiSeriesUnsupported &&
+          formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality
+          ? formValues.selectedEntityField
+          : undefined
+      )
+        ? persistedAssociation
+        : undefined,
+    [
+      dataConnectionId,
+      dataSourceId,
+      formValues.detectorMode,
+      formValues.selectedEntityField,
+      formValues.selectedSeriesId,
+      multiSeriesUnsupported,
+      persistedAssociation,
+      promqlQuery,
+    ]
+  );
+  const persistMetricsAlertAssociation = useCallback(
+    (association: MetricsAlertAssociationState | undefined) => {
+      services.store.dispatch(setMetricsAlertAssociation(association));
+    },
+    [services.store]
+  );
+
+  useEffect(() => {
+    setFormValues(defaultDetectorFormValues);
+    setCreateError('');
+    setExistingAssociationError('');
+    setCreatedMonitor(matchingAssociation ? toCreatedMonitorInfo(matchingAssociation) : null);
+  }, [defaultDetectorFormValues, defaultFormSignature, matchingAssociation]);
+
+  useEffect(() => {
+    if (!matchingAssociation || missingUiDependencies.length > 0) {
+      setIsLoadingExistingAssociation(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const verifyExistingAssociation = async () => {
+      setIsLoadingExistingAssociation(true);
+      try {
+        const [monitorResponse, detectorResponse] = await Promise.all([
+          services.http.get(
+            `/api/alerting/monitors/${encodeURIComponent(matchingAssociation.monitorId)}`,
+            {
+              ...(dataSourceId ? { query: { dataSourceId } } : {}),
+            }
+          ),
+          services.http.get(
+            dataSourceId
+              ? `/api/anomaly_detectors/detectors/${encodeURIComponent(
+                  matchingAssociation.detectorId
+                )}/${encodeURIComponent(dataSourceId)}`
+              : `/api/anomaly_detectors/detectors/${encodeURIComponent(
+                  matchingAssociation.detectorId
+                )}`
+          ),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (monitorResponse?.ok === false) {
+          throw new Error(monitorResponse?.resp || monitorResponse?.error || 'Monitor not found.');
+        }
+
+        const updatedAssociation: MetricsAlertAssociationState = {
+          ...matchingAssociation,
+          monitorName:
+            monitorResponse?.resp?.name ||
+            monitorResponse?.resp?.monitor?.name ||
+            matchingAssociation.monitorName,
+          detectorName: detectorResponse?.name || matchingAssociation.detectorName,
+        };
+
+        setCreatedMonitor(toCreatedMonitorInfo(updatedAssociation));
+        if (
+          updatedAssociation.monitorName !== matchingAssociation.monitorName ||
+          updatedAssociation.detectorName !== matchingAssociation.detectorName
+        ) {
+          persistMetricsAlertAssociation(updatedAssociation);
+        }
+      } catch (_error) {
+        if (cancelled) {
+          return;
+        }
+
+        setCreatedMonitor(null);
+        setExistingAssociationError(
+          i18n.translate('explore.metrics.alerts.tab.existingAssociationUnavailableMessage', {
+            defaultMessage:
+              'The saved monitor or detector for this metric is no longer available. You can create a new alert monitor.',
+          })
+        );
+        persistMetricsAlertAssociation(undefined);
+      } finally {
+        if (!cancelled) {
+          setIsLoadingExistingAssociation(false);
+        }
+      }
+    };
+
+    verifyExistingAssociation();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    dataSourceId,
+    matchingAssociation,
+    missingUiDependencies.length,
+    persistMetricsAlertAssociation,
+    services.http,
+  ]);
+
+  useEffect(() => {
+    if (
+      !isActionAvailable ||
+      matchingAssociation ||
+      createdMonitor ||
+      isCreating ||
+      !promqlQuery ||
+      !dataConnectionId ||
+      seriesInference.seriesCount === 0
+    ) {
+      return;
+    }
+
+    if (
+      multiSeriesUnsupported &&
+      formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality &&
+      !formValues.selectedEntityField
+    ) {
+      return;
+    }
+
+    if (
+      multiSeriesUnsupported &&
+      formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream &&
+      !selectedSeriesOption
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const discoverExistingAssociation = async () => {
+      setIsLoadingExistingAssociation(true);
+
+      try {
+        const detectorSearchPath = dataSourceId
+          ? `/api/anomaly_detectors/detectors/_search/${encodeURIComponent(dataSourceId)}`
+          : '/api/anomaly_detectors/detectors/_search';
+
+        const detectorSearchResponse: any = await services.http.post(detectorSearchPath, {
+          body: JSON.stringify({
+            size: 1000,
+            query: {
+              bool: {
+                filter: [
+                  {
+                    term: {
+                      source_type: PROMETHEUS_SOURCE_TYPE,
+                    },
+                  },
+                  {
+                    term: {
+                      'prometheus_source.data_connection_id': dataConnectionId,
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        });
+
+        if (cancelled || detectorSearchResponse?.ok === false) {
+          return;
+        }
+
+        const detectorMode = multiSeriesUnsupported ? formValues.detectorMode : undefined;
+        const matchingDetectors = (detectorSearchResponse?.response?.detectors || []).filter(
+          (detector: any) =>
+            doesDetectorMatchMetric({
+              detector,
+              promqlQuery,
+              dataConnectionId,
+              detectorMode,
+              selectedEntityField:
+                detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality
+                  ? formValues.selectedEntityField
+                  : undefined,
+              selectedSeriesLabels:
+                detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+                  ? selectedSeriesOption?.labels
+                  : undefined,
+            })
+        );
+
+        if (matchingDetectors.length === 0) {
+          return;
+        }
+
+        const monitorSearchResponse: any = await services.http.post(
+          '/api/alerting/monitors/_search',
+          {
+            body: JSON.stringify({
+              size: 1000,
+              query: {
+                query: {
+                  match_all: {},
+                },
+              },
+            }),
+            ...(dataSourceId ? { query: { dataSourceId } } : {}),
+          }
+        );
+
+        if (cancelled || monitorSearchResponse?.ok === false) {
+          return;
+        }
+
+        const monitorSearchHits = monitorSearchResponse?.resp?.hits?.hits || [];
+        const monitors = monitorSearchHits.map(getMonitorFromSearchHit).filter(Boolean) as Array<{
+          id: string;
+          monitor: any;
+        }>;
+
+        for (const detector of matchingDetectors) {
+          const detectorId = String(detector?.id || '').trim();
+          if (!detectorId) {
+            continue;
+          }
+
+          const matchingMonitor = monitors.find(({ monitor }) =>
+            doesMonitorReferenceDetector(monitor, detectorId)
+          );
+          if (!matchingMonitor) {
+            continue;
+          }
+
+          const discoveredAssociation: MetricsAlertAssociationState = {
+            detectorId,
+            detectorName: detector?.name || 'Prometheus detector',
+            monitorId: matchingMonitor.id,
+            monitorName: matchingMonitor.monitor?.name || 'Alert monitor',
+            promqlQuery,
+            dataConnectionId,
+            dataSourceId: dataSourceId || undefined,
+            detectorMode: detectorMode as MetricsAlertAssociationState['detectorMode'],
+            selectedSeriesId:
+              detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+                ? formValues.selectedSeriesId || undefined
+                : undefined,
+            selectedEntityField:
+              detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality
+                ? formValues.selectedEntityField || undefined
+                : undefined,
+          };
+
+          if (!cancelled) {
+            setExistingAssociationError('');
+            setCreatedMonitor(toCreatedMonitorInfo(discoveredAssociation));
+            persistMetricsAlertAssociation(discoveredAssociation);
+          }
+          return;
+        }
+      } catch (_error) {
+        // Discovery is best-effort. If it fails, leave the create flow available.
+      } finally {
+        if (!cancelled) {
+          setIsLoadingExistingAssociation(false);
+        }
+      }
+    };
+
+    discoverExistingAssociation();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    createdMonitor,
+    dataConnectionId,
+    dataSourceId,
+    formValues.detectorMode,
+    formValues.selectedEntityField,
+    formValues.selectedSeriesId,
+    isActionAvailable,
+    isCreating,
+    matchingAssociation,
+    multiSeriesUnsupported,
+    persistMetricsAlertAssociation,
+    promqlQuery,
+    selectedSeriesOption,
+    seriesInference.seriesCount,
+    services.http,
+  ]);
+
+  const monitorDetailsUrl = useMemo(() => {
+    if (!createdMonitor?.monitorId) {
+      return undefined;
+    }
+    if (!isAlertingUiAvailable) {
+      return undefined;
+    }
+
+    const dataSourceQuery = services.dataSourceEnabled
+      ? `&dataSourceId=${encodeURIComponent(dataSourceId || '')}`
+      : '';
+    const path = `#/monitors/${encodeURIComponent(
+      createdMonitor.monitorId
+    )}?type=monitor&mode=classic${dataSourceQuery}`;
+    return buildAppUrl(services.core.application.getUrlForApp, METRICS_ALERTING_APP_ID, path);
+  }, [
+    createdMonitor?.monitorId,
+    dataSourceId,
+    isAlertingUiAvailable,
+    services.dataSourceEnabled,
+    services.core.application.getUrlForApp,
+  ]);
+
+  const detectorDetailsUrl = useMemo(() => {
+    if (!createdMonitor?.detectorId) {
+      return undefined;
+    }
+    if (!isAnomalyDetectionUiAvailable) {
+      return undefined;
+    }
+
+    return buildAppUrl(
+      services.core.application.getUrlForApp,
+      METRICS_ANOMALY_DETECTION_APP_ID,
+      `#/detectors/${encodeURIComponent(createdMonitor.detectorId)}/results${
+        dataSourceId ? `?dataSourceId=${encodeURIComponent(dataSourceId)}` : ''
+      }`
+    );
+  }, [
+    createdMonitor?.detectorId,
+    dataSourceId,
+    isAnomalyDetectionUiAvailable,
+    services.core.application.getUrlForApp,
+  ]);
+
+  const updateFormValue = <K extends keyof MetricsAlertFormValues>(
+    key: K,
+    value: MetricsAlertFormValues[K]
+  ) => {
+    setFormValues((current) => ({
+      ...current,
+      [key]: value,
+    }));
+    setCreateError('');
+  };
+
+  const handleCreateMonitor = async () => {
+    if (!promqlQuery || !dataConnectionId) {
+      const errorMessage = i18n.translate(
+        'explore.metrics.alerts.tab.error.missingFieldsBodyInline',
+        {
+          defaultMessage: 'Prometheus connection ID and query are required.',
+        }
+      );
+      setCreateError(errorMessage);
+      services.notifications.toasts.addDanger({
+        title: i18n.translate('explore.metrics.alerts.tab.error.missingFieldsTitle', {
+          defaultMessage: 'Unable to create alert monitor',
+        }),
+        text: errorMessage,
+      });
+      return;
+    }
+
+    if (
+      multiSeriesUnsupported &&
+      formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream &&
+      !selectedSeriesOption
+    ) {
+      const errorMessage = i18n.translate(
+        'explore.metrics.alerts.tab.error.missingSeriesSelection',
+        {
+          defaultMessage: 'Select a concrete Prometheus series before creating the detector.',
+        }
+      );
+      setCreateError(errorMessage);
+      return;
+    }
+
+    if (
+      multiSeriesUnsupported &&
+      formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality &&
+      !formValues.selectedEntityField
+    ) {
+      const errorMessage = i18n.translate(
+        'explore.metrics.alerts.tab.error.missingEntityFieldSelection',
+        {
+          defaultMessage: 'Select an entity field before creating the high-cardinality detector.',
+        }
+      );
+      setCreateError(errorMessage);
+      return;
+    }
+
+    const validationError = validateMetricsAlertFormValues(formValues);
+    if (validationError) {
+      setCreateError(validationError);
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError('');
+    setExistingAssociationError('');
+    setCreatedMonitor(null);
+
+    let detectorId = '';
+    let detectorName = '';
+    let monitorId = '';
+    let failingDependency: 'alerting' | 'anomaly_detection' = 'anomaly_detection';
+
+    try {
+      const createDetectorPath = dataSourceId
+        ? `/api/anomaly_detectors/detectors/_create_from_prometheus_query/${encodeURIComponent(
+            dataSourceId
+          )}`
+        : '/api/anomaly_detectors/detectors/_create_from_prometheus_query';
+
+      const createDetectorResponse: any = await services.http.post(createDetectorPath, {
+        body: JSON.stringify({
+          query: promqlQuery,
+          dataConnectionId,
+          description: 'Auto-created from Explore Metrics alerts flow.',
+          detectorMode: formValues.detectorMode,
+          selectedSeries:
+            formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+              ? selectedSeriesOption?.labels
+              : undefined,
+          entityField:
+            formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality
+              ? formValues.selectedEntityField || undefined
+              : undefined,
+        }),
+      });
+
+      detectorId =
+        createDetectorResponse?.detectorId ||
+        createDetectorResponse?.response?._id ||
+        createDetectorResponse?.id ||
+        createDetectorResponse?._id;
+      detectorName = createDetectorResponse?.detectorName || 'Prometheus detector';
+      if (!createDetectorResponse?.ok || !detectorId) {
+        throw new Error(createDetectorResponse?.error || 'Detector creation failed.');
+      }
+
+      const startDetectorPath = dataSourceId
+        ? `/api/anomaly_detectors/detectors/${encodeURIComponent(
+            detectorId
+          )}/start/${encodeURIComponent(dataSourceId)}`
+        : `/api/anomaly_detectors/detectors/${encodeURIComponent(detectorId)}/start`;
+
+      const startDetectorResponse: any = await services.http.post(startDetectorPath);
+      if (!startDetectorResponse?.ok) {
+        throw new Error(startDetectorResponse?.error || 'Detector start failed.');
+      }
+
+      failingDependency = 'alerting';
+      const monitorPayload = buildAlertingMonitorPayload({
+        ...formValues,
+        scheduleIntervalMinutes:
+          formValues.scheduleIntervalMinutes ||
+          toMonitorIntervalMinutes(createDetectorResponse?.detectionInterval),
+        detectorId,
+        exploreMetrics: {
+          detectorId,
+          detectorName,
+          promqlQuery,
+          dataConnectionId,
+          dataSourceId: dataSourceId || undefined,
+          detectorMode: formValues.detectorMode,
+          selectedSeriesId:
+            formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+              ? formValues.selectedSeriesId || undefined
+              : undefined,
+          selectedEntityField:
+            formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality
+              ? formValues.selectedEntityField || undefined
+              : undefined,
+          selectedSeriesLabels:
+            formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+              ? selectedSeriesOption?.labels
+              : undefined,
+        },
+      });
+
+      const createMonitorResponse: any = await services.http.post('/api/alerting/monitors', {
+        body: JSON.stringify(monitorPayload),
+        ...(dataSourceId ? { query: { dataSourceId } } : {}),
+      });
+
+      monitorId =
+        createMonitorResponse?.resp?._id ||
+        createMonitorResponse?.response?._id ||
+        createMonitorResponse?.id ||
+        createMonitorResponse?._id;
+      if (!createMonitorResponse?.ok || !monitorId) {
+        throw new Error(
+          createMonitorResponse?.resp?.error ||
+            createMonitorResponse?.error ||
+            'Monitor creation failed.'
+        );
+      }
+
+      const createdAssociation: MetricsAlertAssociationState = {
+        detectorId,
+        detectorName,
+        monitorId,
+        monitorName: formValues.monitorName.trim(),
+        promqlQuery,
+        dataConnectionId,
+        dataSourceId: dataSourceId || undefined,
+        detectorMode: formValues.detectorMode,
+        selectedSeriesId:
+          formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream
+            ? formValues.selectedSeriesId || undefined
+            : undefined,
+        selectedEntityField:
+          formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality
+            ? formValues.selectedEntityField || undefined
+            : undefined,
+      };
+
+      setCreatedMonitor(toCreatedMonitorInfo(createdAssociation));
+      persistMetricsAlertAssociation(createdAssociation);
+      services.notifications.toasts.addSuccess(
+        `Monitor "${formValues.monitorName.trim()}" successfully created.`
+      );
+    } catch (error: any) {
+      const errorMessage = getDependencyAwareErrorMessage(error, failingDependency);
+      setCreateError(errorMessage);
+      services.notifications.toasts.addDanger({
+        title: i18n.translate('explore.metrics.alerts.tab.error.createMonitorTitle', {
+          defaultMessage: 'Failed to create alert monitor',
+        }),
+        text: errorMessage,
+      });
+
+      if (detectorId && !monitorId) {
+        try {
+          const deleteDetectorPath = dataSourceId
+            ? `/api/anomaly_detectors/detectors/${encodeURIComponent(
+                detectorId
+              )}/${encodeURIComponent(dataSourceId)}`
+            : `/api/anomaly_detectors/detectors/${encodeURIComponent(detectorId)}`;
+          await services.http.delete(deleteDetectorPath);
+        } catch (_rollbackError) {
+          services.notifications.toasts.addWarning({
+            title: i18n.translate('explore.metrics.alerts.tab.error.rollbackTitle', {
+              defaultMessage: 'Partial cleanup required',
+            }),
+            text: i18n.translate('explore.metrics.alerts.tab.error.rollbackBody', {
+              defaultMessage:
+                'The monitor was not created, but the detector could not be cleaned up automatically.',
+            }),
+          });
+        }
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className="visStylePanelBody">
+      <EuiText size="s">
+        <p>
+          {i18n.translate('explore.metrics.alerts.tab.description', {
+            defaultMessage:
+              'Create an anomaly-based monitor from the current Prometheus metric without leaving this page.',
+          })}
+        </p>
+      </EuiText>
+
+      <EuiSpacer size="m" />
+
+      {!supportsPrometheusAlerts && (
+        <>
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="alert"
+            title={i18n.translate('explore.metrics.alerts.tab.unavailable.title', {
+              defaultMessage: 'Prometheus query required',
+            })}
+          >
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.unavailable.description', {
+                defaultMessage:
+                  'Run a PromQL query on a Prometheus metric to create an anomaly-based monitor.',
+              })}
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {existingAssociationError && (
+        <>
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="alert"
+            title={i18n.translate(
+              'explore.metrics.alerts.tab.existingAssociationUnavailableTitle',
+              {
+                defaultMessage: 'Saved alert association unavailable',
+              }
+            )}
+          >
+            <p>{existingAssociationError}</p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {requiresManagedDataSource && isResolvingDataSourceId && (
+        <>
+          <EuiText color="subdued" size="xs">
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.resolvingDataSource', {
+                defaultMessage: 'Resolving the OpenSearch data source for monitor creation...',
+              })}
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {missingManagedDataSource && (
+        <>
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="alert"
+            title={i18n.translate('explore.metrics.alerts.tab.missingDataSourceTitle', {
+              defaultMessage: 'Compatible OpenSearch data source required',
+            })}
+          >
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.missingDataSourceBody', {
+                defaultMessage:
+                  'Alert monitors need a compatible OpenSearch data source when the local cluster is hidden. Select or configure a compatible data source, then try again.',
+              })}
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {missingUiDependencies.length > 0 && (
+        <>
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="alert"
+            title={i18n.translate('explore.metrics.alerts.tab.missingUiDependenciesTitle', {
+              defaultMessage: 'Required alerting dependencies are unavailable',
+            })}
+          >
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.missingUiDependenciesBody', {
+                defaultMessage:
+                  'This Metrics alert flow needs the following OpenSearch Dashboards apps to be available: {dependencies}.',
+                values: {
+                  dependencies: missingUiDependencies.join(', '),
+                },
+              })}
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {createdMonitor && (
+        <>
+          <EuiCallOut
+            size="s"
+            color="success"
+            iconType="check"
+            title={i18n.translate('explore.metrics.alerts.tab.createdTitle', {
+              defaultMessage: 'Monitor available',
+            })}
+          >
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.createdBody', {
+                defaultMessage:
+                  'Using monitor "{monitorName}" and detector "{detectorName}" for this metric.',
+                values: {
+                  monitorName: createdMonitor.monitorName,
+                  detectorName: createdMonitor.detectorName,
+                },
+              })}
+            </p>
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.createdSaveHint', {
+                defaultMessage:
+                  'Save this metric or add it to a dashboard to reopen it with this monitor association.',
+              })}
+            </p>
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              {monitorDetailsUrl && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="xs"
+                    href={monitorDetailsUrl}
+                    data-test-subj="metricsAlertsViewMonitorButton"
+                  >
+                    {i18n.translate('explore.metrics.alerts.tab.viewMonitorButton', {
+                      defaultMessage: 'View monitor',
+                    })}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+              {detectorDetailsUrl && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="xs"
+                    href={detectorDetailsUrl}
+                    data-test-subj="metricsAlertsViewDetectorButton"
+                  >
+                    {i18n.translate('explore.metrics.alerts.tab.viewDetectorButton', {
+                      defaultMessage: 'View detector',
+                    })}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {isLoadingExistingAssociation && (
+        <>
+          <EuiText color="subdued" size="xs">
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.loadingExistingAssociation', {
+                defaultMessage: 'Loading saved monitor association for this metric...',
+              })}
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {isActionAvailable && !createdMonitor && (
+        <>
+          {multiSeriesUnsupported && (
+            <>
+              <EuiCallOut
+                size="s"
+                color="primary"
+                iconType="iInCircle"
+                title={i18n.translate('explore.metrics.alerts.tab.multiSeriesPreviewTitle', {
+                  defaultMessage: 'Multi-series Prometheus query detected',
+                })}
+              >
+                <p>
+                  {i18n.translate('explore.metrics.alerts.tab.multiSeriesPreviewBody', {
+                    defaultMessage:
+                      'This metric currently renders {seriesCount} series. High-cardinality creation will create one detector entity per selected Prometheus label value. You can switch to Single stream to create a detector for one concrete series instead.',
+                    values: {
+                      seriesCount: seriesInference.seriesCount,
+                    },
+                  })}
+                </p>
+                {seriesInference.varyingLabels.length > 0 && (
+                  <p>
+                    {i18n.translate('explore.metrics.alerts.tab.multiSeriesPreviewLabels', {
+                      defaultMessage: 'Varying labels: {labels}.',
+                      values: {
+                        labels: seriesInference.varyingLabels.join(', '),
+                      },
+                    })}
+                  </p>
+                )}
+              </EuiCallOut>
+              <EuiSpacer size="m" />
+            </>
+          )}
+
+          {multiSeriesUnsupported && (
+            <>
+              <EuiFormRow
+                label={i18n.translate('explore.metrics.alerts.tab.detectorModeLabel', {
+                  defaultMessage: 'Detector type',
+                })}
+              >
+                <EuiCompressedSelect
+                  options={[
+                    {
+                      value: PROMETHEUS_DETECTOR_MODES.singleStream,
+                      text: i18n.translate('explore.metrics.alerts.tab.detectorModeSingle', {
+                        defaultMessage: 'Single stream',
+                      }),
+                    },
+                    {
+                      value: PROMETHEUS_DETECTOR_MODES.highCardinality,
+                      text: i18n.translate('explore.metrics.alerts.tab.detectorModeHC', {
+                        defaultMessage: 'High cardinality',
+                      }),
+                    },
+                  ]}
+                  value={formValues.detectorMode}
+                  onChange={(event) =>
+                    updateFormValue(
+                      'detectorMode',
+                      event.target.value as MetricsAlertFormValues['detectorMode']
+                    )
+                  }
+                  data-test-subj="metricsAlertsDetectorModeField"
+                />
+              </EuiFormRow>
+
+              {formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.singleStream && (
+                <EuiFormRow
+                  label={i18n.translate('explore.metrics.alerts.tab.seriesLabel', {
+                    defaultMessage: 'Series',
+                  })}
+                >
+                  <EuiCompressedSelect
+                    options={seriesInference.seriesOptions.map((option) => ({
+                      value: option.id,
+                      text: option.label,
+                    }))}
+                    value={formValues.selectedSeriesId}
+                    onChange={(event) => updateFormValue('selectedSeriesId', event.target.value)}
+                    data-test-subj="metricsAlertsSeriesField"
+                  />
+                </EuiFormRow>
+              )}
+
+              {formValues.detectorMode === PROMETHEUS_DETECTOR_MODES.highCardinality && (
+                <>
+                  <EuiFormRow
+                    label={i18n.translate('explore.metrics.alerts.tab.entityFieldLabel', {
+                      defaultMessage: 'Entity field',
+                    })}
+                    helpText={i18n.translate('explore.metrics.alerts.tab.entityFieldHelpText', {
+                      defaultMessage:
+                        'Prefilled from labels that vary across the currently rendered Prometheus series.',
+                    })}
+                  >
+                    <EuiCompressedSelect
+                      options={entityFieldOptions}
+                      value={formValues.selectedEntityField}
+                      onChange={(event) =>
+                        updateFormValue('selectedEntityField', event.target.value)
+                      }
+                      data-test-subj="metricsAlertsEntityField"
+                    />
+                  </EuiFormRow>
+                  <EuiCallOut
+                    size="s"
+                    color="primary"
+                    iconType="iInCircle"
+                    title={i18n.translate(
+                      'explore.metrics.alerts.tab.highCardinalityEnabledTitle',
+                      {
+                        defaultMessage: 'High-cardinality detector',
+                      }
+                    )}
+                  >
+                    <p>
+                      {i18n.translate('explore.metrics.alerts.tab.highCardinalityEnabledBody', {
+                        defaultMessage:
+                          'The detector will keep the full PromQL query and use "{entityField}" as the entity field.',
+                        values: {
+                          entityField: formValues.selectedEntityField,
+                        },
+                      })}
+                    </p>
+                  </EuiCallOut>
+                  <EuiSpacer size="m" />
+                </>
+              )}
+            </>
+          )}
+
+          <EuiFormRow
+            label={i18n.translate('explore.metrics.alerts.tab.monitorNameLabel', {
+              defaultMessage: 'Monitor name',
+            })}
+          >
+            <EuiCompressedFieldText
+              value={formValues.monitorName}
+              onChange={(event) => updateFormValue('monitorName', event.target.value)}
+              data-test-subj="metricsAlertsMonitorNameField"
+            />
+          </EuiFormRow>
+
+          <EuiFormRow
+            label={i18n.translate('explore.metrics.alerts.tab.scheduleLabel', {
+              defaultMessage: 'Run every',
+            })}
+          >
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiCompressedFieldNumber
+                  min={1}
+                  step={1}
+                  value={
+                    Number.isFinite(formValues.scheduleIntervalMinutes)
+                      ? formValues.scheduleIntervalMinutes
+                      : ''
+                  }
+                  onChange={(event) =>
+                    updateFormValue('scheduleIntervalMinutes', Number(event.target.value || NaN))
+                  }
+                  data-test-subj="metricsAlertsScheduleIntervalField"
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCompressedFieldText value="minutes" disabled />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFormRow>
+
+          <EuiFormRow
+            label={i18n.translate('explore.metrics.alerts.tab.triggerNameLabel', {
+              defaultMessage: 'Trigger name',
+            })}
+          >
+            <EuiCompressedFieldText
+              value={formValues.triggerName}
+              onChange={(event) => updateFormValue('triggerName', event.target.value)}
+              data-test-subj="metricsAlertsTriggerNameField"
+            />
+          </EuiFormRow>
+
+          <EuiFormRow
+            label={i18n.translate('explore.metrics.alerts.tab.severityLabel', {
+              defaultMessage: 'Severity',
+            })}
+          >
+            <EuiCompressedSelect
+              options={MONITOR_SEVERITY_OPTIONS}
+              value={formValues.severity}
+              onChange={(event) => updateFormValue('severity', event.target.value)}
+              data-test-subj="metricsAlertsSeverityField"
+            />
+          </EuiFormRow>
+
+          <EuiFormRow
+            label={i18n.translate('explore.metrics.alerts.tab.gradeThresholdLabel', {
+              defaultMessage: 'Anomaly grade threshold',
+            })}
+          >
+            <EuiCompressedFieldNumber
+              min={0}
+              max={1}
+              step={0.05}
+              value={
+                Number.isFinite(formValues.anomalyGradeThreshold)
+                  ? formValues.anomalyGradeThreshold
+                  : ''
+              }
+              onChange={(event) =>
+                updateFormValue('anomalyGradeThreshold', Number(event.target.value || NaN))
+              }
+              data-test-subj="metricsAlertsAnomalyGradeField"
+            />
+          </EuiFormRow>
+
+          <EuiFormRow
+            label={i18n.translate('explore.metrics.alerts.tab.confidenceThresholdLabel', {
+              defaultMessage: 'Confidence threshold',
+            })}
+          >
+            <EuiCompressedFieldNumber
+              min={0}
+              max={1}
+              step={0.05}
+              value={
+                Number.isFinite(formValues.anomalyConfidenceThreshold)
+                  ? formValues.anomalyConfidenceThreshold
+                  : ''
+              }
+              onChange={(event) =>
+                updateFormValue('anomalyConfidenceThreshold', Number(event.target.value || NaN))
+              }
+              data-test-subj="metricsAlertsConfidenceField"
+            />
+          </EuiFormRow>
+
+          <EuiText color="subdued" size="xs">
+            <p>
+              {i18n.translate('explore.metrics.alerts.tab.actionsNote', {
+                defaultMessage:
+                  'This creates the detector and monitor inline. Notification actions can be added later from the monitor details page.',
+              })}
+            </p>
+          </EuiText>
+
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {createError && !createdMonitor && (
+        <>
+          <EuiCallOut
+            size="s"
+            color="danger"
+            iconType="alert"
+            title={i18n.translate('explore.metrics.alerts.tab.createErrorTitle', {
+              defaultMessage: 'Unable to create monitor',
+            })}
+          >
+            <p>{createError}</p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {!createdMonitor && (
+        <EuiButton
+          size="s"
+          fill
+          disabled={!isActionAvailable || isCreating || isLoadingExistingAssociation}
+          onClick={handleCreateMonitor}
+          data-test-subj="metricsCreateAlertMonitorButton"
+        >
+          {isCreating
+            ? i18n.translate('explore.metrics.alerts.tab.creatingMonitorButton', {
+                defaultMessage: 'Creating detector and monitor...',
+              })
+            : i18n.translate('explore.metrics.alerts.tab.createMonitorButton', {
+                defaultMessage: 'Create alert monitor',
+              })}
+        </EuiButton>
+      )}
+    </div>
+  );
+};

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/prometheus_series_inference.test.ts
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/prometheus_series_inference.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { inferPrometheusSeries } from './prometheus_series_inference';
+
+describe('inferPrometheusSeries', () => {
+  const baseChartConfig = {
+    axesMapping: {
+      x: 'Time',
+      y: 'Value',
+      color: 'Series',
+    },
+  } as any;
+
+  const baseVisData = {
+    numericalColumns: [{ id: 1, name: 'Value', column: 'value' }],
+    categoricalColumns: [{ id: 2, name: 'Series', column: 'series' }],
+    dateColumns: [{ id: 3, name: 'Time', column: 'timestamp' }],
+  } as any;
+
+  test('defaults to high cardinality with instance for a clean multi-instance query', () => {
+    const inference = inferPrometheusSeries(
+      {
+        ...baseVisData,
+        transformedData: [
+          {
+            timestamp: '2026-04-05T00:00:00.000Z',
+            value: 1,
+            series: '{instance="prometheus-a:9090", job="leaf-prometheus"}',
+          },
+          {
+            timestamp: '2026-04-05T00:00:00.000Z',
+            value: 2,
+            series: '{instance="prometheus-b:9090", job="leaf-prometheus"}',
+          },
+        ],
+      },
+      baseChartConfig
+    );
+
+    expect(inference.seriesCount).toBe(2);
+    expect(inference.defaultDetectorMode).toBe('high_cardinality');
+    expect(inference.varyingLabels).toEqual(['instance']);
+    expect(inference.suggestedEntityFields).toEqual(['instance']);
+    expect(inference.defaultEntityField).toBe('instance');
+  });
+
+  test('prioritizes instance ahead of quantile when both vary', () => {
+    const inference = inferPrometheusSeries(
+      {
+        ...baseVisData,
+        transformedData: [
+          {
+            timestamp: '2026-04-05T00:00:00.000Z',
+            value: 1,
+            series: '{instance="prometheus-a:9090", job="leaf-prometheus", quantile="0.5"}',
+          },
+          {
+            timestamp: '2026-04-05T00:00:00.000Z',
+            value: 2,
+            series: '{instance="prometheus-b:9090", job="leaf-prometheus", quantile="0.5"}',
+          },
+          {
+            timestamp: '2026-04-05T00:00:00.000Z',
+            value: 3,
+            series: '{instance="prometheus-a:9090", job="leaf-prometheus", quantile="0.75"}',
+          },
+        ],
+      },
+      baseChartConfig
+    );
+
+    expect(inference.varyingLabels).toEqual(['instance', 'quantile']);
+    expect(inference.suggestedEntityFields).toEqual(['instance', 'quantile']);
+    expect(inference.defaultEntityField).toBe('instance');
+  });
+
+  test('falls back to single stream when the query renders one series', () => {
+    const inference = inferPrometheusSeries(
+      {
+        ...baseVisData,
+        transformedData: [
+          {
+            timestamp: '2026-04-05T00:00:00.000Z',
+            value: 5,
+            series: '{job="leaf-prometheus"}',
+          },
+        ],
+      },
+      baseChartConfig
+    );
+
+    expect(inference.seriesCount).toBe(1);
+    expect(inference.defaultDetectorMode).toBe('single_stream');
+    expect(inference.suggestedEntityFields).toEqual([]);
+  });
+});

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/prometheus_series_inference.ts
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/prometheus_series_inference.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ChartConfig,
+  VisData,
+} from '../../../../../../components/visualizations/visualization_builder.types';
+import { VisColumn } from '../../../../../../components/visualizations/types';
+import {
+  PROMETHEUS_DETECTOR_MODES,
+  PrometheusDetectorMode,
+} from '../../../../utils/metrics_feature_constants';
+
+export interface PrometheusSeriesOption {
+  id: string;
+  label: string;
+  labels: Record<string, string>;
+}
+
+export interface PrometheusSeriesInference {
+  seriesCount: number;
+  seriesOptions: PrometheusSeriesOption[];
+  varyingLabels: string[];
+  suggestedEntityFields: string[];
+  defaultDetectorMode: PrometheusDetectorMode;
+  defaultSeriesId?: string;
+  defaultEntityField?: string;
+}
+
+const SERIES_LABEL_REGEX = /([a-zA-Z_][a-zA-Z0-9_:]*)\s*=\s*"([^"]*)"/g;
+const FALLBACK_SERIES_LABEL_REGEX = /([a-zA-Z_][a-zA-Z0-9_:]*)\s*=\s*([^,{}]+)/g;
+const PRIORITIZED_ENTITY_FIELDS = [
+  'pod',
+  'service',
+  'node',
+  'instance',
+  'container',
+  'namespace',
+  'job',
+];
+const DEPRIORITIZED_ENTITY_FIELDS = new Set(['quantile', 'le']);
+
+const normalizeSeriesId = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (value && typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value ?? '').trim();
+};
+
+const resolveKey = (
+  preferredName: string | undefined,
+  fallbackMatchers: RegExp[],
+  allVisColumns: VisColumn[],
+  candidateRows: Array<Record<string, any>>
+): string | undefined => {
+  if (preferredName) {
+    const column = allVisColumns.find((visColumn) => visColumn.name === preferredName);
+    return column?.column ?? preferredName;
+  }
+
+  if (allVisColumns.length > 0) {
+    const matchedColumn = allVisColumns.find((visColumn) =>
+      fallbackMatchers.some((matcher) => matcher.test(visColumn.name))
+    );
+    if (matchedColumn) {
+      return matchedColumn.column;
+    }
+  }
+
+  const firstRow = candidateRows[0];
+  if (!firstRow) {
+    return undefined;
+  }
+
+  return Object.keys(firstRow).find((key) => fallbackMatchers.some((matcher) => matcher.test(key)));
+};
+
+const parseSeriesLabels = (value: unknown): Record<string, string> => {
+  if (!value) {
+    return {};
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key, rawValue]) => key !== '__name__' && rawValue != null)
+        .map(([key, rawValue]) => [key, String(rawValue)])
+    );
+  }
+
+  const text = String(value).trim();
+  if (!text) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return Object.fromEntries(
+        Object.entries(parsed as Record<string, unknown>)
+          .filter(([key, rawValue]) => key !== '__name__' && rawValue != null)
+          .map(([key, rawValue]) => [key, String(rawValue)])
+      );
+    }
+  } catch (_error) {
+    // Fall through to Prometheus label parsing.
+  }
+
+  const quotedMatches = Array.from(text.matchAll(SERIES_LABEL_REGEX));
+  if (quotedMatches.length > 0) {
+    return Object.fromEntries(quotedMatches.map((match) => [match[1], match[2]]));
+  }
+
+  const fallbackMatches = Array.from(text.matchAll(FALLBACK_SERIES_LABEL_REGEX));
+  if (fallbackMatches.length > 0) {
+    return Object.fromEntries(
+      fallbackMatches.map((match) => [match[1], match[2].trim().replace(/^"|"$/g, '')])
+    );
+  }
+
+  return {};
+};
+
+const buildSeriesLabel = (rawSeriesValue: unknown, labels: Record<string, string>): string => {
+  const rawText = String(rawSeriesValue ?? '').trim();
+  if (rawText) {
+    return rawText;
+  }
+
+  const labelEntries = Object.entries(labels);
+  if (labelEntries.length === 0) {
+    return 'Current metric';
+  }
+
+  const labelText = labelEntries
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}="${value}"`)
+    .join(', ');
+
+  return `{${labelText}}`;
+};
+
+const rankEntityFields = (varyingLabels: string[]): string[] => {
+  const prioritized = PRIORITIZED_ENTITY_FIELDS.filter((field) => varyingLabels.includes(field));
+  const remaining = varyingLabels
+    .filter(
+      (field) =>
+        !prioritized.includes(field) && !DEPRIORITIZED_ENTITY_FIELDS.has(field.toLowerCase())
+    )
+    .sort((left, right) => left.localeCompare(right));
+  const deprioritized = varyingLabels
+    .filter((field) => DEPRIORITIZED_ENTITY_FIELDS.has(field.toLowerCase()))
+    .sort((left, right) => left.localeCompare(right));
+
+  return [...prioritized, ...remaining, ...deprioritized];
+};
+
+export const inferPrometheusSeries = (
+  visData?: VisData,
+  chartConfig?: ChartConfig
+): PrometheusSeriesInference => {
+  const candidateRows = Array.isArray(visData?.transformedData)
+    ? (visData?.transformedData as Array<Record<string, any>>)
+    : [];
+
+  if (candidateRows.length === 0) {
+    return {
+      seriesCount: 0,
+      seriesOptions: [],
+      varyingLabels: [],
+      suggestedEntityFields: [],
+      defaultDetectorMode: PROMETHEUS_DETECTOR_MODES.singleStream,
+    };
+  }
+
+  const allVisColumns = [
+    ...(visData?.numericalColumns ?? []),
+    ...(visData?.categoricalColumns ?? []),
+    ...(visData?.dateColumns ?? []),
+  ];
+  const axesMapping = chartConfig?.axesMapping ?? {};
+  const effectiveSeriesKey = resolveKey(
+    axesMapping.color,
+    [/^series$/i, /^metric$/i, /label/i],
+    allVisColumns,
+    candidateRows
+  );
+
+  if (!effectiveSeriesKey) {
+    return {
+      seriesCount: 1,
+      seriesOptions: [
+        {
+          id: '__current_metric__',
+          label: 'Current metric',
+          labels: {},
+        },
+      ],
+      varyingLabels: [],
+      suggestedEntityFields: [],
+      defaultDetectorMode: PROMETHEUS_DETECTOR_MODES.singleStream,
+      defaultSeriesId: '__current_metric__',
+    };
+  }
+
+  const seriesOptions = Array.from(
+    candidateRows
+      .reduce((accumulator, row) => {
+        const rawSeriesValue = row?.[effectiveSeriesKey];
+        if (rawSeriesValue == null || String(rawSeriesValue).trim() === '') {
+          return accumulator;
+        }
+
+        const id = normalizeSeriesId(rawSeriesValue);
+        if (!id || accumulator.has(id)) {
+          return accumulator;
+        }
+
+        const labels = parseSeriesLabels(rawSeriesValue);
+        accumulator.set(id, {
+          id,
+          label: buildSeriesLabel(rawSeriesValue, labels),
+          labels,
+        });
+        return accumulator;
+      }, new Map<string, PrometheusSeriesOption>())
+      .values()
+  );
+
+  if (seriesOptions.length <= 1) {
+    const singleSeries = seriesOptions[0];
+    return {
+      seriesCount: 1,
+      seriesOptions:
+        seriesOptions.length === 1
+          ? seriesOptions
+          : [
+              {
+                id: '__current_metric__',
+                label: 'Current metric',
+                labels: {},
+              },
+            ],
+      varyingLabels: [],
+      suggestedEntityFields: [],
+      defaultDetectorMode: PROMETHEUS_DETECTOR_MODES.singleStream,
+      defaultSeriesId: singleSeries?.id || '__current_metric__',
+    };
+  }
+
+  const labelValues = seriesOptions.reduce((accumulator, option) => {
+    Object.entries(option.labels).forEach(([key, value]) => {
+      const values = accumulator.get(key) ?? new Set<string>();
+      values.add(value);
+      accumulator.set(key, values);
+    });
+    return accumulator;
+  }, new Map<string, Set<string>>());
+
+  const varyingLabels = Array.from(labelValues.entries())
+    .filter(([key, values]) => key !== '__name__' && values.size > 1)
+    .map(([key]) => key)
+    .sort((left, right) => left.localeCompare(right));
+  const suggestedEntityFields = rankEntityFields(varyingLabels);
+
+  return {
+    seriesCount: seriesOptions.length,
+    seriesOptions,
+    varyingLabels,
+    suggestedEntityFields,
+    defaultDetectorMode: PROMETHEUS_DETECTOR_MODES.highCardinality,
+    defaultSeriesId: seriesOptions[0]?.id,
+    defaultEntityField: suggestedEntityFields[0],
+  };
+};

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.scss
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.scss
@@ -20,6 +20,10 @@
   border-bottom: $euiBorderThin;
 }
 
+.visStylePanelTabs {
+  margin-top: $euiSizeS;
+}
+
 .visStylePanelBody {
   margin-top: $euiSizeM;
 }

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.test.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.test.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
 
 import * as VB from '../../../../../components/visualizations/visualization_builder';
 import * as ReactUse from 'react-use';
@@ -27,6 +29,10 @@ jest.mock('../../../../../components/visualizations/style_panel_render', () => (
   StylePanelRender: () => <div data-test-subj="style-panel">Style Panel</div>,
 }));
 
+jest.mock('./metrics_alerts_panel', () => ({
+  MetricsAlertsPanel: () => <div data-test-subj="metrics-alerts-panel">Metrics Alerts Panel</div>,
+}));
+
 jest.mock('../../../../utils/hooks/use_tab_error', () => ({
   useTabError: jest.fn(),
 }));
@@ -42,13 +48,33 @@ const mockUseOpenSearchDashboards = useOpenSearchDashboards as jest.MockedFuncti
 >;
 
 describe('<ResizableVisControlAndTabs />', () => {
+  const mockApplications$ = new BehaviorSubject(
+    new Map<string, unknown>([['monitors', { id: 'monitors' }]])
+  );
+
   beforeEach(() => {
     mockUseSelector.mockClear();
-    jest.spyOn(ReactUse, 'useObservable').mockReturnValue({});
+    mockApplications$.next(
+      new Map<string, unknown>([['monitors', { id: 'monitors' }]])
+    );
+    jest
+      .spyOn(ReactUse, 'useObservable')
+      .mockImplementation((observable: any, initialValue?: unknown) => {
+        if (observable === mockApplications$) {
+          return mockApplications$.getValue();
+        }
+
+        return initialValue ?? {};
+      });
     jest.spyOn(VB, 'getVisualizationBuilder').mockReturnValue(new VB.VisualizationBuilder({}));
     mockUseTabError.mockReturnValue(null);
     mockUseOpenSearchDashboards.mockReturnValue({
       services: {
+        core: {
+          application: {
+            applications$: mockApplications$,
+          },
+        },
         tabRegistry: {
           getTab: jest.fn().mockReturnValue({
             id: 'explore_visualization_tab',
@@ -81,7 +107,13 @@ describe('<ResizableVisControlAndTabs />', () => {
 
   test('it should NOT display StylePanel if the current active tab is visualization but no data', () => {
     mockUseSelector.mockReturnValue('explore_visualization_tab');
-    jest.spyOn(ReactUse, 'useObservable').mockReturnValue(undefined);
+    jest.spyOn(ReactUse, 'useObservable').mockImplementation((observable: any) => {
+      if (observable === mockApplications$) {
+        return mockApplications$.getValue();
+      }
+
+      return undefined;
+    });
     render(<ResizableVisControlAndTabs />);
     expect(screen.getByTestId('explore-tabs')).toBeInTheDocument();
     expect(screen.queryByTestId('style-panel')).not.toBeInTheDocument();
@@ -102,5 +134,25 @@ describe('<ResizableVisControlAndTabs />', () => {
     render(<ResizableVisControlAndTabs />);
     expect(screen.getByTestId('explore-tabs')).toBeInTheDocument();
     expect(screen.queryByTestId('style-panel')).not.toBeInTheDocument();
+  });
+
+  test('it should display Alerts panel when Alerts tab is selected', () => {
+    mockUseSelector.mockReturnValue('explore_visualization_tab');
+    render(<ResizableVisControlAndTabs />);
+
+    fireEvent.click(screen.getByText('Alerts'));
+
+    expect(screen.getByTestId('metrics-alerts-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('style-panel')).not.toBeInTheDocument();
+  });
+
+  test('it should hide Alerts tab when Alerting UI is unavailable', () => {
+    mockUseSelector.mockReturnValue('explore_visualization_tab');
+    mockApplications$.next(new Map());
+
+    render(<ResizableVisControlAndTabs />);
+
+    expect(screen.queryByText('Alerts')).not.toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
   });
 });

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.tsx
@@ -126,7 +126,7 @@ export const ResizableVisControlAndTabs = () => {
                   <EuiFlexItem>
                     <EuiTitle size="xxs">
                       <p>
-                        {i18n.translate('explore.visualization.stylePanel.title', {
+                        {i18n.translate('explore.metrics.visualization.stylePanel.title', {
                           defaultMessage: 'Metric tools',
                         })}
                       </p>

--- a/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_bottom_container/bottom_right_container/resizable_vis_control_and_tabs.tsx
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './resizable_vis_control_and_tabs.scss';
-
-import { useRef } from 'react';
 import { useObservable } from 'react-use';
 import { useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
@@ -14,6 +13,9 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiResizableContainer,
+  EuiTab,
+  EuiTabs,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { PanelDirection } from '@elastic/eui/src/components/resizable_container/types';
@@ -25,6 +27,10 @@ import { useOpenSearchDashboards } from '../../../../../../../opensearch_dashboa
 import { useTabError } from '../../../../utils/hooks/use_tab_error';
 import { ExploreServices } from '../../../../../types';
 import { EXPLORE_VISUALIZATION_TAB_ID } from '../../../../../../common';
+import { MetricsAlertsPanel } from './metrics_alerts_panel';
+import { METRICS_ALERTING_APP_ID } from '../../../../utils/metrics_feature_constants';
+
+type SidePanelTabId = 'settings' | 'alerts';
 
 export const ResizableVisControlAndTabs = () => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
@@ -32,8 +38,44 @@ export const ResizableVisControlAndTabs = () => {
   const visualizationTabError = useTabError(visualizationTab);
   const visualizationBuilder = getVisualizationBuilder();
   const data = useObservable(visualizationBuilder.data$);
+  const availableApplications = useObservable(
+    services.core.application.applications$,
+    new Map<string, unknown>()
+  ) as ReadonlyMap<string, unknown>;
   const activeTabId = useSelector(selectActiveTab);
   const collapseFn = useRef((id: string, direction: PanelDirection) => {});
+  const [activeSidePanelTab, setActiveSidePanelTab] = useState<SidePanelTabId>('settings');
+  const isAlertingUiAvailable = useMemo(
+    () => availableApplications?.has?.(METRICS_ALERTING_APP_ID) ?? false,
+    [availableApplications]
+  );
+
+  const sidePanelTabs = useMemo(
+    () =>
+      [
+        {
+          id: 'settings' as SidePanelTabId,
+          name: i18n.translate('explore.visualization.stylePanel.settingsTabLabel', {
+            defaultMessage: 'Settings',
+          }),
+        },
+        isAlertingUiAvailable
+          ? {
+              id: 'alerts' as SidePanelTabId,
+              name: i18n.translate('explore.visualization.stylePanel.alertsTabLabel', {
+                defaultMessage: 'Alerts',
+              }),
+            }
+          : null,
+      ].filter(Boolean) as Array<{ id: SidePanelTabId; name: string }>,
+    [isAlertingUiAvailable]
+  );
+
+  useEffect(() => {
+    if (!isAlertingUiAvailable && activeSidePanelTab === 'alerts') {
+      setActiveSidePanelTab('settings');
+    }
+  }, [activeSidePanelTab, isAlertingUiAvailable]);
 
   const onChange = (panelId: string) => {
     collapseFn.current(panelId, 'right');
@@ -74,40 +116,66 @@ export const ResizableVisControlAndTabs = () => {
               minSize="280px"
               paddingSize="none"
             >
-              {Boolean(data) && (
-                <div className="visStylePanelInner">
-                  <EuiFlexGroup
-                    className="visStylePanelTitle"
-                    gutterSize="none"
-                    justifyContent="spaceBetween"
-                    alignItems="center"
-                  >
-                    <EuiFlexItem>
-                      <EuiTitle size="xxs">
-                        <p>
-                          {i18n.translate('explore.visualization.stylePanel.title', {
-                            defaultMessage: 'Settings',
-                          })}
-                        </p>
-                      </EuiTitle>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiButtonIcon
-                        color="text"
-                        aria-label={i18n.translate(
-                          'explore.visualization.stylePanel.toggleAriaLabel',
-                          {
-                            defaultMessage: 'Toggle visualization style panel',
-                          }
-                        )}
-                        iconType="menuRight"
-                        onClick={() => onChange('vis_style_panel')}
-                      />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                  {visualizationBuilder.renderStylePanel({ className: 'visStylePanelBody' })}
-                </div>
-              )}
+              <div className="visStylePanelInner">
+                <EuiFlexGroup
+                  className="visStylePanelTitle"
+                  gutterSize="none"
+                  justifyContent="spaceBetween"
+                  alignItems="center"
+                >
+                  <EuiFlexItem>
+                    <EuiTitle size="xxs">
+                      <p>
+                        {i18n.translate('explore.visualization.stylePanel.title', {
+                          defaultMessage: 'Metric tools',
+                        })}
+                      </p>
+                    </EuiTitle>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonIcon
+                      color="text"
+                      aria-label={i18n.translate(
+                        'explore.visualization.stylePanel.toggleAriaLabel',
+                        {
+                          defaultMessage: 'Toggle visualization style panel',
+                        }
+                      )}
+                      iconType="menuRight"
+                      onClick={() => onChange('vis_style_panel')}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+
+                <EuiTabs className="visStylePanelTabs">
+                  {sidePanelTabs.map((tab) => (
+                    <EuiTab
+                      key={tab.id}
+                      onClick={() => setActiveSidePanelTab(tab.id)}
+                      isSelected={activeSidePanelTab === tab.id}
+                    >
+                      {tab.name}
+                    </EuiTab>
+                  ))}
+                </EuiTabs>
+
+                {activeSidePanelTab === 'settings' ? (
+                  Boolean(data) ? (
+                    visualizationBuilder.renderStylePanel({ className: 'visStylePanelBody' })
+                  ) : (
+                    <EuiText size="xs" className="visStylePanelBody">
+                      <p>
+                        {i18n.translate('explore.visualization.stylePanel.noSettingsMessage', {
+                          defaultMessage:
+                            'Settings will appear after a metric visualization is available.',
+                        })}
+                      </p>
+                    </EuiText>
+                  )
+                ) : (
+                  <MetricsAlertsPanel />
+                )}
+              </div>
             </EuiResizablePanel>
           </>
         );

--- a/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
@@ -13,6 +13,7 @@ import {
   setSavedSearch,
   setQueryState,
   setActiveTab,
+  setMetricsAlertAssociation,
   clearResults,
   clearQueryStatusMap,
   clearLastExecutedData,
@@ -76,13 +77,18 @@ export const useInitPage = () => {
         // Only use saved object's activeTab if there's no activeTab in URL state
         // This preserves user's tab selection from URL
         if (uiState) {
+          const { activeTab, metricsAlertAssociation } = JSON.parse(uiState);
           const urlState = services.osdUrlStateStorage?.get('_a') ?? {};
           // @ts-expect-error TS2339 TODO(ts-error): fixme
           const hasActiveTabInUrl = urlState?.ui?.activeTabId;
-          if (!hasActiveTabInUrl) {
-            const { activeTab } = JSON.parse(uiState);
+
+          if (activeTab && !hasActiveTabInUrl) {
             dispatch(setActiveTab(activeTab));
           }
+
+          dispatch(setMetricsAlertAssociation(metricsAlertAssociation));
+        } else {
+          dispatch(setMetricsAlertAssociation(undefined));
         }
 
         // Add to recently accessed

--- a/src/plugins/explore/public/application/utils/hooks/use_resolved_opensearch_data_source_id.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_resolved_opensearch_data_source_id.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { UiSettingScope } from 'opensearch-dashboards/public';
+
+import { ExploreServices } from '../../../types';
+
+export const useResolvedOpenSearchDataSourceId = (
+  services: ExploreServices,
+  explicitDataSourceId?: string,
+  options?: {
+    onlyWhenHideLocalCluster?: boolean;
+  }
+) => {
+  const shouldUseManagedDataSource =
+    services.dataSourceEnabled && (!options?.onlyWhenHideLocalCluster || services.hideLocalCluster);
+  const normalizedExplicitDataSourceId = shouldUseManagedDataSource
+    ? String(explicitDataSourceId || '').trim()
+    : '';
+  const currentWorkspaceId = (services.core as any)?.workspaces?.currentWorkspaceId$?.getValue?.();
+  const [fallbackDataSourceId, setFallbackDataSourceId] = useState('');
+  const [isResolvingDataSourceId, setIsResolvingDataSourceId] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveFallbackDataSourceId = async () => {
+      const shouldResolveFallback =
+        shouldUseManagedDataSource &&
+        !normalizedExplicitDataSourceId &&
+        !!services.dataSourceManagement?.getDefaultDataSourceId;
+
+      if (!shouldResolveFallback) {
+        setFallbackDataSourceId('');
+        setIsResolvingDataSourceId(false);
+        return;
+      }
+
+      setIsResolvingDataSourceId(true);
+      try {
+        const uiSettingsScope = currentWorkspaceId
+          ? UiSettingScope.WORKSPACE
+          : UiSettingScope.GLOBAL;
+        const defaultDataSourceId = await services.dataSourceManagement!.getDefaultDataSourceId(
+          services.uiSettings,
+          uiSettingsScope
+        );
+        if (!cancelled) {
+          setFallbackDataSourceId(String(defaultDataSourceId || '').trim());
+        }
+      } catch {
+        if (!cancelled) {
+          setFallbackDataSourceId('');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsResolvingDataSourceId(false);
+        }
+      }
+    };
+
+    resolveFallbackDataSourceId();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    currentWorkspaceId,
+    normalizedExplicitDataSourceId,
+    services.dataSourceManagement,
+    services.uiSettings,
+    shouldUseManagedDataSource,
+  ]);
+
+  const dataSourceId = useMemo(() => normalizedExplicitDataSourceId || fallbackDataSourceId, [
+    fallbackDataSourceId,
+    normalizedExplicitDataSourceId,
+  ]);
+
+  return {
+    dataSourceId,
+    isResolvingDataSourceId,
+  };
+};

--- a/src/plugins/explore/public/application/utils/metrics_feature_constants.ts
+++ b/src/plugins/explore/public/application/utils/metrics_feature_constants.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const METRICS_ALERTING_APP_ID = 'monitors';
+export const METRICS_ANOMALY_DETECTION_APP_ID = 'anomaly-detection-dashboards';
+
+export const PROMETHEUS_DETECTOR_MODES = {
+  singleStream: 'single_stream',
+  highCardinality: 'high_cardinality',
+} as const;
+
+export type PrometheusDetectorMode = typeof PROMETHEUS_DETECTOR_MODES[keyof typeof PROMETHEUS_DETECTOR_MODES];
+
+export const MAX_AUTO_PREVIEW_SERIES = 3;

--- a/src/plugins/explore/public/application/utils/state_management/__mocks__/store.ts
+++ b/src/plugins/explore/public/application/utils/state_management/__mocks__/store.ts
@@ -24,8 +24,9 @@ export const createMockStore = (initialState?: Partial<RootState>): MockStore =>
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     },
     ui: {
-      showDatasetFields: false,
-      prompt: '',
+      activeTabId: '',
+      showHistogram: true,
+      wrapCellText: false,
     },
     results: {},
     tab: {},
@@ -68,7 +69,9 @@ export const createMockRootState = (overrides?: Partial<RootState>): RootState =
       dataset: { id: 'test-dataset', type: 'INDEX_PATTERN' },
     },
     ui: {
-      prompt: '',
+      activeTabId: '',
+      showHistogram: true,
+      wrapCellText: false,
     },
     results: {},
     tab: {},

--- a/src/plugins/explore/public/application/utils/state_management/slices/ui/ui_slice.ts
+++ b/src/plugins/explore/public/application/utils/state_management/slices/ui/ui_slice.ts
@@ -4,11 +4,26 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { PrometheusDetectorMode } from '../../../metrics_feature_constants';
+
+export interface MetricsAlertAssociationState {
+  detectorId: string;
+  detectorName: string;
+  monitorId: string;
+  monitorName: string;
+  promqlQuery: string;
+  dataConnectionId: string;
+  dataSourceId?: string;
+  detectorMode?: PrometheusDetectorMode;
+  selectedSeriesId?: string;
+  selectedEntityField?: string;
+}
 
 export interface UIState {
   activeTabId: string;
   showHistogram: boolean;
   wrapCellText: boolean;
+  metricsAlertAssociation?: MetricsAlertAssociationState;
 }
 
 const initialState: UIState = {
@@ -33,9 +48,21 @@ const uiSlice = createSlice({
     setWrapCellText: (state, action: PayloadAction<boolean>) => {
       state.wrapCellText = action.payload;
     },
+    setMetricsAlertAssociation: (
+      state,
+      action: PayloadAction<MetricsAlertAssociationState | undefined>
+    ) => {
+      state.metricsAlertAssociation = action.payload;
+    },
   },
 });
 
-export const { setActiveTab, setUiState, setShowHistogram, setWrapCellText } = uiSlice.actions;
+export const {
+  setActiveTab,
+  setUiState,
+  setShowHistogram,
+  setWrapCellText,
+  setMetricsAlertAssociation,
+} = uiSlice.actions;
 export const uiReducer = uiSlice.reducer;
 export const uiInitialState = uiSlice.getInitialState();

--- a/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.tsx
@@ -72,7 +72,9 @@ export const getSaveButtonRun = (
       saveStateProps.tabDefinition,
       { axesMapping, chartType: visConfig?.type, styleOptions: visConfig?.styles },
       saveStateProps.dataset,
-      saveStateProps.activeTabId
+      saveStateProps.activeTabId,
+      services.store.getState().ui,
+      services.store.getState().query
     );
     const result = await saveSavedExplore({
       savedExplore: savedExploreWithState,

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
@@ -105,7 +105,10 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
         axesMapping: chartConfig?.axesMapping,
         styleOptions: chartConfig?.styles,
       },
-      dataset
+      dataset,
+      activeTabId,
+      services.store.getState().ui,
+      services.store.getState().query
     );
 
     const saveOptions = {

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.ts
@@ -379,9 +379,17 @@ export class VisualizationBuilder {
   renderVisualization({
     timeRange,
     onSelectTimeRange,
+    augmentEchartsSpec,
   }: {
     timeRange?: TimeRange;
     onSelectTimeRange?: (range?: TimeRange) => void;
+    augmentEchartsSpec?: import('./visualization_render').VisualizationRender extends (
+      props: infer P
+    ) => any
+      ? P extends { augmentEchartsSpec?: infer A }
+        ? A
+        : never
+      : never;
   }) {
     return React.createElement(VisualizationRender, {
       data$: this.data$,
@@ -390,6 +398,7 @@ export class VisualizationBuilder {
       timeRange,
       onSelectTimeRange,
       onStyleChange: this.updateStyles.bind(this),
+      augmentEchartsSpec,
     });
   }
 

--- a/src/plugins/explore/public/components/visualizations/visualization_container.scss
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.scss
@@ -1,9 +1,11 @@
 .exploreVisContainer {
   display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overflow-x: auto;
   scrollbar-width: thin;
   flex-grow: 1;
+  min-width: 0;
   border-radius: $euiSizeXS;
 }
 
@@ -11,6 +13,13 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  width: 100%;
+  flex: 1 1 auto;
+}
+
+.exploreVisPreviewBanner {
+  width: 100%;
+  flex: 0 0 auto;
 }
 
 .exploreVisPanel__inner {

--- a/src/plugins/explore/public/components/visualizations/visualization_container.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.test.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 
 import { VisualizationContainer } from './visualization_container';
 import * as VB from './visualization_builder';
@@ -11,6 +13,11 @@ import * as TabResultsHooks from '../../application/utils/hooks/use_tab_results'
 import { BehaviorSubject } from 'rxjs';
 import { VisFieldType } from './types';
 import { VisData } from './visualization_builder.types';
+
+const mockHttpPost = jest.fn();
+const mockApplications$ = new BehaviorSubject<ReadonlyMap<string, unknown>>(
+  new Map([['anomaly-detection-dashboards', { id: 'anomaly-detection-dashboards' }]])
+);
 
 // Mock react-redux before importing any components
 jest.mock('react-redux', () => ({
@@ -38,6 +45,22 @@ jest.mock('../query_panel/utils/use_search_context', () => ({
     timeRange: { from: 'now-15m', to: 'now' },
     query: 'source=test',
   })),
+}));
+
+jest.mock('../../../../opensearch_dashboards_react/public', () => ({
+  ...jest.requireActual('../../../../opensearch_dashboards_react/public'),
+  useOpenSearchDashboards: () => ({
+    services: {
+      core: {
+        application: {
+          applications$: mockApplications$,
+        },
+      },
+      http: {
+        post: mockHttpPost,
+      },
+    },
+  }),
 }));
 
 // Mock the visualization builder
@@ -84,10 +107,114 @@ const mockVisualizationBuilder = {
   reset: jest.fn(),
 };
 
+const defaultVisData: VisData = {
+  transformedData: [
+    { field1: 'value1', count: 10 },
+    { field1: 'value2', count: 20 },
+  ],
+  numericalColumns: [
+    {
+      id: 1,
+      name: 'count',
+      schema: VisFieldType.Numerical,
+      column: 'count',
+      validValuesCount: 2,
+      uniqueValuesCount: 2,
+    },
+  ],
+  categoricalColumns: [
+    {
+      id: 2,
+      name: 'field1',
+      schema: VisFieldType.Categorical,
+      column: 'field1',
+      validValuesCount: 2,
+      uniqueValuesCount: 2,
+    },
+  ],
+  dateColumns: [],
+};
+
+const setPromqlVisualizationData = (rows: Array<Record<string, unknown>>) => {
+  mockVisualizationBuilder.data$.next({
+    transformedData: rows,
+    numericalColumns: [
+      {
+        id: 1,
+        name: 'Value',
+        schema: VisFieldType.Numerical,
+        column: 'Value',
+        validValuesCount: rows.length,
+        uniqueValuesCount: rows.length,
+      },
+    ],
+    categoricalColumns: [
+      {
+        id: 2,
+        name: 'Series',
+        schema: VisFieldType.Categorical,
+        column: 'Series',
+        validValuesCount: rows.length,
+        uniqueValuesCount: new Set(rows.map((row) => row.Series)).size,
+      },
+    ],
+    dateColumns: [
+      {
+        id: 3,
+        name: 'Time',
+        schema: VisFieldType.Date,
+        column: 'Time',
+        validValuesCount: rows.length,
+        uniqueValuesCount: rows.length,
+      },
+    ],
+  });
+
+  mockVisualizationBuilder.visConfig$.next({
+    type: 'line',
+    styles: {
+      legendPosition: 'right',
+      thresholds: [],
+      pageSize: 10,
+    },
+    axesMapping: {
+      x: 'Time',
+      y: 'Value',
+      color: 'Series',
+    },
+  });
+};
+
 describe('VisualizationContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockApplications$.next(
+      new Map([['anomaly-detection-dashboards', { id: 'anomaly-detection-dashboards' }]])
+    );
+    mockVisualizationBuilder.data$.next(defaultVisData);
+    mockVisualizationBuilder.visConfig$.next({
+      type: 'bar',
+      styles: {
+        legendPosition: 'right',
+        thresholds: [],
+        pageSize: 10,
+      },
+      axesMapping: {},
+    });
+    mockHttpPost.mockResolvedValue({
+      ok: true,
+      response: {},
+    });
     jest.spyOn(VB, 'getVisualizationBuilder').mockReturnValue(mockVisualizationBuilder as any);
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PPL',
+          query: 'source = test',
+          dataset: undefined,
+        },
+      })
+    );
   });
 
   it('renders the visualization container', () => {
@@ -118,5 +245,253 @@ describe('VisualizationContainer', () => {
 
     // Should still render without crashing
     expect(screen.getByTestId('exploreVisualizationLoader')).toBeInTheDocument();
+  });
+
+  it('still requests preview when there are fewer than 400 datapoints for PROMQL preview', async () => {
+    const promqlHits = Array.from({ length: 399 }, (_, index) => ({
+      _source: {
+        Time: 1700000000000 + index * 60000,
+        Series: '{instance="localhost:9090"}',
+        Value: index,
+      },
+    }));
+    setPromqlVisualizationData(promqlHits.map((hit) => hit._source));
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+          dataset: { id: 'local' },
+        },
+      })
+    );
+
+    jest.spyOn(TabResultsHooks, 'useTabResults').mockReturnValueOnce({
+      results: {
+        hits: { hits: promqlHits },
+        fieldSchema: [
+          { name: 'Time', type: 'time' },
+          { name: 'Series', type: 'string' },
+          { name: 'Value', type: 'number' },
+        ],
+      } as any,
+    });
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/anomaly_preview',
+        expect.objectContaining({
+          body: expect.any(String),
+        })
+      );
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/forecast_preview',
+        expect.objectContaining({
+          body: expect.any(String),
+        })
+      );
+    });
+
+    const anomalyPreviewCall = mockHttpPost.mock.calls.find(
+      ([path]) => path === '/api/explore/anomaly_preview'
+    );
+    const forecastPreviewCall = mockHttpPost.mock.calls.find(
+      ([path]) => path === '/api/explore/forecast_preview'
+    );
+
+    expect(JSON.parse(anomalyPreviewCall?.[1]?.body ?? '{}')).toMatchObject({
+      promqlQuery: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      dataConnectionId: 'local',
+      seriesValue: '{instance="localhost:9090"}',
+    });
+    expect(JSON.parse(forecastPreviewCall?.[1]?.body ?? '{}')).toMatchObject({
+      promqlQuery: 'rate(go_gc_heap_allocs_bytes_total{instance="localhost:9090"}[5m])',
+      dataConnectionId: 'local',
+      seriesValue: '{instance="localhost:9090"}',
+    });
+
+    expect(screen.queryByText('Preview requires at least 400 datapoints')).not.toBeInTheDocument();
+  });
+
+  it('previews all Prometheus series when there are no more than three', async () => {
+    const rows = [
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 12,
+      },
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-b:9090",job="leaf-prometheus"}',
+        Value: 20,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-b:9090",job="leaf-prometheus"}',
+        Value: 22,
+      },
+    ];
+    setPromqlVisualizationData(rows);
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: { id: 'prome_multi' },
+        },
+      })
+    );
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      const forecastCalls = mockHttpPost.mock.calls.filter(
+        ([path]) => path === '/api/explore/forecast_preview'
+      );
+      expect(forecastCalls).toHaveLength(2);
+    });
+
+    expect(screen.queryByTestId('metricsPreviewSeriesSelector')).not.toBeInTheDocument();
+    const forecastSeriesValues = mockHttpPost.mock.calls
+      .filter(([path]) => path === '/api/explore/forecast_preview')
+      .map(([, options]) => JSON.parse(options?.body ?? '{}')?.seriesValue);
+
+    expect(forecastSeriesValues).toEqual([
+      '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+      '{instance="prometheus-b:9090",job="leaf-prometheus"}',
+    ]);
+  });
+
+  it('asks users to select series when a Prometheus query returns more than three series', async () => {
+    const rows = ['a', 'b', 'c', 'd'].flatMap((instance, index) => [
+      {
+        Time: 1700000000000,
+        Series: `{instance="prometheus-${instance}:9090",job="leaf-prometheus"}`,
+        Value: index * 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: `{instance="prometheus-${instance}:9090",job="leaf-prometheus"}`,
+        Value: index * 10 + 2,
+      },
+    ]);
+    setPromqlVisualizationData(rows);
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: { id: 'prome_multi' },
+        },
+      })
+    );
+
+    render(<VisualizationContainer />);
+
+    expect(await screen.findByTestId('metricsPreviewSeriesSelector')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'This query returns 4 series. Select up to 3 series to generate preview overlays.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      mockHttpPost.mock.calls.filter(([path]) => path === '/api/explore/forecast_preview')
+    ).toHaveLength(0);
+  });
+
+  it('does not request or render preview overlays when Anomaly Detection UI is unavailable', async () => {
+    mockApplications$.next(new Map());
+    setPromqlVisualizationData([
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 12,
+      },
+    ]);
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: { id: 'prome_multi' },
+        },
+      })
+    );
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      expect(mockHttpPost).not.toHaveBeenCalled();
+    });
+
+    expect(screen.queryByTestId('metricsPreviewStatusCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('metricsPreviewSeriesSelector')).not.toBeInTheDocument();
+  });
+
+  it('suppresses preview status when the cluster is missing the AD preview dependency', async () => {
+    setPromqlVisualizationData([
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 12,
+      },
+    ]);
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: { id: 'prome_multi' },
+        },
+      })
+    );
+
+    mockHttpPost.mockImplementation((path: string) => {
+      if (path === '/api/explore/anomaly_preview') {
+        return Promise.resolve({
+          ok: false,
+          message:
+            'Anomaly Detection plugin endpoint not found on this OpenSearch cluster. Ensure the AD plugin is installed/enabled.',
+        });
+      }
+
+      return Promise.resolve({
+        ok: false,
+        message:
+          'Forecasting preview endpoint not found on this OpenSearch cluster. Install/enable the Forecast plugin to use preview.',
+      });
+    });
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      expect(mockHttpPost).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('metricsPreviewStatusCallout')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/visualization_container.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.test.tsx
@@ -15,9 +15,31 @@ import { VisFieldType } from './types';
 import { VisData } from './visualization_builder.types';
 
 const mockHttpPost = jest.fn();
+const mockGetDefaultDataSourceId = jest.fn();
 const mockApplications$ = new BehaviorSubject<ReadonlyMap<string, unknown>>(
   new Map([['anomaly-detection-dashboards', { id: 'anomaly-detection-dashboards' }]])
 );
+const mockServices = {
+  core: {
+    application: {
+      applications$: mockApplications$,
+    },
+    workspaces: {
+      currentWorkspaceId$: {
+        getValue: jest.fn(() => undefined),
+      },
+    },
+  },
+  http: {
+    post: mockHttpPost,
+  },
+  uiSettings: {},
+  dataSourceEnabled: false,
+  hideLocalCluster: false,
+  dataSourceManagement: {
+    getDefaultDataSourceId: mockGetDefaultDataSourceId,
+  },
+};
 
 // Mock react-redux before importing any components
 jest.mock('react-redux', () => ({
@@ -50,16 +72,7 @@ jest.mock('../query_panel/utils/use_search_context', () => ({
 jest.mock('../../../../opensearch_dashboards_react/public', () => ({
   ...jest.requireActual('../../../../opensearch_dashboards_react/public'),
   useOpenSearchDashboards: () => ({
-    services: {
-      core: {
-        application: {
-          applications$: mockApplications$,
-        },
-      },
-      http: {
-        post: mockHttpPost,
-      },
-    },
+    services: mockServices,
   }),
 }));
 
@@ -205,6 +218,10 @@ describe('VisualizationContainer', () => {
       ok: true,
       response: {},
     });
+    mockGetDefaultDataSourceId.mockReset();
+    mockGetDefaultDataSourceId.mockResolvedValue('');
+    mockServices.dataSourceEnabled = false;
+    mockServices.hideLocalCluster = false;
     jest.spyOn(VB, 'getVisualizationBuilder').mockReturnValue(mockVisualizationBuilder as any);
     (useSelector as jest.Mock).mockImplementation((selector) =>
       selector({
@@ -369,6 +386,145 @@ describe('VisualizationContainer', () => {
       '{instance="prometheus-a:9090",job="leaf-prometheus"}',
       '{instance="prometheus-b:9090",job="leaf-prometheus"}',
     ]);
+  });
+
+  it('uses the local cluster for preview routes when local cluster is available', async () => {
+    setPromqlVisualizationData([
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 12,
+      },
+    ]);
+    mockServices.dataSourceEnabled = true;
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: {
+            id: 'prome_multi',
+            dataSource: { id: 'ds-1' },
+          },
+        },
+      })
+    );
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/anomaly_preview',
+        expect.not.objectContaining({
+          query: expect.anything(),
+        })
+      );
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/forecast_preview',
+        expect.not.objectContaining({
+          query: expect.anything(),
+        })
+      );
+    });
+  });
+
+  it('uses the explicit OpenSearch data source id for preview routes when local cluster is hidden', async () => {
+    setPromqlVisualizationData([
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 12,
+      },
+    ]);
+    mockServices.dataSourceEnabled = true;
+    mockServices.hideLocalCluster = true;
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: {
+            id: 'prome_multi',
+            dataSource: { id: 'ds-1' },
+          },
+        },
+      })
+    );
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/anomaly_preview',
+        expect.objectContaining({
+          query: { dataSourceId: 'ds-1' },
+        })
+      );
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/forecast_preview',
+        expect.objectContaining({
+          query: { dataSourceId: 'ds-1' },
+        })
+      );
+    });
+  });
+
+  it('uses the default OpenSearch data source id for preview routes when local cluster is hidden', async () => {
+    setPromqlVisualizationData([
+      {
+        Time: 1700000000000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 10,
+      },
+      {
+        Time: 1700000060000,
+        Series: '{instance="prometheus-a:9090",job="leaf-prometheus"}',
+        Value: 12,
+      },
+    ]);
+    mockServices.dataSourceEnabled = true;
+    mockServices.hideLocalCluster = true;
+    mockGetDefaultDataSourceId.mockResolvedValue('ds-default');
+
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({
+        query: {
+          language: 'PROMQL',
+          query: 'rate(go_gc_heap_allocs_bytes_total{job="leaf-prometheus"}[10m])',
+          dataset: { id: 'prome_multi' },
+        },
+      })
+    );
+
+    render(<VisualizationContainer />);
+
+    await waitFor(() => {
+      expect(mockGetDefaultDataSourceId).toHaveBeenCalled();
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/anomaly_preview',
+        expect.objectContaining({
+          query: { dataSourceId: 'ds-default' },
+        })
+      );
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        '/api/explore/forecast_preview',
+        expect.objectContaining({
+          query: { dataSourceId: 'ds-default' },
+        })
+      );
+    });
   });
 
   it('asks users to select series when a Prometheus query returns more than three series', async () => {

--- a/src/plugins/explore/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.tsx
@@ -3,12 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiPanel } from '@elastic/eui';
-import React, { useCallback, useEffect } from 'react';
+import {
+  EuiCallOut,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+} from '@elastic/eui';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import moment from 'moment';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { i18n } from '@osd/i18n';
+import { useObservable } from 'react-use';
+import dateMath from '@elastic/datemath';
 
-import './visualization_container.scss';
 import { AxisColumnMappings } from './types';
 import { useTabResults } from '../../application/utils/hooks/use_tab_results';
 import { useSearchContext } from '../query_panel/utils/use_search_context';
@@ -22,33 +31,235 @@ import {
   setDateRange,
 } from '../../application/utils/state_management/slices';
 import { executeQueries } from '../../application/utils/state_management/actions/query_actions';
+import { RootState } from '../../application/utils/state_management/store';
+import {
+  MAX_AUTO_PREVIEW_SERIES,
+  METRICS_ANOMALY_DETECTION_APP_ID,
+} from '../../application/utils/metrics_feature_constants';
+import { getColors } from './theme/default_colors';
+
+import './visualization_container.scss';
+
+const MAX_PREVIEW_DATAPOINTS = 500;
+const MIN_VALID_PREVIEW_DATAPOINTS = 2;
+const PROMETHEUS_QUERY_LANGUAGE = 'PROMQL';
+const DEFAULT_FORECAST_COLOR = '#FAA43A';
+const ANOMALY_PREVIEW_MARKER_SIZE = 10;
+const ANOMALY_PREVIEW_COLOR = '#D36086';
+const ANOMALY_PREVIEW_BORDER_COLOR = '#8A1538';
+
+interface PreviewPoint {
+  ts: number;
+  value: number;
+}
+
+interface PreviewSeriesOption {
+  value: string;
+  text: string;
+}
+
+interface SeriesPreviewState {
+  seriesValue: string;
+  points: PreviewPoint[];
+  lastObservedTime?: number;
+  forecastClampToZero: boolean;
+  adPreview: any | null;
+  forecastPreview: any | null;
+}
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  const normalized = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(normalized) ? normalized : undefined;
+};
+
+const downsampleMetricPoints = (points: PreviewPoint[], maxPoints: number): PreviewPoint[] => {
+  if (points.length <= maxPoints) {
+    return points;
+  }
+
+  const step = (points.length - 1) / (maxPoints - 1);
+  const sampled = Array.from({ length: maxPoints }, (_, index) => {
+    const pointIndex = Math.floor(index * step);
+    return points[Math.min(pointIndex, points.length - 1)];
+  });
+
+  sampled[sampled.length - 1] = points[points.length - 1];
+  return sampled;
+};
+
+const setPreviewSeriesOptionsIfChanged = (
+  setPreviewSeriesOptions: React.Dispatch<React.SetStateAction<PreviewSeriesOption[]>>,
+  nextOptions: PreviewSeriesOption[]
+) => {
+  setPreviewSeriesOptions((currentOptions) => {
+    const isSame =
+      currentOptions.length === nextOptions.length &&
+      currentOptions.every(
+        (currentOption, index) =>
+          currentOption.value === nextOptions[index]?.value &&
+          currentOption.text === nextOptions[index]?.text
+      );
+    return isSame ? currentOptions : nextOptions;
+  });
+};
+
+const areStringArraysEqual = (left: string[], right: string[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+const setPreviewSelectedSeriesIfChanged = (
+  setSelectedPreviewSeriesValues: React.Dispatch<React.SetStateAction<string[]>>,
+  nextValues: string[]
+) => {
+  setSelectedPreviewSeriesValues((currentValues) =>
+    areStringArraysEqual(currentValues, nextValues) ? currentValues : nextValues
+  );
+};
+
+const clearSeriesPreviewStatesIfNeeded = (
+  setSeriesPreviewStates: React.Dispatch<React.SetStateAction<SeriesPreviewState[]>>
+) => {
+  setSeriesPreviewStates((currentStates) => (currentStates.length === 0 ? currentStates : []));
+};
+
+const toComboBoxOption = (seriesValue: string): EuiComboBoxOptionOption<string> => ({
+  label: seriesValue,
+  value: seriesValue,
+});
+
+const getColorString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() ? value : undefined;
+
+const getBaseSeriesColor = (series: any): string | undefined =>
+  getColorString(series?.lineStyle?.color) ??
+  getColorString(series?.itemStyle?.color) ??
+  getColorString(series?.color) ??
+  getColorString(series?.areaStyle?.color);
+
+const resolveForecastOverlayColor = (
+  baseSeries: any[],
+  palette: unknown[],
+  seriesValue: string,
+  previewIndex: number
+): string => {
+  const fallbackPalette = getColors().categories;
+  const matchingSeriesIndex = baseSeries.findIndex(
+    (series) => typeof series?.name === 'string' && series.name === seriesValue
+  );
+
+  if (matchingSeriesIndex >= 0) {
+    return (
+      getBaseSeriesColor(baseSeries[matchingSeriesIndex]) ??
+      getColorString(palette[matchingSeriesIndex % Math.max(palette.length, 1)]) ??
+      getColorString(fallbackPalette[matchingSeriesIndex % Math.max(fallbackPalette.length, 1)]) ??
+      DEFAULT_FORECAST_COLOR
+    );
+  }
+
+  return (
+    getColorString(palette[previewIndex % Math.max(palette.length, 1)]) ??
+    getColorString(fallbackPalette[previewIndex % Math.max(fallbackPalette.length, 1)]) ??
+    DEFAULT_FORECAST_COLOR
+  );
+};
+
+const extractPreviewErrorMessage = (error: unknown): string => {
+  if (!error) {
+    return 'Unknown error';
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  const maybeError = error as any;
+  const body = maybeError?.body;
+  const bodyErrorReason = body?.error?.reason || body?.error?.details;
+  const bodyMessage = body?.message;
+
+  if (typeof bodyErrorReason === 'string' && bodyErrorReason.trim()) {
+    return bodyErrorReason;
+  }
+
+  if (typeof bodyMessage === 'string' && bodyMessage.trim()) {
+    return bodyMessage;
+  }
+
+  if (typeof maybeError?.message === 'string' && maybeError.message.trim()) {
+    return maybeError.message;
+  }
+
+  return 'Unknown error';
+};
+
+const formatPreviewFailureMessage = (
+  kind: 'anomaly' | 'forecast',
+  errorMessage: string
+): string => {
+  const normalized = errorMessage.trim();
+  if (!normalized) {
+    return kind === 'anomaly' ? 'Anomaly preview failed.' : 'Forecast preview failed.';
+  }
+
+  if (normalized.startsWith('Anomaly preview') || normalized.startsWith('Forecast preview')) {
+    return normalized;
+  }
+
+  return kind === 'anomaly'
+    ? i18n.translate('explore.visualization.prometheusPreview.anomalyFailure', {
+        defaultMessage: 'Anomaly preview failed: {error}',
+        values: { error: normalized },
+      })
+    : i18n.translate('explore.visualization.prometheusPreview.forecastFailure', {
+        defaultMessage: 'Forecast preview failed: {error}',
+        values: { error: normalized },
+      });
+};
+
+const isMissingAnomalyDetectionDependencyError = (errorMessage: string): boolean => {
+  const normalized = errorMessage.trim().toLowerCase();
+  return (
+    normalized.includes('anomaly detection plugin endpoint not found') ||
+    normalized.includes('/_plugins/_anomaly_detection') ||
+    normalized.includes('/_opendistro/_anomaly_detection') ||
+    normalized.includes('no handler found') ||
+    normalized.includes('endpoint not found')
+  );
+};
 
 export interface UpdateVisualizationProps {
   mappings: AxisColumnMappings;
 }
-// TODO: add back notifications
-// const VISUALIZATION_TOAST_MSG = {
-//   useRule: i18n.translate('explore.visualize.toast.useRule', {
-//     defaultMessage: 'Cannot apply previous configured visualization, use rule matched',
-//   }),
-//   reset: i18n.translate('explore.visualize.toast.reset', {
-//     defaultMessage: 'Cannot apply previous configured visualization, reset',
-//   }),
-//   metricReset: i18n.translate('explore.visualize.toast.metricReset', {
-//     defaultMessage: 'Cannot apply metric type visualization, reset',
-//   }),
-//   switchReset: i18n.translate('explore.visualize.toast.switchReset', {
-//     defaultMessage: 'Cannot apply configured visualization to the current chart type, reset',
-//   }),
-// };
 
 export const VisualizationContainer = React.memo(() => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
   const { results } = useTabResults();
+  const query = useSelector((state: RootState) => state.query);
+  const queryLanguage = query?.language;
+  const queryText = typeof query?.query === 'string' ? query.query : '';
+  const dataConnectionId = typeof query?.dataset?.id === 'string' ? query.dataset.id.trim() : '';
   const searchContext = useSearchContext();
   const dispatch = useDispatch();
 
   const visualizationBuilder = getVisualizationBuilder();
+  const visData = useObservable(visualizationBuilder.data$);
+  const chartConfig = useObservable(visualizationBuilder.visConfig$);
+  const availableApplications = useObservable(
+    services.core.application.applications$,
+    new Map<string, unknown>()
+  ) as ReadonlyMap<string, unknown>;
+
+  const [previewStatusMessage, setPreviewStatusMessage] = useState('');
+  const [previewStatusColor, setPreviewStatusColor] = useState<'primary' | 'warning'>('warning');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewSeriesOptions, setPreviewSeriesOptions] = useState<PreviewSeriesOption[]>([]);
+  const [selectedPreviewSeriesValues, setSelectedPreviewSeriesValues] = useState<string[]>([]);
+  const [seriesPreviewStates, setSeriesPreviewStates] = useState<SeriesPreviewState[]>([]);
+
+  const previewInputSignatureRef = useRef('');
+  const isAnomalyDetectionUiAvailable = useMemo(
+    () => availableApplications?.has?.(METRICS_ANOMALY_DETECTION_APP_ID) ?? false,
+    [availableApplications]
+  );
 
   useEffect(() => {
     if (results) {
@@ -61,10 +272,810 @@ export const VisualizationContainer = React.memo(() => {
   useEffect(() => {
     visualizationBuilder.init();
     return () => {
-      // reset visualization builder
       visualizationBuilder.reset();
     };
   }, [visualizationBuilder]);
+
+  const allVisColumns = useMemo(() => {
+    return [
+      ...(visData?.numericalColumns ?? []),
+      ...(visData?.categoricalColumns ?? []),
+      ...(visData?.dateColumns ?? []),
+    ];
+  }, [visData?.categoricalColumns, visData?.dateColumns, visData?.numericalColumns]);
+
+  const resolveKey = useCallback(
+    (preferredName: string | undefined, fallbackMatchers: RegExp[], candidateRows: any[]) => {
+      if (preferredName) {
+        const column = allVisColumns.find((visColumn) => visColumn.name === preferredName);
+        return column?.column ?? preferredName;
+      }
+
+      if (allVisColumns.length > 0) {
+        const matchedColumn = allVisColumns.find((visColumn) =>
+          fallbackMatchers.some((matcher) => matcher.test(visColumn.name))
+        );
+        if (matchedColumn) {
+          return matchedColumn.column;
+        }
+      }
+
+      const firstRow = candidateRows[0];
+      if (!firstRow) {
+        return undefined;
+      }
+
+      return Object.keys(firstRow).find((key) =>
+        fallbackMatchers.some((matcher) => matcher.test(key))
+      );
+    },
+    [allVisColumns]
+  );
+
+  const parseTimeRangeToEpoch = useCallback((timeRange?: { from?: string; to?: string }) => {
+    const normalizeRelativeNow = (rawValue: string | undefined, parsedValue: number | undefined) =>
+      rawValue?.includes('now') && parsedValue !== undefined
+        ? Math.floor(parsedValue / 60000) * 60000
+        : parsedValue;
+    const from = timeRange?.from ? dateMath.parse(timeRange.from)?.valueOf() : undefined;
+    const to = timeRange?.to
+      ? dateMath.parse(timeRange.to, { roundUp: true })?.valueOf()
+      : undefined;
+    return {
+      from: normalizeRelativeNow(timeRange?.from, from),
+      to: normalizeRelativeNow(timeRange?.to, to),
+    };
+  }, []);
+
+  useEffect(() => {
+    const promqlQuery = queryLanguage === PROMETHEUS_QUERY_LANGUAGE ? queryText.trim() : '';
+
+    const resetPreviewState = () => {
+      previewInputSignatureRef.current = '';
+      clearSeriesPreviewStatesIfNeeded(setSeriesPreviewStates);
+      setPreviewSeriesOptionsIfChanged(setPreviewSeriesOptions, []);
+      setPreviewSelectedSeriesIfChanged(setSelectedPreviewSeriesValues, []);
+      setPreviewStatusMessage('');
+      setPreviewStatusColor('warning');
+      setPreviewLoading(false);
+    };
+
+    if (!isAnomalyDetectionUiAvailable) {
+      resetPreviewState();
+      return;
+    }
+
+    if (!promqlQuery) {
+      resetPreviewState();
+      return;
+    }
+
+    const candidateRows: Array<Record<string, any>> = Array.isArray(visData?.transformedData)
+      ? (visData.transformedData as Array<Record<string, any>>)
+      : Array.isArray((results as any)?.instantHits?.hits)
+      ? (results as any).instantHits.hits.map((hit: any) => hit?._source).filter(Boolean)
+      : Array.isArray((results as any)?.hits?.hits)
+      ? (results as any).hits.hits.map((hit: any) => hit?._source).filter(Boolean)
+      : [];
+
+    if (candidateRows.length === 0) {
+      setPreviewSeriesOptionsIfChanged(setPreviewSeriesOptions, []);
+      setPreviewSelectedSeriesIfChanged(setSelectedPreviewSeriesValues, []);
+      resetPreviewState();
+      return;
+    }
+
+    const axesMapping = chartConfig?.axesMapping ?? {};
+    const effectiveTimeKey = resolveKey(
+      axesMapping.x,
+      [/^time$/i, /timestamp/i, /@timestamp/i],
+      candidateRows
+    );
+    const effectiveValueKey = resolveKey(
+      axesMapping.y,
+      [/^value$/i, /^value #/i, /val/i],
+      candidateRows
+    );
+    const effectiveSeriesKey = resolveKey(
+      axesMapping.color,
+      [/^series$/i, /^metric$/i, /label/i],
+      candidateRows
+    );
+
+    if (!effectiveTimeKey || !effectiveValueKey) {
+      setPreviewSeriesOptionsIfChanged(setPreviewSeriesOptions, []);
+      setPreviewSelectedSeriesIfChanged(setSelectedPreviewSeriesValues, []);
+      resetPreviewState();
+      return;
+    }
+
+    const seriesValues = effectiveSeriesKey
+      ? Array.from(
+          new Set(
+            candidateRows
+              .map((row) =>
+                row?.[effectiveSeriesKey] == null ? '' : String(row[effectiveSeriesKey])
+              )
+              .filter((seriesValue) => seriesValue.trim() !== '')
+          )
+        )
+      : [];
+
+    const nextSeriesOptions = seriesValues.map((seriesValue) => ({
+      value: seriesValue,
+      text: seriesValue,
+    }));
+    setPreviewSeriesOptionsIfChanged(setPreviewSeriesOptions, nextSeriesOptions);
+
+    const shouldAutoPreviewAllSeries =
+      seriesValues.length > 0 && seriesValues.length <= MAX_AUTO_PREVIEW_SERIES;
+    const validSelectedSeriesValues = selectedPreviewSeriesValues
+      .filter((seriesValue) => seriesValues.includes(seriesValue))
+      .slice(0, MAX_AUTO_PREVIEW_SERIES);
+
+    if (!shouldAutoPreviewAllSeries) {
+      setPreviewSelectedSeriesIfChanged(setSelectedPreviewSeriesValues, validSelectedSeriesValues);
+    }
+
+    const seriesValuesToPreview = effectiveSeriesKey
+      ? seriesValues.length === 0
+        ? ['']
+        : shouldAutoPreviewAllSeries
+        ? seriesValues
+        : validSelectedSeriesValues
+      : [''];
+
+    if (seriesValues.length > MAX_AUTO_PREVIEW_SERIES && seriesValuesToPreview.length === 0) {
+      previewInputSignatureRef.current = '';
+      clearSeriesPreviewStatesIfNeeded(setSeriesPreviewStates);
+      setPreviewStatusColor('primary');
+      setPreviewStatusMessage(
+        i18n.translate('explore.visualization.prometheusPreview.selectSeriesMessage', {
+          defaultMessage:
+            'This query returns {seriesCount} series. Select up to {maxSeries} series to generate preview overlays.',
+          values: {
+            seriesCount: seriesValues.length,
+            maxSeries: MAX_AUTO_PREVIEW_SERIES,
+          },
+        })
+      );
+      setPreviewLoading(false);
+      return;
+    }
+
+    const { from, to } = parseTimeRangeToEpoch(searchContext?.timeRange);
+    const previewInputs = seriesValuesToPreview.map((seriesValue) => {
+      const validPoints = candidateRows
+        .filter((row) =>
+          effectiveSeriesKey && seriesValue
+            ? String(row?.[effectiveSeriesKey]) === seriesValue
+            : true
+        )
+        .map((row) => {
+          const rawTimestamp = row?.[effectiveTimeKey];
+          const rawValue = row?.[effectiveValueKey];
+          const timestamp =
+            typeof rawTimestamp === 'number'
+              ? rawTimestamp
+              : rawTimestamp
+              ? new Date(String(rawTimestamp)).getTime()
+              : NaN;
+          const value =
+            typeof rawValue === 'number' ? rawValue : rawValue != null ? Number(rawValue) : NaN;
+          return { ts: timestamp, value };
+        })
+        .filter(
+          (point): point is PreviewPoint =>
+            Number.isFinite(point.ts) && Number.isFinite(point.value)
+        )
+        .sort((left, right) => left.ts - right.ts);
+
+      const sampledPoints = downsampleMetricPoints(validPoints, MAX_PREVIEW_DATAPOINTS);
+      const periodStart = from ?? sampledPoints[0]?.ts;
+      const periodEnd = to ?? sampledPoints[sampledPoints.length - 1]?.ts;
+      const minObserved = sampledPoints.reduce(
+        (currentMin, point) => (point.value < currentMin ? point.value : currentMin),
+        Number.POSITIVE_INFINITY
+      );
+
+      return {
+        seriesValue,
+        validPoints,
+        sampledPoints,
+        periodStart,
+        periodEnd,
+        forecastClampToZero: Number.isFinite(minObserved) && minObserved >= 0,
+        lastObservedTime: sampledPoints[sampledPoints.length - 1]?.ts,
+      };
+    });
+
+    const usablePreviewInputs = previewInputs.filter(
+      (previewInput) =>
+        previewInput.validPoints.length >= MIN_VALID_PREVIEW_DATAPOINTS &&
+        previewInput.periodStart !== undefined &&
+        previewInput.periodEnd !== undefined &&
+        previewInput.periodStart < previewInput.periodEnd
+    );
+
+    if (usablePreviewInputs.length === 0) {
+      setSeriesPreviewStates(
+        previewInputs.map((previewInput) => ({
+          seriesValue: previewInput.seriesValue,
+          points: previewInput.validPoints,
+          lastObservedTime: previewInput.lastObservedTime,
+          forecastClampToZero: previewInput.forecastClampToZero,
+          adPreview: null,
+          forecastPreview: null,
+        }))
+      );
+      setPreviewStatusMessage(
+        i18n.translate('explore.visualization.prometheusPreview.notEnoughUsableDatapointsMessage', {
+          defaultMessage:
+            'Preview requires at least {minPoints} valid numeric datapoints with a usable time range. Current metric has {actualPoints}.',
+          values: {
+            minPoints: MIN_VALID_PREVIEW_DATAPOINTS,
+            actualPoints: Math.max(
+              0,
+              ...previewInputs.map((previewInput) => previewInput.validPoints.length)
+            ),
+          },
+        })
+      );
+      setPreviewStatusColor('warning');
+      setPreviewLoading(false);
+      return;
+    }
+
+    const previewInputSignature = [
+      queryLanguage ?? '',
+      promqlQuery,
+      dataConnectionId,
+      usablePreviewInputs
+        .map(
+          (previewInput) =>
+            `${previewInput.seriesValue}:${previewInput.sampledPoints.length}:${
+              previewInput.periodStart
+            }:${previewInput.periodEnd}:${previewInput.sampledPoints[0]?.ts ?? ''}:${
+              previewInput.sampledPoints[previewInput.sampledPoints.length - 1]?.ts ?? ''
+            }`
+        )
+        .join('||'),
+    ].join('|');
+
+    if (previewInputSignatureRef.current === previewInputSignature) {
+      return;
+    }
+    previewInputSignatureRef.current = previewInputSignature;
+
+    let didCancel = false;
+
+    const executePreview = async () => {
+      setPreviewLoading(true);
+      setPreviewStatusMessage('');
+      setPreviewStatusColor('warning');
+      clearSeriesPreviewStatesIfNeeded(setSeriesPreviewStates);
+
+      try {
+        const seriesResults = await Promise.all(
+          usablePreviewInputs.map(async (previewInput) => {
+            const [anomalyPreviewResult, forecastPreviewResult] = await Promise.allSettled([
+              services.http.post('/api/explore/anomaly_preview', {
+                body: JSON.stringify({
+                  points: previewInput.sampledPoints,
+                  startTime: previewInput.periodStart,
+                  endTime: previewInput.periodEnd,
+                  shingleSize: 8,
+                  promqlQuery,
+                  dataConnectionId,
+                  seriesValue: previewInput.seriesValue,
+                }),
+              }),
+              services.http.post('/api/explore/forecast_preview', {
+                body: JSON.stringify({
+                  points: previewInput.sampledPoints,
+                  startTime: previewInput.periodStart,
+                  endTime: previewInput.periodEnd,
+                  shingleSize: 8,
+                  promqlQuery,
+                  dataConnectionId,
+                  seriesValue: previewInput.seriesValue,
+                }),
+              }),
+            ]);
+
+            return {
+              previewInput,
+              anomalyPreviewResult,
+              forecastPreviewResult,
+            };
+          })
+        );
+
+        if (didCancel) {
+          return;
+        }
+
+        const anomalyDependencyMissingForAllSeries = seriesResults.every(
+          ({ anomalyPreviewResult }) => {
+            if (anomalyPreviewResult.status === 'fulfilled') {
+              return (
+                anomalyPreviewResult.value?.ok !== true &&
+                isMissingAnomalyDetectionDependencyError(
+                  String(
+                    anomalyPreviewResult.value?.error || anomalyPreviewResult.value?.message || ''
+                  )
+                )
+              );
+            }
+
+            return isMissingAnomalyDetectionDependencyError(
+              extractPreviewErrorMessage(anomalyPreviewResult.reason)
+            );
+          }
+        );
+
+        if (anomalyDependencyMissingForAllSeries) {
+          previewInputSignatureRef.current = '';
+          clearSeriesPreviewStatesIfNeeded(setSeriesPreviewStates);
+          setPreviewStatusMessage('');
+          setPreviewStatusColor('warning');
+          setPreviewLoading(false);
+          return;
+        }
+
+        const previewErrors: string[] = [];
+        let emptyAnomalyPreviewCount = 0;
+        let noPositiveAnomalyCount = 0;
+        let successfulAnomalyPreviewCount = 0;
+
+        const nextSeriesPreviewStates = seriesResults.map(
+          ({ previewInput, anomalyPreviewResult, forecastPreviewResult }) => {
+            let adPreview: any | null = null;
+            let forecastPreview: any | null = null;
+            const seriesPrefix = previewInput.seriesValue ? `${previewInput.seriesValue}: ` : '';
+
+            if (anomalyPreviewResult.status === 'fulfilled') {
+              if (anomalyPreviewResult.value?.ok) {
+                adPreview = anomalyPreviewResult.value;
+                successfulAnomalyPreviewCount += 1;
+                const anomalyMeta = anomalyPreviewResult.value?.meta;
+                const anomalyResultCount = toFiniteNumber(anomalyMeta?.anomalyResultCount) ?? 0;
+                const positiveAnomalyCount = toFiniteNumber(anomalyMeta?.positiveAnomalyCount) ?? 0;
+                if (anomalyResultCount === 0) {
+                  emptyAnomalyPreviewCount += 1;
+                } else if (positiveAnomalyCount === 0) {
+                  noPositiveAnomalyCount += 1;
+                }
+              } else {
+                previewErrors.push(
+                  `${seriesPrefix}${formatPreviewFailureMessage(
+                    'anomaly',
+                    anomalyPreviewResult.value?.error ||
+                      anomalyPreviewResult.value?.message ||
+                      'Unknown error'
+                  )}`
+                );
+              }
+            } else {
+              previewErrors.push(
+                `${seriesPrefix}${formatPreviewFailureMessage(
+                  'anomaly',
+                  extractPreviewErrorMessage(anomalyPreviewResult.reason)
+                )}`
+              );
+            }
+
+            if (forecastPreviewResult.status === 'fulfilled') {
+              if (forecastPreviewResult.value?.ok) {
+                forecastPreview = forecastPreviewResult.value;
+              } else {
+                previewErrors.push(
+                  `${seriesPrefix}${formatPreviewFailureMessage(
+                    'forecast',
+                    forecastPreviewResult.value?.error ||
+                      forecastPreviewResult.value?.message ||
+                      'Unknown error'
+                  )}`
+                );
+              }
+            } else {
+              previewErrors.push(
+                `${seriesPrefix}${formatPreviewFailureMessage(
+                  'forecast',
+                  extractPreviewErrorMessage(forecastPreviewResult.reason)
+                )}`
+              );
+            }
+
+            return {
+              seriesValue: previewInput.seriesValue,
+              points: previewInput.validPoints,
+              lastObservedTime: previewInput.lastObservedTime,
+              forecastClampToZero: previewInput.forecastClampToZero,
+              adPreview,
+              forecastPreview,
+            };
+          }
+        );
+
+        setSeriesPreviewStates(nextSeriesPreviewStates);
+
+        const previewInfoMessages: string[] = [];
+        if (
+          successfulAnomalyPreviewCount > 0 &&
+          emptyAnomalyPreviewCount === successfulAnomalyPreviewCount
+        ) {
+          previewInfoMessages.push(
+            i18n.translate(
+              'explore.visualization.prometheusPreview.anomalyEmptyPreviewRowsMessage',
+              {
+                defaultMessage:
+                  'Anomaly preview did not return any preview rows for this metric and time range. This is different from "no anomalies found"; it usually means preview could not produce usable anomaly samples.',
+              }
+            )
+          );
+        } else if (
+          successfulAnomalyPreviewCount > 0 &&
+          noPositiveAnomalyCount === successfulAnomalyPreviewCount
+        ) {
+          previewInfoMessages.push(
+            i18n.translate(
+              'explore.visualization.prometheusPreview.anomalyNoPositiveResultsMessage',
+              {
+                defaultMessage:
+                  'Anomaly preview ran successfully but did not detect positive anomalies in the sampled preview data for this metric and time range.',
+              }
+            )
+          );
+        }
+
+        if (previewErrors.length > 0) {
+          setPreviewStatusColor('warning');
+          setPreviewStatusMessage([...previewErrors, ...previewInfoMessages].join('\n'));
+        } else if (previewInfoMessages.length > 0) {
+          setPreviewStatusColor('primary');
+          setPreviewStatusMessage(previewInfoMessages.join('\n'));
+        }
+      } catch (error) {
+        if (!didCancel) {
+          setPreviewStatusColor('warning');
+          setPreviewStatusMessage(
+            i18n.translate('explore.visualization.prometheusPreview.failedMessage', {
+              defaultMessage: 'Unable to load preview overlays: {error}',
+              values: {
+                error: extractPreviewErrorMessage(error),
+              },
+            })
+          );
+        }
+      } finally {
+        if (!didCancel) {
+          setPreviewLoading(false);
+        }
+      }
+    };
+
+    executePreview();
+
+    return () => {
+      didCancel = true;
+    };
+  }, [
+    chartConfig?.axesMapping,
+    parseTimeRangeToEpoch,
+    queryLanguage,
+    queryText,
+    resolveKey,
+    results,
+    searchContext?.timeRange,
+    services.http,
+    dataConnectionId,
+    isAnomalyDetectionUiAvailable,
+    selectedPreviewSeriesValues,
+    visData?.transformedData,
+  ]);
+
+  const augmentEchartsSpec = useCallback(
+    (spec: any, _ctx: { timeRange: TimeRange }) => {
+      if (!spec || Array.isArray(spec.grid)) {
+        return spec;
+      }
+
+      const xAxes = Array.isArray(spec.xAxis) ? spec.xAxis : [spec.xAxis ?? { type: 'time' }];
+      const yAxes = Array.isArray(spec.yAxis) ? spec.yAxis : [spec.yAxis ?? { type: 'value' }];
+      const baseGrid = spec.grid && typeof spec.grid === 'object' ? spec.grid : {};
+      const baseSeries = Array.isArray(spec.series) ? spec.series : [];
+      const basePalette = Array.isArray(spec.color) ? spec.color : [];
+
+      const augmented: any = {
+        ...spec,
+        grid: {
+          ...baseGrid,
+          left: baseGrid.left ?? 40,
+          right: baseGrid.right ?? 30,
+        },
+        legend: Array.isArray(spec.legend)
+          ? spec.legend.map((legend: any) =>
+              legend && typeof legend === 'object'
+                ? {
+                    ...legend,
+                    itemWidth: ANOMALY_PREVIEW_MARKER_SIZE,
+                    itemHeight: ANOMALY_PREVIEW_MARKER_SIZE,
+                  }
+                : legend
+            )
+          : spec.legend && typeof spec.legend === 'object'
+          ? {
+              ...spec.legend,
+              itemWidth: ANOMALY_PREVIEW_MARKER_SIZE,
+              itemHeight: ANOMALY_PREVIEW_MARKER_SIZE,
+            }
+          : spec.legend,
+        xAxis: xAxes,
+        yAxis: [...yAxes],
+        tooltip: spec.tooltip,
+        series: [...baseSeries],
+      };
+
+      seriesPreviewStates.forEach((previewState, previewIndex) => {
+        const forecastPreview = previewState.forecastPreview;
+        if (forecastPreview?.ok === true && Array.isArray(forecastPreview?.response?.points)) {
+          const forecastSeriesSuffix = previewState.seriesValue
+            ? ` (${previewState.seriesValue})`
+            : '';
+          const forecastColor = resolveForecastOverlayColor(
+            baseSeries,
+            basePalette,
+            previewState.seriesValue,
+            previewIndex
+          );
+          const futureCutoff = previewState.lastObservedTime ?? Number.NEGATIVE_INFINITY;
+          const forecastPoints = (forecastPreview.response.points as any[])
+            .map((point) => {
+              const t = toFiniteNumber(point?.t);
+              const v = toFiniteNumber(point?.v);
+              const lo = toFiniteNumber(point?.lo);
+              const hi = toFiniteNumber(point?.hi);
+              if (t === undefined || v === undefined || t <= futureCutoff) {
+                return null;
+              }
+
+              const forecastValue = previewState.forecastClampToZero ? Math.max(0, v) : v;
+              const lowerBound =
+                lo === undefined
+                  ? undefined
+                  : previewState.forecastClampToZero
+                  ? Math.max(0, lo)
+                  : lo;
+              const upperBound = hi;
+              if (forecastValue === undefined) {
+                return null;
+              }
+
+              return {
+                t,
+                v: forecastValue,
+                lo:
+                  lowerBound !== undefined && upperBound !== undefined
+                    ? Math.min(lowerBound, upperBound)
+                    : lowerBound,
+                hi:
+                  lowerBound !== undefined && upperBound !== undefined
+                    ? Math.max(lowerBound, upperBound)
+                    : upperBound,
+              };
+            })
+            .filter(Boolean);
+
+          if (forecastPoints.length > 0) {
+            const dataForecast = forecastPoints.map((point: any) => [point.t, point.v]);
+            const dataLower = forecastPoints.map((point: any) => [
+              point.t,
+              Number.isFinite(point.lo) ? point.lo : point.v,
+            ]);
+            const dataUpperMinusLower = forecastPoints.map((point: any) => {
+              const lower = Number.isFinite(point.lo) ? point.lo : point.v;
+              const upper = Number.isFinite(point.hi) ? point.hi : point.v;
+              return [point.t, Math.max(0, upper - lower)];
+            });
+
+            augmented.series.push(
+              {
+                name: `Forecast lower${forecastSeriesSuffix}`,
+                type: 'line',
+                xAxisIndex: 0,
+                yAxisIndex: 0,
+                data: dataLower,
+                stack: `forecastBand${forecastSeriesSuffix}`,
+                symbol: 'none',
+                lineStyle: { opacity: 0 },
+                tooltip: { show: false },
+                z: 2,
+              },
+              {
+                name: `Forecast band${forecastSeriesSuffix}`,
+                type: 'line',
+                xAxisIndex: 0,
+                yAxisIndex: 0,
+                data: dataUpperMinusLower,
+                stack: `forecastBand${forecastSeriesSuffix}`,
+                symbol: 'none',
+                lineStyle: { opacity: 0 },
+                areaStyle: { color: forecastColor, opacity: 0.18 },
+                tooltip: { show: false },
+                z: 2,
+              },
+              {
+                name: `Forecast${forecastSeriesSuffix}`,
+                type: 'line',
+                xAxisIndex: 0,
+                yAxisIndex: 0,
+                data: dataForecast,
+                symbol: 'none',
+                lineStyle: { width: 2, type: 'dashed', color: forecastColor },
+                z: 3,
+              }
+            );
+          }
+        }
+
+        const adPreview = previewState.adPreview;
+        if (adPreview?.ok === true) {
+          const anomalies =
+            adPreview?.response?.anomaly_result ?? adPreview?.response?.anomalies ?? [];
+          const observedPoints = previewState.points;
+          const markerBaselineValue =
+            observedPoints.length > 0
+              ? observedPoints.reduce(
+                  (currentMin, point) => (point.value < currentMin ? point.value : currentMin),
+                  Number.POSITIVE_INFINITY
+                )
+              : Number.NaN;
+          const resolveObservedValue = (timestamp: number) => {
+            if (!Number.isFinite(timestamp) || observedPoints.length === 0) {
+              return undefined;
+            }
+
+            if (observedPoints.length === 1) {
+              return observedPoints[0].value;
+            }
+
+            const firstPoint = observedPoints[0];
+            const lastPoint = observedPoints[observedPoints.length - 1];
+            if (timestamp <= firstPoint.ts) {
+              return firstPoint.value;
+            }
+            if (timestamp >= lastPoint.ts) {
+              return lastPoint.value;
+            }
+
+            let left = 0;
+            let right = observedPoints.length - 1;
+            while (left < right) {
+              const mid = Math.floor((left + right) / 2);
+              if (observedPoints[mid].ts < timestamp) {
+                left = mid + 1;
+              } else {
+                right = mid;
+              }
+            }
+
+            const candidates = [observedPoints[left], observedPoints[left - 1]].filter(
+              (point): point is PreviewPoint => point != null
+            );
+            if (candidates.length === 0) {
+              return undefined;
+            }
+
+            const rightPoint = candidates.find((point) => point.ts >= timestamp);
+            const leftPoint =
+              [...candidates].reverse().find((point) => point.ts <= timestamp) ?? candidates[0];
+
+            if (leftPoint && rightPoint && leftPoint.ts !== rightPoint.ts) {
+              const ratio = (timestamp - leftPoint.ts) / (rightPoint.ts - leftPoint.ts);
+              return leftPoint.value + (rightPoint.value - leftPoint.value) * ratio;
+            }
+
+            const nearestPoint = candidates.reduce((best, point) => {
+              if (!best) return point;
+              return Math.abs(point.ts - timestamp) < Math.abs(best.ts - timestamp) ? point : best;
+            }, undefined as PreviewPoint | undefined);
+
+            return nearestPoint?.value;
+          };
+
+          const markerData = (Array.isArray(anomalies) ? anomalies : [])
+            .map((anomaly: any) => {
+              const time =
+                toFiniteNumber(anomaly?.data_end_time) ?? toFiniteNumber(anomaly?.data_start_time);
+              const anomalyGrade = toFiniteNumber(anomaly?.anomaly_grade) ?? 0;
+              const confidence = toFiniteNumber(anomaly?.confidence) ?? 0;
+              const observedValue = time === undefined ? undefined : resolveObservedValue(time);
+              const markerYValue = Number.isFinite(markerBaselineValue)
+                ? markerBaselineValue
+                : observedValue;
+              if (time === undefined || anomalyGrade <= 0 || observedValue === undefined) {
+                return null;
+              }
+              return {
+                value: [time, markerYValue],
+                anomaly_grade: anomalyGrade,
+                confidence,
+                observed_value: observedValue,
+              };
+            })
+            .filter(Boolean);
+
+          if (markerData.length > 0) {
+            const anomalySeriesSuffix = previewState.seriesValue
+              ? ` (${previewState.seriesValue})`
+              : '';
+            augmented.series.push({
+              name: `Anomalies (preview)${anomalySeriesSuffix}`,
+              type: 'scatter',
+              xAxisIndex: 0,
+              yAxisIndex: 0,
+              symbol: 'triangle',
+              legendIcon: 'triangle',
+              symbolOffset: [0, '135%'],
+              itemStyle: {
+                color: ANOMALY_PREVIEW_COLOR,
+                borderColor: ANOMALY_PREVIEW_COLOR,
+                borderWidth: 1,
+                opacity: 1,
+              },
+              clip: false,
+              z: 10,
+              data: markerData,
+              symbolSize: ANOMALY_PREVIEW_MARKER_SIZE,
+              markLine: {
+                silent: true,
+                symbol: 'none',
+                label: { show: false },
+                lineStyle: {
+                  color: 'rgba(211, 96, 134, 0.38)',
+                  width: 1.5,
+                  type: 'dashed',
+                },
+                data: markerData.map((marker: any) => ({ xAxis: marker?.value?.[0] })),
+              },
+              emphasis: {
+                scale: false,
+                itemStyle: {
+                  color: ANOMALY_PREVIEW_COLOR,
+                  borderColor: ANOMALY_PREVIEW_BORDER_COLOR,
+                  borderWidth: 1.5,
+                  shadowBlur: 6,
+                  shadowColor: 'rgba(211, 96, 134, 0.35)',
+                },
+              },
+              tooltip: {
+                trigger: 'item',
+                formatter: (point: any) => {
+                  const timestamp = point?.data?.value?.[0];
+                  const anomalyGrade = point?.data?.anomaly_grade ?? 0;
+                  const confidence = point?.data?.confidence ?? 0;
+                  const observedValue = point?.data?.observed_value;
+                  const timeLabel =
+                    typeof timestamp === 'number' && Number.isFinite(timestamp)
+                      ? moment(timestamp).format('YYYY-MM-DD HH:mm:ss')
+                      : 'Unknown time';
+                  return `${timeLabel}<br/>Anomaly grade: ${
+                    Number(anomalyGrade).toFixed?.(2) ?? anomalyGrade
+                  }<br/>Confidence: ${Number(confidence).toFixed?.(2) ?? confidence}<br/>Value: ${
+                    Number.isFinite(observedValue) ? Number(observedValue).toFixed(4) : 'N/A'
+                  }`;
+                },
+              },
+            });
+          }
+        }
+      });
+
+      return augmented;
+    },
+    [seriesPreviewStates]
+  );
 
   const onSelectTimeRange = useCallback(
     (timeRange?: TimeRange) => {
@@ -84,8 +1095,99 @@ export const VisualizationContainer = React.memo(() => {
     [services, dispatch]
   );
 
+  const previewSeriesComboOptions = useMemo(
+    () => previewSeriesOptions.map((option) => toComboBoxOption(option.value)),
+    [previewSeriesOptions]
+  );
+
+  const selectedPreviewSeriesComboOptions = useMemo(
+    () =>
+      selectedPreviewSeriesValues
+        .filter((seriesValue) =>
+          previewSeriesOptions.some((option) => option.value === seriesValue)
+        )
+        .map(toComboBoxOption),
+    [previewSeriesOptions, selectedPreviewSeriesValues]
+  );
+
   return (
     <div className="exploreVisContainer">
+      {isAnomalyDetectionUiAvailable && (previewLoading || previewStatusMessage) ? (
+        <>
+          <EuiCallOut
+            size="s"
+            title={
+              previewLoading
+                ? i18n.translate('explore.visualization.prometheusPreview.loadingTitle', {
+                    defaultMessage: 'Loading preview overlays',
+                  })
+                : i18n.translate('explore.visualization.prometheusPreview.statusTitle', {
+                    defaultMessage: 'Preview overlay status',
+                  })
+            }
+            color={previewLoading ? 'primary' : previewStatusColor}
+            iconType={previewLoading ? 'refresh' : 'alert'}
+            data-test-subj="metricsPreviewStatusCallout"
+            className="exploreVisPreviewBanner"
+          >
+            <p style={{ whiteSpace: 'pre-line' }}>
+              {previewLoading
+                ? i18n.translate('explore.visualization.prometheusPreview.loadingMessage', {
+                    defaultMessage:
+                      'Generating anomaly and forecast previews from the latest metric datapoints.',
+                  })
+                : previewStatusMessage}
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="s" />
+        </>
+      ) : null}
+      {isAnomalyDetectionUiAvailable && previewSeriesOptions.length > MAX_AUTO_PREVIEW_SERIES ? (
+        <>
+          <EuiFormRow
+            label={i18n.translate(
+              'explore.visualization.prometheusPreview.previewSeriesSelectorLabel',
+              {
+                defaultMessage: 'Preview overlays for series',
+              }
+            )}
+            helpText={i18n.translate(
+              'explore.visualization.prometheusPreview.previewSeriesSelectorHelpText',
+              {
+                defaultMessage:
+                  'Select up to {maxSeries} series. Smaller multi-series charts preview all series automatically.',
+                values: {
+                  maxSeries: MAX_AUTO_PREVIEW_SERIES,
+                },
+              }
+            )}
+            display="rowCompressed"
+          >
+            <EuiComboBox
+              compressed
+              fullWidth
+              placeholder={i18n.translate(
+                'explore.visualization.prometheusPreview.previewSeriesSelectorPlaceholder',
+                {
+                  defaultMessage: 'Select series to preview',
+                }
+              )}
+              options={previewSeriesComboOptions}
+              selectedOptions={selectedPreviewSeriesComboOptions}
+              onChange={(selectedOptions) =>
+                setPreviewSelectedSeriesIfChanged(
+                  setSelectedPreviewSeriesValues,
+                  selectedOptions
+                    .map((option) => option.value || option.label)
+                    .slice(0, MAX_AUTO_PREVIEW_SERIES)
+                )
+              }
+              data-test-subj="metricsPreviewSeriesSelector"
+            />
+          </EuiFormRow>
+          <EuiSpacer size="s" />
+        </>
+      ) : null}
       <EuiPanel
         hasBorder={false}
         hasShadow={false}
@@ -97,6 +1199,7 @@ export const VisualizationContainer = React.memo(() => {
           {visualizationBuilder.renderVisualization({
             timeRange: searchContext?.timeRange,
             onSelectTimeRange,
+            augmentEchartsSpec,
           })}
         </div>
       </EuiPanel>

--- a/src/plugins/explore/public/components/visualizations/visualization_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_container.tsx
@@ -20,6 +20,7 @@ import dateMath from '@elastic/datemath';
 
 import { AxisColumnMappings } from './types';
 import { useTabResults } from '../../application/utils/hooks/use_tab_results';
+import { useResolvedOpenSearchDataSourceId } from '../../application/utils/hooks/use_resolved_opensearch_data_source_id';
 import { useSearchContext } from '../query_panel/utils/use_search_context';
 import { getVisualizationBuilder } from './visualization_builder';
 import { TimeRange } from '../../../../data/common';
@@ -237,6 +238,8 @@ export const VisualizationContainer = React.memo(() => {
   const queryLanguage = query?.language;
   const queryText = typeof query?.query === 'string' ? query.query : '';
   const dataConnectionId = typeof query?.dataset?.id === 'string' ? query.dataset.id.trim() : '';
+  const explicitDataSourceId =
+    typeof query?.dataset?.dataSource?.id === 'string' ? query.dataset.dataSource.id.trim() : '';
   const searchContext = useSearchContext();
   const dispatch = useDispatch();
 
@@ -247,6 +250,11 @@ export const VisualizationContainer = React.memo(() => {
     services.core.application.applications$,
     new Map<string, unknown>()
   ) as ReadonlyMap<string, unknown>;
+  const { dataSourceId, isResolvingDataSourceId } = useResolvedOpenSearchDataSourceId(
+    services,
+    explicitDataSourceId,
+    { onlyWhenHideLocalCluster: true }
+  );
 
   const [previewStatusMessage, setPreviewStatusMessage] = useState('');
   const [previewStatusColor, setPreviewStatusColor] = useState<'primary' | 'warning'>('warning');
@@ -260,6 +268,9 @@ export const VisualizationContainer = React.memo(() => {
     () => availableApplications?.has?.(METRICS_ANOMALY_DETECTION_APP_ID) ?? false,
     [availableApplications]
   );
+  const requiresManagedDataSource = services.dataSourceEnabled && services.hideLocalCluster;
+  const missingManagedDataSource =
+    requiresManagedDataSource && !isResolvingDataSourceId && !dataSourceId;
 
   useEffect(() => {
     if (results) {
@@ -346,6 +357,11 @@ export const VisualizationContainer = React.memo(() => {
     }
 
     if (!promqlQuery) {
+      resetPreviewState();
+      return;
+    }
+
+    if (isResolvingDataSourceId || missingManagedDataSource) {
       resetPreviewState();
       return;
     }
@@ -530,6 +546,7 @@ export const VisualizationContainer = React.memo(() => {
       queryLanguage ?? '',
       promqlQuery,
       dataConnectionId,
+      dataSourceId,
       usablePreviewInputs
         .map(
           (previewInput) =>
@@ -569,6 +586,7 @@ export const VisualizationContainer = React.memo(() => {
                   dataConnectionId,
                   seriesValue: previewInput.seriesValue,
                 }),
+                ...(dataSourceId ? { query: { dataSourceId } } : {}),
               }),
               services.http.post('/api/explore/forecast_preview', {
                 body: JSON.stringify({
@@ -580,6 +598,7 @@ export const VisualizationContainer = React.memo(() => {
                   dataConnectionId,
                   seriesValue: previewInput.seriesValue,
                 }),
+                ...(dataSourceId ? { query: { dataSourceId } } : {}),
               }),
             ]);
 
@@ -615,7 +634,6 @@ export const VisualizationContainer = React.memo(() => {
         );
 
         if (anomalyDependencyMissingForAllSeries) {
-          previewInputSignatureRef.current = '';
           clearSeriesPreviewStatesIfNeeded(setSeriesPreviewStates);
           setPreviewStatusMessage('');
           setPreviewStatusColor('warning');
@@ -770,7 +788,10 @@ export const VisualizationContainer = React.memo(() => {
     searchContext?.timeRange,
     services.http,
     dataConnectionId,
+    dataSourceId,
     isAnomalyDetectionUiAvailable,
+    isResolvingDataSourceId,
+    missingManagedDataSource,
     selectedPreviewSeriesValues,
     visData?.transformedData,
   ]);

--- a/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
@@ -32,6 +32,16 @@ jest.mock('./visualization_empty_state', () => ({
   )),
 }));
 
+jest.mock('./echarts_render', () => ({
+  EchartsRender: jest.fn(() => <div data-test-subj="echartsRender">Echarts Render</div>),
+}));
+
+jest.mock('./metric/metric_component', () => ({
+  MetricChartRender: jest.fn(() => (
+    <div data-test-subj="metricChartRender">Metric Chart Render</div>
+  )),
+}));
+
 jest.mock('../../services/services', () => ({
   getServices: jest.fn(() => ({
     data: {
@@ -239,5 +249,30 @@ describe('VisualizationRender', () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it('passes the raw echarts spec into augmentEchartsSpec and preserves axis mappings', () => {
+    const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+    const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(mockChartConfig);
+    const showRawTable$ = new BehaviorSubject<boolean>(false);
+    const augmentEchartsSpec = jest.fn((spec) => ({
+      ...spec,
+      title: { text: 'augmented' },
+    }));
+
+    render(
+      <VisualizationRender
+        data$={data$}
+        config$={visConfig$}
+        showRawTable$={showRawTable$}
+        augmentEchartsSpec={augmentEchartsSpec}
+      />
+    );
+
+    expect(mockRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        augmentEchartsSpec,
+      })
+    );
   });
 });

--- a/src/plugins/explore/public/components/visualizations/visualization_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useMemo } from 'react';
+import { cloneElement, isValidElement, useMemo } from 'react';
 import { Observable } from 'rxjs';
 import { useObservable } from 'react-use';
 import dateMath from '@elastic/datemath';
@@ -16,6 +16,8 @@ import { TimeRange } from '../../../../data/public';
 import { visualizationRegistry } from './visualization_registry';
 import { convertStringsToMappings } from './visualization_builder_utils';
 import { getAxisConfigByColumnMapping } from './utils/axis';
+import { EchartsRender } from './echarts_render';
+import { MetricChartRender } from './metric/metric_component';
 
 interface Props {
   data$: Observable<VisData | undefined>;
@@ -24,6 +26,7 @@ interface Props {
   timeRange?: TimeRange;
   onSelectTimeRange?: (timeRange?: TimeRange) => void;
   onStyleChange?: (updatedStyle: Partial<TableChartStyle>) => void;
+  augmentEchartsSpec?: (spec: any, context: { timeRange: TimeRange }) => any;
 }
 
 const defaultStyleOptions: TableChartStyle = {
@@ -41,6 +44,7 @@ export const VisualizationRender = ({
   timeRange: inputTimeRange,
   onSelectTimeRange,
   onStyleChange,
+  augmentEchartsSpec,
 }: Props) => {
   const visualizationData = useObservable(data$);
   const visConfig = useObservable(config$);
@@ -109,6 +113,7 @@ export const VisualizationRender = ({
         config={visConfig}
         timeRange={timeRange}
         onSelectTimeRange={onSelectTimeRange}
+        augmentEchartsSpec={augmentEchartsSpec}
       />
     );
   }
@@ -121,11 +126,13 @@ const ChartRender = ({
   config,
   timeRange,
   onSelectTimeRange,
+  augmentEchartsSpec,
 }: {
   data?: VisData;
   config?: RenderChartConfig;
   timeRange: TimeRange;
   onSelectTimeRange?: (timeRange?: TimeRange) => void;
+  augmentEchartsSpec?: (spec: any, context: { timeRange: TimeRange }) => any;
 }) => {
   if (!data) {
     return null;
@@ -155,11 +162,28 @@ const ChartRender = ({
   const allAxisConfig = getAxisConfigByColumnMapping(axisColumnMappings, standardAxes);
   const styles = { ...config.styles, standardAxes: allAxisConfig };
 
-  return rule.render({
+  const renderedChart = rule.render({
     transformedData: data.transformedData,
     styleOptions: styles,
     axisColumnMappings,
     timeRange,
     onSelectTimeRange,
+  } as any);
+
+  if (
+    !augmentEchartsSpec ||
+    !isValidElement(renderedChart) ||
+    (renderedChart.type !== EchartsRender && renderedChart.type !== MetricChartRender)
+  ) {
+    return renderedChart;
+  }
+
+  const renderedSpec = (renderedChart.props as any)?.spec;
+  if (!renderedSpec) {
+    return renderedChart;
+  }
+
+  return cloneElement(renderedChart, {
+    spec: augmentEchartsSpec(renderedSpec, { timeRange }),
   });
 };

--- a/src/plugins/explore/public/saved_explore/transforms.ts
+++ b/src/plugins/explore/public/saved_explore/transforms.ts
@@ -7,12 +7,17 @@ import { i18n } from '@osd/i18n';
 import { DataView as Dataset, IndexPattern } from 'src/plugins/data/common';
 import { InvalidJSONProperty } from '../../../opensearch_dashboards_utils/public';
 import { LegacyState } from '../application/utils/state_management/slices';
+import {
+  MetricsAlertAssociationState,
+  UIState,
+} from '../application/utils/state_management/slices/ui/ui_slice';
 import { SavedExplore, SavedExploreAttributes } from '../types/saved_explore_types';
 import { TabDefinition } from '../services/tab_registry/tab_registry_service';
 import {
   ChartType,
   StyleOptions,
 } from '../components/visualizations/utils/use_visualization_types';
+import { QueryState } from '../application/utils/state_management/slices/query/query_slice';
 
 export interface ExploreState {
   legacy: LegacyState;
@@ -26,13 +31,44 @@ interface VisState {
   axesMapping?: Record<string, string>;
 }
 
+const normalizePromqlText = (value?: string) => String(value || '').trim();
+
+const getPersistableMetricsAlertAssociation = (
+  uiState?: UIState,
+  queryState?: QueryState
+): MetricsAlertAssociationState | undefined => {
+  const association = uiState?.metricsAlertAssociation;
+  if (!association) {
+    return undefined;
+  }
+
+  const currentQuery = normalizePromqlText(queryState?.query as string | undefined);
+  const currentDataConnectionId = String(queryState?.dataset?.id || '').trim();
+  const currentDataSourceId = String(queryState?.dataset?.dataSource?.id || '').trim();
+
+  if (
+    normalizePromqlText(association.promqlQuery) !== currentQuery ||
+    String(association.dataConnectionId || '').trim() !== currentDataConnectionId
+  ) {
+    return undefined;
+  }
+
+  if (association.dataSourceId && association.dataSourceId !== currentDataSourceId) {
+    return undefined;
+  }
+
+  return association;
+};
+
 export const saveStateToSavedObject = (
   obj: SavedExplore,
   flavorId: string,
   tabDefinition?: TabDefinition,
   visState?: VisState,
   dataset?: IndexPattern | Dataset,
-  activeTabId?: string
+  activeTabId?: string,
+  uiState?: UIState,
+  queryState?: QueryState
 ): SavedExplore => {
   // Serialize the state into the saved object
   obj.type = flavorId;
@@ -47,6 +83,7 @@ export const saveStateToSavedObject = (
 
   obj.uiState = JSON.stringify({
     activeTab: activeTabId || tabDefinition?.id || 'logs',
+    metricsAlertAssociation: getPersistableMetricsAlertAssociation(uiState, queryState),
   });
   obj.searchSourceFields = { index: dataset };
 

--- a/src/plugins/explore/server/plugin.ts
+++ b/src/plugins/explore/server/plugin.ts
@@ -13,6 +13,8 @@ import {
 import { capabilitiesProvider } from './capabilities_provider';
 import { exploreSavedObjectType } from './saved_objects';
 import { exploreUiSettings } from './explore_ui_settings';
+import { registerAnomalyPreviewRoutes } from './routes/anomaly_preview';
+import { registerForecastPreviewRoutes } from './routes/forecast_preview';
 
 import { ExplorePluginSetup, ExplorePluginStart } from './types';
 
@@ -77,6 +79,16 @@ export class ExplorePlugin implements Plugin<ExplorePluginSetup, ExplorePluginSt
     // core.uiSettings.register(uiSettings);
     core.uiSettings.register(exploreUiSettings);
     core.savedObjects.registerType(exploreSavedObjectType);
+
+    const router = core.http.createRouter();
+    registerAnomalyPreviewRoutes({
+      router,
+      logger: this.logger,
+    });
+    registerForecastPreviewRoutes({
+      router,
+      logger: this.logger,
+    });
 
     return {};
   }

--- a/src/plugins/explore/server/routes/anomaly_preview.ts
+++ b/src/plugins/explore/server/routes/anomaly_preview.ts
@@ -119,6 +119,9 @@ export function registerAnomalyPreviewRoutes({
     {
       path: '/api/explore/anomaly_preview',
       validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
         body: schema.object({
           // input points are epoch millis timestamps
           points: schema.arrayOf(
@@ -140,7 +143,12 @@ export function registerAnomalyPreviewRoutes({
       },
     },
     async (context, request, response) => {
-      const client = context.core.opensearch.client.asCurrentUser;
+      const dataSourceId = String(
+        (request.query as { dataSourceId?: string })?.dataSourceId || ''
+      ).trim();
+      const client = dataSourceId
+        ? await context.dataSource.opensearch.getClient(dataSourceId)
+        : context.core.opensearch.client.asCurrentUser;
 
       const {
         points,

--- a/src/plugins/explore/server/routes/anomaly_preview.ts
+++ b/src/plugins/explore/server/routes/anomaly_preview.ts
@@ -1,0 +1,394 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import type { Logger, IRouter } from '../../../../core/server';
+import { fetchPrometheusPreviewPoints } from './preview_points';
+
+const DEFAULT_BUCKET_MILLIS = 60_000; // 1 minute buckets (AD requires minute-level interval)
+const DEFAULT_SHINGLE_SIZE = 8;
+const EXPLORE_MIN_PREVIEW_SIZE = 200;
+const MAX_BUCKETS_TARGET = 10_000;
+const TARGET_BUCKETS = 5_000;
+const BUCKET_CANDIDATES_MILLIS = [
+  60_000, // 1m
+  5 * 60_000, // 5m
+  15 * 60_000, // 15m
+  60 * 60_000, // 1h
+  6 * 60 * 60_000, // 6h
+  24 * 60 * 60_000, // 1d
+];
+
+function createTempIndexName() {
+  // Hidden/system-ish index name. Using timestamp + random suffix to avoid collisions.
+  const suffix = Math.random().toString(16).slice(2, 10);
+  return `.explore-ad-preview-${Date.now()}-${suffix}`;
+}
+
+function bucketize(points: Array<{ ts: number; value: number }>, bucketMillis: number) {
+  const buckets = new Map<number, { sum: number; count: number }>();
+  for (const p of points) {
+    const ts = Number(p.ts);
+    const value = Number(p.value);
+    if (!Number.isFinite(ts) || !Number.isFinite(value)) continue;
+    const b = Math.floor(ts / bucketMillis) * bucketMillis;
+    const cur = buckets.get(b);
+    if (cur) {
+      cur.sum += value;
+      cur.count += 1;
+    } else {
+      buckets.set(b, { sum: value, count: 1 });
+    }
+  }
+  const docs = Array.from(buckets.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([timestamp, agg]) => ({
+      timestamp,
+      value: agg.count > 0 ? agg.sum / agg.count : null,
+    }))
+    .filter((d) => d.value !== null) as Array<{ timestamp: number; value: number }>;
+
+  return docs;
+}
+
+function pickBucketMillis(rangeMillis: number) {
+  if (!Number.isFinite(rangeMillis) || rangeMillis <= 0) return DEFAULT_BUCKET_MILLIS;
+  const raw = Math.ceil(rangeMillis / TARGET_BUCKETS);
+  // pick smallest candidate >= raw
+  for (const c of BUCKET_CANDIDATES_MILLIS) {
+    if (c >= raw) return c;
+  }
+  return BUCKET_CANDIDATES_MILLIS[BUCKET_CANDIDATES_MILLIS.length - 1];
+}
+
+function bucketMillisToPeriod(
+  bucketMillis: number
+): { interval: number; unit: 'Minutes' | 'Hours' | 'Days' } {
+  const MIN = 60_000;
+  const HOUR = 60 * MIN;
+  const DAY = 24 * HOUR;
+  if (bucketMillis % DAY === 0)
+    return { interval: Math.max(1, Math.floor(bucketMillis / DAY)), unit: 'Days' };
+  if (bucketMillis % HOUR === 0)
+    return { interval: Math.max(1, Math.floor(bucketMillis / HOUR)), unit: 'Hours' };
+  return { interval: Math.max(1, Math.floor(bucketMillis / MIN)), unit: 'Minutes' };
+}
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  const normalized = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(normalized) ? normalized : undefined;
+};
+
+export function registerAnomalyPreviewRoutes({
+  router,
+  logger,
+}: {
+  router: IRouter;
+  logger: Logger;
+}) {
+  const callAdPreview = async (client: any, body: any) => {
+    const payload = JSON.stringify(body);
+    const previewPath = `/_plugins/_anomaly_detection/detectors/_preview?min_preview_size=${EXPLORE_MIN_PREVIEW_SIZE}`;
+    const legacyPreviewPath = `/_opendistro/_anomaly_detection/detectors/_preview?min_preview_size=${EXPLORE_MIN_PREVIEW_SIZE}`;
+    // OpenSearch AD plugin path (current)
+    try {
+      return await client.transport.request({
+        method: 'POST',
+        path: previewPath,
+        body: payload,
+      });
+    } catch (e: any) {
+      // Some older clusters (Open Distro) use "/_opendistro/_anomaly_detection".
+      // Always try the legacy path if the primary fails (regardless of error shape).
+      try {
+        return await client.transport.request({
+          method: 'POST',
+          path: legacyPreviewPath,
+          body: payload,
+        });
+      } catch (e2: any) {
+        // throw the original error by default; outer handler will format it.
+        throw e;
+      }
+    }
+  };
+
+  router.post(
+    {
+      path: '/api/explore/anomaly_preview',
+      validate: {
+        body: schema.object({
+          // input points are epoch millis timestamps
+          points: schema.arrayOf(
+            schema.object({
+              ts: schema.number(),
+              value: schema.number(),
+            })
+          ),
+          // optional preview range (epoch millis). If omitted, inferred from points.
+          startTime: schema.maybe(schema.number()),
+          endTime: schema.maybe(schema.number()),
+          // bucket size used before indexing (seconds). Defaults to 60.
+          bucketSizeSeconds: schema.maybe(schema.number()),
+          shingleSize: schema.maybe(schema.number()),
+          promqlQuery: schema.maybe(schema.string()),
+          dataConnectionId: schema.maybe(schema.string()),
+          seriesValue: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = context.core.opensearch.client.asCurrentUser;
+
+      const {
+        points,
+        startTime,
+        endTime,
+        bucketSizeSeconds,
+        shingleSize = DEFAULT_SHINGLE_SIZE,
+        promqlQuery,
+        dataConnectionId,
+        seriesValue,
+      } = request.body as {
+        points: Array<{ ts: number; value: number }>;
+        startTime?: number;
+        endTime?: number;
+        bucketSizeSeconds?: number;
+        shingleSize?: number;
+        promqlQuery?: string;
+        dataConnectionId?: string;
+        seriesValue?: string;
+      };
+
+      if (!points?.length) {
+        return response.badRequest({ body: { message: 'points must be a non-empty array' } });
+      }
+
+      // Determine preview time range (prefer request range; fall back to point bounds).
+      const ptsSorted = [...points].sort((a, b) => a.ts - b.ts);
+      const ptsStart = ptsSorted[0]?.ts;
+      const ptsEnd = ptsSorted[ptsSorted.length - 1]?.ts;
+      const periodStart = Number.isFinite(startTime as number) ? (startTime as number) : ptsStart;
+      const periodEnd = Number.isFinite(endTime as number) ? (endTime as number) : ptsEnd;
+      const rangeMillis =
+        Number.isFinite(periodStart) && Number.isFinite(periodEnd) && periodEnd > periodStart
+          ? periodEnd - periodStart
+          : 0;
+
+      // Compute adaptive bucket size unless explicitly provided.
+      let effectiveBucketMillis = pickBucketMillis(rangeMillis);
+      if (Number.isFinite(bucketSizeSeconds) && (bucketSizeSeconds as number) > 0) {
+        effectiveBucketMillis = Math.max(
+          DEFAULT_BUCKET_MILLIS,
+          Math.floor((bucketSizeSeconds as number) * 1000)
+        );
+      }
+
+      let effectivePoints = points;
+      let prometheusStepSeconds: number | undefined;
+      let pointSource = 'request_points';
+
+      if (
+        promqlQuery &&
+        dataConnectionId &&
+        Number.isFinite(periodStart) &&
+        Number.isFinite(periodEnd) &&
+        periodEnd > periodStart
+      ) {
+        try {
+          const requestedPrometheusStepMillis = Math.max(
+            DEFAULT_BUCKET_MILLIS,
+            effectiveBucketMillis,
+            Math.ceil(rangeMillis / MAX_BUCKETS_TARGET)
+          );
+          const densePointsResult = await fetchPrometheusPreviewPoints({
+            client,
+            promqlQuery,
+            dataConnectionId,
+            startTimeMs: periodStart,
+            endTimeMs: periodEnd,
+            preferredSeries: seriesValue,
+            maxPoints: MAX_BUCKETS_TARGET,
+            stepSeconds: Math.ceil(requestedPrometheusStepMillis / 1000),
+          });
+          if (densePointsResult.points.length > 1) {
+            effectivePoints = densePointsResult.points;
+            prometheusStepSeconds = densePointsResult.stepSeconds;
+            pointSource = 'prometheus_direct_query';
+          }
+        } catch (error: any) {
+          logger.warn(
+            `Explore AD preview dense Prometheus fetch failed, falling back to rendered points: ${
+              error?.message ?? error
+            }`
+          );
+          pointSource = 'request_points_fallback';
+        }
+      }
+
+      if (Number.isFinite(prometheusStepSeconds) && prometheusStepSeconds! > 0) {
+        effectiveBucketMillis = Math.max(
+          effectiveBucketMillis,
+          Math.floor(prometheusStepSeconds! * 1000)
+        );
+      }
+
+      // Bucketize; if still too many buckets, bump up to larger candidates.
+      let docs = bucketize(effectivePoints, effectiveBucketMillis);
+      if (!docs.length) {
+        return response.badRequest({
+          body: { message: 'No valid points to preview after bucketing' },
+        });
+      }
+      while (docs.length > MAX_BUCKETS_TARGET) {
+        const next = BUCKET_CANDIDATES_MILLIS.find((c) => c > effectiveBucketMillis);
+        if (!next) break;
+        effectiveBucketMillis = next;
+        docs = bucketize(effectivePoints, effectiveBucketMillis);
+      }
+
+      const tempIndex = createTempIndexName();
+
+      try {
+        // Create a small hidden index to hold the time-series for preview.
+        await client.indices.create({
+          index: tempIndex,
+          body: {
+            settings: {
+              index: {
+                hidden: true,
+                number_of_shards: 1,
+                number_of_replicas: 0,
+                refresh_interval: -1,
+              },
+            },
+            mappings: {
+              dynamic: false,
+              properties: {
+                timestamp: { type: 'date', format: 'epoch_millis' },
+                value: { type: 'double' },
+              },
+            },
+          },
+        });
+
+        const bulkBody: any[] = [];
+        for (const d of docs) {
+          bulkBody.push({ index: { _index: tempIndex } });
+          bulkBody.push({ timestamp: d.timestamp, value: d.value });
+        }
+        await client.bulk({ body: bulkBody, refresh: true });
+
+        // Call AD Preview Detector API against the temporary index.
+        // See: https://docs.opensearch.org/latest/observing-your-data/ad/api/#preview-detector
+        const previewRequestBody = {
+          period_start: periodStart,
+          period_end: periodEnd,
+          detector: {
+            name: 'explore_ad_preview',
+            description: 'AD preview from Explore Metrics',
+            time_field: 'timestamp',
+            indices: [tempIndex],
+            shingle_size: shingleSize,
+            detection_interval: { period: bucketMillisToPeriod(effectiveBucketMillis) },
+            window_delay: { period: { interval: 0, unit: 'Minutes' } },
+            feature_attributes: [
+              {
+                feature_name: 'value_avg',
+                feature_enabled: true,
+                aggregation_query: {
+                  value_avg: { avg: { field: 'value' } },
+                },
+              },
+            ],
+          },
+        };
+
+        const previewResp = await callAdPreview(client, previewRequestBody);
+        const previewBody = previewResp?.body ?? previewResp;
+        const anomalies = Array.isArray(previewBody?.anomaly_result)
+          ? previewBody.anomaly_result
+          : Array.isArray(previewBody?.anomalies)
+          ? previewBody.anomalies
+          : [];
+        const positiveAnomalyGrades = anomalies
+          .map((anomaly: any) => toFiniteNumber(anomaly?.anomaly_grade) ?? 0)
+          .filter((grade) => grade > 0);
+        const maxAnomalyGrade =
+          positiveAnomalyGrades.length > 0
+            ? Math.max(...positiveAnomalyGrades)
+            : anomalies.length > 0
+            ? Math.max(
+                ...anomalies.map((anomaly: any) => toFiniteNumber(anomaly?.anomaly_grade) ?? 0)
+              )
+            : 0;
+        const anomalyStatus =
+          anomalies.length === 0
+            ? 'empty_preview_rows'
+            : positiveAnomalyGrades.length === 0
+            ? 'no_positive_anomalies'
+            : 'positive_anomalies_found';
+
+        return response.ok({
+          body: {
+            ok: true,
+            response: previewBody,
+            meta: {
+              bucketSizeMillis: effectiveBucketMillis,
+              pointsIn: effectivePoints.length,
+              pointsBucketed: docs.length,
+              pointSource,
+              prometheusStepSeconds,
+              anomalyResultCount: anomalies.length,
+              positiveAnomalyCount: positiveAnomalyGrades.length,
+              maxAnomalyGrade,
+              anomalyStatus,
+              minPreviewSize: EXPLORE_MIN_PREVIEW_SIZE,
+              // helpful for client-side tooltip bucketing
+              detectionInterval: bucketMillisToPeriod(effectiveBucketMillis),
+            },
+          },
+        });
+      } catch (e: any) {
+        logger.error(`Explore AD preview failed: ${e?.message ?? e}`);
+        // Return 200 with ok:false so the UI can display the detailed AD error message
+        // without the HTTP client throwing a generic "Response Error".
+        const errBody = e?.body;
+        const errBodyStr =
+          typeof errBody === 'string' ? errBody : errBody ? JSON.stringify(errBody) : '';
+        const errMsg =
+          e?.body?.error?.reason ??
+          e?.body?.error?.root_cause?.[0]?.reason ??
+          e?.body?.error?.type ??
+          (errBodyStr || undefined) ??
+          e?.message ??
+          'Failed to preview anomalies';
+        const looksLikeNoHandler =
+          (typeof errMsg === 'string' &&
+            (errMsg.includes('no handler found for uri') || errMsg.includes('no handler found'))) ||
+          (typeof errBodyStr === 'string' &&
+            (errBodyStr.includes('no handler found for uri') ||
+              errBodyStr.includes('no handler found')));
+
+        return response.ok({
+          body: {
+            ok: false,
+            message: looksLikeNoHandler
+              ? 'Anomaly Detection plugin endpoint not found on this OpenSearch cluster. Ensure the AD plugin is installed/enabled.'
+              : errMsg,
+            details: e?.body?.error ?? e?.body ?? undefined,
+          },
+        });
+      } finally {
+        try {
+          await client.indices.delete({ index: tempIndex });
+        } catch (e: any) {
+          // Best-effort cleanup
+          logger.debug(`Explore AD preview cleanup failed for ${tempIndex}: ${e?.message ?? e}`);
+        }
+      }
+    }
+  );
+}

--- a/src/plugins/explore/server/routes/forecast_preview.ts
+++ b/src/plugins/explore/server/routes/forecast_preview.ts
@@ -301,6 +301,9 @@ export function registerForecastPreviewRoutes({
     {
       path: '/api/explore/forecast_preview',
       validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
         body: schema.object({
           points: schema.arrayOf(
             schema.object({
@@ -320,7 +323,12 @@ export function registerForecastPreviewRoutes({
       },
     },
     async (context, request, response) => {
-      const client = context.core.opensearch.client.asCurrentUser;
+      const dataSourceId = String(
+        (request.query as { dataSourceId?: string })?.dataSourceId || ''
+      ).trim();
+      const client = dataSourceId
+        ? await context.dataSource.opensearch.getClient(dataSourceId)
+        : context.core.opensearch.client.asCurrentUser;
       const {
         points,
         startTime,

--- a/src/plugins/explore/server/routes/forecast_preview.ts
+++ b/src/plugins/explore/server/routes/forecast_preview.ts
@@ -1,0 +1,762 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import type { Logger, IRouter } from '../../../../core/server';
+import { fetchPrometheusPreviewPoints } from './preview_points';
+
+const DEFAULT_BUCKET_MILLIS = 60_000;
+const DEFAULT_SHINGLE_SIZE = 8;
+const MAX_BUCKETS_TARGET = 10_000;
+const TARGET_BUCKETS = 5_000;
+const MIN_DEFAULT_HORIZON_BUCKETS = 12;
+const MAX_DEFAULT_HORIZON_BUCKETS = 72;
+const MIN_BUCKETS_FOR_PROMQL_INTERVAL = 60;
+const BUCKET_CANDIDATES_MILLIS = [
+  60_000, // 1m
+  5 * 60_000, // 5m
+  15 * 60_000, // 15m
+  60 * 60_000, // 1h
+  6 * 60 * 60_000, // 6h
+  24 * 60 * 60_000, // 1d
+];
+const PROMQL_DURATION_TO_MILLIS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 60 * 60_000,
+  d: 24 * 60 * 60_000,
+  w: 7 * 24 * 60 * 60_000,
+  y: 365 * 24 * 60 * 60_000,
+};
+
+function createTempIndexName() {
+  const suffix = Math.random().toString(16).slice(2, 10);
+  return `.explore-forecast-preview-${Date.now()}-${suffix}`;
+}
+
+function createTempForecasterName() {
+  const suffix = Math.random().toString(16).slice(2, 10);
+  return `explore_forecast_preview_${Date.now()}_${suffix}`;
+}
+
+function parsePromqlDurationMillis(durationText?: string) {
+  if (!durationText) return undefined;
+
+  const normalized = durationText.trim();
+  if (!normalized) return undefined;
+
+  const parts = Array.from(normalized.matchAll(/(\d+)(ms|s|m|h|d|w|y)/g));
+  if (parts.length === 0) return undefined;
+
+  let lastIndex = 0;
+  let totalMillis = 0;
+  for (const part of parts) {
+    const [token, amountText, unit] = part;
+    if (part.index !== lastIndex) {
+      return undefined;
+    }
+    totalMillis += Number(amountText) * PROMQL_DURATION_TO_MILLIS[unit];
+    lastIndex += token.length;
+  }
+
+  if (lastIndex !== normalized.length || totalMillis <= 0) {
+    return undefined;
+  }
+
+  return totalMillis;
+}
+
+function parsePromqlRangeVectorMillis(promqlQuery?: string) {
+  if (!promqlQuery) return undefined;
+
+  const bracketMatches = Array.from(promqlQuery.matchAll(/\[([^\]]+)\]/g));
+  if (bracketMatches.length === 0) return undefined;
+
+  for (let index = bracketMatches.length - 1; index >= 0; index -= 1) {
+    const rawBracketContent = bracketMatches[index]?.[1]?.trim();
+    if (!rawBracketContent) continue;
+
+    // Support both range vectors like [5m] and subqueries like [5m:1m].
+    const rangePart = rawBracketContent.split(':')[0]?.trim();
+    const rangeMillis = parsePromqlDurationMillis(rangePart);
+    if (rangeMillis !== undefined) {
+      return rangeMillis;
+    }
+  }
+
+  return undefined;
+}
+
+function formatDurationForMessage(durationMillis?: number) {
+  if (!Number.isFinite(durationMillis) || durationMillis == null || durationMillis <= 0) {
+    return undefined;
+  }
+
+  const duration = Math.round(durationMillis);
+  const SECOND = 1000;
+  const MINUTE = 60 * SECOND;
+  const HOUR = 60 * MINUTE;
+  const DAY = 24 * HOUR;
+
+  if (duration % DAY === 0) {
+    return `${duration / DAY}d`;
+  }
+  if (duration % HOUR === 0) {
+    return `${duration / HOUR}h`;
+  }
+  if (duration % MINUTE === 0) {
+    return `${duration / MINUTE}m`;
+  }
+  if (duration % SECOND === 0) {
+    return `${duration / SECOND}s`;
+  }
+
+  return `${duration}ms`;
+}
+
+function buildForecastPreviewGuidance(rangeMillis: number, promqlLookbackMillis?: number) {
+  const lookbackLabel = formatDurationForMessage(promqlLookbackMillis);
+  const rangeLabel = formatDurationForMessage(rangeMillis);
+
+  if (
+    Number.isFinite(promqlLookbackMillis) &&
+    promqlLookbackMillis != null &&
+    promqlLookbackMillis > 0 &&
+    Number.isFinite(rangeMillis) &&
+    rangeMillis > 0
+  ) {
+    const recommendedRangeMillis = Math.max(60 * 60_000, promqlLookbackMillis * 3);
+    const recommendedRangeLabel = formatDurationForMessage(recommendedRangeMillis);
+
+    if (rangeMillis <= promqlLookbackMillis) {
+      return `This query uses a [${lookbackLabel}] PromQL window, but the selected time range is only ${rangeLabel}. Forecast preview needs a wider history window. Try a time range of at least ${recommendedRangeLabel}.`;
+    }
+
+    if (rangeMillis < promqlLookbackMillis * 3) {
+      return `This query uses a [${lookbackLabel}] PromQL window, and the selected time range (${rangeLabel}) does not leave enough history for reliable forecast preview. Try a wider range such as ${recommendedRangeLabel} or longer.`;
+    }
+
+    if (promqlLookbackMillis < 20 * 60_000) {
+      return 'Try widening the time range, using a smoother PromQL window such as [20m], or choosing a steadier metric.';
+    }
+
+    return 'Try widening the time range or choosing a steadier metric.';
+  }
+
+  return 'Try widening the time range, using a smoother PromQL window such as [20m], or choosing a steadier metric.';
+}
+
+function bucketize(points: Array<{ ts: number; value: number }>, bucketMillis: number) {
+  const buckets = new Map<number, { sum: number; count: number }>();
+  for (const p of points) {
+    const ts = Number(p.ts);
+    const value = Number(p.value);
+    if (!Number.isFinite(ts) || !Number.isFinite(value)) continue;
+    const b = Math.floor(ts / bucketMillis) * bucketMillis;
+    const cur = buckets.get(b);
+    if (cur) {
+      cur.sum += value;
+      cur.count += 1;
+    } else {
+      buckets.set(b, { sum: value, count: 1 });
+    }
+  }
+  return Array.from(buckets.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([timestamp, agg]) => ({
+      timestamp,
+      value: agg.count > 0 ? agg.sum / agg.count : null,
+    }))
+    .filter((d) => d.value !== null) as Array<{ timestamp: number; value: number }>;
+}
+
+function pickBucketMillis(rangeMillis: number) {
+  if (!Number.isFinite(rangeMillis) || rangeMillis <= 0) return DEFAULT_BUCKET_MILLIS;
+  const raw = Math.ceil(rangeMillis / TARGET_BUCKETS);
+  for (const c of BUCKET_CANDIDATES_MILLIS) {
+    if (c >= raw) return c;
+  }
+  return BUCKET_CANDIDATES_MILLIS[BUCKET_CANDIDATES_MILLIS.length - 1];
+}
+
+function bucketMillisToPeriod(
+  bucketMillis: number
+): { interval: number; unit: 'Minutes' | 'Seconds' } {
+  const MIN = 60_000;
+  const SECOND = 1_000;
+  if (bucketMillis < MIN) {
+    return { interval: Math.max(1, Math.ceil(bucketMillis / SECOND)), unit: 'Seconds' };
+  }
+  return { interval: Math.max(1, Math.ceil(bucketMillis / MIN)), unit: 'Minutes' };
+}
+
+async function transportRequest(client: any, opts: { method: string; path: string; body?: any }) {
+  const body = opts.body === undefined ? undefined : JSON.stringify(opts.body);
+  return await client.transport.request({
+    method: opts.method,
+    path: opts.path,
+    ...(body !== undefined ? { body } : {}),
+  });
+}
+
+function looksLikeNoHandler(e: any) {
+  const b = e?.body;
+  const s = typeof b === 'string' ? b : b ? JSON.stringify(b) : '';
+  const msg = e?.message ?? '';
+  const combined = `${s}\n${msg}`;
+  return combined.includes('no handler found for uri') || combined.includes('no handler found');
+}
+
+async function callForecastPreview(client: any, body: any) {
+  try {
+    return await transportRequest(client, {
+      method: 'POST',
+      path: '/_plugins/_forecast/forecasters/_preview',
+      body,
+    });
+  } catch (e: any) {
+    try {
+      return await transportRequest(client, {
+        method: 'POST',
+        path: '/_opendistro/_forecast/forecasters/_preview',
+        body,
+      });
+    } catch (_legacyError: any) {
+      throw e;
+    }
+  }
+}
+
+function normalizeForecastPreviewErrorMessage(
+  rawMessage?: string,
+  options?: { rangeMillis?: number; promqlLookbackMillis?: number }
+) {
+  const normalized = rawMessage?.trim();
+  if (!normalized) {
+    return 'Forecast preview failed.';
+  }
+
+  if (
+    normalized.includes('No data to preview anomaly detection.') ||
+    normalized.includes('No data available for preview.')
+  ) {
+    return `Forecast preview is unavailable for this metric and time range because there are not enough usable forecast samples after preview processing. ${buildForecastPreviewGuidance(
+      options?.rangeMillis ?? 0,
+      options?.promqlLookbackMillis
+    )}`;
+  }
+
+  if (/Time unit .* is not supported/i.test(normalized)) {
+    return 'Forecast preview selected an unsupported interval for this metric. Refresh the page and retry.';
+  }
+
+  return normalized;
+}
+
+function normalizeForecastPreviewErrorDetails(rawDetails: any, normalizedMessage: string) {
+  if (!rawDetails) {
+    return undefined;
+  }
+
+  if (typeof rawDetails === 'string') {
+    return normalizedMessage;
+  }
+
+  if (typeof rawDetails !== 'object') {
+    return rawDetails;
+  }
+
+  const rewriteReason = (details: any) => {
+    if (!details || typeof details !== 'object') {
+      return details;
+    }
+
+    return {
+      ...details,
+      ...(typeof details.reason === 'string' ? { reason: normalizedMessage } : {}),
+    };
+  };
+
+  return {
+    ...rewriteReason(rawDetails),
+    ...(Array.isArray(rawDetails.root_cause)
+      ? {
+          root_cause: rawDetails.root_cause.map((cause: any) => rewriteReason(cause)),
+        }
+      : {}),
+  };
+}
+
+export function registerForecastPreviewRoutes({
+  router,
+  logger,
+}: {
+  router: IRouter;
+  logger: Logger;
+}) {
+  router.post(
+    {
+      path: '/api/explore/forecast_preview',
+      validate: {
+        body: schema.object({
+          points: schema.arrayOf(
+            schema.object({
+              ts: schema.number(),
+              value: schema.number(),
+            })
+          ),
+          startTime: schema.maybe(schema.number()),
+          endTime: schema.maybe(schema.number()),
+          bucketSizeSeconds: schema.maybe(schema.number()),
+          shingleSize: schema.maybe(schema.number()),
+          horizon: schema.maybe(schema.number()),
+          promqlQuery: schema.maybe(schema.string()),
+          dataConnectionId: schema.maybe(schema.string()),
+          seriesValue: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = context.core.opensearch.client.asCurrentUser;
+      const {
+        points,
+        startTime,
+        endTime,
+        bucketSizeSeconds,
+        shingleSize = DEFAULT_SHINGLE_SIZE,
+        horizon,
+        promqlQuery,
+        dataConnectionId,
+        seriesValue,
+      } = request.body as any;
+      const promqlLookbackMillis = parsePromqlRangeVectorMillis(promqlQuery);
+
+      if (!points?.length) {
+        return response.ok({ body: { ok: false, message: 'points must be non-empty' } });
+      }
+
+      const ptsSorted = [...points].sort((a, b) => a.ts - b.ts);
+      const ptsStart = ptsSorted[0]?.ts;
+      const ptsEnd = ptsSorted[ptsSorted.length - 1]?.ts;
+      const periodStart = Number.isFinite(startTime) ? startTime : ptsStart;
+      const periodEnd = Number.isFinite(endTime) ? endTime : ptsEnd;
+      const rangeMillis =
+        Number.isFinite(periodStart) && Number.isFinite(periodEnd) && periodEnd > periodStart
+          ? periodEnd - periodStart
+          : 0;
+      const promqlIntervalBucketCount =
+        promqlLookbackMillis && promqlLookbackMillis > 0
+          ? Math.floor(rangeMillis / promqlLookbackMillis)
+          : 0;
+      const defaultBucketMillis = pickBucketMillis(rangeMillis);
+      let effectiveBucketMillis =
+        promqlLookbackMillis && promqlIntervalBucketCount >= MIN_BUCKETS_FOR_PROMQL_INTERVAL
+          ? promqlLookbackMillis
+          : defaultBucketMillis;
+      if (Number.isFinite(bucketSizeSeconds) && bucketSizeSeconds > 0) {
+        effectiveBucketMillis = Math.max(
+          DEFAULT_BUCKET_MILLIS,
+          Math.floor(bucketSizeSeconds * 1000)
+        );
+      }
+
+      let effectivePoints = points;
+      let prometheusStepSeconds: number | undefined;
+      let pointSource = 'request_points';
+      const buildPrePreviewMeta = (extra?: Record<string, unknown>) => ({
+        executionMode: 'forecast_preview_api',
+        periodStart,
+        periodEnd,
+        requestedPointsIn: points.length,
+        pointsIn: effectivePoints.length,
+        pointSource,
+        prometheusStepSeconds,
+        promqlLookbackMillis,
+        promqlIntervalBucketCount,
+        ...extra,
+      });
+
+      if (promqlQuery) {
+        if (!dataConnectionId) {
+          pointSource = 'prometheus_direct_query_unavailable';
+          return response.ok({
+            body: {
+              ok: false,
+              message:
+                'Forecast preview requires a Prometheus datasource connection for this query. Reopen the metric with a valid Prometheus datasource and try again.',
+              meta: buildPrePreviewMeta({
+                errorMessage:
+                  'Forecast preview requires a Prometheus datasource connection for this query. Reopen the metric with a valid Prometheus datasource and try again.',
+                errorType: 'missing_data_connection_id',
+              }),
+            },
+          });
+        }
+
+        if (
+          !Number.isFinite(periodStart) ||
+          !Number.isFinite(periodEnd) ||
+          periodEnd <= periodStart
+        ) {
+          pointSource = 'prometheus_direct_query_unavailable';
+          return response.ok({
+            body: {
+              ok: false,
+              message:
+                'Forecast preview could not determine a valid time range for direct Prometheus sampling. Adjust the metric time picker and try again.',
+              meta: buildPrePreviewMeta({
+                errorMessage:
+                  'Forecast preview could not determine a valid time range for direct Prometheus sampling. Adjust the metric time picker and try again.',
+                errorType: 'invalid_preview_time_range',
+              }),
+            },
+          });
+        }
+
+        try {
+          const requestedPrometheusStepMillis = Math.max(
+            DEFAULT_BUCKET_MILLIS,
+            effectiveBucketMillis,
+            Math.ceil(rangeMillis / MAX_BUCKETS_TARGET)
+          );
+          const densePointsResult = await fetchPrometheusPreviewPoints({
+            client,
+            promqlQuery,
+            dataConnectionId,
+            startTimeMs: periodStart,
+            endTimeMs: periodEnd,
+            preferredSeries: seriesValue,
+            maxPoints: MAX_BUCKETS_TARGET,
+            stepSeconds: Math.ceil(requestedPrometheusStepMillis / 1000),
+          });
+          if (densePointsResult.points.length > 1) {
+            effectivePoints = densePointsResult.points;
+            prometheusStepSeconds = densePointsResult.stepSeconds;
+            pointSource = 'prometheus_direct_query';
+          } else {
+            pointSource = 'prometheus_direct_query_empty';
+            prometheusStepSeconds = densePointsResult.stepSeconds;
+            effectivePoints = densePointsResult.points;
+            return response.ok({
+              body: {
+                ok: false,
+                message: `Forecast preview could not load enough metric datapoints directly from Prometheus for the selected time range. ${buildForecastPreviewGuidance(
+                  rangeMillis,
+                  promqlLookbackMillis
+                )}`,
+                meta: buildPrePreviewMeta({
+                  errorMessage: `Forecast preview could not load enough metric datapoints directly from Prometheus for the selected time range. ${buildForecastPreviewGuidance(
+                    rangeMillis,
+                    promqlLookbackMillis
+                  )}`,
+                  errorType: 'insufficient_prometheus_preview_points',
+                }),
+              },
+            });
+          }
+        } catch (error: any) {
+          logger.warn(
+            `Explore Forecast preview dense Prometheus fetch failed: ${error?.message ?? error}`
+          );
+          pointSource = 'prometheus_direct_query_failed';
+          return response.ok({
+            body: {
+              ok: false,
+              message: `Forecast preview could not load metric data directly from Prometheus for the selected time range. Check the datasource connection. ${buildForecastPreviewGuidance(
+                rangeMillis,
+                promqlLookbackMillis
+              )}`,
+              details: error?.body?.error ?? error?.body ?? error?.message,
+              meta: buildPrePreviewMeta({
+                errorMessage: `Forecast preview could not load metric data directly from Prometheus for the selected time range. Check the datasource connection. ${buildForecastPreviewGuidance(
+                  rangeMillis,
+                  promqlLookbackMillis
+                )}`,
+                errorType:
+                  error?.body?.error?.type ??
+                  error?.body?.type ??
+                  (typeof error?.message === 'string'
+                    ? 'prometheus_direct_query_failed'
+                    : undefined),
+              }),
+            },
+          });
+        }
+      }
+
+      if (Number.isFinite(prometheusStepSeconds) && prometheusStepSeconds! > 0) {
+        effectiveBucketMillis = Math.max(
+          effectiveBucketMillis,
+          Math.floor(prometheusStepSeconds! * 1000)
+        );
+      }
+
+      let docs = bucketize(effectivePoints, effectiveBucketMillis);
+      while (docs.length > MAX_BUCKETS_TARGET) {
+        const next = BUCKET_CANDIDATES_MILLIS.find((c) => c > effectiveBucketMillis);
+        if (!next) break;
+        effectiveBucketMillis = next;
+        docs = bucketize(effectivePoints, effectiveBucketMillis);
+      }
+      if (!docs.length) {
+        return response.ok({
+          body: { ok: false, message: 'No valid points to preview after bucketing' },
+        });
+      }
+
+      const period = bucketMillisToPeriod(effectiveBucketMillis);
+      const lastObservedPointTime =
+        effectivePoints.length > 0
+          ? Number(effectivePoints[effectivePoints.length - 1]?.ts)
+          : Number.NaN;
+      const horizonBuckets =
+        Number.isFinite(horizon) && horizon > 0
+          ? Math.floor(horizon)
+          : Math.max(
+              MIN_DEFAULT_HORIZON_BUCKETS,
+              Math.min(MAX_DEFAULT_HORIZON_BUCKETS, Math.ceil(docs.length * 0.2))
+            );
+      const buildPreviewMeta = (extra?: Record<string, unknown>) => ({
+        executionMode: 'forecast_preview_api',
+        periodStart,
+        periodEnd,
+        requestedPointsIn: points.length,
+        pointsIn: effectivePoints.length,
+        pointsBucketed: docs.length,
+        bucketSizeMillis: effectiveBucketMillis,
+        forecastInterval: period,
+        horizon: horizonBuckets,
+        pointSource,
+        prometheusStepSeconds,
+        lastObservedPointTime,
+        promqlLookbackMillis,
+        promqlIntervalBucketCount,
+        usedPromqlLookbackInterval:
+          promqlLookbackMillis != null &&
+          promqlLookbackMillis > 0 &&
+          effectiveBucketMillis === promqlLookbackMillis,
+        ...extra,
+      });
+
+      const tempIndex = createTempIndexName();
+
+      try {
+        // Create hidden temp index
+        await client.indices.create({
+          index: tempIndex,
+          body: {
+            settings: {
+              index: {
+                hidden: true,
+                number_of_shards: 1,
+                number_of_replicas: 0,
+                refresh_interval: -1,
+              },
+            },
+            mappings: {
+              dynamic: false,
+              properties: {
+                timestamp: { type: 'date', format: 'epoch_millis' },
+                value: { type: 'double' },
+              },
+            },
+          },
+        });
+
+        const bulkBody: any[] = [];
+        for (const d of docs) {
+          bulkBody.push({ index: { _index: tempIndex } });
+          bulkBody.push({ timestamp: d.timestamp, value: d.value });
+        }
+        await client.bulk({ body: bulkBody, refresh: true });
+
+        // Use inline forecaster + preview API so no forecaster config resource is created.
+        const previewRequestBody = {
+          period_start: periodStart,
+          period_end: periodEnd,
+          forecaster: {
+            name: createTempForecasterName(),
+            description: 'Forecast preview from Explore Metrics',
+            time_field: 'timestamp',
+            indices: [tempIndex],
+            filter_query: { match_all: {} },
+            feature_attributes: [
+              {
+                feature_name: 'value_avg',
+                feature_enabled: true,
+                aggregation_query: {
+                  value_avg: { avg: { field: 'value' } },
+                },
+              },
+            ],
+            forecast_interval: { period },
+            window_delay: { period: { interval: 0, unit: 'Minutes' } },
+            shingle_size: shingleSize,
+            horizon: horizonBuckets,
+          },
+        };
+
+        let previewResp: any;
+        try {
+          previewResp = await callForecastPreview(client, previewRequestBody);
+        } catch (e: any) {
+          if (looksLikeNoHandler(e)) {
+            const normalizedMessage =
+              'Forecasting preview endpoint not found on this OpenSearch cluster. Install/enable the Forecast plugin to use preview.';
+            return response.ok({
+              body: {
+                ok: false,
+                message: normalizedMessage,
+                details: e?.body ?? e?.message,
+                meta: buildPreviewMeta({
+                  errorMessage: normalizedMessage,
+                  errorType: e?.body?.error?.type,
+                }),
+              },
+            });
+          }
+          throw e;
+        }
+
+        const rawForecastResult =
+          previewResp?.body?.forecast_result ?? previewResp?.forecast_result ?? [];
+        const toNum = (x: any) => (x != null && x !== 'NaN' ? Number(x) : NaN);
+        const parsedForecastRows = (Array.isArray(rawForecastResult) ? rawForecastResult : [])
+          .map((item: any) => {
+            const tt = Number(
+              item?.forecast_data_end_time ??
+                item?.forecast_data_start_time ??
+                item?.data_end_time ??
+                item?.data_start_time
+            );
+            const baseDataEndTime = Number(item?.data_end_time ?? item?.data_start_time);
+            const vv = toNum(item?.forecast_value);
+            const ll = toNum(item?.forecast_lower_bound);
+            const hh = toNum(item?.forecast_upper_bound);
+            if (!Number.isFinite(tt) || !Number.isFinite(vv)) return null;
+            return {
+              baseDataEndTime,
+              t: tt,
+              v: vv,
+              lo: Number.isFinite(ll) ? ll : undefined,
+              hi: Number.isFinite(hh) ? hh : undefined,
+            };
+          })
+          .filter(Boolean)
+          .sort((a: any, b: any) => a.t - b.t);
+        const latestForecastBaseEndTime = parsedForecastRows.reduce(
+          (max: number, point: any) =>
+            Number.isFinite(point?.baseDataEndTime) && point.baseDataEndTime > max
+              ? point.baseDataEndTime
+              : max,
+          Number.NEGATIVE_INFINITY
+        );
+        const latestForecastBlock = parsedForecastRows.filter(
+          (point: any) =>
+            Number.isFinite(latestForecastBaseEndTime) &&
+            point?.baseDataEndTime === latestForecastBaseEndTime
+        );
+        const latestFutureForecastBlock = latestForecastBlock.filter(
+          (point: any) => !Number.isFinite(lastObservedPointTime) || point.t > lastObservedPointTime
+        );
+        const fallbackFutureForecastPoints = parsedForecastRows.filter(
+          (point: any) => !Number.isFinite(lastObservedPointTime) || point.t > lastObservedPointTime
+        );
+        const forecastPoints =
+          latestFutureForecastBlock.length > 0
+            ? latestFutureForecastBlock
+            : latestForecastBlock.length > 0
+            ? latestForecastBlock
+            : fallbackFutureForecastPoints;
+
+        if (
+          Array.isArray(rawForecastResult) &&
+          rawForecastResult.length > 0 &&
+          parsedForecastRows.length === 0
+        ) {
+          return response.ok({
+            body: {
+              ok: false,
+              message: `Forecast preview did not produce any future forecast samples for this metric and time range. ${buildForecastPreviewGuidance(
+                rangeMillis,
+                promqlLookbackMillis
+              )}`,
+              response: {
+                periodStart,
+                periodEnd,
+                points: [],
+                forecast_result: rawForecastResult,
+              },
+              meta: buildPreviewMeta({
+                forecastResultCount: rawForecastResult.length,
+                forecastRowsWithValue: 0,
+                errorMessage: `Forecast preview did not produce any future forecast samples for this metric and time range. ${buildForecastPreviewGuidance(
+                  rangeMillis,
+                  promqlLookbackMillis
+                )}`,
+                errorType: 'no_forecast_values',
+              }),
+            },
+          });
+        }
+
+        return response.ok({
+          body: {
+            ok: true,
+            response: {
+              periodStart,
+              periodEnd,
+              points: forecastPoints,
+              forecast_result: rawForecastResult,
+            },
+            meta: buildPreviewMeta({
+              forecastResultCount: Array.isArray(rawForecastResult) ? rawForecastResult.length : 0,
+              forecastRowsWithValue: parsedForecastRows.length,
+              latestForecastBaseEndTime: Number.isFinite(latestForecastBaseEndTime)
+                ? latestForecastBaseEndTime
+                : undefined,
+            }),
+          },
+        });
+      } catch (e: any) {
+        logger.error(`Explore Forecast preview failed: ${e?.message ?? e}`);
+        const rawErrorMessage =
+          e?.body?.error?.reason ??
+          e?.body?.error?.root_cause?.[0]?.reason ??
+          e?.body?.error?.type ??
+          (typeof e?.body === 'string' ? e.body : undefined) ??
+          e?.message;
+        const normalizedMessage = normalizeForecastPreviewErrorMessage(rawErrorMessage, {
+          rangeMillis,
+          promqlLookbackMillis,
+        });
+        return response.ok({
+          body: {
+            ok: false,
+            message: normalizedMessage,
+            details: normalizeForecastPreviewErrorDetails(
+              e?.body?.error ?? e?.body ?? undefined,
+              normalizedMessage
+            ),
+            meta: buildPreviewMeta({
+              errorMessage: normalizedMessage,
+              errorType: e?.body?.error?.type,
+            }),
+          },
+        });
+      } finally {
+        // Best-effort cleanup
+        try {
+          await client.indices.delete({ index: tempIndex });
+        } catch (e: any) {
+          logger.debug(
+            `Explore Forecast preview cleanup failed for ${tempIndex}: ${e?.message ?? e}`
+          );
+        }
+      }
+    }
+  );
+}

--- a/src/plugins/explore/server/routes/preview_points.ts
+++ b/src/plugins/explore/server/routes/preview_points.ts
@@ -1,0 +1,324 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const MAX_PREVIEW_DATAPOINTS = 500;
+const MIN_PROMETHEUS_STEP_SECONDS = 60;
+const TARGET_PREVIEW_DATAPOINTS = 500;
+
+export interface PreviewPoint {
+  ts: number;
+  value: number;
+}
+
+interface FetchPrometheusPreviewPointsArgs {
+  client: any;
+  promqlQuery: string;
+  dataConnectionId: string;
+  startTimeMs: number;
+  endTimeMs: number;
+  preferredSeries?: string;
+  maxPoints?: number;
+  stepSeconds?: number;
+  targetDatapoints?: number;
+}
+
+interface FetchPrometheusPreviewPointsResult {
+  points: PreviewPoint[];
+  selectedSeries?: string;
+  stepSeconds: number;
+}
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  const normalized = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(normalized) ? normalized : undefined;
+};
+
+const downsamplePreviewPoints = (
+  points: PreviewPoint[],
+  maxPoints: number = MAX_PREVIEW_DATAPOINTS
+): PreviewPoint[] => {
+  if (points.length <= maxPoints) {
+    return points;
+  }
+
+  const step = (points.length - 1) / (maxPoints - 1);
+  const sampled = Array.from({ length: maxPoints }, (_, index) => {
+    const pointIndex = Math.floor(index * step);
+    return points[Math.min(pointIndex, points.length - 1)];
+  });
+
+  sampled[sampled.length - 1] = points[points.length - 1];
+  return sampled;
+};
+
+const buildPrometheusStepSeconds = (
+  startTimeMs: number,
+  endTimeMs: number,
+  targetDatapoints: number = TARGET_PREVIEW_DATAPOINTS
+): number => {
+  const rangeMillis = Math.max(0, endTimeMs - startTimeMs);
+  const safeTarget = Math.max(1, Math.floor(targetDatapoints));
+  const rawStepSeconds = Math.ceil(rangeMillis / safeTarget / 1000);
+  return Math.max(MIN_PROMETHEUS_STEP_SECONDS, rawStepSeconds || MIN_PROMETHEUS_STEP_SECONDS);
+};
+
+const extractPayload = (response: any) => response?.body ?? response;
+
+const normalizeSeriesToken = (value: unknown): string =>
+  String(value ?? '')
+    .trim()
+    .replace(/\s+/g, '')
+    .replace(/["']/g, '');
+
+const buildMetricSeriesCandidates = (metric: Record<string, unknown>): string[] => {
+  const entries = Object.entries(metric ?? {}).filter(
+    ([key, value]) => key != null && value != null && String(value).trim() !== ''
+  );
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const sortedEntries = [...entries].sort(([leftKey], [rightKey]) =>
+    leftKey.localeCompare(rightKey)
+  );
+  const quotedPairs = sortedEntries.map(([key, value]) => `${key}="${value}"`);
+  const plainPairs = sortedEntries.map(([key, value]) => `${key}=${value}`);
+  const metricName = metric.__name__ != null ? String(metric.__name__) : '';
+  const labelsWithoutName = sortedEntries.filter(([key]) => key !== '__name__');
+  const quotedLabelPairs = labelsWithoutName.map(([key, value]) => `${key}="${value}"`);
+
+  return Array.from(
+    new Set(
+      [
+        JSON.stringify(metric),
+        plainPairs.join(','),
+        quotedPairs.join(','),
+        `{${quotedPairs.join(',')}}`,
+        metricName && quotedLabelPairs.length > 0
+          ? `${metricName}{${quotedLabelPairs.join(',')}}`
+          : undefined,
+        metricName || undefined,
+      ].filter((candidate): candidate is string => Boolean(candidate && candidate.trim()))
+    )
+  );
+};
+
+const selectSeries = <T extends { candidates: string[]; points: PreviewPoint[]; label?: string }>(
+  seriesList: T[],
+  preferredSeries?: string
+): T | undefined => {
+  if (seriesList.length === 0) {
+    return undefined;
+  }
+
+  if (preferredSeries) {
+    const normalizedPreferred = normalizeSeriesToken(preferredSeries);
+    const exactMatch = seriesList.find((series) =>
+      series.candidates.some((candidate) => normalizeSeriesToken(candidate) === normalizedPreferred)
+    );
+    if (exactMatch) {
+      return exactMatch;
+    }
+  }
+
+  return seriesList.find((series) => series.points.length > 0) ?? seriesList[0];
+};
+
+const parsePrometheusMatrixOrVector = (
+  payload: any,
+  dataConnectionId: string,
+  preferredSeries?: string,
+  maxPoints: number = MAX_PREVIEW_DATAPOINTS
+): FetchPrometheusPreviewPointsResult | undefined => {
+  const results = payload?.results;
+  if (!results || typeof results !== 'object') {
+    return undefined;
+  }
+
+  const dataSourceResult =
+    results?.[dataConnectionId] ??
+    Object.values(results).find((candidate) => candidate && typeof candidate === 'object');
+  const resultType = dataSourceResult?.resultType;
+  const rawResult = Array.isArray(dataSourceResult?.result) ? dataSourceResult.result : undefined;
+
+  if (!rawResult || (resultType !== 'matrix' && resultType !== 'vector')) {
+    return undefined;
+  }
+
+  const seriesList = rawResult.map((series: any) => {
+    const metric = series?.metric && typeof series.metric === 'object' ? series.metric : {};
+    const candidates = buildMetricSeriesCandidates(metric);
+    const rawValues =
+      resultType === 'vector'
+        ? series?.value != null
+          ? [series.value]
+          : []
+        : Array.isArray(series?.values)
+        ? series.values
+        : [];
+    const points = rawValues
+      .map((valuePair: any) => {
+        if (!Array.isArray(valuePair) || valuePair.length < 2) {
+          return null;
+        }
+        const timestampSeconds = toFiniteNumber(valuePair[0]);
+        const value = toFiniteNumber(valuePair[1]);
+        if (timestampSeconds === undefined || value === undefined) {
+          return null;
+        }
+        return {
+          ts: timestampSeconds * 1000,
+          value,
+        };
+      })
+      .filter((point): point is PreviewPoint => Boolean(point))
+      .sort((left, right) => left.ts - right.ts);
+
+    return {
+      label: candidates[0],
+      candidates,
+      points,
+    };
+  });
+
+  const selectedSeries = selectSeries(seriesList, preferredSeries);
+  if (!selectedSeries) {
+    return { points: [], stepSeconds: 0 };
+  }
+
+  return {
+    points: downsamplePreviewPoints(selectedSeries.points, maxPoints),
+    selectedSeries: selectedSeries.label,
+    stepSeconds: 0,
+  };
+};
+
+const parseDataFrame = (
+  payload: any,
+  preferredSeries?: string,
+  maxPoints: number = MAX_PREVIEW_DATAPOINTS
+): FetchPrometheusPreviewPointsResult | undefined => {
+  const fields = Array.isArray(payload?.fields) ? payload.fields : [];
+  const size = Number(payload?.size ?? 0);
+
+  if (fields.length === 0 || size <= 0) {
+    return undefined;
+  }
+
+  const timeField =
+    fields.find((field: any) => /^time$/i.test(field?.name ?? '')) ??
+    fields.find((field: any) => /timestamp|date/i.test(field?.type ?? '')) ??
+    fields[0];
+  const valueField =
+    fields.find((field: any) => /^value$/i.test(field?.name ?? '')) ??
+    fields.find((field: any) => /number|double|long|integer|float/i.test(field?.type ?? ''));
+  const seriesField = fields.find((field: any) => /^series$/i.test(field?.name ?? ''));
+
+  if (!timeField || !valueField) {
+    return undefined;
+  }
+
+  const rows = Array.from({ length: size }, (_, index) => ({
+    time: timeField.values?.[index],
+    value: valueField.values?.[index],
+    series: seriesField?.values?.[index],
+  }));
+
+  const seriesList = Array.from(
+    rows
+      .reduce((accumulator, row) => {
+        const seriesKey = String(row.series ?? '');
+        const current = accumulator.get(seriesKey) ?? {
+          label: seriesKey || undefined,
+          candidates: seriesKey ? [seriesKey] : [],
+          points: [] as PreviewPoint[],
+        };
+
+        const timestamp =
+          typeof row.time === 'number'
+            ? row.time
+            : row.time
+            ? new Date(String(row.time)).getTime()
+            : NaN;
+        const value = typeof row.value === 'number' ? row.value : Number(row.value);
+        if (Number.isFinite(timestamp) && Number.isFinite(value)) {
+          current.points.push({ ts: timestamp, value });
+        }
+
+        accumulator.set(seriesKey, current);
+        return accumulator;
+      }, new Map<string, { label?: string; candidates: string[]; points: PreviewPoint[] }>())
+      .values()
+  ).map((series) => ({
+    ...series,
+    points: series.points.sort((left, right) => left.ts - right.ts),
+  }));
+
+  const selectedSeries = selectSeries(seriesList, preferredSeries);
+  if (!selectedSeries) {
+    return undefined;
+  }
+
+  return {
+    points: downsamplePreviewPoints(selectedSeries.points, maxPoints),
+    selectedSeries: selectedSeries.label,
+    stepSeconds: 0,
+  };
+};
+
+export async function fetchPrometheusPreviewPoints({
+  client,
+  promqlQuery,
+  dataConnectionId,
+  startTimeMs,
+  endTimeMs,
+  preferredSeries,
+  maxPoints = MAX_PREVIEW_DATAPOINTS,
+  stepSeconds: requestedStepSeconds,
+  targetDatapoints,
+}: FetchPrometheusPreviewPointsArgs): Promise<FetchPrometheusPreviewPointsResult> {
+  const stepSeconds =
+    Number.isFinite(requestedStepSeconds) && requestedStepSeconds! > 0
+      ? Math.max(MIN_PROMETHEUS_STEP_SECONDS, Math.floor(requestedStepSeconds!))
+      : buildPrometheusStepSeconds(startTimeMs, endTimeMs, targetDatapoints);
+  const response = await client.transport.request({
+    method: 'POST',
+    path: `/_plugins/_directquery/_query/${encodeURIComponent(dataConnectionId)}`,
+    body: JSON.stringify({
+      query: promqlQuery,
+      language: 'PROMQL',
+      options: {
+        queryType: 'range',
+        start: String(Math.floor(startTimeMs / 1000)),
+        end: String(Math.ceil(endTimeMs / 1000)),
+        step: String(stepSeconds),
+      },
+    }),
+  });
+
+  const payload = extractPayload(response);
+  const nativePrometheusResult = parsePrometheusMatrixOrVector(
+    payload,
+    dataConnectionId,
+    preferredSeries,
+    maxPoints
+  );
+  if (nativePrometheusResult) {
+    return {
+      ...nativePrometheusResult,
+      stepSeconds,
+    };
+  }
+
+  const dataFrameResult = parseDataFrame(payload, preferredSeries, maxPoints);
+  if (dataFrameResult) {
+    return {
+      ...dataFrameResult,
+      stepSeconds,
+    };
+  }
+
+  return { points: [], stepSeconds };
+}


### PR DESCRIPTION
## Summary

This PR adds Prometheus-backed anomaly preview and alert creation flows to the Metrics experience in Explore.

With this change, users can:

- preview anomaly and forecast overlays directly on Metrics charts
- create anomaly detectors and alerting monitors from the Metrics `Alerts` panel
- preserve the created detector/monitor association when saving the metric or adding it to a dashboard
- rediscover an existing detector/monitor for the same metric and avoid re-creating duplicates
- handle multi-series Prometheus queries more intentionally for both preview and detector creation
### Related Issue
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11439

## What changed

### Metrics preview overlays

- Added anomaly preview and forecast preview routes for Metrics
- Rendered preview overlays on top of Metrics visualizations
- For multi-series Prometheus queries:
  - auto-preview overlays for all visible series when series count is small
  - otherwise allow choosing which series to preview
- Forecast overlays now follow the base metric series color instead of using a single fallback color
- Preview behavior is dependency-aware:
  - if AD UI is unavailable, preview requests are suppressed
  - if the backend preview dependency is missing, dead-end preview errors are suppressed

### Metrics Alerts panel

- Added an `Alerts` panel in Metrics for detector/monitor creation
- Supports Prometheus-backed detector creation from the current metric query
- For multi-series queries:
  - detect whether the result is a `single_stream` or `high_cardinality` candidate
  - infer candidate entity fields from varying Prometheus labels
  - prefill detector mode and entity field accordingly
- Persists created detector/monitor association in Explore saved state
- Rehydrates that association when reopening the same saved metric
- If no saved association exists, rediscovery checks for an existing detector/monitor for the same query/data connection and shows it instead of the create flow

### Saved metric / dashboard behavior

- Saving the metric or adding it to a dashboard now preserves the monitor/detector association
- Reopening the same saved Metrics view shows the existing monitor state instead of offering duplicate creation

### Dependency handling

- Hide the `Alerts` tab when Alerting UI is unavailable
- Do not show preview overlays when AD UI is unavailable

### Navigation / deep links

- Fixed `View monitor` deep link behavior for datasource-enabled environments
- Added the required Alerting URL params so classic monitor details open correctly

## Why

The Metrics experience already allows users to explore Prometheus-backed metrics, but the alerting/anomaly workflow was disconnected from that context.

This PR makes the Metrics page a first-class entry point for:

- previewing anomalies and forecasts
- creating detectors and monitors from the current metric query
- preserving that relationship when the metric is saved and reopened

## Multi-series behavior

For multi-series Prometheus queries, this PR intentionally distinguishes between:

- `single_stream`
- `high_cardinality`

Entity field candidates are inferred from the returned Prometheus label sets rather than being hardcoded to `instance`.

Example:

- if only `instance` varies, `instance` is prefilled
- if `instance` and `quantile` both vary, `instance` is preferred as the default

## Duplicate prevention

When a detector/monitor already exists for the same metric query and data connection, the `Alerts` panel will:

- restore the saved association if available, or
- rediscover the existing resources from the backend

This prevents showing the create flow again for the same persisted metric.

## Testing

### Manual

- Verified anomaly preview and forecast preview on Metrics
- Verified multi-series preview behavior
- Verified detector + monitor creation from Metrics
- Verified saving the metric / adding to dashboard preserves the association
- Verified reopening the same metric shows the existing monitor state
- Verified `View detector` and `View monitor` links
- Verified datasource-enabled deep-link behavior

### Automated

- `prettier --check` on touched files
- focused lint/test passes where repo tooling allowed
- some existing repo-level Jest / optimizer / duplicate-mock noise is still present and not introduced by this PR

## Notes

This PR is the OpenSearch Dashboards side of the feature. Full end-to-end behavior depends on the companion AD backend support for Prometheus-backed AD flows. Will link the pr here soon




https://github.com/user-attachments/assets/b782e231-0135-4103-b015-0405f77066b6






