### PR TITLE
fix(vis): scatter chart to allow zero and negative size values

### DIFF
--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.test.ts
@@ -21,11 +21,11 @@ describe('transformToMultiSeriesWithSize', () => {
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
       expect(result.categories).toEqual(['A', 'B']);
-      expect(result.seriesData['A']).toEqual([
+      expect(result.seriesData.A).toEqual([
         [1, 10, 5],
         [3, 30, 10],
       ]);
-      expect(result.seriesData['B']).toEqual([[2, 20, 15]]);
+      expect(result.seriesData.B).toEqual([[2, 20, 15]]);
       expect(result.sizeRange).toEqual({ min: 5, max: 15 });
     });
   });
@@ -39,7 +39,7 @@ describe('transformToMultiSeriesWithSize', () => {
 
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
-      expect(result.seriesData['A']).toEqual([
+      expect(result.seriesData.A).toEqual([
         [1, 10, 0],
         [2, 20, 5],
       ]);
@@ -54,7 +54,7 @@ describe('transformToMultiSeriesWithSize', () => {
 
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
-      expect(result.seriesData['A']).toEqual([
+      expect(result.seriesData.A).toEqual([
         [1, 10, -3],
         [2, 20, 7],
       ]);
@@ -69,8 +69,8 @@ describe('transformToMultiSeriesWithSize', () => {
 
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
-      expect(result.seriesData['A']).toEqual([[1, 10, 0]]);
-      expect(result.seriesData['B']).toEqual([[2, 20, 0]]);
+      expect(result.seriesData.A).toEqual([[1, 10, 0]]);
+      expect(result.seriesData.B).toEqual([[2, 20, 0]]);
       expect(result.sizeRange).toEqual({ min: 0, max: 0 });
     });
   });
@@ -84,7 +84,7 @@ describe('transformToMultiSeriesWithSize', () => {
 
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
-      expect(result.seriesData['A']).toEqual([[2, 20, 5]]);
+      expect(result.seriesData.A).toEqual([[2, 20, 5]]);
       expect(result.sizeRange).toEqual({ min: 5, max: 5 });
     });
 
@@ -96,7 +96,7 @@ describe('transformToMultiSeriesWithSize', () => {
 
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
-      expect(result.seriesData['A']).toEqual([[2, 20, 8]]);
+      expect(result.seriesData.A).toEqual([[2, 20, 8]]);
       expect(result.sizeRange).toEqual({ min: 8, max: 8 });
     });
   });
@@ -111,8 +111,8 @@ describe('transformToMultiSeriesWithSize', () => {
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
       expect(result.sizeRange).toEqual({ min: 0, max: 0 });
-      expect(result.seriesData['A']).toEqual([]);
-      expect(result.seriesData['B']).toEqual([]);
+      expect(result.seriesData.A).toEqual([]);
+      expect(result.seriesData.B).toEqual([]);
     });
 
     it('returns sizeRange { min: 0, max: 0 } when all sizes are non-numeric strings', () => {
@@ -124,7 +124,7 @@ describe('transformToMultiSeriesWithSize', () => {
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
       expect(result.sizeRange).toEqual({ min: 0, max: 0 });
-      expect(result.seriesData['A']).toEqual([]);
+      expect(result.seriesData.A).toEqual([]);
     });
   });
 
@@ -159,7 +159,7 @@ describe('transformToMultiSeriesWithSize', () => {
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
       expect(result.categories).toEqual(['undefined']);
-      expect(result.seriesData['undefined']).toEqual([
+      expect(result.seriesData.undefined).toEqual([
         [1, 10, 5],
         [2, 20, 10],
       ]);
@@ -175,8 +175,8 @@ describe('transformToMultiSeriesWithSize', () => {
 
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
-      expect(result.seriesData['A']).toEqual([[1, 10, 0]]);
-      expect(result.seriesData['B']).toEqual([[4, 40, -2]]);
+      expect(result.seriesData.A).toEqual([[1, 10, 0]]);
+      expect(result.seriesData.B).toEqual([[4, 40, -2]]);
       expect(result.sizeRange).toEqual({ min: -2, max: 0 });
     });
 
@@ -186,7 +186,7 @@ describe('transformToMultiSeriesWithSize', () => {
       const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
 
       expect(result.categories).toEqual(['X']);
-      expect(result.seriesData['X']).toEqual([[5, 50, 0]]);
+      expect(result.seriesData.X).toEqual([[5, 50, 0]]);
       expect(result.sizeRange).toEqual({ min: 0, max: 0 });
     });
   });

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.test.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { transformToMultiSeriesWithSize } from './scatter_chart_utils';
+
+describe('transformToMultiSeriesWithSize', () => {
+  const header = ['x', 'y', 'color', 'size'];
+
+  const buildData = (rows: any[][]) => [header, ...rows];
+
+  describe('basic functionality', () => {
+    it('groups data by color category and returns correct sizeRange', () => {
+      const data = buildData([
+        [1, 10, 'A', 5],
+        [2, 20, 'B', 15],
+        [3, 30, 'A', 10],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.categories).toEqual(['A', 'B']);
+      expect(result.seriesData['A']).toEqual([
+        [1, 10, 5],
+        [3, 30, 10],
+      ]);
+      expect(result.seriesData['B']).toEqual([[2, 20, 15]]);
+      expect(result.sizeRange).toEqual({ min: 5, max: 15 });
+    });
+  });
+
+  describe('zero and negative size values', () => {
+    it('includes data points with size = 0', () => {
+      const data = buildData([
+        [1, 10, 'A', 0],
+        [2, 20, 'A', 5],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.seriesData['A']).toEqual([
+        [1, 10, 0],
+        [2, 20, 5],
+      ]);
+      expect(result.sizeRange).toEqual({ min: 0, max: 5 });
+    });
+
+    it('includes data points with negative size values', () => {
+      const data = buildData([
+        [1, 10, 'A', -3],
+        [2, 20, 'A', 7],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.seriesData['A']).toEqual([
+        [1, 10, -3],
+        [2, 20, 7],
+      ]);
+      expect(result.sizeRange).toEqual({ min: -3, max: 7 });
+    });
+
+    it('handles all-zero sizes', () => {
+      const data = buildData([
+        [1, 10, 'A', 0],
+        [2, 20, 'B', 0],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.seriesData['A']).toEqual([[1, 10, 0]]);
+      expect(result.seriesData['B']).toEqual([[2, 20, 0]]);
+      expect(result.sizeRange).toEqual({ min: 0, max: 0 });
+    });
+  });
+
+  describe('NaN size filtering', () => {
+    it('skips rows where size is NaN', () => {
+      const data = buildData([
+        [1, 10, 'A', NaN],
+        [2, 20, 'A', 5],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.seriesData['A']).toEqual([[2, 20, 5]]);
+      expect(result.sizeRange).toEqual({ min: 5, max: 5 });
+    });
+
+    it('skips rows where size is a non-numeric string', () => {
+      const data = buildData([
+        [1, 10, 'A', 'abc'],
+        [2, 20, 'A', 8],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.seriesData['A']).toEqual([[2, 20, 8]]);
+      expect(result.sizeRange).toEqual({ min: 8, max: 8 });
+    });
+  });
+
+  describe('no valid data points (empty sizeRange fallback)', () => {
+    it('returns sizeRange { min: 0, max: 0 } when all sizes are NaN', () => {
+      const data = buildData([
+        [1, 10, 'A', NaN],
+        [2, 20, 'B', NaN],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.sizeRange).toEqual({ min: 0, max: 0 });
+      expect(result.seriesData['A']).toEqual([]);
+      expect(result.seriesData['B']).toEqual([]);
+    });
+
+    it('returns sizeRange { min: 0, max: 0 } when all sizes are non-numeric strings', () => {
+      const data = buildData([
+        [1, 10, 'A', 'foo'],
+        [2, 20, 'A', 'bar'],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.sizeRange).toEqual({ min: 0, max: 0 });
+      expect(result.seriesData['A']).toEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when transformedData has no rows', () => {
+      expect(() => transformToMultiSeriesWithSize([], 'x', 'y', 'color', 'size')).toThrow(
+        'transformedData must have at least header and one data row'
+      );
+    });
+
+    it('throws when transformedData has only a header', () => {
+      expect(() => transformToMultiSeriesWithSize([header], 'x', 'y', 'color', 'size')).toThrow(
+        'transformedData must have at least header and one data row'
+      );
+    });
+
+    it('throws when a field name is not found in the header', () => {
+      const data = buildData([[1, 10, 'A', 5]]);
+      expect(() =>
+        transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'missing_field')
+      ).toThrow('Cannot find field indices');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('maps null/undefined color values to "undefined" category', () => {
+      const data = buildData([
+        [1, 10, null, 5],
+        [2, 20, undefined, 10],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.categories).toEqual(['undefined']);
+      expect(result.seriesData['undefined']).toEqual([
+        [1, 10, 5],
+        [2, 20, 10],
+      ]);
+    });
+
+    it('filters NaN sizes in some categories while keeping zero sizes in others', () => {
+      const data = buildData([
+        [1, 10, 'A', 0],
+        [2, 20, 'A', NaN],
+        [3, 30, 'B', NaN],
+        [4, 40, 'B', -2],
+      ]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.seriesData['A']).toEqual([[1, 10, 0]]);
+      expect(result.seriesData['B']).toEqual([[4, 40, -2]]);
+      expect(result.sizeRange).toEqual({ min: -2, max: 0 });
+    });
+
+    it('handles a single data row with size = 0', () => {
+      const data = buildData([[5, 50, 'X', 0]]);
+
+      const result = transformToMultiSeriesWithSize(data, 'x', 'y', 'color', 'size');
+
+      expect(result.categories).toEqual(['X']);
+      expect(result.seriesData['X']).toEqual([[5, 50, 0]]);
+      expect(result.sizeRange).toEqual({ min: 0, max: 0 });
+    });
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_chart_utils.ts
@@ -80,7 +80,7 @@ export const transformToMultiSeriesWithSize = (
     const y = row[yFieldIndex];
     const category = String(row[colorFieldIndex] || 'undefined');
     const size = Number(row[sizeFieldIndex]);
-    if (isNaN(size) || size <= 0) return;
+    if (isNaN(size)) return;
     // Track size range
     minSize = Math.min(minSize, size);
     maxSize = Math.max(maxSize, size);
@@ -88,6 +88,12 @@ export const transformToMultiSeriesWithSize = (
     // Add point to corresponding category
     seriesData[category].push([x, y, size]);
   });
+
+  // Handle case where no valid data points were found
+  if (minSize === Infinity || maxSize === -Infinity) {
+    minSize = 0;
+    maxSize = 0;
+  }
 
   return {
     categories,


### PR DESCRIPTION
### Description

Previously, data points with size <= 0 were silently dropped from scatter charts. Only NaN values should be filtered out, as zero and negative sizes are valid data that should be rendered.

Also adds a guard for when all size values are invalid (NaN), resetting sizeRange to {min: 0, max: 0} instead of leaving it as {Infinity, -Infinity}.

This fixed a runtime issue when all size axis values are 0

<img width="1084" height="423" alt="Screenshot 2026-04-13 at 16 39 07" src="https://github.com/user-attachments/assets/027961b8-56d6-4802-8881-0369cfc7857f" />

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
