### PR TITLE
Skip failed DataViews in getMultiple() instead of breaking entire list

### DIFF
--- a/src/plugins/data/common/data_views/data_views/data_views.test.ts
+++ b/src/plugins/data/common/data_views/data_views/data_views.test.ts
@@ -518,5 +518,101 @@ describe('DataViews', () => {
       expect(savedObjectsClient.bulkGet).not.toHaveBeenCalled();
       expect(results[0]).toBe(properDataView);
     });
+
+    test('getMultiple() skips not-found saved objects instead of throwing', async () => {
+      const localPatternsMock = ({
+        clearCache: jest.fn(),
+        get: jest.fn().mockResolvedValue(undefined),
+        getByTitle: jest.fn(),
+        saveToCache: jest.fn(),
+      } as unknown) as IndexPatternsService;
+
+      const localDataViews = new DataViewsService({
+        patterns: localPatternsMock,
+        uiSettings: { get: jest.fn().mockResolvedValue(false), getAll: () => {} } as any,
+        savedObjectsClient: (savedObjectsClient as unknown) as DataViewSavedObjectsClientCommon,
+        apiClient: createFieldsFetcher(),
+        fieldFormats,
+        onNotification: () => {},
+        onError: () => {},
+        onRedirectNoDataView: () => {},
+        onUnsupportedTimePattern: () => {},
+      });
+
+      setDocsourcePayload('valid-id', {
+        id: 'valid-id',
+        version: '1',
+        attributes: { title: 'valid-*' },
+      });
+
+      savedObjectsClient.bulkGet = jest.fn().mockResolvedValue({
+        savedObjects: [
+          { id: 'valid-id', version: '1', attributes: { title: 'valid-*' }, references: [] },
+          {
+            id: 'orphaned-id',
+            attributes: {},
+            type: 'index-pattern',
+            error: { statusCode: 404, message: 'Not found' },
+            references: [],
+          },
+        ],
+      });
+
+      const results = await localDataViews.getMultiple(['valid-id', 'orphaned-id']);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBeInstanceOf(DataView);
+      expect(results[0].id).toBe('valid-id');
+    });
+
+    test('getMultiple() skips objects that throw during processing without breaking others', async () => {
+      const onErrorMock = jest.fn();
+      const localPatternsMock = ({
+        clearCache: jest.fn(),
+        get: jest.fn().mockResolvedValue(undefined),
+        getByTitle: jest.fn(),
+        saveToCache: jest.fn(),
+      } as unknown) as IndexPatternsService;
+
+      const localDataViews = new DataViewsService({
+        patterns: localPatternsMock,
+        uiSettings: { get: jest.fn().mockResolvedValue(false), getAll: () => {} } as any,
+        savedObjectsClient: (savedObjectsClient as unknown) as DataViewSavedObjectsClientCommon,
+        apiClient: createFieldsFetcher(),
+        fieldFormats,
+        onNotification: () => {},
+        onError: onErrorMock,
+        onRedirectNoDataView: () => {},
+        onUnsupportedTimePattern: () => {},
+      });
+
+      setDocsourcePayload('valid-id', {
+        id: 'valid-id',
+        version: '1',
+        attributes: { title: 'valid-*' },
+      });
+
+      savedObjectsClient.bulkGet = jest.fn().mockResolvedValue({
+        savedObjects: [
+          { id: 'valid-id', version: '1', attributes: { title: 'valid-*' }, references: [] },
+          {
+            id: 'corrupt-id',
+            version: '1',
+            attributes: { title: 'corrupt-*', fieldFormatMap: '{invalid json' },
+            references: [],
+          },
+        ],
+      });
+
+      const results = await localDataViews.getMultiple(['valid-id', 'corrupt-id']);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBeInstanceOf(DataView);
+      expect(results[0].id).toBe('valid-id');
+      expect(onErrorMock).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ title: 'Failed to load data view "corrupt-id"' })
+      );
+    });
   });
 });

--- a/src/plugins/data/common/data_views/data_views/data_views.ts
+++ b/src/plugins/data/common/data_views/data_views/data_views.ts
@@ -163,65 +163,71 @@ export class DataViewsService {
       uncachedIds.map((id) => ({ id, type: savedObjectType }))
     );
 
-    // Process each saved object and create DataViews in parallel
+    // Process each saved object and create DataViews in parallel.
+    // Errors on individual objects are caught so one bad entry doesn't break the entire list.
     const newDataViewPromises = response.savedObjects.map(
-      async (savedObject: SavedObject<DataViewAttributes>) => {
-        if (!savedObject.version) {
-          throw new SavedObjectNotFound(
-            savedObjectType,
-            savedObject.id,
-            'management/opensearch-dashboards/indexPatterns'
-          );
-        }
-
-        const spec = this.savedObjectToSpec(savedObject);
-        const parsedFieldFormats: FieldFormatMap = savedObject.attributes.fieldFormatMap
-          ? JSON.parse(savedObject.attributes.fieldFormatMap)
-          : {};
-
-        Object.entries(parsedFieldFormats).forEach(([fieldName, value]) => {
-          const field = spec.fields?.[fieldName];
-          if (field) {
-            field.format = value;
+      async (
+        savedObject: SavedObject<DataViewAttributes>
+      ): Promise<{ id: string; dataView: DataView } | undefined> => {
+        try {
+          if (!savedObject.version) {
+            return undefined;
           }
-        });
 
-        const dataView = await this.create(spec, true);
-        this.patterns.saveToCache(savedObject.id, dataView);
+          const spec = this.savedObjectToSpec(savedObject);
+          const parsedFieldFormats: FieldFormatMap = savedObject.attributes.fieldFormatMap
+            ? JSON.parse(savedObject.attributes.fieldFormatMap)
+            : {};
 
-        if (dataView.isUnsupportedTimePattern()) {
-          this.onUnsupportedTimePattern({
-            id: dataView.id as string,
-            title: dataView.title,
-            index: dataView.getIndex(),
+          Object.entries(parsedFieldFormats).forEach(([fieldName, value]) => {
+            const field = spec.fields?.[fieldName];
+            if (field) {
+              field.format = value;
+            }
           });
-        }
 
-        dataView.resetOriginalSavedObjectBody();
-        return { id: savedObject.id, dataView };
+          const dataView = await this.create(spec, true);
+          this.patterns.saveToCache(savedObject.id, dataView);
+
+          if (dataView.isUnsupportedTimePattern()) {
+            this.onUnsupportedTimePattern({
+              id: dataView.id as string,
+              title: dataView.title,
+              index: dataView.getIndex(),
+            });
+          }
+
+          dataView.resetOriginalSavedObjectBody();
+          return { id: savedObject.id, dataView };
+        } catch (e) {
+          // Skip this DataView — log but don't let it prevent other DataViews from loading
+          this.onError(e, {
+            title: `Failed to load data view "${savedObject.id}"`,
+          });
+          return undefined;
+        }
       }
     );
 
     // Wait for all DataViews to be created
     const newDataViewResults = await Promise.all(newDataViewPromises);
 
-    // Build a map of newly created DataViews
+    // Build a map of newly created DataViews, skipping not-found entries
     const newDataViewsMap: Map<string, DataView> = new Map();
-    newDataViewResults.forEach(({ id, dataView }: { id: string; dataView: DataView }) => {
-      newDataViewsMap.set(id, dataView);
+    newDataViewResults.forEach((result: { id: string; dataView: DataView } | undefined) => {
+      if (result) {
+        newDataViewsMap.set(result.id, result.dataView);
+      }
     });
 
-    // Return DataViews in the same order as input IDs
-    // Throw error if any DataView is missing (shouldn't happen in normal flow)
-    return ids.map((id) => {
+    // Return DataViews in the same order as input IDs, filtering out not-found ones
+    return ids.reduce<DataView[]>((acc, id) => {
       const dataView = cachedDataViews.get(id) || newDataViewsMap.get(id);
-      if (!dataView) {
-        throw new Error(
-          `DataView with id "${id}" was not found in cache or fetch results. This may indicate a failed fetch operation.`
-        );
+      if (dataView) {
+        acc.push(dataView);
       }
-      return dataView;
-    });
+      return acc;
+    }, []);
   };
 
   /**


### PR DESCRIPTION
### Description

`DataViewsService.getMultiple()` uses `bulkGet()` + `Promise.all()` to fetch multiple DataViews in a single request. If **any** saved object in the batch is not found (e.g., orphaned or deleted index pattern) or fails during processing (e.g., corrupt `fieldFormatMap`), the thrown error rejects `Promise.all`, causing the **entire** dataset list to come back empty.

This is a regression from #11413 which optimized individual `get()` calls into a batched `bulkGet()`. The old sequential `get()` calls had natural fault isolation — one failure didn't affect the others. The bulk approach lost that property.

### Root Cause

1. `DatasetSelect` mounts → calls `fetchDatasets()`
2. `fetchDatasets()` calls `dataViews.getIds()` → `dataViews.getMultiple(ids)`
3. `getMultiple()` calls `savedObjectsClient.bulkGet()` to fetch all objects in one request
4. For each returned saved object, `if (!savedObject.version)` throws `SavedObjectNotFound`
5. Since all per-object processing is wrapped in `Promise.all()`, a single throw rejects the entire batch
6. `fetchDatasets()` catches the error at the top level → dataset list stays empty

### Fix

- **Not-found objects** (`!savedObject.version`): silently skipped (this is an expected condition — orphaned IDs from deleted/inaccessible objects)
- **Processing errors** (corrupt JSON, creation failures, etc.): caught by a `try/catch` around each object's processing, reported to the user via `onError` toast notification, and skipped
- **Return value**: filters out failed entries instead of throwing, so valid DataViews still load

### Issues Resolved

Fixes the dataset selector showing no data when any single index pattern in the workspace is orphaned or corrupt.

### Testing the changes

Added two new unit tests:

1. **`getMultiple() skips not-found saved objects instead of throwing`** — verifies that when `bulkGet` returns a mix of valid and 404 saved objects, only the valid ones are returned
2. **`getMultiple() skips objects that throw during processing without breaking others`** — verifies that a corrupt `fieldFormatMap` (invalid JSON) on one object doesn't prevent other objects from loading, and that `onError` is called with the appropriate message

```bash
yarn test:jest src/plugins/data/common/data_views/data_views/data_views.test.ts --no-coverage
```

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
