### PR TITLE
[Explore Vis]add runtime PPL autocomplete and validation path

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/hooks/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/hooks/use_query_panel_editor.ts
@@ -4,7 +4,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { monaco } from '@osd/monaco';
+import { monaco, PPLValidationContext, revalidatePPLModel } from '@osd/monaco';
 import { i18n } from '@osd/i18n';
 
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
@@ -25,6 +25,8 @@ import {
 import { EditorMode } from '../../../application/utils/state_management/types';
 import { useEditorOperations } from './use_editor_operations';
 import { useQueryBuilderState } from './use_query_builder_state';
+
+import { syncPPLValidationContext, shouldUseRuntimeGrammar } from '../../../../../data/public';
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 
@@ -59,6 +61,21 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   const queryLanguageRef = useRef(queryLanguage);
 
   const { switchEditorMode, setEditorRef: setEditor } = useEditorOperations();
+  const detachValidationContextRef = useRef<(() => void) | undefined>();
+  const detachGrammarRefreshRef = useRef<(() => void) | undefined>();
+
+  const dataset = queryState.dataset;
+
+  const getValidationContext = useCallback((): PPLValidationContext => {
+    const currentQuery = services.data.query.queryString.getQuery();
+    const dsId = currentQuery.dataset?.dataSource?.id;
+    const dsVersion = currentQuery.dataset?.dataSource?.version;
+    return {
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      dataSourceId: dsId,
+      dataSourceVersion: dsVersion,
+    };
+  }, [services.data.query.queryString]);
 
   // Keep the refs updated with latest context
   useEffect(() => {
@@ -73,6 +90,33 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   useEffect(() => {
     queryLanguageRef.current = queryLanguage;
   }, [queryLanguage]);
+
+  // Sync PPL validation context when datasource changes
+  useEffect(() => {
+    const editor = editorRef.current;
+    const dsId = dataset?.dataSource?.id;
+    const dsVersion = dataset?.dataSource?.version;
+    syncPPLValidationContext(editor, {
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      dataSourceId: dsId,
+      dataSourceVersion: dsVersion,
+    });
+    const model = editor?.getModel();
+    if (model) {
+      void revalidatePPLModel(model);
+    }
+  }, [dataset?.dataSource?.id, dataset?.dataSource?.version, editorRef]);
+
+  // Cleanup validation context on unmount
+  useEffect(
+    () => () => {
+      detachValidationContextRef.current?.();
+      detachValidationContextRef.current = undefined;
+      detachGrammarRefreshRef.current?.();
+      detachGrammarRefreshRef.current = undefined;
+    },
+    []
+  );
 
   keyboardShortcut?.useKeyboardShortcut({
     id: 'focus_query_bar',
@@ -163,6 +207,8 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
           isPromptModeRef,
           editorTextRef,
           queryLanguageRef,
+          detachValidationContextRef,
+          detachGrammarRefreshRef,
         },
         {
           setEditorRef,
@@ -171,7 +217,8 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
           switchEditorMode,
           updateDecorations,
           clearDecorations,
-        }
+        },
+        getValidationContext
       ),
     [
       setEditorRef,
@@ -180,6 +227,7 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
       setEditorIsFocused,
       updateDecorations,
       clearDecorations,
+      getValidationContext,
     ]
   );
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor_utils.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor_utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { monaco } from '@osd/monaco';
+import { monaco, PPLValidationContext, revalidatePPLModel } from '@osd/monaco';
 import { i18n } from '@osd/i18n';
 import { DEFAULT_DATA } from '../../../../../../data/common';
 
@@ -19,6 +19,11 @@ import { getSpacebarAction } from './spacebar_action';
 import { getEscapeAction } from './escape_action';
 import { EditorMode } from '../../../../application/utils/state_management/types';
 import { getAutocompleteContext } from '../../../../application/utils/multi_query_utils';
+import {
+  attachPPLValidationContext,
+  attachPPLGrammarRefresh,
+  pplGrammarCache,
+} from '../../../../../../data/public';
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 
@@ -77,6 +82,8 @@ export const editorMount = (
     isPromptModeRef: React.MutableRefObject<boolean>;
     editorTextRef: React.MutableRefObject<string>;
     queryLanguageRef: React.MutableRefObject<string>;
+    detachValidationContextRef: React.MutableRefObject<(() => void) | undefined>;
+    detachGrammarRefreshRef: React.MutableRefObject<(() => void) | undefined>;
   },
   actions: {
     setEditorRef: (editor: IStandaloneCodeEditor) => void;
@@ -88,9 +95,32 @@ export const editorMount = (
       language: string
     ) => void;
     clearDecorations: (editor: monaco.editor.IStandaloneCodeEditor | null) => void;
-  }
+  },
+  getValidationContext: () => PPLValidationContext
 ) => {
   actions.setEditorRef(editor);
+
+  // Attach PPL runtime validation context
+  refs.detachValidationContextRef.current?.();
+  refs.detachGrammarRefreshRef.current?.();
+  refs.detachValidationContextRef.current = attachPPLValidationContext(
+    editor,
+    getValidationContext
+  );
+
+  refs.detachGrammarRefreshRef.current = attachPPLGrammarRefresh(
+    editor,
+    getValidationContext,
+    (listener) => pplGrammarCache.subscribeToGrammarUpdates(listener),
+    revalidatePPLModel
+  );
+
+  // Revalidate immediately so any initial content that was validated before
+  // the context was attached gets re-checked with the runtime grammar.
+  const model = editor.getModel();
+  if (model) {
+    void revalidatePPLModel(model);
+  }
 
   const focusDisposable = editor.onDidFocusEditorText(() => {
     actions.setEditorIsFocused(true);


### PR DESCRIPTION
### Description

Currently, both visualization editor and explore app have a standalone editor.

This pr adds runtime PPL autocomplete and validation path, while keeping the compiled grammar path as the fallback where runtime grammar is unavailable or not used.

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11762#issue-4272877822

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
