### PR TITLE
fix(osd-agents): Fix TypeScript strict mode errors in ts-node compilation

### DIFF
--- a/packages/osd-agents/src/ag_ui/base_ag_ui_adapter.ts
+++ b/packages/osd-agents/src/ag_ui/base_ag_ui_adapter.ts
@@ -380,7 +380,7 @@ export class BaseAGUIAdapter {
         }
       }
     } catch (error) {
-      this.logger.debug('Error detecting PPL query', { error: error.message });
+      this.logger.debug('Error detecting PPL query', { error: (error as Error).message });
     }
 
     return null;

--- a/packages/osd-agents/src/agents/langgraph/react_graph_builder.ts
+++ b/packages/osd-agents/src/agents/langgraph/react_graph_builder.ts
@@ -50,27 +50,27 @@ const ReactStateAnnotation = Annotation.Root({
   }),
   clientContext: Annotation<any[]>({
     reducer: (x, y) => y || x,
-    default: () => undefined,
+    default: () => (undefined as unknown) as any[],
   }),
   clientTools: Annotation<any[]>({
     reducer: (x, y) => y || x,
-    default: () => undefined,
+    default: () => (undefined as unknown) as any[],
   }),
   threadId: Annotation<string>({
     reducer: (x, y) => y || x,
-    default: () => undefined,
+    default: () => (undefined as unknown) as string,
   }),
   runId: Annotation<string>({
     reducer: (x, y) => y || x,
-    default: () => undefined,
+    default: () => (undefined as unknown) as string,
   }),
   modelId: Annotation<string>({
     reducer: (x, y) => y || x,
-    default: () => undefined,
+    default: () => (undefined as unknown) as string,
   }),
   lastToolExecution: Annotation<number>({
     reducer: (x, y) => y || x,
-    default: () => undefined,
+    default: () => (undefined as unknown) as number,
   }),
 });
 

--- a/packages/osd-agents/src/mcp/http_client.ts
+++ b/packages/osd-agents/src/mcp/http_client.ts
@@ -37,7 +37,7 @@ export class HTTPMCPClient extends BaseMCPClient {
         version: '1.0.0',
       },
       {
-        capabilities: { tools: {}, sampling: {} },
+        capabilities: { sampling: {} },
       }
     );
 

--- a/packages/osd-agents/src/mcp/local_client.ts
+++ b/packages/osd-agents/src/mcp/local_client.ts
@@ -25,7 +25,11 @@ export class LocalMCPClient extends BaseMCPClient {
     const transport = new StdioClientTransport({
       command: this.config.command,
       args: this.config.args || [],
-      env: { ...process.env, ...this.config.env },
+      env: Object.fromEntries(
+        Object.entries({ ...process.env, ...this.config.env }).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined
+        )
+      ),
     });
 
     this.client = new Client(
@@ -34,7 +38,7 @@ export class LocalMCPClient extends BaseMCPClient {
         version: '1.0.0',
       },
       {
-        capabilities: { tools: {}, sampling: {} },
+        capabilities: { sampling: {} },
       }
     );
 

--- a/packages/osd-agents/src/utils/ag_ui_audit_logger.ts
+++ b/packages/osd-agents/src/utils/ag_ui_audit_logger.ts
@@ -80,7 +80,7 @@ export class AGUIAuditLogger extends BaseLogger {
       ag_ui_event: {
         type: event.type,
         timestamp: event.timestamp,
-        timestamp_human: this.toHumanTimestamp(event.timestamp),
+        timestamp_human: this.toHumanTimestamp(event.timestamp ?? 0),
         ...this.sanitizeEvent(event),
       },
     };


### PR DESCRIPTION
### Description

Fix several TypeScript strict mode errors in `packages/osd-agents` that prevent `yarn start:ag-ui` from compiling under `ts-node`.

**Root cause:** These errors were introduced by the TypeScript 4.6.4 → 6.0.2 upgrade in [7773eda](https://github.com/opensearch-project/OpenSearch-Dashboards/commit/7773edacd4b3148b026c2085dd90b9333c992ce6) (#11687). The upgrade changed the `osd-agents` tsconfig (added `moduleResolution: "bundler"`, `rootDir`) and TS 6's stricter type checking surfaced errors in the existing source files. However, the source files were not updated to match the stricter rules.

**Why `yarn typecheck` didn't catch this:** The root `yarn typecheck` command runs the OSD project's TypeScript configuration, which does not include `packages/osd-agents/`. This package has its own local `tsconfig.json` with stricter settings. When `ts-node` compiles the package at runtime via `yarn start:ag-ui`, it uses the local strict config, surfacing errors that the root typecheck misses. See #11768 for a tracking issue to include `osd-agents` in the root typecheck.

**Fixes:**
- `base_ag_ui_adapter.ts` — Cast catch clause `error` from `unknown` to `Error` (TS18046)
- `local_client.ts` — Filter `undefined` values from `process.env` spread to satisfy `Record<string, string>` (TS2322)
- `local_client.ts` / `http_client.ts` — Remove `tools` from MCP Client capabilities object, which doesn't exist in the `@modelcontextprotocol/sdk` type definition (TS2353)
- `ag_ui_audit_logger.ts` — Add nullish coalescing for optional `event.timestamp` parameter (TS2345)
- `react_graph_builder.ts` — Cast `undefined` defaults to expected types in LangGraph `Annotation` declarations (TS2322)

### Issues Resolved

Fixes `yarn start:ag-ui` failing to compile in `packages/osd-agents` after the TS 6 upgrade (#11687).

Related: #11768 — `yarn typecheck` should include `packages/osd-agents` to catch these errors in CI

## Screenshot

N/A — no UI changes.

## Testing the changes

```bash
cd packages/osd-agents
yarn start:ag-ui
```

Should compile and start the AG-UI server without TypeScript errors. Previously failed with 10+ TS errors.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
