### PR TITLE
Fix 'occured' -> 'occurred' typos across 7 files

### DIFF
--- a/src/core/public/notifications/toasts/error_toast.test.tsx
+++ b/src/core/public/notifications/toasts/error_toast.test.tsx
@@ -49,7 +49,7 @@ function render(props: ErrorToastProps = {}) {
     <ErrorToast
       openModal={openModal}
       error={props.error || new Error('error message')}
-      title={props.title || 'An error occured'}
+      title={props.title || 'An error occurred'}
       toastMessage={props.toastMessage || 'This is the toast message'}
       i18nContext={() => ({ children }) => <React.Fragment>{children}</React.Fragment>}
     />

--- a/src/dev/i18n/utils/utils.js
+++ b/src/dev/i18n/utils/utils.js
@@ -126,7 +126,7 @@ export function* traverseNodes(nodes) {
  * Forms an formatted error message for parser errors.
  *
  * This function returns a string which represents an error message and a place in the code where the error happened.
- * In total five lines of the code are displayed: the line where the error occured, two lines before and two lines after.
+ * In total five lines of the code are displayed: the line where the error occurred, two lines before and two lines after.
  *
  * @param {string} content a code string where parsed error happened
  * @param {{ loc: { line: number, column: number }, message: string }} error an object that contains an error message and

--- a/src/dev/run_check_published_api_changes.ts
+++ b/src/dev/run_check_published_api_changes.ts
@@ -213,7 +213,7 @@ async function run(folder: string, { opts }: { opts: Options }): Promise<boolean
     log.info(`${folder} API: updated documentation ✔`);
   }
 
-  // If the api signature changed or any errors or warnings occured, exit with an error
+  // If the api signature changed or any errors or warnings occurred, exit with an error
   // NOTE: Because of https://github.com/Microsoft/web-build-tools/issues/1258
   //  api-extractor will not return `succeeded: false` when the API changes.
   return !apiReportChanged && succeeded;

--- a/src/plugins/agent_traces/public/components/query_panel/query_panel_widgets/save_query/save_query.tsx
+++ b/src/plugins/agent_traces/public/components/query_panel/query_panel_widgets/save_query/save_query.tsx
@@ -117,7 +117,7 @@ export const SaveQueryButton = () => {
     } catch (error) {
       services.notifications.toasts.addDanger(
         i18n.translate('agentTraces.queryPanel.saveQuery.failedToSaveQuery', {
-          defaultMessage: 'An error occured while saving your query{errorMessage}',
+          defaultMessage: 'An error occurred while saving your query{errorMessage}',
           values: { errorMessage: error.message ? `: ${error.message}` : '' },
         })
       );

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -351,7 +351,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
         this.props.intl.formatMessage(
           {
             id: 'data.search_bar.save_query.failedToSaveQuery',
-            defaultMessage: 'An error occured while saving your query{errorMessage}',
+            defaultMessage: 'An error occurred while saving your query{errorMessage}',
           },
           { errorMessage: error.message ? `: ${error.message}` : '' }
         )

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/save_query/save_query.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/save_query/save_query.tsx
@@ -117,7 +117,7 @@ export const SaveQueryButton = () => {
     } catch (error) {
       services.notifications.toasts.addDanger(
         i18n.translate('explore.editor.queryPanel.saveQuery.saveQueryFailure', {
-          defaultMessage: 'An error occured while saving your query{errorMessage}',
+          defaultMessage: 'An error occurred while saving your query{errorMessage}',
           values: { errorMessage: error.message ? `: ${error.message}` : '' },
         })
       );

--- a/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.tsx
+++ b/src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.tsx
@@ -141,7 +141,7 @@ export class OptInExampleFlyout extends React.PureComponent<Props, State> {
         >
           <FormattedMessage
             id="telemetry.callout.errorLoadingClusterStatisticsDescription"
-            defaultMessage="An unexpected error occured while attempting to fetch the cluster statistics.
+            defaultMessage="An unexpected error occurred while attempting to fetch the cluster statistics.
               This can occur because OpenSearch failed, OpenSearch Dashboards failed, or there is a network error.
               Check OpenSearch Dashboards, then reload the page and try again."
           />


### PR DESCRIPTION
Fix 7 instances of `occured` → `occurred` across source files.

| File | Kind |
|------|------|
| `src/dev/i18n/utils/utils.js` | Comment |
| `src/dev/run_check_published_api_changes.ts` | Comment |
| `src/plugins/data/public/ui/search_bar/search_bar.tsx` | Inline comment |
| `src/plugins/telemetry_management_section/public/components/opt_in_example_flyout.tsx` | Comment |
| `src/plugins/explore/public/components/query_panel/query_panel_widgets/save_query/save_query.tsx` | Comment |
| `src/plugins/agent_traces/public/components/query_panel/query_panel_widgets/save_query/save_query.tsx` | Comment |
| `src/core/public/notifications/toasts/error_toast.test.tsx` | Test comment |

String/comment-only change.

Signed-off-by DCO.