### PR TITLE
test(dashboard): Add data-driven migration test framework and fixtures

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -24,6 +24,7 @@
       - [Query panel actions](plugins/explore/query-panel-actions.md)
     - [Data_persistence](plugins/data_persistence.md)
   - Saved_objects
+    - [Data_driven_migration_testing](saved_objects/data_driven_migration_testing.md)
     - [Pluggable_storage_backend](saved_objects/pluggable_storage_backend.md)
     - [Saved_object_repository_factory_design](saved_objects/saved_object_repository_factory_design.md)
   - Telemetry

--- a/docs/saved_objects/data_driven_migration_testing.md
+++ b/docs/saved_objects/data_driven_migration_testing.md
@@ -1,0 +1,126 @@
+# Data-Driven Migration Testing
+
+## Problem
+
+Saved object migrations transform JSON attributes between OSD versions (e.g., fixing `visState`, `panelsJSON`, `searchSourceJSON`). Today, migration tests are scattered across individual plugins with no unified framework. When a migration is added or modified, there's no systematic way to verify it works across all storage backends.
+
+## Proposal
+
+A data-driven test framework using JSON fixtures that define input/output pairs for each migration:
+
+```
+tests/migrations/fixtures/
+├── dashboard/
+│   ├── v1.0.0.json    # { input: {...}, expected: {...} }
+│   ├── v2.0.0.json
+│   └── v7.3.0.json
+├── visualization/
+│   ├── v1.0.0.json
+│   └── v7.10.0.json
+├── index-pattern/
+│   └── v1.0.0.json
+└── search/
+    └── v1.0.0.json
+```
+
+### Fixture format
+
+```json
+{
+  "description": "Migrate dashboard searchSource index pattern from string to reference",
+  "type": "dashboard",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "test-dash",
+    "type": "dashboard",
+    "attributes": {
+      "title": "My Dashboard",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"logstash-*\"}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "references_length": 1,
+    "references_contain": [
+      { "type": "index-pattern", "id": "logstash-*" }
+    ],
+    "attributes_has": ["kibanaSavedObjectMeta"]
+  }
+}
+```
+
+### Test runner
+
+Each plugin has a `migration_fixtures.test.ts` that loads fixtures and runs them through the plugin's migration functions:
+
+```typescript
+import { dashboardSavedObjectTypeMigrations } from './dashboard_migrations';
+
+const fixtures = loadFixtures(path.join(__dirname, 'test_fixtures'));
+const migrations = dashboardSavedObjectTypeMigrations;
+const contextMock = savedObjectsServiceMock.createMigrationContext();
+
+describe('dashboard data-driven migration tests', () => {
+  fixtures.forEach((fixture) => {
+    const migration = migrations[fixture.migrationVersion];
+    it(fixture.description, () => {
+      const result = migration(fixture.input, contextMock);
+      // Asserts on references_length, references_contain,
+      // attributes_has, attributes_equals
+    });
+  });
+});
+```
+
+## Current coverage
+
+Existing migration tests by plugin (as of this writing):
+
+| Plugin | Migration test file | Versions covered |
+|--------|-------------------|-----------------|
+| dashboard | `dashboard_migrations.test.ts`, `migrations_730.test.ts` | 7.0.0, 7.3.0 |
+| visualization | `visualization_migrations.test.ts` | 7.0.0, 7.2.0, 7.4.2, 7.10.0 |
+| search | `search_migrations.test.ts` | 7.0.0, 7.4.0, 7.9.3 |
+
+These tests exist but are not data-driven — they're hand-written per migration function.
+
+## When to use
+
+### Add a fixture when:
+- Adding a new migration to a saved object type
+- Modifying an existing migration function
+- Fixing a bug in migration logic
+- Adding a new saved object type with migrations
+
+### Update fixtures when:
+- Changing the saved object schema (attributes structure)
+- Adding new fields that need migration defaults
+- Changing reference handling
+
+## Benefits
+
+- **Backend-agnostic** — same fixtures test OpenSearch, SQLite, DynamoDB, or any future backend
+- **Regression safety** — fixtures catch unintended changes to migration output
+- **Documentation** — fixtures serve as concrete examples of what each migration does
+- **AI-friendly** — structured JSON fixtures are easy for AI tools to generate, validate, and extend
+- **CI integration** — a check can detect when `migrations` map changes and remind authors to add/update fixtures
+
+## Future: CI reminder
+
+A GitHub Action or pre-commit hook that:
+1. Detects changes to files matching `**/migrations*.ts` or `migrations:` in saved object type definitions
+2. Checks if corresponding fixtures were added/updated
+3. Posts a reminder comment if not
+
+```yaml
+# .github/workflows/migration-check.yml
+- name: Check migration fixtures
+  run: |
+    CHANGED=$(git diff --name-only origin/main | grep -E "migration" || true)
+    FIXTURES=$(git diff --name-only origin/main | grep "fixtures/" || true)
+    if [ -n "$CHANGED" ] && [ -z "$FIXTURES" ]; then
+      echo "⚠️ Migration files changed but no test fixtures updated"
+    fi
+```

--- a/src/plugins/dashboard/server/saved_objects/migration_fixtures.test.ts
+++ b/src/plugins/dashboard/server/saved_objects/migration_fixtures.test.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { savedObjectsServiceMock } from '../../../../core/server/mocks';
+import { dashboardSavedObjectTypeMigrations } from './dashboard_migrations';
+
+interface MigrationFixture {
+  description: string;
+  type: string;
+  migrationVersion: string;
+  input: Record<string, any>;
+  expected: {
+    references_length?: number;
+    references_contain?: Array<{ type: string; id: string }>;
+    attributes_has?: string[];
+    attributes_equals?: Record<string, any>;
+  };
+}
+
+function loadFixtures(dir: string): MigrationFixture[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')));
+}
+
+const fixtures = loadFixtures(path.join(__dirname, 'test_fixtures'));
+const migrations = dashboardSavedObjectTypeMigrations as Record<string, any>;
+const contextMock = savedObjectsServiceMock.createMigrationContext();
+const allVersions = Object.keys(migrations);
+const testedVersions = new Set<string>();
+
+describe('dashboard data-driven migration tests', () => {
+  fixtures.forEach((fixture) => {
+    const migration = migrations[fixture.migrationVersion];
+    if (!migration) {
+      it.skip(`${fixture.description} (v${fixture.migrationVersion} not found)`, () => {});
+      return;
+    }
+    testedVersions.add(fixture.migrationVersion);
+
+    it(fixture.description, () => {
+      const result = migration(fixture.input, contextMock);
+      if (fixture.expected.references_length !== undefined) {
+        expect(result.references?.length).toBe(fixture.expected.references_length);
+      }
+      if (fixture.expected.references_contain) {
+        for (const ref of fixture.expected.references_contain) {
+          expect(result.references).toEqual(expect.arrayContaining([expect.objectContaining(ref)]));
+        }
+      }
+      if (fixture.expected.attributes_has) {
+        for (const key of fixture.expected.attributes_has) {
+          expect(result.attributes).toHaveProperty(key);
+        }
+      }
+      if (fixture.expected.attributes_equals) {
+        for (const [key, value] of Object.entries(fixture.expected.attributes_equals)) {
+          expect(result.attributes[key]).toEqual(value);
+        }
+      }
+    });
+  });
+
+  // Coverage summary — JSON output parseable by CI tools
+  afterAll(() => {
+    const untested = allVersions.filter((v) => !testedVersions.has(v));
+    const coverage = {
+      type: 'dashboard',
+      totalMigrations: allVersions.length,
+      testedMigrations: testedVersions.size,
+      coveragePercent: Math.round((testedVersions.size / allVersions.length) * 100),
+      testedVersions: [...testedVersions].sort(),
+      untestedVersions: untested.sort(),
+      fixtureCount: fixtures.length,
+    };
+    // eslint-disable-next-line no-console
+    console.log(`\n--- Migration Coverage: dashboard ---\n${JSON.stringify(coverage, null, 2)}`);
+    if (untested.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log(`⚠️  Untested: ${untested.join(', ')}. Add fixtures to test_fixtures/`);
+    }
+  });
+});

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/6.7.2_migrate_match_all.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/6.7.2_migrate_match_all.json
@@ -1,0 +1,23 @@
+{
+  "description": "Dashboard 6.7.2: Migrate match_all query to default query language",
+  "type": "dashboard",
+  "migrationVersion": "6.7.2",
+  "input": {
+    "id": "dash-match-all",
+    "type": "dashboard",
+    "attributes": {
+      "title": "Dashboard with match_all",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"match_all\":{}},\"filter\":[]}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "attributes_equals": {
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    }
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/6.7.2_no_op_normal_query.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/6.7.2_no_op_normal_query.json
@@ -1,0 +1,23 @@
+{
+  "description": "Dashboard 6.7.2: No-op when query is not match_all",
+  "type": "dashboard",
+  "migrationVersion": "6.7.2",
+  "input": {
+    "id": "dash-normal-query",
+    "type": "dashboard",
+    "attributes": {
+      "title": "Dashboard with normal query",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"status:200\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "attributes_equals": {
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"status:200\",\"language\":\"kuery\"},\"filter\":[]}"
+      }
+    }
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_empty_dashboard.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_empty_dashboard.json
@@ -1,0 +1,21 @@
+{
+  "description": "Dashboard 7.0.0: Handle empty dashboard with no panels",
+  "type": "dashboard",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "empty-dash",
+    "type": "dashboard",
+    "attributes": {
+      "title": "Empty Dashboard",
+      "panelsJSON": "[]",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "references_length": 0,
+    "attributes_has": ["panelsJSON", "kibanaSavedObjectMeta"]
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_extract_index_pattern.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_extract_index_pattern.json
@@ -1,0 +1,22 @@
+{
+  "description": "Dashboard 7.0.0: Extract searchSource index pattern into references",
+  "type": "dashboard",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "dash-with-index",
+    "type": "dashboard",
+    "attributes": {
+      "title": "Dashboard with index pattern",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      },
+      "panelsJSON": "[]"
+    },
+    "references": []
+  },
+  "expected": {
+    "references_contain": [
+      { "type": "index-pattern", "id": "logstash-*" }
+    ]
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_extract_references.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_extract_references.json
@@ -1,0 +1,25 @@
+{
+  "description": "Dashboard 7.0.0: Extract panel references from panelsJSON into top-level references array",
+  "type": "dashboard",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "test-dash-1",
+    "type": "dashboard",
+    "attributes": {
+      "title": "My Dashboard",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[]}"
+      },
+      "panelsJSON": "[{\"id\":\"viz-1\",\"type\":\"visualization\",\"gridData\":{\"x\":0,\"y\":0,\"w\":24,\"h\":15}},{\"id\":\"search-1\",\"type\":\"search\",\"gridData\":{\"x\":24,\"y\":0,\"w\":24,\"h\":15}}]"
+    },
+    "references": []
+  },
+  "expected": {
+    "references_length": 2,
+    "references_contain": [
+      { "type": "visualization", "id": "viz-1" },
+      { "type": "search", "id": "search-1" }
+    ],
+    "attributes_has": ["panelsJSON", "kibanaSavedObjectMeta"]
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_mixed_panel_types.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/7.0.0_mixed_panel_types.json
@@ -1,0 +1,25 @@
+{
+  "description": "Dashboard 7.0.0: Multiple panels with mixed types",
+  "type": "dashboard",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "dash-mixed-panels",
+    "type": "dashboard",
+    "attributes": {
+      "title": "Dashboard with mixed panel types",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+      },
+      "panelsJSON": "[{\"id\":\"viz-1\",\"type\":\"visualization\",\"gridData\":{\"x\":0,\"y\":0,\"w\":24,\"h\":15}},{\"id\":\"viz-2\",\"type\":\"visualization\",\"gridData\":{\"x\":24,\"y\":0,\"w\":24,\"h\":15}},{\"id\":\"search-1\",\"type\":\"search\",\"gridData\":{\"x\":0,\"y\":15,\"w\":48,\"h\":15}}]"
+    },
+    "references": []
+  },
+  "expected": {
+    "references_length": 3,
+    "references_contain": [
+      { "type": "visualization", "id": "viz-1" },
+      { "type": "visualization", "id": "viz-2" },
+      { "type": "search", "id": "search-1" }
+    ]
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/7.9.3_migrate_match_all.json
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/7.9.3_migrate_match_all.json
@@ -1,0 +1,23 @@
+{
+  "description": "Dashboard 7.9.3: Migrate match_all query (same as 6.7.2, re-applied for safety)",
+  "type": "dashboard",
+  "migrationVersion": "7.9.3",
+  "input": {
+    "id": "dash-match-all-v2",
+    "type": "dashboard",
+    "attributes": {
+      "title": "Old dashboard with match_all",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"match_all\":{}},\"filter\":[{\"meta\":{\"index\":\"logstash-*\"}}]}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "attributes_equals": {
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[{\"meta\":{\"index\":\"logstash-*\"}}]}"
+      }
+    }
+  }
+}

--- a/src/plugins/dashboard/server/saved_objects/test_fixtures/README.md
+++ b/src/plugins/dashboard/server/saved_objects/test_fixtures/README.md
@@ -1,0 +1,46 @@
+# Data-Driven Migration Test Fixtures
+
+Drop a JSON file here to add a migration test. No code changes needed.
+
+## Fixture format
+
+```json
+{
+  "description": "Human-readable description of what this migration does",
+  "type": "dashboard",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "test-id",
+    "type": "dashboard",
+    "attributes": { ... },
+    "references": []
+  },
+  "expected": {
+    "references_length": 2,
+    "references_contain": [{ "type": "index-pattern", "id": "logs-*" }],
+    "attributes_has": ["panelsJSON"],
+    "attributes_equals": { "key": "expected-value" }
+  }
+}
+```
+
+## Expected fields (all optional)
+
+| Field | What it checks |
+|-------|---------------|
+| `references_length` | Exact count of references after migration |
+| `references_contain` | References array includes these objects |
+| `attributes_has` | These attribute keys exist |
+| `attributes_equals` | These attribute key/values match exactly |
+
+## Adding a test
+
+1. Create a JSON file: `<version>_<description>.json`
+2. Set `migrationVersion` to the migration version to test
+3. Define `input` (the saved object before migration)
+4. Define `expected` (what to assert after migration)
+5. Run: `yarn test:jest <path>/migration_fixtures.test.ts`
+
+## Current fixtures
+
+See JSON files in this directory.

--- a/src/plugins/visualizations/server/saved_objects/migration_fixtures.test.ts
+++ b/src/plugins/visualizations/server/saved_objects/migration_fixtures.test.ts
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { savedObjectsServiceMock } from '../../../../core/server/mocks';
+import { visualizationSavedObjectTypeMigrations } from './visualization_migrations';
+
+interface MigrationFixture {
+  description: string;
+  type: string;
+  migrationVersion: string;
+  input: Record<string, any>;
+  expected: {
+    references_length?: number;
+    references_contain?: Array<{ type: string; id: string }>;
+    attributes_has?: string[];
+    attributes_equals?: Record<string, any>;
+  };
+}
+
+function loadFixtures(dir: string): MigrationFixture[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')));
+}
+
+const fixtures = loadFixtures(path.join(__dirname, 'test_fixtures'));
+const migrations = visualizationSavedObjectTypeMigrations as Record<string, any>;
+const contextMock = savedObjectsServiceMock.createMigrationContext();
+const allVersions = Object.keys(migrations);
+const testedVersions = new Set<string>();
+
+describe('visualization data-driven migration tests', () => {
+  fixtures.forEach((fixture) => {
+    const migration = migrations[fixture.migrationVersion];
+    if (!migration) {
+      it.skip(`${fixture.description} (v${fixture.migrationVersion} not found)`, () => {});
+      return;
+    }
+    testedVersions.add(fixture.migrationVersion);
+
+    it(fixture.description, () => {
+      const result = migration(fixture.input, contextMock);
+      if (fixture.expected.references_length !== undefined) {
+        expect(result.references?.length).toBe(fixture.expected.references_length);
+      }
+      if (fixture.expected.references_contain) {
+        for (const ref of fixture.expected.references_contain) {
+          expect(result.references).toEqual(expect.arrayContaining([expect.objectContaining(ref)]));
+        }
+      }
+      if (fixture.expected.attributes_has) {
+        for (const key of fixture.expected.attributes_has) {
+          expect(result.attributes).toHaveProperty(key);
+        }
+      }
+      if (fixture.expected.attributes_equals) {
+        for (const [key, value] of Object.entries(fixture.expected.attributes_equals)) {
+          expect(result.attributes[key]).toEqual(value);
+        }
+      }
+    });
+  });
+
+  afterAll(() => {
+    const untested = allVersions.filter((v) => !testedVersions.has(v));
+    const coverage = {
+      type: 'visualization',
+      totalMigrations: allVersions.length,
+      testedMigrations: testedVersions.size,
+      coveragePercent: Math.round((testedVersions.size / allVersions.length) * 100),
+      testedVersions: [...testedVersions].sort(),
+      untestedVersions: untested.sort(),
+      fixtureCount: fixtures.length,
+    };
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n--- Migration Coverage: visualization ---\n${JSON.stringify(coverage, null, 2)}`
+    );
+    if (untested.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log(`⚠️  Untested: ${untested.join(', ')}. Add fixtures to test_fixtures/`);
+    }
+  });
+});

--- a/src/plugins/visualizations/server/saved_objects/test_fixtures/7.0.0_extract_index_pattern.json
+++ b/src/plugins/visualizations/server/saved_objects/test_fixtures/7.0.0_extract_index_pattern.json
@@ -1,0 +1,23 @@
+{
+  "description": "Visualization 7.0.0: Extract index pattern reference from searchSourceJSON",
+  "type": "visualization",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "viz-with-index",
+    "type": "visualization",
+    "attributes": {
+      "title": "My Visualization",
+      "visState": "{\"type\":\"histogram\",\"params\":{}}",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "references_contain": [
+      { "type": "index-pattern", "id": "logstash-*" }
+    ],
+    "attributes_has": ["visState", "kibanaSavedObjectMeta"]
+  }
+}

--- a/src/plugins/visualizations/server/saved_objects/test_fixtures/7.9.3_migrate_match_all.json
+++ b/src/plugins/visualizations/server/saved_objects/test_fixtures/7.9.3_migrate_match_all.json
@@ -1,0 +1,24 @@
+{
+  "description": "Visualization 7.9.3: Migrate match_all query to default query",
+  "type": "visualization",
+  "migrationVersion": "7.9.3",
+  "input": {
+    "id": "viz-match-all",
+    "type": "visualization",
+    "attributes": {
+      "title": "Viz with match_all",
+      "visState": "{\"type\":\"metric\",\"params\":{}}",
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"match_all\":{}}}"
+      }
+    },
+    "references": []
+  },
+  "expected": {
+    "attributes_equals": {
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      }
+    }
+  }
+}

--- a/src/plugins/visualizations/server/saved_objects/test_fixtures/README.md
+++ b/src/plugins/visualizations/server/saved_objects/test_fixtures/README.md
@@ -1,0 +1,46 @@
+# Data-Driven Migration Test Fixtures
+
+Drop a JSON file here to add a migration test. No code changes needed.
+
+## Fixture format
+
+```json
+{
+  "description": "Human-readable description of what this migration does",
+  "type": "visualization",
+  "migrationVersion": "7.0.0",
+  "input": {
+    "id": "test-id",
+    "type": "visualization",
+    "attributes": { ... },
+    "references": []
+  },
+  "expected": {
+    "references_length": 2,
+    "references_contain": [{ "type": "index-pattern", "id": "logs-*" }],
+    "attributes_has": ["panelsJSON"],
+    "attributes_equals": { "key": "expected-value" }
+  }
+}
+```
+
+## Expected fields (all optional)
+
+| Field | What it checks |
+|-------|---------------|
+| `references_length` | Exact count of references after migration |
+| `references_contain` | References array includes these objects |
+| `attributes_has` | These attribute keys exist |
+| `attributes_equals` | These attribute key/values match exactly |
+
+## Adding a test
+
+1. Create a JSON file: `<version>_<description>.json`
+2. Set `migrationVersion` to the migration version to test
+3. Define `input` (the saved object before migration)
+4. Define `expected` (what to assert after migration)
+5. Run: `yarn test:jest <path>/migration_fixtures.test.ts`
+
+## Current fixtures
+
+See JSON files in this directory.


### PR DESCRIPTION
## Description

Data-driven migration test framework using JSON fixtures, with a working implementation for dashboard migrations.

### What's in this PR

**Proposal doc** (`docs/saved_objects/data_driven_migration_testing.md`):
- JSON fixture format with input/expected output pairs
- When to add/update fixtures
- Current migration test coverage inventory
- CI reminder workflow sketch

**Test runner** (`src/plugins/dashboard/server/saved_objects/migration_fixtures.test.ts`):
- Loads JSON fixtures from `test_fixtures/`
- Runs each through the corresponding migration function
- Asserts on references, attributes, and structure

**Fixtures** (`src/plugins/dashboard/server/saved_objects/test_fixtures/`):
- `7.0.0_extract_references.json` — panel references extraction
- `7.0.0_empty_dashboard.json` — empty dashboard edge case

### How to add a migration test

Drop a JSON file in `test_fixtures/`:
```json
{
  "description": "What this migration does",
  "type": "dashboard",
  "migrationVersion": "7.0.0",
  "input": { ... },
  "expected": { "references_length": 2, "attributes_has": ["panelsJSON"] }
}
```

### Benefits

- **Backend-agnostic** — same fixtures work for OpenSearch, SQLite, or any future backend
- **AI-friendly** — structured JSON fixtures are easy for AI tools to generate and validate
- **Self-documenting** — fixtures serve as concrete examples of what each migration does

### Related

- RFC: #11772
- SQLite backend PR: #11771

### Check List
- [x] All tests pass locally (2 fixture tests)
- [x] New functionality includes testing
- [x] New functionality has been documented
- [ ] Commits are signed