### PR TITLE
fix(chat): Fix synthetic message ID mismatch and potential XSS in export

### DIFF
--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -465,6 +465,7 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
                       }}
                       timeline={isShareable ? timeline : undefined}
                       threadId={isShareable ? threadId : undefined}
+                      shareTargetMessage={isShareable ? assistantMsg : undefined}
                     />
                   ));
               }

--- a/src/plugins/chat/public/components/message_row.tsx
+++ b/src/plugins/chat/public/components/message_row.tsx
@@ -18,6 +18,8 @@ interface MessageRowProps {
   onResend?: (message: Message) => void;
   timeline?: Message[];
   threadId?: string;
+  /** Original assistant message for ShareModal when rendering synthetic array content messages */
+  shareTargetMessage?: AssistantMessage;
 }
 
 export const MessageRow: React.FC<MessageRowProps> = ({
@@ -26,6 +28,7 @@ export const MessageRow: React.FC<MessageRowProps> = ({
   onResend,
   timeline,
   threadId,
+  shareTargetMessage,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
@@ -157,7 +160,7 @@ export const MessageRow: React.FC<MessageRowProps> = ({
         <ShareModal
           onClose={() => setShowShareModal(false)}
           timeline={timeline}
-          targetMessage={message as AssistantMessage}
+          targetMessage={(shareTargetMessage || message) as AssistantMessage}
           threadId={threadId}
         />
       )}

--- a/src/plugins/chat/public/services/export/investigation_export_service.ts
+++ b/src/plugins/chat/public/services/export/investigation_export_service.ts
@@ -27,6 +27,9 @@ export async function collectChatExportData(
   options: ChatExportOptions
 ): Promise<ChatExportData> {
   const targetIndex = timeline.findIndex((m) => m.id === targetMessage.id);
+  if (targetIndex === -1) {
+    throw new Error(`Target message ${targetMessage.id} not found in timeline`);
+  }
   const { text: question, image: questionImage } = findPrecedingQuestion(timeline, targetIndex);
 
   return {

--- a/src/plugins/chat/public/services/export/pdf_template.test.ts
+++ b/src/plugins/chat/public/services/export/pdf_template.test.ts
@@ -170,4 +170,15 @@ describe('generatePDFReport', () => {
     expect(result).not.toContain('<script>alert');
     expect(result).toContain('&lt;script&gt;');
   });
+
+  it('should escape HTML in questionImage mimeType', () => {
+    const data = {
+      ...baseData,
+      questionImage: { base64: 'abc', mimeType: '" onerror="alert(1)' },
+    };
+    const result = generatePDFReport(data, baseOptions);
+    // The " should be escaped to &quot; preventing attribute breakout
+    expect(result).not.toContain('" onerror="');
+    expect(result).toContain('&quot;');
+  });
 });

--- a/src/plugins/chat/public/services/export/pdf_template.ts
+++ b/src/plugins/chat/public/services/export/pdf_template.ts
@@ -134,7 +134,9 @@ export function generatePDFReport(data: ChatExportData, options: ChatExportOptio
         <div class="text">${escape(data.question)}</div>
         ${
           data.questionImage
-            ? `<img src="data:${data.questionImage.mimeType};base64,${data.questionImage.base64}" alt="Question context" style="max-width:100%;border-radius:6px;margin-top:12px;" />`
+            ? `<img src="data:${escape(data.questionImage.mimeType)};base64,${escape(
+                data.questionImage.base64
+              )}" alt="Question context" style="max-width:100%;border-radius:6px;margin-top:12px;" />`
             : ''
         }
       </div>


### PR DESCRIPTION
- Fix synthetic message ID mismatch: when assistantMsg.content is an array, pass the original assistantMsg via shareTargetMessage prop through MessageRow to ShareModal so the timeline ID lookup succeeds
- Add guard in collectChatExportData to throw clear error if target message not found in timeline (caught by ShareModal error handler)
- Escape questionImage.mimeType and base64 in PDF template img tag to prevent XSS via crafted mimeType attribute breakout
- Add XSS test for questionImage mimeType escaping


### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
