### PR TITLE
[Workspace] Fix checkbox still be checked after deletion or update in collaborator list page

### DIFF
--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -158,6 +158,7 @@ export const WorkspaceCollaboratorTable = ({
   handleSubmitPermissionSettings,
 }: Props) => {
   const [selection, setSelection] = useState<PermissionSetting[]>([]);
+  const tableRef = useRef<EuiInMemoryTable<PermissionSettingWithAccessLevelAndDisplayedType>>(null);
   const {
     overlays,
     services: { notifications },
@@ -344,6 +345,7 @@ export const WorkspaceCollaboratorTable = ({
               }),
             });
             setSelection([]);
+            tableRef.current?.setSelection([]);
             modal.close();
           }
         },
@@ -381,6 +383,10 @@ export const WorkspaceCollaboratorTable = ({
         selection={selection}
         handleSubmitPermissionSettings={handleSubmitPermissionSettings}
         openChangeAccessLevelModal={openChangeAccessLevelModal}
+        onSelectionReset={() => {
+          setSelection([]);
+          tableRef.current?.setSelection([]);
+        }}
       />
     );
   };
@@ -471,6 +477,7 @@ export const WorkspaceCollaboratorTable = ({
 
   return (
     <EuiInMemoryTable
+      ref={tableRef}
       items={items}
       columns={columns}
       compressed={true}
@@ -491,6 +498,7 @@ const Actions = ({
   handleSubmitPermissionSettings,
   openDeleteConfirmModal,
   openChangeAccessLevelModal,
+  onSelectionReset,
 }: {
   isTableAction: boolean;
   selection?: PermissionSettingWithAccessLevelAndDisplayedType[];
@@ -514,6 +522,7 @@ const Actions = ({
     selections: PermissionSettingWithAccessLevelAndDisplayedType[];
     type: WorkspaceCollaboratorAccessLevel;
   }) => { close: () => void };
+  onSelectionReset?: () => void;
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const {
@@ -560,6 +569,7 @@ const Actions = ({
                   },
                 }),
               });
+              onSelectionReset?.();
             }
             modal.close();
           },

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   EuiSearchBarProps,
   EuiBasicTableColumn,


### PR DESCRIPTION


### Description

In workspace collaborator list page, select one or more items to delete or update access level, after the operation, the checkbox are still be checked.

### Issues Resolved

No issue.

## Screenshot

<img width="1744" height="799" alt="image" src="https://github.com/user-attachments/assets/326f8892-a481-4d33-a515-bc6485b1dd84" />


<img width="1666" height="741" alt="image" src="https://github.com/user-attachments/assets/b39ab5b6-6f7d-469e-a7f9-378d92fde174" />


https://github.com/user-attachments/assets/ede0ce40-e473-48e3-92c6-f6482815ad17







## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
