### PR TITLE
[Chat] Improve session management and add recent conversations to empty screen

### DIFF
--- a/src/plugins/chat/public/components/chat_header.test.tsx
+++ b/src/plugins/chat/public/components/chat_header.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChatHeader } from './chat_header';
+
+describe('ChatHeader tooltips', () => {
+  const defaultProps = {
+    isStreaming: false,
+    onNewChat: jest.fn(),
+    onClose: jest.fn(),
+  };
+
+  it('should have tooltip on new chat button', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const newChatButton = screen.getByLabelText('New chat');
+    const tooltip = newChatButton.closest('[class*="euiToolTip"]');
+
+    expect(tooltip).toBeTruthy();
+  });
+
+  it('should have tooltip on close button', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const closeButton = screen.getByLabelText('Close chatbot');
+    const tooltip = closeButton.closest('[class*="euiToolTip"]');
+
+    expect(tooltip).toBeTruthy();
+  });
+
+  it('should have tooltip on history button', () => {
+    const onShowHistory = jest.fn();
+    render(<ChatHeader {...defaultProps} onShowHistory={onShowHistory} />);
+
+    const historyButton = screen.getByLabelText('Show conversation history');
+    const tooltip = historyButton.closest('[class*="euiToolTip"]');
+
+    expect(tooltip).toBeTruthy();
+  });
+
+  it('should have tooltip on back button', () => {
+    const onBack = jest.fn();
+    render(<ChatHeader {...defaultProps} showBackButton={true} onBack={onBack} />);
+
+    const backButton = screen.getByLabelText('Go back');
+    const tooltip = backButton.closest('[class*="euiToolTip"]');
+
+    expect(tooltip).toBeTruthy();
+  });
+});

--- a/src/plugins/chat/public/components/chat_header.tsx
+++ b/src/plugins/chat/public/components/chat_header.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiText, EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiText, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import './chat_header.scss';
 
@@ -41,25 +41,37 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
       >
         <EuiFlexItem grow={false}>
           {showBackButton && onBack ? (
-            <EuiButtonIcon
-              iconType="arrowLeft"
-              onClick={onBack}
-              aria-label={i18n.translate('chat.header.goBackAriaLabel', {
+            <EuiToolTip
+              content={i18n.translate('chat.header.goBackTooltip', {
                 defaultMessage: 'Go back',
               })}
-              size="m"
-              color="text"
-            />
+            >
+              <EuiButtonIcon
+                iconType="arrowLeft"
+                onClick={onBack}
+                aria-label={i18n.translate('chat.header.goBackAriaLabel', {
+                  defaultMessage: 'Go back',
+                })}
+                size="m"
+                color="text"
+              />
+            </EuiToolTip>
           ) : (
-            <EuiButtonIcon
-              iconType="chatLeft"
-              onClick={onShowHistory}
-              aria-label={i18n.translate('chat.header.showHistoryAriaLabel', {
-                defaultMessage: 'Show conversation history',
+            <EuiToolTip
+              content={i18n.translate('chat.header.showHistoryTooltip', {
+                defaultMessage: 'View all conversations',
               })}
-              size="m"
-              color="text"
-            />
+            >
+              <EuiButtonIcon
+                iconType="chatLeft"
+                onClick={onShowHistory}
+                aria-label={i18n.translate('chat.header.showHistoryAriaLabel', {
+                  defaultMessage: 'Show conversation history',
+                })}
+                size="m"
+                color="text"
+              />
+            </EuiToolTip>
           )}
         </EuiFlexItem>
         {displayTitle && (
@@ -71,25 +83,37 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         )}
       </EuiFlexGroup>
       <div className="chatHeader__buttons">
-        <EuiButtonIcon
-          iconType="documentEdit"
-          onClick={onNewChat}
-          disabled={isStreaming}
-          aria-label={i18n.translate('chat.header.newChatAriaLabel', {
-            defaultMessage: 'New chat',
+        <EuiToolTip
+          content={i18n.translate('chat.header.newChatTooltip', {
+            defaultMessage: 'Start a new conversation',
           })}
-          size="m"
-          color="text"
-        />
-        <EuiButtonIcon
-          iconType="cross"
-          onClick={onClose}
-          aria-label={i18n.translate('chat.header.closeChatAriaLabel', {
-            defaultMessage: 'Close chatbot',
+        >
+          <EuiButtonIcon
+            iconType="documentEdit"
+            onClick={onNewChat}
+            disabled={isStreaming}
+            aria-label={i18n.translate('chat.header.newChatAriaLabel', {
+              defaultMessage: 'New chat',
+            })}
+            size="m"
+            color="text"
+          />
+        </EuiToolTip>
+        <EuiToolTip
+          content={i18n.translate('chat.header.closeChatTooltip', {
+            defaultMessage: 'Close chat window',
           })}
-          size="m"
-          color="text"
-        />
+        >
+          <EuiButtonIcon
+            iconType="cross"
+            onClick={onClose}
+            aria-label={i18n.translate('chat.header.closeChatAriaLabel', {
+              defaultMessage: 'Close chatbot',
+            })}
+            size="m"
+            color="text"
+          />
+        </EuiToolTip>
       </div>
     </div>
   );

--- a/src/plugins/chat/public/components/chat_messages.scss
+++ b/src/plugins/chat/public/components/chat_messages.scss
@@ -53,6 +53,7 @@
     gap: 8px;
     width: 100%;
     max-width: 320px;
+    margin-bottom: 16px;
   }
 
   &__suggestionCard {

--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -80,6 +80,30 @@ describe('ChatMessages', () => {
     });
   });
 
+  describe('conversation history card in empty state', () => {
+    it('should render conversation history card alongside existing starter suggestions and call onShowHistory when clicked', () => {
+      const onShowHistory = jest.fn();
+      const { getByText } = render(
+        <ChatMessages {...defaultProps} onShowHistory={onShowHistory} />
+      );
+
+      // Verify all starter suggestions are still present
+      expect(getByText('Ask questions about your data')).toBeTruthy();
+      expect(getByText('/investigate an issue')).toBeTruthy();
+      expect(getByText('Explain a concept')).toBeTruthy();
+      // And the new history card
+      expect(getByText('View conversation history')).toBeTruthy();
+
+      // Click the history card
+      const historyCard = getByText('View conversation history').closest(
+        '.chatMessages__suggestionCard'
+      );
+      historyCard?.click();
+
+      expect(onShowHistory).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('smart scroll functionality', () => {
     // Mock scrollIntoView
     beforeEach(() => {

--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -80,10 +80,10 @@ describe('ChatMessages', () => {
     });
   });
 
-  describe('conversation history card in empty state', () => {
-    it('should render conversation history card alongside existing starter suggestions and call onShowHistory when clicked', () => {
+  describe('conversation history in empty state', () => {
+    it('should render starter suggestions without conversation history when services are not provided', () => {
       const onShowHistory = jest.fn();
-      const { getByText } = render(
+      const { getByText, queryByText } = render(
         <ChatMessages {...defaultProps} onShowHistory={onShowHistory} />
       );
 
@@ -91,16 +91,44 @@ describe('ChatMessages', () => {
       expect(getByText('Ask questions about your data')).toBeTruthy();
       expect(getByText('/investigate an issue')).toBeTruthy();
       expect(getByText('Explain a concept')).toBeTruthy();
-      // And the new history card
-      expect(getByText('View conversation history')).toBeTruthy();
+      // RecentSessions should not render without required props
+      expect(queryByText('RECENT')).toBeNull();
+    });
 
-      // Click the history card
-      const historyCard = getByText('View conversation history').closest(
-        '.chatMessages__suggestionCard'
+    it('should render RecentSessions component when all required props are provided', async () => {
+      const onShowHistory = jest.fn();
+      const onSelectConversation = jest.fn();
+      const mockConversationHistoryService = {
+        getConversations: jest.fn().mockResolvedValue({
+          conversations: [
+            {
+              id: '1',
+              threadId: 'thread-1',
+              name: 'Test conversation',
+              messages: [],
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          ],
+          hasMore: false,
+          total: 1,
+        }),
+      };
+
+      const { findByText } = render(
+        <ChatMessages
+          {...defaultProps}
+          onShowHistory={onShowHistory}
+          conversationHistoryService={mockConversationHistoryService as any}
+          onSelectConversation={onSelectConversation}
+        />
       );
-      historyCard?.click();
 
-      expect(onShowHistory).toHaveBeenCalledTimes(1);
+      // Verify starter suggestions are present
+      expect(await findByText('Ask questions about your data')).toBeTruthy();
+      // RecentSessions should render with required props
+      expect(await findByText('RECENT')).toBeTruthy();
+      expect(await findByText('Test conversation')).toBeTruthy();
     });
   });
 

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -14,6 +14,11 @@ import './chat_messages.scss';
 import { ChatSuggestions } from './chat_suggestions';
 import { ToolCallGroup } from './tool_call_group';
 import { AssistantActionService } from '../../../context_provider/public';
+import { RecentSessions } from './recent_sessions';
+import {
+  ConversationHistoryService,
+  SavedConversation,
+} from '../services/conversation_history_service';
 
 /**
  * Determine tool status based on tool call and result
@@ -67,6 +72,8 @@ interface ChatMessagesProps {
   startResponse?: boolean;
   threadId?: string;
   onShowHistory?: () => void;
+  conversationHistoryService?: ConversationHistoryService;
+  onSelectConversation?: (conversation: SavedConversation) => void;
 }
 
 /**
@@ -239,6 +246,8 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
   startResponse,
   threadId,
   onShowHistory,
+  conversationHistoryService,
+  onSelectConversation,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -441,26 +450,14 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
                   </EuiFlexGroup>
                 </EuiPanel>
               ))}
-              {onShowHistory && (
-                <EuiPanel
-                  paddingSize="m"
-                  hasBorder
-                  className="chatMessages__suggestionCard"
-                  onClick={onShowHistory}
-                >
-                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type="clock" color="accent" />
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <EuiText size="s">
-                        <span>View conversation history</span>
-                      </EuiText>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiPanel>
-              )}
             </div>
+            {conversationHistoryService && onSelectConversation && onShowHistory && (
+              <RecentSessions
+                conversationHistoryService={conversationHistoryService}
+                onSelectConversation={onSelectConversation}
+                onViewAll={onShowHistory}
+              />
+            )}
           </div>
         )}
 

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -31,7 +31,8 @@ interface SuggestionItem {
   icon: string;
   iconColor?: string;
   text: string;
-  prompt: string;
+  prompt?: string;
+  action?: () => void;
 }
 
 const STARTER_SUGGESTIONS: SuggestionItem[] = [
@@ -65,6 +66,7 @@ interface ChatMessagesProps {
   onFillInput?: (content: string) => void;
   startResponse?: boolean;
   threadId?: string;
+  onShowHistory?: () => void;
 }
 
 /**
@@ -236,6 +238,7 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
   onFillInput,
   startResponse,
   threadId,
+  onShowHistory,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -418,7 +421,13 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
                   paddingSize="m"
                   hasBorder
                   className="chatMessages__suggestionCard"
-                  onClick={() => onFillInput?.(suggestion.prompt)}
+                  onClick={() => {
+                    if (suggestion.action) {
+                      suggestion.action();
+                    } else if (suggestion.prompt) {
+                      onFillInput?.(suggestion.prompt);
+                    }
+                  }}
                 >
                   <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
                     <EuiFlexItem grow={false}>
@@ -432,6 +441,25 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
                   </EuiFlexGroup>
                 </EuiPanel>
               ))}
+              {onShowHistory && (
+                <EuiPanel
+                  paddingSize="m"
+                  hasBorder
+                  className="chatMessages__suggestionCard"
+                  onClick={onShowHistory}
+                >
+                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type="clock" color="accent" />
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiText size="s">
+                        <span>View conversation history</span>
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPanel>
+              )}
             </div>
           </div>
         )}

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -81,7 +81,6 @@ describe('ChatWindow', () => {
           includeFullHistory: true,
         }),
       },
-      restoreLatestConversation: jest.fn().mockResolvedValue(null),
       saveConversation: jest.fn(),
       loadConversation: jest.fn(),
     } as any;
@@ -334,47 +333,21 @@ describe('ChatWindow', () => {
   });
 
   describe('persistence integration', () => {
-    it('should restore timeline from persisted messages on mount', async () => {
-      const mockEvents = [
-        {
-          type: 'MESSAGES_SNAPSHOT',
-          messages: [
-            { id: '1', role: 'user' as const, content: 'Hello' },
-            { id: '2', role: 'assistant' as const, content: 'Hi there!' },
-          ],
-          timestamp: Date.now(),
-        },
-      ];
-      mockChatService.restoreLatestConversation.mockResolvedValue(mockEvents);
-
+    it('should start with fresh conversation on mount', async () => {
       renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
-      // Wait for restoration to complete
+      // Wait for initialization to complete
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      // Should call restoreLatestConversation on mount
-      expect(mockChatService.restoreLatestConversation).toHaveBeenCalled();
-    });
-
-    it('should not restore timeline when no persisted messages exist', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
-      renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Should call restoreLatestConversation but timeline should remain empty
-      expect(mockChatService.restoreLatestConversation).toHaveBeenCalled();
+      // Should call newThread to start fresh
+      expect(mockChatService.newThread).toHaveBeenCalled();
     });
 
     it('should sync timeline changes with ChatService for persistence', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
       const ref = React.createRef<ChatWindowInstance>();
       renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
 
-      // Wait for initial restoration
+      // Wait for initialization
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // Clear previous calls
@@ -410,12 +383,10 @@ describe('ChatWindow', () => {
     });
 
     it('should call saveConversation on every timeline update', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
       const ref = React.createRef<ChatWindowInstance>();
       renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
 
-      // Wait for initial restoration
+      // Wait for initialization
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // Clear previous calls
@@ -447,88 +418,6 @@ describe('ChatWindow', () => {
 
       // Should be called after timeline updates
       expect(mockChatService.saveConversation).toHaveBeenCalled();
-    });
-
-    it('should replay events including synthetic tool call events when restoring with unfinished tool calls', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { ChatEventHandler } = require('../services/chat_event_handler');
-      const mockHandleEvent = jest.fn();
-      ChatEventHandler.mockImplementation(() => ({
-        handleEvent: mockHandleEvent,
-        clearState: jest.fn(),
-      }));
-
-      // The service returns events with synthetic TOOL_CALL_* events already injected
-      const mockEvents = [
-        {
-          type: 'MESSAGES_SNAPSHOT',
-          messages: [
-            { id: 'user-1', role: 'user' as const, content: 'Run a command' },
-            { id: 'assistant-1', role: 'assistant' as const, content: '', toolCalls: [] },
-          ],
-          timestamp: Date.now(),
-        },
-        {
-          type: 'TOOL_CALL_START',
-          toolCallId: 'tool-call-1',
-          toolCallName: 'execute_command',
-          parentMessageId: 'assistant-1',
-          timestamp: Date.now(),
-        },
-        {
-          type: 'TOOL_CALL_ARGS',
-          toolCallId: 'tool-call-1',
-          delta: '{"command": "ls -la"}',
-          timestamp: Date.now(),
-        },
-        { type: 'TOOL_CALL_END', toolCallId: 'tool-call-1', timestamp: Date.now() },
-      ];
-
-      mockChatService.restoreLatestConversation.mockResolvedValue(mockEvents);
-
-      renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      });
-
-      expect(mockHandleEvent).toHaveBeenCalledTimes(mockEvents.length);
-      const calledTypes = mockHandleEvent.mock.calls.map((call: any) => call[0]?.type);
-      expect(calledTypes).toContain('TOOL_CALL_START');
-      expect(calledTypes).toContain('TOOL_CALL_ARGS');
-      expect(calledTypes).toContain('TOOL_CALL_END');
-    });
-
-    it('should replay all events through eventHandler when restoring', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { ChatEventHandler } = require('../services/chat_event_handler');
-      const mockHandleEvent = jest.fn();
-      ChatEventHandler.mockImplementation(() => ({
-        handleEvent: mockHandleEvent,
-        clearState: jest.fn(),
-      }));
-
-      const mockEvents = [
-        {
-          type: 'MESSAGES_SNAPSHOT',
-          messages: [
-            { id: 'user-1', role: 'user' as const, content: 'Hello' },
-            { id: 'assistant-1', role: 'assistant' as const, content: 'Hi' },
-          ],
-          timestamp: Date.now(),
-        },
-      ];
-
-      mockChatService.restoreLatestConversation.mockResolvedValue(mockEvents);
-
-      renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      });
-
-      expect(mockHandleEvent).toHaveBeenCalledTimes(1);
-      expect(mockHandleEvent.mock.calls[0][0].type).toBe('MESSAGES_SNAPSHOT');
     });
   });
 
@@ -570,21 +459,10 @@ describe('ChatWindow', () => {
 
   describe('message resending functionality', () => {
     it('should resend user message and truncate timeline', async () => {
-      const initialTimeline = [
-        { id: 'user-1', role: 'user' as const, content: 'First message' },
-        { id: 'assistant-1', role: 'assistant' as const, content: 'First response' },
-        { id: 'user-2', role: 'user' as const, content: 'Second message' },
-        { id: 'assistant-2', role: 'assistant' as const, content: 'Second response' },
-      ];
-
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'MESSAGES_SNAPSHOT', messages: initialTimeline, timestamp: Date.now() },
-      ]);
-
       const ref = React.createRef<ChatWindowInstance>();
       renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
 
-      // Wait for initial timeline to be set
+      // Wait for initialization
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
@@ -624,18 +502,10 @@ describe('ChatWindow', () => {
     });
 
     it('should not resend non-user messages', async () => {
-      const initialTimeline = [
-        { id: 'assistant-1', role: 'assistant' as const, content: 'Assistant message' },
-      ];
-
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'MESSAGES_SNAPSHOT', messages: initialTimeline, timestamp: Date.now() },
-      ]);
-
       const ref = React.createRef<ChatWindowInstance>();
       renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
 
-      // Wait for initial timeline to be set
+      // Wait for initialization
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
@@ -855,123 +725,15 @@ describe('ChatWindow', () => {
     });
   });
 
-  describe('loading screen functionality', () => {
-    it('should display loading screen with spinner and message while restoring conversation', () => {
-      // Mock restoreLatestConversation to never resolve, keeping isRestoring true
-      mockChatService.restoreLatestConversation.mockImplementation(
-        () => new Promise(() => {}) // Never resolves
-      );
-
-      const { getByText, container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Should show loading spinner and message
-      expect(getByText('Loading conversation...')).toBeTruthy();
-      const spinner = container.querySelector('.euiLoadingSpinner');
-      expect(spinner).toBeTruthy();
-    });
-
-    it('should hide loading screen after successful restoration', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        {
-          type: 'MESSAGES_SNAPSHOT',
-          messages: [{ id: '1', role: 'user', content: 'Hello' }],
-          timestamp: Date.now(),
-        },
-      ]);
-
-      const { queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for restoration to complete
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Loading screen should be hidden
-      expect(queryByText('Restoring conversation...')).toBeNull();
-    });
-
-    it('should hide loading screen when restoration returns null', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
-      const { queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for restoration to complete
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Loading screen should be hidden
-      expect(queryByText('Restoring conversation...')).toBeNull();
-    });
-  });
-
-  describe('retry button functionality', () => {
-    it('should display error message and retry button when restoration fails', async () => {
-      const errorMessage = 'Network connection failed';
-      mockChatService.restoreLatestConversation.mockRejectedValue(new Error(errorMessage));
-
-      const { getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for restoration to fail
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Should show error title, message, and retry button
-      expect(getByText('Failed to restore conversation')).toBeTruthy();
-      expect(getByText(errorMessage)).toBeTruthy();
-      expect(getByText('Retry')).toBeTruthy();
-    });
-
-    it('should retry restoration when retry button is clicked and clear error on success', async () => {
-      mockChatService.restoreLatestConversation
-        .mockRejectedValueOnce(new Error('First attempt failed'))
-        .mockResolvedValueOnce([
-          {
-            type: 'MESSAGES_SNAPSHOT',
-            messages: [{ id: '1', role: 'user', content: 'Hello' }],
-            timestamp: Date.now(),
-          },
-        ]);
-
-      const { getByText, queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for first restoration to fail
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Verify error is shown
-      expect(getByText('Failed to restore conversation')).toBeTruthy();
-
-      // Click retry button
-      const retryButton = getByText('Retry');
-      await act(async () => {
-        retryButton.click();
-      });
-
-      // Wait for retry to complete
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Error should be cleared and restoration should succeed
-      expect(queryByText('Failed to restore conversation')).toBeNull();
-      expect(mockChatService.restoreLatestConversation).toHaveBeenCalledTimes(2);
-    });
-  });
-
   describe('component lifecycle', () => {
-    it('should initialize with empty timeline', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
+    it('should initialize with fresh conversation', async () => {
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
-      // Wait for restoration to complete
+      // Wait for initialization to complete
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(container).toBeTruthy();
-      expect(mockChatService.restoreLatestConversation).toHaveBeenCalled();
+      expect(mockChatService.newThread).toHaveBeenCalled();
     });
 
     it('should handle component unmount gracefully', () => {
@@ -980,7 +742,7 @@ describe('ChatWindow', () => {
       expect(() => unmount()).not.toThrow();
     });
 
-    it('should reset thread ID on unmount to avoid restore latest logic issues', () => {
+    it('should reset thread ID on unmount for clean restart', () => {
       mockCore.chat.resetThreadId = jest.fn();
 
       const { unmount } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
@@ -1016,109 +778,8 @@ describe('ChatWindow', () => {
     });
   });
 
-  describe('conversation loading abort functionality', () => {
-    it('should abort ongoing restoring latest after show history click', async () => {
-      // Mock a long-running restoration that never resolves
-      mockChatService.restoreLatestConversation.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            // @ts-expect-error TS2304 TODO(ts-error): fixme
-            resolveRestore = resolve;
-          })
-      );
-
-      mockChatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
-        conversations: [],
-        total: 0,
-        page: 1,
-        pageSize: 10,
-      });
-
-      const { getByLabelText, queryByText, getByText } = renderWithContext(
-        <ChatWindow onClose={jest.fn()} />
-      );
-
-      // Wait a bit to ensure loading state is set
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Verify loading screen is shown
-      expect(queryByText('Loading conversation...')).toBeTruthy();
-
-      // Click the "Show conversation history" button to abort loading and show history
-      const historyButton = getByLabelText('Show conversation history');
-      await act(async () => {
-        historyButton.click();
-      });
-
-      // Wait for state updates
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Loading screen should be hidden immediately
-      expect(queryByText('Loading conversation...')).toBeNull();
-
-      // Conversation history panel should be shown instead
-      expect(getByText('All conversations')).toBeTruthy();
-
-      // Verify restoration was called but aborted
-      expect(mockChatService.restoreLatestConversation).toHaveBeenCalled();
-    });
-
-    it('should abort conversation loading when handleCloseHistory is called', async () => {
-      // Mock a long-running restoration that never resolves
-      mockChatService.restoreLatestConversation.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            // @ts-expect-error TS2304 TODO(ts-error): fixme
-            resolveRestore = resolve;
-          })
-      );
-
-      const { getByLabelText, queryByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait a bit to ensure loading state is set
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Verify loading screen is shown
-      expect(queryByText('Loading conversation...')).toBeTruthy();
-
-      // Click the "Show conversation history" button to show history
-      const historyButton = getByLabelText('Show conversation history');
-      await act(async () => {
-        historyButton.click();
-      });
-
-      // Wait for state updates
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Now click back button to close history (which should abort loading)
-      const backButton = getByLabelText('Go back');
-      await act(async () => {
-        backButton.click();
-      });
-
-      // Wait for state updates
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Loading screen should be hidden immediately
-      expect(queryByText('Loading conversation...')).toBeNull();
-
-      // Verify restoration was called but not completed
-      expect(mockChatService.restoreLatestConversation).toHaveBeenCalled();
-    });
-
-    it('should abort loading when selecting a conversation and then closing history', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
+  describe('conversation loading functionality', () => {
+    it('should load selected conversation from history', async () => {
       // Mock getConversations to return a conversation
       mockChatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
         conversations: [
@@ -1135,20 +796,20 @@ describe('ChatWindow', () => {
         pageSize: 10,
       });
 
-      // Mock loadConversation to never resolve
-      mockChatService.loadConversation.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            // @ts-expect-error TS2304 TODO(ts-error): fixme
-            resolveLoad = resolve;
-          })
-      );
+      // Mock loadConversation to resolve with events
+      mockChatService.loadConversation.mockResolvedValue([
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: '1', role: 'user', content: 'Hello from history' }],
+          timestamp: Date.now(),
+        },
+      ]);
 
       const { getByLabelText, getByText, queryByText } = renderWithContext(
         <ChatWindow onClose={jest.fn()} />
       );
 
-      // Wait for initial restoration to complete
+      // Wait for initialization
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -1169,34 +830,16 @@ describe('ChatWindow', () => {
         conversationItem.click();
       });
 
-      // Wait a bit to ensure loading state is set
+      // Wait for loading to complete
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
-      // Verify loading screen is shown
-      expect(queryByText('Loading conversation...')).toBeTruthy();
-
-      // Click back button to abort loading
-      const backButton = getByLabelText('Go back');
-      await act(async () => {
-        backButton.click();
-      });
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Loading screen should be hidden immediately
-      expect(queryByText('Loading conversation...')).toBeNull();
-
-      // Verify loadConversation was called but not completed
-      expect(mockChatService.loadConversation).toHaveBeenCalled();
+      // Verify loadConversation was called
+      expect(mockChatService.loadConversation).toHaveBeenCalledWith('thread-1');
     });
 
-    it('should not show error toast when loading is aborted', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
+    it('should show error toast when loading conversation fails', async () => {
       mockChatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
         conversations: [
           {
@@ -1212,18 +855,12 @@ describe('ChatWindow', () => {
         pageSize: 10,
       });
 
-      // Mock loadConversation to reject after a delay
-      let rejectLoad: any;
-      mockChatService.loadConversation.mockImplementation(
-        () =>
-          new Promise((resolve, reject) => {
-            rejectLoad = reject;
-          })
-      );
+      // Mock loadConversation to reject
+      mockChatService.loadConversation.mockRejectedValue(new Error('Loading failed'));
 
       const { getByLabelText, getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
-      // Wait for initial restoration
+      // Wait for initialization
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -1244,29 +881,16 @@ describe('ChatWindow', () => {
       });
 
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
-      // Abort by clicking back
-      const backButton = getByLabelText('Go back');
-      await act(async () => {
-        backButton.click();
-      });
-
-      // Now reject the promise (simulating error after abort)
-      await act(async () => {
-        rejectLoad(new Error('Loading failed'));
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      // Verify no error toast was shown (since loading was aborted)
-      expect(mockCore.notifications.toasts.addWarning).not.toHaveBeenCalled();
+      // Verify error toast was shown
+      expect(mockCore.notifications.toasts.addWarning).toHaveBeenCalled();
     });
   });
 
   describe('handleSelectConversation', () => {
     beforeEach(() => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
       mockChatService.conversationHistoryService.getConversations = jest.fn().mockResolvedValue({
         conversations: [
           {

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -35,6 +35,7 @@ jest.mock('../services/chat_event_handler', () => ({
   ChatEventHandler: jest.fn().mockImplementation(() => ({
     handleEvent: jest.fn(),
     clearState: jest.fn(),
+    stopToolResultStreaming: jest.fn(),
   })),
 }));
 
@@ -699,6 +700,49 @@ describe('ChatWindow', () => {
 
       expect(mockChatService.newThread).toHaveBeenCalled();
     });
+
+    it('should cancel ongoing streaming when starting a new chat', async () => {
+      const ref = React.createRef<ChatWindowInstance>();
+
+      const unsubscribeMock = jest.fn();
+      const streamingObservable = {
+        subscribe: jest.fn(() => ({ unsubscribe: unsubscribeMock })),
+      };
+
+      mockChatService.sendMessage.mockResolvedValue({
+        observable: streamingObservable,
+        userMessage: { id: 'user-1', content: 'test', role: 'user' },
+      });
+      mockChatService.abort = jest.fn();
+
+      renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
+
+      // Start streaming by sending a message
+      await act(async () => {
+        await ref.current?.sendMessage({ content: 'test message' });
+      });
+
+      // Wait for subscription to be created
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(streamingObservable.subscribe).toHaveBeenCalled();
+
+      // Start a new chat while streaming is active
+      await act(async () => {
+        ref.current?.startNewChat();
+      });
+
+      // Verify abort was called to stop backend streaming
+      expect(mockChatService.abort).toHaveBeenCalled();
+
+      // Verify subscription was unsubscribed
+      expect(unsubscribeMock).toHaveBeenCalled();
+
+      // Verify newThread was called to start fresh
+      expect(mockChatService.newThread).toHaveBeenCalled();
+    });
   });
 
   describe('error handling', () => {
@@ -905,6 +949,13 @@ describe('ChatWindow', () => {
         page: 1,
         pageSize: 10,
       });
+
+      // Mock loadConversation to simulate setting thread ID
+      mockChatService.loadConversation = jest.fn().mockImplementation(async (threadId: string) => {
+        // Simulate the real behavior: loadConversation sets the thread ID
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return [];
+      });
     });
 
     it('should call eventHandler.clearState before replaying events to prevent state bleed', async () => {
@@ -920,6 +971,7 @@ describe('ChatWindow', () => {
       ChatEventHandler.mockImplementation(() => ({
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
+        stopToolResultStreaming: jest.fn(),
       }));
 
       const mockEvents = [
@@ -929,7 +981,10 @@ describe('ChatWindow', () => {
           timestamp: Date.now(),
         },
       ];
-      mockChatService.loadConversation.mockResolvedValue(mockEvents);
+      mockChatService.loadConversation.mockImplementation(async (threadId: string) => {
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return mockEvents;
+      });
 
       const { getByLabelText, getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -968,6 +1023,7 @@ describe('ChatWindow', () => {
       ChatEventHandler.mockImplementation(() => ({
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
+        stopToolResultStreaming: jest.fn(),
       }));
 
       const mockEvents = [
@@ -983,7 +1039,10 @@ describe('ChatWindow', () => {
           timestamp: Date.now(),
         },
       ];
-      mockChatService.loadConversation.mockResolvedValue(mockEvents);
+      mockChatService.loadConversation.mockImplementation(async (threadId: string) => {
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return mockEvents;
+      });
 
       const { getByLabelText, getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
@@ -1011,6 +1070,283 @@ describe('ChatWindow', () => {
       const calledTypes = mockHandleEvent.mock.calls.map((call: any) => call[0]?.type);
       expect(calledTypes).toContain('MESSAGES_SNAPSHOT');
       expect(calledTypes).toContain('TOOL_CALL_START');
+    });
+
+    it('should cancel ongoing streaming when switching to another conversation', async () => {
+      const ref = React.createRef<ChatWindowInstance>();
+
+      // Mock ongoing streaming
+      const unsubscribeMock = jest.fn();
+      const streamingObservable = {
+        subscribe: jest.fn(() => ({ unsubscribe: unsubscribeMock })),
+      };
+
+      mockChatService.sendMessage.mockResolvedValue({
+        observable: streamingObservable,
+        userMessage: { id: 'user-1', content: 'test', role: 'user' },
+      });
+      mockChatService.abort = jest.fn();
+
+      // Mock conversation loading
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: 'u1', role: 'user', content: 'Old conversation' }],
+          timestamp: Date.now(),
+        },
+      ];
+      mockChatService.loadConversation.mockImplementation(async (threadId: string) => {
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return mockEvents;
+      });
+
+      const { getByLabelText, getByText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      // Wait for initialization
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      // Start streaming by sending a message
+      await act(async () => {
+        await ref.current?.sendMessage({ content: 'test message' });
+      });
+
+      // Wait for subscription to be created
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(streamingObservable.subscribe).toHaveBeenCalled();
+
+      // Open history panel and switch to another conversation while streaming
+      const historyButton = getByLabelText('Show conversation history');
+      await act(async () => {
+        historyButton.click();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      const conversationItem = getByText('Test conversation');
+      await act(async () => {
+        conversationItem.click();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      // Verify abort was called to stop backend streaming
+      expect(mockChatService.abort).toHaveBeenCalled();
+
+      // Verify subscription was unsubscribed
+      expect(unsubscribeMock).toHaveBeenCalled();
+
+      // Verify conversation was loaded
+      expect(mockChatService.loadConversation).toHaveBeenCalledWith('thread-1');
+    });
+
+    it('should prevent streaming events from previous conversation affecting new conversation', async () => {
+      const ref = React.createRef<ChatWindowInstance>();
+
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      const mockHandleEvent = jest.fn();
+      const mockClearState = jest.fn();
+      ChatEventHandler.mockImplementation(() => ({
+        handleEvent: mockHandleEvent,
+        clearState: mockClearState,
+        stopToolResultStreaming: jest.fn(),
+      }));
+
+      // Mock ongoing streaming that continues after switch
+      let streamingCallbacks: any = null;
+      const streamingObservable = {
+        subscribe: jest.fn((callbacks: any) => {
+          streamingCallbacks = callbacks;
+          return { unsubscribe: jest.fn() };
+        }),
+      };
+
+      mockChatService.sendMessage.mockResolvedValue({
+        observable: streamingObservable,
+        userMessage: { id: 'user-1', content: 'test', role: 'user' },
+      });
+      mockChatService.abort = jest.fn();
+
+      // Mock conversation loading
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: 'u1', role: 'user', content: 'Old conversation' }],
+          timestamp: Date.now(),
+        },
+      ];
+      mockChatService.loadConversation.mockImplementation(async (threadId: string) => {
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return mockEvents;
+      });
+
+      const { getByLabelText, getByText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      // Wait for initialization
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      // Start streaming
+      await act(async () => {
+        await ref.current?.sendMessage({ content: 'test message' });
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(streamingObservable.subscribe).toHaveBeenCalled();
+
+      // Track handleEvent calls before switching
+      const callsBeforeSwitch = mockHandleEvent.mock.calls.length;
+
+      // Switch to another conversation
+      const historyButton = getByLabelText('Show conversation history');
+      await act(async () => {
+        historyButton.click();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      const conversationItem = getByText('Test conversation');
+      await act(async () => {
+        conversationItem.click();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      // Verify clearState was called (resetting event handler state)
+      expect(mockClearState).toHaveBeenCalled();
+
+      // Try to emit events from the old streaming (simulating race condition)
+      if (streamingCallbacks) {
+        await act(async () => {
+          streamingCallbacks.next({ type: 'message', content: 'late event from old stream' });
+        });
+      }
+
+      // New conversation's events should be processed, but old streaming events should not
+      // interfere because subscription was canceled
+      const callsAfterSwitch = mockHandleEvent.mock.calls.length;
+      expect(callsAfterSwitch).toBeGreaterThan(callsBeforeSwitch);
+    });
+
+    it('should not save incomplete message when switching conversations during streaming', async () => {
+      const ref = React.createRef<ChatWindowInstance>();
+
+      // Mock streaming with partial message
+      let streamingCallbacks: any = null;
+      const streamingObservable = {
+        subscribe: jest.fn((callbacks: any) => {
+          streamingCallbacks = callbacks;
+          // Emit partial assistant message
+          setTimeout(() => {
+            callbacks.next({
+              type: 'TEXT_MESSAGE_START',
+              messageId: 'assist-1',
+              timestamp: Date.now(),
+            });
+            callbacks.next({
+              type: 'TEXT_MESSAGE_CONTENT',
+              messageId: 'assist-1',
+              delta: 'Partial response...',
+              timestamp: Date.now(),
+            });
+          }, 5);
+          return { unsubscribe: jest.fn() };
+        }),
+      };
+
+      mockChatService.sendMessage.mockResolvedValue({
+        observable: streamingObservable,
+        userMessage: { id: 'user-1', content: 'test', role: 'user' },
+      });
+
+      // Mock conversation loading
+      const mockEvents = [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: 'u1', role: 'user', content: 'Old conversation' }],
+          timestamp: Date.now(),
+        },
+      ];
+      mockChatService.loadConversation.mockImplementation(async (threadId: string) => {
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return mockEvents;
+      });
+      mockChatService.saveConversation = jest.fn();
+
+      const { getByLabelText, getByText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      // Start streaming
+      await act(async () => {
+        await ref.current?.sendMessage({ content: 'test message' });
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+
+      // Clear previous saveConversation calls
+      mockChatService.saveConversation.mockClear();
+
+      // Switch to another conversation while streaming
+      const historyButton = getByLabelText('Show conversation history');
+      await act(async () => {
+        historyButton.click();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      const conversationItem = getByText('Test conversation');
+      await act(async () => {
+        conversationItem.click();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      // Verify that incomplete message was NOT saved during the switch
+      // The isLoading flag should prevent saving incomplete state
+      const savedCalls = mockChatService.saveConversation.mock.calls;
+
+      // Check if any saved timeline contains the partial assistant message
+      const savedPartialMessage = savedCalls.some((call: any) => {
+        const timeline = call[0];
+        return timeline.some(
+          (msg: any) => msg.role === 'assistant' && msg.content?.includes('Partial response')
+        );
+      });
+
+      // Should NOT save the partial message during conversation switch
+      expect(savedPartialMessage).toBe(false);
     });
   });
 

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -71,6 +71,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   const [isLoading, setIsLoading] = useState(false);
   const handleSendRef = useRef<typeof handleSend>();
   const currentSubscriptionRef = useRef<any>(null);
+  const conversationLoadAbortControllerRef = useRef<AbortController | null>(null);
   const {screenshotFeatureEnabled,isCapturing, capturePageContainer} = usePageContainerCapture();
   const [screenshotData, setScreenshotData] = useState<{pageTitle: string, createdAt: moment.Moment} & PageContainerImageData>();
   const [toolCallStates, setToolCallStates] = useState<Record<string, any>>({});
@@ -323,17 +324,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     subscribeToMessageStream(textContent, [...truncatedTimeline,...additionalMessages]);
   }, [timeline, subscribeToMessageStream, setInput, setTimeline]);
 
-  const handleNewChat = useCallback(() => {
-    chatService.newThread();
-    setTimeline([]);
-    setCurrentRunId(null);
-    setIsStreaming(false);
-    setPendingConfirmation(null);
-    confirmationService.cleanAll();
-    setShowHistory(false);
-  }, [chatService, confirmationService]);
-
-  const handleStop = useCallback(() => {
+  // Helper function to stop streaming and clean up subscriptions
+  const stopStreaming = useCallback(() => {
     // Abort the current streaming request
     chatService.abort();
     // Unsubscribe from current observable if exists
@@ -342,11 +334,30 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       currentSubscriptionRef.current = null;
     }
 
+    // Stop tool result streaming if active
+    eventHandler.stopToolResultStreaming();
+
     // Update streaming state (both ref and state for React 18 compatibility)
     isStreamingRef.current = false;
     setIsStreaming(false);
     setStartResponse(false);
-  }, [chatService]);
+  }, [chatService, eventHandler]);
+
+  const handleNewChat = useCallback(() => {
+    // Stop any ongoing streaming before starting a new chat
+    stopStreaming();
+
+    chatService.newThread();
+    setTimeline([]);
+    setCurrentRunId(null);
+    setPendingConfirmation(null);
+    confirmationService.cleanAll();
+    setShowHistory(false);
+  }, [chatService, confirmationService, stopStreaming]);
+
+  const handleStop = useCallback(() => {
+    stopStreaming();
+  }, [stopStreaming]);
 
   const handleApproveConfirmation = useCallback(() => {
     if (pendingConfirmation) {
@@ -408,42 +419,71 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   }, []);
 
   const handleSelectConversation = useCallback(async (conversation: SavedConversation) => {
+    // Stop any ongoing streaming before switching conversations
+    stopStreaming();
+
+    // Abort any ongoing conversation loading
+    if (conversationLoadAbortControllerRef.current) {
+      conversationLoadAbortControllerRef.current.abort();
+    }
+
+    // Create new abort controller for this load operation
+    const abortController = new AbortController();
+    conversationLoadAbortControllerRef.current = abortController;
+
     setIsLoading(true);
 
     try {
       // Load the conversation and get AG-UI event array
       const events = await chatService.loadConversation(conversation.threadId);
 
+      // Check if this load was aborted (user switched to another conversation)
+      if (abortController.signal.aborted) {
+        return;
+      }
+
       if (events) {
         // Reset UI state
         eventHandler.clearState();
         setCurrentRunId(null);
-        setIsStreaming(false);
         setPendingConfirmation(null);
         confirmationService.cleanAll();
         setShowHistory(false);
         setIsLoading(false);
 
+        // Replay all events to reconstruct the conversation
         for (const event of events) {
+          // Check abort signal during replay
+          if (abortController.signal.aborted) {
+            return;
+          }
           await eventHandler.handleEvent(event);
         }
       }
     } catch (error: any) {
-      toasts?.addWarning({
-        title: i18n.translate('chat.window.loadConversationErrorTitle', {
-          defaultMessage: 'Failed to load conversation',
-        }),
-        text:
-          error instanceof Error
-            ? error.message
-            : i18n.translate('chat.window.loadConversationErrorMessage', {
-                defaultMessage: 'An unexpected error occurred while loading the conversation.',
-              }),
-      });
+      if (!abortController.signal.aborted) {
+        toasts?.addWarning({
+          title: i18n.translate('chat.window.loadConversationErrorTitle', {
+            defaultMessage: 'Failed to load conversation',
+          }),
+          text:
+            error instanceof Error
+              ? error.message
+              : i18n.translate('chat.window.loadConversationErrorMessage', {
+                  defaultMessage: 'An unexpected error occurred while loading the conversation.',
+                }),
+        });
+      }
     } finally {
-      setIsLoading(false);
+      if (!abortController.signal.aborted) {
+        setIsLoading(false);
+      }
+      // Clear abort controller reference
+      if (conversationLoadAbortControllerRef.current === abortController) {
+        conversationLoadAbortControllerRef.current = null;
+      }
     }
-  }, [chatService, eventHandler, confirmationService, toasts]);
+  }, [chatService, eventHandler, confirmationService, toasts, stopStreaming]);
 
   const windowInstance = useMemo<ChatWindowInstance>(() => ({
     startNewChat: () => handleNewChat(),

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -500,6 +500,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             onRejectConfirmation={handleRejectConfirmation}
             onFillInput={setInput}
             threadId={chatService.getThreadId()}
+            onShowHistory={handleShowHistory}
             {...enhancedProps}
             startResponse={startResponse}
           />

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -541,6 +541,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             onFillInput={setInput}
             threadId={chatService.getThreadId()}
             onShowHistory={handleShowHistory}
+            conversationHistoryService={chatService.conversationHistoryService}
+            onSelectConversation={handleSelectConversation}
             {...enhancedProps}
             startResponse={startResponse}
           />

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -68,11 +68,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const [pendingConfirmation, setPendingConfirmation] = useState<ConfirmationRequest | null>(null);
   const [showHistory, setShowHistory] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [restoreError, setRestoreError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const handleSendRef = useRef<typeof handleSend>();
   const currentSubscriptionRef = useRef<any>(null);
-  const loadingAbortControllerRef = useRef<AbortController | null>(null);
   const {screenshotFeatureEnabled,isCapturing, capturePageContainer} = usePageContainerCapture();
   const [screenshotData, setScreenshotData] = useState<{pageTitle: string, createdAt: moment.Moment} & PageContainerImageData>();
   const [toolCallStates, setToolCallStates] = useState<Record<string, any>>({});
@@ -150,54 +148,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     };
   }, [eventHandler]);
 
-  // Extracted restoration logic to avoid duplication
-  const restoreConversationTimeline = useCallback(async () => {
-    // Create abort controller for this loading operation
-    const abortController = new AbortController();
-    loadingAbortControllerRef.current = abortController;
-
-    setIsLoading(true);
-    setRestoreError(null);
-
-    try {
-      // Check if aborted before starting
-      if (abortController.signal.aborted) return;
-
-      const events = await chatService.restoreLatestConversation();
-
-      // Check if aborted after async operation
-      if (abortController.signal.aborted) return;
-
-      eventHandler.clearState();
-      setIsLoading(false);
-
-      if (events) {
-        for (const event of events) {
-          if (abortController.signal.aborted) return;
-          await eventHandler.handleEvent(event);
-        }
-      }
-    } catch (error: any) {
-      // Don't show error if aborted
-      if (!abortController.signal.aborted) {
-        console.error('Error restoring conversation:', error);
-        setRestoreError(error.message || 'Failed to restore conversation');
-      }
-    } finally {
-      // Only update loading state if not aborted
-      if (!abortController.signal.aborted) {
-        setIsLoading(false);
-      }
-      // Clear the abort controller reference
-      if (loadingAbortControllerRef.current === abortController) {
-        loadingAbortControllerRef.current = null;
-      }
-    }
-  }, [chatService, eventHandler]);
-
-  // Restore timeline from latest conversation on component mount
+  // Initialize with fresh conversation on mount
   useMount(() => {
-    restoreConversationTimeline();
+    chatService.newThread();
   });
 
   // Save conversation to history whenever timeline changes
@@ -207,7 +160,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     }
   }, [timeline, chatService, isLoading]);
 
-  // Clear thread ID so next mount can restore the latest conversation
+  // Clear thread ID on unmount to start fresh next time
   useUnmount(() => {
     services.core.chat.resetThreadId()
   });
@@ -378,7 +331,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     setPendingConfirmation(null);
     confirmationService.cleanAll();
     setShowHistory(false);
-    setRestoreError(null);
   }, [chatService, confirmationService]);
 
   const handleStop = useCallback(() => {
@@ -448,40 +400,19 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   }, [timeline]);
 
   const handleShowHistory = useCallback(() => {
-    loadingAbortControllerRef.current?.abort();
-    setIsLoading(false);
     setShowHistory(true);
-    setRestoreError(null);
   }, []);
 
   const handleCloseHistory = useCallback(() => {
-    // Abort any ongoing loading operation
-    if (loadingAbortControllerRef.current) {
-      loadingAbortControllerRef.current.abort();
-      loadingAbortControllerRef.current = null;
-    }
-
-    // Reset loading state and show history panel
-    setIsLoading(false);
     setShowHistory(false);
   }, []);
 
   const handleSelectConversation = useCallback(async (conversation: SavedConversation) => {
-    // Create abort controller for this loading operation
-    const abortController = new AbortController();
-    loadingAbortControllerRef.current = abortController;
-
     setIsLoading(true);
 
     try {
-      // Check if aborted before starting
-      if (abortController.signal.aborted) return;
-
       // Load the conversation and get AG-UI event array
       const events = await chatService.loadConversation(conversation.threadId);
-
-      // Check if aborted after async operation
-      if (abortController.signal.aborted) return;
 
       if (events) {
         // Reset UI state
@@ -494,34 +425,23 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         setIsLoading(false);
 
         for (const event of events) {
-          if (abortController.signal.aborted) return;
           await eventHandler.handleEvent(event);
         }
       }
     } catch (error: any) {
-      // Don't show error if aborted
-      if (!abortController.signal.aborted) {
-        toasts?.addWarning({
-          title: i18n.translate('chat.window.loadConversationErrorTitle', {
-            defaultMessage: 'Failed to load conversation',
-          }),
-          text:
-            error instanceof Error
-              ? error.message
-              : i18n.translate('chat.window.loadConversationErrorMessage', {
-                  defaultMessage: 'An unexpected error occurred while loading the conversation.',
-                }),
-        });
-      }
+      toasts?.addWarning({
+        title: i18n.translate('chat.window.loadConversationErrorTitle', {
+          defaultMessage: 'Failed to load conversation',
+        }),
+        text:
+          error instanceof Error
+            ? error.message
+            : i18n.translate('chat.window.loadConversationErrorMessage', {
+                defaultMessage: 'An unexpected error occurred while loading the conversation.',
+              }),
+      });
     } finally {
-      // Only update loading state if not aborted
-      if (!abortController.signal.aborted) {
-        setIsLoading(false);
-      }
-      // Clear the abort controller reference
-      if (loadingAbortControllerRef.current === abortController) {
-        loadingAbortControllerRef.current = null;
-      }
+      setIsLoading(false);
     }
   }, [chatService, eventHandler, confirmationService, toasts]);
 
@@ -563,25 +483,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
               defaultMessage: 'Loading conversation...',
             })}
           </EuiText>
-        </div>
-      ) : restoreError ? (
-        <div className="chatWindow__errorContainer">
-          <EuiText color="danger" textAlign="center">
-            <h3>
-              {i18n.translate('chat.window.restoreErrorTitle', {
-                defaultMessage: 'Failed to restore conversation',
-              })}
-            </h3>
-            <p>{restoreError}</p>
-          </EuiText>
-          <EuiButton
-            onClick={restoreConversationTimeline}
-            iconType="refresh"
-          >
-            {i18n.translate('chat.window.retryButton', {
-              defaultMessage: 'Retry',
-            })}
-          </EuiButton>
         </div>
       ) : showHistory ? (
         <ConversationHistoryPanel

--- a/src/plugins/chat/public/components/chat_window_conversation_name.test.tsx
+++ b/src/plugins/chat/public/components/chat_window_conversation_name.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { act } from 'react';
 import { render } from '@testing-library/react';
 import { ChatWindow } from './chat_window';
 import { coreMock } from '../../../../core/public/mocks';
@@ -13,6 +13,7 @@ import { ChatProvider } from '../contexts/chat_context';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { ChatEventHandler } from '../services/chat_event_handler';
 
 // Create mock observable before using it in mocks
 const mockObservable = of({ toolDefinitions: [], toolCallStates: {} });
@@ -35,7 +36,7 @@ jest.mock('../services/chat_event_handler', () => ({
   ChatEventHandler: jest.fn().mockImplementation((config) => ({
     handleEvent: jest.fn().mockImplementation(async (event) => {
       if (event.type === 'MESSAGES_SNAPSHOT' && event.messages) {
-        config.callbacks.onTimelineUpdate(() => event.messages);
+        config.callbacks.onTimelineUpdate(event.messages);
       }
     }),
     clearState: jest.fn(),
@@ -44,6 +45,16 @@ jest.mock('../services/chat_event_handler', () => ({
 
 jest.mock('../actions/graph_timeseries_data_action', () => ({
   useGraphTimeseriesDataAction: jest.fn(),
+}));
+
+// Mock scrollIntoView
+Element.prototype.scrollIntoView = jest.fn();
+
+// Mock ResizeObserver
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
 }));
 
 describe('ChatWindow - Conversation Name', () => {
@@ -71,7 +82,6 @@ describe('ChatWindow - Conversation Name', () => {
         userMessage: { id: '1', content: 'test', role: 'user' },
       }),
       newThread: jest.fn(),
-      restoreLatestConversation: jest.fn().mockResolvedValue(null),
       saveConversation: jest.fn(),
       getThreadId: jest.fn().mockReturnValue('mock-thread-id'),
       setChatWindowInstance: jest.fn(),
@@ -110,13 +120,45 @@ describe('ChatWindow - Conversation Name', () => {
     );
   };
 
+  // Helper function to simulate sending a message which populates the timeline
+  const sendMessageAndUpdateTimeline = async (messages: any[], rendered: any) => {
+    // Cast the mocked ChatEventHandler to jest.Mock to access mock properties
+    const MockedChatEventHandler = ChatEventHandler as jest.MockedClass<typeof ChatEventHandler>;
+
+    const mockHandleEvent = jest.fn().mockImplementation(async (event: any) => {
+      if (event.type === 'MESSAGES_SNAPSHOT' && event.messages) {
+        // Get the config that was passed to ChatEventHandler
+        const mockInstance =
+          MockedChatEventHandler.mock.results[MockedChatEventHandler.mock.results.length - 1]
+            ?.value;
+        if (mockInstance) {
+          // Directly call handleEvent implementation from our mock
+          const config =
+            MockedChatEventHandler.mock.calls[MockedChatEventHandler.mock.calls.length - 1][0];
+          if (config?.callbacks?.onTimelineUpdate) {
+            config.callbacks.onTimelineUpdate(event.messages);
+          }
+        }
+      }
+    });
+
+    // Simulate the event handler receiving a MESSAGES_SNAPSHOT event
+    await act(async () => {
+      await mockHandleEvent({
+        type: 'MESSAGES_SNAPSHOT',
+        messages,
+        timestamp: Date.now(),
+      });
+      // Wait for React state updates
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+  };
+
   describe('conversation name extraction', () => {
     it('should not display conversation name when timeline is empty', async () => {
-      mockChatService.restoreLatestConversation.mockResolvedValue(null);
-
       const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
 
-      // Wait for restoration to complete
+      // Wait for initialization
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       // ChatHeader should not have the title text when there's no message
@@ -133,18 +175,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '1', role: 'user' as const, content: 'How can I find the largest index?' },
         { id: '2', role: 'assistant' as const, content: 'You can use...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('How can I find the largest index?');
     });
@@ -161,18 +196,11 @@ describe('ChatWindow - Conversation Name', () => {
         },
         { id: '2', role: 'assistant' as const, content: 'The weather is...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('What is the weather today?');
     });
@@ -190,19 +218,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '3', role: 'user' as const, content: 'Can you describe this image?' },
         { id: '4', role: 'assistant' as const, content: 'Sure...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Should use the first user message with text content
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('Can you describe this image?');
     });
@@ -218,19 +238,11 @@ describe('ChatWindow - Conversation Name', () => {
         },
         { id: '2', role: 'assistant' as const, content: 'I see an image...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Title should not be rendered when conversationName is empty
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).not.toBeInTheDocument();
     });
 
@@ -240,18 +252,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '2', role: 'user' as const, content: 'Tell me about TypeScript' },
         { id: '3', role: 'assistant' as const, content: 'TypeScript is...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('Tell me about TypeScript');
     });
@@ -263,18 +268,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '3', role: 'user' as const, content: 'How do I debug my code?' },
         { id: '4', role: 'assistant' as const, content: 'You can use...' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('How do I debug my code?');
     });
@@ -286,18 +284,11 @@ describe('ChatWindow - Conversation Name', () => {
         { id: '1', role: 'user' as const, content: longMessage },
         { id: '2', role: 'assistant' as const, content: 'Response' },
       ];
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      const rendered = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(messages, rendered);
 
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      const titleElement = container.querySelector('.chatHeader__title');
+      const titleElement = rendered.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       // Full text should be present (CSS handles truncation)
       expect(titleElement?.textContent).toBe(longMessage);
@@ -306,46 +297,29 @@ describe('ChatWindow - Conversation Name', () => {
       expect(titleElement).toHaveClass('chatHeader__title');
     });
 
-    it('should update conversation name when new messages are added', async () => {
-      // Start with a conversation that has messages
-      const initialMessages = [
+    it('should update conversation name when loading different conversations', async () => {
+      // Load first conversation
+      const firstMessages = [
         { id: '1', role: 'user' as const, content: 'Initial message' },
         { id: '2', role: 'assistant' as const, content: 'Initial response' },
       ];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'test-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages: initialMessages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
+      const rendered1 = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(firstMessages, rendered1);
 
-      const { container } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for initial restoration
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Should have initial title
-      let titleElement = container.querySelector('.chatHeader__title');
+      let titleElement = rendered1.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('Initial message');
 
-      // Now test with a different conversation
-      const newMessages = [{ id: '3', role: 'user' as const, content: 'New conversation started' }];
+      // Load second conversation in a new window instance
+      const secondMessages = [
+        { id: '3', role: 'user' as const, content: 'New conversation started' },
+      ];
 
-      mockChatService.restoreLatestConversation.mockResolvedValue([
-        { type: 'RUN_STARTED', threadId: 'new-thread-id', timestamp: Date.now() },
-        { type: 'MESSAGES_SNAPSHOT', messages: newMessages, timestamp: Date.now() },
-        { type: 'RUN_FINISHED', timestamp: Date.now() },
-      ]);
+      const rendered2 = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+      await sendMessageAndUpdateTimeline(secondMessages, rendered2);
 
-      // Unmount and remount to simulate loading a different conversation
-      const { container: newContainer } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
-
-      // Wait for restoration to complete
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Now title should be updated
-      titleElement = newContainer.querySelector('.chatHeader__title');
+      titleElement = rendered2.container.querySelector('.chatHeader__title');
       expect(titleElement).toBeInTheDocument();
       expect(titleElement?.textContent).toBe('New conversation started');
     });

--- a/src/plugins/chat/public/components/index.ts
+++ b/src/plugins/chat/public/components/index.ts
@@ -5,3 +5,4 @@
 
 export { ChatWindow } from './chat_window';
 export { ChatHeaderButton } from './chat_header_button';
+export { RecentSessions } from './recent_sessions';

--- a/src/plugins/chat/public/components/recent_sessions.scss
+++ b/src/plugins/chat/public/components/recent_sessions.scss
@@ -1,0 +1,25 @@
+.recentSessions {
+  width: 100%;
+  max-width: 320px;
+
+  &__item {
+    cursor: pointer;
+    transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+    &:hover {
+      background-color: $euiColorLightestShade;
+    }
+
+    &:active {
+      transform: scale(0.99);
+    }
+  }
+
+  &__itemTitle {
+    min-width: 0;
+
+    span {
+      overflow: hidden;
+    }
+  }
+}

--- a/src/plugins/chat/public/components/recent_sessions.test.tsx
+++ b/src/plugins/chat/public/components/recent_sessions.test.tsx
@@ -300,4 +300,51 @@ describe('RecentSessions', () => {
       .closest('.recentSessions__item');
     expect(invalidConv?.textContent).toBe('Invalid timestamp conversation');
   });
+
+  it('should not update state after component unmounts', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const delayedService = ({
+      getConversations: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  conversations: mockConversations,
+                  hasMore: false,
+                  total: 3,
+                }),
+              50
+            )
+          )
+      ),
+    } as unknown) as ConversationHistoryService;
+
+    const { unmount } = render(
+      <RecentSessions
+        conversationHistoryService={delayedService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    // Unmount before the async call completes
+    unmount();
+
+    // Wait for the async call to complete
+    await waitFor(
+      () => {
+        expect(delayedService.getConversations).toHaveBeenCalled();
+      },
+      { timeout: 100 }
+    );
+
+    // No React state update warnings should be logged
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Can't perform a React state update on an unmounted component")
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/src/plugins/chat/public/components/recent_sessions.test.tsx
+++ b/src/plugins/chat/public/components/recent_sessions.test.tsx
@@ -1,0 +1,303 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecentSessions } from './recent_sessions';
+import {
+  ConversationHistoryService,
+  SavedConversation,
+} from '../services/conversation_history_service';
+
+describe('RecentSessions', () => {
+  const mockConversations: SavedConversation[] = [
+    {
+      id: '1',
+      threadId: 'thread-1',
+      name: 'First conversation',
+      messages: [],
+      createdAt: Date.now() - 1000 * 60 * 60, // 1 hour ago
+      updatedAt: Date.now() - 1000 * 60 * 30, // 30 minutes ago
+    },
+    {
+      id: '2',
+      threadId: 'thread-2',
+      name: 'Second conversation',
+      messages: [],
+      createdAt: Date.now() - 1000 * 60 * 60 * 24, // 1 day ago
+      updatedAt: Date.now() - 1000 * 60 * 60 * 2, // 2 hours ago
+    },
+    {
+      id: '3',
+      threadId: 'thread-3',
+      name: 'Third conversation',
+      messages: [],
+      createdAt: Date.now() - 1000 * 60 * 60 * 24 * 3, // 3 days ago
+      updatedAt: Date.now() - 1000 * 60 * 60 * 24, // 1 day ago
+    },
+  ];
+
+  const mockConversationHistoryService = ({
+    getConversations: jest.fn().mockResolvedValue({
+      conversations: mockConversations,
+      hasMore: false,
+      total: 3,
+    }),
+  } as unknown) as ConversationHistoryService;
+
+  const mockOnSelectConversation = jest.fn();
+  const mockOnViewAll = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render loading state with EuiLoadingContent', async () => {
+    const slowService = ({
+      getConversations: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  conversations: mockConversations,
+                  hasMore: false,
+                  total: 3,
+                }),
+              100
+            )
+          )
+      ),
+    } as unknown) as ConversationHistoryService;
+
+    render(
+      <RecentSessions
+        conversationHistoryService={slowService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    // Initially should show loading with title and loading content
+    expect(screen.getByText('RECENT')).toBeInTheDocument();
+    expect(document.querySelector('.euiLoadingContent')).toBeInTheDocument();
+
+    // Wait for conversations to load
+    await waitFor(() => {
+      expect(screen.getByText('First conversation')).toBeInTheDocument();
+      expect(document.querySelector('.euiLoadingContent')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should render conversation list after loading', async () => {
+    render(
+      <RecentSessions
+        conversationHistoryService={mockConversationHistoryService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('First conversation')).toBeInTheDocument();
+      expect(screen.getByText('Second conversation')).toBeInTheDocument();
+      expect(screen.getByText('Third conversation')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('View all')).toBeInTheDocument();
+  });
+
+  it('should call onSelectConversation when clicking a conversation', async () => {
+    render(
+      <RecentSessions
+        conversationHistoryService={mockConversationHistoryService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('First conversation')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('First conversation'));
+
+    expect(mockOnSelectConversation).toHaveBeenCalledWith(mockConversations[0]);
+  });
+
+  it('should call onViewAll when clicking View all button', async () => {
+    render(
+      <RecentSessions
+        conversationHistoryService={mockConversationHistoryService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('View all')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('View all'));
+
+    expect(mockOnViewAll).toHaveBeenCalled();
+  });
+
+  it('should not render when conversations list is empty', async () => {
+    const emptyService = ({
+      getConversations: jest.fn().mockResolvedValue({
+        conversations: [],
+        hasMore: false,
+        total: 0,
+      }),
+    } as unknown) as ConversationHistoryService;
+
+    const { container } = render(
+      <RecentSessions
+        conversationHistoryService={emptyService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      expect(emptyService.getConversations).toHaveBeenCalled();
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should not render when there is an error', async () => {
+    const errorService = ({
+      getConversations: jest.fn().mockRejectedValue(new Error('Failed to load')),
+    } as unknown) as ConversationHistoryService;
+
+    const { container } = render(
+      <RecentSessions
+        conversationHistoryService={errorService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      expect(errorService.getConversations).toHaveBeenCalled();
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should display relative time correctly using moment.fromNow()', async () => {
+    render(
+      <RecentSessions
+        conversationHistoryService={mockConversationHistoryService}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('First conversation')).toBeInTheDocument();
+    });
+
+    // moment.fromNow() returns formats like "30 minutes ago", "2 hours ago", "a day ago"
+    // Just verify that relative time text is present for at least one conversation
+    const allText = screen.getByText('First conversation').closest('.recentSessions__item')
+      ?.textContent;
+    expect(allText).toContain('ago');
+  });
+
+  it('should apply ellipsis styles to long conversation titles', async () => {
+    const longTitleConversations = [
+      {
+        id: '1',
+        threadId: 'thread-1',
+        name: 'This is a very long conversation title that should be truncated with ellipsis',
+        messages: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const serviceWithLongTitle = ({
+      getConversations: jest.fn().mockResolvedValue({
+        conversations: longTitleConversations,
+        hasMore: false,
+        total: 1,
+      }),
+    } as unknown) as ConversationHistoryService;
+
+    render(
+      <RecentSessions
+        conversationHistoryService={serviceWithLongTitle}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      const titleElement = screen.getByText(longTitleConversations[0].name);
+      expect(titleElement).toBeInTheDocument();
+
+      // Check that the parent has the ellipsis class
+      const itemTitle = titleElement.closest('.recentSessions__itemTitle');
+      expect(itemTitle).toBeInTheDocument();
+    });
+  });
+
+  it('should hide date display for conversations with invalid timestamps', async () => {
+    const conversationsWithInvalid = [
+      {
+        id: '1',
+        threadId: 'thread-1',
+        name: 'Valid conversation',
+        messages: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now() - 1000 * 60 * 30, // 30 minutes ago
+      },
+      {
+        id: '2',
+        threadId: 'thread-2',
+        name: 'Invalid timestamp conversation',
+        messages: [],
+        createdAt: Date.now(),
+        updatedAt: NaN, // Invalid timestamp
+      },
+    ];
+
+    const serviceWithInvalidTimestamp = ({
+      getConversations: jest.fn().mockResolvedValue({
+        conversations: conversationsWithInvalid,
+        hasMore: false,
+        total: 2,
+      }),
+    } as unknown) as ConversationHistoryService;
+
+    render(
+      <RecentSessions
+        conversationHistoryService={serviceWithInvalidTimestamp}
+        onSelectConversation={mockOnSelectConversation}
+        onViewAll={mockOnViewAll}
+      />
+    );
+
+    await waitFor(() => {
+      // Both conversations should be displayed
+      expect(screen.getByText('Valid conversation')).toBeInTheDocument();
+      expect(screen.getByText('Invalid timestamp conversation')).toBeInTheDocument();
+    });
+
+    // Valid conversation should have a date
+    const validConv = screen.getByText('Valid conversation').closest('.recentSessions__item');
+    expect(validConv?.textContent).toContain('ago');
+
+    // Invalid timestamp conversation should not have a date
+    const invalidConv = screen
+      .getByText('Invalid timestamp conversation')
+      .closest('.recentSessions__item');
+    expect(invalidConv?.textContent).toBe('Invalid timestamp conversation');
+  });
+});

--- a/src/plugins/chat/public/components/recent_sessions.tsx
+++ b/src/plugins/chat/public/components/recent_sessions.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
+import { useMount, useUnmount } from 'react-use';
 import {
   EuiText,
   EuiFlexGroup,
@@ -64,12 +65,13 @@ export const RecentSessions: React.FC<RecentSessionsProps> = ({
     }
   }, [conversationHistoryService]);
 
-  useEffect(() => {
+  useMount(() => {
     loadRecentConversations();
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, [loadRecentConversations]);
+  });
+
+  useUnmount(() => {
+    isMountedRef.current = false;
+  });
 
   if (isLoading) {
     return (

--- a/src/plugins/chat/public/components/recent_sessions.tsx
+++ b/src/plugins/chat/public/components/recent_sessions.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiButtonEmpty,
+  EuiLoadingContent,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import moment from 'moment';
+import {
+  ConversationHistoryService,
+  SavedConversation,
+} from '../services/conversation_history_service';
+import './recent_sessions.scss';
+
+interface RecentSessionsProps {
+  conversationHistoryService: ConversationHistoryService;
+  onSelectConversation: (conversation: SavedConversation) => void;
+  onViewAll: () => void;
+}
+
+export const RecentSessions: React.FC<RecentSessionsProps> = ({
+  conversationHistoryService,
+  onSelectConversation,
+  onViewAll,
+}) => {
+  const [conversations, setConversations] = useState<SavedConversation[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRecentConversations = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await conversationHistoryService.getConversations({
+        page: 0,
+        pageSize: 3,
+      });
+      setConversations(result.conversations);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load recent conversations:', err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : i18n.translate('chat.recentSessions.loadErrorMessage', {
+              defaultMessage: 'Failed to load recent conversations',
+            })
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conversationHistoryService]);
+
+  useEffect(() => {
+    loadRecentConversations();
+  }, [loadRecentConversations]);
+
+  if (isLoading) {
+    return (
+      <div className="recentSessions">
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem>
+            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  <strong>
+                    {i18n.translate('chat.recentSessions.title', {
+                      defaultMessage: 'RECENT',
+                    })}
+                  </strong>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiLoadingContent lines={3} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
+    );
+  }
+
+  if (error || conversations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="recentSessions">
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <strong>
+                  {i18n.translate('chat.recentSessions.title', {
+                    defaultMessage: 'RECENT',
+                  })}
+                </strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty size="xs" onClick={onViewAll} flush="right">
+                {i18n.translate('chat.recentSessions.viewAll', {
+                  defaultMessage: 'View all',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            {conversations.map((conversation) => (
+              <EuiFlexItem key={conversation.id}>
+                <EuiPanel
+                  paddingSize="m"
+                  hasBorder
+                  className="recentSessions__item"
+                  onClick={() => onSelectConversation(conversation)}
+                >
+                  <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
+                    <EuiFlexItem className="recentSessions__itemTitle">
+                      <EuiText size="s" className="eui-textTruncate">
+                        <span>{conversation.name}</span>
+                      </EuiText>
+                    </EuiFlexItem>
+                    {moment(conversation.updatedAt).isValid() && (
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="xs" color="subdued">
+                          {moment(conversation.updatedAt).fromNow()}
+                        </EuiText>
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                </EuiPanel>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/src/plugins/chat/public/components/recent_sessions.tsx
+++ b/src/plugins/chat/public/components/recent_sessions.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   EuiText,
   EuiFlexGroup,
@@ -34,6 +34,7 @@ export const RecentSessions: React.FC<RecentSessionsProps> = ({
   const [conversations, setConversations] = useState<SavedConversation[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
 
   const loadRecentConversations = useCallback(async () => {
     setIsLoading(true);
@@ -43,10 +44,12 @@ export const RecentSessions: React.FC<RecentSessionsProps> = ({
         page: 0,
         pageSize: 3,
       });
+      if (!isMountedRef.current) return;
       setConversations(result.conversations);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Failed to load recent conversations:', err);
+      if (!isMountedRef.current) return;
       setError(
         err instanceof Error
           ? err.message
@@ -55,12 +58,17 @@ export const RecentSessions: React.FC<RecentSessionsProps> = ({
             })
       );
     } finally {
-      setIsLoading(false);
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [conversationHistoryService]);
 
   useEffect(() => {
     loadRecentConversations();
+    return () => {
+      isMountedRef.current = false;
+    };
   }, [loadRecentConversations]);
 
   if (isLoading) {

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -1205,6 +1205,79 @@ describe('ChatEventHandler', () => {
     });
   });
 
+  describe('stopToolResultStreaming', () => {
+    it('should stop active tool result streaming and reset state', async () => {
+      const toolCallId = 'tool-123';
+      const mockResult = { success: true, data: 'test result' };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      // Mock sendToolResult to return observable with unsubscribe
+      const mockToolMessage: ToolMessage = {
+        id: `tool-result-${toolCallId}`,
+        role: 'tool',
+        content: JSON.stringify(mockResult),
+        toolCallId,
+      };
+
+      const mockUnsubscribe = jest.fn();
+      const mockObservable = {
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+      };
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: mockObservable,
+        toolMessage: mockToolMessage,
+      });
+
+      // Trigger tool call flow to start streaming
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_action',
+      } as ToolCallStartEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      // Verify streaming was started
+      expect(mockObservable.subscribe).toHaveBeenCalled();
+
+      // Clear previous calls
+      mockOnStreamingStateChange.mockClear();
+      mockOnStartResponse.mockClear();
+
+      // Stop the streaming
+      chatEventHandler.stopToolResultStreaming();
+
+      // Verify unsubscribe was called
+      expect(mockUnsubscribe).toHaveBeenCalled();
+
+      // Verify state was reset
+      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false);
+      expect(mockOnStartResponse).toHaveBeenCalledWith(false);
+    });
+
+    it('should handle stopToolResultStreaming when no streaming is active', () => {
+      // Should not throw when there's no active subscription
+      expect(() => {
+        chatEventHandler.stopToolResultStreaming();
+      }).not.toThrow();
+
+      // State callbacks should not be called when there's no active streaming
+      expect(mockOnStreamingStateChange).not.toHaveBeenCalled();
+      expect(mockOnStartResponse).not.toHaveBeenCalled();
+    });
+  });
+
   describe('telemetry', () => {
     let mockTelemetryRecorder: {
       recordEvent: jest.Mock;

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Subscription } from 'rxjs';
 import { EventType } from '../../common/events';
 import type {
   Event as ChatEvent,
@@ -63,7 +64,7 @@ export class ChatEventHandler {
   private onStartResponse: (flag: boolean) => void;
   private onSendToolResultStateChange?: (isSending: boolean) => void;
   private getTimeline: () => Message[];
-  private toolResultSubscription: any = null;
+  private toolResultSubscription: Subscription | null = null;
 
   // Telemetry tracking
   private interactionStartTime: number | null = null;
@@ -740,6 +741,8 @@ export class ChatEventHandler {
     if (this.toolResultSubscription) {
       this.toolResultSubscription.unsubscribe();
       this.toolResultSubscription = null;
+      this.onStreamingStateChange(false);
+      this.onStartResponse(false);
     }
   }
 }

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -63,6 +63,7 @@ export class ChatEventHandler {
   private onStartResponse: (flag: boolean) => void;
   private onSendToolResultStateChange?: (isSending: boolean) => void;
   private getTimeline: () => Message[];
+  private toolResultSubscription: any = null;
 
   // Telemetry tracking
   private interactionStartTime: number | null = null;
@@ -674,7 +675,7 @@ export class ChatEventHandler {
       // Set streaming state and subscribe to the response stream
       this.onStreamingStateChange(true);
 
-      observable.subscribe({
+      const subscription = observable.subscribe({
         next: (event: ChatEvent) => {
           // Handle the assistant's response to the tool result
           this.handleEvent(event);
@@ -684,12 +685,17 @@ export class ChatEventHandler {
           console.error('Tool result response error:', error);
           this.onStreamingStateChange(false);
           this.onStartResponse(false);
+          this.toolResultSubscription = null;
         },
         complete: () => {
           this.onStreamingStateChange(false);
           this.onStartResponse(false);
+          this.toolResultSubscription = null;
         },
       });
+
+      // Store subscription so it can be unsubscribed in clearState
+      this.toolResultSubscription = subscription;
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to send tool result:', error);
@@ -722,5 +728,18 @@ export class ChatEventHandler {
     this.lastTextMessageStartId = null;
     // @ts-expect-error TS2339 TODO(ts-error): fixme
     this._lastAssistantMessageId = null;
+
+    // Stop tool result streaming if active
+    this.stopToolResultStreaming();
+  }
+
+  /**
+   * Stop tool result streaming if active
+   */
+  stopToolResultStreaming(): void {
+    if (this.toolResultSubscription) {
+      this.toolResultSubscription.unsubscribe();
+      this.toolResultSubscription = null;
+    }
   }
 }

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -410,7 +410,6 @@ export class ChatService {
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
-        // @ts-expect-error TS2345 TODO(ts-error): fixme
         const events = await this.conversationHistoryService.getConversation(threadId);
 
         if (events) {


### PR DESCRIPTION
### Description

This PR improves the chat window component with better session management and enhanced empty screen UX.

**Key changes:**

- **Added recent conversations component** - The empty screen now displays the 3 most recent conversations with session titles and relative update times (e.g., "30 minutes ago", "2 hours ago"). Users can click on any recent conversation to load it directly. The component includes a "View all" button to open the full conversation history panel.

- **Removed auto-restore functionality** - Eliminated the automatic restoration of the latest conversation on component mount. The chat window now starts with a fresh conversation instead, providing a cleaner user experience and preventing stale state issues.

- **Added streaming cancellation on session changes** - Implemented proper cleanup logic to stop ongoing message streams when users switch conversations or start a new chat. This prevents streaming events from a previous conversation affecting the newly loaded conversation.

- **Improved UI feedback** - Added tooltips to header action buttons (new chat, close, history) to improve discoverability and user guidance.

### Screenshots

**Empty screen with recent conversations:**

https://github.com/user-attachments/assets/0e52eb00-b494-4324-89a3-7abf5dbe81d4

### Testing the changes

#### Manual testing:

1. Start the OpenSearch Dashboards dev server
2. Open the chat window with an empty conversation
3. Verify the recent conversations section appears below the starter suggestions
4. Click on a recent conversation - verify it loads correctly
5. Click "View all" - verify the conversation history panel opens
6. Send a message and observe streaming behavior
7. While a message is streaming, click "New chat" - verify that:
   - The stream stops immediately
   - A new conversation starts with clean state
   - Recent conversations are updated
8. While streaming is active, click on a different conversation in the recent list - verify that:
   - The stream stops
   - The selected conversation loads correctly
9. Hover over header buttons (new chat, history, close) and verify tooltips appear

#### Automated testing:

- All behaviors are covered by unit tests
- Recent sessions component has comprehensive test coverage (9 tests)
- Tests verify:
  - Loading states with EuiLoadingContent
  - Conversation list rendering with relative times
  - Click interactions
  - Empty and error states
  - Invalid timestamp handling (dates are hidden gracefully)

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest` (53 tests passing for chat components)
  - [x] TypeScript compilation passes
- [x] New functionality includes testing.
  - [x] `recent_sessions.test.tsx` with 9 comprehensive tests
  - [x] Updated `chat_messages.test.tsx` to cover integration
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

### Technical Details

**New component: RecentSessions**
- Displays up to 3 most recent conversations
- Shows conversation title with text ellipsis for long titles
- Shows relative update time using moment.js `fromNow()`
- Gracefully handles invalid timestamps by hiding date display
- Includes loading state with EuiLoadingContent
- Automatically hides when no conversations exist or on error
- Follows OpenSearch Dashboards component conventions

**Files modified:**
- `src/plugins/chat/public/components/recent_sessions.tsx` (new)
- `src/plugins/chat/public/components/recent_sessions.scss` (new)
- `src/plugins/chat/public/components/recent_sessions.test.tsx` (new)
- `src/plugins/chat/public/components/chat_messages.tsx` (updated)
- `src/plugins/chat/public/components/chat_messages.scss` (updated)
- `src/plugins/chat/public/components/chat_messages.test.tsx` (updated)
- `src/plugins/chat/public/components/chat_window.tsx` (updated)
- `src/plugins/chat/public/components/index.ts` (updated)