### PR TITLE
fix: use sorted rows for Data Table vis filter actions

### DIFF
--- a/src/plugins/vis_type_table/public/components/table_vis_dynamic_table.test.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_dynamic_table.test.tsx
@@ -372,6 +372,52 @@ describe('TableVisDynamicTable', () => {
     });
   });
 
+  // Regression test for https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11453
+  it('should emit sorted rows in filterBucket so the targeted cell value is preserved', () => {
+    const tableWithFilterable: FormattedTableContext = {
+      ...mockTable,
+      formattedColumns: [
+        {
+          id: 'col1',
+          title: 'Column 1',
+          formatter: { convert: (v: any) => v } as any,
+          filterable: true,
+        },
+        {
+          id: 'col2',
+          title: 'Column 2',
+          formatter: { convert: (v: any) => v } as any,
+          filterable: false,
+        },
+      ],
+    };
+
+    // Sort descending by col2 → sorted order is [value2(20), value3(15), value1(10)]
+    const uiStateSortedDesc: TableUiState = {
+      ...mockUiState,
+      sort: { colIndex: 1, direction: 'desc' },
+    };
+
+    const { getAllByTestId } = render(
+      <TableVisDynamicTable
+        table={tableWithFilterable}
+        visConfig={mockVisConfig}
+        event={mockHandlers.event}
+        uiState={uiStateSortedDesc}
+      />
+    );
+
+    fireEvent.click(getAllByTestId('tableVisFilterForValue')[0]);
+
+    const payload = (mockHandlers.event as jest.Mock).mock.calls[0][0];
+    const { table, row, column } = payload.data.data[0];
+
+    // The first rendered row after sort-desc on col2 is value2/20; the filter
+    // event must reference that same row, not the first row of the unsorted
+    // response.
+    expect(table.rows[row][table.columns[column].id]).toBe('value2');
+  });
+
   it('should sanitize HTML content using dompurify', () => {
     const tableWithLink: FormattedTableContext = {
       ...mockTable,

--- a/src/plugins/vis_type_table/public/components/table_vis_dynamic_table.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_dynamic_table.tsx
@@ -381,7 +381,7 @@ export const TableVisDynamicTable: React.FC<DynamicTableProps> = ({
           {
             table: {
               columns: columns.filter((column) => formattedColumnIds.includes(column.id)),
-              rows,
+              rows: sortedRows,
             },
             row: actualRowIndex,
             column: columnIndex,


### PR DESCRIPTION
## Description

Fixes a regression in the Data Table visualization where clicking the filter-for-value / filter-out-value (+/-) buttons in a cell would filter on the **wrong value** once the table had been sorted.

`TableVisDynamicTable` computes the clicked row's index against `sortedRows` (the paginated/sorted view the user sees), but handed the downstream `filterBucket` event the **unsorted** `rows` array from the original response. The filter action then looked up `rows[actualRowIndex]`, pulling a value from a different row entirely.

One-line fix: pass `sortedRows` (not `rows`) in the event payload, matching the indexing basis.

This is the exact same bug previously fixed by #4837 in the old `<OuiDataGrid>`-based table; it was reintroduced by the table re-write in #11031 (shipped in 3.5).

## Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11453

## Root Cause

In `src/plugins/vis_type_table/public/components/table_vis_dynamic_table.tsx`:

```ts
const filterBucket = (rowIndex, columnIndex, negate) => {
  const actualRowIndex = pageIndex * pageSize + rowIndex;   // index into sortedRows
  event({
    name: 'filterBucket',
    data: {
      data: [{
        table: {
          columns: columns.filter(...),
          rows,                 // BUG: unsorted response rows
        },
        row: actualRowIndex,    // index basis mismatch
        column: columnIndex,
      }],
      negate,
    },
  });
};
```

Downstream, `createFiltersFromValueClickAction` → `createFilter` does `table.rows[rowIndex][column.id]` (`src/plugins/data/public/actions/filters/create_filters_from_value_click.ts:102`), so with sort applied, `rows[actualRowIndex]` points to a different logical row than the cell the user clicked.

With no sort applied `sortedRows === rows`, which explains the reporter's observation that some tables "work initially but fail after sorting."

## Fix

Change the event payload to use `sortedRows`:

```ts
table: {
  columns: columns.filter(...),
  rows: sortedRows,   // was: rows
},
```

## Testing the Changes

Manual:
1. Open any Data Table visualization with multiple rows (e.g., the `[Logs] Chart and Visualization demo` dashboard in the nightly playground, scroll to the APM table).
2. Sort by any column.
3. Click the (+) button next to any cell.
4. The added filter should match the value in the clicked cell (previously it would filter a different value).
5. Also verify: filter-out (–), remove filter, sort a different column, add another filter — all should consistently reflect the clicked cell.

Automated:
- Added regression test `should emit sorted rows in filterBucket so the targeted cell value is preserved` in `table_vis_dynamic_table.test.tsx`. The test sorts rows descending on a numeric column and asserts the `filterBucket` payload resolves to the top-row value (`value2`), which would fail against the unsorted `rows` array.
- `yarn test:jest src/plugins/vis_type_table/public/components/table_vis_dynamic_table.test.tsx` — 17/17 passing.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
