### PR TITLE
fix: restore UTF-8 BOM in CSV exports for Excel compatibility

### DIFF
--- a/packages/osd-std/src/auto_bom.test.ts
+++ b/packages/osd-std/src/auto_bom.test.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { autoBom } from './auto_bom';
+
+function blobToBytes(blob: Blob): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+// UTF-8 BOM is the byte sequence EF BB BF
+const UTF8_BOM = [0xef, 0xbb, 0xbf];
+
+describe('autoBom', () => {
+  it('prepends BOM for text/csv;charset=utf-8', async () => {
+    const blob = new Blob(['a,b,c'], { type: 'text/csv;charset=utf-8' });
+    const result = autoBom(blob);
+    expect(result).not.toBe(blob);
+    const bytes = await blobToBytes(result);
+    expect(Array.from(bytes.slice(0, 3))).toEqual(UTF8_BOM);
+  });
+
+  it('prepends BOM for text/plain;charset=utf-8', async () => {
+    const blob = new Blob(['hello'], { type: 'text/plain;charset=utf-8' });
+    const result = autoBom(blob);
+    expect(result).not.toBe(blob);
+    const bytes = await blobToBytes(result);
+    expect(Array.from(bytes.slice(0, 3))).toEqual(UTF8_BOM);
+  });
+
+  it('does not prepend BOM when charset is not utf-8', async () => {
+    const blob = new Blob(['a,b,c'], { type: 'text/csv' });
+    const result = autoBom(blob);
+    expect(result).toBe(blob);
+  });
+
+  it('does not prepend BOM for application/json', async () => {
+    const blob = new Blob(['{}'], { type: 'application/json' });
+    const result = autoBom(blob);
+    expect(result).toBe(blob);
+  });
+
+  it('does not prepend BOM for application/octet-stream', async () => {
+    const blob = new Blob(['binary'], { type: 'application/octet-stream' });
+    const result = autoBom(blob);
+    expect(result).toBe(blob);
+  });
+
+  it('preserves the original MIME type', async () => {
+    const blob = new Blob(['data'], { type: 'text/csv;charset=utf-8' });
+    const result = autoBom(blob);
+    expect(result.type).toBe('text/csv;charset=utf-8');
+  });
+});

--- a/packages/osd-std/src/auto_bom.ts
+++ b/packages/osd-std/src/auto_bom.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+const UTF8_TEXT_MIME_RE = /^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i;
+
+/**
+ * Prepend a UTF-8 BOM (U+FEFF) to a Blob whose MIME type indicates
+ * `charset=utf-8` text content (e.g. `text/csv;charset=utf-8`).
+ *
+ * This restores the behavior of the old `@elastic/filesaver` package,
+ * which ran this check automatically.  The replacement `file-saver`
+ * library defaults `autoBom` to `false` and only applies it in the
+ * legacy IE code-path, so callers must handle it themselves.
+ */
+export function autoBom(blob: Blob): Blob {
+  if (UTF8_TEXT_MIME_RE.test(blob.type)) {
+    return new Blob(['\uFEFF', blob], { type: blob.type });
+  }
+  return blob;
+}

--- a/packages/osd-std/src/index.ts
+++ b/packages/osd-std/src/index.ts
@@ -44,3 +44,4 @@ export { validateObject } from './validate_object';
 export * from './rxjs_7';
 export { parse, stringify } from './json';
 export * from './clean';
+export { autoBom } from './auto_bom';

--- a/src/plugins/agent_traces/public/application/utils/state_management/actions/export_actions.ts
+++ b/src/plugins/agent_traces/public/application/utils/state_management/actions/export_actions.ts
@@ -5,6 +5,7 @@
 
 import { Dispatch } from 'redux';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 import { AgentTracesServices } from '../../../../types';
 import { AppDispatch, RootState } from '../store';
 import { processDisplayedColumnNames } from '../../../../helpers/use_displayed_columns';
@@ -77,7 +78,7 @@ export const exportToCsv = (
     // Download CSV
     const fileName = options.fileName || `agent_traces_export_${new Date().toISOString()}.csv`;
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-    saveAs(blob, fileName);
+    saveAs(autoBom(blob), fileName);
   };
 };
 
@@ -166,7 +167,7 @@ export const exportMaxSizeCsv = (
       // Download CSV
       const fileName = options.fileName || `agent_traces_export_${new Date().toISOString()}.csv`;
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-      saveAs(blob, fileName);
+      saveAs(autoBom(blob), fileName);
     } catch (error) {
       // Error exporting CSV
       throw error;

--- a/src/plugins/agent_traces/public/components/tabs/action_bar/download_csv/use_download_csv.ts
+++ b/src/plugins/agent_traces/public/components/tabs/action_bar/download_csv/use_download_csv.ts
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { unparse } from 'papaparse';
 import moment from 'moment';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 import { DownloadCsvFormId, MAX_DOWNLOAD_CSV_COUNT } from './constants';
 import { OpenSearchSearchHit } from '../../../../types/doc_views_types';
 import { useDispatch } from '../../../../application/legacy/discover/application/utils/state_management';
@@ -56,7 +57,7 @@ export const formatRowsForCsv = ({
 export const saveDataAsCsv = (csvData: string) => {
   const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' });
   const fileName = `opensearch_export_${moment().format('YYYY-MM-DD')}`;
-  saveAs(blob, fileName);
+  saveAs(autoBom(blob), fileName);
 };
 
 export const useDiscoverDownloadCsv = ({

--- a/src/plugins/discover/public/application/components/download_csv/use_download_csv.ts
+++ b/src/plugins/discover/public/application/components/download_csv/use_download_csv.ts
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { unparse } from 'papaparse';
 import moment from 'moment';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 import { useDiscoverContext } from '../../view_components/context';
 import { DownloadCsvFormId, MAX_DOWNLOAD_CSV_COUNT } from './constants';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
@@ -57,7 +58,7 @@ export const formatRowsForCsv = ({
 export const saveDataAsCsv = (csvData: string) => {
   const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' });
   const fileName = `opensearch_export_${moment().format('YYYY-MM-DD')}`;
-  saveAs(blob, fileName);
+  saveAs(autoBom(blob), fileName);
 };
 
 export const useDiscoverDownloadCsv = ({

--- a/src/plugins/explore/public/application/utils/state_management/actions/export_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/export_actions.ts
@@ -5,6 +5,7 @@
 
 import { Dispatch } from 'redux';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 import { ExploreServices } from '../../../../types';
 import { AppDispatch, RootState } from '../store';
 import { processDisplayedColumnNames } from '../../../../helpers/use_displayed_columns';
@@ -76,7 +77,7 @@ export const exportToCsv = (options: { fileName?: string; services?: ExploreServ
     // Download CSV
     const fileName = options.fileName || `explore_export_${new Date().toISOString()}.csv`;
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-    saveAs(blob, fileName);
+    saveAs(autoBom(blob), fileName);
   };
 };
 
@@ -165,7 +166,7 @@ export const exportMaxSizeCsv = (
       // Download CSV
       const fileName = options.fileName || `explore_export_${new Date().toISOString()}.csv`;
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-      saveAs(blob, fileName);
+      saveAs(autoBom(blob), fileName);
     } catch (error) {
       // Error exporting CSV
       throw error;

--- a/src/plugins/explore/public/components/tabs/action_bar/download_csv/use_download_csv.ts
+++ b/src/plugins/explore/public/components/tabs/action_bar/download_csv/use_download_csv.ts
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { unparse } from 'papaparse';
 import moment from 'moment';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 import { DownloadCsvFormId, MAX_DOWNLOAD_CSV_COUNT } from './constants';
 import { OpenSearchSearchHit } from '../../../../types/doc_views_types';
 import { useDispatch } from '../../../../application/legacy/discover/application/utils/state_management';
@@ -56,7 +57,7 @@ export const formatRowsForCsv = ({
 export const saveDataAsCsv = (csvData: string) => {
   const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' });
   const fileName = `opensearch_export_${moment().format('YYYY-MM-DD')}`;
-  saveAs(blob, fileName);
+  saveAs(autoBom(blob), fileName);
 };
 
 export const useDiscoverDownloadCsv = ({

--- a/src/plugins/inspector/public/views/data/lib/export_csv.ts
+++ b/src/plugins/inspector/public/views/data/lib/export_csv.ts
@@ -30,6 +30,7 @@
 
 import { isObject } from 'lodash';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 
 import { DataViewColumn, DataViewRow } from '../types';
 
@@ -88,5 +89,5 @@ export function exportAsCsv({
   const csv = new Blob([buildCsv(columns, rows, csvSeparator, quoteValues, valueFormatter)], {
     type,
   });
-  saveAs(csv, filename);
+  saveAs(autoBom(csv), filename);
 }

--- a/src/plugins/vis_type_table/public/utils/convert_to_csv_data.ts
+++ b/src/plugins/vis_type_table/public/utils/convert_to_csv_data.ts
@@ -30,6 +30,7 @@
 
 import { isObject } from 'lodash';
 import { saveAs } from 'file-saver';
+import { autoBom } from '@osd/std';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { CSV_SEPARATOR_SETTING, CSV_QUOTE_VALUES_SETTING } from '../../../share/public';
 import { OpenSearchDashboardsDatatable } from '../../../expressions/public';
@@ -79,6 +80,6 @@ export const toCsv = function (formatted: boolean, { rows, columns, uiSettings }
 export const exportAsCsv = function (formatted: boolean, csvData: CSVDataProps) {
   const csv = new Blob([toCsv(formatted, csvData)], { type: 'text/csv;charset=utf-8' });
   const type = formatted ? 'formatted' : 'raw';
-  if (csvData.filename) saveAs(csv, `${csvData.filename}-${type}.csv`);
-  else saveAs(csv, `unsaved-${type}.csv`);
+  if (csvData.filename) saveAs(autoBom(csv), `${csvData.filename}-${type}.csv`);
+  else saveAs(autoBom(csv), `unsaved-${type}.csv`);
 };


### PR DESCRIPTION
### Description

PR #9484 replaced `@elastic/filesaver` with `file-saver`, which inadvertently removed the UTF-8 BOM from CSV exports. The old `@elastic/filesaver` had an `auto_bom()` function that automatically prepended the BOM (`U+FEFF` / `EF BB BF`) for `text/*;charset=utf-8` blobs. The replacement `file-saver` library defaults `autoBom` to `false` and only applies it in the legacy IE code path, so modern browsers never received the BOM.

Without the BOM, Excel does not recognize the file as UTF-8 and renders non-ASCII characters incorrectly.

**Changes:**
- Add a shared `autoBom()` utility in `@osd/std` that restores the `@elastic/filesaver` behavior
- Apply `autoBom()` to all CSV export `saveAs()` call sites across inspector, vis_type_table, discover, explore, and agent_traces plugins
- Add unit tests for the new utility

### Issues Resolved

fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11807

## Screenshot

<img width="437" height="203" alt="image" src="https://github.com/user-attachments/assets/d9cb3e3c-9a41-4d81-9112-e4d2d346998f" />


## Testing the changes

1. Create a table visualization with non-ASCII text (e.g. Chinese, Japanese, accented characters)
2. Download CSV (both Raw and Formatted) and open in Excel — characters should render correctly
3. Verify the downloaded CSV file starts with bytes `EF BB BF` (UTF-8 BOM) using a hex editor or Notepad++
4. Download CSV from Discover page and verify the same
5. Download CSV from Inspector Data view and verify the same
6. Run `yarn test:jest packages/osd-std/src/auto_bom.test.ts` — all 6 tests pass

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

