### PR TITLE
fix: Restore gulp-babel and add build sanity check to PR CI

### DIFF
--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -201,6 +201,46 @@ jobs:
           path: ${{ env.YARN_CACHE_LOCATION }}
           key: yarn-Windows-${{ hashFiles('**/yarn.lock') }}
 
+  build-sanity:
+    name: Build release artifact sanity check
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          filter: blob:none
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Yarn
+        run: |
+          npm uninstall -g yarn
+          npm i -g yarn@1.22.10
+          yarn config set network-timeout 1000000 -g
+
+      - name: Configure Yarn Cache
+        run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
+
+      - name: Restore Yarn Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.YARN_CACHE_LOCATION }}
+          key: yarn-Linux-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: yarn-Linux-
+
+      - name: Run bootstrap
+        run: yarn osd bootstrap
+
+      - name: Build release artifact
+        run: yarn build --skip-os-packages --release
+
   build-test:
     name: Build and Verify on ${{ matrix.name }} (ciGroup${{ matrix.group }})
     needs: [changes, prepare-source, prepare-windows-cache]
@@ -957,6 +997,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - build-sanity
       - build-test
       - build-plugins-artifact
       - integration-tests
@@ -970,6 +1011,7 @@ jobs:
         run: |
           results=( \
             "${{ needs.lint-and-validate.result }}" \
+            "${{ needs.build-sanity.result }}" \
             "${{ needs.build-test.result }}" \
             "${{ needs.integration-tests.result }}" \
             "${{ needs.functional-tests.result }}" \

--- a/package.json
+++ b/package.json
@@ -499,6 +499,7 @@
     "grunt-cli": "^1.4.3",
     "grunt-peg": "^2.0.1",
     "grunt-run": "^0.8.1",
+    "gulp-babel": "^8.0.0",
     "has-ansi": "^3.0.0",
     "history": "^4.9.0",
     "immer": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13048,6 +13048,16 @@ grunt@^1.5.2:
     nopt "~3.0.6"
     rimraf "~3.0.2"
 
+gulp-babel@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-8.0.0.tgz#e0da96f4f2ec4a88dd3a3030f476e38ab2126d87"
+  integrity sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==
+  dependencies:
+    plugin-error "^1.0.1"
+    replace-ext "^1.0.0"
+    through2 "^2.0.0"
+    vinyl-sourcemaps-apply "^0.2.0"
+
 gulp-zip@^5.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/gulp-zip/-/gulp-zip-5.1.0.tgz#38cc1d4c61bc2ab06b452ce463cbe2adc52b935e"
@@ -20663,6 +20673,11 @@ source-map@0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
   integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
 
+source-map@^0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -23120,6 +23135,13 @@ vinyl-sourcemap@^1.1.0:
     now-and-later "^2.0.0"
     remove-bom-buffer "^3.0.0"
     vinyl "^2.0.0"
+
+vinyl-sourcemaps-apply@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
+  integrity sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==
+  dependencies:
+    source-map "^0.5.1"
 
 vinyl@^2.0.0, vinyl@^2.1.0, vinyl@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
### Description

Restore `gulp-babel` to devDependencies and add a build sanity check to the PR CI workflow to prevent this class of issue from reaching main.

### Root Cause

`gulp-babel` was removed in #11805 as part of a dependency cleanup. The audit incorrectly classified it as unused because:
1. The grep search looked for `'gulp-babel'` as a string but the import uses `gulpBabel` (camelCase variable name)
2. The file that imports it (`src/dev/build/tasks/transpile_babel_task.ts`) is only executed during `yarn build` (release artifact builds), not during `yarn start`, `yarn test:jest`, or `yarn osd bootstrap`

This meant all PR CI checks passed (bootstrap, lint, unit tests), but the post-merge build failed with `Cannot find module 'gulp-babel'`.

### Why CI Didn't Catch It

The PR CI workflow (`build_and_test_workflow.yml`) does not run `yarn build`. It only runs:
- `yarn osd bootstrap`
- Lint (`yarn lint`)
- Unit tests (`yarn test:jest`)
- Integration tests
- Functional tests

The `yarn build` (release artifact build) is only run by:
- `post_merge_test.yml` — runs after merge to main (where the failure was caught)
- `build_with_plugins_workflow.yml` — manual trigger only

### Changes

1. Restore `gulp-babel` ^8.0.0 to devDependencies in `package.json`
2. Add `build-sanity` job to `.github/workflows/build_and_test_workflow.yml`:
   - Runs `yarn build --skip-os-packages --release` on every PR with code changes
   - Added to the merge gate as a required check
   - Only runs when code files change (same filter as other jobs)

### Verification

```bash
yarn osd bootstrap --single-version=loose  # passes
yarn build --skip-os-packages --release     # passes
```

### Issues Resolved

Fixes the build failure introduced by #11805.

### Check List

- [x] All tests pass
- [x] `yarn build --skip-os-packages --release` passes
- [x] Commits are signed per the DCO using --signoff
