### PR TITLE
[Explore] Fill the update button with primary color if query changed

### DIFF
--- a/src/plugins/agent_traces/public/components/top_nav/query_execution_button/query_execution_button.test.tsx
+++ b/src/plugins/agent_traces/public/components/top_nav/query_execution_button/query_execution_button.test.tsx
@@ -248,6 +248,17 @@ describe('QueryExecutionButton', () => {
     expect(screen.getByText('Update')).toBeInTheDocument();
     // Verify the button has the primary color (blue) for consistent theming
     expect(button).toHaveClass('euiButton--primary');
+    // Verify the button is filled when needsUpdate is true
+    expect(button).toHaveClass('euiButton--fill');
+  });
+
+  it('shows unfilled button in Refresh state', () => {
+    renderWithProvider(<QueryExecutionButton />);
+
+    const button = screen.getByTestId('querySubmitButton');
+    expect(screen.getByText('Refresh')).toBeInTheDocument();
+    expect(button).toHaveClass('euiButton--primary');
+    expect(button).not.toHaveClass('euiButton--fill');
   });
 
   describe('Cancel Button Functionality', () => {

--- a/src/plugins/agent_traces/public/components/top_nav/query_execution_button/query_execution_button.tsx
+++ b/src/plugins/agent_traces/public/components/top_nav/query_execution_button/query_execution_button.tsx
@@ -93,6 +93,7 @@ export const QueryExecutionButton: React.FC<QueryExecutionButtonProps> = ({
       })}
       compressed={true}
       color="primary"
+      fill={needsUpdate}
     >
       {buttonText}
     </EuiSuperUpdateButton>

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/query_execution_button.test.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/query_execution_button.test.tsx
@@ -47,12 +47,16 @@ describe('QueryExecutionButton', () => {
   it('shows Refresh when query is not dirty', () => {
     render(<QueryExecutionButton />);
     expect(screen.getByText('Refresh')).toBeInTheDocument();
+    const button = screen.getByTestId('exploreQueryExecutionButton');
+    expect(button).not.toHaveClass('euiButton--fill');
   });
 
   it('shows Update when query is dirty', () => {
     (useQueryBuilderState as jest.Mock).mockReturnValue(buildState({ isQueryEditorDirty: true }));
     render(<QueryExecutionButton />);
     expect(screen.getByText('Update')).toBeInTheDocument();
+    const button = screen.getByTestId('exploreQueryExecutionButton');
+    expect(button).toHaveClass('euiButton--fill');
   });
 
   it('disables button when date range is invalid', () => {

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/query_execution_button.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/query_execution_button.tsx
@@ -65,6 +65,7 @@ export const QueryExecutionButton: React.FC<QueryExecutionButtonProps> = ({
       })}
       compressed={true}
       color="primary"
+      fill={needsUpdate}
     >
       {buttonText}
     </EuiSuperUpdateButton>

--- a/src/plugins/explore/public/application/pages/metrics/metrics_query_panel.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_query_panel.tsx
@@ -90,6 +90,7 @@ export const MetricsQueryPanel: React.FC = () => {
   const syncEditorText = useCallback(
     (updatedRows: QueryRow[]) => {
       const combined = joinRows(updatedRows);
+      if (combined === lastDispatchedRef.current) return;
       lastDispatchedRef.current = combined;
       setEditorText(combined);
       const currentQuery = queryString.getQuery();

--- a/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.test.tsx
+++ b/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.test.tsx
@@ -248,6 +248,17 @@ describe('QueryExecutionButton', () => {
     expect(screen.getByText('Update')).toBeInTheDocument();
     // Verify the button has the primary color (blue) for consistent theming
     expect(button).toHaveClass('euiButton--primary');
+    // Verify the button is filled when needsUpdate is true
+    expect(button).toHaveClass('euiButton--fill');
+  });
+
+  it('shows unfilled button in Refresh state', () => {
+    renderWithProvider(<QueryExecutionButton />);
+
+    const button = screen.getByTestId('exploreQueryExecutionButton');
+    expect(screen.getByText('Refresh')).toBeInTheDocument();
+    expect(button).toHaveClass('euiButton--primary');
+    expect(button).not.toHaveClass('euiButton--fill');
   });
 
   describe('Cancel Button Functionality', () => {

--- a/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.tsx
+++ b/src/plugins/explore/public/components/top_nav/query_execution_button/query_execution_button.tsx
@@ -93,6 +93,7 @@ export const QueryExecutionButton: React.FC<QueryExecutionButtonProps> = ({
       })}
       compressed={true}
       color="primary"
+      fill={needsUpdate}
     >
       {buttonText}
     </EuiSuperUpdateButton>


### PR DESCRIPTION
### Description

In Explore logs, traces, metrics, the update (run query) button is far on the top right, and it's hard to notice that user needs to click Update, especially in query builder mode.

@kamingleung suggested a small change to make it fill with primary color. After UI is updated and reflects query result, it goes back to original "Refresh" without the fill.

This PR additionally avoids showing update on Metrics page Query tab switch

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/18b3a7b1-f228-48d3-9572-8898fb8b3e70" />
<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/2190db5c-e775-45a2-83f0-805df954d781" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
