### PR TITLE
[Explore] add series limit and truncation warnings in metrics

### DIFF
--- a/src/plugins/data/common/data_frames/utils.test.ts
+++ b/src/plugins/data/common/data_frames/utils.test.ts
@@ -594,4 +594,36 @@ describe('convertResult', () => {
     // Verify instantFieldSchema is preserved
     expect((result as any).instantFieldSchema).toEqual(instantSchema);
   });
+
+  it('should pass through truncation metadata from data frame meta', () => {
+    const response: IDataFrameResponse = {
+      took: 100,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: { total: 0, max_score: 0, hits: [] },
+      body: {
+        fields: [
+          { name: 'Time', type: 'time', values: [1702483200000] },
+          { name: 'Value', type: 'number', values: [0.95] },
+        ],
+        size: 1,
+        name: 'prometheus-data',
+        meta: {
+          truncation: {
+            tableTruncated: true,
+            totalSeriesCount: 3000,
+            displayedSeriesCount: 2000,
+          },
+        },
+      },
+      type: DATA_FRAME_TYPES.DEFAULT,
+    };
+
+    const result = convertResult({ response });
+    expect((result as any).truncation).toEqual({
+      tableTruncated: true,
+      totalSeriesCount: 3000,
+      displayedSeriesCount: 2000,
+    });
+  });
 });

--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -144,6 +144,11 @@ export const convertResult = ({
     (searchResponse as any).instantFieldSchema = instantData.schema;
   }
 
+  // Pass through truncation metadata for Prometheus queries
+  if (data.meta?.truncation) {
+    (searchResponse as any).truncation = data.meta.truncation;
+  }
+
   if (data.hasOwnProperty('aggs')) {
     const dataWithAggs = data as IDataFrameWithAggs;
     if (!dataWithAggs.aggs) {

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.test.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.test.tsx
@@ -16,7 +16,19 @@ const mockDispose = jest.fn();
 const mockIsDisposed = jest.fn(() => false);
 const mockDispatchAction = jest.fn();
 const mockGetHeight = jest.fn(() => 200);
-const mockGetZr = jest.fn(() => ({ on: jest.fn(), off: jest.fn() }));
+const mockGetWidth = jest.fn(() => 400);
+const mockConvertToPixel = jest.fn(() => [100, 50]);
+const mockConvertFromPixel = jest.fn(() => [1000, 15]);
+const mockZrOn = jest.fn();
+const mockZrOff = jest.fn();
+const mockZrAdd = jest.fn();
+const mockZrRemove = jest.fn();
+const mockGetZr = jest.fn(() => ({
+  on: mockZrOn,
+  off: mockZrOff,
+  add: mockZrAdd,
+  remove: mockZrRemove,
+}));
 
 const mockEchartsInstance = {
   setOption: mockSetOption,
@@ -27,28 +39,50 @@ const mockEchartsInstance = {
   isDisposed: mockIsDisposed,
   dispatchAction: mockDispatchAction,
   getHeight: mockGetHeight,
+  getWidth: mockGetWidth,
+  convertToPixel: mockConvertToPixel,
+  convertFromPixel: mockConvertFromPixel,
   getZr: mockGetZr,
 };
 
-jest.mock('echarts', () => ({
-  init: jest.fn(() => mockEchartsInstance),
-}));
+jest.mock('echarts', () => {
+  class MockZrShape {
+    attr = jest.fn();
+    constructor(public opts: any = {}) {}
+  }
+  return {
+    init: jest.fn(() => mockEchartsInstance),
+    graphic: {
+      Line: MockZrShape,
+      Circle: MockZrShape,
+    },
+  };
+});
 
-// --- shared cursor mock ---
-const mockPublishCursor = jest.fn();
-let mockSharedCursor: { idx: number; yRatio: number } | null = null;
+// --- shared cursor bus mock ---
+let mockBusSubscriber: ((s: { idx: number; yRatio: number } | null) => void) | null = null;
+const mockPublish = jest.fn();
+const mockSubscribe = jest.fn((cb) => {
+  mockBusSubscriber = cb;
+  return () => {
+    mockBusSubscriber = null;
+  };
+});
+let mockBus: { publish: jest.Mock; subscribe: jest.Mock } | null = {
+  publish: mockPublish,
+  subscribe: mockSubscribe,
+};
 
 jest.mock('../hooks/cursor_context', () => ({
-  useSharedCursor: () => [mockSharedCursor, mockPublishCursor],
+  useCursorBus: () => mockBus,
 }));
 
 // --- ResizeObserver mock ---
-class MockResizeObserver {
-  observe = jest.fn();
-  unobserve = jest.fn();
-  disconnect = jest.fn();
-}
-global.ResizeObserver = MockResizeObserver as any;
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+})) as any;
 
 // --- helpers ---
 const singleValues: Array<[number, string]> = [
@@ -77,7 +111,8 @@ const multiSeries = [
 describe('SparklineChart', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSharedCursor = null;
+    mockBusSubscriber = null;
+    mockBus = { publish: mockPublish, subscribe: mockSubscribe };
   });
 
   // --- formatValue (tested indirectly via yAxis formatter) ---
@@ -115,8 +150,10 @@ describe('SparklineChart', () => {
     render(<SparklineChart values={singleValues} height={150} />);
 
     expect(echarts.init).toHaveBeenCalled();
-    expect(mockSetOption).toHaveBeenCalledTimes(1);
-    const opts = mockSetOption.mock.calls[0][0];
+    // Find the setOption call that carries the chart config (has `series`).
+    const configCall = mockSetOption.mock.calls.find(([opt]: any) => opt && opt.series);
+    expect(configCall).toBeDefined();
+    const opts = configCall![0];
     expect(opts.series).toHaveLength(1);
     expect(opts.series[0].name).toBe('value');
     expect(opts.series[0].data).toEqual([
@@ -167,20 +204,25 @@ describe('SparklineChart', () => {
   });
 
   // --- shared cursor ---
-  it('dispatches showTip when sharedCursor is set', () => {
-    mockSharedCursor = { idx: 1, yRatio: 0.5 };
-    render(<SparklineChart values={singleValues} height={100} />);
-
-    expect(mockDispatchAction).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'showTip', dataIndex: 1 })
-    );
+  it('subscribes to the cursor bus and adds zr shapes on mount', () => {
+    render(<SparklineChart series={multiSeries} height={100} />);
+    expect(mockSubscribe).toHaveBeenCalled();
+    // 2 crosshair lines + one dot per series
+    expect(mockZrAdd).toHaveBeenCalledTimes(2 + multiSeries.length);
   });
 
-  it('dispatches hideTip when sharedCursor is null', () => {
-    mockSharedCursor = null;
+  it('hides tooltip on remote-cursor null event', () => {
     render(<SparklineChart values={singleValues} height={100} />);
-
+    // Trigger a null update via the bus
+    mockBusSubscriber?.(null);
     expect(mockDispatchAction).toHaveBeenCalledWith(expect.objectContaining({ type: 'hideTip' }));
+  });
+
+  it('unsubscribes and removes zr shapes on unmount', () => {
+    const { unmount } = render(<SparklineChart series={multiSeries} height={100} />);
+    const addCalls = mockZrAdd.mock.calls.length;
+    unmount();
+    expect(mockZrRemove).toHaveBeenCalledTimes(addCalls);
   });
 
   // --- cleanup ---

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.test.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.test.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { SparklineChart, SERIES_COLORS } from './sparkline';
+
+// --- echarts mock ---
+const mockSetOption = jest.fn();
+const mockOn = jest.fn();
+const mockOff = jest.fn();
+const mockResize = jest.fn();
+const mockDispose = jest.fn();
+const mockIsDisposed = jest.fn(() => false);
+const mockDispatchAction = jest.fn();
+const mockGetHeight = jest.fn(() => 200);
+const mockGetZr = jest.fn(() => ({ on: jest.fn(), off: jest.fn() }));
+
+const mockEchartsInstance = {
+  setOption: mockSetOption,
+  on: mockOn,
+  off: mockOff,
+  resize: mockResize,
+  dispose: mockDispose,
+  isDisposed: mockIsDisposed,
+  dispatchAction: mockDispatchAction,
+  getHeight: mockGetHeight,
+  getZr: mockGetZr,
+};
+
+jest.mock('echarts', () => ({
+  init: jest.fn(() => mockEchartsInstance),
+}));
+
+// --- shared cursor mock ---
+const mockPublishCursor = jest.fn();
+let mockSharedCursor: { idx: number; yRatio: number } | null = null;
+
+jest.mock('../hooks/cursor_context', () => ({
+  useSharedCursor: () => [mockSharedCursor, mockPublishCursor],
+}));
+
+// --- ResizeObserver mock ---
+class MockResizeObserver {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+global.ResizeObserver = MockResizeObserver as any;
+
+// --- helpers ---
+const singleValues: Array<[number, string]> = [
+  [1000, '10'],
+  [2000, '20'],
+  [3000, '30'],
+];
+
+const multiSeries = [
+  {
+    name: 'cpu',
+    values: [
+      [1000, '10'],
+      [2000, '20'],
+    ] as Array<[number, string]>,
+  },
+  {
+    name: 'mem',
+    values: [
+      [1000, '30'],
+      [2000, '40'],
+    ] as Array<[number, string]>,
+  },
+];
+
+describe('SparklineChart', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSharedCursor = null;
+  });
+
+  // --- formatValue (tested indirectly via yAxis formatter) ---
+  describe('formatValue via yAxis formatter', () => {
+    it.each([
+      [2e9, '2.0 G'],
+      [5e6, '5.0 M'],
+      [15000, '15.0 k'],
+      [500, '500'],
+      [3.5, '3.5'],
+      [0.05, '0.050'],
+      [0, '0'],
+      [0.001, '0.00100'],
+    ])('formats %s as %s', (input, expected) => {
+      render(<SparklineChart values={singleValues} height={100} />);
+      const opts = mockSetOption.mock.calls[0][0];
+      expect(opts.yAxis.axisLabel.formatter(input)).toBe(expected);
+    });
+  });
+
+  // --- no data state ---
+  it('renders no-data message when values is undefined', () => {
+    render(<SparklineChart height={100} />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('renders no-data message when only one data point', () => {
+    render(<SparklineChart values={[[1000, '10']]} height={100} />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  // --- single series rendering ---
+  it('initializes echarts and sets option for single series', () => {
+    const echarts = jest.requireMock('echarts');
+    render(<SparklineChart values={singleValues} height={150} />);
+
+    expect(echarts.init).toHaveBeenCalled();
+    expect(mockSetOption).toHaveBeenCalledTimes(1);
+    const opts = mockSetOption.mock.calls[0][0];
+    expect(opts.series).toHaveLength(1);
+    expect(opts.series[0].name).toBe('value');
+    expect(opts.series[0].data).toEqual([
+      [1000000, 10],
+      [2000000, 20],
+      [3000000, 30],
+    ]);
+  });
+
+  // --- multi-series rendering ---
+  it('renders multiple series with SERIES_COLORS palette', () => {
+    render(<SparklineChart series={multiSeries} height={100} />);
+
+    const opts = mockSetOption.mock.calls[0][0];
+    expect(opts.series).toHaveLength(2);
+    expect(opts.series[0].color).toBe(SERIES_COLORS[0]);
+    expect(opts.series[1].color).toBe(SERIES_COLORS[1]);
+  });
+
+  // --- brush / onTimeRangeChange ---
+  it('configures brush when onTimeRangeChange is provided', () => {
+    const onTimeRangeChange = jest.fn();
+    render(
+      <SparklineChart values={singleValues} height={100} onTimeRangeChange={onTimeRangeChange} />
+    );
+
+    const opts = mockSetOption.mock.calls[0][0];
+    expect(opts.brush).toBeDefined();
+    expect(mockDispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'takeGlobalCursor', key: 'brush' })
+    );
+  });
+
+  it('calls onTimeRangeChange on brushEnd event', () => {
+    const onTimeRangeChange = jest.fn();
+    render(
+      <SparklineChart values={singleValues} height={100} onTimeRangeChange={onTimeRangeChange} />
+    );
+
+    const brushEndHandler = mockOn.mock.calls.find(([evt]: any) => evt === 'brushEnd')?.[1];
+    expect(brushEndHandler).toBeDefined();
+
+    brushEndHandler({ areas: [{ coordRange: [1609459200000, 1609462800000] }] });
+    expect(onTimeRangeChange).toHaveBeenCalledWith(
+      new Date(1609459200000).toISOString(),
+      new Date(1609462800000).toISOString()
+    );
+  });
+
+  // --- shared cursor ---
+  it('dispatches showTip when sharedCursor is set', () => {
+    mockSharedCursor = { idx: 1, yRatio: 0.5 };
+    render(<SparklineChart values={singleValues} height={100} />);
+
+    expect(mockDispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'showTip', dataIndex: 1 })
+    );
+  });
+
+  it('dispatches hideTip when sharedCursor is null', () => {
+    mockSharedCursor = null;
+    render(<SparklineChart values={singleValues} height={100} />);
+
+    expect(mockDispatchAction).toHaveBeenCalledWith(expect.objectContaining({ type: 'hideTip' }));
+  });
+
+  // --- cleanup ---
+  it('disposes echarts instance on unmount', () => {
+    const { unmount } = render(<SparklineChart values={singleValues} height={100} />);
+    unmount();
+    expect(mockDispose).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
@@ -8,7 +8,7 @@ import * as echarts from 'echarts';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
-import { useSharedCursor } from '../hooks/cursor_context';
+import { useCursorBus } from '../hooks/cursor_context';
 
 interface SeriesData {
   name: string;
@@ -47,6 +47,9 @@ export const SERIES_COLORS = [
   '#5A467A',
 ];
 
+// Grid padding constants (kept in sync with the chart `grid` option below).
+const GRID = { top: 8, right: 36, bottom: 48, left: 60 };
+
 function formatValue(v: number): string {
   const abs = Math.abs(v);
   if (abs >= 1e9) return (v / 1e9).toFixed(1) + ' G';
@@ -72,7 +75,7 @@ export const SparklineChart: React.FC<ChartProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const instanceRef = useRef<echarts.ECharts | null>(null);
-  const [sharedCursor, publishCursor] = useSharedCursor();
+  const bus = useCursorBus();
 
   const allSeries = useMemo(() => {
     if (multiSeries && multiSeries.length > 0) return multiSeries;
@@ -119,12 +122,7 @@ export const SparklineChart: React.FC<ChartProps> = ({
     const baseOption: echarts.EChartsOption = {
       animation: false,
       color: allSeries.map((_, i) => getColor(i)),
-      grid: {
-        top: 8,
-        right: 36,
-        bottom: 48,
-        left: 60,
-      },
+      grid: GRID,
       legend: legendConfig,
       tooltip: {
         trigger: 'axis',
@@ -248,47 +246,179 @@ export const SparklineChart: React.FC<ChartProps> = ({
     };
   }, [onTimeRangeChange]);
 
-  // Shared cursor: publish on hover
+  // Shared cursor: draw crosshair + per-series dots directly on the zrender
+  // layer. Using zrender shapes (not setOption/graphic) keeps mouse moves cheap
+  // — we just mutate shape attrs. The chart under the real cursor also shows
+  // the native tooltip; remote charts get lines + dots only.
   useEffect(() => {
     const inst = instanceRef.current;
-    if (!inst) return;
+    if (!inst || !bus) return;
+    const zr = inst.getZr();
+    const zrGraphic: any = (echarts as any).graphic;
+    if (!zrGraphic?.Line || !zrGraphic?.Circle) return;
 
-    const onAxisPointer = (params: any) => {
-      const dataIndex = params.batch?.[0]?.dataIndex;
-      if (dataIndex != null && timestamps.length > 0) {
-        const plotH = inst.getHeight() - 8 - 28;
-        publishCursor({ idx: dataIndex, yRatio: 0.5 });
-      }
-    };
-    const onGlobalOut = () => publishCursor(null);
+    const lineColor = isDarkMode ? '#555' : '#999';
+    const dotStroke = isDarkMode ? '#1e1e1e' : '#fff';
 
-    inst.on('updateAxisPointer', onAxisPointer);
-    inst.getZr().on('globalout', onGlobalOut);
-    return () => {
-      if (!inst.isDisposed()) {
-        inst.off('updateAxisPointer', onAxisPointer);
-        inst.getZr().off('globalout', onGlobalOut);
-      }
-    };
-  }, [publishCursor, timestamps]);
+    const vLine = new zrGraphic.Line({
+      z: 100,
+      silent: true,
+      invisible: true,
+      style: { stroke: lineColor, lineWidth: 1, lineDash: [3, 3] },
+    });
+    const hLine = new zrGraphic.Line({
+      z: 100,
+      silent: true,
+      invisible: true,
+      style: { stroke: lineColor, lineWidth: 1, lineDash: [3, 3] },
+    });
+    zr.add(vLine);
+    zr.add(hLine);
 
-  // Shared cursor: receive from other charts
-  useEffect(() => {
-    const inst = instanceRef.current;
-    if (!inst || sharedCursor === null) {
-      if (instanceRef.current && !instanceRef.current.isDisposed()) {
-        instanceRef.current.dispatchAction({ type: 'hideTip' });
-      }
-      return;
-    }
-    if (sharedCursor.idx < timestamps.length) {
-      inst.dispatchAction({
-        type: 'showTip',
-        seriesIndex: 0,
-        dataIndex: sharedCursor.idx,
+    // One dot per series, positioned at (xIdx, seriesValue).
+    const dots: any[] = parsed.map((_, i) => {
+      const dot = new zrGraphic.Circle({
+        z: 101,
+        silent: true,
+        invisible: true,
+        shape: { cx: 0, cy: 0, r: 3 },
+        style: { fill: getColor(i), stroke: dotStroke, lineWidth: 1 },
       });
-    }
-  }, [sharedCursor, timestamps]);
+      zr.add(dot);
+      return dot;
+    });
+
+    let isLocalHover = false;
+
+    const hideOverlay = () => {
+      vLine.attr({ invisible: true });
+      hLine.attr({ invisible: true });
+      dots.forEach((d) => d.attr({ invisible: true }));
+    };
+
+    const showOverlay = (idx: number, yRatio: number) => {
+      const plotTop = GRID.top;
+      const plotBot = inst.getHeight() - GRID.bottom;
+      const plotLeft = GRID.left;
+      const plotRight = inst.getWidth() - GRID.right;
+      if (plotBot <= plotTop || plotRight <= plotLeft) return;
+      if (idx < 0 || idx >= timestamps.length) return;
+
+      const xValue = timestamps[idx];
+      const xyPx = inst.convertToPixel({ gridIndex: 0 }, [xValue, 0]) as
+        | [number, number]
+        | null
+        | undefined;
+      if (!xyPx) return;
+      const xPx = xyPx[0];
+      const yPx = plotTop + yRatio * (plotBot - plotTop);
+
+      vLine.attr({
+        invisible: false,
+        shape: { x1: xPx, y1: plotTop, x2: xPx, y2: plotBot },
+      });
+      hLine.attr({
+        invisible: false,
+        shape: { x1: plotLeft, y1: yPx, x2: plotRight, y2: yPx },
+      });
+
+      // Position a dot at the data value of each series for the given index.
+      parsed.forEach((s, i) => {
+        const pt = s.data[idx];
+        const dot = dots[i];
+        if (!pt || isNaN(pt[1])) {
+          dot.attr({ invisible: true });
+          return;
+        }
+        const px = inst.convertToPixel({ gridIndex: 0 }, [pt[0], pt[1]]) as
+          | [number, number]
+          | null
+          | undefined;
+        if (!px) {
+          dot.attr({ invisible: true });
+          return;
+        }
+        dot.attr({
+          invisible: false,
+          shape: { cx: px[0], cy: px[1], r: 3 },
+        });
+      });
+    };
+
+    const onMouseMove = (params: any) => {
+      if (timestamps.length === 0) return;
+      const x = params.offsetX;
+      const y = params.offsetY;
+
+      const plotTop = GRID.top;
+      const plotBot = inst.getHeight() - GRID.bottom;
+      const plotLeft = GRID.left;
+      const plotRight = inst.getWidth() - GRID.right;
+      if (x < plotLeft || x > plotRight || y < plotTop || y > plotBot || plotBot <= plotTop) {
+        return;
+      }
+
+      const pt = inst.convertFromPixel({ gridIndex: 0 }, [x, y]) as
+        | [number, number]
+        | null
+        | undefined;
+      if (!pt || pt[0] == null) return;
+      const xValue = pt[0];
+
+      let idx = 0;
+      let minDist = Infinity;
+      for (let i = 0; i < timestamps.length; i++) {
+        const d = Math.abs(timestamps[i] - xValue);
+        if (d < minDist) {
+          minDist = d;
+          idx = i;
+        }
+      }
+
+      const yRatio = Math.max(0, Math.min(1, (y - plotTop) / (plotBot - plotTop)));
+
+      isLocalHover = true;
+      // Show overlay locally too — the per-series dots are useful even on the
+      // hovered chart. The native axisPointer vertical line will also render
+      // but they overlap visually; the tooltip stays local because we do not
+      // hideTip here.
+      showOverlay(idx, yRatio);
+      bus.publish({ idx, yRatio });
+    };
+
+    const onGlobalOut = () => {
+      isLocalHover = false;
+      hideOverlay();
+      bus.publish(null);
+    };
+
+    zr.on('mousemove', onMouseMove);
+    zr.on('globalout', onGlobalOut);
+
+    const unsubscribe = bus.subscribe((state) => {
+      if (isLocalHover) return; // local hover is handled by onMouseMove
+      if (!state) {
+        hideOverlay();
+        if (!inst.isDisposed()) inst.dispatchAction({ type: 'hideTip' });
+        return;
+      }
+      // Remote update — make sure any lingering tooltip/pointer on this chart
+      // is hidden, then render our overlay.
+      if (!inst.isDisposed()) inst.dispatchAction({ type: 'hideTip' });
+      showOverlay(state.idx, state.yRatio);
+    });
+
+    return () => {
+      unsubscribe();
+      if (!inst.isDisposed()) {
+        zr.off('mousemove', onMouseMove);
+        zr.off('globalout', onGlobalOut);
+        zr.remove(vLine);
+        zr.remove(hLine);
+        dots.forEach((d) => zr.remove(d));
+      }
+    };
+  }, [bus, timestamps, parsed, isDarkMode, getColor]);
 
   if (!hasData) {
     return (

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
@@ -130,10 +130,18 @@ export const SparklineChart: React.FC<ChartProps> = ({
         backgroundColor: isDarkMode ? '#1e1e1e' : '#fff',
         borderColor: isDarkMode ? '#444' : '#ddd',
         textStyle: { fontSize: 12, color: isDarkMode ? '#ddd' : '#333' },
+        // Build the tooltip with DOM APIs and assign user-controlled strings
+        // via textContent so Prometheus-supplied series names cannot inject
+        // markup. ECharts accepts HTMLElement / DocumentFragment return values.
         formatter: (params: any) => {
           const items = Array.isArray(params) ? params : [params];
           if (!items.length) return '';
-          const time = new Date(items[0].value[0]).toLocaleString([], {
+          const frag = document.createDocumentFragment();
+
+          const header = document.createElement('div');
+          header.style.fontWeight = '500';
+          header.style.marginBottom = '4px';
+          header.textContent = new Date(items[0].value[0]).toLocaleString([], {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',
@@ -141,18 +149,33 @@ export const SparklineChart: React.FC<ChartProps> = ({
             minute: '2-digit',
             second: '2-digit',
           });
+          frag.appendChild(header);
+
           const sorted = [...items].sort((a, b) => (b.value[1] ?? 0) - (a.value[1] ?? 0));
-          const lines = sorted.map(
-            (p: any) =>
-              `<span style="display:inline-block;width:10px;height:3px;background:${
-                p.color
-              };border-radius:1px;margin-right:6px"></span>${
-                p.seriesName
-              } <b style="float:right;margin-left:12px">${formatValue(p.value[1])}</b>`
-          );
-          return `<div style="font-weight:500;margin-bottom:4px">${time}</div>${lines.join(
-            '<br/>'
-          )}`;
+          sorted.forEach((p: any, i: number) => {
+            if (i > 0) frag.appendChild(document.createElement('br'));
+
+            const swatch = document.createElement('span');
+            swatch.style.display = 'inline-block';
+            swatch.style.width = '10px';
+            swatch.style.height = '3px';
+            // Series color is sourced from our SERIES_COLORS palette, not user
+            // input, so setting it as a style value is safe.
+            swatch.style.background = p.color;
+            swatch.style.borderRadius = '1px';
+            swatch.style.marginRight = '6px';
+            frag.appendChild(swatch);
+
+            frag.appendChild(document.createTextNode(`${p.seriesName} `));
+
+            const value = document.createElement('b');
+            value.style.float = 'right';
+            value.style.marginLeft = '12px';
+            value.textContent = formatValue(p.value[1]);
+            frag.appendChild(value);
+          });
+
+          return frag as any;
         },
       },
       xAxis: {

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useRef, useState, useCallback, useMemo, useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useRef, useMemo, useEffect, useCallback } from 'react';
+import * as echarts from 'echarts';
 import { EuiText } from '@elastic/eui';
-import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { i18n } from '@osd/i18n';
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { useSharedCursor } from '../hooks/cursor_context';
 
 interface SeriesData {
@@ -25,46 +25,6 @@ interface ChartProps {
   yMax?: number;
   isDarkMode?: boolean;
   onTimeRangeChange?: (from: string, to: string) => void;
-}
-
-const PADDING = { top: 8, right: 36, bottom: 28, left: 60 };
-
-function formatValue(v: number, range?: number): string {
-  // When range is provided and small relative to values, use enough precision to differentiate
-  if (range !== undefined && range > 0) {
-    const magnitude = Math.abs(v);
-    if (magnitude > 0 && range / magnitude < 0.01) {
-      // Very small range relative to value — need extra precision
-      const decimals = Math.max(2, Math.ceil(-Math.log10(range)) + 1);
-      return v.toFixed(Math.min(decimals, 6));
-    }
-  }
-  const abs = Math.abs(v);
-  if (abs >= 1e9) return (v / 1e9).toFixed(1) + ' G';
-  if (abs >= 1e6) return (v / 1e6).toFixed(1) + ' M';
-  if (abs >= 1e4) return (v / 1e3).toFixed(1) + ' k';
-  if (abs >= 100) return v.toFixed(0);
-  if (abs >= 1) return v.toFixed(1);
-  if (abs >= 0.01) return v.toFixed(3);
-  if (abs === 0) return '0';
-  return v.toPrecision(3);
-}
-
-function formatTime(ts: number): string {
-  const d = new Date(ts * 1000);
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-}
-
-function formatTooltipTime(ts: number): string {
-  const d = new Date(ts * 1000);
-  return d.toLocaleString([], {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
 }
 
 // Classic series color palette
@@ -87,39 +47,32 @@ export const SERIES_COLORS = [
   '#5A467A',
 ];
 
+function formatValue(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return (v / 1e9).toFixed(1) + ' G';
+  if (abs >= 1e6) return (v / 1e6).toFixed(1) + ' M';
+  if (abs >= 1e4) return (v / 1e3).toFixed(1) + ' k';
+  if (abs >= 100) return v.toFixed(0);
+  if (abs >= 1) return v.toFixed(1);
+  if (abs >= 0.01) return v.toFixed(3);
+  if (abs === 0) return '0';
+  return v.toPrecision(3);
+}
+
 export const SparklineChart: React.FC<ChartProps> = ({
   values,
   height,
   stroke = euiThemeVars.euiColorPrimary,
   label = 'value',
   series: multiSeries,
-  yMin: propYMin,
-  yMax: propYMax,
+  yMin,
+  yMax,
   isDarkMode = false,
   onTimeRangeChange,
 }) => {
-  const colors = SERIES_COLORS;
-  const gridColor = isDarkMode ? '#2a2a2a' : '#efefef';
-  const textColor = isDarkMode ? '#8e8e8e' : '#999';
-  const legendColor = isDarkMode ? '#aaa' : '#666';
-  const tooltipBg = isDarkMode ? '#1e1e1e' : '#fff';
-  const tooltipBorder = isDarkMode ? '#444' : '#ddd';
-  const tooltipShadow = isDarkMode ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.12)';
-  const crosshairColor = isDarkMode ? '#555' : '#999';
-  const dotStroke = isDarkMode ? '#1e1e1e' : '#fff';
   const containerRef = useRef<HTMLDivElement>(null);
-  const [hover, setHover] = useState<{
-    x: number;
-    y: number;
-    idx: number;
-    clientX: number;
-    clientY: number;
-  } | null>(null);
-  const [containerWidth, setContainerWidth] = useState(0);
+  const instanceRef = useRef<echarts.ECharts | null>(null);
   const [sharedCursor, publishCursor] = useSharedCursor();
-  const crosshairIdx = hover ? hover.idx : sharedCursor?.idx ?? null;
-  const [dragStart, setDragStart] = useState<number | null>(null); // idx at mousedown
-  const draggingRef = useRef(false);
 
   const allSeries = useMemo(() => {
     if (multiSeries && multiSeries.length > 0) return multiSeries;
@@ -127,103 +80,217 @@ export const SparklineChart: React.FC<ChartProps> = ({
     return [];
   }, [multiSeries, values, label]);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
   const parsed = useMemo(
     () =>
       allSeries.map((s) => ({
         name: s.name,
-        nums: s.values.map(([, v]) => parseFloat(v)),
-        timestamps: s.values.map(([t]) => t),
+        data: s.values.map(([t, v]) => [t * 1000, parseFloat(v)] as [number, number]),
       })),
     [allSeries]
   );
 
-  // Global min/max/timestamps from first series (all share same time range)
-  const timestamps = useMemo(() => parsed[0]?.timestamps || [], [parsed]);
-  const allNums = useMemo(() => parsed.flatMap((p) => p.nums).filter((v) => !isNaN(v)), [parsed]);
+  const hasData = useMemo(() => parsed.some((s) => s.data.length >= 2), [parsed]);
 
-  const getIdxFromEvent = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!containerRef.current || timestamps.length < 2) return null;
-      const rect = containerRef.current.getBoundingClientRect();
-      const mx = e.clientX - rect.left;
-      const plotW = rect.width - PADDING.left - PADDING.right;
-      const relX = mx - PADDING.left;
-      const idx = Math.round((relX / plotW) * (timestamps.length - 1));
-      return idx >= 0 && idx < timestamps.length ? idx : null;
-    },
-    [timestamps.length]
+  const timestamps = useMemo(() => parsed[0]?.data.map(([t]) => t) || [], [parsed]);
+
+  const getColor = useCallback(
+    (i: number) => (allSeries.length > 1 ? SERIES_COLORS[i % SERIES_COLORS.length] : stroke),
+    [allSeries.length, stroke]
   );
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!containerRef.current || timestamps.length < 2) return;
-      const rect = containerRef.current.getBoundingClientRect();
-      const mx = e.clientX - rect.left;
-      const my = e.clientY - rect.top;
-      const plotW = rect.width - PADDING.left - PADDING.right;
-      const relX = mx - PADDING.left;
-      const idx = Math.round((relX / plotW) * (timestamps.length - 1));
-      if (idx >= 0 && idx < timestamps.length) {
-        setHover({ x: mx, y: my, idx, clientX: e.clientX, clientY: e.clientY });
-        if (dragStart !== null && Math.abs(idx - dragStart) > 1) draggingRef.current = true;
-        const plotH = rect.height - PADDING.top - PADDING.bottom;
-        const yRatio = Math.max(0, Math.min(1, (my - PADDING.top) / plotH));
-        publishCursor({ idx, yRatio });
-      }
-    },
-    [timestamps.length, publishCursor, dragStart]
-  );
+  const option = useMemo((): echarts.EChartsOption | null => {
+    if (!hasData) return null;
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const idx = getIdxFromEvent(e);
-      if (idx !== null) {
-        setDragStart(idx);
-        draggingRef.current = false;
-      }
-    },
-    [getIdxFromEvent]
-  );
+    const textColor = isDarkMode ? '#8e8e8e' : '#999';
+    const splitLineColor = isDarkMode ? '#2a2a2a' : '#efefef';
 
-  const handleMouseUp = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (dragStart === null || !draggingRef.current || !onTimeRangeChange) {
-        setDragStart(null);
-        draggingRef.current = false;
-        return;
-      }
-      const endIdx = getIdxFromEvent(e);
-      if (endIdx !== null && endIdx !== dragStart) {
-        const lo = Math.min(dragStart, endIdx);
-        const hi = Math.max(dragStart, endIdx);
-        const from = new Date(timestamps[lo] * 1000).toISOString();
-        const to = new Date(timestamps[hi] * 1000).toISOString();
-        onTimeRangeChange(from, to);
-      }
-      setDragStart(null);
-      draggingRef.current = false;
-    },
-    [dragStart, timestamps, onTimeRangeChange, getIdxFromEvent]
-  );
+    const legendConfig: echarts.EChartsOption['legend'] = {
+      type: 'scroll',
+      bottom: 0,
+      left: 60,
+      right: 36,
+      itemWidth: 12,
+      itemHeight: 3,
+      textStyle: { fontSize: 10, color: isDarkMode ? '#aaa' : '#666' },
+      pageIconSize: 10,
+      pageTextStyle: { fontSize: 10 },
+    };
 
-  const handleMouseLeave = useCallback(() => {
-    setHover(null);
-    setDragStart(null);
-    draggingRef.current = false;
-    publishCursor(null);
-  }, [publishCursor]);
+    const baseOption: echarts.EChartsOption = {
+      animation: false,
+      color: allSeries.map((_, i) => getColor(i)),
+      grid: {
+        top: 8,
+        right: 36,
+        bottom: 48,
+        left: 60,
+      },
+      legend: legendConfig,
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'cross', label: { show: false } },
+        backgroundColor: isDarkMode ? '#1e1e1e' : '#fff',
+        borderColor: isDarkMode ? '#444' : '#ddd',
+        textStyle: { fontSize: 12, color: isDarkMode ? '#ddd' : '#333' },
+        formatter: (params: any) => {
+          const items = Array.isArray(params) ? params : [params];
+          if (!items.length) return '';
+          const time = new Date(items[0].value[0]).toLocaleString([], {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          });
+          const sorted = [...items].sort((a, b) => (b.value[1] ?? 0) - (a.value[1] ?? 0));
+          const lines = sorted.map(
+            (p: any) =>
+              `<span style="display:inline-block;width:10px;height:3px;background:${
+                p.color
+              };border-radius:1px;margin-right:6px"></span>${
+                p.seriesName
+              } <b style="float:right;margin-left:12px">${formatValue(p.value[1])}</b>`
+          );
+          return `<div style="font-weight:500;margin-bottom:4px">${time}</div>${lines.join(
+            '<br/>'
+          )}`;
+        },
+      },
+      xAxis: {
+        type: 'time',
+        axisLabel: { fontSize: 10, color: textColor },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        min: yMin,
+        max: yMax,
+        axisLabel: {
+          fontSize: 10,
+          color: textColor,
+          formatter: (v: number) => formatValue(v),
+        },
+        splitLine: { lineStyle: { color: splitLineColor, type: 'dashed' } },
+      },
+      series: parsed.map((s, i) => ({
+        name: s.name,
+        type: 'line' as const,
+        data: s.data,
+        showSymbol: false,
+        lineStyle: { width: 1 },
+        areaStyle: { opacity: 0.2 },
+        color: getColor(i),
+      })),
+    };
 
-  if (allNums.length < 2) {
+    // Add brush tool for drag-to-select time range when onTimeRangeChange is provided
+    if (onTimeRangeChange) {
+      baseOption.brush = {
+        toolbox: ['lineX'],
+        xAxisIndex: 0,
+      };
+      baseOption.toolbox = { show: false };
+    }
+
+    return baseOption;
+  }, [hasData, parsed, allSeries, isDarkMode, yMin, yMax, getColor, onTimeRangeChange]);
+
+  // Init / dispose
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const inst = echarts.init(containerRef.current);
+    instanceRef.current = inst;
+    const ro = new ResizeObserver(() => inst.resize());
+    ro.observe(containerRef.current);
+    return () => {
+      ro.disconnect();
+      inst.dispose();
+      instanceRef.current = null;
+    };
+  }, []);
+
+  // Set option and activate brush tool
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (inst && option) {
+      inst.setOption(option, { notMerge: true });
+      // Activate brush tool for drag-to-select if configured
+      if (onTimeRangeChange) {
+        inst.dispatchAction({
+          type: 'takeGlobalCursor',
+          key: 'brush',
+          brushOption: { brushType: 'lineX', brushMode: 'single' },
+        });
+      }
+    }
+  }, [option, onTimeRangeChange]);
+
+  // Brush end → time range change
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst || !onTimeRangeChange) return;
+
+    const onBrushEnd = (params: any) => {
+      const [from, to] = params.areas?.[0]?.coordRange ?? [];
+      if (from != null && to != null) {
+        onTimeRangeChange(new Date(from).toISOString(), new Date(to).toISOString());
+      }
+    };
+
+    inst.on('brushEnd', onBrushEnd);
+    return () => {
+      if (!inst.isDisposed()) {
+        inst.off('brushEnd', onBrushEnd);
+      }
+    };
+  }, [onTimeRangeChange]);
+
+  // Shared cursor: publish on hover
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst) return;
+
+    const onAxisPointer = (params: any) => {
+      const dataIndex = params.batch?.[0]?.dataIndex;
+      if (dataIndex != null && timestamps.length > 0) {
+        const plotH = inst.getHeight() - 8 - 28;
+        publishCursor({ idx: dataIndex, yRatio: 0.5 });
+      }
+    };
+    const onGlobalOut = () => publishCursor(null);
+
+    inst.on('updateAxisPointer', onAxisPointer);
+    inst.getZr().on('globalout', onGlobalOut);
+    return () => {
+      if (!inst.isDisposed()) {
+        inst.off('updateAxisPointer', onAxisPointer);
+        inst.getZr().off('globalout', onGlobalOut);
+      }
+    };
+  }, [publishCursor, timestamps]);
+
+  // Shared cursor: receive from other charts
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst || sharedCursor === null) {
+      if (instanceRef.current && !instanceRef.current.isDisposed()) {
+        instanceRef.current.dispatchAction({ type: 'hideTip' });
+      }
+      return;
+    }
+    if (sharedCursor.idx < timestamps.length) {
+      inst.dispatchAction({
+        type: 'showTip',
+        seriesIndex: 0,
+        dataIndex: sharedCursor.idx,
+      });
+    }
+  }, [sharedCursor, timestamps]);
+
+  if (!hasData) {
     return (
       <div
         style={{
@@ -241,259 +308,5 @@ export const SparklineChart: React.FC<ChartProps> = ({
     );
   }
 
-  const isMulti = allSeries.length > 1;
-  const min = propYMin !== undefined ? propYMin : Math.min(...allNums);
-  const max = propYMax !== undefined ? propYMax : Math.max(...allNums);
-  const range = max - min || 1;
-  const legendH = isMulti ? Math.ceil(allSeries.length / 8) * 16 + 4 : 16;
-  const pad = { ...PADDING, bottom: PADDING.bottom + legendH };
-
-  const yTicks: number[] = [];
-  const tickCount = 4;
-  for (let i = 0; i <= tickCount; i++) yTicks.push(min + (range * i) / tickCount);
-
-  const xTickCount = Math.min(4, timestamps.length - 1);
-  const xTicks: number[] = [];
-  for (let i = 0; i <= xTickCount; i++)
-    xTicks.push(Math.round((i / xTickCount) * (timestamps.length - 1)));
-
-  const plotW = containerWidth - pad.left - pad.right;
-  const plotH = height - pad.top - pad.bottom;
-  const totalH = height;
-
-  const getColor = (i: number) => (isMulti ? colors[i % colors.length] : stroke);
-
-  return (
-    <div
-      ref={containerRef}
-      style={{
-        width: '100%',
-        height: totalH,
-        position: 'relative',
-        userSelect: 'none',
-        cursor: dragStart !== null && draggingRef.current ? 'col-resize' : 'crosshair',
-      }}
-      onMouseMove={handleMouseMove}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseLeave}
-    >
-      <svg width="100%" height={totalH} style={{ display: 'block' }}>
-        {/* Y-axis grid */}
-        {yTicks.map((v, i) => {
-          const y = pad.top + plotH - ((v - min) / range) * plotH;
-          return (
-            <g key={`y-${i}`}>
-              <line
-                x1={pad.left}
-                y1={y}
-                x2="100%"
-                y2={y}
-                stroke={gridColor}
-                strokeWidth="1"
-                strokeDasharray="3,3"
-              />
-              <text x={pad.left - 6} y={y + 4} textAnchor="end" fontSize="10" fill={textColor}>
-                {formatValue(v, range)}
-              </text>
-            </g>
-          );
-        })}
-        {/* X-axis labels */}
-        {plotW > 0 &&
-          xTicks.map((idx) => {
-            const x = pad.left + (idx / (timestamps.length - 1)) * plotW;
-            return (
-              <text
-                key={`x-${idx}`}
-                x={x}
-                y={pad.top + plotH + 16}
-                textAnchor="middle"
-                fontSize="10"
-                fill={textColor}
-              >
-                {formatTime(timestamps[idx])}
-              </text>
-            );
-          })}
-        {/* Area fill + lines */}
-        {plotW > 0 &&
-          parsed.map((s, si) => {
-            const linePoints = s.nums
-              .map((v, i) => {
-                const x = pad.left + (i / (s.nums.length > 1 ? s.nums.length - 1 : 1)) * plotW;
-                const y = pad.top + plotH - ((v - min) / range) * plotH;
-                return `${x},${y}`;
-              })
-              .join(' ');
-            const firstX = pad.left;
-            const lastX = pad.left + plotW;
-            const baseY = pad.top + plotH;
-            const areaPoints = `${firstX},${baseY} ${linePoints} ${lastX},${baseY}`;
-            const color = getColor(si);
-            return (
-              <g key={si}>
-                <polygon fill={color} fillOpacity={0.2} points={areaPoints} stroke="none" />
-                <polyline fill="none" stroke={color} strokeWidth="1" points={linePoints} />
-              </g>
-            );
-          })}
-        {/* Drag selection overlay */}
-        {dragStart !== null &&
-          hover &&
-          draggingRef.current &&
-          plotW > 0 &&
-          (() => {
-            const lo = Math.min(dragStart, hover.idx);
-            const hi = Math.max(dragStart, hover.idx);
-            const x1 = pad.left + (lo / (timestamps.length - 1)) * plotW;
-            const x2 = pad.left + (hi / (timestamps.length - 1)) * plotW;
-            return (
-              <rect
-                x={x1}
-                y={pad.top}
-                width={x2 - x1}
-                height={plotH}
-                fill={isDarkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,100,200,0.1)'}
-                stroke={isDarkMode ? 'rgba(255,255,255,0.3)' : 'rgba(0,100,200,0.3)'}
-                strokeWidth="1"
-              />
-            );
-          })()}
-        {/* Hover crosshair */}
-        {crosshairIdx !== null &&
-          crosshairIdx >= 0 &&
-          crosshairIdx < timestamps.length &&
-          plotW > 0 && (
-            <>
-              <line
-                x1={pad.left + (crosshairIdx / (timestamps.length - 1)) * plotW}
-                y1={pad.top}
-                x2={pad.left + (crosshairIdx / (timestamps.length - 1)) * plotW}
-                y2={pad.top + plotH}
-                stroke={crosshairColor}
-                strokeWidth="1"
-                strokeDasharray="3,3"
-              />
-              {parsed.map((s, si) => {
-                const v = s.nums[crosshairIdx];
-                if (isNaN(v)) return null;
-                const cx = pad.left + (crosshairIdx / (timestamps.length - 1)) * plotW;
-                const cy = pad.top + plotH - ((v - min) / range) * plotH;
-                return (
-                  <g key={si}>
-                    <circle
-                      cx={cx}
-                      cy={cy}
-                      r={3}
-                      fill={getColor(si)}
-                      stroke={dotStroke}
-                      strokeWidth="1"
-                    />
-                  </g>
-                );
-              })}
-              {(() => {
-                const yRatio = hover
-                  ? Math.max(0, Math.min(1, (hover.y - pad.top) / plotH))
-                  : sharedCursor?.yRatio ?? null;
-                if (yRatio === null) return null;
-                const cy = pad.top + yRatio * plotH;
-                return (
-                  <line
-                    x1={pad.left}
-                    y1={cy}
-                    x2={pad.left + plotW}
-                    y2={cy}
-                    stroke={crosshairColor}
-                    strokeWidth="1"
-                    strokeDasharray="3,3"
-                  />
-                );
-              })()}
-            </>
-          )}
-      </svg>
-      {/* Legend */}
-      <div
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: pad.left,
-          right: pad.right,
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '2px 8px',
-          fontSize: 10,
-          color: legendColor,
-        }}
-      >
-        {allSeries.map((s, i) => (
-          <span key={i} style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-            <span
-              style={{
-                display: 'inline-block',
-                width: 12,
-                height: 3,
-                backgroundColor: getColor(i),
-                borderRadius: 1,
-              }}
-            />
-            {s.name}
-          </span>
-        ))}
-      </div>
-      {/* Tooltip */}
-      {hover &&
-        createPortal(
-          <div
-            style={{
-              position: 'fixed',
-              left: hover.clientX + 12,
-              top: hover.clientY - 40,
-              background: tooltipBg,
-              border: `1px solid ${tooltipBorder}`,
-              borderRadius: 4,
-              padding: '6px 10px',
-              fontSize: 12,
-              boxShadow: `0 2px 8px ${tooltipShadow}`,
-              pointerEvents: 'none',
-              zIndex: 10000,
-              whiteSpace: 'nowrap',
-              maxHeight: 400,
-              overflowY: 'auto',
-            }}
-          >
-            <div style={{ fontWeight: 500, marginBottom: 4 }}>
-              {formatTooltipTime(timestamps[hover.idx])}
-            </div>
-            {parsed
-              .map((s, si) => ({ name: s.name, val: s.nums[hover.idx], color: getColor(si) }))
-              .filter((r) => !isNaN(r.val))
-              .sort((a, b) => b.val - a.val)
-              .map((r, i) => (
-                <div
-                  key={i}
-                  style={{ display: 'flex', alignItems: 'center', gap: 6, lineHeight: '18px' }}
-                >
-                  <span
-                    style={{
-                      display: 'inline-block',
-                      width: 10,
-                      height: 3,
-                      backgroundColor: r.color,
-                      borderRadius: 1,
-                    }}
-                  />
-                  <span>{r.name}</span>
-                  <span style={{ fontWeight: 600, marginLeft: 'auto', paddingLeft: 12 }}>
-                    {formatValue(r.val, range)}
-                  </span>
-                </div>
-              ))}
-          </div>,
-          document.body
-        )}
-    </div>
-  );
+  return <div ref={containerRef} style={{ width: '100%', height }} />;
 };

--- a/src/plugins/explore/public/application/pages/metrics/explore/hooks/cursor_context.ts
+++ b/src/plugins/explore/public/application/pages/metrics/explore/hooks/cursor_context.ts
@@ -31,6 +31,11 @@ export function createCursorBus(): CursorContextValue {
   };
 }
 
+/** Returns the raw bus so callers can subscribe without triggering React re-renders. */
+export function useCursorBus(): CursorContextValue | null {
+  return useContext(CursorContext);
+}
+
 /** Hook that subscribes to the shared cursor and returns the current state. */
 export function useSharedCursor(): [CursorState | null, (state: CursorState | null) => void] {
   const bus = useContext(CursorContext);

--- a/src/plugins/explore/public/application/utils/state_management/slices/results/results_slice.ts
+++ b/src/plugins/explore/public/application/utils/state_management/slices/results/results_slice.ts
@@ -19,6 +19,11 @@ export interface IPrometheusSearchResult extends ISearchResult {
     total: number;
   };
   instantFieldSchema?: Array<Partial<IFieldType>>;
+  truncation?: {
+    tableTruncated: boolean;
+    totalSeriesCount: number;
+    displayedSeriesCount: number;
+  };
 }
 
 export interface ResultMetadata {

--- a/src/plugins/explore/public/components/data_table/metrics_raw_table.test.tsx
+++ b/src/plugins/explore/public/components/data_table/metrics_raw_table.test.tsx
@@ -230,6 +230,28 @@ describe('MetricsRawTable', () => {
     expect(screen.getByText('20.3')).toBeInTheDocument();
   });
 
+  describe('truncation warning', () => {
+    it('shows warning when table data is truncated', () => {
+      const truncatedResult: IPrometheusSearchResult = {
+        ...mockSearchResult,
+        truncation: {
+          tableTruncated: true,
+          totalSeriesCount: 3000,
+          displayedSeriesCount: 2000,
+        },
+      };
+
+      render(<MetricsRawTable searchResult={truncatedResult} />);
+      expect(screen.getByTestId('metricsRawTableTruncationWarning')).toBeInTheDocument();
+      expect(screen.getByText(/2,000 of 3,000/)).toBeInTheDocument();
+    });
+
+    it('does not show warning when data is not truncated', () => {
+      render(<MetricsRawTable searchResult={mockSearchResult} />);
+      expect(screen.queryByTestId('metricsRawTableTruncationWarning')).not.toBeInTheDocument();
+    });
+  });
+
   describe('sorting', () => {
     const sortableSearchResult: IPrometheusSearchResult = {
       ...mockSearchResult,

--- a/src/plugins/explore/public/components/data_table/metrics_raw_table.tsx
+++ b/src/plugins/explore/public/components/data_table/metrics_raw_table.tsx
@@ -7,6 +7,7 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiButtonIcon,
+  EuiCallOut,
   EuiCopy,
   EuiFlexGroup,
   EuiFlexItem,
@@ -225,9 +226,27 @@ export const MetricsRawTable: React.FC<MetricsRawTableProps> = ({ searchResult }
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   };
 
+  const truncation = searchResult?.truncation;
+
   return (
     <>
       <EuiSpacer size="s" />
+      {truncation?.tableTruncated && (
+        <EuiCallOut
+          size="s"
+          color="warning"
+          iconType="alert"
+          title={i18n.translate('explore.metricsRawTable.truncationWarning', {
+            defaultMessage:
+              'Showing {displayed} of {total} series. Refine your query to see all results.',
+            values: {
+              displayed: truncation.displayedSeriesCount.toLocaleString(),
+              total: truncation.totalSeriesCount.toLocaleString(),
+            },
+          })}
+          data-test-subj="metricsRawTableTruncationWarning"
+        />
+      )}
       <EuiFlexGroup direction="row" gutterSize="none" justifyContent="spaceBetween">
         <EuiFlexItem>
           <EuiFlexGroup

--- a/src/plugins/explore/public/components/tabs/metrics_vis_tab.scss
+++ b/src/plugins/explore/public/components/tabs/metrics_vis_tab.scss
@@ -11,8 +11,14 @@
 
   &__chartTypeToggle {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
+    gap: $euiSizeS;
     padding: $euiSizeXS;
+
+    [data-test-subj="seriesLimitDisclaimer"] {
+      margin-right: auto;
+    }
   }
 
   &__chartArea {

--- a/src/plugins/explore/public/components/tabs/metrics_vis_tab.tsx
+++ b/src/plugins/explore/public/components/tabs/metrics_vis_tab.tsx
@@ -5,14 +5,24 @@
 
 import './metrics_vis_tab.scss';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useObservable } from 'react-use';
 import { useSelector } from 'react-redux';
 import { createPortal } from 'react-dom';
 import { i18n } from '@osd/i18n';
-import { EuiButtonGroup, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiButtonGroup,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 
 import { VisualizationContainer } from '../visualizations/visualization_container';
+import { useTabResults } from '../../application/utils/hooks/use_tab_results';
 import { ExploreMetricsRawTable } from '../data_table/explore_metrics_raw_table';
 import { ActionBar } from './action_bar/action_bar';
 import { EXPLORE_ACTION_BAR_SLOT_ID } from './tabs';
@@ -20,6 +30,8 @@ import { getVisualizationBuilder } from '../visualizations/visualization_builder
 import { shouldSkipQueryExecution } from '../../application/utils/state_management/actions/query_actions';
 import { RootState } from '../../application/utils/state_management/store';
 import { ChartType } from '../visualizations/utils/use_visualization_types';
+
+const DEFAULT_SERIES_LIMIT = 20;
 
 const QUICK_CHART_TYPES: Array<{ id: ChartType; label: string; iconType: string }> = [
   {
@@ -47,7 +59,9 @@ const QUICK_CHART_TYPES: Array<{ id: ChartType; label: string; iconType: string 
 export const MetricsVisTab = () => {
   const [slot, setSlot] = useState<HTMLElement | null>(null);
   const [isSettingsCollapsed, setIsSettingsCollapsed] = useState(true);
+  const [showAllSeries, setShowAllSeries] = useState(false);
   const visualizationBuilder = getVisualizationBuilder();
+  const { results } = useTabResults();
   const data = useObservable(visualizationBuilder.data$);
   const visConfig = useObservable(visualizationBuilder.visConfig$);
   const query = useSelector((state: RootState) => state.query);
@@ -56,7 +70,49 @@ export const MetricsVisTab = () => {
     setSlot(document.getElementById(EXPLORE_ACTION_BAR_SLOT_ID));
   }, []);
 
+  useEffect(() => {
+    setShowAllSeries(false);
+  }, [query]);
+
+  const { limitedRows, totalSeriesCount } = useMemo(() => {
+    const allRows = results?.hits?.hits || [];
+    if (allRows.length === 0) return { limitedRows: allRows, totalSeriesCount: 0 };
+
+    const seriesSet = new Set<string>();
+    for (const hit of allRows) {
+      const s = hit._source?.Series;
+      if (s !== undefined) seriesSet.add(String(s));
+    }
+    const total = seriesSet.size;
+
+    if (showAllSeries || total <= DEFAULT_SERIES_LIMIT) {
+      return { limitedRows: allRows, totalSeriesCount: total };
+    }
+
+    const allowed = new Set<string>();
+    const filtered: typeof allRows = [];
+    for (const hit of allRows) {
+      const s = String(hit._source?.Series ?? '');
+      if (allowed.size < DEFAULT_SERIES_LIMIT || allowed.has(s)) {
+        allowed.add(s);
+        filtered.push(hit);
+      }
+    }
+    return { limitedRows: filtered, totalSeriesCount: total };
+  }, [results, showAllSeries]);
+
+  // Override VisualizationContainer's handleData with limited rows.
+  // React fires child effects before parent effects, so this runs after
+  // VisualizationContainer's own handleData(allRows) call.
+  useEffect(() => {
+    if (results && limitedRows !== (results.hits?.hits || [])) {
+      const fieldSchema = results.fieldSchema || [];
+      visualizationBuilder.handleData(limitedRows, fieldSchema);
+    }
+  }, [visualizationBuilder, results, limitedRows]);
+
   const showSettings = Boolean(data) && !shouldSkipQueryExecution(query);
+  const showSeriesDisclaimer = !showAllSeries && totalSeriesCount > DEFAULT_SERIES_LIMIT;
 
   const onToggleCollapsed = () => {
     setIsSettingsCollapsed((prev) => !prev);
@@ -75,6 +131,43 @@ export const MetricsVisTab = () => {
 
   const chartTypeToggle = showSettings && visConfig?.type && (
     <div className="metricsVisTab__chartTypeToggle">
+      {showSeriesDisclaimer && (
+        <EuiFlexGroup
+          gutterSize="s"
+          alignItems="center"
+          responsive={false}
+          data-test-subj="seriesLimitDisclaimer"
+        >
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="warning">
+              <EuiIcon type="alert" size="s" />{' '}
+              {i18n.translate('explore.visualization.seriesLimitWarning', {
+                defaultMessage: 'Showing {limit} of {count} available series',
+                values: {
+                  limit: DEFAULT_SERIES_LIMIT,
+                  count: totalSeriesCount.toLocaleString(),
+                },
+              })}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              onClick={() => setShowAllSeries(true)}
+              data-test-subj="showAllSeriesButton"
+              title={i18n.translate('explore.visualization.showAllSeriesTooltip', {
+                defaultMessage:
+                  'Rendering too many series may impact performance and make data harder to read. Consider refining your queries.',
+              })}
+            >
+              {i18n.translate('explore.visualization.showAllSeries', {
+                defaultMessage: 'Show {count}',
+                values: { count: totalSeriesCount.toLocaleString() },
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      )}
       <EuiButtonGroup
         legend={i18n.translate('explore.metricsVisTab.chartTypeLegend', {
           defaultMessage: 'Chart type',

--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.test.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.test.ts
@@ -372,8 +372,8 @@ describe('promqlSearchStrategy', () => {
       expect(instantRows[1].mode).toBe('idle');
     });
 
-    it('should respect MAX_SERIES_VIZ limit for visualization and MAX_SERIES_TABLE for table', async () => {
-      // Create 150 series - more than MAX_SERIES_VIZ (100) but less than MAX_SERIES_TABLE (2000)
+    it('should include all series up to MAX_SERIES_TABLE in visualization data', async () => {
+      // Create 150 series - all should be included in viz data (no MAX_SERIES_VIZ limit)
       const resultSeries = Array.from({ length: 150 }, (_, i) => ({
         metric: { series: `series-${i}` },
         values: [[1638316800, i]],
@@ -410,12 +410,57 @@ describe('promqlSearchStrategy', () => {
         {}
       );
 
-      // Visualization data (fields) should be limited to MAX_SERIES_VIZ (100)
+      // All 150 series should be in viz data (no MAX_SERIES_VIZ cap)
       // @ts-expect-error TS2339 TODO(ts-error): fixme
-      expect(resultData.body.size).toBe(100);
+      expect(resultData.body.size).toBe(150);
       // @ts-expect-error TS2339 TODO(ts-error): fixme
       const instantRows = resultData.body.meta?.instantData.rows;
       expect(instantRows.length).toBe(150);
+    });
+
+    it('should include truncation metadata when series are not truncated', async () => {
+      const resultSeries = Array.from({ length: 5 }, (_, i) => ({
+        metric: { series: `series-${i}` },
+        values: [[1638316800, i]],
+      }));
+
+      const mockPrometheusResponse = {
+        queryId: 'query-1',
+        sessionId: 'session-1',
+        results: {
+          'dataset-1': {
+            resultType: 'matrix',
+            result: resultSeries,
+          },
+        },
+      };
+
+      mockPrometheusManagerQuery(mockPrometheusResponse);
+      const strategy = promqlSearchStrategyProvider(config$, logger, usage);
+      const resultData = await strategy.search(
+        emptyRequestHandlerContext,
+        ({
+          body: {
+            query: {
+              query: 'few_series',
+              dataset: { id: 'dataset-1' },
+              language: 'PROMQL',
+            },
+            timeRange: {
+              from: '2021-12-01T00:00:00.000Z',
+              to: '2021-12-01T01:00:00.000Z',
+            },
+          },
+        } as unknown) as IOpenSearchDashboardsSearchRequest<unknown>,
+        {}
+      );
+
+      // @ts-expect-error TS2339 TODO(ts-error): fixme
+      const truncation = resultData.body.meta?.truncation;
+      expect(truncation).toBeDefined();
+      expect(truncation.tableTruncated).toBe(false);
+      expect(truncation.totalSeriesCount).toBe(5);
+      expect(truncation.displayedSeriesCount).toBe(5);
     });
   });
 

--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
@@ -54,8 +54,6 @@ function parseTimeValue(
 
 // MAX_SERIES_TABLE: Maximum series for table display
 const MAX_SERIES_TABLE = 2000;
-// MAX_SERIES_VIZ: Maximum series for visualization. This should be lower than MAX_SERIES_TABLE
-const MAX_SERIES_VIZ = 100;
 // We'll want to re-evaluate this when we provide an affordance for step configuration
 const MAX_DATAPOINTS = DEFAULT_RESOLUTION * MAX_SERIES_TABLE;
 
@@ -269,6 +267,7 @@ function createDataFrame(
 ): IDataFrame {
   const allVizRows: Array<Record<string, unknown>> = [];
   const allLabelKeys = new Set<string>();
+  let totalSeriesCount = 0;
 
   // instantDataMap is used for table display, we only show the latest datapoint in the table.
   const instantDataMap = new Map<
@@ -288,6 +287,7 @@ function createDataFrame(
 
     const queryResult = result.response.results[datasetId];
     const series = normalizeResult(queryResult?.resultType, queryResult?.result);
+    totalSeriesCount += series.length;
 
     series.forEach((metricResult, i) => {
       if (i >= MAX_SERIES_TABLE) return;
@@ -349,7 +349,7 @@ function createDataFrame(
           existing.valuesByQuery[result.label] = Number(value);
         }
 
-        if (seriesIndex < MAX_SERIES_VIZ) {
+        if (seriesIndex < MAX_SERIES_TABLE) {
           allVizRows.push({
             Time: timeMs,
             Series: escapedSeriesName,
@@ -420,6 +420,15 @@ function createDataFrame(
       rows: allInstantRows,
     },
   };
+
+  const tableTruncated = totalSeriesCount > MAX_SERIES_TABLE;
+  if (tableTruncated || totalSeriesCount > 0) {
+    meta.truncation = {
+      tableTruncated,
+      totalSeriesCount,
+      displayedSeriesCount: Math.min(totalSeriesCount, MAX_SERIES_TABLE),
+    };
+  }
 
   if (!isSingleQuery) {
     meta.multiQuery = {


### PR DESCRIPTION
### Description

This PR

- limits series in metrics chart to 20 (previously 100), and adds a warning and button to show all series in the chart (at most 2000).
- adds warning to table if total series exceeds 2000, since table only shows 2000
- pick a missed commit that moves sparklines to echarts. It used custom svg charts to workaround a cursor crosshair sync issue, but we implemented the same feature with echarts.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="3026" height="1646" alt="image" src="https://github.com/user-attachments/assets/10d076a8-aeba-4455-b342-e88949e808b8" />
<img width="3026" height="1646" alt="image" src="https://github.com/user-attachments/assets/48cb6b9a-95e5-41d9-beb2-13ec80d25c17" />


## Testing the changes

UT

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
