### PR TITLE
fix(visualization): preserve saved pie chart colors and legend visibility on dashboards

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.test.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.test.ts
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { VisualizeEmbeddable } from './visualize_embeddable';
+import { PersistedState } from '../persisted_state';
+
+// transferCustomizationsToUiState only depends on a small slice of `this`;
+// build a minimal stub and bind the prototype method onto it so we can
+// exercise the behavior against a real PersistedState without standing up
+// the full embeddable (which needs data plugin, timefilter, etc.).
+type CallableTransfer = () => void;
+type CallableReset = () => void;
+
+interface StubState {
+  input: { vis?: { [key: string]: unknown }; table?: unknown };
+  vis: { uiState: PersistedState };
+  parent?: unknown;
+  visCustomizations?: unknown;
+  uiStateChangeHandler: () => void;
+  resetUiStateChanges: CallableReset;
+}
+
+const proto = (VisualizeEmbeddable.prototype as unknown) as {
+  transferCustomizationsToUiState: CallableTransfer;
+  resetUiStateChanges: CallableReset;
+};
+
+const transfer = proto.transferCustomizationsToUiState;
+const resetChanges = proto.resetUiStateChanges;
+
+const buildStub = (savedUiState: Record<string, unknown>, input: StubState['input']): StubState => {
+  const stub: StubState = {
+    input,
+    vis: { uiState: new PersistedState(savedUiState) },
+    parent: { id: 'parent' },
+    uiStateChangeHandler: () => {},
+    // Bind the helper through `this` so the stub mirrors the real instance.
+    resetUiStateChanges() {
+      resetChanges.call(stub);
+    },
+  };
+  return stub;
+};
+
+describe('VisualizeEmbeddable.transferCustomizationsToUiState', () => {
+  it('preserves saved slice colors when the dashboard panel only customizes legendOpen', () => {
+    // Saved viz uiState (e.g. colors set via the Visualize editor + a default
+    // legend state). Mirrors `uiStateJSON` deserialized into PersistedState.
+    const savedUiState = {
+      vis: {
+        colors: { 'Slice A': '#ff0000', 'Slice B': '#00ff00' },
+        legendOpen: true,
+      },
+    };
+    // Mirrors a Flight-style sample dashboard where the panel embeddableConfig
+    // only carries `{vis: {legendOpen: false}}` — no `colors`.
+    const stub = buildStub(savedUiState, { vis: { legendOpen: false } });
+
+    transfer.call(stub);
+
+    expect(stub.vis.uiState.get('vis.colors')).toEqual({
+      'Slice A': '#ff0000',
+      'Slice B': '#00ff00',
+    });
+    expect(stub.vis.uiState.get('vis.legendOpen')).toBe(false);
+  });
+
+  it('lets dashboard color overrides take precedence while keeping unmodified saved colors', () => {
+    const savedUiState = {
+      vis: { colors: { 'Slice A': '#ff0000', 'Slice B': '#00ff00' } },
+    };
+    // Dashboard overrides only Slice A. Slice B should still come from defaults.
+    const stub = buildStub(savedUiState, { vis: { colors: { 'Slice A': '#0000ff' } } });
+
+    transfer.call(stub);
+
+    expect(stub.vis.uiState.get('vis.colors')).toEqual({
+      'Slice A': '#0000ff',
+      'Slice B': '#00ff00',
+    });
+  });
+
+  it('falls back to saved defaults when the panel has no customizations', () => {
+    const savedUiState = {
+      vis: { colors: { 'Slice A': '#ff0000' }, legendOpen: false },
+    };
+    const stub = buildStub(savedUiState, {});
+
+    transfer.call(stub);
+
+    expect(stub.vis.uiState.get('vis.colors')).toEqual({ 'Slice A': '#ff0000' });
+    expect(stub.vis.uiState.get('vis.legendOpen')).toBe(false);
+  });
+
+  it('reverts to saved defaults after the dashboard customization is removed', () => {
+    const savedUiState = {
+      vis: { colors: { 'Slice A': '#ff0000' }, legendOpen: true },
+    };
+    const stub = buildStub(savedUiState, { vis: { legendOpen: false } });
+
+    transfer.call(stub);
+    expect(stub.vis.uiState.get('vis.legendOpen')).toBe(false);
+
+    // Subsequent cycle: panel embeddableConfig is now empty.
+    stub.input = {};
+    transfer.call(stub);
+
+    expect(stub.vis.uiState.get('vis.legendOpen')).toBe(true);
+    expect(stub.vis.uiState.get('vis.colors')).toEqual({ 'Slice A': '#ff0000' });
+  });
+});

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.test.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.test.ts
@@ -47,7 +47,7 @@ interface StubState {
   resetUiStateChanges: CallableReset;
 }
 
-const proto = (VisualizeEmbeddable.prototype as unknown) as {
+const proto = VisualizeEmbeddable.prototype as unknown as {
   transferCustomizationsToUiState: CallableTransfer;
   resetUiStateChanges: CallableReset;
 };

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -79,8 +79,6 @@ import {
 } from '../../../vis_augmenter/public';
 import { VisSavedObject } from '../types';
 
-const getKeys = <T extends {}>(o: T): Array<keyof T> => Object.keys(o) as Array<keyof T>;
-
 export interface VisualizeEmbeddableConfiguration {
   vis: Vis;
   indexPatterns?: IIndexPattern[];
@@ -237,11 +235,20 @@ export class VisualizeEmbeddable
         this.visCustomizations = visCustomizations;
         // Turn this off or the uiStateChangeHandler will fire for every modification.
         this.vis.uiState.off('change', this.uiStateChangeHandler);
-        this.vis.uiState.clearAllKeys();
+        // Reset back to the saved viz defaults before re-applying. clearAllKeys
+        // would null _mergedState entries for any key in _changedState, dropping
+        // saved siblings (e.g. custom slice colors when the dashboard panel only
+        // overrides legendOpen).
+        this.resetUiStateChanges();
         if (visCustomizations.vis) {
-          this.vis.uiState.set('vis', visCustomizations.vis);
-          getKeys(visCustomizations).forEach((key) => {
-            this.vis.uiState.set(key, visCustomizations[key]);
+          // Apply each property of input.vis individually. set('vis', input.vis)
+          // would replace the entire 'vis' subtree in _mergedState and lose any
+          // saved sibling keys not present in input.vis.
+          Object.keys(visCustomizations.vis).forEach((subKey) => {
+            this.vis.uiState.set(
+              `vis.${subKey}`,
+              (visCustomizations.vis as Record<string, unknown>)[subKey]
+            );
           });
         }
         if (visCustomizations.table) {
@@ -250,8 +257,14 @@ export class VisualizeEmbeddable
         this.vis.uiState.on('change', this.uiStateChangeHandler);
       }
     } else if (this.parent) {
-      this.vis.uiState.clearAllKeys();
+      this.resetUiStateChanges();
     }
+  }
+
+  private resetUiStateChanges() {
+    Object.keys(this.vis.uiState.getChanges()).forEach((key) => {
+      this.vis.uiState.reset(key);
+    });
   }
 
   public async handleChanges() {

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -79,8 +79,6 @@ import {
 } from '../../../vis_augmenter/public';
 import { VisSavedObject } from '../types';
 
-const getKeys = <T extends {}>(o: T): Array<keyof T> => Object.keys(o) as Array<keyof T>;
-
 export interface VisualizeEmbeddableConfiguration {
   vis: Vis;
   indexPatterns?: IIndexPattern[];
@@ -245,11 +243,20 @@ export class VisualizeEmbeddable
         this.visCustomizations = visCustomizations;
         // Turn this off or the uiStateChangeHandler will fire for every modification.
         this.vis.uiState.off('change', this.uiStateChangeHandler);
-        this.vis.uiState.clearAllKeys();
+        // Reset back to the saved viz defaults before re-applying. clearAllKeys
+        // would null _mergedState entries for any key in _changedState, dropping
+        // saved siblings (e.g. custom slice colors when the dashboard panel only
+        // overrides legendOpen).
+        this.resetUiStateChanges();
         if (visCustomizations.vis) {
-          this.vis.uiState.set('vis', visCustomizations.vis);
-          getKeys(visCustomizations).forEach((key) => {
-            this.vis.uiState.set(key, visCustomizations[key]);
+          // Apply each property of input.vis individually. set('vis', input.vis)
+          // would replace the entire 'vis' subtree in _mergedState and lose any
+          // saved sibling keys not present in input.vis.
+          Object.keys(visCustomizations.vis).forEach((subKey) => {
+            this.vis.uiState.set(
+              `vis.${subKey}`,
+              (visCustomizations.vis as Record<string, unknown>)[subKey]
+            );
           });
         }
         if (visCustomizations.table) {
@@ -258,8 +265,14 @@ export class VisualizeEmbeddable
         this.vis.uiState.on('change', this.uiStateChangeHandler);
       }
     } else if (this.parent) {
-      this.vis.uiState.clearAllKeys();
+      this.resetUiStateChanges();
     }
+  }
+
+  private resetUiStateChanges() {
+    Object.keys(this.vis.uiState.getChanges()).forEach((key) => {
+      this.vis.uiState.reset(key);
+    });
   }
 
   public async handleChanges() {

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -271,7 +271,16 @@ export class VisualizeEmbeddable
 
   private resetUiStateChanges() {
     Object.keys(this.vis.uiState.getChanges()).forEach((key) => {
+      const before = this.vis.uiState.get(key);
       this.vis.uiState.reset(key);
+      // PersistedState.reset() restores a key to its saved default, but it cannot
+      // clear a top-level key that has no saved default (its cleanPath is a no-op
+      // for top-level keys). When there is nothing to restore, reset() leaves the
+      // dashboard override in place, so explicitly null the key out to fall back
+      // to the saved/auto defaults (mirrors the previous clearAllKeys behavior).
+      if (_.isEqual(before, this.vis.uiState.get(key))) {
+        this.vis.uiState.set(key, null);
+      }
     });
   }
 

--- a/src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
+++ b/src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
@@ -76,11 +76,13 @@ describe('visualization renderer', () => {
     renderedTrees.length = 0;
   });
 
-  // The renderer creates a fresh ExprVis on every call. <Visualization>'s React
-  // constructor only runs on the initial mount, so without an explicit assignment
-  // here later ExprVis instances would carry an empty PersistedState. When the
-  // chart unmounts and remounts (e.g. data goes to zero hits and then returns)
-  // the legend and color lookup would lose saved colors / legend visibility.
+  // Regression test for https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9597
+  // The renderer creates a fresh ExprVis on every call. Without explicitly wiring
+  // its uiState from handlers.uiState, only the first ExprVis has the persisted
+  // uiState (set by <Visualization>'s constructor). After the chart unmounts (e.g.
+  // a filter narrows the result set to zero hits) and remounts, the new
+  // VislibVisController is built from the latest ExprVis, whose uiState was never
+  // wired up — so saved pie-slice colors and legend visibility are lost.
   it('wires handlers.uiState onto every ExprVis it constructs', async () => {
     const renderer = visualization();
     const domNode = document.createElement('div');

--- a/src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
+++ b/src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { visualization } from './visualization_renderer';
+import { PersistedState } from '../persisted_state';
+
+const renderedTrees: any[] = [];
+
+jest.mock('react-dom/client', () => ({
+  createRoot: () => ({
+    render: (tree: any) => {
+      renderedTrees.push(tree);
+    },
+    unmount: () => {},
+  }),
+}));
+
+jest.mock('react-dom', () => ({
+  flushSync: (fn: () => void) => fn(),
+}));
+
+jest.mock('../components', () => ({
+  Visualization: function MockVisualization(props: any) {
+    return props;
+  },
+}));
+
+jest.mock('../services', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { BaseVisType } = require('../vis_types/base_vis_type');
+  const visType = new BaseVisType({
+    name: 'pie',
+    title: 'pie',
+    icon: 'pie-icon',
+    visualization: class {
+      render() {
+        return Promise.resolve();
+      }
+      destroy() {}
+    },
+  });
+  return {
+    getTypes: () => ({ get: () => visType }),
+  };
+});
+
+describe('visualization renderer', () => {
+  beforeEach(() => {
+    renderedTrees.length = 0;
+  });
+
+  // The renderer creates a fresh ExprVis on every call. <Visualization>'s React
+  // constructor only runs on the initial mount, so without an explicit assignment
+  // here later ExprVis instances would carry an empty PersistedState. When the
+  // chart unmounts and remounts (e.g. data goes to zero hits and then returns)
+  // the legend and color lookup would lose saved colors / legend visibility.
+  it('wires handlers.uiState onto every ExprVis it constructs', async () => {
+    const renderer = visualization();
+    const domNode = document.createElement('div');
+    const persistedState = new PersistedState({
+      vis: {
+        colors: { 'Slice A': '#ff0000' },
+        legendOpen: false,
+      },
+    });
+
+    const handlers: any = {
+      uiState: persistedState,
+      event: jest.fn(),
+      done: jest.fn(),
+      onDestroy: jest.fn(),
+    };
+
+    const config: any = {
+      visType: 'pie',
+      title: 'Pie Chart',
+      visConfig: { type: 'pie' },
+      visData: { hits: 1 },
+      params: {},
+    };
+
+    await renderer.render(domNode, config, handlers);
+    await renderer.render(domNode, config, handlers);
+    await renderer.render(domNode, config, handlers);
+
+    expect(renderedTrees).toHaveLength(3);
+    for (const tree of renderedTrees) {
+      // The renderer should pass through the embeddable's persisted state...
+      expect(tree.props.uiState).toBe(persistedState);
+      // ...and also wire it onto the freshly-constructed ExprVis so that
+      // downstream consumers (legend, color lookup) reading vis.getUiState()
+      // see the saved colors and legend visibility — even on remount.
+      expect(tree.props.vis.getUiState()).toBe(persistedState);
+      expect(tree.props.vis.getUiState().get('vis.colors')).toEqual({
+        'Slice A': '#ff0000',
+      });
+      expect(tree.props.vis.getUiState().get('vis.legendOpen')).toBe(false);
+    }
+  });
+});

--- a/src/plugins/visualizations/public/expressions/visualization_renderer.tsx
+++ b/src/plugins/visualizations/public/expressions/visualization_renderer.tsx
@@ -55,6 +55,13 @@ export const visualization = (): ExpressionRenderDefinition<VisRenderValue> => (
     vis.eventsSubject = { next: handlers.event };
 
     const uiState = handlers.uiState || vis.getUiState();
+    // A fresh ExprVis is constructed on every render. <Visualization>'s React
+    // constructor only fires on the initial mount, so without this assignment
+    // every subsequent ExprVis would carry an empty PersistedState. Downstream
+    // consumers (vislib's legend, color lookup) read vis.getUiState() when the
+    // chart mounts; if the chart ever unmounts and remounts (e.g. zero hits
+    // then results return) they would lose saved colors and legend visibility.
+    vis.setUiState(uiState);
 
     let root = rootsMap.get(domNode);
     if (!root) {


### PR DESCRIPTION
### Description

Two related defects in how `VisualizeEmbeddable` and the visualization expression renderer manage `PersistedState`. Both manifest as the symptom in #9597 (pie chart resets to default colors and legend visibility), but they fire under different conditions, so addressing only one leaves the other in place.

#### Bug 1 — `transferCustomizationsToUiState` clobbers the entire `vis` subtree

`transferCustomizationsToUiState` previously applied dashboard panel customizations with:

```ts
this.vis.uiState.clearAllKeys();
this.vis.uiState.set('vis', visCustomizations.vis);
```

`PersistedState.set('vis', value)` replaces the **entire `vis` subtree** in `_mergedState` (the `mergeMethod` returns `sourceValue` whenever the merge key matches the requested keyPath at the root). Any saved key not present in `input.vis` is dropped from `_mergedState`. The Flight sample dashboard's pie panels store:

```json
"embeddableConfig":{"vis":{"legendOpen":false}}
```

— no `colors`. So a viz saved with custom slice colors via the Visualize editor renders on that dashboard with **default** colors, even on initial load with no filter applied.

`clearAllKeys` has the same shape: `set(key, null)` nulls `_mergedState[key]` via the merge, so subsequent sets cannot fall back to `_defaultState` either.

**Fix:** iterate `input.vis` and `set('vis.<subKey>', value)` per property; replace `clearAllKeys` with iterated `reset(key)`, which restores `_mergedState[key]` from `_defaultState[key]` before re-applying customizations.

#### Bug 2 — renderer creates a fresh `ExprVis` whose `uiState` is never wired up

The visualization expression renderer constructs a new `ExprVis` on every render call. `ExprVis`'s constructor initializes `this.uiState = new PersistedState()` (empty). The only thing that wired it to the embeddable's persisted state was `<Visualization>`'s React constructor — which fires once per mount.

When data goes to zero hits (filter or time range), `<Visualization>` swaps to `<VisualizationNoResults>` and unmounts `<VisualizationChart>`. When the data returns, `<VisualizationChart>` remounts; its `componentDidMount` builds a brand-new `VislibVisController` from the **latest** `props.vis` — whichever fresh `ExprVis` the renderer last produced. That `ExprVis` was never wired, so vislib's color lookup got an empty `vis.colors` and the legend's `vis.legendOpen` fell back to its `true` default. This is the symptom from the original bug report's filter-cycle reproduction.

**Fix:** call `vis.setUiState(uiState)` in the renderer immediately after constructing the `ExprVis`, so the persisted state is wired on every render, not just the first React mount.

### Issues Resolved

Fixes #9597

## Screenshot

No UI markup change — the visible difference is "your saved colors render correctly, on the initial load and across filter/time-range cycles." The video on the linked issue demonstrates the original behavior.

## Testing the changes

**Manual reproduction**

Both pre-existing repros for the issue are covered.

1. Install Sample flight data (Home → "Try sample data").
2. In the Visualize editor, edit `[Flights] Airline Carrier`. Click each legend entry → **Change color** → pick obviously non-default colors. Save.
3. **Initial-load case (Bug 1):** Open `[Flights] Global Flight Dashboard`. Without applying any filter, confirm the pie viz now renders with your saved colors. Before this PR it would render with defaults because the panel's `embeddableConfig.vis.legendOpen` clobbered the saved color subtree.
4. **Filter-cycle case (Bug 2):** Add a filter such as `Carrier : "DefinitelyNotARealAirline"`. The pie shows "No results found." Remove the filter. After this PR your custom colors persist; before, they reverted.
5. **Time-range variant of Bug 2:** Set the time picker to a window with no flights, then expand it back to a window with flights. Same expected behavior.
6. In the Visualize editor, toggle the legend closed and save; verify the legend stays closed across the same filter cycle on the dashboard.

**Automated**

Two new Jest unit tests, all passing locally:

```
yarn test:jest src/plugins/visualizations/public/embeddable/visualize_embeddable.test.ts
yarn test:jest src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx
```

- [`visualize_embeddable.test.ts`](src/plugins/visualizations/public/embeddable/visualize_embeddable.test.ts) exercises `transferCustomizationsToUiState` against a real `PersistedState` and asserts that saved colors survive when the panel only customizes `legendOpen`, that dashboard color overrides take precedence on a per-slice basis, that no panel customizations leaves the saved defaults intact, and that removing a previous customization reverts to the saved default.
- [`visualization_renderer.test.tsx`](src/plugins/visualizations/public/expressions/visualization_renderer.test.tsx) calls the renderer three times against a single DOM node (simulating the unmount/remount cycle) and asserts every captured React tree's `vis.getUiState()` returns the persisted state including `vis.colors` and `vis.legendOpen`.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (new tests for both fixes)
  - [ ] `yarn test:jest_integration` (no integration coverage added; existing suites unaffected)
- [x] New functionality includes testing.
- [ ] New functionality has been documented. (bug fix; no new behavior)
- [x] Commits are signed per the DCO using --signoff