### PR TITLE
[Variable] Variables and incontext editor should be compatible with new dashboard

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -128,6 +128,12 @@ export const DashboardEditor = () => {
                   // Emit event to trigger dashboard save
                   eventEmitter.emit('triggerDashboardSave');
                 }}
+                onEnterEditMode={() => {
+                  // Switch to edit mode
+                  if (appState) {
+                    appState.transitions.set('viewMode', ViewMode.EDIT);
+                  }
+                }}
               />
             )}
           </>

--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -114,6 +114,7 @@ export const DashboardEditor = () => {
               indexPatterns={indexPatterns}
               currentContainer={currentContainer}
               dashboardIdFromUrl={dashboardIdFromUrl}
+              eventEmitter={eventEmitter}
             />
             {/* Variables are only available in explore-enabled workspaces (observability / analytics) */}
             {variableEnabled && isExploreWorkspace && currentContainer.variableService && (
@@ -122,6 +123,11 @@ export const DashboardEditor = () => {
                 interpolationService={currentContainer.variableInterpolationService}
                 isEditMode={currentAppState?.viewMode === ViewMode.EDIT}
                 getPanelQueries={() => currentContainer.getPanelQueries()}
+                dashboardId={savedDashboardInstance?.id}
+                onSaveDashboard={() => {
+                  // Emit event to trigger dashboard save
+                  eventEmitter.emit('triggerDashboardSave');
+                }}
               />
             )}
           </>

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
@@ -28,6 +28,7 @@ interface DashboardTopNavProps {
   indexPatterns: IndexPattern[];
   currentContainer?: DashboardContainer;
   dashboardIdFromUrl?: string;
+  eventEmitter?: any;
 }
 
 export enum UrlParams {
@@ -48,6 +49,7 @@ const TopNav = ({
   currentContainer,
   indexPatterns,
   dashboardIdFromUrl,
+  eventEmitter,
 }: DashboardTopNavProps) => {
   const [topNavMenu, setTopNavMenu] = useState<any>();
   const [topRightControls, setTopRightControls] = useState<TopNavControlData[]>([]);
@@ -100,6 +102,19 @@ const TopNav = ({
       });
     }
   }, [currentContainer, services]);
+
+  // Listen for triggerDashboardSave event from DashboardVariables
+  useEffect(() => {
+    if (eventEmitter) {
+      const handleTriggerSave = () => {
+        handleSave();
+      };
+      eventEmitter.on('triggerDashboardSave', handleTriggerSave);
+      return () => {
+        eventEmitter.off('triggerDashboardSave', handleTriggerSave);
+      };
+    }
+  }, [eventEmitter, handleSave]);
 
   // Register/unregister save shortcut based on edit mode
   useEffect(() => {

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/dashboard_variables.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/dashboard_variables.tsx
@@ -22,6 +22,7 @@ export interface DashboardVariablesProps {
   getPanelQueries?: () => string[];
   dashboardId?: string;
   onSaveDashboard?: () => void;
+  onEnterEditMode?: () => void;
 }
 
 /**
@@ -35,12 +36,14 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
   getPanelQueries,
   dashboardId,
   onSaveDashboard,
+  onEnterEditMode,
 }) => {
   const { services } = useOpenSearchDashboards<DashboardServices>();
   const { notifications } = services;
   const [isVariableEditorOpen, setIsVariableEditorOpen] = useState(false);
   const [isVariableManagementOpen, setIsVariableManagementOpen] = useState(false);
   const [editingVariable, setEditingVariable] = useState<Variable | undefined>(undefined);
+  const [pendingAddVariable, setPendingAddVariable] = useState(false);
 
   const handleAddVariable = useCallback(() => {
     // Check if dashboard is saved before adding variable
@@ -57,6 +60,7 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
       // Trigger dashboard save
       if (onSaveDashboard) {
         onSaveDashboard();
+        setPendingAddVariable(true);
       }
       return;
     }
@@ -127,6 +131,18 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
     }
   }, [isEditMode]);
 
+  // Open variable editor after dashboard is saved
+  useEffect(() => {
+    if (pendingAddVariable && dashboardId) {
+      setPendingAddVariable(false);
+
+      if (!isEditMode && onEnterEditMode) {
+        onEnterEditMode();
+      }
+      setIsVariableEditorOpen(true);
+    }
+  }, [pendingAddVariable, dashboardId, isEditMode, onEnterEditMode]);
+
   return (
     <>
       <VariablesBar
@@ -161,11 +177,7 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
               onClose={handleCloseVariableEditor}
               onSave={handleSaveVariable}
               existingVariable={editingVariable}
-              existingVariableNames={variableService.getVariables().map((v) => v.name)}
-              existingVariableLabels={variableService
-                .getVariables()
-                .map((v) => v.label)
-                .filter((label): label is string => Boolean(label))}
+              existingVariables={variableService.getVariables()}
               interpolationService={interpolationService}
             />,
             panelContainer

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/dashboard_variables.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/dashboard_variables.tsx
@@ -162,6 +162,10 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
               onSave={handleSaveVariable}
               existingVariable={editingVariable}
               existingVariableNames={variableService.getVariables().map((v) => v.name)}
+              existingVariableLabels={variableService
+                .getVariables()
+                .map((v) => v.label)
+                .filter((label): label is string => Boolean(label))}
               interpolationService={interpolationService}
             />,
             panelContainer

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/dashboard_variables.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/dashboard_variables.tsx
@@ -20,6 +20,8 @@ export interface DashboardVariablesProps {
   interpolationService?: IVariableInterpolationService;
   isEditMode: boolean;
   getPanelQueries?: () => string[];
+  dashboardId?: string;
+  onSaveDashboard?: () => void;
 }
 
 /**
@@ -31,6 +33,8 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
   interpolationService,
   isEditMode,
   getPanelQueries,
+  dashboardId,
+  onSaveDashboard,
 }) => {
   const { services } = useOpenSearchDashboards<DashboardServices>();
   const { notifications } = services;
@@ -39,10 +43,28 @@ export const DashboardVariables: React.FC<DashboardVariablesProps> = ({
   const [editingVariable, setEditingVariable] = useState<Variable | undefined>(undefined);
 
   const handleAddVariable = useCallback(() => {
+    // Check if dashboard is saved before adding variable
+    if (!dashboardId) {
+      notifications.toasts.addWarning({
+        title: i18n.translate('dashboard.variableEditor.saveDashboardFirst.title', {
+          defaultMessage: 'Save dashboard first',
+        }),
+        text: i18n.translate('dashboard.variableEditor.saveDashboardFirst.text', {
+          defaultMessage: 'Please save the dashboard before adding variables.',
+        }),
+      });
+
+      // Trigger dashboard save
+      if (onSaveDashboard) {
+        onSaveDashboard();
+      }
+      return;
+    }
+
     setEditingVariable(undefined);
     setIsVariableManagementOpen(false);
     setIsVariableEditorOpen(true);
-  }, []);
+  }, [dashboardId, notifications.toasts, onSaveDashboard]);
 
   const handleManageVariables = useCallback(() => {
     setIsVariableEditorOpen(false);

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
@@ -31,8 +31,7 @@ export interface VariableEditorFlyoutProps {
   onClose: () => void;
   onSave: (variable: Omit<Variable, 'id' | 'current'>) => Promise<void>;
   existingVariable?: Variable;
-  existingVariableNames?: string[];
-  existingVariableLabels?: string[];
+  existingVariables?: Variable[];
   interpolationService?: IVariableInterpolationService;
 }
 
@@ -83,8 +82,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
   onClose,
   onSave,
   existingVariable,
-  existingVariableNames = [],
-  existingVariableLabels = [],
+  existingVariables = [],
   interpolationService,
 }) => {
   const [name, setName] = useState(existingVariable?.name || '');
@@ -165,14 +163,12 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
 
     // Build a set of all existing names and labels (excluding current variable when editing)
     const allExistingIdentifiers = new Set<string>();
-    existingVariableNames.forEach((n) => {
-      if (!existingVariable || existingVariable.name !== n) {
-        allExistingIdentifiers.add(n);
-      }
-    });
-    existingVariableLabels.forEach((l) => {
-      if (!existingVariable || existingVariable.label !== l) {
-        allExistingIdentifiers.add(l);
+    existingVariables.forEach((v) => {
+      if (!existingVariable || existingVariable.id !== v.id) {
+        allExistingIdentifiers.add(v.name);
+        if (v?.label) {
+          allExistingIdentifiers.add(v.label);
+        }
       }
     });
 
@@ -229,16 +225,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
 
     setError(null);
     return true;
-  }, [
-    name,
-    label,
-    type,
-    query,
-    customValues,
-    existingVariableNames,
-    existingVariableLabels,
-    existingVariable,
-  ]);
+  }, [name, label, type, query, customValues, existingVariables, existingVariable]);
 
   const handleSave = useCallback(async () => {
     if (!validateForm()) return;
@@ -423,7 +410,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
               onQueryChange={setQuery}
               onLanguageChange={handleLanguageChange}
               onDatasetChange={setDataset}
-              existingVariableNames={existingVariableNames}
+              existingVariableNames={existingVariables.map((v) => v.name)}
               interpolationService={interpolationService}
               regex={regex}
               onRegexChange={setRegex}

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
@@ -32,6 +32,7 @@ export interface VariableEditorFlyoutProps {
   onSave: (variable: Omit<Variable, 'id' | 'current'>) => Promise<void>;
   existingVariable?: Variable;
   existingVariableNames?: string[];
+  existingVariableLabels?: string[];
   interpolationService?: IVariableInterpolationService;
 }
 
@@ -83,6 +84,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
   onSave,
   existingVariable,
   existingVariableNames = [],
+  existingVariableLabels = [],
   interpolationService,
 }) => {
   const [name, setName] = useState(existingVariable?.name || '');
@@ -161,16 +163,25 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
       return false;
     }
 
-    // Check for duplicate variable names (skip the current variable when editing)
+    // Build a set of all existing names and labels (excluding current variable when editing)
+    const allExistingIdentifiers = new Set<string>();
+    existingVariableNames.forEach((n) => {
+      if (!existingVariable || existingVariable.name !== n) {
+        allExistingIdentifiers.add(n);
+      }
+    });
+    existingVariableLabels.forEach((l) => {
+      if (!existingVariable || existingVariable.label !== l) {
+        allExistingIdentifiers.add(l);
+      }
+    });
+
+    // Check if name conflicts with any existing name or label
     const trimmedName = name.trim();
-    const isDuplicate = existingVariableNames.some(
-      (existingName) =>
-        existingName === trimmedName && (!existingVariable || existingVariable.name !== trimmedName)
-    );
-    if (isDuplicate) {
+    if (allExistingIdentifiers.has(trimmedName)) {
       setError(
-        i18n.translate('dashboard.variableEditor.nameDuplicate', {
-          defaultMessage: 'A variable with the name "{name}" already exists',
+        i18n.translate('dashboard.variableEditor.nameConflict', {
+          defaultMessage: 'The name "{name}" conflicts with an existing variable name or label',
           values: { name: trimmedName },
         })
       );
@@ -181,6 +192,18 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
       setError(
         i18n.translate('dashboard.variableEditor.labelTooLong', {
           defaultMessage: 'Variable label must not exceed 40 characters',
+        })
+      );
+      return false;
+    }
+
+    // Check if label conflicts with any existing name or label
+    const trimmedLabel = label.trim();
+    if (trimmedLabel && allExistingIdentifiers.has(trimmedLabel)) {
+      setError(
+        i18n.translate('dashboard.variableEditor.labelConflict', {
+          defaultMessage: 'The label "{label}" conflicts with an existing variable name or label',
+          values: { label: trimmedLabel },
         })
       );
       return false;
@@ -206,7 +229,16 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
 
     setError(null);
     return true;
-  }, [name, label, type, query, customValues, existingVariableNames, existingVariable]);
+  }, [
+    name,
+    label,
+    type,
+    query,
+    customValues,
+    existingVariableNames,
+    existingVariableLabels,
+    existingVariable,
+  ]);
 
   const handleSave = useCallback(async () => {
     if (!validateForm()) return;
@@ -371,7 +403,10 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
             <EuiSuperSelect
               options={variableTypeOptions}
               valueOfSelected={type}
-              onChange={(t) => setType(t)}
+              onChange={(t) => {
+                setType(t);
+                setError(null);
+              }}
               data-test-subj="variableEditorType"
               compressed
             />

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
@@ -331,7 +331,7 @@ export const VariablesBar: React.FC<VariablesBarProps> = ({
       )}
       {!isCollapsed && (
         <>
-          {isEditMode && (
+          {isEditMode && variables.length > 0 && (
             <EuiFlexItem grow={false}>
               <EuiSmallButtonEmpty
                 iconType="list"

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -187,6 +187,17 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
         }
       })
     );
+
+    // Subscribe to container input changes to update VariableService dashboardId
+    this.variableSubscriptions.push(
+      this.getInput$().subscribe((input) => {
+        // When dashboard is saved and gets an ID, update VariableService
+        if (input.id && input.id !== initialInput.id) {
+          this.variableService.setDashboardId(input.id);
+        }
+      })
+    );
+
     this.initVariableRefreshSubscription();
   }
 

--- a/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
@@ -189,7 +189,7 @@ export const getNavActions = (
             });
           },
           containerInfo: {
-            containerId: currentContainer.id,
+            containerId: currentContainer.getInput().id,
             containerName: currentContainer.getTitle(),
           },
         });

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -54,6 +54,14 @@ export class VariableService {
   }
 
   /**
+   * Update the dashboard ID after dashboard is saved.
+   * This allows variables to be saved to the dashboard after it gets an ID.
+   */
+  public setDashboardId(dashboardId: string): void {
+    this.dashboardId = dashboardId;
+  }
+
+  /**
    * Initialize the service with variables loaded from dashboard saved object.
    * This should be called once after creating the service.
    *
@@ -451,8 +459,9 @@ export class VariableService {
    * @param variables - Updated variables array
    */
   private async saveVariables(variables: Variable[]): Promise<void> {
+    // Dashboard must be saved before adding/updating variables
     if (!this.dashboardId || !this.savedObjectsClient) {
-      return;
+      throw new Error('Dashboard must be saved before adding variables');
     }
 
     try {

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -159,14 +159,14 @@ export class VariableService {
     let newRuntimeState: VariableState | undefined;
 
     if (updates.type && updates.type !== existing.type) {
-      // Type changed — rebuild from scratch
+      // Type changed — rebuild from scratch and clear any error/loading states
       updatedVariable = this.buildVariable(id, { ...existing, ...updates } as Omit<
         Variable,
         'id' | 'current'
       >);
       const options = this.deriveOptions(updatedVariable);
       updatedVariable.current = options.length > 0 ? [options[0]] : undefined;
-      newRuntimeState = { options };
+      newRuntimeState = { options, loading: false, error: undefined };
     } else {
       updatedVariable = { ...existing, ...updates } as Variable;
 

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -459,8 +459,11 @@ export class VariableService {
    * @param variables - Updated variables array
    */
   private async saveVariables(variables: Variable[]): Promise<void> {
+    if (!this.savedObjectsClient) {
+      throw new Error('SavedObjectsClient is not initialized');
+    }
     // Dashboard must be saved before adding/updating variables
-    if (!this.dashboardId || !this.savedObjectsClient) {
+    if (!this.dashboardId) {
       throw new Error('Dashboard must be saved before adding variables');
     }
 
@@ -472,8 +475,6 @@ export class VariableService {
 
       this.variables$.next(variables);
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('[VariableService] Failed to save variables to dashboard:', error);
       throw error;
     }
   }

--- a/src/plugins/embeddable/public/lib/actions/edit_panel_action.test.tsx
+++ b/src/plugins/embeddable/public/lib/actions/edit_panel_action.test.tsx
@@ -81,7 +81,7 @@ test('redirects to app using state transfer with by value mode', async () => {
   embeddable.getRoot = jest.fn(() => ({
     getTitle: () => 'containerTitle',
     id: 'containerId',
-    getInput: () => ({ panels: {} }),
+    getInput: () => ({ id: 'containerId', panels: {} }),
   }));
   await action.execute({ embeddable });
   expect(stateTransferMock.navigateToEditor).toHaveBeenCalledWith('ultraVisualize', {
@@ -115,6 +115,7 @@ test('redirects to app using state transfer without by value mode', async () => 
   embeddable.getRoot = jest.fn(() => ({
     getTitle: () => 'containerTitle',
     id: 'containerId',
+    getInput: () => ({ id: 'containerId' }),
   }));
 
   await action.execute({ embeddable });

--- a/src/plugins/embeddable/public/lib/actions/edit_panel_action.ts
+++ b/src/plugins/embeddable/public/lib/actions/edit_panel_action.ts
@@ -131,7 +131,7 @@ export class EditPanelAction implements Action<ActionContext> {
     if (container) {
       return {
         containerName: container.getTitle() ?? '',
-        containerId: container.id,
+        containerId: container.getInput().id,
       };
     }
   }

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -192,10 +192,10 @@ export class VisualizeEmbeddableFactory
       );
     } else {
       const container =
-        parent?.id && parent?.getTitle()
+        parent && parent.getInput().id && parent.getTitle()
           ? {
               containerInfo: {
-                containerId: parent.id,
+                containerId: parent.getInput().id,
                 containerName: parent.getTitle() ?? '',
               },
             }


### PR DESCRIPTION
### Description
1. Variables should be created after saving dashboard with newly dashboard
2. Fixes an issue where the dashboard container ID was not properly passed to the visualization editor when working with newly saved dashboards.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
