### PR TITLE
[Explore] fix minor bugs in Metric builder

### DIFF
--- a/src/plugins/explore/public/application/pages/metrics/metrics_query_panel.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_query_panel.tsx
@@ -32,9 +32,11 @@ import {
   selectIsLoading,
   selectIsPromptEditorMode,
   selectPromptToQueryIsLoading,
+  selectQueryLanguage,
   selectQueryString,
 } from '../../../application/utils/state_management/selectors';
 import { setIsQueryEditorDirty } from '../../../application/utils/state_management/slices/query_editor/query_editor_slice';
+import { onEditorRunActionCreator } from '../../../application/utils/state_management/actions/query_editor';
 import { PrometheusClient } from './explore/services/prometheus_client';
 import { RootState } from '../../../application/utils/state_management/store';
 import { getQueryLabel } from '../../../../../data/common';
@@ -65,6 +67,20 @@ export const MetricsQueryPanel: React.FC = () => {
   const setEditorText = useSetEditorText();
   const setEditorTextWithQuery = useSetEditorTextWithQuery();
   usePPLExecuteQueryAction(setEditorTextWithQuery);
+
+  const handleRun = useCallback(() => {
+    const editorText =
+      editorRef.current?.getValue() ??
+      String(services.data.query.queryString.getQuery().query || '');
+    // @ts-expect-error TS2345 TODO(ts-error): fixme
+    dispatch(onEditorRunActionCreator(services, editorText));
+  }, [dispatch, services, editorRef]);
+
+  const queryLanguage = useSelector(selectQueryLanguage);
+  const languageTitle = useMemo(() => {
+    const languageService = services.data.query.queryString.getLanguageService();
+    return languageService.getLanguage(queryLanguage)?.title ?? queryLanguage;
+  }, [queryLanguage, services.data.query.queryString]);
 
   const client = useMemo(() => new PrometheusClient(services, dataConnectionId), [
     services,
@@ -239,6 +255,8 @@ export const MetricsQueryPanel: React.FC = () => {
                       onCodeChange={onCodeChange}
                       onModeChange={onModeChange}
                       onRemove={removeRow}
+                      onRun={handleRun}
+                      languageTitle={languageTitle}
                       canRemove={rows.length > 1}
                       isDragging={snapshot.isDragging}
                       dragHandleProps={provided.dragHandleProps}

--- a/src/plugins/explore/public/application/pages/metrics/promql_builder/promql_parser.test.ts
+++ b/src/plugins/explore/public/application/pages/metrics/promql_builder/promql_parser.test.ts
@@ -109,6 +109,11 @@ describe('parsePromQL', () => {
     expect(r1).toBe(r2);
   });
 
+  it('returns canBuild=false for bare number literal', () => {
+    const result = parsePromQL('123');
+    expect(result.canBuild).toBe(false);
+  });
+
   it('returns canBuild=false for syntax errors', () => {
     const result = parsePromQL('sum(');
     expect(result.canBuild).toBe(false);

--- a/src/plugins/explore/public/application/pages/metrics/promql_builder/promql_parser.ts
+++ b/src/plugins/explore/public/application/pages/metrics/promql_builder/promql_parser.ts
@@ -141,7 +141,7 @@ export function parsePromQL(query: string): ParseResult {
       const visitor = new BuilderStateVisitor();
       visitor.visit(tree);
 
-      if (!visitor.canBuild) {
+      if (!visitor.canBuild || !visitor.metric) {
         result = { canBuild: false, state: emptyState() };
       } else {
         result = {

--- a/src/plugins/explore/public/application/pages/metrics/query_panel/query_row.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/query_panel/query_row.tsx
@@ -21,6 +21,7 @@ import {
 import classNames from 'classnames';
 import { CodeEditor } from '../../../../../../opensearch_dashboards_react/public';
 import { queryEditorOptions } from '../../../../components/query_panel/query_panel_editor/use_query_panel_editor/editor_options';
+import { getCommandEnterAction } from '../../../../components/query_panel/query_panel_editor/use_query_panel_editor/command_enter_action';
 import { PrometheusClient } from '../explore/services/prometheus_client';
 import { PromQLBuilder, parsePromQL } from '../promql_builder';
 import type { BuilderState } from '../promql_builder';
@@ -42,6 +43,8 @@ export interface QueryRowProps {
   onCodeChange: (rowId: string, query: string) => void;
   onModeChange: (rowId: string, mode: RowMode) => void;
   onRemove: (rowId: string) => void;
+  onRun: () => void;
+  languageTitle: string;
   canRemove: boolean;
   isDragging: boolean;
   dragHandleProps: DragHandleProps;
@@ -56,6 +59,8 @@ export const QueryRowComponent: React.FC<QueryRowProps> = React.memo(
     onCodeChange,
     onModeChange,
     onRemove,
+    onRun,
+    languageTitle,
     canRemove,
     isDragging,
     dragHandleProps,
@@ -149,6 +154,7 @@ export const QueryRowComponent: React.FC<QueryRowProps> = React.memo(
                   options={queryEditorOptions}
                   useLatestTheme
                   editorDidMount={(editor) => {
+                    editor.addAction(getCommandEnterAction(onRun));
                     editor.onDidContentSizeChange(() => {
                       const contentHeight = editor.getContentHeight();
                       const maxHeight = 100;
@@ -166,6 +172,14 @@ export const QueryRowComponent: React.FC<QueryRowProps> = React.memo(
                     });
                   }}
                 />
+                {!row.query && (
+                  <div className="exploreQueryPanelEditor__placeholder">
+                    {i18n.translate('explore.metricsQueryPanel.codePlaceholder', {
+                      defaultMessage: 'Search using </> {language}',
+                      values: { language: languageTitle },
+                    })}
+                  </div>
+                )}
               </div>
             )}
           </EuiFlexItem>

--- a/src/plugins/explore/public/application/pages/metrics/query_panel/row_state.test.ts
+++ b/src/plugins/explore/public/application/pages/metrics/query_panel/row_state.test.ts
@@ -29,6 +29,13 @@ describe('row_state', () => {
       expect(rows[0].builderState).not.toBeNull();
     });
 
+    it('falls back to code mode for bare number literal', () => {
+      const rows = initRows('123', nextId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].mode).toBe('code');
+      expect(rows[0].query).toBe('123');
+    });
+
     it('assigns unique IDs', () => {
       const rows = initRows('', nextId);
       expect(rows[0].id).toBe('row-1');


### PR DESCRIPTION
### Description

This PR

1. if promql cannot be parsed (e.g. `1` is valid query, but not valid metric name), it becomes empty on tab switch. fix it to fallback to code mode if builder mode is empty. If it's explicitly unsupported/incorrect syntax like `cpu[abcd]`, builder already falls back to code correctly
2. add placeholder for query code editor
3. pass onRun to code editor to support keyboard shortcuts

2 and 3 are needed because metrics multi-query component uses `CodeEditor`, rather than wrapped `QueryPanelEditor` used previously.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="4580" height="530" alt="image" src="https://github.com/user-attachments/assets/c008eff5-c49b-4acd-bf32-61d737b1f7ac" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
