### PR TITLE
[Chat] Skip tool result dispatch when another window already submitted it

### DIFF
--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -1442,4 +1442,198 @@ describe('ChatEventHandler', () => {
       Date.now = originalDateNow;
     });
   });
+
+  describe('sendToolResultToAssistant skip handling (duplicate tool result)', () => {
+    it('should append system info message (not tool message) when sendToolResult returns skipped', async () => {
+      const toolCallId = 'tool-skip-1';
+      const mockResult = { success: true, data: 'test result' };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      const constructedToolMessage: ToolMessage = {
+        id: `tool-result-${toolCallId}`,
+        role: 'tool',
+        content: JSON.stringify(mockResult),
+        toolCallId,
+      };
+
+      const emptyObservable = {
+        subscribe: jest.fn().mockImplementation(({ complete }) => {
+          if (complete) complete();
+          return { unsubscribe: jest.fn() };
+        }),
+      };
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: emptyObservable,
+        toolMessage: constructedToolMessage,
+        skipped: { reason: 'result_already_exists' },
+      });
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      const toolMessagesInTimeline = timeline.filter((m) => m.role === 'tool');
+      expect(toolMessagesInTimeline).not.toContainEqual(constructedToolMessage);
+
+      const systemMessages = timeline.filter((m) => m.role === 'system');
+      const skipInfoMessage = systemMessages.find((m) =>
+        (m as any).content?.includes('another window')
+      );
+      expect(skipInfoMessage).toBeDefined();
+      expect((skipInfoMessage as any).id).toMatch(/^tool-skipped-/);
+    });
+
+    it('should not subscribe to the observable or flip streaming state when skipped', async () => {
+      const toolCallId = 'tool-skip-2';
+      const mockResult = 'string result';
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      const subscribeSpy = jest.fn();
+      const emptyObservable = { subscribe: subscribeSpy };
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: emptyObservable,
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: mockResult,
+          toolCallId,
+        },
+        skipped: { reason: 'result_already_exists' },
+      });
+
+      mockOnStreamingStateChange.mockClear();
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      expect(subscribeSpy).not.toHaveBeenCalled();
+      expect(mockOnStreamingStateChange).not.toHaveBeenCalledWith(true);
+    });
+
+    it('should still call onSendToolResultStateChange(true) then (false) when skipped', async () => {
+      const mockOnSendToolResultStateChange = jest.fn();
+      const handlerWithCallback = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2740 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStreamingStateChange: mockOnStreamingStateChange,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+        },
+      });
+
+      const toolCallId = 'tool-skip-3';
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue({ ok: true });
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: { subscribe: jest.fn() },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'result_already_exists' },
+      });
+
+      await handlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      await handlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await handlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(true);
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should follow the normal dispatch path when skipped is undefined', async () => {
+      const toolCallId = 'tool-no-skip';
+      const mockResult = { ok: true };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      const constructedToolMessage: ToolMessage = {
+        id: `tool-result-${toolCallId}`,
+        role: 'tool',
+        content: JSON.stringify(mockResult),
+        toolCallId,
+      };
+
+      const subscribeSpy = jest.fn().mockReturnValue({ unsubscribe: jest.fn() });
+      const observable = { subscribe: subscribeSpy };
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable,
+        toolMessage: constructedToolMessage,
+      });
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      expect(timeline).toContainEqual(constructedToolMessage);
+      const skipInfoMessage = timeline.find((m) => (m as any).id?.startsWith('tool-skipped-'));
+      expect(skipInfoMessage).toBeUndefined();
+      expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -662,7 +662,7 @@ export class ChatEventHandler {
 
       const messages = this.getTimeline();
 
-      const { observable, toolMessage } = await this.chatService.sendToolResult(
+      const { observable, toolMessage, skipped } = await this.chatService.sendToolResult(
         toolCallId,
         result,
         messages
@@ -670,6 +670,19 @@ export class ChatEventHandler {
 
       // Notify that sending tool result is complete
       this.onSendToolResultStateChange?.(false);
+
+      if (skipped) {
+        // Another window already persisted a tool result for this toolCallId.
+        // Skip appending the locally-constructed toolMessage and surface an
+        // informational system message instead.
+        const infoMessage: SystemMessage = {
+          id: `tool-skipped-${toolCallId}-${Date.now()}`,
+          role: 'system',
+          content: 'This tool result was already submitted from another window.',
+        };
+        this.onTimelineUpdate((prev) => [...prev, infoMessage]);
+        return;
+      }
 
       this.onTimelineUpdate((prev) => [...prev, toolMessage]);
 

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -786,6 +786,116 @@ describe('ChatService', () => {
         'Thread ID is required to send a tool result'
       );
     });
+
+    describe('skip branch (duplicate tool result across windows)', () => {
+      // Snapshot containing both the synced tool call and a ToolMessage with
+      // the same toolCallId — another window has already persisted the result.
+      const createSnapshotWithToolResult = (toolCallId: string) => [
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          timestamp: Date.now(),
+          messages: [
+            { role: 'user', id: 'user-msg-1', content: 'Run it' },
+            {
+              role: 'assistant',
+              id: 'assistant-msg-1',
+              content: 'Running',
+              toolCalls: [
+                {
+                  id: toolCallId,
+                  type: 'function',
+                  function: { name: 'test_tool', arguments: '{}' },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              id: 'tool-msg-1',
+              content: '"already done"',
+              toolCallId,
+            },
+          ],
+        },
+      ];
+
+      beforeEach(() => {
+        mockCoreChatService.getMemoryProvider = jest
+          .fn()
+          .mockReturnValue({ includeFullHistory: false });
+      });
+
+      it('should skip dispatch and return skipped reason when tool result already exists', async () => {
+        const toolCallId = 'tool-call-duplicate';
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createSnapshotWithToolResult(toolCallId));
+
+        const response = await chatService.sendToolResult(toolCallId, { ok: true }, []);
+
+        expect(mockAgent.runAgent).not.toHaveBeenCalled();
+        expect(response.skipped).toEqual({ reason: 'result_already_exists' });
+        expect(response.toolMessage).toEqual({
+          id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+          role: 'tool',
+          content: JSON.stringify({ ok: true }),
+          toolCallId,
+        });
+      });
+
+      it('should return an observable that completes without emitting on skip', async () => {
+        const toolCallId = 'tool-call-complete-only';
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createSnapshotWithToolResult(toolCallId));
+
+        const response = await chatService.sendToolResult(toolCallId, 'result', []);
+
+        const nextSpy = jest.fn();
+        const errorSpy = jest.fn();
+        const completeSpy = jest.fn();
+
+        response.observable.subscribe({
+          next: nextSpy,
+          error: errorSpy,
+          complete: completeSpy,
+        });
+
+        expect(nextSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(completeSpy).toHaveBeenCalledTimes(1);
+        expect((chatService as any).activeRequests.size).toBe(0);
+      });
+
+      it('should short-circuit result_already_exists over synced when both are present in the same snapshot', async () => {
+        const toolCallId = 'tool-call-both-present';
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createSnapshotWithToolResult(toolCallId));
+
+        const response = await chatService.sendToolResult(toolCallId, 'result', []);
+
+        expect(response.skipped).toEqual({ reason: 'result_already_exists' });
+        expect(mockAgent.runAgent).not.toHaveBeenCalled();
+      });
+
+      it('should NOT skip when snapshot contains only the synced tool call without a tool result', async () => {
+        const toolCallId = 'tool-call-synced-only';
+        const mockObservable = new Observable<BaseEvent>();
+        mockAgent.runAgent.mockReturnValue(mockObservable);
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
+
+        const response = await chatService.sendToolResult(toolCallId, { ok: true }, []);
+
+        expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
+        expect(response.skipped).toBeUndefined();
+      });
+    });
   });
 
   describe('abort', () => {

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -397,24 +397,44 @@ export class ChatService {
   }
 
   /**
-   * Wait for tool call result to be synced to agentic memory
-   * Polls the conversation history to check if the tool call has been saved
+   * Wait for tool call to be synced to agentic memory.
+   *
+   * Returns `{ shouldSend: false, reason: 'result_already_exists' }` if a
+   * ToolMessage with the same toolCallId is already in history (another
+   * window persisted it first). Returns `{ shouldSend: true, reason: 'synced'
+   * | 'timeout_fallback' | 'no_thread_id' }` otherwise — caller should
+   * dispatch.
    */
   private async waitForToolCallSync(
     toolCallId: string,
     maxAttempts: number = 10,
     intervalMs: number = 1000
-  ): Promise<void> {
+  ): Promise<{ shouldSend: boolean; reason: string }> {
     const threadId = this.getThreadId();
-    if (!threadId) return;
+    if (!threadId) return { shouldSend: true, reason: 'no_thread_id' };
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
         const events = await this.conversationHistoryService.getConversation(threadId);
 
         if (events) {
-          // Check for tool call in MESSAGES_SNAPSHOT events
-          // The tool call is stored in assistant messages' toolCalls array
+          const toolResultExists = events.some((event) => {
+            if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
+              const messages = (event as any).messages as Message[];
+              return messages.some(
+                (msg) =>
+                  msg.role === 'tool' &&
+                  'toolCallId' in msg &&
+                  (msg as any).toolCallId === toolCallId
+              );
+            }
+            return false;
+          });
+
+          if (toolResultExists) {
+            return { shouldSend: false, reason: 'result_already_exists' };
+          }
+
           const toolCallSynced = events.some((event) => {
             if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
               const messages = (event as any).messages as Message[];
@@ -430,7 +450,7 @@ export class ChatService {
           });
 
           if (toolCallSynced) {
-            return; // Tool call has been synced
+            return { shouldSend: true, reason: 'synced' };
           }
         }
       } catch (error) {
@@ -442,11 +462,13 @@ export class ChatService {
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
 
-    // If we've exhausted all attempts, log a warning but continue
+    // If we've exhausted all attempts, log a warning but still proceed —
+    // losing a tool result is worse than occasionally duplicating.
     // eslint-disable-next-line no-console
     console.warn(
       `Tool call sync check timed out after ${maxAttempts} attempts for toolCallId: ${toolCallId}`
     );
+    return { shouldSend: true, reason: 'timeout_fallback' };
   }
 
   public async sendToolResult(
@@ -456,6 +478,7 @@ export class ChatService {
   ): Promise<{
     observable: any;
     toolMessage: ToolMessage;
+    skipped?: { reason: 'result_already_exists' };
   }> {
     const requestId = this.generateRequestId();
 
@@ -504,7 +527,21 @@ export class ChatService {
     // Wait for tool call result to be synced to agentic memory only when not including full history
     // (when full history is included, messages are passed directly so no sync wait needed)
     if (!includeFullHistory) {
-      await this.waitForToolCallSync(toolCallId);
+      const syncResult = await this.waitForToolCallSync(toolCallId);
+
+      // Another window already persisted a tool result for this toolCallId —
+      // skip dispatch to avoid a duplicate in history. Return a completed
+      // empty observable and signal the skip via `skipped` so callers can
+      // avoid appending a phantom tool message to their local timeline.
+      if (!syncResult.shouldSend) {
+        const emptyObservable = new Observable((subscriber) => subscriber.complete());
+        this.removeActiveRequest(requestId);
+        return {
+          observable: emptyObservable,
+          toolMessage,
+          skipped: { reason: 'result_already_exists' },
+        };
+      }
     }
 
     // Continue the conversation with the tool result


### PR DESCRIPTION
### Description

Fix duplicate `ToolMessage` entries in conversation history when two chat windows share the same thread and both execute the same frontend tool call.

**Problem**

When two chat windows are open in the same session (same `threadId`, same agentic-memory history), both can register frontend tool handlers for the same assistant tool call. Both will invoke `ChatService.sendToolResult` for the same `toolCallId`. The previous `waitForToolCallSync` only checked whether the tool _call_ was visible in history — not whether a tool _result_ for that same `toolCallId` was already written. So both windows dispatched via `agent.runAgent` and both results landed in conversation history. The next user message then sent duplicate `ToolMessage` entries to the agent, corrupting its view of the conversation.

This only affects the agentic-memory path (`includeFullHistory === false`). The full-history path passes messages directly and is unchanged.

**Fix**

- `waitForToolCallSync` now returns `{ shouldSend, reason }` instead of `void`. Before checking whether the tool call has been synced, it first scans for an existing `ToolMessage` with the same `toolCallId` and short-circuits with `{ shouldSend: false, reason: 'result_already_exists' }` when found.
- `sendToolResult` branches on that result: when `shouldSend` is false, it skips `agent.runAgent`, cleans up the active-request entry, and returns a completed empty observable plus a `skipped: { reason: 'result_already_exists' }` marker. The constructed `ToolMessage` is still returned so callers can keep their return-shape contract.
- `ChatEventHandler.sendToolResultToAssistant` honors the skip marker: it does not append the locally-constructed `ToolMessage` to the timeline (the authoritative copy is already in history) and surfaces a short system message — `"This tool result was already submitted from another window."` — so the user understands why no assistant response streamed.

Existing behaviors (synced dispatch, timeout fallback, full-history bypass, missing-threadId throw) are unchanged.

### Issues Resolved

N/A

## Screenshot


<img width="1337" height="917" alt="image" src="https://github.com/user-attachments/assets/f39bdd81-84b5-4c33-a96e-b6c001755db1" />



## Testing the changes

Automated:
- `yarn test:jest src/plugins/chat/public/services/chat_service.test.ts` — 4 new tests under `describe('skip branch (duplicate tool result across windows)')` cover: skip-and-return-reason, empty-observable completion with `activeRequests` cleanup, short-circuit ordering of `result_already_exists` over `synced`, and non-skip on the synced-only path.
- `yarn test:jest src/plugins/chat/public/services/chat_event_handler.test.ts` — 4 new tests under `describe('sendToolResultToAssistant skip handling')` cover: system info message appended in place of tool message, no subscribe/no streaming flip on skip, `onSendToolResultStateChange(true)` then `(false)` still fires, and normal dispatch path when `skipped` is undefined.

Manual:## Testing the changes

Automated:
- `yarn test:jest src/plugins/chat/public/services/chat_service.test.ts` — 4 new tests under `describe('skip branch (duplicate tool result across windows)')` cover: skip-and-return-reason, empty-observable completion with `activeRequests` cleanup, short-circuit ordering of `result_already_exists` over `synced`, and non-skip on the synced-only path.
- `yarn test:jest src/plugins/chat/public/services/chat_event_handler.test.ts` — 4 new tests under `describe('sendToolResultToAssistant skip handling')` cover: system info message appended in place of tool message, no subscribe/no streaming flip on skip, `onSendToolResultStateChange(true)` then `(false)` still fires, and normal dispatch path when `skipped` is undefined.

Manual:

Prerequisites:
- Install the sample `logs` dataset (Home → Add sample data → Sample web logs → Add data).
- Install and enable the investigation plugin.

Steps:
1. Open an observability workspace and navigate to **Discover → logs**.
2. Open the chat panel, type `/investigate hello`, send the message, and wait for the investigation card to be created in the response.
3. Open the same page in a new browser tab (same session, same thread) and load the same conversation.
4. In the new tab, click **✅** on the investigation card and wait for the investigation to be created.
5. Return to the original tab and click **✅** on the investigation card.

Expected result: The original tab does not create a second investigation. Instead the chat shows the system message **"This tool result was already submitted from another window."** confirming the duplicate dispatch was skipped.


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
