### PR TITLE
Disable Data Source management for unsupported OS Versions

### DIFF
--- a/src/plugins/data_source_management/opensearch_dashboards.json
+++ b/src/plugins/data_source_management/opensearch_dashboards.json
@@ -7,5 +7,6 @@
   "optionalPlugins": ["dataSource"],
   "requiredBundles": ["opensearchDashboardsReact", "dataSource", "opensearchDashboardsUtils"],
   "extraPublicDirs": ["public/components/utils"],
-  "configPath": ["data_source_management"]
+  "configPath": ["data_source_management"],
+  "supportedOSDataSourceVersions": ">=2.13.0"
 }

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -18,6 +18,7 @@ import {
 import { toMountPoint } from '../../../../src/plugins/opensearch_dashboards_react/public';
 import { DashboardDirectQuerySyncBanner } from './components/direct_query_data_sources_components/direct_query_sync/direct_query_sync_banner';
 import { parseUrlHash } from '../../opensearch_dashboards_utils/public';
+import semver from 'semver';
 
 import { PLUGIN_NAME } from '../common';
 import { createDataSourceSelector } from './components/data_source_selector/create_data_source_selector';
@@ -121,6 +122,7 @@ export class DataSourceManagementPlugin
   private core: CoreStart | null = null;
   private currentAppId: string | undefined = undefined;
   private config: ConfigSchema;
+  private managementApp: any = null;
 
   constructor(initializerContext: { config: { get: () => ConfigSchema } }) {
     this.config = initializerContext.config.get();
@@ -148,7 +150,7 @@ export class DataSourceManagementPlugin
 
     this.featureFlagStatus = !!dataSource;
 
-    opensearchDashboardsSection.registerApp({
+    this.managementApp = opensearchDashboardsSection.registerApp({
       id: DSM_APP_ID,
       title: PLUGIN_NAME,
       order: 1,
@@ -255,6 +257,17 @@ export class DataSourceManagementPlugin
   public start(core: CoreStart): DataSourceManagementPluginStart {
     this.started = true;
     this.core = core;
+
+    if (!this.featureFlagStatus && this.managementApp) {
+      core.http
+        .get<{ version: string }>('/internal/data-source-management/localClusterVersion')
+        .then(({ version }) => {
+          if (semver.satisfies(version, '~1.3.0 || ~2.11.0')) {
+            this.managementApp.disable();
+          }
+        })
+        .catch(() => {});
+    }
 
     setApplication(core.application);
     setWorkspaces(core.workspaces);

--- a/src/plugins/data_source_management/public/plugin.ts
+++ b/src/plugins/data_source_management/public/plugin.ts
@@ -6,6 +6,7 @@
 import React from 'react';
 import { i18n } from '@osd/i18n';
 import { DataSourcePluginSetup } from 'src/plugins/data_source/public';
+import semver from 'semver';
 import {
   AppMountParameters,
   CoreSetup,
@@ -18,8 +19,8 @@ import {
 import { toMountPoint } from '../../../../src/plugins/opensearch_dashboards_react/public';
 import { DashboardDirectQuerySyncBanner } from './components/direct_query_data_sources_components/direct_query_sync/direct_query_sync_banner';
 import { parseUrlHash } from '../../opensearch_dashboards_utils/public';
-import semver from 'semver';
 
+import * as pluginManifest from '../opensearch_dashboards.json';
 import { PLUGIN_NAME } from '../common';
 import { createDataSourceSelector } from './components/data_source_selector/create_data_source_selector';
 
@@ -262,10 +263,16 @@ export class DataSourceManagementPlugin
       core.http
         .get<{ version: string }>('/internal/data-source-management/localClusterVersion')
         .then(({ version }) => {
-          if (semver.satisfies(version, '~1.3.0 || ~2.11.0')) {
-            this.managementApp.disable();
+          if (
+            version &&
+            pluginManifest.supportedOSDataSourceVersions &&
+            !semver.satisfies(version, pluginManifest.supportedOSDataSourceVersions)
+          ) {
+            this.managementApp!.disable();
           }
         })
+        // Fail-open: if version fetch fails, keep the management page enabled
+        // rather than blocking access when the version is unknown
         .catch(() => {});
     }
 

--- a/src/plugins/data_source_management/server/plugin.ts
+++ b/src/plugins/data_source_management/server/plugin.ts
@@ -137,7 +137,12 @@ export class DataSourceManagementPlugin
       }
     );
 
-    setupRoutes({ router, client: openSearchDataSourceManagementClient, dataSourceEnabled });
+    setupRoutes({
+      router,
+      client: openSearchDataSourceManagementClient,
+      dataSourceEnabled,
+      logger: this.logger,
+    });
 
     return {};
   }

--- a/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.test.ts
+++ b/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.test.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { httpServiceMock, httpServerMock } from '../../../../../core/server/mocks';
+import { httpServiceMock, httpServerMock, loggingSystemMock } from '../../../../core/server/mocks';
 import { registerLocalClusterVersionRoute } from './fetch_local_cluster_version';
 
 describe('fetch_local_cluster_version route', () => {
   let router: ReturnType<typeof httpServiceMock.createRouter>;
   let mockContext: any;
   let mockResponse: ReturnType<typeof httpServerMock.createResponseFactory>;
+  const logger = loggingSystemMock.createLogger();
 
   beforeEach(() => {
     router = httpServiceMock.createRouter();
@@ -25,7 +26,7 @@ describe('fetch_local_cluster_version route', () => {
         },
       },
     };
-    registerLocalClusterVersionRoute(router);
+    registerLocalClusterVersionRoute(router, logger);
   });
 
   it('registers GET /internal/data-source-management/localClusterVersion', () => {
@@ -55,5 +56,6 @@ describe('fetch_local_cluster_version route', () => {
     await handler(mockContext, httpServerMock.createOpenSearchDashboardsRequest(), mockResponse);
 
     expect(mockResponse.ok).toHaveBeenCalledWith({ body: { version: '' } });
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.test.ts
+++ b/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpServiceMock, httpServerMock } from '../../../../../core/server/mocks';
+import { registerLocalClusterVersionRoute } from './fetch_local_cluster_version';
+
+describe('fetch_local_cluster_version route', () => {
+  let router: ReturnType<typeof httpServiceMock.createRouter>;
+  let mockContext: any;
+  let mockResponse: ReturnType<typeof httpServerMock.createResponseFactory>;
+
+  beforeEach(() => {
+    router = httpServiceMock.createRouter();
+    mockResponse = httpServerMock.createResponseFactory();
+    mockContext = {
+      core: {
+        opensearch: {
+          client: {
+            asCurrentUser: {
+              info: jest.fn(),
+            },
+          },
+        },
+      },
+    };
+    registerLocalClusterVersionRoute(router);
+  });
+
+  it('registers GET /internal/data-source-management/localClusterVersion', () => {
+    expect(router.get).toHaveBeenCalledTimes(1);
+    expect(router.get.mock.calls[0][0].path).toBe(
+      '/internal/data-source-management/localClusterVersion'
+    );
+  });
+
+  it('returns cluster version on success', async () => {
+    mockContext.core.opensearch.client.asCurrentUser.info.mockResolvedValue({
+      body: { version: { number: '2.11.0' } },
+    });
+
+    const handler = router.get.mock.calls[0][1];
+    await handler(mockContext, httpServerMock.createOpenSearchDashboardsRequest(), mockResponse);
+
+    expect(mockResponse.ok).toHaveBeenCalledWith({ body: { version: '2.11.0' } });
+  });
+
+  it('returns empty version on failure', async () => {
+    mockContext.core.opensearch.client.asCurrentUser.info.mockRejectedValue(
+      new Error('connection refused')
+    );
+
+    const handler = router.get.mock.calls[0][1];
+    await handler(mockContext, httpServerMock.createOpenSearchDashboardsRequest(), mockResponse);
+
+    expect(mockResponse.ok).toHaveBeenCalledWith({ body: { version: '' } });
+  });
+});

--- a/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.ts
+++ b/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.ts
@@ -3,19 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IRouter } from '../../../../../core/server';
+import { IRouter, Logger } from '../../../../core/server';
 
-export function registerLocalClusterVersionRoute(router: IRouter) {
+export function registerLocalClusterVersionRoute(router: IRouter, logger: Logger) {
   router.get(
     {
       path: '/internal/data-source-management/localClusterVersion',
-      validate: false,
+      validate: {},
     },
     async (context, request, response) => {
       try {
         const { body } = await context.core.opensearch.client.asCurrentUser.info();
         return response.ok({ body: { version: body.version.number } });
       } catch (e) {
+        logger.warn(`Failed to fetch local cluster version: ${e}`);
         return response.ok({ body: { version: '' } });
       }
     }

--- a/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.ts
+++ b/src/plugins/data_source_management/server/routes/fetch_local_cluster_version.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../../core/server';
+
+export function registerLocalClusterVersionRoute(router: IRouter) {
+  router.get(
+    {
+      path: '/internal/data-source-management/localClusterVersion',
+      validate: false,
+    },
+    async (context, request, response) => {
+      try {
+        const { body } = await context.core.opensearch.client.asCurrentUser.info();
+        return response.ok({ body: { version: body.version.number } });
+      } catch (e) {
+        return response.ok({ body: { version: '' } });
+      }
+    }
+  );
+}

--- a/src/plugins/data_source_management/server/routes/index.ts
+++ b/src/plugins/data_source_management/server/routes/index.ts
@@ -13,6 +13,7 @@ import { registerDatasourcesRoute } from './datasources_router';
 import { registerPplRoute } from './ppl';
 import { DSLFacet } from '../services/facets/dsl_facet';
 import { PPLFacet } from '../services/facets/ppl_facet';
+import { registerLocalClusterVersionRoute } from './fetch_local_cluster_version';
 
 export function defineRoutes(router: IRouter) {
   router.get(
@@ -51,4 +52,5 @@ export function setupRoutes({
   }
   registerDataConnectionsRoute(router, dataSourceEnabled);
   registerDatasourcesRoute(router, dataSourceEnabled);
+  registerLocalClusterVersionRoute(router);
 }

--- a/src/plugins/data_source_management/server/routes/index.ts
+++ b/src/plugins/data_source_management/server/routes/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IRouter, ILegacyClusterClient } from '../../../../core/server';
+import { IRouter, ILegacyClusterClient, Logger } from '../../../../core/server';
 import { registerDslRoute } from './dsl';
 import {
   registerDataConnectionsRoute,
@@ -35,10 +35,12 @@ export function setupRoutes({
   router,
   client,
   dataSourceEnabled,
+  logger,
 }: {
   router: IRouter;
   client: ILegacyClusterClient;
   dataSourceEnabled: boolean;
+  logger: Logger;
 }) {
   registerPplRoute({ router, facet: new PPLFacet(client) });
   registerDslRoute({ router, facet: new DSLFacet(client) }, dataSourceEnabled);
@@ -52,5 +54,5 @@ export function setupRoutes({
   }
   registerDataConnectionsRoute(router, dataSourceEnabled);
   registerDatasourcesRoute(router, dataSourceEnabled);
-  registerLocalClusterVersionRoute(router);
+  registerLocalClusterVersionRoute(router, logger);
 }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->
With the feature of single OSD. We are aiming to run the single Version of OSD across all backend OS version. For 1.3,2.11 version we don;t support the Data Source Management page this PR aims to disable it for those versions. 

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->
1.3
<img width="1724" height="1047" alt="Screenshot 2026-04-30 at 1 32 25 PM" src="https://github.com/user-attachments/assets/efe50176-3c9a-47d5-9ff8-150b9eaa4d94" />

2.11
<img width="1724" height="1047" alt="Screenshot 2026-04-30 at 1 41 19 PM" src="https://github.com/user-attachments/assets/b757e5c6-c34b-4c7f-802a-b277b1531429" />

2.19
<img width="1724" height="1047" alt="Screenshot 2026-04-30 at 1 43 26 PM" src="https://github.com/user-attachments/assets/b75d9160-e401-4a08-88af-da704c9937cc" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
