### PR TITLE
[Bug] Dataset Discover loading

### DIFF
--- a/src/plugins/data/public/query/query_service.ts
+++ b/src/plugins/data/public/query/query_service.ts
@@ -101,7 +101,13 @@ export class QueryService {
     indexPatterns,
     application,
   }: QueryServiceStartDependencies): IQueryStart {
-    this.queryStringManager.getDatasetService().init(indexPatterns);
+    const preInitDefault = this.queryStringManager.getDefaultQuery();
+    this.queryStringManager
+      .getDatasetService()
+      .init(indexPatterns)
+      .then(() => {
+        this.queryStringManager.refreshDefaultQuery(preInitDefault);
+      });
     return {
       addToQueryLog: createAddToQueryLog({
         storage,

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
@@ -445,6 +445,61 @@ describe('DatasetService', () => {
     // expect(service.getRecentDatasets().length).toEqual(4);
   });
 
+  test('fetchDefaultDataset preserves the saved object type for non-INDEX_PATTERN datasets', async () => {
+    jest.clearAllMocks();
+    uiSettings = coreMock.createSetup().uiSettings;
+    uiSettings.get = jest.fn().mockImplementation((setting: string) => {
+      if (setting === UI_SETTINGS.SEARCH_MAX_RECENT_DATASETS) return 4;
+      if (setting === 'defaultIndex') return 'id';
+      if (setting === UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED) return true;
+    });
+    sessionStorage = new DataStorage(window.sessionStorage, 'opensearchDashboards.');
+    service = new DatasetService(uiSettings, sessionStorage);
+
+    indexPatterns = ({
+      ...dataPluginMock.createStartContract().indexPatterns,
+      get: jest.fn().mockResolvedValue({
+        id: 'id',
+        title: 'my-index-*',
+        type: DEFAULT_DATA.SET_TYPES.INDEX,
+      }),
+      getDataSource: jest.fn().mockResolvedValue(undefined),
+    } as unknown) as IndexPatternsContract;
+    service.init(indexPatterns);
+
+    await waitFor(() => {
+      const def = service.getDefault();
+      expect(def?.type).toBe(DEFAULT_DATA.SET_TYPES.INDEX);
+    });
+  });
+
+  test('fetchDefaultDataset defaults to INDEX_PATTERN when saved object type is missing', async () => {
+    jest.clearAllMocks();
+    uiSettings = coreMock.createSetup().uiSettings;
+    uiSettings.get = jest.fn().mockImplementation((setting: string) => {
+      if (setting === UI_SETTINGS.SEARCH_MAX_RECENT_DATASETS) return 4;
+      if (setting === 'defaultIndex') return 'id';
+      if (setting === UI_SETTINGS.QUERY_ENHANCEMENTS_ENABLED) return true;
+    });
+    sessionStorage = new DataStorage(window.sessionStorage, 'opensearchDashboards.');
+    service = new DatasetService(uiSettings, sessionStorage);
+
+    indexPatterns = ({
+      ...dataPluginMock.createStartContract().indexPatterns,
+      get: jest.fn().mockResolvedValue({
+        id: 'id',
+        title: 'my-index-*',
+      }),
+      getDataSource: jest.fn().mockResolvedValue(undefined),
+    } as unknown) as IndexPatternsContract;
+    service.init(indexPatterns);
+
+    await waitFor(() => {
+      const def = service.getDefault();
+      expect(def?.type).toBe(DEFAULT_DATA.SET_TYPES.INDEX_PATTERN);
+    });
+  });
+
   test('test get default dataset ', async () => {
     jest.clearAllMocks();
     uiSettings = coreMock.createSetup().uiSettings;

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -367,13 +367,16 @@ export class DatasetService {
       dataSource = await this.indexPatterns?.getDataSource(indexPattern.dataSourceRef?.id);
     }
 
-    const dataType = this.typesRegistry.get(DEFAULT_DATA.SET_TYPES.INDEX_PATTERN);
+    const actualType = indexPattern.type || DEFAULT_DATA.SET_TYPES.INDEX_PATTERN;
+    const dataType =
+      this.typesRegistry.get(actualType) ??
+      this.typesRegistry.get(DEFAULT_DATA.SET_TYPES.INDEX_PATTERN);
     if (dataType) {
       const dataset = dataType.toDataset([
         {
           id: indexPattern.id,
           title: indexPattern.title,
-          type: DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+          type: actualType,
           meta: {
             type: DATA_STRUCTURE_META_TYPES.CUSTOM,
             ...(indexPattern.displayName && { displayName: indexPattern.displayName }),

--- a/src/plugins/data/public/query/query_string/query_string_manager.test.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.test.ts
@@ -206,6 +206,100 @@ describe('QueryStringManager', () => {
     expect(query).toHaveProperty('dataset', dataset);
   });
 
+  describe('getDefaultQuery', () => {
+    const datasetWithSqlPplOnly = {
+      id: 'test-dataset',
+      title: 'Test Dataset',
+      type: DEFAULT_DATA.SET_TYPES.INDEX,
+    };
+
+    test('clamps language to the first supportedLanguages entry when default language is unsupported', () => {
+      service.getDatasetService().getDefault = jest.fn().mockReturnValue(datasetWithSqlPplOnly);
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn().mockReturnValue(['PPL', 'SQL']),
+      });
+      service.getLanguageService().getLanguage = jest.fn().mockReturnValue({
+        getQueryString: jest.fn().mockReturnValue(''),
+      });
+
+      const defaultQuery = service.getDefaultQuery();
+
+      expect(defaultQuery.language).toBe('PPL');
+      expect(defaultQuery.dataset).toEqual(datasetWithSqlPplOnly);
+    });
+
+    test('keeps the default language when it is in the dataset supportedLanguages', () => {
+      service.getDatasetService().getDefault = jest.fn().mockReturnValue(datasetWithSqlPplOnly);
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn().mockReturnValue(['kuery', 'PPL', 'SQL']),
+      });
+      service.getLanguageService().getLanguage = jest.fn().mockReturnValue({
+        getQueryString: jest.fn().mockReturnValue(''),
+      });
+
+      const defaultQuery = service.getDefaultQuery();
+
+      expect(defaultQuery.language).toBe('kuery');
+      expect(defaultQuery.dataset).toEqual(datasetWithSqlPplOnly);
+    });
+
+    test('keeps the default language when dataset type reports no supportedLanguages', () => {
+      service.getDatasetService().getDefault = jest.fn().mockReturnValue(datasetWithSqlPplOnly);
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn().mockReturnValue(undefined),
+      });
+      service.getLanguageService().getLanguage = jest.fn().mockReturnValue({
+        getQueryString: jest.fn().mockReturnValue(''),
+      });
+
+      const defaultQuery = service.getDefaultQuery();
+
+      expect(defaultQuery.language).toBe('kuery');
+    });
+  });
+
+  describe('refreshDefaultQuery', () => {
+    const stalePreInitDefault = { query: '', language: 'kuery' };
+    const datasetAfterInit = {
+      id: 'test-dataset',
+      title: 'Test Dataset',
+      type: DEFAULT_DATA.SET_TYPES.INDEX,
+    };
+
+    beforeEach(() => {
+      service.getLanguageService().getLanguage = jest.fn().mockReturnValue({
+        getQueryString: jest.fn().mockReturnValue(''),
+      });
+    });
+
+    test('re-seeds query$ from the dataset-aware default when user has not touched it', () => {
+      service.getDatasetService().getDefault = jest.fn().mockReturnValue(datasetAfterInit);
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn().mockReturnValue(['PPL', 'SQL']),
+      });
+
+      service.refreshDefaultQuery(stalePreInitDefault);
+
+      const refreshed = service.getQuery();
+      expect(refreshed.dataset).toEqual(datasetAfterInit);
+      expect(refreshed.language).toBe('PPL');
+    });
+
+    test('does not overwrite a query the user has already set', () => {
+      const userQuery = { query: 'SELECT *', language: 'SQL' };
+      service.setQuery(userQuery);
+
+      service.getDatasetService().getDefault = jest.fn().mockReturnValue(datasetAfterInit);
+      service.getDatasetService().getType = jest.fn().mockReturnValue({
+        supportedLanguages: jest.fn().mockReturnValue(['PPL', 'SQL']),
+      });
+
+      service.refreshDefaultQuery(stalePreInitDefault);
+
+      expect(service.getQuery()).toEqual(userQuery);
+    });
+  });
+
   describe('setQuery', () => {
     beforeEach(() => {
       // Mock dataset service and language service methods

--- a/src/plugins/data/public/query/query_string/query_string_manager.ts
+++ b/src/plugins/data/public/query/query_string/query_string_manager.ts
@@ -54,10 +54,12 @@ export class QueryStringManager {
     private readonly defaultSearchInterceptor: ISearchInterceptor,
     private readonly notifications: NotificationsSetup
   ) {
-    this.query$ = new BehaviorSubject<Query>(this.getDefaultQuery());
-    this.queryHistory = createHistory({ storage: this.sessionStorage });
+    // datasetService and languageService must exist before getDefaultQuery() runs,
+    // otherwise the initial query skips the dataset-aware language clamp.
     this.datasetService = new DatasetService(uiSettings, this.sessionStorage);
     this.languageService = new LanguageService(this.defaultSearchInterceptor, this.storage);
+    this.query$ = new BehaviorSubject<Query>(this.getDefaultQuery());
+    this.queryHistory = createHistory({ storage: this.sessionStorage });
     try {
       const application = getApplication();
       if (application && application.currentAppId$) {
@@ -106,7 +108,14 @@ export class QueryStringManager {
       defaultDataset &&
       this.languageService
     ) {
-      const newQuery = { ...query, dataset: defaultDataset };
+      let languageId = defaultLanguageId;
+      const supportedLanguages = this.datasetService
+        .getType(defaultDataset.type)
+        ?.supportedLanguages(defaultDataset);
+      if (supportedLanguages && !supportedLanguages.includes(languageId)) {
+        languageId = supportedLanguages[0];
+      }
+      const newQuery = { ...query, language: languageId, dataset: defaultDataset };
 
       return {
         ...newQuery,
@@ -115,6 +124,18 @@ export class QueryStringManager {
     }
 
     return query;
+  }
+
+  /**
+   * Re-seeds query$ from getDefaultQuery() if the user hasn't changed the query yet.
+   * Called after DatasetService.init() resolves so the default dataset (and any
+   * language clamp it implies) can be applied to the initial query.
+   */
+  public refreshDefaultQuery(previousDefault: Query): void {
+    const currentQuery = this.query$.getValue();
+    if (isEqual(currentQuery, previousDefault)) {
+      this.query$.next(this.getDefaultQuery());
+    }
   }
 
   public formatQuery(query: Query | string | undefined): Query {

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -563,8 +563,10 @@ export const useSearch = (services: DiscoverViewServices) => {
       const isDataQueryDefault = dataQuery.query === defaultQuery.query;
       const savedSearchQuery = savedSearchInstance.searchSource.getField('query');
 
-      // Use eixisting query, if eixisting query match default, use query from saved search
-      const query = isDataQueryDefault ? savedSearchQuery ?? dataQuery : dataQuery;
+      // Use existing query; if it matches default, prefer savedSearchQuery, then the freshly
+      // computed defaultQuery (which reflects the post-init default dataset and language clamp),
+      // falling back to dataQuery for back-compat.
+      const query = isDataQueryDefault ? savedSearchQuery ?? defaultQuery ?? dataQuery : dataQuery;
 
       const isEnhancementsEnabled = await uiSettings.get('query:enhancements:enabled');
       if (isEnhancementsEnabled && query.dataset) {


### PR DESCRIPTION
### Description
  Fixes a 500 error (Unsupported index pattern type INDEXES) on initial Discover load when the default index pattern was created via the dataset management "Save as" flow. DQL/Lucene was being issued against a dataset that only supports PPL/SQL, and the request routed through the default search strategy which rejects any non-empty indexType.

  Builds on #11788 (search-source hydration for non-INDEX_PATTERN datasets). That PR made dashboard panels render for these datasets; this one fixes the language selection on initial load so Discover doesn't blow up on the same datasets.

  Root cause

  Three compounding issues:

  1. fetchDefaultDataset() hardcoded the dataset type to INDEX_PATTERN regardless of what the saved object actually stored. So when an INDEXES-typed saved object was the default, the dataset returned to callers lied about its type and the language guard never fired.
  2. getDefaultQuery() did not clamp the default language to the dataset's supportedLanguages. Even if the dataset type had been correct, DQL/Lucene would still be chosen for an INDEXES dataset that only supports PPL/SQL.
  3. QueryStringManager seeded query$ before datasetService existed, and DatasetService.init() is async. The BehaviorSubject emitted a stale default (no dataset, kuery), consumers cached it, and the post-init default was never applied. Classic Discover's use_search.ts then used the stale value as the initial query.

  Fix

  - dataset_service.ts — fetchDefaultDataset(): read indexPattern.type from the loaded saved object (fall back to INDEX_PATTERN when absent), and pass the real type through to toDataset().
  - query_string_manager.ts — getDefaultQuery(): clamp defaultLanguageId to the dataset's supportedLanguages when the current default isn't in the list. Mirrors the guard already in setQuery().
  - query_string_manager.ts — constructor ordering: instantiate datasetService and languageService before seeding query$, so the initial default can run the dataset-aware clamp.
  - query_string_manager.ts — new refreshDefaultQuery(previousDefault): re-seeds query$ from getDefaultQuery() after DatasetService.init() resolves, but only when the user hasn't touched the query yet.
  - query_service.ts — start(): snapshots the pre-init default, awaits the init promise, then calls
  refreshDefaultQuery(preInitDefault). This is the hook that connects the async init to the BehaviorSubject.
  - use_search.ts (classic Discover): when there is no saved-search query and dataQuery equals the default, prefer the freshly computed defaultQuery over the stale dataQuery.

  Tests

  - dataset_service.test.ts — fetchDefaultDataset preserves non-INDEX_PATTERN saved-object type; defaults to INDEX_PATTERN when the saved object has none.
  - query_string_manager.test.ts —
    - getDefaultQuery clamps unsupported language to first supported entry, keeps it when supported, tolerates undefined supportedLanguages.
    - refreshDefaultQuery re-seeds query$ when untouched; does not overwrite a query the user has already set.
  - Full existing suite still passes: 52/52 across both files.

  Manual verification

  - Created an index pattern via Dashboards Management → Data Sources → "Save as" (stores type: "INDEXES" on the saved object).
  - Set it as the default index pattern.
  - Reloaded Discover — DQL/Lucene no longer 500s; language defaults to PPL, payload routes through a strategy that accepts indexType: "INDEXES".
  - PPL/SQL still work; traditional INDEX_PATTERN defaults still default to DQL.

  Pending / follow-up

  Still open for owner input: DatasetService.saveDataset() writes type: dataset.type (e.g. INDEXES) into the
  index-pattern saved object. This PR makes every read path tolerant of that, but the real question is whether INDEXES on the saved index-pattern object is intentional:

  - If yes → this PR is the right long-term fix and nothing else is needed.
  - If no → the save path should normalize to INDEX_PATTERN at write time, and the existing INDEXES-typed saved objects will need a migration. The read-path fixes here remain valuable either way (defense in depth, plus they unblock existing customer data).

  Also worth flagging for a future PR: the UI should restrict the language-switcher to only show languages the current dataset supports, so a user can't manually select DQL against an INDEXES dataset and hit the same 500 that way.

## Screenshot

Before:
<img width="1631" height="809" alt="Before" src="https://github.com/user-attachments/assets/f72e32f6-57ca-48a0-9716-36b98162434d" />

After:
<img width="1628" height="810" alt="After" src="https://github.com/user-attachments/assets/c5f9a51e-2e28-40b8-8ed8-19f617015ba6" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
