### PR TITLE
[Banner] Fix global banner overlap with sidecar

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3001,7 +3001,13 @@ exports[`Header handles visibility and lock changes 1`] = `
     }
   }
 >
-  <HeaderBanner />
+  <HeaderBanner
+    style={
+      Object {
+        "paddingRight": 648,
+      }
+    }
+  />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -10399,7 +10405,13 @@ exports[`Header renders application header without title 1`] = `
     }
   }
 >
-  <HeaderBanner />
+  <HeaderBanner
+    style={
+      Object {
+        "paddingRight": 648,
+      }
+    }
+  />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -14839,7 +14851,13 @@ exports[`Header renders condensed header 1`] = `
     }
   }
 >
-  <HeaderBanner />
+  <HeaderBanner
+    style={
+      Object {
+        "paddingRight": 648,
+      }
+    }
+  />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -20516,7 +20534,13 @@ exports[`Header renders page header with application title 1`] = `
     }
   }
 >
-  <HeaderBanner />
+  <HeaderBanner
+    style={
+      Object {
+        "paddingRight": 648,
+      }
+    }
+  />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -25160,7 +25184,13 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
     }
   }
 >
-  <HeaderBanner />
+  <HeaderBanner
+    style={
+      Object {
+        "paddingRight": 648,
+      }
+    }
+  />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -717,7 +717,7 @@ export function Header({
 
   return (
     <>
-      <HeaderBanner globalBanner={globalBanner} />
+      <HeaderBanner globalBanner={globalBanner} style={sidecarPaddingStyle} />
       <header className={className} data-test-subj="headerGlobalNav">
         <div id="globalHeaderBars">
           {!useUpdatedHeader && useExpandedHeader && renderLegacyExpandedHeader()}

--- a/src/core/public/chrome/ui/header/header_banner.tsx
+++ b/src/core/public/chrome/ui/header/header_banner.tsx
@@ -9,17 +9,26 @@
  * GitHub history for details.
  */
 
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { ChromeGlobalBanner } from '../../chrome_service';
 
 interface HeaderBannerProps {
   globalBanner?: ChromeGlobalBanner;
+  style?: CSSProperties;
 }
 
 /**
  * HeaderBanner component that renders the banner in the header
  * This component is extracted from the Header component for better separation and extensibility
  */
-export const HeaderBanner: React.FC<HeaderBannerProps> = ({ globalBanner }) => {
-  return <>{globalBanner && <div className="globalBanner">{globalBanner.component}</div>}</>;
+export const HeaderBanner: React.FC<HeaderBannerProps> = ({ globalBanner, style }) => {
+  return (
+    <>
+      {globalBanner && (
+        <div className="globalBanner" style={style}>
+          {globalBanner.component}
+        </div>
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
### Description

Fix banner overlap with sidecar (chatbot)

### Issues Resolved

NA

## Screenshot

https://github.com/user-attachments/assets/b81a68f8-3b79-4dd2-8636-6c995a5fccfc

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
