### PR TITLE
fix: time bucket config option not render

### DIFF
--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.test.tsx
@@ -44,8 +44,8 @@ const mockCategoricalColumns: VisColumn[] = [
 ];
 
 const mockAxisColumnMappings: AxisColumnMappings = {
-  [AxisRole.X]: mockCategoricalColumns[0],
-  [AxisRole.Y]: mockNumericalColumns[0],
+  [AxisRole.X]: [mockCategoricalColumns[0]],
+  [AxisRole.Y]: [mockNumericalColumns[0]],
 };
 
 jest.mock('@osd/i18n', () => ({
@@ -313,14 +313,16 @@ describe('BarVisStyleControls', () => {
       ...defaultProps,
       axisColumnMappings: {
         ...mockAxisColumnMappings,
-        [AxisRole.COLOR]: {
-          id: 5,
-          name: 'Color Category',
-          schema: VisFieldType.Categorical,
-          column: 'color',
-          validValuesCount: 10,
-          uniqueValuesCount: 5,
-        },
+        [AxisRole.COLOR]: [
+          {
+            id: 5,
+            name: 'Color Category',
+            schema: VisFieldType.Categorical,
+            column: 'color',
+            validValuesCount: 10,
+            uniqueValuesCount: 5,
+          },
+        ],
       },
     };
 
@@ -338,22 +340,26 @@ describe('BarVisStyleControls', () => {
       ...defaultProps,
       axisColumnMappings: {
         ...mockAxisColumnMappings,
-        [AxisRole.COLOR]: {
-          id: 5,
-          name: 'Color Category',
-          schema: VisFieldType.Categorical,
-          column: 'color',
-          validValuesCount: 10,
-          uniqueValuesCount: 5,
-        },
-        [AxisRole.FACET]: {
-          id: 6,
-          name: 'Facet Category',
-          schema: VisFieldType.Categorical,
-          column: 'facet',
-          validValuesCount: 10,
-          uniqueValuesCount: 5,
-        },
+        [AxisRole.COLOR]: [
+          {
+            id: 5,
+            name: 'Color Category',
+            schema: VisFieldType.Categorical,
+            column: 'color',
+            validValuesCount: 10,
+            uniqueValuesCount: 5,
+          },
+        ],
+        [AxisRole.FACET]: [
+          {
+            id: 6,
+            name: 'Facet Category',
+            schema: VisFieldType.Categorical,
+            column: 'facet',
+            validValuesCount: 10,
+            uniqueValuesCount: 5,
+          },
+        ],
       },
     };
 
@@ -371,14 +377,16 @@ describe('BarVisStyleControls', () => {
       ...defaultProps,
       axisColumnMappings: {
         ...mockAxisColumnMappings,
-        [AxisRole.COLOR]: {
-          id: 5,
-          name: 'Color Category',
-          schema: VisFieldType.Categorical,
-          column: 'color',
-          validValuesCount: 10,
-          uniqueValuesCount: 5,
-        },
+        [AxisRole.COLOR]: [
+          {
+            id: 5,
+            name: 'Color Category',
+            schema: VisFieldType.Categorical,
+            column: 'color',
+            validValuesCount: 10,
+            uniqueValuesCount: 5,
+          },
+        ],
       },
     };
 
@@ -565,14 +573,16 @@ describe('BarVisStyleControls', () => {
       ...defaultProps,
       axisColumnMappings: {
         ...mockAxisColumnMappings,
-        x: {
-          id: 1,
-          name: 'Date X',
-          schema: VisFieldType.Date,
-          column: 'column',
-          validValuesCount: 100,
-          uniqueValuesCount: 50,
-        },
+        x: [
+          {
+            id: 1,
+            name: 'Date X',
+            schema: VisFieldType.Date,
+            column: 'column',
+            validValuesCount: 100,
+            uniqueValuesCount: 50,
+          },
+        ],
       },
     };
 

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -36,7 +36,10 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
     onStyleChange({ [key]: value });
   };
 
-  const axes = [axisColumnMappings[AxisRole.X], axisColumnMappings[AxisRole.Y]];
+  const axes = [
+    ...(axisColumnMappings[AxisRole.X] ?? []),
+    ...(axisColumnMappings[AxisRole.Y] ?? []),
+  ];
   const hasDate = axes.some((axis) => axis?.schema === VisFieldType.Date);
 
   // 3 bucket types for bar chart:

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.test.tsx
@@ -30,8 +30,8 @@ const mockNumericalColumns: VisColumn[] = [
 ];
 
 const mockAxisColumnMappings: AxisColumnMappings = {
-  [AxisRole.X]: mockNumericalColumns[0],
-  [AxisRole.Y]: mockNumericalColumns[1],
+  [AxisRole.X]: [mockNumericalColumns[0]],
+  [AxisRole.Y]: [mockNumericalColumns[1]],
 };
 
 jest.mock('../bar/bucket_options.tsx', () => ({
@@ -120,7 +120,7 @@ describe('BarVisStyleControls', () => {
 
   test('render correct bucket panel for one numerical fields', async () => {
     const mockSingleAxisColumnMappings: AxisColumnMappings = {
-      [AxisRole.X]: mockNumericalColumns[0],
+      [AxisRole.X]: [mockNumericalColumns[0]],
     };
 
     const propsWithNumBucket = {

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.tsx
@@ -35,7 +35,10 @@ export const HistogramVisStyleControls: React.FC<HistogramVisStyleControlsProps>
     onStyleChange({ [key]: value });
   };
 
-  const axes = [axisColumnMappings[AxisRole.X], axisColumnMappings[AxisRole.Y]];
+  const axes = [
+    ...(axisColumnMappings[AxisRole.X] ?? []),
+    ...(axisColumnMappings[AxisRole.Y] ?? []),
+  ];
   const hasNum = axes.some((axis) => axis?.schema === VisFieldType.Numerical);
 
   // bucket types for histogram chart:

--- a/src/plugins/explore/public/saved_explore/transforms.ts
+++ b/src/plugins/explore/public/saved_explore/transforms.ts
@@ -13,6 +13,7 @@ import {
   ChartType,
   StyleOptions,
 } from '../components/visualizations/utils/use_visualization_types';
+import { AxisFieldNameMappings } from '../components/visualizations/types';
 
 export interface ExploreState {
   legacy: LegacyState;
@@ -23,7 +24,7 @@ export interface ExploreState {
 interface VisState {
   chartType?: ChartType;
   styleOptions?: StyleOptions;
-  axesMapping?: Record<string, string>;
+  axesMapping?: AxisFieldNameMappings;
 }
 
 export const saveStateToSavedObject = (


### PR DESCRIPTION
### Description
Fixed time bucket config option not render issue

Root cause:
`axisColumnMappings[AxisRole.X]` now is an array instead of a single axis value, the previous `hasDate` always `false` which makes UI NOT showing the time bucket config.

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
