### PR TITLE
[CVE-2017-16100] Replace dns-sync with Node built-in dns.promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,6 @@
     "core-js": "^3.6.5",
     "deep-freeze-strict": "^1.1.1",
     "del": "^6.1.1",
-    "dns-sync": "npm:@amoo-miki/dns-sync@^0.2.1",
     "dompurify": "^3.4.0",
     "echarts": "^6.0.0",
     "elastic-apm-node": "^4.10.0",

--- a/src/plugins/data_source/server/routes/test_connection.ts
+++ b/src/plugins/data_source/server/routes/test_connection.ts
@@ -83,7 +83,11 @@ export const registerTestConnectionRoute = async (
       // Validate endpoint before attempting connection
       const { endpoint } = dataSourceAttr;
 
-      const validationResult = isValidURL(endpoint, endpointDeniedIPs, endpointAllowlistedSuffixes);
+      const validationResult = await isValidURL(
+        endpoint,
+        endpointDeniedIPs,
+        endpointAllowlistedSuffixes
+      );
       if (!validationResult.valid) {
         // Log detailed error for server-side debugging
         logger.error(`Endpoint validation failed for ${endpoint}: ${validationResult.error}`);

--- a/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.test.ts
@@ -16,18 +16,17 @@ import { DataSourceSavedObjectsClientWrapper } from './data_source_saved_objects
 import { SavedObject } from 'opensearch-dashboards/public';
 import { DATA_SOURCE_TITLE_LENGTH_LIMIT } from '../util/constants';
 
-// Mock dns-sync module to allow DNS resolution in tests
-jest.mock('dns-sync', () => ({
-  resolve: jest.fn((hostname: string) => {
-    // Return a mock IP address for test hostnames
-    if (hostname === 'test.com') {
-      return '1.2.3.4';
-    }
-    if (hostname === '127.0.0.1') {
-      return '127.0.0.1';
-    }
-    return '1.2.3.4'; // Default mock IP for any other hostname
-  }),
+// Mock dns module to avoid real DNS lookups in tests
+jest.mock('dns', () => ({
+  promises: {
+    lookup: jest.fn(async (hostname: string) => {
+      if (hostname === '127.0.0.1') {
+        return { address: '127.0.0.1', family: 4 };
+      }
+      // Default mock IP for any other hostname (e.g., test.com)
+      return { address: '1.2.3.4', family: 4 };
+    }),
+  },
 }));
 
 describe('DataSourceSavedObjectsClientWrapper', () => {

--- a/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.ts
@@ -259,12 +259,12 @@ export class DataSourceSavedObjectsClientWrapper {
     // @ts-expect-error TS2339 TODO(ts-error): fixme
     const { title, endpoint, auth } = attributes;
     this.validateTitle(title);
-    this.validateEndpoint(endpoint);
+    await this.validateEndpoint(endpoint);
     await this.validateAuth(auth);
   }
 
-  private validateEndpoint(endpoint: string) {
-    const validationResult = isValidURL(
+  private async validateEndpoint(endpoint: string) {
+    const validationResult = await isValidURL(
       endpoint,
       this.endpointBlockedIps,
       this.endpointAllowlistedSuffixes

--- a/src/plugins/data_source/server/util/endpoint_validator.test.js
+++ b/src/plugins/data_source/server/util/endpoint_validator.test.js
@@ -31,47 +31,47 @@ describe('endpoint_validator', function () {
     'ff00::/8',
   ];
 
-  it('Url1 that should be blocked should return invalid with error', function () {
-    const result = validator.isValidURL('http://127.0.0.1', ['127.0.0.0/8']);
+  it('Url1 that should be blocked should return invalid with error', async function () {
+    const result = await validator.isValidURL('http://127.0.0.1', ['127.0.0.0/8']);
     expect(result.valid).toEqual(false);
     expect(result.error).toBeDefined();
   });
 
-  it('Url2 that is invalid should return invalid with error', function () {
-    const result = validator.isValidURL('www.test.com', []);
+  it('Url2 that is invalid should return invalid with error', async function () {
+    const result = await validator.isValidURL('www.test.com', []);
     expect(result.valid).toEqual(false);
     expect(result.error).toBeDefined();
   });
 
-  it('Url3 that is invalid should return invalid with error', function () {
-    const result = validator.isValidURL('ftp://www.test.com', []);
+  it('Url3 that is invalid should return invalid with error', async function () {
+    const result = await validator.isValidURL('ftp://www.test.com', []);
     expect(result.valid).toEqual(false);
     expect(result.error).toBeDefined();
   });
 
-  it('Url4 that should be blocked should return invalid with error', function () {
-    const result = validator.isValidURL('http://169.254.169.254/latest/meta-data/', [
+  it('Url4 that should be blocked should return invalid with error', async function () {
+    const result = await validator.isValidURL('http://169.254.169.254/latest/meta-data/', [
       '169.254.0.0/16',
     ]);
     expect(result.valid).toEqual(false);
     expect(result.error).toBeDefined();
   });
 
-  it('Url5 that should not be blocked should return valid', function () {
-    const result = validator.isValidURL('https://www.opensearch.org', ['127.0.0.0/8']);
+  it('Url5 that should not be blocked should return valid', async function () {
+    const result = await validator.isValidURL('https://www.opensearch.org', ['127.0.0.0/8']);
     expect(result.valid).toEqual(true);
     expect(result.error).toBeUndefined();
   });
 
-  it('Url6 that should not be blocked should return valid when null IPs', function () {
-    const result = validator.isValidURL('https://www.opensearch.org');
+  it('Url6 that should not be blocked should return valid when null IPs', async function () {
+    const result = await validator.isValidURL('https://www.opensearch.org');
     expect(result.valid).toEqual(true);
     expect(result.error).toBeUndefined();
   });
 
-  it('allowlisted url should bypass IP validation', function () {
+  it('allowlisted url should bypass IP validation', async function () {
     const allowlistedSuffixes = ['.allowlisted-service.example.com'];
-    const result = validator.isValidURL(
+    const result = await validator.isValidURL(
       'https://test.allowlisted-service.example.com',
       BLOCKED_IP_LIST,
       allowlistedSuffixes
@@ -80,9 +80,9 @@ describe('endpoint_validator', function () {
     expect(result.error).toBeUndefined();
   });
 
-  it('non-allowlisted url should go through normal IP validation', function () {
+  it('non-allowlisted url should go through normal IP validation', async function () {
     const allowlistedSuffixes = ['.allowlisted-service.example.com'];
-    const result = validator.isValidURL(
+    const result = await validator.isValidURL(
       'https://www.opensearch.org',
       BLOCKED_IP_LIST,
       allowlistedSuffixes
@@ -91,9 +91,9 @@ describe('endpoint_validator', function () {
     expect(result.error).toBeUndefined();
   });
 
-  it('url not matching allowlist should be validated normally', function () {
+  it('url not matching allowlist should be validated normally', async function () {
     const allowlistedSuffixes = ['.allowlisted.example.com'];
-    const result = validator.isValidURL(
+    const result = await validator.isValidURL(
       'https://notallowlisted.example.com',
       BLOCKED_IP_LIST,
       allowlistedSuffixes

--- a/src/plugins/data_source/server/util/endpoint_validator.ts
+++ b/src/plugins/data_source/server/util/endpoint_validator.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// @ts-expect-error TS7016 TODO(ts-error): fixme
-import dns from 'dns-sync';
+import { promises as dnsPromises } from 'dns';
 import IPCIDR from 'ip-cidr';
 
 export interface URLValidationResult {
@@ -13,11 +12,11 @@ export interface URLValidationResult {
   userMessage?: string; // Safe message for client response
 }
 
-export function isValidURL(
+export async function isValidURL(
   endpoint: string,
   deniedIPs?: string[],
   allowlistedSuffixes?: string[]
-): URLValidationResult {
+): Promise<URLValidationResult> {
   // Check the format of URL, URL has be in the format as
   // scheme://server/path/resource otherwise an TypeError
   // would be thrown.
@@ -47,7 +46,7 @@ export function isValidURL(
     }
   }
 
-  const ip = getIpAddress(url);
+  const ip = await getIpAddress(url);
   if (!ip) {
     return {
       valid: false,
@@ -76,17 +75,21 @@ export function isValidURL(
 /**
  * Resolve hostname to IP address
  * @param {object} urlObject
- * @returns {string} configuredIP
- * or null if it cannot be resolve
+ * @returns {Promise<string | null>} configuredIP
+ * or null if it cannot be resolved.
  * According to RFC, all IPv6 IP address needs to be in []
  * such as [::1].
  * So if we detect a IPv6 address, we remove brackets.
  */
-function getIpAddress(urlObject: URL) {
+async function getIpAddress(urlObject: URL): Promise<string | null> {
   const hostname = urlObject.hostname;
-  const configuredIP = dns.resolve(hostname);
-  if (configuredIP) {
-    return configuredIP;
+  try {
+    const { address } = await dnsPromises.lookup(hostname);
+    if (address) {
+      return address;
+    }
+  } catch {
+    // Fall through to bracketed-IPv6 handling below.
   }
   if (hostname.startsWith('[') && hostname.endsWith(']')) {
     return hostname.substr(1).slice(0, -1);

--- a/src/plugins/vis_type_timeline/server/series_functions/graphite.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/graphite.js
@@ -51,7 +51,7 @@ export default new Datasource('graphite', {
   help: i18n.translate('timeline.help.functions.graphiteHelpText', {
     defaultMessage: `[experimental] Pull data from graphite. Configure your graphite server in OpenSearch Dashboards's Advanced Settings`,
   }),
-  fn: function graphite(args, tlConfig) {
+  fn: async function graphite(args, tlConfig) {
     const config = args.byName;
 
     const time = {
@@ -72,7 +72,7 @@ export default new Datasource('graphite', {
       );
     }
 
-    if (!isValidConfig(blockedIPs, allowedUrls, configuredUrl)) {
+    if (!(await isValidConfig(blockedIPs, allowedUrls, configuredUrl))) {
       throw new Error(
         i18n.translate('timeline.help.functions.invalidGraphiteConfig', {
           defaultMessage: `The Graphite URL provided by you is invalid. Please update your config from OpenSearch Dashboards' Advanced Settings.`,

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.js
@@ -3,22 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import dns from 'dns-sync';
+import { promises as dnsPromises } from 'dns';
 import IPCIDR from 'ip-cidr';
 /**
  * Resolve hostname to IP address
  * @param {object} urlObject
- * @returns {string} configuredIP
- * or null if it cannot be resolve
+ * @returns {Promise<string | null>} configuredIP
+ * or null if it cannot be resolved.
  * According to RFC, all IPv6 IP address needs to be in []
  * such as [::1]
  * So if we detect a IPv6 address, we remove brackets
  */
-function getIpAddress(urlObject) {
+async function getIpAddress(urlObject) {
   const hostname = urlObject.hostname;
-  const configuredIP = dns.resolve(hostname);
-  if (configuredIP) {
-    return configuredIP;
+  try {
+    const { address } = await dnsPromises.lookup(hostname);
+    if (address) {
+      return address;
+    }
+  } catch {
+    // Fall through to bracketed-IPv6 handling below.
   }
   if (hostname.startsWith('[') && hostname.endsWith(']')) {
     return hostname.substr(1).slice(0, -1);
@@ -33,16 +37,16 @@ function getIpAddress(urlObject) {
  * range of an IP address block
  * @param {string} configuredUrls
  * @param {Array|string} deniedIPs
- * @returns {boolean} true if the configuredUrl is denied
+ * @returns {Promise<boolean>} true if the configuredUrl is denied
  */
-function isDeniedURL(configuredUrl, deniedIPs) {
+async function isDeniedURL(configuredUrl, deniedIPs) {
   let configuredUrlObject;
   try {
     configuredUrlObject = new URL(configuredUrl);
   } catch (err) {
     return true;
   }
-  const ip = exports.getIpAddress(configuredUrlObject);
+  const ip = await exports.getIpAddress(configuredUrlObject);
   if (!ip) {
     return true;
   }
@@ -57,15 +61,18 @@ function isDeniedURL(configuredUrl, deniedIPs) {
  * @param {Array|string} deniedIPs
  * @param {Array|string} allowedUrls
  * @param {string} configuredUrls
- * @returns {boolean} true if the configuredUrl is valid
+ * @returns {Promise<boolean>} true if the configuredUrl is valid
  */
-function isValidConfig(deniedIPs, allowedUrls, configuredUrl) {
+async function isValidConfig(deniedIPs, allowedUrls, configuredUrl) {
   if (deniedIPs.length === 0) {
     if (!allowedUrls.includes(configuredUrl)) return false;
   } else if (allowedUrls.length === 0) {
-    if (exports.isDeniedURL(configuredUrl, deniedIPs)) return false;
+    if (await exports.isDeniedURL(configuredUrl, deniedIPs)) return false;
   } else {
-    if (exports.isDeniedURL(configuredUrl, deniedIPs) || !allowedUrls.includes(configuredUrl))
+    if (
+      (await exports.isDeniedURL(configuredUrl, deniedIPs)) ||
+      !allowedUrls.includes(configuredUrl)
+    )
       return false;
   }
   return true;

--- a/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.test.js
+++ b/src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.test.js
@@ -6,27 +6,27 @@
 import * as helper from './graphite_helper';
 
 describe('graphite_helper', function () {
-  it('valid Url should not be blocked and isDeniedURL should return false', function () {
-    expect(helper.isDeniedURL('https://opensearch.org', ['127.0.0.0/8'])).toEqual(false);
+  it('valid Url should not be blocked and isDeniedURL should return false', async function () {
+    expect(await helper.isDeniedURL('https://opensearch.org', ['127.0.0.0/8'])).toEqual(false);
   });
 
-  it('blocked Url should be blocked and isDeniedURL should return true', function () {
-    expect(helper.isDeniedURL('https://127.0.0.1', ['127.0.0.0/8'])).toEqual(true);
+  it('blocked Url should be blocked and isDeniedURL should return true', async function () {
+    expect(await helper.isDeniedURL('https://127.0.0.1', ['127.0.0.0/8'])).toEqual(true);
   });
 
-  it('invalid Url should be blocked and isDeniedURL should return true', function () {
-    expect(helper.isDeniedURL('www.opensearch.org', ['127.0.0.0/8'])).toEqual(true);
+  it('invalid Url should be blocked and isDeniedURL should return true', async function () {
+    expect(await helper.isDeniedURL('www.opensearch.org', ['127.0.0.0/8'])).toEqual(true);
   });
 
-  it('denylist should be checked if denylist is enabled', function () {
-    jest.spyOn(helper, 'isDeniedURL').mockReturnValueOnce(false);
-    helper.isValidConfig(['127.0.0.0/8'], [], 'https://opensearch.org');
+  it('denylist should be checked if denylist is enabled', async function () {
+    jest.spyOn(helper, 'isDeniedURL').mockResolvedValueOnce(false);
+    await helper.isValidConfig(['127.0.0.0/8'], [], 'https://opensearch.org');
     expect(helper.isDeniedURL).toBeCalled();
   });
 
-  it('denylist should be checked it both allowlist and denylist are enabled', function () {
-    jest.spyOn(helper, 'isDeniedURL').mockReturnValueOnce(false);
-    helper.isValidConfig(
+  it('denylist should be checked it both allowlist and denylist are enabled', async function () {
+    jest.spyOn(helper, 'isDeniedURL').mockResolvedValueOnce(false);
+    await helper.isValidConfig(
       ['127.0.0.0/8'],
       ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite'],
       'https://opensearch.org'
@@ -34,9 +34,9 @@ describe('graphite_helper', function () {
     expect(helper.isDeniedURL).toBeCalled();
   });
 
-  it('with only allowlist, isValidConfig should return false for Url not in the allowlist', function () {
+  it('with only allowlist, isValidConfig should return false for Url not in the allowlist', async function () {
     expect(
-      helper.isValidConfig(
+      await helper.isValidConfig(
         [],
         ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite'],
         'https://opensearch.org'
@@ -44,9 +44,9 @@ describe('graphite_helper', function () {
     ).toEqual(false);
   });
 
-  it('with only allowlist, isValidConfig should return true for Url in the allowlist', function () {
+  it('with only allowlist, isValidConfig should return true for Url in the allowlist', async function () {
     expect(
-      helper.isValidConfig(
+      await helper.isValidConfig(
         [],
         ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite'],
         'https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite'
@@ -54,17 +54,17 @@ describe('graphite_helper', function () {
     ).toEqual(true);
   });
 
-  it('with only denylist, isValidConfig should return false for Url in the denylist', function () {
-    expect(helper.isValidConfig(['127.0.0.0/8'], [], 'https://127.0.0.1')).toEqual(false);
+  it('with only denylist, isValidConfig should return false for Url in the denylist', async function () {
+    expect(await helper.isValidConfig(['127.0.0.0/8'], [], 'https://127.0.0.1')).toEqual(false);
   });
 
-  it('with only denylist, isValidConfig should return true for Url not in the denylist', function () {
-    expect(helper.isValidConfig(['127.0.0.0/8'], [], 'https://opensearch.org')).toEqual(true);
+  it('with only denylist, isValidConfig should return true for Url not in the denylist', async function () {
+    expect(await helper.isValidConfig(['127.0.0.0/8'], [], 'https://opensearch.org')).toEqual(true);
   });
 
-  it('with both denylist and allowlist, isValidConfig should return false if allowlist check fails', function () {
+  it('with both denylist and allowlist, isValidConfig should return false if allowlist check fails', async function () {
     expect(
-      helper.isValidConfig(
+      await helper.isValidConfig(
         ['127.0.0.0/8'],
         ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite'],
         'https://opensearch.org'
@@ -72,9 +72,9 @@ describe('graphite_helper', function () {
     ).toEqual(false);
   });
 
-  it('with both denylist and allowlist, isValidConfig should return false if denylist check fails', function () {
+  it('with both denylist and allowlist, isValidConfig should return false if denylist check fails', async function () {
     expect(
-      helper.isValidConfig(
+      await helper.isValidConfig(
         ['127.0.0.0/8'],
         ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite'],
         'https://127.0.0.1'
@@ -82,9 +82,9 @@ describe('graphite_helper', function () {
     ).toEqual(false);
   });
 
-  it('with conflict denylist and allowlist, isValidConfig should return false if denylist check fails', function () {
+  it('with conflict denylist and allowlist, isValidConfig should return false if denylist check fails', async function () {
     expect(
-      helper.isValidConfig(['127.0.0.0/8'], ['https://127.0.0.1'], 'https://127.0.0.1')
+      await helper.isValidConfig(['127.0.0.0/8'], ['https://127.0.0.1'], 'https://127.0.0.1')
     ).toEqual(false);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9879,7 +9879,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -10334,14 +10334,6 @@ dns-packet@^5.2.2:
   integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
-
-"dns-sync@npm:@amoo-miki/dns-sync@^0.2.1":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@amoo-miki/dns-sync/-/dns-sync-0.2.2.tgz#e713eb46c3ddf6fde37e9453a31a4440ca45a8e7"
-  integrity sha512-GoWRmng1RpnFXrfITbAgfndTjvBgf438jRq1Q5m1Db9HfN9qR/TlRRcl7LXsvq+oS3iUzXyNECzoU62jHPilKw==
-  dependencies:
-    debug "^4"
-    shelljs "~0.8"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -12657,7 +12649,7 @@ glob@^13.0.0:
     minipass "^7.1.2"
     path-scurry "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -13797,7 +13789,7 @@ internal-slot@^1.0.3, internal-slot@^1.0.5:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
-interpret@^1.0.0, interpret@^1.4.0:
+interpret@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
@@ -19226,13 +19218,6 @@ real-require@^0.2.0:
   resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
   integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  dependencies:
-    resolve "^1.1.6"
-
 rechoir@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.1.tgz#9478a96a1ca135b5e88fc027f03ee92d6c645686"
@@ -19604,7 +19589,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.9.0:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.9.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -20333,15 +20318,6 @@ shell-quote@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
-
-shelljs@~0.8:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
-  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

Removes the `dns-sync` dependency (aliased to `@amoo-miki/dns-sync@^0.2.1`) in favor of Node's built-in `dns.promises.lookup`.

The patched fork was added in #7811 to address [CVE-2017-16100](https://nvd.nist.gov/vuln/detail/CVE-2017-16100) (ReDoS in dns-sync's hostname validation regex) because the original `dns-sync` package was unmaintained and the upstream fix ([skoranga/node-dns-sync#10](https://github.com/skoranga/node-dns-sync/pull/10)) was — and remains — unmerged. Now that Node 18+ is the minimum version and `dns.promises` is stable, we can drop the dependency entirely:

- Eliminates CVE-2017-16100 (the vulnerable regex no longer exists in our code path; `getaddrinfo` performs hostname validation natively).
- Removes a personal-account npm package from our dependency tree, eliminating the supply-chain surface area.
- Removes one external dependency without replacement.

## Why the helpers had to become async

Node has no synchronous DNS API — there is no `dns.lookupSync()`, and the platform has deliberately never shipped one because it would block the event loop. The reason `dns-sync` *appeared* synchronous is that it cheated: under the hood it called `shelljs.exec()` to spawn a child Node process, ran an async `dns.lookup` inside that child, printed the address to stdout, and parsed the result back in the parent. That made the call look synchronous to JavaScript, but it actually:

- spawned a full Node process per lookup (~50–200ms overhead)
- blocked the event loop for the entire duration
- depended on `shelljs` and ad-hoc command-line argument formatting

Switching to `dns.promises.lookup(host)` uses the platform's native, non-blocking API — but it returns a `Promise`. That forces the immediate caller to `await` it, which forces *its* caller to be `async`, and so on up the chain until we reach a function that is either already `async` or a place where returning a `Promise` is acceptable. In this codebase the cascade stopped quickly:

- `endpoint_validator.ts::isValidURL` → its only callers (`validateEndpoint` and the `test_connection.ts` route handler) were already in async-friendly territory; we just added one `await`.
- `graphite_helper.js::isValidConfig` → called only from `graphite.js::fn`, which is invoked through a wrapper at `datasource.js:86` that already does `Promise.resolve(originalFunction(...)).then(...)`. Returning a `Promise` from `fn` was already supported.

The trade-off is intentional: a small async-cascade in exchange for losing the per-call subprocess fork, the event-loop block, the CVE, and the personal-account dependency.

## Changes

Two call sites are affected, both server-side only:

- `src/plugins/data_source/server/util/endpoint_validator.ts` — `isValidURL` and its `getIpAddress` helper become async.
- `src/plugins/vis_type_timeline/server/series_functions/helpers/graphite_helper.js` — `getIpAddress`, `isDeniedURL`, and `isValidConfig` become async.

The async cascade is propagated through:
- `data_source_saved_objects_client_wrapper.ts::validateEndpoint` (already invoked from an async path)
- `routes/test_connection.ts` (already an async route handler)
- `series_functions/graphite.js::fn` (its wrapper at `datasource.js` already supports promise-returning functions via `Promise.resolve(originalFunction(...)).then(...)`)

## Behavioral equivalence

`dnsSync.resolve(host)` returned the resolved address string or `null` on failure. `await dns.promises.lookup(host)` returns `{address, family}` on success and throws on failure → caught and converted to `null`. Output is identical for valid hosts, invalid hosts, IPv4, IPv6, and the bracketed-IPv6 fallback path (`[::1]`).

## Issues Resolved

- Removes CVE-2017-16100 entirely (no longer applicable, not just patched).

## Testing

- `yarn test:jest src/plugins/data_source/ src/plugins/vis_type_timeline/` — **64 suites, 405 tests passing** (includes the directly-affected `endpoint_validator.test.js`, `graphite_helper.test.js`, `data_source_saved_objects_client_wrapper.test.ts`, `test_connection.test.ts`).
- `yarn typecheck` — clean.
- `node scripts/eslint` on changed files — clean.

## Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration` (no integration tests cover these helpers)
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff