### PR TITLE
Remove final trailing comma since cypress 13 dont support

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -371,6 +371,7 @@ jobs:
           for i in "${SPEC_ARRAY[@]}"; do
             FORMATTED_SPEC+="cypress/integration/core-opensearch-dashboards/opensearch-dashboards/${i},"
           done
+          FORMATTED_SPEC=${FORMATTED_SPEC%,}
           echo "SPEC=${FORMATTED_SPEC}" >> $GITHUB_ENV
           echo "SPEC=${FORMATTED_SPEC}"
 


### PR DESCRIPTION
### Description

cypress 13 don't support "," at the end of file path: cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/*.js,

So I [deleted "," ](https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml#L49) in FT repo. But didn't do the same in osd

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/25488324732/job/74791480774?pr=11897
Some OSD cypress tests CI groups start to fail, these groups are running FTR tests, related to recent Cypress update.
## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
