### PR TITLE
refactor: drop resize-observer-polyfill for native ResizeObserver

### DIFF
--- a/changelogs/fragments/7007.yml
+++ b/changelogs/fragments/7007.yml
@@ -1,2 +1,0 @@
-refactor:
-- Drop resize-observer-polyfill in favor of the native ResizeObserver ([#7007](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3824))

--- a/changelogs/fragments/7007.yml
+++ b/changelogs/fragments/7007.yml
@@ -1,0 +1,2 @@
+refactor:
+- Drop resize-observer-polyfill in favor of the native ResizeObserver ([#7007](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3824))

--- a/package.json
+++ b/package.json
@@ -553,7 +553,6 @@
     "redux-mock-store": "^1.5.4",
     "regenerate": "^1.4.0",
     "reselect": "^4.0.0",
-    "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^6.1.2",
     "selenium-webdriver": "^4.0.0-alpha.7",
     "simple-git": "^3.36.0",

--- a/src/dev/jest/mocks/resize_observer_mock.js
+++ b/src/dev/jest/mocks/resize_observer_mock.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// jsdom does not implement ResizeObserver. Tests get a no-op stand-in here so
+// component code that constructs a ResizeObserver doesn't throw on import.
+// Tests that need to drive resize callbacks should override this with
+// jest.spyOn(global, 'ResizeObserver').mockImplementation(...) -- see
+// src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.test.ts
+// for an example.
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+module.exports = ResizeObserver;

--- a/src/dev/jest/setup/polyfills.js
+++ b/src/dev/jest/setup/polyfills.js
@@ -51,3 +51,9 @@ global.TextDecoder = TextDecoder;
 // but Jest's Babel transform uses the classic runtime (React.createElement)
 // to avoid issues with jest.mock() factory functions.
 global.React = require('react');
+
+// jsdom does not implement ResizeObserver. Source code that previously imported
+// from `resize-observer-polyfill` now relies on the global; provide a no-op so
+// component constructors don't throw. Individual tests can spy on this global
+// to assert observe/unobserve behavior.
+global.ResizeObserver = require('../mocks/resize_observer_mock');

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -32,7 +32,6 @@ import { InjectedIntl, injectI18n } from '@osd/i18n/react';
 import classNames from 'classnames';
 import { cloneDeep, compact, get, isEqual } from 'lodash';
 import React, { Component } from 'react';
-import ResizeObserver from 'resize-observer-polyfill';
 import {
   OpenSearchDashboardsReactContextValue,
   withOpenSearchDashboards,

--- a/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.test.ts
@@ -31,11 +31,10 @@
 import { ResizeChecker } from './resize_checker';
 import { EventEmitter } from 'events';
 
-// If you want to know why these mocks are created,
-// please check: https://github.com/elastic/kibana/pull/44750
-jest.mock('resize-observer-polyfill');
-import ResizeObserver from 'resize-observer-polyfill';
-
+// Replace the global no-op ResizeObserver (registered in jest setup) with one
+// whose observe()/unobserve() route through the test's MockElement so tests
+// can drive resize notifications via dispatchEvent('resize'). See the
+// upstream rationale at https://github.com/elastic/kibana/pull/44750.
 class MockElement {
   public clientWidth: number;
   public clientHeight: number;
@@ -62,14 +61,23 @@ class MockElement {
   }
 }
 
-(ResizeObserver as any).mockImplementation(function (this: any, callback: any) {
-  this.observe = function (el: MockElement) {
-    el.addEventListener('resize', callback);
-  };
-  this.disconnect = function () {};
-  this.unobserve = function (el: MockElement) {
-    el.removeEventListener('resize', callback);
-  };
+beforeAll(() => {
+  jest
+    .spyOn(global, 'ResizeObserver')
+    .mockImplementation(function (this: ResizeObserver, callback: ResizeObserverCallback) {
+      this.observe = (el: Element) => {
+        ((el as unknown) as MockElement).addEventListener('resize', callback as any);
+      };
+      this.disconnect = () => {};
+      this.unobserve = (el: Element) => {
+        ((el as unknown) as MockElement).removeEventListener('resize', callback as any);
+      };
+      return this;
+    });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 describe('Resize Checker', () => {

--- a/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.ts
@@ -30,7 +30,6 @@
 
 import { EventEmitter } from 'events';
 import { isEqual } from 'lodash';
-import ResizeObserver from 'resize-observer-polyfill';
 
 function getSize(el: HTMLElement): [number, number] {
   return [el.clientWidth, el.clientHeight];

--- a/src/plugins/vis_builder/tsconfig.json
+++ b/src/plugins/vis_builder/tsconfig.json
@@ -57,8 +57,7 @@
       "jest",
       "react",
       "flot",
-      "@testing-library/jest-dom",
-      "resize-observer-polyfill"
+      "@testing-library/jest-dom"
     ]
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -19543,9 +19543,9 @@ reselect@^4.1.7:
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
 resize-observer-polyfill@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@4lolo/resize-observer-polyfill/-/resize-observer-polyfill-1.5.2.tgz#58868fc7224506236b5550d0c68357f0a874b84b"
-  integrity sha512-HY4JYLITsWBOdeqCF/x3q7Aa2PVl/BmfkPv4H/Qzplc4Lrn9cKmWz6jHyAREH9tFuD0xELjJVgX3JaEmdcXu3g==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-alpn@^1.0.0:
   version "1.2.1"


### PR DESCRIPTION
### Description

Removes `resize-observer-polyfill` in favor of the native `ResizeObserver`.

This is a fresh take on #7007 (which has been stale and has merge conflicts). The polyfill was added when OSD targeted older browsers and TypeScript 4.6; neither is the case anymore. ResizeObserver has been baseline in every OSD-supported browser since Safari 13.1 (2020), and TypeScript 6.0 (currently in use here) ships it in `lib.dom.d.ts` so no `@types` package is needed.

### Changes

- `package.json` / `yarn.lock` — remove the direct devDependency on `resize-observer-polyfill`
- `resize_checker.ts` and `search_bar.tsx` — drop the import; both now use the global `ResizeObserver`
- `vis_builder/tsconfig.json` — drop `"resize-observer-polyfill"` from `types` (TS 6 has it natively)
- `resize_checker.test.ts` — replace `jest.mock('resize-observer-polyfill')` with `jest.spyOn(global, 'ResizeObserver').mockImplementation(...)` + `restoreAllMocks()` cleanup
- `src/dev/jest/mocks/resize_observer_mock.js` (new) — shared no-op mock so jsdom-based suites don't throw on construction
- `src/dev/jest/setup/polyfills.js` — register the mock on `global.ResizeObserver`
- `changelogs/fragments/7007.yml` — changelog entry

### Differences from #7007

- **No `@types/resize-observer-browser`.** TS 6 ships the type natively. The original PR added `@types/resize-observer-browser` as a fallback for TS 4.6.
- **Fixes a duplicate-import bug.** The original PR's diff replaced the polyfill import in `search_bar.tsx` with `import { get, isEqual } from 'lodash'`, which would have produced a TS duplicate-identifier error since lodash is already imported on the previous line. This version just removes the line.
- **Shared mock follows the existing repo pattern** in `packages/osd-apm-topology/src/test_utils/jest.setup.ts`, rather than inventing a new convention.

### Yarn lockfile note

`yarn.lock` now resolves `resize-observer-polyfill` to the canonical `1.5.1` from npm rather than the `@4lolo/resize-observer-polyfill@1.5.2` fork that OSD's previous direct devDependency was steering it to. The polyfill itself remains in `node_modules` as a transitive of `@elastic/charts` and `react-use`; nothing in OSD's own source imports it anymore.

### Issues Resolved

Closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3824

### Testing the changes

- `yarn test:jest src/plugins/opensearch_dashboards_utils/public/resize_checker/resize_checker.test.ts` — 9/9 pass
- `yarn test:jest src/plugins/data/public/ui/search_bar/search_bar.test.tsx` — 9/9 pass
- `yarn typecheck` — no new errors (the 2 pre-existing errors on `main` are in unrelated files: `http_server.mocks.ts` and `split_stream.test.ts`)
- ESLint clean on changed files

Manual browser smoke test (resize browser with a saved search open + open a vis that uses ResizeChecker) is recommended before merge but was not done in this drafting environment — flagging for reviewers with a running dev server.

### Browser compatibility

`ResizeObserver` is baseline-supported in every browser OSD targets (Chrome 64+, Edge 79+, Firefox 69+, Safari 13.1+). See [MDN browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#browser_compatibility).

### Changelog
- refactor: drop resize-observer-polyfill for native ResizeObserver ([#3824](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3824))

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (targeted: resize_checker + search_bar suites)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)