### PR TITLE
Fix Discover embed layout height

### DIFF
--- a/src/plugins/data_explorer/public/components/app_container.scss
+++ b/src/plugins/data_explorer/public/components/app_container.scss
@@ -39,6 +39,16 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
   }
 }
 
+// In embed mode the header is hidden, so no offset is needed
+// stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+.hidden-chrome .deLayout {
+  height: 100vh;
+
+  &.dsc--next {
+    height: 100vh;
+  }
+}
+
 .mainPage {
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
### Description

Fixes incorrect Discover layout height in embedded mode.

When Discover is opened with `?embed`, the global header is hidden and `#app-wrapper` receives the `hidden-chrome` class. However, the Discover layout still used header-based height offsets, which caused extra empty space at the bottom of the embedded view.

This PR adds a CSS-only override for `.hidden-chrome .deLayout`, including the `.dsc--next` variant, so the embedded Discover layout uses the full viewport height.

### Issues Resolved

Fixes #11091

## Screenshot

Before:

<img width="1874" height="948" alt="image" src="https://github.com/user-attachments/assets/efe94dfd-2c61-444d-83e4-978ceaad9b06" />

After:

<img width="1896" height="1039" alt="image" src="https://github.com/user-attachments/assets/97963896-59aa-4b6a-8bfc-7d15deffe7cd" />

## Testing the changes

Manually tested locally:

1. Started OpenSearch Dashboards locally.
2. Opened Discover in embedded mode with `?embed`.
3. Confirmed the extra empty space at the bottom is removed.
4. Confirmed normal Discover layout still renders correctly without `?embed`.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff