### PR TITLE
[Variable] Fix explore visualization crashes when dashboard variables change due to multi axis

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_variables/query_panel/variable_query_panel.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/query_panel/variable_query_panel.tsx
@@ -112,6 +112,7 @@ export interface VariableQueryPanelProps {
   onUseTimeFilterChange?: (useTimeFilter: boolean) => void;
   /** Callback to notify parent about preview validation state */
   onPreviewValidationChange?: (isValid: boolean) => void;
+  currentVariableName?: string;
 }
 
 export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
@@ -128,6 +129,7 @@ export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
   useTimeFilter = false,
   onUseTimeFilterChange,
   onPreviewValidationChange,
+  currentVariableName,
 }) => {
   const { services } = useOpenSearchDashboards<DashboardServices>();
   const { data } = services;
@@ -372,7 +374,11 @@ export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
       // Interpolate variable references before executing the preview query
       let queryToExecute = query.trim();
       if (interpolationService && interpolationService.hasVariables(queryToExecute)) {
-        queryToExecute = interpolationService.interpolate(queryToExecute, language);
+        queryToExecute = interpolationService.interpolate(
+          queryToExecute,
+          language,
+          currentVariableName
+        );
       }
 
       const options = await executeQueryForOptions(
@@ -428,6 +434,7 @@ export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
     regex,
     useTimeFilter,
     onPreviewValidationChange,
+    currentVariableName,
   ]);
 
   // Keep ref updated for use in editorDidMount closure

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
@@ -446,6 +446,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
               useTimeFilter={useTimeFilter}
               onUseTimeFilterChange={setUseTimeFilter}
               onPreviewValidationChange={setIsPreviewValid}
+              currentVariableName={name}
             />
           )}
 

--- a/src/plugins/dashboard/public/application/utils/update_saved_dashboard.ts
+++ b/src/plugins/dashboard/public/application/utils/update_saved_dashboard.ts
@@ -50,7 +50,7 @@ export function updateSavedDashboard(
   savedDashboard.variablesJSON =
     appState.variables && appState.variables.length > 0
       ? JSON.stringify({ variables: appState.variables })
-      : undefined;
+      : '';
 
   const timeFrom = savedDashboard.timeRestore
     ? FilterUtils.convertTimeToUTCString(timeFilter.getTime().from)

--- a/src/plugins/dashboard/public/variables/variable_interpolation_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_interpolation_service.test.ts
@@ -217,6 +217,42 @@ describe('VariableInterpolationService', () => {
     });
   });
 
+  describe('interpolate — order constraint', () => {
+    it('should only interpolate variables that come before currentVarName', () => {
+      const svc = new VariableInterpolationService(() => [
+        makeCustomVar({ id: '1', name: 'a', current: ['value-a'] }),
+        makeCustomVar({ id: '2', name: 'b', current: ['value-b'] }),
+        makeCustomVar({ id: '3', name: 'c', current: ['value-c'] }),
+      ]);
+      // When interpolating for variable 'b', only 'a' (before 'b') should be interpolated
+      expect(svc.interpolate('$a and $b and $c', undefined, 'b')).toBe('value-a and $b and $c');
+    });
+
+    it('should interpolate all variables when currentVarName is not provided', () => {
+      const svc = new VariableInterpolationService(() => [
+        makeCustomVar({ id: '1', name: 'a', current: ['value-a'] }),
+        makeCustomVar({ id: '2', name: 'b', current: ['value-b'] }),
+      ]);
+      expect(svc.interpolate('$a and $b')).toBe('value-a and value-b');
+    });
+
+    it('should interpolate nothing when currentVarName is the first variable', () => {
+      const svc = new VariableInterpolationService(() => [
+        makeCustomVar({ id: '1', name: 'a', current: ['value-a'] }),
+        makeCustomVar({ id: '2', name: 'b', current: ['value-b'] }),
+      ]);
+      expect(svc.interpolate('$a and $b', undefined, 'a')).toBe('$a and $b');
+    });
+
+    it('should handle both ${var} and $var syntax with order constraint', () => {
+      const svc = new VariableInterpolationService(() => [
+        makeCustomVar({ id: '1', name: 'a', current: ['value-a'] }),
+        makeCustomVar({ id: '2', name: 'b', current: ['value-b'] }),
+      ]);
+      expect(svc.interpolate('${a} and $b', undefined, 'b')).toBe('value-a and $b');
+    });
+  });
+
   describe('getCurrentValues', () => {
     it('should return name-value map', () => {
       const svc = new VariableInterpolationService(() => [

--- a/src/plugins/dashboard/public/variables/variable_interpolation_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_interpolation_service.ts
@@ -33,9 +33,10 @@ export interface IVariableInterpolationService {
    * Interpolate variables in a query string
    * @param query - The query string with variable placeholders
    * @param language - The query language (e.g., 'PPL', 'PROMQL') for formatting multi-select values
+   * @param currentVarName - Optional name of the current variable (for order constraint)
    * @returns The query string with variables replaced by their values
    */
-  interpolate(query: string, language?: string): string;
+  interpolate(query: string, language?: string, currentVarName?: string): string;
 
   /**
    * Get current variable values as a key-value map
@@ -80,13 +81,21 @@ export class VariableInterpolationService implements IVariableInterpolationServi
    *
    * @param query - The query string with variable placeholders
    * @param language - The query language for formatting multi-select values
+   * @param currentVarName - Optional name of the current variable (for order constraint)
    * @example
    * // Multi-select with PPL:
    * // Query: source=logs | where service IN $service
    * // Variables: [{ name: 'service', current: 'api,web', multi: true }]
    * // Result: source=logs | where service IN ('api', 'web')
+   *
+   * @example
+   * // Partial interpolation with order constraint:
+   * // Query: $a and $b
+   * // Variables: [{ name: 'a', value: 'value-a' }, { name: 'b', value: 'value-b' }]
+   * // currentVarName: 'b'
+   * // Result: value-a and $b (only 'a' is interpolated because it comes before 'b')
    */
-  interpolate(query: string, language?: string): string {
+  interpolate(query: string, language?: string, currentVarName?: string): string {
     if (!query || typeof query !== 'string') {
       return query;
     }
@@ -94,6 +103,15 @@ export class VariableInterpolationService implements IVariableInterpolationServi
     const variables = this.getVariables();
     const valuesMap = new Map(variables.map((v) => [v.name, v]));
     const lang = (language || '').toUpperCase();
+
+    // If currentVarName is provided, only interpolate variables that come before it
+    let precedingVarNames: Set<string> | undefined;
+    if (currentVarName) {
+      const currentVarIndex = variables.findIndex((v) => v.name === currentVarName);
+      if (currentVarIndex !== -1) {
+        precedingVarNames = new Set(variables.slice(0, currentVarIndex).map((v) => v.name));
+      }
+    }
 
     return query.replace(
       VariableInterpolationService.VARIABLE_PATTERN,
@@ -103,6 +121,12 @@ export class VariableInterpolationService implements IVariableInterpolationServi
 
         if (variable === undefined) {
           // Variable not found, keep original placeholder
+          return match;
+        }
+
+        // If we have order constraints and this variable comes after current variable,
+        // keep the placeholder
+        if (precedingVarNames && !precedingVarNames.has(varName)) {
           return match;
         }
 
@@ -244,7 +268,7 @@ export class VariableInterpolationService implements IVariableInterpolationServi
  */
 export const createNoOpVariableInterpolationService = (): IVariableInterpolationService => ({
   hasVariables: () => false,
-  interpolate: (query: string) => query,
+  interpolate: (query: string, _language?: string, _currentVarName?: string) => query,
   getCurrentValues: () => ({}),
   getVariables: () => [],
 });

--- a/src/plugins/dashboard/public/variables/variable_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.test.ts
@@ -328,6 +328,21 @@ describe('VariableService', () => {
       // Variables should still have both items
       expect(service.getVariables()).toHaveLength(2);
     });
+
+    it('should use empty string when removing last variable', async () => {
+      const { service, mockSavedObjectsClient } = createService(
+        [makeCustomVariable()],
+        'dashboard-123'
+      );
+      await service.removeVariable('custom-1');
+
+      expect(service.getVariables()).toHaveLength(0);
+      // Verify that empty string (not undefined) was passed to savedObjectsClient.update
+      // This ensures the variablesJSON field is cleared from the saved object
+      expect(mockSavedObjectsClient.update).toHaveBeenCalledWith('dashboard', 'dashboard-123', {
+        variablesJSON: '',
+      });
+    });
   });
 
   describe('updateVariableValue', () => {

--- a/src/plugins/dashboard/public/variables/variable_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.test.ts
@@ -5,6 +5,7 @@
 
 import { VariableService } from './variable_service';
 import { Variable, VariableType, VariableSortOrder, CustomVariable, QueryVariable } from './types';
+import { VariableInterpolationService } from './variable_interpolation_service';
 
 jest.mock('./variable_query_utils', () => ({
   ...jest.requireActual('./variable_query_utils'),
@@ -387,6 +388,69 @@ describe('VariableService', () => {
       service.updateVariableValue('env-1', ['prod']);
       await new Promise((resolve) => setTimeout(resolve, 10));
       expect(mockExecuteQueryWithType).not.toHaveBeenCalled();
+    });
+
+    it('should only refresh variables that come after the changed variable', async () => {
+      mockExecuteQueryWithType.mockResolvedValue({
+        options: ['host-a', 'host-b'],
+        optionType: 'string',
+      });
+
+      // Variable order: varB (depends on varA), varA, varC (depends on varA)
+      const varB = makeQueryVariable({
+        id: 'var-b',
+        name: 'varB',
+        query: "source=logs | where field = '${varA}' | dedup host | fields host",
+      });
+      const varA = makeCustomVariable({ id: 'var-a', name: 'varA', current: ['value1'] });
+      const varC = makeQueryVariable({
+        id: 'var-c',
+        name: 'varC',
+        query: "source=logs | where field = '${varA}' | dedup service | fields service",
+      });
+      const { service } = createService([varB, varA, varC]);
+
+      mockExecuteQueryWithType.mockClear();
+      service.updateVariableValue('var-a', ['value2']);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // varC should be refreshed (after varA), but varB should not (before varA)
+      expect(mockExecuteQueryWithType).toHaveBeenCalledTimes(1);
+      const calledQuery = mockExecuteQueryWithType.mock.calls[0][1].query;
+      expect(calledQuery).toContain('varA');
+      expect(calledQuery).toContain('service'); // varC's query
+    });
+
+    it('should partially interpolate when some variables are before and some after', async () => {
+      mockExecuteQueryWithType.mockResolvedValue({
+        options: ['result-1', 'result-2'],
+        optionType: 'string',
+      });
+
+      // Variable order: varA, varC (depends on varA and varB), varB
+      const varA = makeCustomVariable({ id: 'var-a', name: 'varA', current: ['value-a'] });
+      const varC = makeQueryVariable({
+        id: 'var-c',
+        name: 'varC',
+        query: "source=logs | where fieldA = '${varA}' AND fieldB = '${varB}'",
+      });
+      const varB = makeCustomVariable({ id: 'var-b', name: 'varB', current: ['value-b'] });
+      const { service } = createService([varA, varC, varB]);
+
+      // Set up interpolation service
+      const interpolationService = new VariableInterpolationService(() =>
+        service.getVariablesWithState()
+      );
+      service.setInterpolationService(interpolationService);
+
+      mockExecuteQueryWithType.mockClear();
+      await service.refreshVariableOptions('var-c');
+
+      // varC should be refreshed with varA interpolated but varB kept as placeholder
+      expect(mockExecuteQueryWithType).toHaveBeenCalledTimes(1);
+      const calledQuery = mockExecuteQueryWithType.mock.calls[0][1].query;
+      expect(calledQuery).toContain('value-a'); // varA interpolated
+      expect(calledQuery).toContain('${varB}'); // varB kept as placeholder
     });
   });
 

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -530,7 +530,9 @@ export class VariableService {
     }
 
     try {
-      const variablesJSON = variables.length > 0 ? JSON.stringify({ variables }) : undefined;
+      // Use empty string to clear variablesJSON when all variables are deleted
+      // Using undefined would not remove the field from saved object
+      const variablesJSON = variables.length > 0 ? JSON.stringify({ variables }) : '';
       await this.savedObjectsClient.update('dashboard', this.dashboardId, {
         variablesJSON,
       });

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -482,8 +482,14 @@ export class VariableService {
 
   private refreshDependentVariables(changedVarName: string): void {
     const variables = this.getVariables();
+    const changedVarIndex = variables.findIndex((v) => v.name === changedVarName);
+    if (changedVarIndex === -1) return;
+
     const pattern = new RegExp(`\\$\\{${changedVarName}\\}|\\$${changedVarName}\\b`);
-    for (const v of variables) {
+    // Only refresh variables that come AFTER the changed variable
+    // Variables before the changed variable cannot reference it due to order constraints
+    for (let i = changedVarIndex + 1; i < variables.length; i++) {
+      const v = variables[i];
       if (v.type === VariableType.Query) {
         const qv = v as QueryVariable;
         if (pattern.test(qv.query)) {
@@ -502,7 +508,8 @@ export class VariableService {
     }
     let query = variable.query;
     if (this.interpolationService && this.interpolationService.hasVariables(query)) {
-      query = this.interpolationService.interpolate(query, variable.language);
+      // Enforce order constraint: only interpolate variables that appear before current variable
+      query = this.interpolationService.interpolate(query, variable.language, variable.name);
     }
     return executeQueryForOptionsWithType(
       this.dataPlugin,

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.test.ts
@@ -946,5 +946,80 @@ describe('VisualizationRegistry', () => {
         [AxisRole.Y]: ['field1', 'field4', 'field5'],
       });
     });
+
+    it('should try multiple rules and return first successful match', () => {
+      // Rule 1 requires x, y, color (needs 1 categorical + 2 numerical)
+      const rule1 = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Categorical },
+          [AxisRole.Y]: { type: VisFieldType.Numerical },
+          [AxisRole.COLOR]: { type: VisFieldType.Numerical },
+        },
+      ]);
+      // Rule 2 requires only x, y (needs 1 categorical + 1 numerical)
+      const rule2 = makeRule(90, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Categorical },
+          [AxisRole.Y]: { type: VisFieldType.Numerical },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('bar', 'Bar', [rule1, rule2]));
+
+      // Saved mapping has 3 roles, but only 1 numerical column available
+      // Rule 1 will fail, Rule 2 should succeed
+      const allColumns = [
+        col('category', VisFieldType.Categorical, 1),
+        col('value', VisFieldType.Numerical, 2),
+      ];
+      const result = registry.reuseAxesMapping(
+        'bar',
+        {
+          [AxisRole.X]: 'old_category',
+          [AxisRole.Y]: 'old_value1',
+          [AxisRole.COLOR]: 'old_value2',
+        },
+        allColumns
+      );
+      // Should fail since savedAxesMapping has 3 roles but no rule matches 3 roles
+      expect(result).toBeUndefined();
+    });
+
+    it('should fallback to simpler rule when complex rule cannot be filled', () => {
+      // Register a chart type with the same roles but different column requirements
+      const rule1 = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Categorical },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      const rule2 = makeRule(90, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Categorical },
+          [AxisRole.Y]: { type: VisFieldType.Numerical }, // Non-multi, only needs 1
+        },
+      ]);
+      registry.registerVisualization(makeVisType('bar', 'Bar', [rule1, rule2]));
+
+      // Saved has multi-axis Y, but only 1 numerical column available
+      const allColumns = [
+        col('category', VisFieldType.Categorical, 1),
+        col('value', VisFieldType.Numerical, 2),
+      ];
+      const result = registry.reuseAxesMapping(
+        'bar',
+        {
+          [AxisRole.X]: 'old_category',
+          [AxisRole.Y]: ['old_value1', 'old_value2'], // Multi-axis
+        },
+        allColumns
+      );
+      // Rule 1 (multi) needs at least 1 field but both are missing, can use available "value"
+      // Rule 2 (single) also matches but Y is array which doesn't match
+      // Since both old fields are gone and we have 1 numerical column, Rule 1 should succeed
+      expect(result).toEqual({
+        [AxisRole.X]: 'category',
+        [AxisRole.Y]: ['value'],
+      });
+    });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.test.ts
@@ -801,5 +801,150 @@ describe('VisualizationRegistry', () => {
       );
       expect(result).toEqual({ [AxisRole.X]: 'new_date', [AxisRole.Y]: 'new_num' });
     });
+
+    it('should handle multi-axis with array values (all fields survive)', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const allColumns = [
+        col('timestamp', VisFieldType.Date, 1),
+        col('max(field)', VisFieldType.Numerical, 2),
+        col('count', VisFieldType.Numerical, 3),
+      ];
+      const result = registry.reuseAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: ['max(field)', 'count'] },
+        allColumns
+      );
+      expect(result).toEqual({
+        [AxisRole.X]: 'timestamp',
+        [AxisRole.Y]: ['max(field)', 'count'],
+      });
+    });
+
+    it('should handle multi-axis with partial field survival (variable change scenario)', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      // Variable changed from max to min: "max(field)" is gone, "count" survives
+      const allColumns = [
+        col('timestamp', VisFieldType.Date, 1),
+        col('min(field)', VisFieldType.Numerical, 2),
+        col('count', VisFieldType.Numerical, 3),
+      ];
+      const result = registry.reuseAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: ['max(field)', 'count'] },
+        allColumns
+      );
+      expect(result).toEqual({
+        [AxisRole.X]: 'timestamp',
+        [AxisRole.Y]: ['count', 'min(field)'],
+      });
+    });
+
+    it('should handle multi-axis with all fields missing', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      // All Y fields are gone, but new numerical columns are available
+      const allColumns = [
+        col('timestamp', VisFieldType.Date, 1),
+        col('new_field1', VisFieldType.Numerical, 2),
+        col('new_field2', VisFieldType.Numerical, 3),
+      ];
+      const result = registry.reuseAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: ['max(field)', 'count'] },
+        allColumns
+      );
+      expect(result).toEqual({
+        [AxisRole.X]: 'timestamp',
+        [AxisRole.Y]: ['new_field1', 'new_field2'],
+      });
+    });
+
+    it('should return undefined for multi-axis when no fields available', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      // No numerical columns available
+      const allColumns = [col('timestamp', VisFieldType.Date, 1)];
+      const result = registry.reuseAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: ['max(field)', 'count'] },
+        allColumns
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle empty saved mapping value (undefined/null)', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.X]: { type: VisFieldType.Date },
+          [AxisRole.Y]: { type: VisFieldType.Numerical },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('line', 'Line', [rule]));
+
+      const allColumns = [
+        col('timestamp', VisFieldType.Date, 1),
+        col('value', VisFieldType.Numerical, 2),
+      ];
+      const result = registry.reuseAxesMapping(
+        'line',
+        { [AxisRole.X]: 'timestamp', [AxisRole.Y]: undefined as any },
+        allColumns
+      );
+      expect(result).toEqual({
+        [AxisRole.X]: 'timestamp',
+        [AxisRole.Y]: 'value',
+      });
+    });
+
+    it('should preserve array structure for multi-axis even with partial survival', () => {
+      const rule = makeRule(100, [
+        {
+          [AxisRole.Y]: { type: VisFieldType.Numerical, multi: true },
+        },
+      ]);
+      registry.registerVisualization(makeVisType('metric', 'Metric', [rule]));
+
+      // "field1" survives, "field2" and "field3" are gone
+      const allColumns = [
+        col('field1', VisFieldType.Numerical, 1),
+        col('field4', VisFieldType.Numerical, 2),
+        col('field5', VisFieldType.Numerical, 3),
+      ];
+      const result = registry.reuseAxesMapping(
+        'metric',
+        { [AxisRole.Y]: ['field1', 'field2', 'field3'] },
+        allColumns
+      );
+      // Should return array structure with surviving field + new fields
+      expect(result).toEqual({
+        [AxisRole.Y]: ['field1', 'field4', 'field5'],
+      });
+    });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.ts
@@ -179,9 +179,9 @@ export class VisualizationRegistry {
    */
   public reuseAxesMapping(
     chartType: string,
-    savedAxesMapping: Record<string, string>,
+    savedAxesMapping: AxisFieldNameMappings,
     allColumns: VisColumn[]
-  ): Record<string, string> | undefined {
+  ): AxisFieldNameMappings | undefined {
     const rules = this.getVisualization(chartType)?.getRules();
     if (!rules) return undefined;
 
@@ -189,44 +189,94 @@ export class VisualizationRegistry {
     const savedRoles = Object.keys(savedAxesMapping);
     const savedRoleSet = new Set(savedRoles);
 
-    // Find the best rule: keys must match, and surviving fields' types must agree
-    type TypeMapping = Record<string, { type: VisFieldType }>;
-    let matched: TypeMapping | undefined;
+    const toFieldArray = (value: string | string[] | undefined): string[] => {
+      if (!value) return [];
+      return Array.isArray(value) ? value : [value];
+    };
+
+    // Helper: check if field exists and has expected type
+    const isValidField = (fieldName: string, expectedType?: VisFieldType): boolean => {
+      const fieldType = columnTypeByName.get(fieldName);
+      return !!fieldType && fieldType === expectedType;
+    };
+
+    // Find matching rule: Roles must align and existing fields must have compatible types
+    let matchedRule: AxisTypeMapping | undefined;
     for (const rule of rules) {
-      matched = rule.mappings.find((m) => {
-        const keys = Object.keys(m);
-        if (keys.length !== savedRoles.length || !keys.every((k) => savedRoleSet.has(k))) {
+      matchedRule = rule.mappings.find((ruleMapping) => {
+        const mappingKeys = Object.keys(ruleMapping);
+        if (
+          mappingKeys.length !== savedRoles.length ||
+          !mappingKeys.every((k) => savedRoleSet.has(k))
+        ) {
           return false;
         }
-        return savedRoles.every((role) => {
-          const fieldType = columnTypeByName.get(savedAxesMapping[role]);
-          return !fieldType || fieldType === (m as TypeMapping)[role].type;
-        });
-      }) as TypeMapping | undefined;
-      if (matched) break;
-    }
-    if (!matched) return undefined;
 
-    // Lock surviving fields first, then fill missing roles with same-type replacements
-    const result: Record<string, string> = {};
+        return savedRoles.every((role) => {
+          const savedFieldNames = toFieldArray(savedAxesMapping[role]);
+          const expectedType = (ruleMapping as AxisTypeMapping)[role as AxisRole]?.type;
+          return savedFieldNames.every((savedFieldName) => {
+            const savedFieldType = columnTypeByName.get(savedFieldName);
+            return !savedFieldType || savedFieldType === expectedType;
+          });
+        });
+      }) as AxisTypeMapping | undefined;
+
+      if (matchedRule) break;
+    }
+    if (!matchedRule) return undefined;
+
+    // Preserve surviving fields and identify missing roles
+    const result: AxisFieldNameMappings = {};
     const used = new Set<string>();
     const missingRoles: string[] = [];
 
     for (const role of savedRoles) {
-      const fieldType = columnTypeByName.get(savedAxesMapping[role]);
-      if (fieldType && fieldType === matched[role].type) {
-        result[role] = savedAxesMapping[role];
-        used.add(savedAxesMapping[role]);
+      const savedValue = savedAxesMapping[role];
+      const fieldNames = toFieldArray(savedValue);
+      const expectedType = matchedRule[role as AxisRole]?.type;
+      const survivingFields = fieldNames.filter((name) => isValidField(name, expectedType));
+
+      if (survivingFields.length === 0) {
+        // All fields lost or empty
+        missingRoles.push(role);
+      } else if (survivingFields.length === fieldNames.length) {
+        // All fields survived - preserve original structure
+        result[role] = savedValue;
+        survivingFields.forEach((f) => used.add(f));
       } else {
+        // Partial survival - preserve structure but mark as incomplete
+        result[role] = Array.isArray(savedValue) ? survivingFields : survivingFields[0];
+        survivingFields.forEach((f) => used.add(f));
         missingRoles.push(role);
       }
     }
 
+    // Fill missing roles with unused columns of matching type
     for (const role of missingRoles) {
-      const col = allColumns.find((c) => c.schema === matched![role].type && !used.has(c.name));
-      if (!col) return undefined;
-      result[role] = col.name;
-      used.add(col.name);
+      const axisRole = role as AxisRole;
+      const ruleConfig = matchedRule[axisRole];
+      if (!ruleConfig) continue;
+
+      const { type: expectedType, multi: isMulti } = ruleConfig;
+      const existingFields = toFieldArray(result[role]);
+
+      const availableColumns = allColumns.filter(
+        (c) => c.schema === expectedType && !used.has(c.name)
+      );
+
+      if (isMulti) {
+        // Multi-axis: combine existing + all available columns
+        if (existingFields.length === 0 && availableColumns.length === 0) return undefined;
+        result[role] = [...existingFields, ...availableColumns.map((c) => c.name)];
+        availableColumns.forEach((c) => used.add(c.name));
+      } else {
+        // Single-axis: use existing field or find one replacement
+        if (existingFields.length > 0) continue;
+        if (availableColumns.length === 0) return undefined;
+        result[role] = availableColumns[0].name;
+        used.add(availableColumns[0].name);
+      }
     }
 
     return result;

--- a/src/plugins/explore/public/components/visualizations/visualization_registry.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_registry.ts
@@ -200,10 +200,10 @@ export class VisualizationRegistry {
       return !!fieldType && fieldType === expectedType;
     };
 
-    // Find matching rule: Roles must align and existing fields must have compatible types
-    let matchedRule: AxisTypeMapping | undefined;
+    // Find all matching rules: Roles must align and existing fields must have compatible types
+    const matchedRules: AxisTypeMapping[] = [];
     for (const rule of rules) {
-      matchedRule = rule.mappings.find((ruleMapping) => {
+      const candidateRules = rule.mappings.filter((ruleMapping) => {
         const mappingKeys = Object.keys(ruleMapping);
         if (
           mappingKeys.length !== savedRoles.length ||
@@ -220,66 +220,82 @@ export class VisualizationRegistry {
             return !savedFieldType || savedFieldType === expectedType;
           });
         });
-      }) as AxisTypeMapping | undefined;
+      }) as AxisTypeMapping[];
 
-      if (matchedRule) break;
+      matchedRules.push(...candidateRules);
     }
-    if (!matchedRule) return undefined;
+    if (matchedRules.length === 0) return undefined;
 
-    // Preserve surviving fields and identify missing roles
-    const result: AxisFieldNameMappings = {};
-    const used = new Set<string>();
-    const missingRoles: string[] = [];
+    // Try each matched rule until we find one that produces a complete result
+    for (const matchedRule of matchedRules) {
+      // Preserve surviving fields and identify missing roles
+      const result: AxisFieldNameMappings = {};
+      const used = new Set<string>();
+      const missingRoles: string[] = [];
 
-    for (const role of savedRoles) {
-      const savedValue = savedAxesMapping[role];
-      const fieldNames = toFieldArray(savedValue);
-      const expectedType = matchedRule[role as AxisRole]?.type;
-      const survivingFields = fieldNames.filter((name) => isValidField(name, expectedType));
+      for (const role of savedRoles) {
+        const savedValue = savedAxesMapping[role];
+        const fieldNames = toFieldArray(savedValue);
+        const expectedType = matchedRule[role as AxisRole]?.type;
+        const survivingFields = fieldNames.filter((name) => isValidField(name, expectedType));
 
-      if (survivingFields.length === 0) {
-        // All fields lost or empty
-        missingRoles.push(role);
-      } else if (survivingFields.length === fieldNames.length) {
-        // All fields survived - preserve original structure
-        result[role] = savedValue;
-        survivingFields.forEach((f) => used.add(f));
-      } else {
-        // Partial survival - preserve structure but mark as incomplete
-        result[role] = Array.isArray(savedValue) ? survivingFields : survivingFields[0];
-        survivingFields.forEach((f) => used.add(f));
-        missingRoles.push(role);
+        if (survivingFields.length === 0) {
+          // All fields lost or empty
+          missingRoles.push(role);
+        } else if (survivingFields.length === fieldNames.length) {
+          // All fields survived - preserve original structure
+          result[role] = savedValue;
+          survivingFields.forEach((f) => used.add(f));
+        } else {
+          // Partial survival - preserve structure but mark as incomplete
+          result[role] = Array.isArray(savedValue) ? survivingFields : survivingFields[0];
+          survivingFields.forEach((f) => used.add(f));
+          missingRoles.push(role);
+        }
+      }
+
+      // Try to fill missing roles with unused columns of matching type
+      let failed = false;
+      for (const role of missingRoles) {
+        const axisRole = role as AxisRole;
+        const ruleConfig = matchedRule[axisRole];
+        if (!ruleConfig) continue;
+
+        const { type: expectedType, multi: isMulti } = ruleConfig;
+        const existingFields = toFieldArray(result[role]);
+
+        const availableColumns = allColumns.filter(
+          (c) => c.schema === expectedType && !used.has(c.name)
+        );
+
+        if (isMulti) {
+          // Multi-axis: combine existing + all available columns
+          if (existingFields.length === 0 && availableColumns.length === 0) {
+            failed = true;
+            break;
+          }
+          result[role] = [...existingFields, ...availableColumns.map((c) => c.name)];
+          availableColumns.forEach((c) => used.add(c.name));
+        } else {
+          // Single-axis: use existing field or find one replacement
+          if (existingFields.length > 0) continue;
+          if (availableColumns.length === 0) {
+            failed = true;
+            break;
+          }
+          result[role] = availableColumns[0].name;
+          used.add(availableColumns[0].name);
+        }
+      }
+
+      // If this rule worked, return the result
+      if (!failed) {
+        return result;
       }
     }
 
-    // Fill missing roles with unused columns of matching type
-    for (const role of missingRoles) {
-      const axisRole = role as AxisRole;
-      const ruleConfig = matchedRule[axisRole];
-      if (!ruleConfig) continue;
-
-      const { type: expectedType, multi: isMulti } = ruleConfig;
-      const existingFields = toFieldArray(result[role]);
-
-      const availableColumns = allColumns.filter(
-        (c) => c.schema === expectedType && !used.has(c.name)
-      );
-
-      if (isMulti) {
-        // Multi-axis: combine existing + all available columns
-        if (existingFields.length === 0 && availableColumns.length === 0) return undefined;
-        result[role] = [...existingFields, ...availableColumns.map((c) => c.name)];
-        availableColumns.forEach((c) => used.add(c.name));
-      } else {
-        // Single-axis: use existing field or find one replacement
-        if (existingFields.length > 0) continue;
-        if (availableColumns.length === 0) return undefined;
-        result[role] = availableColumns[0].name;
-        used.add(availableColumns[0].name);
-      }
-    }
-
-    return result;
+    // None of the matched rules could produce a complete result
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
### Description

 - Fixed explore visualization crashes when dashboard variables change (e.g., switching function from max to min)
 - Fixed reuseAxesMapping method to properly handle multi-axis fields with array values
 - Fixed when there is only one variable on the dashboard, deleting the variable and refreshing the page will cause the variable to reappear without actually being deleted.
 - Fixed: Variable order constraints are enforced everywhere

### Issues Resolved
When dashboard variables change and cause column names to change (e.g., ${function} changes from max to min, resulting in column name change from max(field) to min(field)), explore visualizations would crash with the error:
Cannot load saved visualization with id xxx at explore_embeddable.tsx:520

Root cause:
The reuseAxesMapping method in VisualizationRegistry incorrectly treated array values as map keys when checking field types:

// Before (broken for multi-axis arrays):
const fieldType = columnTypeByName.get(savedAxesMapping[role]);
// When savedAxesMapping[role] = ["max(field)", "count"], this would fail

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
