### PR TITLE
fix: saved explore not load due to DatasetProvider race condition

### DIFF
--- a/src/plugins/explore/public/application/context/dataset_context/dataset_context.tsx
+++ b/src/plugins/explore/public/application/context/dataset_context/dataset_context.tsx
@@ -43,6 +43,9 @@ export const DatasetProvider: React.FC<{ children: React.ReactNode }> = ({ child
 
   useEffect(() => {
     let isMounted = true;
+    // Reset the fetching guard when dependencies change so the new fetch isn't
+    // blocked by a stale in-flight request from the previous effect invocation.
+    isFetchingRef.current = false;
 
     const fetchDataset = async () => {
       // Prevent parallel executions


### PR DESCRIPTION
When opening a saved explore via URL, the DatasetProvider could get stuck with dataset=undefined, showing the "Select data" empty state instead of query results.

### Issue screenshot: results not load, time picker not show, ui is in a crappy state
<img width="1460" height="991" alt="Screenshot 2026-05-12 at 12 50 43" src="https://github.com/user-attachments/assets/030c4be1-ff69-4abf-b1b5-721b2a0db6d9" />


### Root cause:
The DatasetProvider uses isFetchingRef to prevent parallel fetches. When loadReduxState resolves an initial dataset and the effect starts fetching, useInitPage then dispatches setQueryState with the saved explore's dataset. This triggers the useEffect cleanup (setting isMounted=false for the old closure) and a new effect invocation. However, isFetchingRef.current is still true from the previous fetch that hasn't completed yet. The new effect returns early, and when the old fetch completes it discards its result (isMounted=false). This leaves dataset permanently undefined.

### Timeline of the race:
1. Effect fires with initial dataset → isFetchingRef=true, starts fetch
2. datasetFromState changes → cleanup sets isMounted=false
3. New effect fires → isFetchingRef is still true → returns early
4. Old fetch completes → isMounted=false → result discarded
5. Dataset context stuck at undefined

### Fix:
Reset `isFetchingRef.current=false` at the top of each effect invocation. This ensures a new fetch can proceed when dependencies change, while still preventing parallel fetches within the same effect invocation. The isMounted pattern already correctly discards stale results from previous closures.



<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
