### PR TITLE
fix(osd-optimizer): fix build problems for tailwind v4

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -22,6 +22,7 @@ This guide applies to all development within the OpenSearch Dashboards project a
   - [General](#general)
   - [HTML](#html)
   - [SASS files](#sass-files)
+  - [Tailwind CSS](#tailwind-css)
   - [TypeScript/JavaScript](#typescriptjavascript)
   - [React](#react)
   - [API endpoints](#api-endpoints)
@@ -626,6 +627,47 @@ export const Component = () => {
 ```
 
 Do not use the underscore `_` SASS file naming pattern when importing directly into a javascript file.
+
+### Tailwind CSS
+
+OpenSearch Dashboards supports [Tailwind CSS v4](https://tailwindcss.com/) inside `.scss` files. The `@osd/optimizer` build pipes SCSS through `sass-loader` → `@tailwindcss/postcss` automatically — no per-plugin Tailwind config is required.
+
+To opt in, import Tailwind into the **top** of an SCSS entry file with a plugin-scoped prefix:
+
+```scss
+// my_plugin/public/styles/my_plugin.scss
+@import "tailwindcss/theme" prefix(plg);
+@import "tailwindcss/utilities" prefix(plg);
+
+@source "../components";
+@source "../views";
+```
+
+Then write utilities with the prefix you chose: `<div className="plg:flex plg:gap-2 plg:text-sm" />`. Use a short prefix (matching your plugin's three-letter SASS prefix) to avoid colliding with other plugins, since utilities are emitted to a single global stylesheet.
+
+#### Conventions
+
+- **Always use a prefix.** Unprefixed utilities collide across plugins and with EUI/OUI class names.
+- **Import the modular entrypoints**, not `@import "tailwindcss"`. The full entry wraps everything in `@layer base/components/utilities`, which OSD then has to strip — see [limitations](#limitations) below.
+- **`@source` directives** tell Tailwind v4 where to scan for utility classes. Point them at directories containing your `.tsx`/`.html` files.
+- **Theme tokens** (custom colors, spacing) go in an `@theme inline { ... }` block in your SCSS entry.
+
+#### Limitations
+
+Tailwind in OSD is utilities-only — several pieces of the default Tailwind experience are intentionally disabled. Be aware of:
+
+1. **No Preflight (CSS reset).** The `tailwindcss/utilities` and `tailwindcss/theme` entrypoints don't include preflight, and importing `tailwindcss/preflight` would fight EUI's own reset. Consequences:
+   - `border-2` won't render a border in code copy-pasted from Tailwind docs without first setting `border-style: solid`. Tailwind v4 defaults `border` to `0 solid` and relies on preflight to fix it.
+   - List, heading, and form-element resets you'd expect from a fresh Tailwind project are not applied. Lean on EUI components or explicit utilities (`list-disc`, `font-bold`).
+2. **No components layer.** Tailwind plugins that register component-layer rules (`addComponents`) won't have a declared `@layer components` to live in, so their output collides with utilities by source order. Prefer utility-only Tailwind plugins.
+3. **Utilities are unlayered.** The modular entrypoints emit utilities without an `@layer utilities` wrapper, which is what lets them win against unlayered EUI styles. Side effect: variant ties (e.g., `:hover` vs `[data-state=active]`) are decided by emit order, not layer precedence. Resolve conflicts by (in order) plain CSS, an explicit `!important` variant, or scoping the loser.
+4. **No layer-ordering declaration.** The `@layer theme, base, components, utilities;` line that the full `tailwindcss` entry emits is absent. Mixing your own `@layer` rules with Tailwind output may produce unexpected precedence — prefer unlayered CSS.
+5. **Re-scans only on SCSS change.** Tailwind v4's `@source` scanning runs when the SCSS entry rebuilds. Adding a new `.tsx` file with arbitrary-value utilities like `plg:text-[48px]` won't emit them until the SCSS changes. Workarounds: `touch` the SCSS file, restart the dev server, or prefer theme-token utilities (`plg:text-4xl`) which are always emitted.
+6. **Global stylesheet, not scoped.** Every plugin's compiled utilities ship in a global bundle. Always prefix; avoid generic class names in adjacent custom CSS.
+
+#### Build details
+
+The pipeline lives in `packages/osd-optimizer`. SCSS is compiled with sass-embedded, then passed through `@tailwindcss/postcss` and a small `postcss.config.js` plugin that strips Tailwind's dependency messages.
 
 ### TypeScript/JavaScript
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -639,16 +639,23 @@ To opt in, import Tailwind into the **top** of an SCSS entry file with a plugin-
 @import "tailwindcss/theme" prefix(plg);
 @import "tailwindcss/utilities" prefix(plg);
 
+// Optional: scope preflight (CSS reset) to a plugin-specific body class with
+// [CSS @scope](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope) so it
+// doesn't leak into OSD/EUI surfaces. Toggle the body class on app mount/unmount.
+@scope (body.plg-app-active) {
+  @import "tailwindcss/preflight";
+}
+
 @source "../components";
 @source "../views";
 ```
 
-Then write utilities with the prefix you chose: `<div className="plg:flex plg:gap-2 plg:text-sm" />`. Use a short prefix (matching your plugin's three-letter SASS prefix) to avoid colliding with other plugins, since utilities are emitted to a single global stylesheet.
+Then write utilities with the prefix you chose: `<div className="plg:flex plg:gap-2 plg:text-sm" />`. Use a short prefix to avoid colliding with other plugins, since utilities are emitted to a single global stylesheet.
 
 #### Conventions
 
-- **Always use a prefix.** Unprefixed utilities collide across plugins and with EUI/OUI class names.
-- **Import the modular entrypoints**, not `@import "tailwindcss"`. The full entry wraps everything in `@layer base/components/utilities`, which OSD then has to strip — see [limitations](#limitations) below.
+- **Always use a prefix, unique per plugin.** Utilities ship in a single global stylesheet, so unprefixed names collide with OUI. Prefix uniqueness matters because Tailwind namespaces `@theme` tokens by prefix, and two plugins sharing `plg` would write to the same `--plg-color-primary`.
+- **Import the modular entrypoints**, not `@import "tailwindcss"`. The full entry wraps everything in `@layer base/components/utilities`, which loses specificity to OSD's unlayered EUI styles; the modular imports emit unlayered utilities directly.
 - **`@source` directives** tell Tailwind v4 where to scan for utility classes. Point them at directories containing your `.tsx`/`.html` files.
 - **Theme tokens** (custom colors, spacing) go in an `@theme inline { ... }` block in your SCSS entry.
 
@@ -656,18 +663,13 @@ Then write utilities with the prefix you chose: `<div className="plg:flex plg:ga
 
 Tailwind in OSD is utilities-only — several pieces of the default Tailwind experience are intentionally disabled. Be aware of:
 
-1. **No Preflight (CSS reset).** The `tailwindcss/utilities` and `tailwindcss/theme` entrypoints don't include preflight, and importing `tailwindcss/preflight` would fight EUI's own reset. Consequences:
-   - `border-2` won't render a border in code copy-pasted from Tailwind docs without first setting `border-style: solid`. Tailwind v4 defaults `border` to `0 solid` and relies on preflight to fix it.
-   - List, heading, and form-element resets you'd expect from a fresh Tailwind project are not applied. Lean on EUI components or explicit utilities (`list-disc`, `font-bold`).
-2. **No components layer.** Tailwind plugins that register component-layer rules (`addComponents`) won't have a declared `@layer components` to live in, so their output collides with utilities by source order. Prefer utility-only Tailwind plugins.
-3. **Utilities are unlayered.** The modular entrypoints emit utilities without an `@layer utilities` wrapper, which is what lets them win against unlayered EUI styles. Side effect: variant ties (e.g., `:hover` vs `[data-state=active]`) are decided by emit order, not layer precedence. Resolve conflicts by (in order) plain CSS, an explicit `!important` variant, or scoping the loser.
-4. **No layer-ordering declaration.** The `@layer theme, base, components, utilities;` line that the full `tailwindcss` entry emits is absent. Mixing your own `@layer` rules with Tailwind output may produce unexpected precedence — prefer unlayered CSS.
-5. **Re-scans only on SCSS change.** Tailwind v4's `@source` scanning runs when the SCSS entry rebuilds. Adding a new `.tsx` file with arbitrary-value utilities like `plg:text-[48px]` won't emit them until the SCSS changes. Workarounds: `touch` the SCSS file, restart the dev server, or prefer theme-token utilities (`plg:text-4xl`) which are always emitted.
-6. **Global stylesheet, not scoped.** Every plugin's compiled utilities ship in a global bundle. Always prefix; avoid generic class names in adjacent custom CSS.
+1. **Preflight (CSS reset) only partially overrides OSD styles.** `@scope` contains preflight to your surface without raising specificity, so most typed selector rules (e.g. `h1, h2, ... { font-size: inherit }`) win against the browser defaults and give you the reset. But preflight's universal-selector rules like `*, ::before, ::after { border: 0 solid }` stay at (0,0,0) and lose to OSD's typed rules (e.g., `legacy_light_theme.css` has `input { border: 1px solid }` at (0,0,1)). Where you actually want preflight's reset to land, add class-prefixed overrides like `body.plg-app-active input { border-width: 0 }` (0,1,1) to beat the typed rule. In practice this is mainly form borders.
+2. **Tailwind output is unlayered.** The modular entrypoints emit theme and utilities without `@layer` wrappers since OUI is not layered. Side effects: Tailwind plugins that register component-layer rules (`addComponents`) collide with utilities by source order (prefer utility-only plugins); variant ties (e.g., `:hover` vs `[data-state=active]`) are decided by emit order; mixing your own `@layer` rules with Tailwind output may produce unexpected precedence (prefer unlayered CSS). Resolve conflicts by (in order) plain CSS, an explicit `!important` variant, or scoping the loser.
+3. **Re-scans only on SCSS change.** Tailwind v4's `@source` scanning runs when the SCSS entry rebuilds. Adding a new `.tsx` file with arbitrary-value utilities like `plg:text-[48px]` won't emit them until the SCSS changes. Workarounds: `touch` the SCSS file or prefer theme-token utilities (`plg:text-4xl`) which are always emitted.
 
 #### Build details
 
-The pipeline lives in `packages/osd-optimizer`. SCSS is compiled with sass-embedded, then passed through `@tailwindcss/postcss` and a small `postcss.config.js` plugin that strips Tailwind's dependency messages.
+The pipeline lives in `packages/osd-optimizer`. SCSS is compiled with sass-embedded, then passed through `@tailwindcss/postcss` and a small `postcss.config.js` plugin.
 
 ### TypeScript/JavaScript
 

--- a/packages/osd-apm-topology/src/celestial.scss
+++ b/packages/osd-apm-topology/src/celestial.scss
@@ -1,6 +1,7 @@
 /* Celestial styles. Tailwind v4 directives are processed by @tailwindcss/postcss
    in osd-optimizer's postcss-loader step after sass-loader passes them through. */
-@import "tailwindcss" prefix(osd);
+@import "tailwindcss/theme" prefix(osd);
+@import "tailwindcss/utilities" prefix(osd);
 
 @theme {
   /* Converting sizing to pixel instead of rem to keep size of nodes consistent no matter the font size*/

--- a/packages/osd-optimizer/postcss.config.js
+++ b/packages/osd-optimizer/postcss.config.js
@@ -69,12 +69,7 @@ module.exports = {
   plugins: [
     /*require('autoprefixer')()*/
     normalizeTailwindImports(),
-    // Plugins should import "tailwindcss/theme" + "tailwindcss/utilities" rather
-    // than the full "tailwindcss" entry. The full entry wraps utilities in
-    // @layer base/utilities, which lose specificity to OSD's unlayered EUI styles
-    // and forces a fragile postcss post-process to unwrap them. The modular
-    // imports emit unlayered utilities directly and skip preflight.
-    // Postcss is safe to include unconditionally. Bails out for files without Tailwind directives.
+    // Safe to include unconditionally. Bails out for files without Tailwind directives.
     // eslint-disable-next-line import/no-unresolved -- package uses `exports` field; resolver lacks support
     require('@tailwindcss/postcss')(),
     stripTailwindDeps(),

--- a/packages/osd-optimizer/postcss.config.js
+++ b/packages/osd-optimizer/postcss.config.js
@@ -46,9 +46,29 @@ function stripTailwindDeps() {
 }
 stripTailwindDeps.postcss = true;
 
+/**
+ * Restores the space between the import URL and the `prefix(...)` directive
+ * in `@import "tailwindcss/..." prefix(xxx)` rules. Sass `style: 'compressed'`
+ * strips whitespace inside `@import` params, producing
+ * `@import"tailwindcss/theme"prefix(osd)`, which @tailwindcss/postcss does
+ * not parse — it silently skips the import and emits zero utilities.
+ */
+function normalizeTailwindImports() {
+  return {
+    postcssPlugin: 'postcss-normalize-tailwind-imports',
+    Once(root) {
+      root.walkAtRules('import', (rule) => {
+        rule.params = rule.params.replace(/("tailwindcss\/[^"]+")(prefix)/g, '$1 $2');
+      });
+    },
+  };
+}
+normalizeTailwindImports.postcss = true;
+
 module.exports = {
   plugins: [
     /*require('autoprefixer')()*/
+    normalizeTailwindImports(),
     // Plugins should import "tailwindcss/theme" + "tailwindcss/utilities" rather
     // than the full "tailwindcss" entry. The full entry wraps utilities in
     // @layer base/utilities, which lose specificity to OSD's unlayered EUI styles

--- a/packages/osd-optimizer/postcss.config.js
+++ b/packages/osd-optimizer/postcss.config.js
@@ -46,43 +46,17 @@ function stripTailwindDeps() {
 }
 stripTailwindDeps.postcss = true;
 
-/**
- * Removes @layer wrappers from Tailwind v4 output.
- *
- * Layered rules always lose to unlayered ones. Since OSD's existing styles
- * (EUI, etc.) are unlayered, Tailwind utilities inside @layer get overridden.
- * Only runs when @tailwindcss/postcss processed the file.
- *  - Removes @layer base (Tailwind reset conflicts with OSD)
- *  - Unwraps @layer theme / utilities (keeps content, drops wrapper)
- *  - Keeps @layer properties (@property declarations are fine in layers)
- */
-function stripCssLayers() {
-  return {
-    postcssPlugin: 'postcss-strip-css-layers',
-    OnceExit(root, { result }) {
-      const tailwindRan = result.messages.some((msg) => msg.plugin === '@tailwindcss/postcss');
-      if (!tailwindRan) return;
-
-      root.walkAtRules('layer', (rule) => {
-        const name = rule.params.trim();
-        if (name === 'base' || name === 'components' || name.includes(',')) {
-          rule.remove();
-        } else if (name === 'theme' || name === 'utilities') {
-          rule.replaceWith(rule.nodes);
-        }
-      });
-    },
-  };
-}
-stripCssLayers.postcss = true;
-
 module.exports = {
   plugins: [
     /*require('autoprefixer')()*/
-    // Safe to include unconditionally. Bails out for files without Tailwind directives.
+    // Plugins should import "tailwindcss/theme" + "tailwindcss/utilities" rather
+    // than the full "tailwindcss" entry. The full entry wraps utilities in
+    // @layer base/utilities, which lose specificity to OSD's unlayered EUI styles
+    // and forces a fragile postcss post-process to unwrap them. The modular
+    // imports emit unlayered utilities directly and skip preflight.
+    // Postcss is safe to include unconditionally. Bails out for files without Tailwind directives.
     // eslint-disable-next-line import/no-unresolved -- package uses `exports` field; resolver lacks support
     require('@tailwindcss/postcss')(),
-    stripCssLayers(),
     stripTailwindDeps(),
   ],
 };

--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -278,9 +278,7 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
                     implementation: sassCompiler,
                     sassOptions: {
                       sourceMap: !worker.dist,
-                      // tailwindcss uses @import "tailwindcss/theme" prefix(osd),
-                      // this is not exactly SASS syntax and breaks if style is compressed.
-                      style: 'expanded',
+                      style: worker.dist ? 'compressed' : 'expanded',
                       quietDeps: true,
                       loadPaths: [
                         Path.resolve(worker.repoRoot, 'node_modules'),

--- a/packages/osd-optimizer/src/worker/webpack.config.ts
+++ b/packages/osd-optimizer/src/worker/webpack.config.ts
@@ -278,7 +278,9 @@ export function getWebpackConfig(bundle: Bundle, bundleRefs: BundleRefs, worker:
                     implementation: sassCompiler,
                     sassOptions: {
                       sourceMap: !worker.dist,
-                      style: worker.dist ? 'compressed' : 'expanded',
+                      // tailwindcss uses @import "tailwindcss/theme" prefix(osd),
+                      // this is not exactly SASS syntax and breaks if style is compressed.
+                      style: 'expanded',
                       quietDeps: true,
                       loadPaths: [
                         Path.resolve(worker.repoRoot, 'node_modules'),


### PR DESCRIPTION
### Description

Tailwind v4 utilities were missing from built artifacts. This is because `sassOptions.style: 'compressed'` strips whitespace from `@import "tailwindcss" prefix(osd)` before postcss runs and broke tokenizer. This happens because the prefix is a tailwind feature and not valid sass syntax.

We can either always use `expanded`, or add a post processing step to restore the space before `prefix(xyz)`. This PR adds a step to restore the missing space.

Additionally instead of custom logic to strip layers at optimizer, plugins should do

```scss
@import "tailwindcss/theme" prefix(xxx);
@import "tailwindcss/utilities" prefix(xxx);
```
instead of
```scss
@import "tailwindcss" prefix(xxx);
```

This is better because layers aren't working (OUI is not layered), and individual modules don't have layers. The optimal solution would be wrapping OUI and OSD styles in layers, but it is a much larger refactor. As a short term solution, there are some limitations and they are added to dev guide.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

built and run in dist mode

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
