### PR TITLE
[Chat] Add maturity-based sync polling and resend affordance for tool result dispatch

### DIFF
--- a/src/core/public/chat/types.ts
+++ b/src/core/public/chat/types.ts
@@ -64,6 +64,21 @@ export interface DeveloperMessage extends BaseMessage {
 export interface SystemMessage extends BaseMessage {
   role: 'system';
   content: string;
+  /**
+   * When set, this system message corresponds to a failed tool result
+   * submission for the given tool call. The UI may use this (together with
+   * `canResend`) to offer a resend affordance.
+   */
+  toolCallId?: string;
+  /**
+   * Whether the associated tool result submission can be retried by the user.
+   */
+  canResend?: boolean;
+  /**
+   * The tool result payload to resend. Stored directly on the timeline message
+   * so no external map is needed.
+   */
+  toolResult?: any;
 }
 
 /**

--- a/src/plugins/chat/common/types.ts
+++ b/src/plugins/chat/common/types.ts
@@ -63,6 +63,9 @@ export const DeveloperMessageSchema = BaseMessageSchema.extend({
 export const SystemMessageSchema = BaseMessageSchema.extend({
   role: z.literal('system'),
   content: z.string(),
+  toolCallId: z.string().optional(),
+  canResend: z.boolean().optional(),
+  toolResult: z.any().optional(),
 });
 
 export const AssistantMessageSchema = BaseMessageSchema.extend({

--- a/src/plugins/chat/public/components/chat_input.test.tsx
+++ b/src/plugins/chat/public/components/chat_input.test.tsx
@@ -350,74 +350,72 @@ describe('ChatInput', () => {
     });
   });
 
-  describe('isSendingToolResult behavior', () => {
-    it('should disable input when isSendingToolResult is true', () => {
-      const { getByPlaceholderText } = render(
-        <ChatInput {...defaultProps} isSendingToolResult={true} />
-      );
+  describe('disabled behavior', () => {
+    it('should disable input when disabled is true', () => {
+      const { getByPlaceholderText } = render(<ChatInput {...defaultProps} disabled={true} />);
 
       const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
       expect(input.disabled).toBe(true);
     });
 
-    it('should enable input when isSendingToolResult is false', () => {
-      const { getByPlaceholderText } = render(
-        <ChatInput {...defaultProps} isSendingToolResult={false} />
-      );
+    it('should enable input when disabled is false', () => {
+      const { getByPlaceholderText } = render(<ChatInput {...defaultProps} disabled={false} />);
 
       const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
       expect(input.disabled).toBe(false);
     });
 
-    it('should enable input when isSendingToolResult is not provided', () => {
+    it('should enable input when disabled is not provided', () => {
       const { getByPlaceholderText } = render(<ChatInput {...defaultProps} />);
 
       const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
       expect(input.disabled).toBe(false);
     });
 
-    it('should disable send button when isSendingToolResult is true', () => {
+    it('should disable send button when disabled is true', () => {
       const { getByLabelText } = render(
-        <ChatInput {...defaultProps} input="test" isSendingToolResult={true} />
+        <ChatInput {...defaultProps} input="test" disabled={true} />
       );
 
       const button = getByLabelText('Send message') as HTMLButtonElement;
       expect(button.disabled).toBe(true);
     });
 
-    it('should enable send button when isSendingToolResult is false and input has content', () => {
+    it('should enable send button when disabled is false and input has content', () => {
       const { getByLabelText } = render(
-        <ChatInput {...defaultProps} input="test" isSendingToolResult={false} />
+        <ChatInput {...defaultProps} input="test" disabled={false} />
       );
 
       const button = getByLabelText('Send message') as HTMLButtonElement;
       expect(button.disabled).toBe(false);
     });
 
-    it('should have disabled attribute on input when isSendingToolResult is true', () => {
+    it('should show custom placeholder when provided', () => {
       const { getByPlaceholderText } = render(
-        <ChatInput {...defaultProps} isSendingToolResult={true} />
+        <ChatInput {...defaultProps} disabled={true} placeholder="Waiting for confirmation..." />
       );
 
-      const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
-      // Verify the input has the disabled attribute
-      expect(input).toHaveAttribute('disabled');
+      expect(getByPlaceholderText('Waiting for confirmation...')).toBeTruthy();
     });
 
-    it('should transition input state when isSendingToolResult changes', () => {
+    it('should show default placeholder when none provided', () => {
+      const { getByPlaceholderText } = render(<ChatInput {...defaultProps} />);
+
+      expect(getByPlaceholderText('How can I help you today?')).toBeTruthy();
+    });
+
+    it('should transition input state when disabled changes', () => {
       const { getByPlaceholderText, rerender } = render(
-        <ChatInput {...defaultProps} isSendingToolResult={false} />
+        <ChatInput {...defaultProps} disabled={false} />
       );
 
       const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
       expect(input.disabled).toBe(false);
 
-      // Simulate tool result sending starts
-      rerender(<ChatInput {...defaultProps} isSendingToolResult={true} />);
+      rerender(<ChatInput {...defaultProps} disabled={true} />);
       expect(input.disabled).toBe(true);
 
-      // Simulate tool result sending completes
-      rerender(<ChatInput {...defaultProps} isSendingToolResult={false} />);
+      rerender(<ChatInput {...defaultProps} disabled={false} />);
       expect(input.disabled).toBe(false);
     });
   });

--- a/src/plugins/chat/public/components/chat_input.tsx
+++ b/src/plugins/chat/public/components/chat_input.tsx
@@ -15,7 +15,6 @@ import { SlashCommandMenu } from './slash_command_menu';
 import { ChatContextPopover } from './chat_context_popover';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../core/public';
-import { ConfirmationRequest } from '../services/confirmation_service';
 
 import './chat_input.scss';
 
@@ -24,8 +23,8 @@ interface ChatInputProps {
   input: string;
   isCapturing: boolean;
   isStreaming: boolean;
-  isSendingToolResult?: boolean;
-  pendingConfirmation?: ConfirmationRequest | null;
+  disabled?: boolean;
+  placeholder?: string;
   onInputChange: (value: string) => void;
   onSend: () => void;
   onStop: () => void;
@@ -39,8 +38,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   input,
   isCapturing,
   isStreaming,
-  isSendingToolResult = false,
-  pendingConfirmation,
+  disabled = false,
+  placeholder,
   onInputChange,
   onSend,
   onStop,
@@ -109,13 +108,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           <EuiTextArea
             inputRef={inputRef}
             placeholder={
-              pendingConfirmation
-                ? i18n.translate('chat.input.waitingForConfirmation', {
-                    defaultMessage: 'Waiting for confirmation...',
-                  })
-                : i18n.translate('chat.input.placeholder', {
-                    defaultMessage: 'How can I help you today?',
-                  })
+              placeholder ||
+              i18n.translate('chat.input.placeholder', {
+                defaultMessage: 'How can I help you today?',
+              })
             }
             value={input}
             onChange={(e) => onInputChange(e.target.value)}
@@ -124,7 +120,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             fullWidth
             resize="none"
             rows={2}
-            disabled={isSendingToolResult || !!pendingConfirmation}
+            disabled={disabled}
           />
           {ghostText && (
             <div className="chatInput__ghostText" aria-hidden="true">
@@ -145,9 +141,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         <EuiButtonIcon
           iconType={isStreaming ? 'stop' : 'sortUp'}
           onClick={isStreaming ? onStop : onSend}
-          isDisabled={
-            (!isStreaming && input.trim().length === 0) || isCapturing || isSendingToolResult
-          }
+          isDisabled={(!isStreaming && input.trim().length === 0) || isCapturing || disabled}
           aria-label={isStreaming ? 'Stop generating' : 'Send message'}
           size="m"
           color={isStreaming ? 'danger' : 'primary'}

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -66,6 +66,11 @@ interface ChatMessagesProps {
   timeline: Message[];
   isStreaming: boolean;
   onResendMessage?: (message: Message) => void;
+  onResendToolResult?: (params: {
+    messageId: string;
+    toolCallId: string;
+    toolResult: any;
+  }) => Promise<void>;
   onApproveConfirmation?: () => void;
   onRejectConfirmation?: () => void;
   onFillInput?: (content: string) => void;
@@ -240,6 +245,7 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
   timeline,
   isStreaming,
   onResendMessage,
+  onResendToolResult,
   onApproveConfirmation,
   onRejectConfirmation,
   onFillInput,
@@ -542,7 +548,9 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
 
           // Handle system messages as errors
           if (message.role === 'system') {
-            return <ErrorRow key={message.id} error={message} />;
+            return (
+              <ErrorRow key={message.id} error={message} onResendToolResult={onResendToolResult} />
+            );
           }
 
           return null;

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -35,7 +35,7 @@ jest.mock('../services/chat_event_handler', () => ({
   ChatEventHandler: jest.fn().mockImplementation(() => ({
     handleEvent: jest.fn(),
     clearState: jest.fn(),
-    stopToolResultStreaming: jest.fn(),
+    cancelToolResultDispatch: jest.fn(),
   })),
 }));
 
@@ -971,7 +971,7 @@ describe('ChatWindow', () => {
       ChatEventHandler.mockImplementation(() => ({
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
-        stopToolResultStreaming: jest.fn(),
+        cancelToolResultDispatch: jest.fn(),
       }));
 
       const mockEvents = [
@@ -1023,7 +1023,7 @@ describe('ChatWindow', () => {
       ChatEventHandler.mockImplementation(() => ({
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
-        stopToolResultStreaming: jest.fn(),
+        cancelToolResultDispatch: jest.fn(),
       }));
 
       const mockEvents = [
@@ -1160,7 +1160,7 @@ describe('ChatWindow', () => {
       ChatEventHandler.mockImplementation(() => ({
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
-        stopToolResultStreaming: jest.fn(),
+        cancelToolResultDispatch: jest.fn(),
       }));
 
       // Mock ongoing streaming that continues after switch
@@ -1702,6 +1702,135 @@ describe('ChatWindow', () => {
 
       // Verify chatService.abort was called
       expect(mockChatService.abort).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('hasPendingResend blocking input', () => {
+    it('should prevent sending messages when a canResend system message exists in timeline', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      let capturedOnTimelineUpdate: any;
+      ChatEventHandler.mockImplementation((config: any) => {
+        capturedOnTimelineUpdate = config.callbacks.onTimelineUpdate;
+        return {
+          handleEvent: jest.fn(),
+          clearState: jest.fn(),
+          cancelToolResultDispatch: jest.fn(),
+        };
+      });
+
+      const ref = React.createRef<ChatWindowInstance>();
+      renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
+
+      // Inject a canResend system message into the timeline
+      await act(async () => {
+        capturedOnTimelineUpdate((prev: any[]) => [
+          ...prev,
+          {
+            id: 'timeout-msg-1',
+            role: 'system',
+            content: 'Sync timeout',
+            toolCallId: 'tool-1',
+            canResend: true,
+            toolResult: { ok: true },
+          },
+        ]);
+      });
+
+      // Try to send a message — should be blocked
+      await act(async () => {
+        await ref.current?.sendMessage({ content: 'should be blocked' });
+      });
+
+      expect(mockChatService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should disable the input textarea when a canResend system message exists', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      let capturedOnTimelineUpdate: any;
+      ChatEventHandler.mockImplementation((config: any) => {
+        capturedOnTimelineUpdate = config.callbacks.onTimelineUpdate;
+        return {
+          handleEvent: jest.fn(),
+          clearState: jest.fn(),
+          cancelToolResultDispatch: jest.fn(),
+        };
+      });
+
+      const { getByPlaceholderText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+
+      // Inject a canResend system message
+      await act(async () => {
+        capturedOnTimelineUpdate((prev: any[]) => [
+          ...prev,
+          {
+            id: 'timeout-msg-2',
+            role: 'system',
+            content: 'Sync timeout',
+            toolCallId: 'tool-2',
+            canResend: true,
+            toolResult: { data: 'test' },
+          },
+        ]);
+      });
+
+      const input = getByPlaceholderText(
+        'Resend the tool result to continue...'
+      ) as HTMLTextAreaElement;
+      expect(input.disabled).toBe(true);
+    });
+
+    it('should re-enable input after canResend message is removed from timeline', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      let capturedOnTimelineUpdate: any;
+      ChatEventHandler.mockImplementation((config: any) => {
+        capturedOnTimelineUpdate = config.callbacks.onTimelineUpdate;
+        return {
+          handleEvent: jest.fn(),
+          clearState: jest.fn(),
+          cancelToolResultDispatch: jest.fn(),
+          sendToolResultToAssistant: jest.fn().mockResolvedValue(undefined),
+        };
+      });
+
+      const ref = React.createRef<ChatWindowInstance>();
+      const { getByPlaceholderText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      // Inject a canResend system message
+      await act(async () => {
+        capturedOnTimelineUpdate((prev: any[]) => [
+          ...prev,
+          {
+            id: 'timeout-msg-3',
+            role: 'system',
+            content: 'Sync timeout',
+            toolCallId: 'tool-3',
+            canResend: true,
+            toolResult: { ok: true },
+          },
+        ]);
+      });
+
+      // Verify disabled
+      const input = getByPlaceholderText(
+        'Resend the tool result to continue...'
+      ) as HTMLTextAreaElement;
+      expect(input.disabled).toBe(true);
+
+      // Remove the canResend message (simulates what handleResendToolResult does)
+      await act(async () => {
+        capturedOnTimelineUpdate((prev: any[]) =>
+          prev.filter((msg: any) => msg.id !== 'timeout-msg-3')
+        );
+      });
+
+      // Input should be re-enabled with default placeholder
+      const enabledInput = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
+      expect(enabledInput.disabled).toBe(false);
     });
   });
 });

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../common/events';
 import type {
   Message,
+  SystemMessage,
   UserMessage,
 } from '../../common/types';
 import { ChatLayoutMode } from '../types';
@@ -78,6 +79,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   const resendAvailable = !!chatService.conversationHistoryService.getMemoryProvider().includeFullHistory;
   const [startResponse, setStartResponse] = useState(false);
   const [isSendingToolResult, setIsSendingToolResult] = useState(false);
+  const isSendingToolResultRef = useRef(false);
+  isSendingToolResultRef.current = isSendingToolResult;
+
+  const hasPendingResend = useMemo(
+    () => timeline.some((msg) => msg.role === 'system' && (msg as SystemMessage).canResend),
+    [timeline]
+  );
 
   // Use ref to track streaming state synchronously for React 18 compatibility
   // React 18 batches state updates, so we need a ref for immediate checks
@@ -233,7 +241,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   const handleSend = async (options?: {input?: string, messages?: Message[]}) => {
     const messageContent = options?.input ?? input.trim();
     // Use ref for immediate check since React 18 batches state updates
-    if (!messageContent || isStreamingRef.current) return;
+    if (!messageContent || isStreamingRef.current || hasPendingResend) return;
 
     // Prepare additional messages for sending (but don't add to timeline yet)
     let additionalMessages = options?.messages ?? [];
@@ -324,6 +332,17 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     subscribeToMessageStream(textContent, [...truncatedTimeline,...additionalMessages]);
   }, [timeline, subscribeToMessageStream, setInput, setTimeline]);
 
+  const handleResendToolResult = useCallback(
+    async ({ messageId, toolCallId, toolResult }: { messageId: string; toolCallId: string; toolResult: any }) => {
+      // Avoid concurrent resends while streaming or already sending a tool result
+      if (isStreamingRef.current || isSendingToolResultRef.current) return;
+      // Remove the error message from timeline
+      setTimeline((prev) => prev.filter((msg) => msg.id !== messageId));
+      await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
+    },
+    [eventHandler, setTimeline]
+  );
+
   // Helper function to stop streaming and clean up subscriptions
   const stopStreaming = useCallback(() => {
     // Abort the current streaming request
@@ -334,8 +353,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       currentSubscriptionRef.current = null;
     }
 
-    // Stop tool result streaming if active
-    eventHandler.stopToolResultStreaming();
+    // Cancel any in-flight tool result dispatch
+    eventHandler.cancelToolResultDispatch();
 
     // Update streaming state (both ref and state for React 18 compatibility)
     isStreamingRef.current = false;
@@ -536,6 +555,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             timeline={timeline}
             isStreaming={isStreaming}
             onResendMessage={resendAvailable ? handleResendMessage : undefined}
+            onResendToolResult={handleResendToolResult}
             onApproveConfirmation={handleApproveConfirmation}
             onRejectConfirmation={handleRejectConfirmation}
             onFillInput={setInput}
@@ -583,8 +603,18 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             input={input}
             isCapturing={isCapturing}
             isStreaming={isStreaming}
-            isSendingToolResult={isSendingToolResult}
-            pendingConfirmation={pendingConfirmation}
+            disabled={isSendingToolResult || hasPendingResend || !!pendingConfirmation}
+            placeholder={
+              pendingConfirmation
+                ? i18n.translate('chat.input.waitingForConfirmation', {
+                    defaultMessage: 'Waiting for confirmation...',
+                  })
+                : hasPendingResend
+                ? i18n.translate('chat.input.pendingResend', {
+                    defaultMessage: 'Resend the tool result to continue...',
+                  })
+                : undefined
+            }
             onInputChange={setInput}
             onSend={handleSend}
             onStop={handleStop}

--- a/src/plugins/chat/public/components/error_row.scss
+++ b/src/plugins/chat/public/components/error_row.scss
@@ -30,4 +30,8 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
   }
+
+  &__actions {
+    margin-top: 4px;
+  }
 }

--- a/src/plugins/chat/public/components/error_row.test.tsx
+++ b/src/plugins/chat/public/components/error_row.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { ErrorRow } from './error_row';
+import type { SystemMessage } from '../../common/types';
+
+describe('ErrorRow', () => {
+  const baseError: SystemMessage = {
+    id: 'error-1',
+    role: 'system',
+    content: 'Something failed',
+  };
+
+  it('should not render resend button when canResend is false', () => {
+    const { queryByTestId } = render(<ErrorRow error={baseError} />);
+    expect(queryByTestId('chatErrorRowResendToolResult')).toBeNull();
+  });
+
+  it('should render resend button when canResend, toolCallId, toolResult, and callback are present', () => {
+    const error: SystemMessage = {
+      ...baseError,
+      toolCallId: 'tool-1',
+      canResend: true,
+      toolResult: { ok: true },
+    };
+    const onResend = jest.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(<ErrorRow error={error} onResendToolResult={onResend} />);
+    expect(getByTestId('chatErrorRowResendToolResult')).toBeTruthy();
+  });
+
+  it('should call onResendToolResult with messageId, toolCallId, and toolResult on click and disable button during send', async () => {
+    let resolveSend: () => void = () => {};
+    const onResend = jest.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+
+    const error: SystemMessage = {
+      ...baseError,
+      id: 'msg-123',
+      toolCallId: 'tool-456',
+      canResend: true,
+      toolResult: { data: 'test' },
+    };
+
+    const { getByTestId } = render(<ErrorRow error={error} onResendToolResult={onResend} />);
+    const button = getByTestId('chatErrorRowResendToolResult');
+
+    fireEvent.click(button);
+
+    expect(onResend).toHaveBeenCalledWith({
+      messageId: 'msg-123',
+      toolCallId: 'tool-456',
+      toolResult: { data: 'test' },
+    });
+
+    // Button should be disabled while sending
+    expect(button.closest('button')).toBeDisabled();
+
+    // Resolve the promise
+    resolveSend();
+
+    await waitFor(() => {
+      expect(button.closest('button')).not.toBeDisabled();
+    });
+  });
+});

--- a/src/plugins/chat/public/components/error_row.tsx
+++ b/src/plugins/chat/public/components/error_row.tsx
@@ -3,16 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { EuiText, EuiIcon } from '@elastic/eui';
+import React, { useState } from 'react';
+import { EuiText, EuiIcon, EuiButtonEmpty } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import type { SystemMessage } from '../../common/types';
 import './error_row.scss';
 
 interface ErrorRowProps {
   error: SystemMessage;
+  onResendToolResult?: (params: {
+    messageId: string;
+    toolCallId: string;
+    toolResult: any;
+  }) => Promise<void>;
 }
 
-export const ErrorRow: React.FC<ErrorRowProps> = ({ error }) => {
+export const ErrorRow: React.FC<ErrorRowProps> = ({ error, onResendToolResult }) => {
+  const [isResending, setIsResending] = useState(false);
+  const canResend = Boolean(
+    error.canResend && error.toolCallId && error.toolResult && onResendToolResult
+  );
+
+  const handleResend = async () => {
+    if (!error.toolCallId || !error.toolResult || !onResendToolResult) return;
+    setIsResending(true);
+    try {
+      await onResendToolResult({
+        messageId: error.id,
+        toolCallId: error.toolCallId,
+        toolResult: error.toolResult,
+      });
+    } finally {
+      setIsResending(false);
+    }
+  };
+
   return (
     <div className="errorRow">
       <div className="errorRow__icon">
@@ -21,7 +46,9 @@ export const ErrorRow: React.FC<ErrorRowProps> = ({ error }) => {
       <div className="errorRow__content">
         <div className="errorRow__info">
           <EuiText size="s" style={{ fontWeight: 600, color: '#BD271E' }}>
-            Something went wrong
+            {i18n.translate('chat.errorRow.title', {
+              defaultMessage: 'Something went wrong',
+            })}
           </EuiText>
         </div>
         <div className="errorRow__message">
@@ -29,6 +56,23 @@ export const ErrorRow: React.FC<ErrorRowProps> = ({ error }) => {
             {error.content}
           </EuiText>
         </div>
+        {canResend && (
+          <div className="errorRow__actions">
+            <EuiButtonEmpty
+              size="xs"
+              iconType="refresh"
+              color="danger"
+              isLoading={isResending}
+              isDisabled={isResending}
+              onClick={handleResend}
+              data-test-subj="chatErrorRowResendToolResult"
+            >
+              {i18n.translate('chat.errorRow.resendToolResult', {
+                defaultMessage: 'Resend tool result',
+              })}
+            </EuiButtonEmpty>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -240,7 +240,7 @@ describe('ChatEventHandler', () => {
       };
 
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -583,7 +583,8 @@ describe('ChatEventHandler', () => {
       expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
         toolCallId,
         mockRejectedResult,
-        expect.any(Array)
+        expect.any(Array),
+        expect.any(AbortSignal)
       );
     });
 
@@ -603,7 +604,7 @@ describe('ChatEventHandler', () => {
       };
 
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -638,7 +639,8 @@ describe('ChatEventHandler', () => {
       expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
         toolCallId,
         mockApprovedResult,
-        expect.any(Array)
+        expect.any(Array),
+        expect.any(AbortSignal)
       );
     });
   });
@@ -725,11 +727,15 @@ describe('ChatEventHandler', () => {
         toolCallId,
       };
 
-      let completeCallback: any;
+      const teardowns: Array<() => void> = [];
       const mockObservable = {
-        subscribe: jest.fn((callbacks) => {
-          completeCallback = callbacks.complete;
-          return { unsubscribe: jest.fn() };
+        subscribe: jest.fn(() => {
+          return {
+            unsubscribe: jest.fn(),
+            add: jest.fn((fn: () => void) => {
+              teardowns.push(fn);
+            }),
+          };
         }),
       };
 
@@ -756,11 +762,11 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
-      // Clear previous calls to focus on the completion callback
+      // Clear previous calls to focus on the teardown
       mockOnStartResponse.mockClear();
 
-      // Trigger completion
-      completeCallback();
+      // Trigger teardown (simulates subscription completing in RxJS)
+      teardowns.forEach((fn) => fn());
 
       // Verify onStartResponse was called with false on completion
       expect(mockOnStartResponse).toHaveBeenCalledWith(false);
@@ -781,10 +787,16 @@ describe('ChatEventHandler', () => {
       };
 
       let errorCallback: any;
+      const teardowns: Array<() => void> = [];
       const mockObservable = {
         subscribe: jest.fn((callbacks) => {
           errorCallback = callbacks.error;
-          return { unsubscribe: jest.fn() };
+          return {
+            unsubscribe: jest.fn(),
+            add: jest.fn((fn: () => void) => {
+              teardowns.push(fn);
+            }),
+          };
         }),
       };
 
@@ -814,8 +826,9 @@ describe('ChatEventHandler', () => {
       // Clear previous calls to focus on the error callback
       mockOnStartResponse.mockClear();
 
-      // Trigger error
+      // Trigger error and teardown (simulates RxJS behavior)
       errorCallback(new Error('Test error'));
+      teardowns.forEach((fn) => fn());
 
       // Verify onStartResponse was called with false on error
       expect(mockOnStartResponse).toHaveBeenCalledWith(false);
@@ -1034,7 +1047,7 @@ describe('ChatEventHandler', () => {
 
       let sendToolResultCalled = false;
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockImplementation(async () => {
@@ -1082,7 +1095,7 @@ describe('ChatEventHandler', () => {
       };
 
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -1171,7 +1184,7 @@ describe('ChatEventHandler', () => {
       };
 
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -1205,7 +1218,7 @@ describe('ChatEventHandler', () => {
     });
   });
 
-  describe('stopToolResultStreaming', () => {
+  describe('cancelToolResultDispatch', () => {
     it('should stop active tool result streaming and reset state', async () => {
       const toolCallId = 'tool-123';
       const mockResult = { success: true, data: 'test result' };
@@ -1221,8 +1234,17 @@ describe('ChatEventHandler', () => {
       };
 
       const mockUnsubscribe = jest.fn();
+      const teardowns: Array<() => void> = [];
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+        subscribe: jest.fn().mockReturnValue({
+          unsubscribe: jest.fn(() => {
+            mockUnsubscribe();
+            teardowns.forEach((fn) => fn());
+          }),
+          add: jest.fn((fn: () => void) => {
+            teardowns.push(fn);
+          }),
+        }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -1256,7 +1278,7 @@ describe('ChatEventHandler', () => {
       mockOnStartResponse.mockClear();
 
       // Stop the streaming
-      chatEventHandler.stopToolResultStreaming();
+      chatEventHandler.cancelToolResultDispatch();
 
       // Verify unsubscribe was called
       expect(mockUnsubscribe).toHaveBeenCalled();
@@ -1266,10 +1288,10 @@ describe('ChatEventHandler', () => {
       expect(mockOnStartResponse).toHaveBeenCalledWith(false);
     });
 
-    it('should handle stopToolResultStreaming when no streaming is active', () => {
+    it('should handle cancelToolResultDispatch when no streaming is active', () => {
       // Should not throw when there's no active subscription
       expect(() => {
-        chatEventHandler.stopToolResultStreaming();
+        chatEventHandler.cancelToolResultDispatch();
       }).not.toThrow();
 
       // State callbacks should not be called when there's no active streaming
@@ -1605,7 +1627,7 @@ describe('ChatEventHandler', () => {
         toolCallId,
       };
 
-      const subscribeSpy = jest.fn().mockReturnValue({ unsubscribe: jest.fn() });
+      const subscribeSpy = jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() });
       const observable = { subscribe: subscribeSpy };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -1634,6 +1656,346 @@ describe('ChatEventHandler', () => {
       const skipInfoMessage = timeline.find((m) => (m as any).id?.startsWith('tool-skipped-'));
       expect(skipInfoMessage).toBeUndefined();
       expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sendToolResultToAssistant abort and non-result_already_exists skip reasons', () => {
+    // Helper that drives the tool-call pipeline through to sendToolResult.
+    const runToolCallPipeline = async (handler: ChatEventHandler, toolCallId: string) => {
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+    };
+
+    beforeEach(() => {
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue({ ok: true });
+    });
+
+    it('should pass an AbortSignal to chatService.sendToolResult', async () => {
+      const toolCallId = 'tool-abort-signal-passthrough';
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+      });
+
+      await runToolCallPipeline(chatEventHandler, toolCallId);
+
+      const passedSignal = (mockChatService.sendToolResult as jest.Mock).mock.calls[0][3];
+      expect(passedSignal).toBeInstanceOf(AbortSignal);
+      expect(passedSignal.aborted).toBe(false);
+    });
+
+    it('should abort the in-flight signal when cancelToolResultDispatch is called', async () => {
+      const toolCallId = 'tool-abort-on-stop';
+
+      // Keep the send pending so there is a live abort controller to cancel.
+      let resolveSend: (v: any) => void = () => {};
+      mockChatService.sendToolResult = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSend = resolve;
+          })
+      );
+
+      // Kick off the send but don't await it — we need to inspect state
+      // while it's mid-flight.
+      const pipelinePromise = runToolCallPipeline(chatEventHandler, toolCallId);
+
+      // Wait a microtask so the handler has invoked sendToolResult and
+      // captured the AbortController.
+      await new Promise((r) => setImmediate(r));
+
+      const passedSignal = (mockChatService.sendToolResult as jest.Mock).mock.calls[0][3];
+      expect(passedSignal.aborted).toBe(false);
+
+      chatEventHandler.cancelToolResultDispatch();
+
+      expect(passedSignal.aborted).toBe(true);
+
+      // Allow the send promise to resolve with the aborted skip reason so
+      // the handler completes without unhandled rejections.
+      resolveSend({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'aborted' },
+      });
+
+      await pipelinePromise;
+    });
+
+    it('should fire onSendToolResultStateChange(true) once at dispatch and (false) on stop', async () => {
+      const mockOnSendToolResultStateChange = jest.fn();
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2740 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStreamingStateChange: mockOnStreamingStateChange,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+        },
+      });
+
+      const toolCallId = 'tool-state-change-on-stop';
+
+      let resolveSend: (v: any) => void = () => {};
+      mockChatService.sendToolResult = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSend = resolve;
+          })
+      );
+
+      const pipelinePromise = runToolCallPipeline(handler, toolCallId);
+      await new Promise((r) => setImmediate(r));
+
+      // Only the initial `(true)` should have been emitted so far.
+      const trueCallsBeforeStop = mockOnSendToolResultStateChange.mock.calls.filter(
+        (c) => c[0] === true
+      ).length;
+      expect(trueCallsBeforeStop).toBe(1);
+
+      handler.cancelToolResultDispatch();
+
+      resolveSend({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'aborted' },
+      });
+
+      await pipelinePromise;
+
+      // The `finally` block emits (false) once the awaited promise resolves.
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
+
+      // `(true)` should still have been emitted exactly once — stop() must
+      // not re-emit `(true)`.
+      const finalTrueCallCount = mockOnSendToolResultStateChange.mock.calls.filter(
+        (c) => c[0] === true
+      ).length;
+      expect(finalTrueCallCount).toBe(1);
+    });
+
+    it('should be a no-op when no send is in flight and no subscription is active', () => {
+      // Fresh handler with no active send.
+      chatEventHandler.cancelToolResultDispatch();
+
+      // Both branches are null on a fresh handler, so no callbacks fire.
+      expect(mockOnStreamingStateChange).not.toHaveBeenCalled();
+      expect(mockOnStartResponse).not.toHaveBeenCalled();
+    });
+
+    it('should abort the previous in-flight send when a new tool result send starts', async () => {
+      const firstToolCallId = 'tool-first';
+      const secondToolCallId = 'tool-second';
+
+      // Capture both signals as the handler dispatches.
+      const sendMock = jest.fn().mockImplementation(
+        () => new Promise(() => {}) // never resolves — we only care about the signals
+      );
+      mockChatService.sendToolResult = sendMock;
+
+      runToolCallPipeline(chatEventHandler, firstToolCallId);
+      await new Promise((r) => setImmediate(r));
+
+      const firstSignal = sendMock.mock.calls[0][3];
+      expect(firstSignal.aborted).toBe(false);
+
+      runToolCallPipeline(chatEventHandler, secondToolCallId);
+      await new Promise((r) => setImmediate(r));
+
+      const secondSignal = sendMock.mock.calls[1][3];
+
+      // First should now be cancelled, second is fresh.
+      expect(firstSignal.aborted).toBe(true);
+      expect(secondSignal.aborted).toBe(false);
+    });
+
+    it('should skip silently when sendToolResult returns skipped reason aborted', async () => {
+      const toolCallId = 'tool-skip-aborted';
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: { subscribe: jest.fn() },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'aborted' },
+      });
+
+      await runToolCallPipeline(chatEventHandler, toolCallId);
+
+      // No user-facing system message and no tool message should have been
+      // appended — the cancellation is intentional and silent.
+      const systemMessages = timeline.filter((m) => m.role === 'system');
+      const toolMessages = timeline.filter((m) => m.role === 'tool');
+      expect(systemMessages).toHaveLength(0);
+      expect(toolMessages).toHaveLength(0);
+    });
+
+    it('should append a resendable system message when sendToolResult returns skipped reason sync_timeout', async () => {
+      const toolCallId = 'tool-skip-sync-timeout';
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: { subscribe: jest.fn() },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'sync_timeout' },
+      });
+
+      await runToolCallPipeline(chatEventHandler, toolCallId);
+
+      const systemMessages = timeline.filter((m) => m.role === 'system') as any[];
+      const timeoutMessage = systemMessages.find((m) =>
+        (m.id as string).startsWith('tool-sync-timeout-')
+      );
+      expect(timeoutMessage).toBeDefined();
+      expect(timeoutMessage.toolCallId).toBe(toolCallId);
+      expect(timeoutMessage.canResend).toBe(true);
+      expect(timeoutMessage.content).toMatch(/resend/i);
+
+      // No tool message should have been appended since dispatch was skipped.
+      const toolMessages = timeline.filter((m) => m.role === 'tool');
+      expect(toolMessages).toHaveLength(0);
+    });
+
+    it('should not emit onSendToolResultStateChange(false) from a superseded send', async () => {
+      const mockOnSendToolResultStateChange = jest.fn();
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2740 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStreamingStateChange: mockOnStreamingStateChange,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+        },
+      });
+
+      // First send will be held pending so we can start a second send.
+      let resolveFirst: (v: any) => void = () => {};
+      const sendMock = jest.fn();
+      sendMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+      );
+      sendMock.mockImplementationOnce(() =>
+        Promise.resolve({
+          observable: {
+            subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+          },
+          toolMessage: {
+            id: 'tool-result-second',
+            role: 'tool',
+            content: '{}',
+            toolCallId: 'tool-second',
+          },
+        })
+      );
+      mockChatService.sendToolResult = sendMock;
+
+      // Start first send (stays pending)
+      const firstPromise = runToolCallPipeline(handler, 'tool-first');
+      await new Promise((r) => setImmediate(r));
+
+      // Start second send — this aborts the first controller and replaces it
+      await runToolCallPipeline(handler, 'tool-second');
+
+      // Now resolve the first send so its finally block runs
+      resolveFirst({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: 'tool-result-first',
+          role: 'tool',
+          content: '{}',
+          toolCallId: 'tool-first',
+        },
+        skipped: { reason: 'aborted' },
+      });
+      await firstPromise;
+
+      // The first send's finally block should NOT have emitted (false) because
+      // the controller was already replaced by the second send.
+      const falseCalls = mockOnSendToolResultStateChange.mock.calls.filter((c) => c[0] === false);
+      // Only the second send should have emitted (false) — exactly once.
+      expect(falseCalls.length).toBe(1);
+    });
+
+    it('should append a non-resendable system message when sendToolResult returns skipped reason no_thread_id', async () => {
+      const toolCallId = 'tool-skip-no-thread';
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: { subscribe: jest.fn() },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'no_thread_id' },
+      });
+
+      await runToolCallPipeline(chatEventHandler, toolCallId);
+
+      const systemMessages = timeline.filter((m) => m.role === 'system') as any[];
+      const noThreadMessage = systemMessages.find((m) =>
+        (m.id as string).startsWith('tool-no-thread-')
+      );
+      expect(noThreadMessage).toBeDefined();
+      expect(noThreadMessage.toolCallId).toBe(toolCallId);
+      // No resend affordance — retrying without a thread would hit the same path.
+      expect(noThreadMessage.canResend).toBeUndefined();
     });
   });
 });

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
+import { i18n } from '@osd/i18n';
 import { EventType } from '../../common/events';
 import type {
   Event as ChatEvent,
@@ -65,6 +66,11 @@ export class ChatEventHandler {
   private onSendToolResultStateChange?: (isSending: boolean) => void;
   private getTimeline: () => Message[];
   private toolResultSubscription: Subscription | null = null;
+
+  // Controls the currently in-flight tool result send (polling + agent stream).
+  // When aborted, `waitForToolCallSync` bails out with reason 'aborted' and the
+  // agent fetch is cancelled.
+  private toolResultAbortController: AbortController | null = null;
 
   // Telemetry tracking
   private interactionStartTime: number | null = null;
@@ -655,67 +661,157 @@ export class ChatEventHandler {
   /**
    * Send tool result back to assistant
    */
-  private async sendToolResultToAssistant(toolCallId: string, result: any): Promise<void> {
+  async sendToolResultToAssistant(toolCallId: string, result: any): Promise<void> {
+    // Abort any in-flight tool result send so we don't leak controllers or
+    // race two dispatches against the same toolCallId.
+    if (this.toolResultAbortController) {
+      this.toolResultAbortController.abort();
+    }
+    const abortController = new AbortController();
+    this.toolResultAbortController = abortController;
+
+    // Release our claim on the shared slot — but only if it's still ours.
+    // A later send may have already replaced it.
+    const releaseController = () => {
+      if (this.toolResultAbortController === abortController) {
+        this.toolResultAbortController = null;
+      }
+    };
+
+    let observable: Observable<ChatEvent>;
+    let toolMessage: ToolMessage;
+    let skipped:
+      | { reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted' }
+      | undefined;
+
     try {
       // Notify that we're starting to send tool result
       this.onSendToolResultStateChange?.(true);
-
       const messages = this.getTimeline();
 
-      const { observable, toolMessage, skipped } = await this.chatService.sendToolResult(
+      ({ observable, toolMessage, skipped } = await this.chatService.sendToolResult(
         toolCallId,
         result,
-        messages
-      );
-
-      // Notify that sending tool result is complete
-      this.onSendToolResultStateChange?.(false);
-
-      if (skipped) {
-        // Another window already persisted a tool result for this toolCallId.
-        // Skip appending the locally-constructed toolMessage and surface an
-        // informational system message instead.
-        const infoMessage: SystemMessage = {
-          id: `tool-skipped-${toolCallId}-${Date.now()}`,
-          role: 'system',
-          content: 'This tool result was already submitted from another window.',
-        };
-        this.onTimelineUpdate((prev) => [...prev, infoMessage]);
-        return;
-      }
-
-      this.onTimelineUpdate((prev) => [...prev, toolMessage]);
-
-      // Set streaming state and subscribe to the response stream
-      this.onStreamingStateChange(true);
-
-      const subscription = observable.subscribe({
-        next: (event: ChatEvent) => {
-          // Handle the assistant's response to the tool result
-          this.handleEvent(event);
-        },
-        error: (error: any) => {
-          // eslint-disable-next-line no-console
-          console.error('Tool result response error:', error);
-          this.onStreamingStateChange(false);
-          this.onStartResponse(false);
-          this.toolResultSubscription = null;
-        },
-        complete: () => {
-          this.onStreamingStateChange(false);
-          this.onStartResponse(false);
-          this.toolResultSubscription = null;
-        },
-      });
-
-      // Store subscription so it can be unsubscribed in clearState
-      this.toolResultSubscription = subscription;
+        messages,
+        abortController.signal
+      ));
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to send tool result:', error);
-      this.onSendToolResultStateChange?.(false);
-      this.onStreamingStateChange(false);
+      releaseController();
+
+      // Surface the failure in the timeline so the user can tell the
+      // conversation is out of sync (the assistant never received the
+      // result) rather than silently showing a failed tool row.
+      const failureMessage: SystemMessage = {
+        id: `tool-send-failed-${toolCallId}-${Date.now()}`,
+        role: 'system',
+        content: i18n.translate('chat.toolResult.sendFailed', {
+          defaultMessage:
+            'Failed to send tool result to the assistant. The conversation may be out of sync.',
+        }),
+      };
+      this.onTimelineUpdate((prev) => [...prev, failureMessage]);
+      return;
+    } finally {
+      // Only notify "done" if a newer send has not replaced the controller.
+      if (
+        this.toolResultAbortController === abortController ||
+        this.toolResultAbortController === null
+      ) {
+        this.onSendToolResultStateChange?.(false);
+      }
     }
+
+    if (skipped) {
+      if (skipped.reason === 'aborted') {
+        // User initiated the abort (e.g. via cancelToolResultDispatch). No
+        // user-facing system message — the cancellation is intentional.
+        releaseController();
+        return;
+      }
+
+      if (skipped.reason === 'sync_timeout') {
+        // Sync polling exhausted without observing the tool call in history.
+        // Store the result on the system message so the user can retry via
+        // the resend affordance without needing an external map.
+        const timeoutMessage: SystemMessage = {
+          id: `tool-sync-timeout-${toolCallId}-${Date.now()}`,
+          role: 'system',
+          content: i18n.translate('chat.toolResult.syncTimeout', {
+            defaultMessage:
+              'We could not confirm the tool call was synced before sending the result. You can resend the tool result to try again.',
+          }),
+          toolCallId,
+          canResend: true,
+          toolResult: result,
+        };
+        this.onTimelineUpdate((prev) => [...prev, timeoutMessage]);
+        releaseController();
+        return;
+      }
+
+      if (skipped.reason === 'no_thread_id') {
+        // No thread id is an unusual state — surface it so the user isn't
+        // left wondering why nothing happened. No resend affordance since
+        // retrying without a thread would hit the same path.
+        const noThreadMessage: SystemMessage = {
+          id: `tool-no-thread-${toolCallId}-${Date.now()}`,
+          role: 'system',
+          content: i18n.translate('chat.toolResult.noThreadId', {
+            defaultMessage:
+              'Tool result could not be sent because the conversation thread is missing. Start a new chat and try again.',
+          }),
+          toolCallId,
+        };
+        this.onTimelineUpdate((prev) => [...prev, noThreadMessage]);
+        releaseController();
+        return;
+      }
+
+      // result_already_exists: another window already persisted a tool
+      // result for this toolCallId. Skip appending the locally-constructed
+      // toolMessage and surface an informational system message instead.
+      const infoMessage: SystemMessage = {
+        id: `tool-skipped-${toolCallId}-${Date.now()}`,
+        role: 'system',
+        content: i18n.translate('chat.toolResult.alreadySubmitted', {
+          defaultMessage: 'This tool result was already submitted from another window.',
+        }),
+      };
+      this.onTimelineUpdate((prev) => [...prev, infoMessage]);
+      releaseController();
+      return;
+    }
+
+    this.onTimelineUpdate((prev) => [...prev, toolMessage]);
+
+    // Set streaming state and subscribe to the response stream
+    this.onStreamingStateChange(true);
+
+    const subscription = observable.subscribe({
+      next: (event: ChatEvent) => {
+        // Handle the assistant's response to the tool result
+        this.handleEvent(event);
+      },
+      error: (error: Error) => {
+        // A deliberate abort surfaces as AbortError — treat it as a quiet
+        // cancellation rather than a real error.
+        if (error?.name !== 'AbortError') {
+          // eslint-disable-next-line no-console
+          console.error('Tool result response error:', error);
+        }
+      },
+    });
+    subscription.add(() => {
+      this.onStreamingStateChange(false);
+      this.onStartResponse(false);
+      this.toolResultSubscription = null;
+      releaseController();
+    });
+
+    // Store subscription so it can be unsubscribed in clearState
+    this.toolResultSubscription = subscription;
   }
 
   // timelineToMessages method removed - timeline is now directly AG-UI compatible
@@ -743,19 +839,26 @@ export class ChatEventHandler {
     // @ts-expect-error TS2339 TODO(ts-error): fixme
     this._lastAssistantMessageId = null;
 
-    // Stop tool result streaming if active
-    this.stopToolResultStreaming();
+    // Cancel any in-flight tool result dispatch
+    this.cancelToolResultDispatch();
   }
 
   /**
-   * Stop tool result streaming if active
+   * Cancel the in-flight tool result dispatch if active.
+   *
+   * Aborts both the pre-dispatch polling loop and the post-dispatch agent
+   * stream via `toolResultAbortController`. Also unsubscribes from the
+   * wrapped observable, triggering the registered teardown callback for
+   * state cleanup.
    */
-  stopToolResultStreaming(): void {
+  cancelToolResultDispatch(): void {
+    if (this.toolResultAbortController) {
+      this.toolResultAbortController.abort();
+      this.toolResultAbortController = null;
+    }
     if (this.toolResultSubscription) {
       this.toolResultSubscription.unsubscribe();
       this.toolResultSubscription = null;
-      this.onStreamingStateChange(false);
-      this.onStartResponse(false);
     }
   }
 }

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -765,26 +765,36 @@ describe('ChatService', () => {
             },
           ]);
         }
-        // Third call returns MESSAGES_SNAPSHOT with the tool call
+        // Subsequent calls return MESSAGES_SNAPSHOT with the tool call
         return Promise.resolve(createMockMessagesSnapshot(toolCallId));
       });
 
       const response = await chatService.sendToolResult(toolCallId, { success: true }, []);
 
-      // Verify getConversation was called multiple times (polling)
-      expect(chatService.conversationHistoryService.getConversation).toHaveBeenCalledTimes(3);
+      // Verify getConversation was polled multiple times. We require 3
+      // consecutive synced observations before treating the tool call as
+      // stably synced, so after the first synced snapshot (call #3) two more
+      // confirming polls are needed (calls #4 and #5).
+      expect(chatService.conversationHistoryService.getConversation).toHaveBeenCalledTimes(5);
       expect(response.toolMessage.toolCallId).toBe(toolCallId);
     });
-    it('should throw error when thread ID is not set', async () => {
+    it('should skip dispatch with reason no_thread_id when thread ID is not set', async () => {
       // Create a new service without calling newThread
       const newService = new ChatService(mockUiSettings, mockCoreChatService);
 
       // Mock getThreadId to return undefined
       mockCoreChatService.getThreadId.mockReturnValue(undefined);
 
-      await expect(newService.sendToolResult('tool-123', 'result', [])).rejects.toThrow(
-        'Thread ID is required to send a tool result'
-      );
+      const response = await newService.sendToolResult('tool-123', 'result', []);
+
+      expect(response.skipped).toEqual({ reason: 'no_thread_id' });
+      expect(mockAgent.runAgent).not.toHaveBeenCalled();
+      expect(response.toolMessage).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'tool',
+        content: 'result',
+        toolCallId: 'tool-123',
+      });
     });
 
     describe('skip branch (duplicate tool result across windows)', () => {
@@ -894,6 +904,198 @@ describe('ChatService', () => {
 
         expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
         expect(response.skipped).toBeUndefined();
+      });
+    });
+
+    describe('abort signal', () => {
+      beforeEach(() => {
+        mockCoreChatService.getMemoryProvider = jest
+          .fn()
+          .mockReturnValue({ includeFullHistory: false });
+      });
+
+      it('should skip with reason aborted when signal is already aborted before dispatch', async () => {
+        const toolCallId = 'tool-call-abort-early';
+        const controller = new AbortController();
+        controller.abort();
+
+        // getConversation should not even be consulted — the early-out fires
+        // before sync polling.
+        chatService.conversationHistoryService.getConversation = jest.fn();
+
+        const response = await chatService.sendToolResult(
+          toolCallId,
+          { ok: true },
+          [],
+          controller.signal
+        );
+
+        expect(response.skipped).toEqual({ reason: 'aborted' });
+        expect(mockAgent.runAgent).not.toHaveBeenCalled();
+        expect(chatService.conversationHistoryService.getConversation).not.toHaveBeenCalled();
+        expect((chatService as any).activeRequests.size).toBe(0);
+      });
+
+      it('should skip with reason aborted when signal fires during sync polling', async () => {
+        const toolCallId = 'tool-call-abort-mid-sync';
+        const controller = new AbortController();
+
+        // Return a pending snapshot so the poller loops (no synced observation)
+        chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue([
+          {
+            type: 'MESSAGES_SNAPSHOT',
+            timestamp: Date.now(),
+            messages: [{ role: 'user', id: 'u1', content: 'hi' }],
+          },
+        ]);
+
+        // Fire the abort shortly after the first poll resolves so the
+        // interruptible sleep can observe it.
+        setTimeout(() => controller.abort(), 5);
+
+        const response = await chatService.sendToolResult(
+          toolCallId,
+          { ok: true },
+          [],
+          controller.signal
+        );
+
+        expect(response.skipped).toEqual({ reason: 'aborted' });
+        expect(mockAgent.runAgent).not.toHaveBeenCalled();
+        expect((chatService as any).activeRequests.size).toBe(0);
+      });
+
+      it('should emit AbortError and call agent.abort when signal fires after dispatch', async () => {
+        const toolCallId = 'tool-call-abort-during-stream';
+        const controller = new AbortController();
+
+        // Minimal observable that never emits/completes so we can control
+        // lifecycle via the abort signal alone.
+        const pendingObservable = new Observable<BaseEvent>(() => {
+          // intentionally no-op — the wrapping Observable in sendToolResult
+          // owns the termination path
+          return () => {};
+        });
+        mockAgent.runAgent.mockReturnValue(pendingObservable);
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
+
+        const response = await chatService.sendToolResult(
+          toolCallId,
+          { ok: true },
+          [],
+          controller.signal
+        );
+
+        expect(response.skipped).toBeUndefined();
+        expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
+
+        const nextSpy = jest.fn();
+        const errorSpy = jest.fn();
+        const completeSpy = jest.fn();
+
+        response.observable.subscribe({
+          next: nextSpy,
+          error: errorSpy,
+          complete: completeSpy,
+        });
+
+        controller.abort();
+
+        expect(mockAgent.abort).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const emittedError = errorSpy.mock.calls[0][0];
+        expect(emittedError).toBeInstanceOf(Error);
+        expect(emittedError.name).toBe('AbortError');
+        expect(completeSpy).not.toHaveBeenCalled();
+        expect(nextSpy).not.toHaveBeenCalled();
+        expect((chatService as any).activeRequests.size).toBe(0);
+      });
+
+      it('should emit AbortError synchronously when signal is already aborted at subscribe time', async () => {
+        const toolCallId = 'tool-call-abort-at-subscribe';
+        const controller = new AbortController();
+
+        // Keep the underlying observable inert so only the abort path drives
+        // termination.
+        const pendingObservable = new Observable<BaseEvent>(() => () => {});
+        mockAgent.runAgent.mockReturnValue(pendingObservable);
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
+
+        const response = await chatService.sendToolResult(
+          toolCallId,
+          { ok: true },
+          [],
+          controller.signal
+        );
+
+        // Abort after dispatch but before subscribing — the subscribe path
+        // should detect the pre-aborted signal and emit AbortError immediately.
+        controller.abort();
+
+        const errorSpy = jest.fn();
+        const completeSpy = jest.fn();
+
+        response.observable.subscribe({
+          error: errorSpy,
+          complete: completeSpy,
+        });
+
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy.mock.calls[0][0].name).toBe('AbortError');
+        expect(completeSpy).not.toHaveBeenCalled();
+      });
+
+      it('should not emit twice when signal fires during an active subscription', async () => {
+        const toolCallId = 'tool-call-abort-no-double-emit';
+        const controller = new AbortController();
+
+        // Observable that emits one value, then stays open until aborted.
+        let innerEmit: ((v: BaseEvent) => void) | null = null;
+        const gatedObservable = new Observable<BaseEvent>((subscriber) => {
+          innerEmit = (v) => subscriber.next(v);
+          return () => {};
+        });
+        mockAgent.runAgent.mockReturnValue(gatedObservable);
+
+        chatService.conversationHistoryService.getConversation = jest
+          .fn()
+          .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
+
+        const response = await chatService.sendToolResult(
+          toolCallId,
+          { ok: true },
+          [],
+          controller.signal
+        );
+
+        const nextSpy = jest.fn();
+        const errorSpy = jest.fn();
+        const completeSpy = jest.fn();
+
+        response.observable.subscribe({
+          next: nextSpy,
+          error: errorSpy,
+          complete: completeSpy,
+        });
+
+        // Deliver one value so the subscription is live.
+        innerEmit!({ type: 'RUN_STARTED' } as BaseEvent);
+        expect(nextSpy).toHaveBeenCalledTimes(1);
+
+        // Abort, then try to shove more values through — they should be
+        // swallowed by the `settled` guard rather than reaching the subscriber.
+        controller.abort();
+        innerEmit!({ type: 'RUN_FINISHED' } as BaseEvent);
+
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(nextSpy).toHaveBeenCalledTimes(1);
+        expect(completeSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -397,98 +397,192 @@ export class ChatService {
   }
 
   /**
+   * Number of consecutive polls in which the tool call id must be observed
+   * in history before we treat it as stably synced. Any pending observation
+   * or error resets the streak. This guards against transient snapshots
+   * where the id briefly appears then disappears as memory is rewritten.
+   */
+  private readonly TOOL_CALL_SYNC_MATURITY_THRESHOLD = 3;
+
+  /**
+   * Sleep for `ms` milliseconds, bailing out early if `signal` aborts.
+   * Returns true if the sleep was interrupted by the signal, false if the
+   * timer completed normally.
+   */
+  private interruptibleSleep(ms: number, signal?: AbortSignal): Promise<boolean> {
+    if (signal?.aborted) return Promise.resolve(true);
+
+    return new Promise<boolean>((resolve) => {
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+        resolve(true);
+      };
+      const timeoutId = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve(false);
+      }, ms);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  /**
    * Wait for tool call to be synced to agentic memory.
    *
-   * Returns `{ shouldSend: false, reason: 'result_already_exists' }` if a
-   * ToolMessage with the same toolCallId is already in history (another
-   * window persisted it first). Returns `{ shouldSend: true, reason: 'synced'
-   * | 'timeout_fallback' | 'no_thread_id' }` otherwise — caller should
-   * dispatch.
+   * Polls conversation history up to `maxAttempts` times, waiting `intervalMs`
+   * between polls. Returns one of:
+   * - `{ shouldSend: true,  reason: 'synced' }`              — tool call is in
+   *   history, caller may dispatch the tool result.
+   * - `{ shouldSend: false, reason: 'result_already_exists' }` — another
+   *   window persisted a tool result first; caller should skip dispatch.
+   * - `{ shouldSend: false, reason: 'sync_timeout' }`        — polling
+   *   exhausted without observing sync; caller should skip dispatch and
+   *   surface a resendable failure to the user.
+   * - `{ shouldSend: false, reason: 'no_thread_id' }`        — no thread id
+   *   available; caller should skip dispatch.
+   * - `{ shouldSend: false, reason: 'aborted' }`             — caller-supplied
+   *   abort signal fired; caller should skip dispatch.
+   *
+   * Note: exhausted attempts no longer silently proceed — the caller must
+   * decide whether to resend.
    */
   private async waitForToolCallSync(
     toolCallId: string,
-    maxAttempts: number = 10,
-    intervalMs: number = 1000
-  ): Promise<{ shouldSend: boolean; reason: string }> {
+    maxAttempts: number = 15,
+    intervalMs: number = 1000,
+    signal?: AbortSignal
+  ): Promise<{
+    shouldSend: boolean;
+    reason: 'synced' | 'no_thread_id' | 'result_already_exists' | 'sync_timeout' | 'aborted';
+  }> {
+    if (signal?.aborted) return { shouldSend: false, reason: 'aborted' };
+
     const threadId = this.getThreadId();
-    if (!threadId) return { shouldSend: true, reason: 'no_thread_id' };
+    if (!threadId) return { shouldSend: false, reason: 'no_thread_id' };
+
+    const checkSyncStatus = async (): Promise<'result_already_exists' | 'synced' | 'pending'> => {
+      const events = await this.conversationHistoryService.getConversation(threadId);
+      if (!events) return 'pending';
+
+      const hasToolResult = events.some((event) => {
+        if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
+          const messages = (event as any).messages as Message[];
+          return messages.some(
+            (msg) =>
+              msg.role === 'tool' && 'toolCallId' in msg && (msg as any).toolCallId === toolCallId
+          );
+        }
+        return false;
+      });
+      if (hasToolResult) return 'result_already_exists';
+
+      const hasToolCall = events.some((event) => {
+        if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
+          const messages = (event as any).messages as Message[];
+          return messages.some(
+            (msg) =>
+              msg.role === 'assistant' &&
+              'toolCalls' in msg &&
+              Array.isArray((msg as any).toolCalls) &&
+              (msg as any).toolCalls.some((tc: any) => tc.id === toolCallId)
+          );
+        }
+        return false;
+      });
+      return hasToolCall ? 'synced' : 'pending';
+    };
+
+    let consecutiveSyncedPolls = 0;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (signal?.aborted) return { shouldSend: false, reason: 'aborted' };
+
       try {
-        const events = await this.conversationHistoryService.getConversation(threadId);
+        const status = await checkSyncStatus();
+        if (signal?.aborted) return { shouldSend: false, reason: 'aborted' };
 
-        if (events) {
-          const toolResultExists = events.some((event) => {
-            if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
-              const messages = (event as any).messages as Message[];
-              return messages.some(
-                (msg) =>
-                  msg.role === 'tool' &&
-                  'toolCallId' in msg &&
-                  (msg as any).toolCallId === toolCallId
-              );
-            }
-            return false;
-          });
-
-          if (toolResultExists) {
-            return { shouldSend: false, reason: 'result_already_exists' };
-          }
-
-          const toolCallSynced = events.some((event) => {
-            if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
-              const messages = (event as any).messages as Message[];
-              return messages.some(
-                (msg) =>
-                  msg.role === 'assistant' &&
-                  'toolCalls' in msg &&
-                  Array.isArray((msg as any).toolCalls) &&
-                  (msg as any).toolCalls.some((tc: any) => tc.id === toolCallId)
-              );
-            }
-            return false;
-          });
-
-          if (toolCallSynced) {
+        if (status === 'result_already_exists') {
+          return { shouldSend: false, reason: 'result_already_exists' };
+        }
+        if (status === 'synced') {
+          // Require `TOOL_CALL_SYNC_MATURITY_THRESHOLD` consecutive synced
+          // observations before treating the tool call as stably synced.
+          // This guards against transient snapshots where the id appears
+          // briefly before being rewritten.
+          consecutiveSyncedPolls += 1;
+          if (consecutiveSyncedPolls >= this.TOOL_CALL_SYNC_MATURITY_THRESHOLD) {
             return { shouldSend: true, reason: 'synced' };
           }
+        } else {
+          // Pending — id not yet in snapshot. Reset the streak so the
+          // maturity guarantee is "consecutive", not "cumulative".
+          consecutiveSyncedPolls = 0;
         }
       } catch (error) {
+        // Reset the streak on any error — maturity requires uninterrupted
+        // successful observations.
+        consecutiveSyncedPolls = 0;
         // eslint-disable-next-line no-console
         console.warn(`Failed to check tool call sync status (attempt ${attempt + 1}):`, error);
       }
 
-      // Wait before next attempt
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      // Wait before next attempt (skip the wait after the final attempt).
+      // The sleep is interruptible so `cancelToolResultDispatch` aborts
+      // immediately rather than waiting for the next tick.
+      if (attempt < maxAttempts - 1) {
+        const interrupted = await this.interruptibleSleep(intervalMs, signal);
+        if (interrupted) return { shouldSend: false, reason: 'aborted' };
+      }
     }
 
-    // If we've exhausted all attempts, log a warning but still proceed —
-    // losing a tool result is worse than occasionally duplicating.
+    // Exhausted attempts without observing sync — do NOT silently dispatch.
+    // Surface the failure so the caller can show a system message and let the
+    // user decide whether to resend.
     // eslint-disable-next-line no-console
     console.warn(
       `Tool call sync check timed out after ${maxAttempts} attempts for toolCallId: ${toolCallId}`
     );
-    return { shouldSend: true, reason: 'timeout_fallback' };
+    return { shouldSend: false, reason: 'sync_timeout' };
   }
 
   public async sendToolResult(
     toolCallId: string,
     result: any,
-    messages: Message[]
+    messages: Message[],
+    signal?: AbortSignal
   ): Promise<{
     observable: any;
     toolMessage: ToolMessage;
-    skipped?: { reason: 'result_already_exists' };
+    skipped?: {
+      reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted';
+    };
   }> {
     const requestId = this.generateRequestId();
 
     this.addActiveRequest(requestId);
+
     const toolMessage: ToolMessage = {
       id: this.generateMessageId(),
       role: 'tool',
       content: typeof result === 'string' ? result : JSON.stringify(result),
       toolCallId,
     };
+
+    // Helper to return a completed empty observable paired with a skip
+    // reason. Centralizes active-request cleanup so callers don't have to
+    // repeat it in each branch.
+    const skip = (
+      reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted'
+    ) => {
+      this.removeActiveRequest(requestId);
+      return {
+        observable: new Observable((subscriber) => subscriber.complete()),
+        toolMessage,
+        skipped: { reason },
+      };
+    };
+
+    // Early-out if the caller aborted before we even began.
+    if (signal?.aborted) return skip('aborted');
 
     // Get workspace-aware data source ID
     const dataSourceId = await this.getWorkspaceAwareDataSourceId();
@@ -511,7 +605,10 @@ export class ChatService {
     const threadId = this.getThreadId();
 
     if (!threadId) {
-      throw new Error('Thread ID is required to send a tool result');
+      // No thread id — dispatch isn't possible. Skip rather than throwing so
+      // callers can surface a user-visible system message instead of a
+      // silent console error.
+      return skip('no_thread_id');
     }
 
     const runInput: RunAgentInput = {
@@ -527,40 +624,72 @@ export class ChatService {
     // Wait for tool call result to be synced to agentic memory only when not including full history
     // (when full history is included, messages are passed directly so no sync wait needed)
     if (!includeFullHistory) {
-      const syncResult = await this.waitForToolCallSync(toolCallId);
+      const syncResult = await this.waitForToolCallSync(toolCallId, undefined, undefined, signal);
 
-      // Another window already persisted a tool result for this toolCallId —
-      // skip dispatch to avoid a duplicate in history. Return a completed
-      // empty observable and signal the skip via `skipped` so callers can
-      // avoid appending a phantom tool message to their local timeline.
+      // Sync check returned a reason to skip dispatch:
+      // - `result_already_exists`: another window already persisted a tool
+      //   result. Skip to avoid a duplicate.
+      // - `sync_timeout`: polling exhausted. Skip and surface the failure so
+      //   the user can resend.
+      // - `aborted`: caller cancelled via the AbortSignal. Skip silently.
       if (!syncResult.shouldSend) {
-        const emptyObservable = new Observable((subscriber) => subscriber.complete());
-        this.removeActiveRequest(requestId);
-        return {
-          observable: emptyObservable,
-          toolMessage,
-          skipped: { reason: 'result_already_exists' },
-        };
+        return skip(syncResult.reason as Exclude<typeof syncResult.reason, 'synced'>);
       }
     }
+
+    // If the signal fired between sync completion and dispatch, bail out.
+    if (signal?.aborted) return skip('aborted');
 
     // Continue the conversation with the tool result
     const observable = this.agent.runAgent(runInput, dataSourceId);
 
-    // Wrap observable to track completion
+    // Wrap observable to track completion and honor the caller's abort
+    // signal. When the signal fires, we abort the underlying agent fetch and
+    // surface an AbortError to subscribers so they can distinguish a
+    // cancellation from a real stream error.
     const trackedObservable = new Observable((subscriber: any) => {
+      // `settled` guards against emitting twice when the abort handler races
+      // with the inner subscription's error/complete (aborting the agent
+      // typically triggers both paths).
+      let settled = false;
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        signal?.removeEventListener('abort', onAbort);
+        this.removeActiveRequest(requestId);
+        fn();
+      };
+
+      const onAbort = () => {
+        settle(() => {
+          this.agent.abort();
+          const abortError = new Error('Tool result send aborted');
+          abortError.name = 'AbortError';
+          subscriber.error(abortError);
+        });
+      };
+
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+
       const subscription = observable.subscribe({
-        next: (value: any) => subscriber.next(value),
-        error: (error: any) => {
-          this.removeActiveRequest(requestId);
-          subscriber.error(error);
+        next: (value: any) => {
+          if (!settled) subscriber.next(value);
         },
-        complete: () => {
-          this.removeActiveRequest(requestId);
-          subscriber.complete();
-        },
+        error: (error: any) => settle(() => subscriber.error(error)),
+        complete: () => settle(() => subscriber.complete()),
       });
-      return () => subscription.unsubscribe();
+
+      return () => {
+        settle(() => {
+          /* no-op — unsubscribe path just needs cleanup, not an error */
+        });
+        subscription.unsubscribe();
+      };
     });
 
     this.events$ = trackedObservable;


### PR DESCRIPTION
   ### Description

   This PR improves the reliability of tool result dispatch by addressing an instability in the sync polling mechanism and adding user-facing recovery when dispatch cannot proceed.

   **Problem:**

   When a tool call completes locally, the client polls agentic memory to confirm the tool call id exists before sending the tool result. Two issues existed:

   1. **Transient sync observations:** The tool call id would appear in one poll response but disappear in the next (due to memory rewrites). Sending the tool result based on a single observation could
   result in an orphaned tool result — one that references a tool call id the LLM does not recognize. This triggers a validation error on the LLM side and invalidates the entire session.

   2. **Timeout fallback sent anyway:** When polling exhausted all attempts without confirming sync, the old code sent the tool result regardless. But an orphaned tool result corrupts the session rather
   than just losing a single turn.

   **Changes:**

   - **Maturity-based sync polling:** Require 3 consecutive successful observations of the tool call id before treating it as stably synced. Any pending or error response resets the streak. Increased max
   attempts from 10 to 15. Polling sleep is now interruptible via `AbortSignal`.
   - **Skip dispatch on timeout:** When polling exhausts without confirming the tool call id, dispatch is skipped. A resendable system message with the tool result payload is appended to the timeline so
   the user can retry.
   - **Skip dispatch when thread id is missing:** Previously threw an error. Now returns a typed skip reason (`no_thread_id`) so callers can surface a user-visible message.
   - **Abort signal propagation:** `sendToolResult` accepts an `AbortSignal` that flows through sync polling → agent dispatch → response stream. `cancelToolResultDispatch()` aborts both pre-dispatch
   polling and post-dispatch agent stream. Starting a new send automatically aborts any in-flight previous send.
   - **Resend UI:** `ErrorRow` renders a "Resend tool result" button when the system message carries `canResend: true` and `toolResult`. The button is disabled during send. `ChatWindow` removes the error
   message and calls `sendToolResultToAssistant` directly.
   - **Type changes:** Added `toolCallId`, `canResend`, and `toolResult` fields to `SystemMessage`.

   ## Screenshot

[video.webm](https://github.com/user-attachments/assets/80cffece-9d5c-4c1d-8176-54c7c9fd1381)

   ## Testing the changes

   1. Trigger a tool call in chat that requires sync polling (non-full-history memory provider).
   2. Verify the tool result is sent successfully after 3 consecutive synced observations.
   3. Simulate a sync timeout (e.g., by disconnecting the backend briefly) — verify a "Resend tool result" button appears.
   4. Click the resend button — verify the error message is removed and the tool result is re-dispatched.
   5. Click "Stop" during tool result dispatch — verify the abort cancels immediately without leaving stale state.

   ### Check List

   - [x] All tests pass
     - [x] `yarn test:jest`
     - [ ] `yarn test:jest_integration`
   - [x] New functionality includes testing.
   - [ ] New functionality has been documented.
   - [x] Commits are signed per the DCO using --signoff