### PR TITLE
[Chat] Fix tool running state showing incorrectly on snapshot-loaded conversations

### DIFF
--- a/src/core/public/chat/types.ts
+++ b/src/core/public/chat/types.ts
@@ -107,7 +107,6 @@ export interface ToolMessage {
   content: string;
   role: 'tool';
   toolCallId: string;
-  error?: string;
 }
 
 /**

--- a/src/plugins/chat/common/index.ts
+++ b/src/plugins/chat/common/index.ts
@@ -6,3 +6,17 @@
 export const PLUGIN_ID = 'chat';
 export const PLUGIN_NAME = 'chat';
 export const CHAT_DEFAULT_AG_UI_URL = 'http://localhost:3000';
+
+/**
+ * Prefix used on the tool result content when a tool execution fails locally
+ * (e.g. JSON parse error, thrown exception in the executor).
+ *
+ * The ToolMessage built by `chatService.sendToolResult` only stringifies the
+ * result into `content` — it does not carry an `error` flag. By prefixing the
+ * error text with this string, the same content survives a snapshot reload
+ * and `getToolStatus` can detect it to render the tool row in an error state
+ * without needing a separate local-only ToolMessage that would diverge from
+ * agentic memory. Using natural-language prose rather than a JSON metadata
+ * field keeps the payload readable for the LLM on the next turn.
+ */
+export const TOOL_EXECUTION_ERROR_PREFIX = 'Tool execution failed: ';

--- a/src/plugins/chat/common/types.test.ts
+++ b/src/plugins/chat/common/types.test.ts
@@ -197,19 +197,6 @@ describe('Chat Types and Schemas', () => {
         expect(result.success).toBe(true);
       });
 
-      it('should validate tool message with error', () => {
-        const validMessage = {
-          id: 'msg-123',
-          content: 'Tool error',
-          role: 'tool' as const,
-          toolCallId: 'tool-123',
-          error: 'Tool execution failed',
-        };
-
-        const result = ToolMessageSchema.safeParse(validMessage);
-        expect(result.success).toBe(true);
-      });
-
       it('should reject tool message without toolCallId', () => {
         const invalidMessage = {
           id: 'msg-123',

--- a/src/plugins/chat/common/types.ts
+++ b/src/plugins/chat/common/types.ts
@@ -84,7 +84,6 @@ export const ToolMessageSchema = z.object({
   content: z.string(),
   role: z.literal('tool'),
   toolCallId: z.string(),
-  error: z.string().optional(),
 });
 
 export const MessageSchema = z.discriminatedUnion('role', [

--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -7,7 +7,9 @@ import { render } from '@testing-library/react';
 import { ChatMessages } from './chat_messages';
 import { ChatLayoutMode } from '../types';
 import type { Message, AssistantMessage, ToolMessage, UserMessage } from '../../common/types';
+import { TOOL_EXECUTION_ERROR_PREFIX } from '../../common';
 import { convertTimelineToMessageRows } from './chat_messages';
+import { AssistantActionService, ToolCallState } from '../../../context_provider/public';
 
 // Mock the child components
 jest.mock('./message_row', () => ({
@@ -598,11 +600,15 @@ describe('convertTimelineToMessageRows', () => {
           },
         ],
       } as AssistantMessage,
-      // No tool result - tool is running
+      // No tool result - tool is running (tracked via toolCallStates)
       { id: 'msg-3', role: 'assistant', content: 'Processing continues' } as AssistantMessage,
     ];
 
-    const result = convertTimelineToMessageRows(timeline);
+    const toolCallStates = new Map<string, ToolCallState>([
+      ['tool-1', { id: 'tool-1', name: 'search', status: 'executing', timestamp: Date.now() }],
+    ]);
+
+    const result = convertTimelineToMessageRows(timeline, toolCallStates);
 
     // Should continue processing and show all messages
     expect(result).toHaveLength(4);
@@ -705,11 +711,15 @@ describe('convertTimelineToMessageRows', () => {
           },
         ],
       } as AssistantMessage,
-      // No result for tool-2 - it's running
+      // No result for tool-2 - it's running (tracked via toolCallStates)
       { id: 'msg-4', role: 'assistant', content: 'Still processing' } as AssistantMessage,
     ];
 
-    const result = convertTimelineToMessageRows(timeline);
+    const toolCallStates = new Map<string, ToolCallState>([
+      ['tool-2', { id: 'tool-2', name: 'task2', status: 'executing', timestamp: Date.now() }],
+    ]);
+
+    const result = convertTimelineToMessageRows(timeline, toolCallStates);
 
     // Should not group when continuation has running tools, continue processing
     expect(result).toHaveLength(6);
@@ -739,6 +749,38 @@ describe('convertTimelineToMessageRows', () => {
     expect(result[5]).toMatchObject({ role: 'assistant', id: 'msg-4' });
   });
 
+  it('should treat historical tool calls with no result and no state as errors', () => {
+    // Snapshot-loaded conversation where the tool call never produced a
+    // ToolMessage and has no event-driven state — it was abandoned, not
+    // still running.
+    const timeline: Message[] = [
+      { id: 'msg-1', role: 'user', content: 'Search' } as UserMessage,
+      {
+        id: 'msg-2',
+        role: 'assistant',
+        content: 'Searching...',
+        toolCalls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: { name: 'search', arguments: '{}' },
+          },
+        ],
+      } as AssistantMessage,
+    ];
+
+    const result = convertTimelineToMessageRows(timeline);
+
+    expect(result).toHaveLength(3);
+    expect(result[2]).toMatchObject({ role: 'toolCall' });
+    const toolCallRow = result[2] as { role: 'toolCall'; toolCall: any };
+    expect(toolCallRow.toolCall).toMatchObject({
+      id: 'tool-1',
+      toolName: 'search',
+      status: 'error',
+    });
+  });
+
   it('should preserve error status for failed tool calls', () => {
     const timeline: Message[] = [
       { id: 'msg-1', role: 'user', content: 'Do something' } as UserMessage,
@@ -756,9 +798,8 @@ describe('convertTimelineToMessageRows', () => {
       {
         id: 'tool-result-1',
         role: 'tool',
-        content: 'Error occurred',
+        content: `${TOOL_EXECUTION_ERROR_PREFIX}Tool execution failed`,
         toolCallId: 'tool-1',
-        error: 'Tool execution failed',
       } as ToolMessage,
       { id: 'msg-3', role: 'assistant', content: 'Sorry, error' } as AssistantMessage,
     ];
@@ -770,7 +811,7 @@ describe('convertTimelineToMessageRows', () => {
     expect(toolCallGroup.toolCalls[0]).toMatchObject({
       id: 'tool-1',
       status: 'error',
-      result: 'Error occurred',
+      result: `${TOOL_EXECUTION_ERROR_PREFIX}Tool execution failed`,
     });
   });
 });
@@ -856,8 +897,26 @@ describe('share button with running tool calls', () => {
     threadId: 'thread-1',
   };
 
+  afterEach(() => {
+    // The AssistantActionService is a process-wide singleton, so stray
+    // toolCallStates from one test can bleed into the next. Drain it after
+    // every test so each case starts from a clean map.
+    const service = AssistantActionService.getInstance();
+    const ids = Array.from(service.getCurrentState().toolCallStates.keys());
+    ids.forEach((id) => service.clearToolCallState(id));
+  });
+
   it('should not pass timeline when tool calls are still running', () => {
-    // Simulate a turn where the assistant has text content but a tool call has no result yet
+    // Simulate a turn where the assistant has text content but a tool call is
+    // still executing (tracked in the event-driven toolCallStates).
+    const service = AssistantActionService.getInstance();
+    service.updateToolCallState('tc1', {
+      id: 'tc1',
+      name: 'SearchTool',
+      status: 'executing',
+      timestamp: Date.now(),
+    });
+
     const timeline: Message[] = [
       { id: '1', role: 'user', content: 'Question' } as UserMessage,
       {
@@ -868,7 +927,7 @@ describe('share button with running tool calls', () => {
           { id: 'tc1', type: 'function', function: { name: 'SearchTool', arguments: '{}' } },
         ],
       } as AssistantMessage,
-      // No ToolMessage for tc1 — tool is still running
+      // No ToolMessage for tc1 — tool is still running per toolCallStates
     ];
 
     const { getAllByTestId } = render(<ChatMessages {...defaultProps} timeline={timeline} />);

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -5,15 +5,18 @@
 
 import React, { useRef, useEffect, useMemo, useCallback } from 'react';
 import { EuiIcon, EuiText, EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { useObservable } from 'react-use';
+import { map } from 'rxjs/operators';
 import { ChatLayoutMode } from '../types';
 import { MessageRow } from './message_row';
 import { TimelineToolCall, ToolCallRow } from './tool_call_row';
 import { ErrorRow } from './error_row';
 import type { Message, AssistantMessage, ToolMessage, ToolCall } from '../../common/types';
+import { TOOL_EXECUTION_ERROR_PREFIX } from '../../common';
 import './chat_messages.scss';
 import { ChatSuggestions } from './chat_suggestions';
 import { ToolCallGroup } from './tool_call_group';
-import { AssistantActionService } from '../../../context_provider/public';
+import { AssistantActionService, ToolCallState } from '../../../context_provider/public';
 import { RecentSessions } from './recent_sessions';
 import {
   ConversationHistoryService,
@@ -21,14 +24,43 @@ import {
 } from '../services/conversation_history_service';
 
 /**
- * Determine tool status based on tool call and result
+ * Determine tool status.
+ *
+ * Source of truth is the event-driven `toolCallStates` map maintained by
+ * `AssistantActionService` — it is updated in response to AG-UI events
+ * (TOOL_CALL_START / TOOL_CALL_END / TOOL_CALL_RESULT) and reflects the real
+ * lifecycle of the tool call.
+ *
+ * When there is no event state (e.g. historical tool calls loaded from a
+ * snapshot), status is derived from the ToolMessage in the timeline. At that
+ * point the absence of a ToolMessage means the call is abandoned — the run
+ * ended before the tool finished — not that it is still running.
+ *
+ * The chat event handler prefixes the tool result content with
+ * `TOOL_EXECUTION_ERROR_PREFIX` when a tool throws locally (see
+ * `handleToolCallEnd`). `chatService.sendToolResult` passes that string
+ * straight into the ToolMessage `content`, so detecting the prefix here
+ * lets a reloaded conversation render the tool row as an error without
+ * relying on a separate local-only ToolMessage.
  */
 function getToolStatus(
   toolCall: ToolCall,
+  toolCallStates?: Map<string, ToolCallState>,
   toolResult?: ToolMessage
 ): 'running' | 'completed' | 'error' {
-  if (!toolResult) return 'running';
-  if (toolResult.error) return 'error';
+  const state = toolCallStates?.get(toolCall.id);
+  if (state) {
+    switch (state.status) {
+      case 'complete':
+        return 'completed';
+      case 'failed':
+        return 'error';
+      default:
+        return 'running';
+    }
+  }
+  if (!toolResult) return 'error';
+  if (toolResult.content?.startsWith(TOOL_EXECUTION_ERROR_PREFIX)) return 'error';
   return 'completed';
 }
 
@@ -94,7 +126,10 @@ interface ChatMessagesProps {
  * @param timeline - Array of messages from the conversation
  * @returns Array of message rows ready for display
  */
-export const convertTimelineToMessageRows = (timeline: Message[]) => {
+export const convertTimelineToMessageRows = (
+  timeline: Message[],
+  toolCallStates?: Map<string, ToolCallState>
+) => {
   const result: Array<
     | Message
     | { role: 'toolCallGroup'; toolCalls: TimelineToolCall[] }
@@ -115,22 +150,26 @@ export const convertTimelineToMessageRows = (timeline: Message[]) => {
       type: 'tool_call' as const,
       id: toolCall.id,
       toolName: toolCall.function.name,
-      status: getToolStatus(toolCall, toolResult),
+      status: getToolStatus(toolCall, toolCallStates, toolResult),
       arguments: toolCall.function.arguments,
       result: toolResult?.content,
       timestamp: Date.now(),
     };
   };
 
-  // Helper: Check if any tool call is running
+  // Helper: Check if a tool call is still running.
+  // Only event-driven toolCallStates can indicate "running" — a missing
+  // ToolMessage on a historical (state-less) tool call means it was
+  // abandoned, not that it is currently executing.
+  const isToolRunning = (toolCall: ToolCall): boolean => {
+    const state = toolCallStates?.get(toolCall.id);
+    if (!state) return false;
+    return state.status === 'pending' || state.status === 'executing';
+  };
+
   const hasRunningTool = (toolCalls?: ToolCall[]): boolean => {
     if (!toolCalls?.length) return false;
-    return toolCalls.some((tc) => {
-      const toolResult = timeline.find(
-        (msg): msg is ToolMessage => msg.role === 'tool' && msg.toolCallId === tc.id
-      );
-      return !toolResult; // No result means still running
-    });
+    return toolCalls.some(isToolRunning);
   };
 
   // Helper: Check if tool has custom renderer
@@ -260,6 +299,19 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
   const userHasScrolledUp = useRef<boolean>(false);
   const isAutoScrolling = useRef<boolean>(false);
 
+  // Subscribe to the real, event-driven tool call states so the UI reflects
+  // the actual TOOL_CALL_START/END/RESULT lifecycle rather than inferring
+  // status from ToolMessage presence in the timeline.
+  const assistantActionService = useMemo(() => AssistantActionService.getInstance(), []);
+  const toolCallStates$ = useMemo(
+    () => assistantActionService.getState$().pipe(map((state) => state.toolCallStates)),
+    [assistantActionService]
+  );
+  const toolCallStates = useObservable(
+    toolCallStates$,
+    assistantActionService.getCurrentState().toolCallStates
+  );
+
   // Context is now handled by RFC hooks and context pills
   // No need for separate context display here
 
@@ -353,7 +405,10 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
 
   // Context is now handled by RFC hooks - no subscriptions needed
 
-  const messageRows = useMemo(() => convertTimelineToMessageRows(timeline), [timeline]);
+  const messageRows = useMemo(() => convertTimelineToMessageRows(timeline, toolCallStates), [
+    timeline,
+    toolCallStates,
+  ]);
 
   const lastAssistantMessageIndex = useMemo(
     () => messageRows.findLastIndex((message) => message.role === 'assistant'),

--- a/src/plugins/chat/public/components/tool_call_row.tsx
+++ b/src/plugins/chat/public/components/tool_call_row.tsx
@@ -490,7 +490,11 @@ export const ToolCallRow: React.FC<ToolCallRowProps> = ({
           i18n.translate('chat.toolCall.errorMessage', {
             defaultMessage: 'Error message: {errorMessage}',
             values: {
-              errorMessage: toolCall.result,
+              errorMessage:
+                toolCall.result ||
+                i18n.translate('chat.toolCall.errorNoResult', {
+                  defaultMessage: 'No results',
+                }),
             },
           })}
         {!isError && toolCall.result && isValidJSON(toolCall.result) ? (

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -7,6 +7,7 @@ import { ChatEventHandler } from './chat_event_handler';
 import { AssistantActionService } from '../../../context_provider/public';
 import { ChatService } from './chat_service';
 import { EventType } from '../../common/events';
+import { TOOL_EXECUTION_ERROR_PREFIX } from '../../common';
 import type {
   TextMessageStartEvent,
   TextMessageContentEvent,
@@ -29,11 +30,13 @@ const mockAssistantActionService = ({
   hasAction: jest.fn().mockReturnValue(true),
   getCurrentState: mockGetCurrentState,
   isUserConfirmRequired: jest.fn().mockReturnValue(false),
+  clearAllToolCallStates: jest.fn(),
 } as unknown) as jest.Mocked<AssistantActionService>;
 
 const mockChatService = ({
   sendToolResult: jest.fn(),
   getCurrentDataSourceId: jest.fn().mockReturnValue(undefined),
+  resetConnection: jest.fn(),
 } as unknown) as jest.Mocked<ChatService>;
 
 const mockConfirmationService = {
@@ -533,6 +536,20 @@ describe('ChatEventHandler', () => {
       // The timeline should have been updated twice: once for TEXT_MESSAGE_START and once for TOOL_CALL_START
       expect(mockOnTimelineUpdate).toHaveBeenCalledTimes(2);
     });
+
+    it('should drain AssistantActionService tool call states', async () => {
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: 'tool-1',
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      chatEventHandler.clearState();
+
+      // Process-wide singleton state must be drained so stale pending/executing
+      // entries from this run do not bleed into the next conversation.
+      expect(mockAssistantActionService.clearAllToolCallStates).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('user confirmation handling', () => {
@@ -669,8 +686,69 @@ describe('ChatEventHandler', () => {
       // Should handle JSON parse error gracefully
       expect(mockAssistantActionService.updateToolCallState).toHaveBeenCalledWith(toolCallId, {
         status: 'failed',
-        error: expect.stringContaining('Unexpected token'),
+        error: expect.objectContaining({ message: expect.stringContaining('Unexpected token') }),
       });
+    });
+
+    it('should prefix the tool result content with the execution error prefix when tool execution throws', async () => {
+      const toolCallId = 'tool-err-1';
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '',
+          toolCallId,
+        } as ToolMessage,
+      });
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      // Invalid JSON will throw from JSON.parse inside handleToolCallEnd,
+      // reaching the outer catch that is responsible for delivering the
+      // error to the assistant.
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: 'invalid-json',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      // The payload sent to the assistant starts with the execution error
+      // prefix so a snapshot reload can render the tool row as an error
+      // via getToolStatus — no local-only ToolMessage is appended, which
+      // keeps the UI consistent with the persisted agentic memory.
+      expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
+        toolCallId,
+        expect.stringContaining(TOOL_EXECUTION_ERROR_PREFIX),
+        expect.any(Array),
+        expect.any(AbortSignal)
+      );
+
+      // No locally-constructed error ToolMessage should be appended to the
+      // timeline — only the toolMessage returned by sendToolResult.
+      const localErrorMessage = timeline.find((msg) => msg.id === `tool-error-${toolCallId}`);
+      expect(localErrorMessage).toBeUndefined();
+
+      // The error field must be a proper Error object (not a plain string).
+      expect(mockAssistantActionService.updateToolCallState).toHaveBeenCalledWith(
+        toolCallId,
+        expect.objectContaining({
+          status: 'failed',
+          error: expect.any(Error),
+        })
+      );
     });
 
     it('should handle missing tool call', async () => {

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -6,6 +6,7 @@
 import { Observable, Subscription } from 'rxjs';
 import { i18n } from '@osd/i18n';
 import { EventType } from '../../common/events';
+import { TOOL_EXECUTION_ERROR_PREFIX } from '../../common';
 import type {
   Event as ChatEvent,
   TextMessageStartEvent,
@@ -158,9 +159,7 @@ export class ChatEventHandler {
     // Clear any remaining active messages (cleanup)
     this.activeAssistantMessages.clear();
     // Reset the connection state to allow new chats
-    if (this.chatService && (this.chatService as any).resetConnection) {
-      (this.chatService as any).resetConnection();
-    }
+    this.chatService.resetConnection();
 
     // Record success telemetry only if no error occurred during this run
     if (this.telemetryRecorder && !this.runErrorOccurred) {
@@ -402,7 +401,7 @@ export class ChatEventHandler {
         toolCall.function.name,
         args,
         toolCallId,
-        await this.chatService?.getCurrentDataSourceId()
+        await this.chatService.getCurrentDataSourceId()
       );
 
       // Check if tool execution was cancelled (e.g., due to cleanup)
@@ -412,15 +411,14 @@ export class ChatEventHandler {
       }
 
       if (result.userRejected) {
-        // User rejected the tool execution
+        // User rejected the tool execution. Hold off on marking 'failed'
+        // until the rejection has actually been delivered to the assistant,
+        // so the tool row keeps its running indicator during the send
+        // rather than showing a failed state while still doing work.
+        await this.sendToolResultToAssistant(toolCallId, result);
         this.assistantActionService.updateToolCallState(toolCallId, {
           status: 'failed',
         });
-
-        // Send rejection message back to assistant
-        if (this.chatService && (this.chatService as any).sendToolResult) {
-          await this.sendToolResultToAssistant(toolCallId, result);
-        }
 
         // Clean up pending tool call
         this.pendingToolCalls.delete(toolCallId);
@@ -436,43 +434,49 @@ export class ChatEventHandler {
         });
         // Don't send result back immediately, wait for TOOL_CALL_RESULT event
       } else {
-        // Tool was executed locally
-
+        // Tool was executed locally. Hold off on marking 'complete' until
+        // the result has actually been delivered to the assistant and the
+        // next streaming turn has started. Otherwise there would be a
+        // confusing window where the tool row shows a checkmark while the
+        // UI is still waiting on the network round-trip with no visible
+        // activity. If the send itself fails, `sendToolResultToAssistant`
+        // appends a system message to the timeline so the user can see the
+        // conversation is out of sync — the tool call itself still
+        // completed locally, so mark it 'complete'.
+        await this.sendToolResultToAssistant(toolCallId, result.data);
         this.assistantActionService.updateToolCallState(toolCallId, {
           status: 'complete',
           result: result.data,
         });
-
-        // Send tool result back to assistant if chatService is available
-        if (this.chatService && (this.chatService as any).sendToolResult) {
-          await this.sendToolResultToAssistant(toolCallId, result.data);
-        }
       }
     } catch (error: any) {
       // eslint-disable-next-line no-console
       console.error(`Error executing tool ${toolCall.function.name}:`, error);
 
+      // Send error back to assistant. Prefix the content with
+      // `TOOL_EXECUTION_ERROR_PREFIX` so a snapshot reload can render the
+      // tool row as an error via `getToolStatus` — `chatService.sendToolResult`
+      // passes this string straight into the ToolMessage content (which is
+      // what is persisted to agentic memory), so the UI can detect the
+      // prefix without needing a separate local-only ToolMessage that
+      // would diverge from the saved conversation. Natural-language prose
+      // also keeps the payload readable for the LLM on the next turn.
+      //
+      // Hold off on marking 'failed' until the error has actually been
+      // delivered, so the tool row keeps its running indicator during the
+      // send rather than flipping to a failed state while the UI is still
+      // doing work. `sendToolResultToAssistant` owns the timeline append on
+      // success, skip, and send failure.
+      await this.sendToolResultToAssistant(
+        toolCallId,
+        `${TOOL_EXECUTION_ERROR_PREFIX}${error.message}`
+      );
+
       // Update state to failed
       this.assistantActionService.updateToolCallState(toolCallId, {
         status: 'failed',
-        error: error.message,
+        error: error instanceof Error ? error : new Error(error.message),
       });
-
-      // Add error tool result message to timeline
-      const errorToolMessage: ToolMessage = {
-        id: `tool-error-${toolCallId}`,
-        role: 'tool',
-        content: error.message,
-        toolCallId,
-        error: error.message,
-      };
-
-      this.onTimelineUpdate((prev) => [...prev, errorToolMessage]);
-
-      // Send error back to assistant
-      if (this.chatService && (this.chatService as any).sendToolResult) {
-        await this.sendToolResultToAssistant(toolCallId, { error: error.message });
-      }
     } finally {
       // Clean up pending tool call
       this.pendingToolCalls.delete(toolCallId);
@@ -510,6 +514,14 @@ export class ChatEventHandler {
     };
 
     this.onTimelineUpdate((prev) => [...prev, toolMessage]);
+
+    // Mark the tool call as complete now that the agent has reported a result.
+    // This keeps the event-driven toolCallStates in sync with the real
+    // TOOL_CALL_RESULT event so the UI reflects the actual running status.
+    this.assistantActionService.updateToolCallState(toolCallId, {
+      status: 'complete',
+      result: resultContent,
+    });
 
     // Clear pending tool if it was an agent-only tool
     if (this.toolExecutor.isPendingAgentResponse(toolCallId)) {
@@ -661,7 +673,13 @@ export class ChatEventHandler {
   }
 
   /**
-   * Send tool result back to assistant
+   * Send tool result back to assistant.
+   *
+   * On send failure, appends a system message to the timeline so the user
+   * can tell the conversation is out of sync (the assistant never received
+   * the result). The originating tool call is still considered complete from
+   * the local perspective — it ran and produced a result — the delivery is
+   * what failed, and that is surfaced via the system message.
    */
   async sendToolResultToAssistant(toolCallId: string, result: any): Promise<void> {
     // Abort any in-flight tool result send so we don't leak controllers or
@@ -838,6 +856,11 @@ export class ChatEventHandler {
     this.pendingToolCalls.clear();
     this.toolExecutor.clearAllPendingTools();
     this.lastTextMessageStartId = null;
+    // Drain the process-wide AssistantActionService tool call states so
+    // stale pending/executing entries from a previous run do not bleed
+    // into a freshly replayed or newly started conversation and leave
+    // phantom running indicators on its tool calls.
+    this.assistantActionService.clearAllToolCallStates();
     // @ts-expect-error TS2339 TODO(ts-error): fixme
     this._lastAssistantMessageId = null;
 

--- a/src/plugins/chat/public/services/export/investigation_export_service.test.ts
+++ b/src/plugins/chat/public/services/export/investigation_export_service.test.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Message, AssistantMessage, UserMessage, ToolMessage } from '../../../common/types';
+import { TOOL_EXECUTION_ERROR_PREFIX } from '../../../common';
 import {
   collectChatExportData,
   findPrecedingQuestion,
@@ -142,13 +143,13 @@ describe('extractTraces', () => {
       {
         id: 'tr1',
         role: 'tool',
-        content: 'Error occurred',
+        content: `${TOOL_EXECUTION_ERROR_PREFIX}timeout`,
         toolCallId: 'tc1',
-        error: 'timeout',
       } as ToolMessage,
     ];
     const traces = extractTraces(timeline, 1);
     expect(traces[0].error).toBe('timeout');
+    expect(traces[0].result).toBeUndefined();
   });
 
   it('should extract multiple tool calls', () => {

--- a/src/plugins/chat/public/services/export/investigation_export_service.ts
+++ b/src/plugins/chat/public/services/export/investigation_export_service.ts
@@ -9,6 +9,7 @@ import type {
   ToolMessage,
   TextInputContent,
 } from '../../../common/types';
+import { TOOL_EXECUTION_ERROR_PREFIX } from '../../../common';
 import { ChatExportData, ChatExportOptions, ChatTraceStep, QuestionImage } from './types';
 import { generatePDFReport } from './pdf_template';
 import { generateMarkdownReport } from './markdown_template';
@@ -156,11 +157,21 @@ export function extractTraces(timeline: Message[], targetIndex: number): ChatTra
         (m) => m.role === 'tool' && (m as ToolMessage).toolCallId === toolCall.id
       ) as ToolMessage | undefined;
 
+      // Local tool execution errors are now encoded as a prefix on the
+      // ToolMessage content (see chat_event_handler.handleToolCallEnd).
+      // Strip the prefix for the export so the trace shows the raw error
+      // message in the dedicated `error` slot, and omit the redundant
+      // `result` in that case.
+      const hasExecutionError = toolResult?.content?.startsWith(TOOL_EXECUTION_ERROR_PREFIX);
+      const error = hasExecutionError
+        ? toolResult!.content.slice(TOOL_EXECUTION_ERROR_PREFIX.length)
+        : undefined;
+
       traces.push({
         toolName: toolCall.function.name,
         arguments: toolCall.function.arguments,
-        result: toolResult?.content,
-        error: toolResult?.error,
+        result: hasExecutionError ? undefined : toolResult?.content,
+        error,
       });
     }
   }

--- a/src/plugins/context_provider/public/services/assistant_action_service.test.ts
+++ b/src/plugins/context_provider/public/services/assistant_action_service.test.ts
@@ -584,4 +584,61 @@ describe('AssistantActionService', () => {
       expect(toolCallState?.status).toBe('failed');
     });
   });
+
+  describe('clearToolCallState', () => {
+    it('should remove the specified tool call state entry', () => {
+      service.updateToolCallState('call-1', { name: 'a', status: 'executing' });
+      service.updateToolCallState('call-2', { name: 'b', status: 'executing' });
+
+      service.clearToolCallState('call-1');
+
+      const state = service.getCurrentState();
+      expect(state.toolCallStates.has('call-1')).toBe(false);
+      expect(state.toolCallStates.has('call-2')).toBe(true);
+    });
+
+    it('should not notify subscribers when the id does not exist', () => {
+      const subscriber = jest.fn();
+      service.getState$().subscribe(subscriber);
+      subscriber.mockClear();
+
+      service.clearToolCallState('never-existed');
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearAllToolCallStates', () => {
+    it('should remove every tool call state entry', () => {
+      service.updateToolCallState('call-1', { name: 'a', status: 'executing' });
+      service.updateToolCallState('call-2', { name: 'b', status: 'pending' });
+
+      service.clearAllToolCallStates();
+
+      const state = service.getCurrentState();
+      expect(state.toolCallStates.size).toBe(0);
+    });
+
+    it('should notify subscribers once when the map had entries', () => {
+      service.updateToolCallState('call-1', { name: 'a', status: 'executing' });
+
+      const subscriber = jest.fn();
+      service.getState$().subscribe(subscriber);
+      subscriber.mockClear();
+
+      service.clearAllToolCallStates();
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not notify subscribers when already empty', () => {
+      const subscriber = jest.fn();
+      service.getState$().subscribe(subscriber);
+      subscriber.mockClear();
+
+      service.clearAllToolCallStates();
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/plugins/context_provider/public/services/assistant_action_service.ts
+++ b/src/plugins/context_provider/public/services/assistant_action_service.ts
@@ -143,6 +143,40 @@ export class AssistantActionService {
     });
   };
 
+  /**
+   * Remove a tool call state entry. Safe to call when the entry does not
+   * exist — it is a no-op in that case. Subscribers are only notified when
+   * the map actually changes.
+   */
+  clearToolCallState = (id: string) => {
+    const currentState = this.state$.getValue();
+    if (!currentState.toolCallStates.has(id)) return;
+
+    const newToolCallStates = new Map(currentState.toolCallStates);
+    newToolCallStates.delete(id);
+
+    this.state$.next({
+      ...currentState,
+      toolCallStates: newToolCallStates,
+    });
+  };
+
+  /**
+   * Remove all tool call state entries in a single update. Useful when
+   * resetting conversation state (e.g. switching conversations) so stale
+   * entries from a previous run do not bleed into the next. No-ops and
+   * avoids notifying subscribers when the map is already empty.
+   */
+  clearAllToolCallStates = () => {
+    const currentState = this.state$.getValue();
+    if (currentState.toolCallStates.size === 0) return;
+
+    this.state$.next({
+      ...currentState,
+      toolCallStates: new Map(),
+    });
+  };
+
   getActionRenderer = (name: string) => {
     const currentState = this.state$.getValue();
     const action = currentState.actions.get(name);


### PR DESCRIPTION
### Description

  When loading a previously saved conversation (snapshot), tool calls that never received a result were incorrectly displayed as "Running xxx tools" indefinitely. This happened because the old implementation inferred running status solely from the absence of a `ToolMessage` in the timeline — which is indistinguishable from an abandoned tool call in a historical conversation.

  This PR introduces an event-driven `toolCallStates` map as the source of truth for tool running status:

  - **Active conversations**: Tool status is tracked via AG-UI lifecycle events (`TOOL_CALL_START` / `TOOL_CALL_END` / `TOOL_CALL_RESULT`), reflecting real execution state.
  - **Snapshot-loaded conversations**: When no event state exists, a missing `ToolMessage` is treated as an abandoned (error) tool call — not a running one. The tool row now shows an error state with "No
  results" instead of spinning forever.

  Key changes:
  - Remove the `error` field from `ToolMessage` (it was frontend-only and lost on reload). Replace with a content prefix (`TOOL_EXECUTION_ERROR_PREFIX`) that survives persistence.
  - Add `clearToolCallState` / `clearAllToolCallStates` to `AssistantActionService` to prevent stale state from bleeding across conversations.
  - Add a system message when `sendToolResult` fails, so users can see the conversation is out of sync.
  - Fix `tool_call_row.tsx` to show "No results" fallback when a tool errors without a result message.
  - Clean up `chatService` access by removing `as any` casts for `resetConnection` and `sendToolResult`.

## Screenshot
[video.webm](https://github.com/user-attachments/assets/3b4b28b4-09c3-4f66-af23-b197adcc11dc)


### Check List
  - [x] New functionality includes testing.
    - [x] All tests pass, including unit test, integration test.
  - [ ] New functionality has user manual doc added.
  - [x] Commits are signed per the DCO using --signoff.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).