### PR TITLE
feat(plugins): Add backend_compatibility plugin for legacy ES support

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -426,3 +426,7 @@
 # @experimental Set the value to true to enable context provider
 # contextProvider:
 #   enabled: true
+
+# @experimental Enable legacy Elasticsearch backend compatibility.
+# This feature is currently being developed and should be used with caution in production environments.
+# backendCompatibility.enabled: false

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -35,6 +35,7 @@
       - [I18n](../src/dev/i18n/README.md)
     - plugins
       - [Application_config](../src/plugins/application_config/README.md)
+      - [Backend_compatibility](../src/plugins/backend_compatibility/README.md)
       - [Banner](../src/plugins/banner/README.md)
       - [Bfetch](../src/plugins/bfetch/README.md)
       - [Charts](../src/plugins/charts/README.md)

--- a/src/plugins/backend_compatibility/README.md
+++ b/src/plugins/backend_compatibility/README.md
@@ -1,0 +1,87 @@
+# Backend Compatibility Plugin
+
+Enables OpenSearch Dashboards to connect to legacy Elasticsearch 6.x and 7.x clusters.
+
+## How It Works
+
+The plugin registers a custom `Transport` class with the OpenSearch client. Every client API call (`search`, `bulk`, `index`, etc.) passes through `transport.request()` — making it the single point where all cluster communication can be intercepted and adapted.
+
+```
+OSD Plugin calls client.search(params)
+    │
+    ▼
+CompatibilityTransport.request(params)
+    │
+    ├─ Detect backend (lazy, once per instance)
+    ├─ Match URL path against route table
+    ├─ Translate request for target backend
+    ├─ Execute request via underlying Transport
+    └─ Normalize response to OpenSearch format
+    │
+    ▼
+OpenSearch-compatible response returned to caller
+```
+
+## Backend Handling
+
+| Backend | Request | Response |
+|---------|---------|----------|
+| OpenSearch 1.x+ | Pass-through | Pass-through |
+| Elasticsearch 7.0–7.10.2 | Pass-through | Strip `_type` from documents |
+| Elasticsearch 6.0–6.8 | Full translation | Full normalization |
+
+When disabled, no Transport is registered — zero runtime overhead.
+
+## Key Design Decisions
+
+**Single interception point.** Instead of wrapping 15+ individual client methods with Proxies, the Transport intercepts at the HTTP serialization boundary where all methods converge into one `request()` call.
+
+**Lazy detection.** Backend version is detected on the first request via `GET /`. This naturally handles timing issues where saved object migrations run before the plugin's `start()` phase.
+
+**Declarative route table.** URL path patterns are matched against an ordered array of entries. Each entry maps to request/response translator functions. Adding support for a new API means adding one entry.
+
+**Zero core knowledge of Elasticsearch.** Core provides a generic hook (`registerClientTransport`). All version detection and translation logic lives in the plugin.
+
+## What Gets Translated (ES 6.x)
+
+| Area | Translations |
+|------|-------------|
+| Documents | `_type` injection, `if_seq_no`/`if_primary_term` stripping, `/_create` → `/_doc` rewrite, `/_update` path rewrite |
+| Search | `calendar_interval` → `interval`, unsupported agg/query removal, `hits.total` normalization |
+| Mappings | Typed ↔ typeless format, `include_type_name`, field type downgrades |
+| Field Caps | Strip unsupported parameters |
+| Scroll | Response normalization |
+| Index Resolution | Synthesize `/_resolve/index` from `/_cat/indices` + `/_cat/aliases` |
+
+## Configuration
+
+```yaml
+# opensearch_dashboards.yml
+backendCompatibility.enabled: true  # Default: false
+```
+
+## File Structure
+
+```
+server/
+├── plugin.ts                      # Registers Transport with core
+├── config.ts                      # Schema (enabled: boolean)
+└── transport/
+    ├── compatibility_transport.ts # Transport subclass, route table, request() override
+    ├── backend_detector.ts        # GET / → BackendInfo
+    ├── types.ts                   # BackendInfo, DEFAULT_DOCUMENT_TYPE
+    └── adapters/
+        ├── search_adapter.ts      # Search/msearch/aggregation transforms
+        ├── document_adapter.ts    # Bulk/CRUD/_type/seq_no handling
+        ├── mapping_adapter.ts     # Typed mappings, field type downgrades
+        ├── field_caps_adapter.ts  # Parameter filtering
+        ├── scroll_adapter.ts      # Scroll response normalization
+        └── normalization_utils.ts # isPlainObject, synthesizeSeqNo, normalizeTotalHits
+```
+
+## Limitations
+
+- Optimistic concurrency disabled on ES 6.x (concurrent writes can silently overwrite)
+- Single Transport class registration (sufficient but not extensible to multiple plugins)
+- Scripted field syntax differences not auto-translated
+- `track_total_hits` unavailable on ES 6.x (counts above 10,000 may be inexact)

--- a/src/plugins/backend_compatibility/common/index.ts
+++ b/src/plugins/backend_compatibility/common/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const PLUGIN_ID = 'backendCompatibility';
+export const PLUGIN_NAME = 'Backend Compatibility';

--- a/src/plugins/backend_compatibility/opensearch_dashboards.json
+++ b/src/plugins/backend_compatibility/opensearch_dashboards.json
@@ -1,0 +1,10 @@
+{
+  "id": "backendCompatibility",
+  "version": "1.0.0",
+  "opensearchDashboardsVersion": "opensearchDashboards",
+  "server": true,
+  "ui": false,
+  "requiredPlugins": [],
+  "optionalPlugins": [],
+  "requiredBundles": []
+}

--- a/src/plugins/backend_compatibility/server/config.ts
+++ b/src/plugins/backend_compatibility/server/config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type BackendCompatibilityConfig = TypeOf<typeof configSchema>;

--- a/src/plugins/backend_compatibility/server/index.ts
+++ b/src/plugins/backend_compatibility/server/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PluginInitializerContext, PluginConfigDescriptor } from 'src/core/server';
+import { BackendCompatibilityPlugin } from './plugin';
+import { configSchema, BackendCompatibilityConfig } from './config';
+
+export const config: PluginConfigDescriptor<BackendCompatibilityConfig> = {
+  schema: configSchema,
+};
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new BackendCompatibilityPlugin(initializerContext);
+}
+
+export type { BackendCompatibilityConfig } from './config';
+export type { BackendCompatibilityPluginSetup, BackendCompatibilityPluginStart } from './plugin';
+export type { BackendInfo, BackendDistribution } from './transport/types';

--- a/src/plugins/backend_compatibility/server/plugin.ts
+++ b/src/plugins/backend_compatibility/server/plugin.ts
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { first } from 'rxjs/operators';
 import { CoreSetup, CoreStart, Logger, Plugin, PluginInitializerContext } from 'src/core/server';
-import { BackendCompatibilityConfig } from './config';
 import { CompatibilityTransport } from './transport/compatibility_transport';
 import { BackendInfo } from './transport/types';
 import { PLUGIN_NAME } from '../common';
@@ -28,17 +26,9 @@ export class BackendCompatibilityPlugin
   }
 
   public async setup(core: CoreSetup): Promise<BackendCompatibilityPluginSetup> {
-    const config = await this.initializerContext.config
-      .create<BackendCompatibilityConfig>()
-      .pipe(first())
-      .toPromise();
-
-    if (!config.enabled) {
-      this.logger.info(`${PLUGIN_NAME} is disabled`);
-      return {};
-    }
-
-    this.logger.info(`Setting up ${PLUGIN_NAME}`);
+    this.logger.warn(
+      `[EXPERIMENTAL] ${PLUGIN_NAME} is enabled. Legacy backend compatibility is experimental and may change in future releases.`
+    );
     core.opensearch.registerClientTransport(CompatibilityTransport);
     this.logger.info('CompatibilityTransport registered with core');
     return {};

--- a/src/plugins/backend_compatibility/server/plugin.ts
+++ b/src/plugins/backend_compatibility/server/plugin.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { first } from 'rxjs/operators';
+import { CoreSetup, CoreStart, Logger, Plugin, PluginInitializerContext } from 'src/core/server';
+import { BackendCompatibilityConfig } from './config';
+import { CompatibilityTransport } from './transport/compatibility_transport';
+import { BackendInfo } from './transport/types';
+import { PLUGIN_NAME } from '../common';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface BackendCompatibilityPluginSetup {}
+
+export interface BackendCompatibilityPluginStart {
+  getBackendInfo: () => BackendInfo | undefined;
+}
+
+export class BackendCompatibilityPlugin
+  implements Plugin<BackendCompatibilityPluginSetup, BackendCompatibilityPluginStart> {
+  private readonly logger: Logger;
+  private readonly initializerContext: PluginInitializerContext;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+    this.initializerContext = initializerContext;
+  }
+
+  public async setup(core: CoreSetup): Promise<BackendCompatibilityPluginSetup> {
+    const config = await this.initializerContext.config
+      .create<BackendCompatibilityConfig>()
+      .pipe(first())
+      .toPromise();
+
+    if (!config.enabled) {
+      this.logger.info(`${PLUGIN_NAME} is disabled`);
+      return {};
+    }
+
+    this.logger.info(`Setting up ${PLUGIN_NAME}`);
+    core.opensearch.registerClientTransport(CompatibilityTransport);
+    this.logger.info('CompatibilityTransport registered with core');
+    return {};
+  }
+
+  public async start(core: CoreStart): Promise<BackendCompatibilityPluginStart> {
+    return {
+      getBackendInfo: () => CompatibilityTransport.lastDetectedBackend ?? undefined,
+    };
+  }
+
+  public stop() {
+    this.logger.info(`Stopping ${PLUGIN_NAME}`);
+  }
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/document_adapter.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/document_adapter.test.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  translateBulkRequest,
+  translateCreateRequest,
+  translateDocRequest,
+  translateMgetRequest,
+  translateDeleteByQueryRequest,
+  translateResponse,
+} from './document_adapter';
+import { BackendInfo } from '../types';
+
+const es6Backend: BackendInfo = {
+  distribution: 'elasticsearch',
+  version: '6.8.23',
+  majorVersion: 6,
+  minorVersion: 8,
+  patchVersion: 23,
+};
+
+describe('document_adapter', () => {
+  describe('translateBulkRequest', () => {
+    it('adds _type to bulk action metadata', () => {
+      const params = {
+        bulkBody: [{ index: { _index: 'test', _id: '1' } }, { field: 'value' }],
+      };
+      const result = translateBulkRequest(params, es6Backend);
+      expect(result.bulkBody[0].index._type).toBe('_doc');
+    });
+
+    it('does not overwrite existing _type', () => {
+      const params = {
+        bulkBody: [{ index: { _index: 'test', _id: '1', _type: 'custom' } }, { field: 'value' }],
+      };
+      const result = translateBulkRequest(params, es6Backend);
+      expect(result.bulkBody[0].index._type).toBe('custom');
+    });
+
+    it('strips if_seq_no and if_primary_term from action metadata', () => {
+      const params = {
+        bulkBody: [
+          { index: { _index: 'test', _id: '1', if_seq_no: 5, if_primary_term: 1 } },
+          { field: 'value' },
+        ],
+      };
+      const result = translateBulkRequest(params, es6Backend);
+      expect(result.bulkBody[0].index.if_seq_no).toBeUndefined();
+      expect(result.bulkBody[0].index.if_primary_term).toBeUndefined();
+    });
+
+    it('strips if_seq_no from querystring', () => {
+      const params = {
+        bulkBody: [{ index: { _index: 'test', _id: '1' } }, { field: 'value' }],
+        querystring: { if_seq_no: 1, if_primary_term: 1, refresh: 'true' },
+      };
+      const result = translateBulkRequest(params, es6Backend);
+      expect(result.querystring.if_seq_no).toBeUndefined();
+      expect(result.querystring.refresh).toBe('true');
+    });
+
+    it('clears body and uses bulkBody for the transformed data', () => {
+      const params = {
+        body: [{ index: { _index: 'test', _id: '1' } }, { field: 'value' }],
+      };
+      const result = translateBulkRequest(params, es6Backend);
+      expect(result.body).toBeUndefined();
+      expect(result.bulkBody).toBeDefined();
+      expect(result.bulkBody[0].index._type).toBe('_doc');
+    });
+
+    it('returns params unchanged when no array source', () => {
+      const params = { body: { something: 'else' } };
+      expect(translateBulkRequest(params, es6Backend)).toBe(params);
+    });
+
+    it('handles all bulk action types', () => {
+      const params = {
+        bulkBody: [
+          { create: { _index: 'test', _id: '2' } },
+          { field: 'a' },
+          { update: { _index: 'test', _id: '3' } },
+          { doc: { field: 'b' } },
+          { delete: { _index: 'test', _id: '4' } },
+        ],
+      };
+      const result = translateBulkRequest(params, es6Backend);
+      expect(result.bulkBody[0].create._type).toBe('_doc');
+      expect(result.bulkBody[2].update._type).toBe('_doc');
+      expect(result.bulkBody[4].delete._type).toBe('_doc');
+    });
+  });
+
+  describe('translateCreateRequest', () => {
+    it('rewrites /_create to /_doc with op_type=create', () => {
+      const params = { path: '/test-index/_create/1', querystring: {} };
+      const result = translateCreateRequest(params, es6Backend);
+      expect(result.path).toBe('/test-index/_doc/1');
+      expect(result.querystring.op_type).toBe('create');
+    });
+
+    it('strips seq_no from querystring', () => {
+      const params = {
+        path: '/test/_create/1',
+        querystring: { if_seq_no: 3, if_primary_term: 1 },
+      };
+      const result = translateCreateRequest(params, es6Backend);
+      expect(result.querystring.if_seq_no).toBeUndefined();
+      expect(result.querystring.if_primary_term).toBeUndefined();
+    });
+  });
+
+  describe('translateDocRequest', () => {
+    it('strips seq_no from querystring', () => {
+      const params = {
+        path: '/test/_doc/1',
+        querystring: { if_seq_no: 5, if_primary_term: 1, routing: 'abc' },
+      };
+      const result = translateDocRequest(params, es6Backend);
+      expect(result.querystring.if_seq_no).toBeUndefined();
+      expect(result.querystring.routing).toBe('abc');
+    });
+
+    it('rewrites _update path for ES 6.x', () => {
+      const params = { path: '/my-index/_update/doc-id', querystring: {} };
+      const result = translateDocRequest(params, es6Backend);
+      expect(result.path).toBe('/my-index/_doc/doc-id/_update');
+    });
+
+    it('strips _source params on _update rewrite', () => {
+      const params = {
+        path: '/idx/_update/1',
+        querystring: { _source_include: 'a', _source_excludes: 'b' },
+      };
+      const result = translateDocRequest(params, es6Backend);
+      expect(result.querystring._source_include).toBeUndefined();
+      expect(result.querystring._source_excludes).toBeUndefined();
+    });
+
+    it('does not rewrite non-update paths', () => {
+      const params = { path: '/my-index/_doc/1', querystring: {} };
+      const result = translateDocRequest(params, es6Backend);
+      expect(result.path).toBe('/my-index/_doc/1');
+    });
+  });
+
+  describe('translateMgetRequest', () => {
+    it('adds _type to each doc', () => {
+      const params = {
+        body: {
+          docs: [
+            { _index: 'test', _id: '1' },
+            { _index: 'test', _id: '2' },
+          ],
+        },
+      };
+      const result = translateMgetRequest(params, es6Backend);
+      expect(result.body.docs[0]._type).toBe('_doc');
+      expect(result.body.docs[1]._type).toBe('_doc');
+    });
+
+    it('does not overwrite existing _type', () => {
+      const params = {
+        body: { docs: [{ _index: 'test', _id: '1', _type: 'custom' }] },
+      };
+      const result = translateMgetRequest(params, es6Backend);
+      expect(result.body.docs[0]._type).toBe('custom');
+    });
+
+    it('passes through non-plain-object body', () => {
+      const params = { body: 'string body' };
+      expect(translateMgetRequest(params, es6Backend)).toBe(params);
+    });
+  });
+
+  describe('translateDeleteByQueryRequest', () => {
+    it('strips seq_no from querystring', () => {
+      const params = {
+        path: '/test/_delete_by_query',
+        querystring: { if_seq_no: 1, if_primary_term: 1, conflicts: 'proceed' },
+      };
+      const result = translateDeleteByQueryRequest(params, es6Backend);
+      expect(result.querystring.if_seq_no).toBeUndefined();
+      expect(result.querystring.conflicts).toBe('proceed');
+    });
+  });
+
+  describe('translateResponse', () => {
+    it('strips _type and synthesizes _seq_no for single doc response', () => {
+      const response = { body: { _index: 'test', _type: '_doc', _id: '1', _version: 2 } };
+      translateResponse(response, es6Backend);
+      expect(response.body._type).toBeUndefined();
+      expect(response.body._seq_no).toBe(2);
+      expect(response.body._primary_term).toBe(1);
+    });
+
+    it('normalizes bulk response items', () => {
+      const response = {
+        body: {
+          items: [
+            { index: { _index: 'test', _type: '_doc', _id: '1', _version: 1 } },
+            { create: { _index: 'test', _type: '_doc', _id: '2', _version: 1 } },
+          ],
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.items[0].index._type).toBeUndefined();
+      expect(response.body.items[0].index._seq_no).toBe(1);
+      expect(response.body.items[1].create._type).toBeUndefined();
+    });
+
+    it('normalizes mget response docs', () => {
+      const response = {
+        body: {
+          docs: [
+            { _index: 'test', _type: '_doc', _id: '1', _version: 5 },
+            { _index: 'test', _id: '2', error: { type: 'not_found' } },
+          ],
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.docs[0]._type).toBeUndefined();
+      expect(response.body.docs[0]._seq_no).toBe(5);
+      // Error docs should not be normalized
+      expect(response.body.docs[1].error).toBeDefined();
+    });
+
+    it('returns response unchanged when body is empty', () => {
+      const response = { body: null };
+      expect(translateResponse(response, es6Backend)).toBe(response);
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/adapters/document_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/document_adapter.ts
@@ -4,7 +4,10 @@
  */
 
 import { BackendInfo, DEFAULT_DOCUMENT_TYPE } from '../types';
-import { isPlainObject, synthesizeSeqNo } from './normalization_utils';
+import { isPlainObject, synthesizeSeqNo, extractQueryString } from './normalization_utils';
+
+/** Bulk action verbs used in bulk request/response processing */
+const DOC_ACTIONS = ['index', 'create', 'update', 'delete'] as const;
 
 /**
  * ES 6.x doesn't support if_seq_no/if_primary_term — stripping disables OCC.
@@ -30,7 +33,7 @@ export function translateBulkRequest(params: any, backend: BackendInfo): any {
 
   const transformed = source.map((item: any) => {
     if (!item || typeof item !== 'object') return item;
-    for (const action of ['index', 'create', 'update', 'delete']) {
+    for (const action of DOC_ACTIONS) {
       if (action in item) {
         const meta = { ...item[action] };
         if (!meta._type && !meta.type) {
@@ -53,8 +56,7 @@ export function translateBulkRequest(params: any, backend: BackendInfo): any {
 
 export function translateCreateRequest(params: any, backend: BackendInfo): any {
   const newPath = params.path.replace('/_create', '/_doc');
-  const existing =
-    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const existing = extractQueryString(params);
   const qs = stripSeqNoFromQuerystring({ ...existing, op_type: 'create' });
   return { ...params, path: newPath, querystring: qs };
 }
@@ -95,13 +97,14 @@ export function translateDeleteByQueryRequest(params: any, backend: BackendInfo)
 
 export function translateResponse(response: any, backend: BackendInfo): any {
   const body = response?.body || response;
-  if (!body) return response;
+  if (!body || typeof body !== 'object') return response;
 
   if (body._id !== undefined) normalizeDocResponse(body);
 
   if (Array.isArray(body.items)) {
     body.items.forEach((item: any) => {
-      for (const action of ['index', 'create', 'update', 'delete']) {
+      if (!item || typeof item !== 'object') return;
+      for (const action of DOC_ACTIONS) {
         if (item[action]) normalizeDocResponse(item[action]);
       }
     });
@@ -109,7 +112,7 @@ export function translateResponse(response: any, backend: BackendInfo): any {
 
   if (Array.isArray(body.docs)) {
     body.docs.forEach((doc: any) => {
-      if (doc && !doc.error) normalizeDocResponse(doc);
+      if (doc && typeof doc === 'object' && !doc.error) normalizeDocResponse(doc);
     });
   }
 

--- a/src/plugins/backend_compatibility/server/transport/adapters/document_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/document_adapter.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BackendInfo, DEFAULT_DOCUMENT_TYPE } from '../types';
+import { isPlainObject, synthesizeSeqNo } from './normalization_utils';
+
+/**
+ * ES 6.x doesn't support if_seq_no/if_primary_term — stripping disables OCC.
+ * We can't convert to _version because migration reindexing resets _version to 1.
+ */
+function stripSeqNoFromQuerystring(
+  qs: Record<string, any> | undefined
+): Record<string, any> | undefined {
+  if (!qs) return qs;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { if_seq_no, if_primary_term, ...rest } = qs;
+  return rest;
+}
+
+export function translateBulkRequest(params: any, backend: BackendInfo): any {
+  // opensearch-js passes bulk data as bulkBody (for NDJSON serialization) or body
+  const source = Array.isArray(params.bulkBody)
+    ? params.bulkBody
+    : Array.isArray(params.body)
+    ? params.body
+    : null;
+  if (!source) return params;
+
+  const transformed = source.map((item: any) => {
+    if (!item || typeof item !== 'object') return item;
+    for (const action of ['index', 'create', 'update', 'delete']) {
+      if (action in item) {
+        const meta = { ...item[action] };
+        if (!meta._type && !meta.type) {
+          meta._type = DEFAULT_DOCUMENT_TYPE;
+        }
+        delete meta.if_seq_no;
+        delete meta.if_primary_term;
+        return { [action]: meta };
+      }
+    }
+    return item;
+  });
+  return {
+    ...params,
+    body: undefined,
+    bulkBody: transformed,
+    querystring: stripSeqNoFromQuerystring(params.querystring),
+  };
+}
+
+export function translateCreateRequest(params: any, backend: BackendInfo): any {
+  const newPath = params.path.replace('/_create', '/_doc');
+  const existing =
+    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const qs = stripSeqNoFromQuerystring({ ...existing, op_type: 'create' });
+  return { ...params, path: newPath, querystring: qs };
+}
+
+export function translateDocRequest(params: any, backend: BackendInfo): any {
+  const qs = stripSeqNoFromQuerystring(params.querystring);
+  let { path } = params;
+
+  // /{index}/_update/{id} → /{index}/_doc/{id}/_update
+  const updateMatch = path.match(/^(\/[^/]+)\/_update\/(.+)$/);
+  if (updateMatch) {
+    path = `${updateMatch[1]}/_doc/${updateMatch[2]}/_update`;
+    if (qs) {
+      delete qs._source_include;
+      delete qs._source_exclude;
+      delete qs._source_includes;
+      delete qs._source_excludes;
+    }
+  }
+
+  return { ...params, path, querystring: qs };
+}
+
+export function translateMgetRequest(params: any, backend: BackendInfo): any {
+  if (!isPlainObject(params.body) || !params.body.docs) {
+    return params;
+  }
+  const docs = params.body.docs.map((doc: any) => ({
+    ...doc,
+    _type: doc._type || DEFAULT_DOCUMENT_TYPE,
+  }));
+  return { ...params, body: { ...params.body, docs } };
+}
+
+export function translateDeleteByQueryRequest(params: any, backend: BackendInfo): any {
+  return { ...params, querystring: stripSeqNoFromQuerystring(params.querystring) };
+}
+
+export function translateResponse(response: any, backend: BackendInfo): any {
+  const body = response?.body || response;
+  if (!body) return response;
+
+  if (body._id !== undefined) normalizeDocResponse(body);
+
+  if (Array.isArray(body.items)) {
+    body.items.forEach((item: any) => {
+      for (const action of ['index', 'create', 'update', 'delete']) {
+        if (item[action]) normalizeDocResponse(item[action]);
+      }
+    });
+  }
+
+  if (Array.isArray(body.docs)) {
+    body.docs.forEach((doc: any) => {
+      if (doc && !doc.error) normalizeDocResponse(doc);
+    });
+  }
+
+  return response;
+}
+
+function normalizeDocResponse(doc: any): void {
+  delete doc._type;
+  synthesizeSeqNo(doc);
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/field_caps_adapter.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/field_caps_adapter.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { translateRequest, translateResponse } from './field_caps_adapter';
+import { BackendInfo } from '../types';
+
+const es6Backend: BackendInfo = {
+  distribution: 'elasticsearch',
+  version: '6.8.23',
+  majorVersion: 6,
+  minorVersion: 8,
+  patchVersion: 23,
+};
+
+describe('field_caps_adapter', () => {
+  describe('translateRequest', () => {
+    it('removes include_unmapped from querystring', () => {
+      const params = {
+        path: '/test/_field_caps',
+        querystring: { include_unmapped: true, fields: '*' },
+        body: undefined,
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.querystring.include_unmapped).toBeUndefined();
+      expect(result.querystring.fields).toBe('*');
+    });
+
+    it('removes index_filter and runtime_mappings from body', () => {
+      const params = {
+        path: '/test/_field_caps',
+        querystring: {},
+        body: {
+          index_filter: { range: { '@timestamp': { gte: 'now-1d' } } },
+          runtime_mappings: { day_of_week: { type: 'keyword' } },
+          fields: ['*'],
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.index_filter).toBeUndefined();
+      expect(result.body.runtime_mappings).toBeUndefined();
+      expect(result.body.fields).toEqual(['*']);
+    });
+
+    it('sets body to undefined when only unsupported fields remain', () => {
+      const params = {
+        path: '/test/_field_caps',
+        querystring: {},
+        body: {
+          index_filter: { match_all: {} },
+          runtime_mappings: {},
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body).toBeUndefined();
+    });
+
+    it('passes through non-plain-object body', () => {
+      const params = {
+        path: '/test/_field_caps',
+        querystring: {},
+        body: 'raw string',
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body).toBe('raw string');
+    });
+  });
+
+  describe('translateResponse', () => {
+    it('adds metadata_field: false to all field capabilities', () => {
+      const response = {
+        body: {
+          fields: {
+            title: { text: { type: 'text', searchable: true, aggregatable: false } },
+            status: { keyword: { type: 'keyword', searchable: true, aggregatable: true } },
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.fields.title.text.metadata_field).toBe(false);
+      expect(response.body.fields.status.keyword.metadata_field).toBe(false);
+    });
+
+    it('returns response unchanged when no fields', () => {
+      const response = { body: { indices: ['test'] } };
+      const result = translateResponse(response, es6Backend);
+      expect(result).toBe(response);
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/adapters/field_caps_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/field_caps_adapter.ts
@@ -4,11 +4,10 @@
  */
 
 import { BackendInfo } from '../types';
-import { isPlainObject } from './normalization_utils';
+import { isPlainObject, extractQueryString } from './normalization_utils';
 
 export function translateRequest(params: any, backend: BackendInfo): any {
-  const existing =
-    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const existing = extractQueryString(params);
   const qs = { ...existing };
   delete qs.include_unmapped;
 

--- a/src/plugins/backend_compatibility/server/transport/adapters/field_caps_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/field_caps_adapter.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BackendInfo } from '../types';
+import { isPlainObject } from './normalization_utils';
+
+export function translateRequest(params: any, backend: BackendInfo): any {
+  const existing =
+    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const qs = { ...existing };
+  delete qs.include_unmapped;
+
+  let body = params.body;
+  // Only transform body if it's a plain object (not pre-serialized string)
+  if (isPlainObject(body)) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { index_filter, runtime_mappings, ...restBody } = body;
+    body = Object.keys(restBody).length > 0 ? restBody : undefined;
+  }
+
+  return { ...params, querystring: qs, body };
+}
+
+export function translateResponse(response: any, backend: BackendInfo): any {
+  const body = response?.body || response;
+  if (!body?.fields) return response;
+
+  for (const fieldTypes of Object.values(body.fields)) {
+    if (fieldTypes && typeof fieldTypes === 'object') {
+      for (const capability of Object.values(fieldTypes as any)) {
+        if (capability && typeof capability === 'object') {
+          (capability as any).metadata_field = false;
+        }
+      }
+    }
+  }
+
+  return response;
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/index.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * as searchAdapter from './search_adapter';
+export * as documentAdapter from './document_adapter';
+export * as mappingAdapter from './mapping_adapter';
+export * as fieldCapsAdapter from './field_caps_adapter';
+export * as scrollAdapter from './scroll_adapter';
+export * from './normalization_utils';

--- a/src/plugins/backend_compatibility/server/transport/adapters/mapping_adapter.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/mapping_adapter.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  translateRequest,
+  translateIndexCreateRequest,
+  translateResponse,
+  downgradeFieldTypes,
+  UNSUPPORTED_ES6_TYPES,
+} from './mapping_adapter';
+import { BackendInfo } from '../types';
+
+const es6Backend: BackendInfo = {
+  distribution: 'elasticsearch',
+  version: '6.8.23',
+  majorVersion: 6,
+  minorVersion: 8,
+  patchVersion: 23,
+};
+
+describe('mapping_adapter', () => {
+  describe('downgradeFieldTypes', () => {
+    it('downgrades flattened to object with enabled:false', () => {
+      const { properties, downgrades } = downgradeFieldTypes({
+        labels: { type: 'flattened' },
+      });
+      expect(properties.labels).toEqual({ type: 'object', enabled: false });
+      expect(downgrades).toHaveLength(1);
+    });
+
+    it('downgrades search_as_you_type to text', () => {
+      const { properties } = downgradeFieldTypes({
+        suggest: { type: 'search_as_you_type', max_shingle_size: 3 },
+      });
+      expect(properties.suggest.type).toBe('text');
+      expect(properties.suggest.max_shingle_size).toBeUndefined();
+    });
+
+    it('downgrades constant_keyword to keyword with null_value', () => {
+      const { properties } = downgradeFieldTypes({
+        env: { type: 'constant_keyword', value: 'production' },
+      });
+      expect(properties.env).toEqual({ type: 'keyword', null_value: 'production' });
+    });
+
+    it('downgrades histogram to object with enabled:false', () => {
+      const { properties } = downgradeFieldTypes({
+        latency: { type: 'histogram' },
+      });
+      expect(properties.latency).toEqual({ type: 'object', enabled: false });
+    });
+
+    it('downgrades wildcard to keyword', () => {
+      const { properties } = downgradeFieldTypes({
+        path: { type: 'wildcard' },
+      });
+      expect(properties.path.type).toBe('keyword');
+    });
+
+    it('downgrades version to keyword', () => {
+      const { properties } = downgradeFieldTypes({
+        semver: { type: 'version' },
+      });
+      expect(properties.semver).toEqual({ type: 'keyword' });
+    });
+
+    it('downgrades match_only_text to text', () => {
+      const { properties } = downgradeFieldTypes({
+        logs: { type: 'match_only_text' },
+      });
+      expect(properties.logs).toEqual({ type: 'text' });
+    });
+
+    it('downgrades unsigned_long to long', () => {
+      const { properties } = downgradeFieldTypes({
+        big_id: { type: 'unsigned_long' },
+      });
+      expect(properties.big_id).toEqual({ type: 'long' });
+    });
+
+    it('leaves supported types unchanged', () => {
+      const { properties, downgrades } = downgradeFieldTypes({
+        name: { type: 'keyword' },
+        count: { type: 'long' },
+      });
+      expect(properties.name).toEqual({ type: 'keyword' });
+      expect(properties.count).toEqual({ type: 'long' });
+      expect(downgrades).toHaveLength(0);
+    });
+
+    it('recursively downgrades nested properties', () => {
+      const { properties, downgrades } = downgradeFieldTypes({
+        parent: {
+          type: 'object',
+          properties: {
+            child: { type: 'flattened' },
+          },
+        },
+      });
+      expect(properties.parent.properties!.child).toEqual({ type: 'object', enabled: false });
+      expect(downgrades).toHaveLength(1);
+      expect(downgrades[0]).toContain('parent.child');
+    });
+
+    it('downgrades multi-fields', () => {
+      const { properties, downgrades } = downgradeFieldTypes({
+        title: {
+          type: 'text',
+          fields: {
+            search: { type: 'search_as_you_type', max_shingle_size: 3 },
+            raw: { type: 'keyword' },
+          },
+        },
+      });
+      expect(properties.title.fields!.search.type).toBe('text');
+      expect(properties.title.fields!.raw.type).toBe('keyword');
+      expect(downgrades).toHaveLength(1);
+    });
+  });
+
+  describe('UNSUPPORTED_ES6_TYPES', () => {
+    it('contains all expected types', () => {
+      expect(UNSUPPORTED_ES6_TYPES).toContain('flattened');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('search_as_you_type');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('constant_keyword');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('histogram');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('wildcard');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('version');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('match_only_text');
+      expect(UNSUPPORTED_ES6_TYPES).toContain('unsigned_long');
+    });
+  });
+
+  describe('translateRequest', () => {
+    it('adds include_type_name=true to querystring', () => {
+      const params = { path: '/my-index/_mapping', querystring: {}, body: undefined };
+      const result = translateRequest(params, es6Backend);
+      expect(result.querystring.include_type_name).toBe(true);
+    });
+
+    it('rewrites /{index}/_mapping to /{index}/_doc/_mapping', () => {
+      const params = { path: '/my-index/_mapping', querystring: {}, body: undefined };
+      const result = translateRequest(params, es6Backend);
+      expect(result.path).toBe('/my-index/_doc/_mapping');
+    });
+
+    it('does not double-insert _doc in path', () => {
+      const params = { path: '/my-index/_doc/_mapping', querystring: {}, body: undefined };
+      const result = translateRequest(params, es6Backend);
+      expect(result.path).toBe('/my-index/_doc/_mapping');
+    });
+
+    it('downgrades field types in PUT mapping body', () => {
+      const params = {
+        path: '/my-index/_mapping',
+        querystring: {},
+        body: { properties: { data: { type: 'flattened' } } },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.properties.data).toEqual({ type: 'object', enabled: false });
+    });
+
+    it('passes through non-plain-object body', () => {
+      const buf = Buffer.from('{}');
+      const params = { path: '/idx/_mapping', querystring: {}, body: buf };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body).toBe(buf);
+    });
+  });
+
+  describe('translateIndexCreateRequest', () => {
+    it('wraps typeless mappings in _doc for ES 6.x', () => {
+      const params = {
+        path: '/new-index',
+        querystring: {},
+        body: {
+          mappings: { properties: { title: { type: 'text' } } },
+          settings: { number_of_shards: 1 },
+        },
+      };
+      const result = translateIndexCreateRequest(params, es6Backend);
+      expect(result.body.mappings._doc).toBeDefined();
+      expect(result.body.mappings._doc.properties.title).toEqual({ type: 'text' });
+      expect(result.querystring.include_type_name).toBe(true);
+    });
+
+    it('downgrades field types before wrapping', () => {
+      const params = {
+        path: '/new-index',
+        querystring: {},
+        body: {
+          mappings: { properties: { data: { type: 'flattened' } } },
+        },
+      };
+      const result = translateIndexCreateRequest(params, es6Backend);
+      expect(result.body.mappings._doc.properties.data).toEqual({
+        type: 'object',
+        enabled: false,
+      });
+    });
+
+    it('passes through when body is not plain object', () => {
+      const params = { path: '/new-index', querystring: {}, body: 'raw' };
+      const result = translateIndexCreateRequest(params, es6Backend);
+      expect(result.body).toBe('raw');
+      expect(result.querystring.include_type_name).toBe(true);
+    });
+
+    it('passes through when no mappings in body', () => {
+      const params = {
+        path: '/new-index',
+        querystring: {},
+        body: { settings: { number_of_shards: 1 } },
+      };
+      const result = translateIndexCreateRequest(params, es6Backend);
+      expect(result.body.mappings).toBeUndefined();
+    });
+  });
+
+  describe('translateResponse', () => {
+    it('unwraps typed mappings from response', () => {
+      const response = {
+        body: {
+          'my-index': {
+            mappings: {
+              _doc: { properties: { title: { type: 'text' } } },
+            },
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body['my-index'].mappings.properties).toEqual({ title: { type: 'text' } });
+    });
+
+    it('leaves typeless mappings unchanged', () => {
+      const response = {
+        body: {
+          'my-index': {
+            mappings: { properties: { title: { type: 'text' } } },
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body['my-index'].mappings.properties).toEqual({ title: { type: 'text' } });
+    });
+
+    it('handles null/undefined mappings', () => {
+      const response = { body: { 'my-index': { mappings: null } } };
+      expect(() => translateResponse(response, es6Backend)).not.toThrow();
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/adapters/mapping_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/mapping_adapter.ts
@@ -4,13 +4,13 @@
  */
 
 import { BackendInfo, DEFAULT_DOCUMENT_TYPE } from '../types';
-import { isPlainObject } from './normalization_utils';
+import { isPlainObject, extractQueryString } from './normalization_utils';
 
 interface FieldDefinition {
   type?: string;
   properties?: Record<string, FieldDefinition>;
   enabled?: boolean;
-  dynamic?: boolean | string;
+  dynamic?: boolean | 'true' | 'false' | 'strict';
   value?: any;
   null_value?: any;
   [key: string]: any;
@@ -44,10 +44,10 @@ const FIELD_TYPE_DOWNGRADES: Record<string, FieldTypeDowngrader> = {
     return { ...rest, type: 'text' };
   },
 
-  constant_keyword: (def) => ({
-    type: 'keyword',
-    ...(def.value !== undefined && { null_value: def.value }),
-  }),
+  constant_keyword: (def) => {
+    const { value, type, ...rest } = def;
+    return { ...rest, type: 'keyword', ...(value !== undefined && { null_value: value }) };
+  },
 
   histogram: (def) => ({
     type: 'object',
@@ -158,8 +158,7 @@ function downgradeMappings(mappings: any): { mappings: any; downgrades: string[]
 // ── Request/Response Translators ─────────────────────────────────────────────
 
 export function translateRequest(params: any, backend: BackendInfo): any {
-  const existing =
-    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const existing = extractQueryString(params);
   const qs = { ...existing, include_type_name: true };
 
   // Rewrite /{index}/_mapping → /{index}/_doc/_mapping (ES 6.x requires type in path)
@@ -180,8 +179,7 @@ export function translateRequest(params: any, backend: BackendInfo): any {
 }
 
 export function translateIndexCreateRequest(params: any, backend: BackendInfo): any {
-  const existing =
-    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const existing = extractQueryString(params);
   const qs = { ...existing, include_type_name: true };
 
   if (!isPlainObject(params.body) || !params.body.mappings) {

--- a/src/plugins/backend_compatibility/server/transport/adapters/mapping_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/mapping_adapter.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BackendInfo, DEFAULT_DOCUMENT_TYPE } from '../types';
+import { isPlainObject } from './normalization_utils';
+
+interface FieldDefinition {
+  type?: string;
+  properties?: Record<string, FieldDefinition>;
+  enabled?: boolean;
+  dynamic?: boolean | string;
+  value?: any;
+  null_value?: any;
+  [key: string]: any;
+}
+
+type FieldTypeDowngrader = (def: FieldDefinition) => FieldDefinition;
+
+/**
+ * Field types not supported in ES 6.x and their downgrade strategies.
+ *
+ * | Type               | Introduced | Downgrade Strategy                    |
+ * |--------------------|------------|---------------------------------------|
+ * | flattened          | ES 7.3     | object with enabled:false             |
+ * | search_as_you_type | ES 7.2     | text (loses edge ngram functionality) |
+ * | constant_keyword   | ES 7.7     | keyword with null_value               |
+ * | histogram          | ES 7.6     | object with enabled:false             |
+ * | wildcard           | ES 7.9     | keyword (loses wildcard optimization) |
+ * | version            | ES 7.10    | keyword                               |
+ * | match_only_text    | ES 7.14    | text                                  |
+ * | unsigned_long      | ES 7.10    | long (values > 2^63-1 will overflow)  |
+ */
+const FIELD_TYPE_DOWNGRADES: Record<string, FieldTypeDowngrader> = {
+  flattened: (def) => ({
+    type: 'object',
+    enabled: false,
+  }),
+
+  search_as_you_type: (def) => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { max_shingle_size, ...rest } = def;
+    return { ...rest, type: 'text' };
+  },
+
+  constant_keyword: (def) => ({
+    type: 'keyword',
+    ...(def.value !== undefined && { null_value: def.value }),
+  }),
+
+  histogram: (def) => ({
+    type: 'object',
+    enabled: false,
+  }),
+
+  wildcard: (def) => {
+    const { ...rest } = def;
+    return { ...rest, type: 'keyword' };
+  },
+
+  version: (def) => ({
+    type: 'keyword',
+  }),
+
+  match_only_text: (def) => ({
+    type: 'text',
+  }),
+
+  unsigned_long: (def) => ({
+    type: 'long',
+  }),
+};
+
+export const UNSUPPORTED_ES6_TYPES = Object.keys(FIELD_TYPE_DOWNGRADES);
+
+export function downgradeFieldTypes(
+  properties: Record<string, FieldDefinition>,
+  path: string = ''
+): { properties: Record<string, FieldDefinition>; downgrades: string[] } {
+  const downgrades: string[] = [];
+  const result: Record<string, FieldDefinition> = {};
+
+  for (const [fieldName, fieldDef] of Object.entries(properties)) {
+    const fieldPath = path ? `${path}.${fieldName}` : fieldName;
+    let newDef = { ...fieldDef };
+
+    if (fieldDef.type && FIELD_TYPE_DOWNGRADES[fieldDef.type]) {
+      const downgrader = FIELD_TYPE_DOWNGRADES[fieldDef.type];
+      newDef = downgrader(fieldDef);
+      downgrades.push(
+        `${fieldPath}: ${fieldDef.type} → ${newDef.type}${
+          newDef.enabled === false ? ' (disabled)' : ''
+        }`
+      );
+    }
+
+    if (fieldDef.properties) {
+      const nested = downgradeFieldTypes(fieldDef.properties, fieldPath);
+      newDef.properties = nested.properties;
+      downgrades.push(...nested.downgrades);
+    }
+
+    if (fieldDef.fields) {
+      const multiFields: Record<string, FieldDefinition> = {};
+      for (const [subName, subDef] of Object.entries(
+        fieldDef.fields as Record<string, FieldDefinition>
+      )) {
+        const subPath = `${fieldPath}.${subName}`;
+        if (subDef.type && FIELD_TYPE_DOWNGRADES[subDef.type]) {
+          const downgrader = FIELD_TYPE_DOWNGRADES[subDef.type];
+          multiFields[subName] = downgrader(subDef);
+          downgrades.push(`${subPath}: ${subDef.type} → ${multiFields[subName].type}`);
+        } else {
+          multiFields[subName] = subDef;
+        }
+      }
+      newDef.fields = multiFields;
+    }
+
+    result[fieldName] = newDef;
+  }
+
+  return { properties: result, downgrades };
+}
+
+function downgradeMappings(mappings: any): { mappings: any; downgrades: string[] } {
+  if (!mappings || typeof mappings !== 'object') {
+    return { mappings, downgrades: [] };
+  }
+
+  // Typeless format: { properties: { ... } }
+  if ('properties' in mappings && typeof mappings.properties === 'object') {
+    const result = downgradeFieldTypes(mappings.properties);
+    return {
+      mappings: { ...mappings, properties: result.properties },
+      downgrades: result.downgrades,
+    };
+  }
+
+  // Typed format: { _doc: { properties: { ... } } }
+  const allDowngrades: string[] = [];
+  const newMappings: any = {};
+
+  for (const [typeName, typeMapping] of Object.entries(mappings)) {
+    if (typeMapping && typeof typeMapping === 'object' && 'properties' in (typeMapping as any)) {
+      const result = downgradeFieldTypes((typeMapping as any).properties);
+      newMappings[typeName] = { ...typeMapping, properties: result.properties };
+      allDowngrades.push(...result.downgrades);
+    } else {
+      newMappings[typeName] = typeMapping;
+    }
+  }
+
+  return { mappings: newMappings, downgrades: allDowngrades };
+}
+
+// ── Request/Response Translators ─────────────────────────────────────────────
+
+export function translateRequest(params: any, backend: BackendInfo): any {
+  const existing =
+    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const qs = { ...existing, include_type_name: true };
+
+  // Rewrite /{index}/_mapping → /{index}/_doc/_mapping (ES 6.x requires type in path)
+  let { path } = params;
+  if (path && !path.includes(`/${DEFAULT_DOCUMENT_TYPE}/`)) {
+    path = path.replace(/^(\/[^/]+)\/_mapping(s)?/, `$1/${DEFAULT_DOCUMENT_TYPE}/_mapping$2`);
+  }
+
+  let body = params.body;
+  if (isPlainObject(body)) {
+    if (body.properties || Object.values(body).some((v: any) => v?.properties)) {
+      const { mappings: downgradedBody } = downgradeMappings(body);
+      body = downgradedBody;
+    }
+  }
+
+  return { ...params, path, querystring: qs, body };
+}
+
+export function translateIndexCreateRequest(params: any, backend: BackendInfo): any {
+  const existing =
+    typeof params.querystring === 'object' && params.querystring !== null ? params.querystring : {};
+  const qs = { ...existing, include_type_name: true };
+
+  if (!isPlainObject(params.body) || !params.body.mappings) {
+    return { ...params, querystring: qs };
+  }
+
+  let mappings = params.body.mappings;
+
+  if ('properties' in mappings) {
+    const { mappings: downgradedMappings } = downgradeMappings(mappings);
+    mappings = downgradedMappings;
+  }
+
+  // Wrap in _doc type for ES 6.x
+  if ('properties' in mappings) {
+    const typedMappings = { [DEFAULT_DOCUMENT_TYPE]: mappings };
+    return {
+      ...params,
+      querystring: qs,
+      body: { ...params.body, mappings: typedMappings },
+    };
+  }
+
+  return { ...params, querystring: qs, body: { ...params.body, mappings } };
+}
+
+export function translateResponse(response: any, backend: BackendInfo): any {
+  const body = response?.body || response;
+  if (!body) return response;
+
+  for (const [indexName, indexData] of Object.entries(body)) {
+    if (indexData && typeof indexData === 'object' && 'mappings' in (indexData as any)) {
+      (indexData as any).mappings = unwrapTypedMappings((indexData as any).mappings);
+    }
+  }
+
+  return response;
+}
+
+export function translateGetIndexResponse(response: any, backend: BackendInfo): any {
+  return translateResponse(response, backend);
+}
+
+function unwrapTypedMappings(mappings: any): any {
+  if (!mappings || typeof mappings !== 'object') return mappings;
+  if ('properties' in mappings) return mappings;
+
+  const keys = Object.keys(mappings);
+  if (keys.length === 1) {
+    const typeMapping = mappings[keys[0]];
+    if (typeMapping && typeof typeMapping === 'object' && 'properties' in typeMapping) {
+      return typeMapping;
+    }
+  }
+  return mappings;
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/normalization_utils.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/normalization_utils.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  isPlainObject,
+  removeType,
+  synthesizeSeqNo,
+  normalizeTotalHits,
+} from './normalization_utils';
+
+describe('normalization_utils', () => {
+  describe('isPlainObject', () => {
+    it('returns true for plain objects', () => {
+      expect(isPlainObject({})).toBe(true);
+      expect(isPlainObject({ key: 'value' })).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isPlainObject(null)).toBe(false);
+    });
+
+    it('returns false for arrays', () => {
+      expect(isPlainObject([])).toBe(false);
+      expect(isPlainObject([1, 2, 3])).toBe(false);
+    });
+
+    it('returns false for primitives', () => {
+      expect(isPlainObject('string')).toBe(false);
+      expect(isPlainObject(42)).toBe(false);
+      expect(isPlainObject(undefined)).toBe(false);
+    });
+
+    it('returns false for Buffer', () => {
+      expect(isPlainObject(Buffer.from('test'))).toBe(false);
+    });
+
+    it('returns false for serialized Buffer format', () => {
+      expect(isPlainObject({ type: 'Buffer', data: [1, 2, 3] })).toBe(false);
+    });
+
+    it('returns true for objects with type field that is not Buffer', () => {
+      expect(isPlainObject({ type: 'keyword' })).toBe(true);
+    });
+  });
+
+  describe('removeType', () => {
+    it('removes _type from a document', () => {
+      const doc = { _index: 'test', _type: '_doc', _id: '1' };
+      expect(removeType(doc)).toEqual({ _index: 'test', _id: '1' });
+    });
+
+    it('returns doc unchanged when no _type', () => {
+      const doc = { _index: 'test', _id: '1' };
+      expect(removeType(doc)).toEqual({ _index: 'test', _id: '1' });
+    });
+
+    it('returns null/undefined unchanged', () => {
+      expect(removeType(null)).toBeNull();
+      expect(removeType(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('synthesizeSeqNo', () => {
+    it('synthesizes _seq_no from _version when _seq_no is missing', () => {
+      const doc = { _id: '1', _version: 7 };
+      synthesizeSeqNo(doc);
+      expect(doc).toEqual({ _id: '1', _version: 7, _seq_no: 7, _primary_term: 1 });
+    });
+
+    it('does not overwrite existing _seq_no', () => {
+      const doc = { _id: '1', _version: 7, _seq_no: 10, _primary_term: 2 };
+      synthesizeSeqNo(doc);
+      expect(doc._seq_no).toBe(10);
+      expect(doc._primary_term).toBe(2);
+    });
+
+    it('does nothing when _version is absent', () => {
+      const doc = { _id: '1' };
+      synthesizeSeqNo(doc);
+      expect(doc).toEqual({ _id: '1' });
+    });
+  });
+
+  describe('normalizeTotalHits', () => {
+    it('converts number to object format', () => {
+      expect(normalizeTotalHits(42)).toEqual({ value: 42, relation: 'eq' });
+    });
+
+    it('passes through object format', () => {
+      const total = { value: 100, relation: 'gte' };
+      expect(normalizeTotalHits(total)).toBe(total);
+    });
+
+    it('returns zero for undefined', () => {
+      expect(normalizeTotalHits(undefined)).toEqual({ value: 0, relation: 'eq' });
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/adapters/normalization_utils.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/normalization_utils.ts
@@ -41,3 +41,9 @@ export function normalizeTotalHits(
   if (typeof total === 'number') return { value: total, relation: 'eq' };
   return total;
 }
+
+export function extractQueryString(params: { querystring?: any }): Record<string, any> {
+  return typeof params.querystring === 'object' && params.querystring !== null
+    ? params.querystring
+    : {};
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/normalization_utils.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/normalization_utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Strings and Buffers (e.g. from DevTools console proxy) produce malformed
+ * objects with numeric keys when spread — callers must check before spreading params.body.
+ */
+export function isPlainObject(value: any): value is Record<string, any> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  if (Buffer.isBuffer(value)) {
+    return false;
+  }
+  if (value.type === 'Buffer' && Array.isArray(value.data)) {
+    return false;
+  }
+  return true;
+}
+
+export function removeType(doc: any): any {
+  if (!doc || typeof doc !== 'object') return doc;
+  const { _type, ...rest } = doc;
+  return rest;
+}
+
+export function synthesizeSeqNo(doc: any): any {
+  if (doc._version !== undefined && doc._seq_no === undefined) {
+    doc._seq_no = doc._version;
+    doc._primary_term = 1;
+  }
+  return doc;
+}
+
+export function normalizeTotalHits(
+  total: number | { value: number; relation: string } | undefined
+): { value: number; relation: string } {
+  if (total === undefined) return { value: 0, relation: 'eq' };
+  if (typeof total === 'number') return { value: total, relation: 'eq' };
+  return total;
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/scroll_adapter.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/scroll_adapter.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { translateRequest, translateResponse } from './scroll_adapter';
+import { BackendInfo } from '../types';
+
+const es6Backend: BackendInfo = {
+  distribution: 'elasticsearch',
+  version: '6.8.23',
+  majorVersion: 6,
+  minorVersion: 8,
+  patchVersion: 23,
+};
+
+describe('scroll_adapter', () => {
+  describe('translateRequest', () => {
+    it('passes through params unchanged', () => {
+      const params = { path: '/_search/scroll', body: { scroll_id: 'abc' } };
+      expect(translateRequest(params, es6Backend)).toBe(params);
+    });
+  });
+
+  describe('translateResponse', () => {
+    it('normalizes numeric hits.total to object format', () => {
+      const response = {
+        body: {
+          hits: { total: 100, hits: [] },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.total).toEqual({ value: 100, relation: 'eq' });
+    });
+
+    it('strips _type from hits', () => {
+      const response = {
+        body: {
+          hits: {
+            total: { value: 1, relation: 'eq' },
+            hits: [{ _index: 'test', _type: '_doc', _id: '1', _source: {} }],
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.hits[0]._type).toBeUndefined();
+      expect(response.body.hits.hits[0]._id).toBe('1');
+    });
+
+    it('synthesizes _seq_no from _version', () => {
+      const response = {
+        body: {
+          hits: {
+            total: 1,
+            hits: [{ _index: 'test', _id: '1', _version: 4, _source: {} }],
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.hits[0]._seq_no).toBe(4);
+      expect(response.body.hits.hits[0]._primary_term).toBe(1);
+    });
+
+    it('returns response unchanged when no hits', () => {
+      const response = { body: { _scroll_id: 'abc' } };
+      expect(translateResponse(response, es6Backend)).toBe(response);
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/adapters/scroll_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/scroll_adapter.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BackendInfo } from '../types';
+import { normalizeTotalHits, synthesizeSeqNo } from './normalization_utils';
+
+export function translateRequest(params: any, backend: BackendInfo): any {
+  return params;
+}
+
+export function translateResponse(response: any, backend: BackendInfo): any {
+  const body = response?.body || response;
+  if (!body?.hits) return response;
+
+  body.hits.total = normalizeTotalHits(body.hits.total);
+
+  if (Array.isArray(body.hits.hits)) {
+    body.hits.hits = body.hits.hits.map((hit: any) => {
+      if (!hit) return hit;
+      const { _type, ...rest } = hit;
+      synthesizeSeqNo(rest);
+      return rest;
+    });
+  }
+
+  return response;
+}

--- a/src/plugins/backend_compatibility/server/transport/adapters/search_adapter.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/search_adapter.test.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  translateRequest,
+  translateResponse,
+  translateMsearchRequest,
+  translateMsearchResponse,
+} from './search_adapter';
+import { BackendInfo } from '../types';
+
+const es6Backend: BackendInfo = {
+  distribution: 'elasticsearch',
+  version: '6.8.23',
+  majorVersion: 6,
+  minorVersion: 8,
+  patchVersion: 23,
+};
+
+describe('search_adapter', () => {
+  describe('translateRequest', () => {
+    it('removes track_total_hits', () => {
+      const params = { body: { track_total_hits: true, query: { match_all: {} } } };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.track_total_hits).toBeUndefined();
+      expect(result.body.query).toEqual({ match_all: {} });
+    });
+
+    it('passes through when body is not a plain object', () => {
+      const params = { body: 'raw string' };
+      expect(translateRequest(params, es6Backend)).toBe(params);
+    });
+
+    it('passes through when body is undefined', () => {
+      const params = { path: '/_search' };
+      expect(translateRequest(params, es6Backend)).toBe(params);
+    });
+
+    it('converts calendar_interval to interval in date_histogram', () => {
+      const params = {
+        body: {
+          aggs: {
+            dates: { date_histogram: { field: '@timestamp', calendar_interval: '1d' } },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggs.dates.date_histogram.interval).toBe('1d');
+      expect(result.body.aggs.dates.date_histogram.calendar_interval).toBeUndefined();
+    });
+
+    it('converts fixed_interval to interval in date_histogram', () => {
+      const params = {
+        body: {
+          aggs: {
+            dates: { date_histogram: { field: '@timestamp', fixed_interval: '30s' } },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggs.dates.date_histogram.interval).toBe('30s');
+      expect(result.body.aggs.dates.date_histogram.fixed_interval).toBeUndefined();
+    });
+
+    it('converts auto_date_histogram to date_histogram with heuristic interval', () => {
+      const params = {
+        body: {
+          aggs: {
+            dates: { auto_date_histogram: { field: '@timestamp', buckets: 5 } },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggs.dates.date_histogram).toBeDefined();
+      expect(result.body.aggs.dates.date_histogram.field).toBe('@timestamp');
+      expect(result.body.aggs.dates.date_histogram.interval).toBe('month');
+      expect(result.body.aggs.dates.auto_date_histogram).toBeUndefined();
+    });
+
+    it('converts geotile_grid to geohash_grid', () => {
+      const params = {
+        body: {
+          aggs: {
+            grid: { geotile_grid: { field: 'location', precision: 8 } },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggs.grid.geohash_grid).toBeDefined();
+      expect(result.body.aggs.grid.geohash_grid.field).toBe('location');
+      expect(result.body.aggs.grid.geotile_grid).toBeUndefined();
+    });
+
+    it('drops unsupported aggregations', () => {
+      const params = {
+        body: {
+          aggs: {
+            valid: { terms: { field: 'status' } },
+            invalid: { rare_terms: { field: 'status' } },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggs.valid.terms).toBeDefined();
+      expect(result.body.aggs.invalid).toEqual({});
+    });
+
+    it('drops unsupported query types', () => {
+      const params = {
+        body: {
+          query: {
+            bool: {
+              must: [{ match: { title: 'test' } }, { intervals: { title: {} } }],
+            },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.query.bool.must).toHaveLength(2);
+      expect(result.body.query.bool.must[0]).toEqual({ match: { title: 'test' } });
+      expect(result.body.query.bool.must[1].intervals).toBeUndefined();
+    });
+
+    it('recursively transforms nested bool queries', () => {
+      const params = {
+        body: {
+          query: {
+            bool: {
+              must: [
+                {
+                  bool: {
+                    should: [{ match: { a: '1' } }],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.query.bool.must[0].bool.should).toEqual([{ match: { a: '1' } }]);
+    });
+
+    it('transforms query_string default_field=* to all_fields', () => {
+      const params = {
+        body: {
+          query: { query_string: { query: 'test', default_field: '*' } },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.query.query_string.all_fields).toBe(true);
+      expect(result.body.query.query_string.default_field).toBeUndefined();
+    });
+
+    it('processes aggregations under both aggs and aggregations keys', () => {
+      const params = {
+        body: {
+          aggregations: {
+            dates: { date_histogram: { field: '@timestamp', calendar_interval: '1h' } },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggregations.dates.date_histogram.interval).toBe('1h');
+    });
+
+    it('recursively transforms sub-aggregations', () => {
+      const params = {
+        body: {
+          aggs: {
+            outer: {
+              terms: { field: 'status' },
+              aggs: {
+                inner: { date_histogram: { field: '@timestamp', fixed_interval: '5m' } },
+              },
+            },
+          },
+        },
+      };
+      const result = translateRequest(params, es6Backend);
+      expect(result.body.aggs.outer.aggs.inner.date_histogram.interval).toBe('5m');
+    });
+  });
+
+  describe('translateResponse', () => {
+    it('normalizes numeric hits.total to object format', () => {
+      const response = { body: { hits: { total: 42, hits: [] } } };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.total).toEqual({ value: 42, relation: 'eq' });
+    });
+
+    it('passes through object-format hits.total', () => {
+      const response = { body: { hits: { total: { value: 10, relation: 'gte' }, hits: [] } } };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.total).toEqual({ value: 10, relation: 'gte' });
+    });
+
+    it('strips _type from hits', () => {
+      const response = {
+        body: {
+          hits: {
+            total: 1,
+            hits: [{ _index: 'test', _type: '_doc', _id: '1', _source: {} }],
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.hits[0]._type).toBeUndefined();
+      expect(response.body.hits.hits[0]._id).toBe('1');
+    });
+
+    it('synthesizes _seq_no from _version when missing', () => {
+      const response = {
+        body: {
+          hits: {
+            total: 1,
+            hits: [{ _index: 'test', _id: '1', _version: 3, _source: {} }],
+          },
+        },
+      };
+      translateResponse(response, es6Backend);
+      expect(response.body.hits.hits[0]._seq_no).toBe(3);
+      expect(response.body.hits.hits[0]._primary_term).toBe(1);
+    });
+
+    it('returns response unchanged when no hits', () => {
+      const response = { body: { acknowledged: true } };
+      const result = translateResponse(response, es6Backend);
+      expect(result).toBe(response);
+    });
+  });
+
+  describe('translateMsearchRequest', () => {
+    it('transforms search bodies at odd indices', () => {
+      const params = {
+        body: [
+          { index: 'test' },
+          { query: { match_all: {} }, track_total_hits: true },
+          { index: 'other' },
+          { query: { match_all: {} }, track_total_hits: 10 },
+        ],
+      };
+      const result = translateMsearchRequest(params, es6Backend);
+      expect(result.body[0]).toEqual({ index: 'test' });
+      expect(result.body[1].track_total_hits).toBeUndefined();
+      expect(result.body[2]).toEqual({ index: 'other' });
+      expect(result.body[3].track_total_hits).toBeUndefined();
+    });
+
+    it('returns params unchanged when body is not an array', () => {
+      const params = { body: { query: {} } };
+      expect(translateMsearchRequest(params, es6Backend)).toBe(params);
+    });
+  });
+
+  describe('translateMsearchResponse', () => {
+    it('normalizes each sub-response', () => {
+      const response = {
+        body: {
+          responses: [
+            { hits: { total: 5, hits: [{ _type: '_doc', _id: '1' }] } },
+            { hits: { total: 0, hits: [] } },
+          ],
+        },
+      };
+      translateMsearchResponse(response, es6Backend);
+      expect(response.body.responses[0].hits.total).toEqual({ value: 5, relation: 'eq' });
+      expect(response.body.responses[0].hits.hits[0]._type).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/adapters/search_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/search_adapter.ts
@@ -154,6 +154,9 @@ function transformAutoDateHistogram(adh: Record<string, any>): Record<string, an
 function transformGeotileToGeohash(gt: Record<string, any>): Record<string, any> {
   const result: Record<string, any> = { field: gt.field };
   if (typeof gt.precision === 'number') {
+    // Geotile zoom levels (0–29) map to geohash precision (1–12) at different rates.
+    // Geotile uses web mercator zoom; geohash uses character-based precision.
+    // Approximate spatial equivalence: zoom 4 ≈ geohash 2, zoom 10 ≈ geohash 5, zoom 20 ≈ geohash 9.
     const p = gt.precision;
     if (p <= 4) result.precision = Math.max(1, Math.ceil(p / 2));
     else if (p <= 10) result.precision = Math.min(5, 3 + Math.floor((p - 5) / 2));

--- a/src/plugins/backend_compatibility/server/transport/adapters/search_adapter.ts
+++ b/src/plugins/backend_compatibility/server/transport/adapters/search_adapter.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BackendInfo } from '../types';
+import { isPlainObject, normalizeTotalHits, synthesizeSeqNo } from './normalization_utils';
+
+const UNSUPPORTED_ES6_AGGREGATIONS = [
+  'rare_terms',
+  'variable_width_histogram',
+  'multi_terms',
+  'rate',
+  't_test',
+  'moving_percentiles',
+  'normalize',
+  'boxplot',
+  'string_stats',
+];
+
+const UNSUPPORTED_ES6_QUERIES = ['intervals', 'distance_feature', 'pinned'];
+
+export function translateRequest(params: any, backend: BackendInfo): any {
+  if (!isPlainObject(params.body)) {
+    return params;
+  }
+
+  const body = { ...params.body };
+
+  if ('track_total_hits' in body) {
+    delete body.track_total_hits;
+  }
+
+  if (body.aggs) body.aggs = transformAggregations(body.aggs);
+  if (body.aggregations) body.aggregations = transformAggregations(body.aggregations);
+  if (body.query) body.query = transformQuery(body.query);
+
+  return { ...params, body };
+}
+
+export function translateMsearchRequest(params: any, backend: BackendInfo): any {
+  if (!params.body || !Array.isArray(params.body)) return params;
+
+  const transformed = params.body.map((item: any, index: number) => {
+    if (index % 2 === 1 && item && typeof item === 'object') {
+      return translateRequest({ ...params, body: item }, backend).body;
+    }
+    return item;
+  });
+  return { ...params, body: transformed };
+}
+
+export function translateResponse(response: any, backend: BackendInfo): any {
+  const body = response?.body || response;
+  if (!body?.hits) return response;
+
+  body.hits.total = normalizeTotalHits(body.hits.total);
+
+  if (Array.isArray(body.hits.hits)) {
+    body.hits.hits = body.hits.hits.map((hit: any) => {
+      if (!hit) return hit;
+      const { _type, ...rest } = hit;
+      synthesizeSeqNo(rest);
+      return rest;
+    });
+  }
+
+  return response;
+}
+
+export function translateMsearchResponse(response: any, backend: BackendInfo): any {
+  const body = response?.body || response;
+  if (!body?.responses) return response;
+
+  body.responses = body.responses.map((res: any) => {
+    const wrapped = { body: res };
+    translateResponse(wrapped, backend);
+    return wrapped.body;
+  });
+
+  return response;
+}
+
+function transformAggregations(aggs: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+  for (const [name, agg] of Object.entries(aggs)) {
+    if (!agg || typeof agg !== 'object') {
+      result[name] = agg;
+      continue;
+    }
+    result[name] = transformAggregation(agg);
+  }
+  return result;
+}
+
+const AGG_TRANSFORMS: Record<string, (value: any) => { key: string; value: any }> = {
+  date_histogram: (v) => ({ key: 'date_histogram', value: transformDateHistogram(v) }),
+  auto_date_histogram: (v) => ({ key: 'date_histogram', value: transformAutoDateHistogram(v) }),
+  geotile_grid: (v) => ({ key: 'geohash_grid', value: transformGeotileToGeohash(v) }),
+};
+
+function transformAggregation(agg: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(agg)) {
+    if (UNSUPPORTED_ES6_AGGREGATIONS.includes(key)) continue;
+
+    const isObj = value && typeof value === 'object';
+
+    if (isObj && AGG_TRANSFORMS[key]) {
+      const { key: outKey, value: outValue } = AGG_TRANSFORMS[key](value);
+      result[outKey] = outValue;
+    } else if (isObj && (key === 'aggs' || key === 'aggregations')) {
+      result[key] = transformAggregations(value);
+    } else if (isObj && ('aggs' in value || 'aggregations' in value)) {
+      result[key] = transformAggregation(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function transformDateHistogram(dh: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(dh)) {
+    if (key === 'calendar_interval' || key === 'fixed_interval') {
+      result.interval = value;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+const BUCKET_INTERVALS: Array<[number, string]> = [
+  [10, 'month'],
+  [30, 'week'],
+  [100, 'day'],
+];
+
+function transformAutoDateHistogram(adh: Record<string, any>): Record<string, any> {
+  const buckets = adh.buckets as number | undefined;
+  const interval = buckets
+    ? BUCKET_INTERVALS.find(([max]) => buckets <= max)?.[1] ?? 'hour'
+    : 'day';
+
+  const result: Record<string, any> = { field: adh.field, interval };
+  if (adh.time_zone) result.time_zone = adh.time_zone;
+  if (adh.format) result.format = adh.format;
+  if (adh.min_doc_count !== undefined) result.min_doc_count = adh.min_doc_count;
+  return result;
+}
+
+function transformGeotileToGeohash(gt: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = { field: gt.field };
+  if (typeof gt.precision === 'number') {
+    const p = gt.precision;
+    if (p <= 4) result.precision = Math.max(1, Math.ceil(p / 2));
+    else if (p <= 10) result.precision = Math.min(5, 3 + Math.floor((p - 5) / 2));
+    else if (p <= 20) result.precision = Math.min(9, 6 + Math.floor((p - 11) / 3));
+    else result.precision = Math.min(12, 10 + Math.floor((p - 21) / 3));
+  }
+  if (gt.size !== undefined) result.size = gt.size;
+  if (gt.shard_size !== undefined) result.shard_size = gt.shard_size;
+  if (gt.bounds !== undefined) result.bounds = gt.bounds;
+  return result;
+}
+
+const recurseOn = (field: string) => (v: any) => ({ ...v, [field]: transformQuery(v[field]) });
+
+const QUERY_TRANSFORMS: Record<string, (value: any) => any> = {
+  bool: (v) => transformBoolQuery(v),
+  nested: recurseOn('query'),
+  has_child: recurseOn('query'),
+  has_parent: recurseOn('query'),
+  constant_score: recurseOn('filter'),
+  dis_max: (v) => ({ ...v, queries: (v.queries || []).map(transformQuery) }),
+  boosting: (v) => ({
+    positive: transformQuery(v.positive),
+    negative: transformQuery(v.negative),
+    negative_boost: v.negative_boost,
+  }),
+  function_score: (v) => ({
+    ...v,
+    ...(v.query && { query: transformQuery(v.query) }),
+    ...(v.functions && {
+      functions: v.functions.map((fn: any) =>
+        fn.filter ? { ...fn, filter: transformQuery(fn.filter) } : fn
+      ),
+    }),
+  }),
+  query_string: (v) => {
+    const qs = { ...v };
+    if (qs.default_field === '*' && !qs.all_fields) {
+      qs.all_fields = true;
+      delete qs.default_field;
+    }
+    return qs;
+  },
+};
+
+function transformQuery(query: any): any {
+  if (!query || typeof query !== 'object') return query;
+  const result: any = {};
+  for (const [key, value] of Object.entries(query)) {
+    if (UNSUPPORTED_ES6_QUERIES.includes(key)) continue;
+
+    if (QUERY_TRANSFORMS[key] && value && typeof value === 'object') {
+      result[key] = QUERY_TRANSFORMS[key](value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+const BOOL_CLAUSES = ['must', 'filter', 'should', 'must_not'] as const;
+
+function transformBoolQuery(bool: any): any {
+  const result: any = {};
+  const mapQ = (q: any) => (Array.isArray(q) ? q.map(transformQuery) : transformQuery(q));
+
+  for (const clause of BOOL_CLAUSES) {
+    if (bool[clause]) result[clause] = mapQ(bool[clause]);
+  }
+  if (bool.minimum_should_match !== undefined)
+    result.minimum_should_match = bool.minimum_should_match;
+  if (bool.boost !== undefined) result.boost = bool.boost;
+  return result;
+}

--- a/src/plugins/backend_compatibility/server/transport/backend_detector.test.ts
+++ b/src/plugins/backend_compatibility/server/transport/backend_detector.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { detectBackend, ClusterInfoResponse } from './backend_detector';
+
+describe('backend_detector', () => {
+  describe('detectBackend', () => {
+    it('detects OpenSearch by distribution field', () => {
+      const info: ClusterInfoResponse = {
+        name: 'node1',
+        cluster_name: 'opensearch-cluster',
+        cluster_uuid: 'abc123',
+        version: {
+          number: '2.11.0',
+          distribution: 'opensearch',
+          build_type: 'tar',
+        },
+      };
+      const result = detectBackend(info);
+      expect(result.distribution).toBe('opensearch');
+      expect(result.majorVersion).toBe(2);
+      expect(result.minorVersion).toBe(11);
+      expect(result.patchVersion).toBe(0);
+    });
+
+    it('detects OpenSearch by tagline', () => {
+      const info: ClusterInfoResponse = {
+        name: 'node1',
+        cluster_name: 'cluster',
+        cluster_uuid: 'abc123',
+        version: { number: '1.3.0' },
+        tagline: 'The OpenSearch Project',
+      };
+      const result = detectBackend(info);
+      expect(result.distribution).toBe('opensearch');
+    });
+
+    it('detects Elasticsearch 6.x', () => {
+      const info: ClusterInfoResponse = {
+        name: 'node1',
+        cluster_name: 'es-cluster',
+        cluster_uuid: 'def456',
+        version: {
+          number: '6.8.23',
+          build_type: 'tar',
+          lucene_version: '7.7.3',
+        },
+        tagline: 'You Know, for Search',
+      };
+      const result = detectBackend(info);
+      expect(result.distribution).toBe('elasticsearch');
+      expect(result.majorVersion).toBe(6);
+      expect(result.minorVersion).toBe(8);
+      expect(result.patchVersion).toBe(23);
+    });
+
+    it('detects Elasticsearch 7.x', () => {
+      const info: ClusterInfoResponse = {
+        name: 'node1',
+        cluster_name: 'es-cluster',
+        cluster_uuid: 'ghi789',
+        version: {
+          number: '7.10.2',
+          build_type: 'tar',
+        },
+        tagline: 'You Know, for Search',
+      };
+      const result = detectBackend(info);
+      expect(result.distribution).toBe('elasticsearch');
+      expect(result.majorVersion).toBe(7);
+      expect(result.minorVersion).toBe(10);
+    });
+
+    it('throws on unparseable version', () => {
+      const info: ClusterInfoResponse = {
+        name: 'node1',
+        cluster_name: 'cluster',
+        cluster_uuid: 'abc',
+        version: { number: 'not-a-version' },
+      };
+      expect(() => detectBackend(info)).toThrow('Unable to parse backend version');
+    });
+  });
+});

--- a/src/plugins/backend_compatibility/server/transport/backend_detector.ts
+++ b/src/plugins/backend_compatibility/server/transport/backend_detector.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import semver from 'semver';
+import { BackendDistribution, BackendInfo } from './types';
+
+export interface ClusterInfoResponse {
+  name: string;
+  cluster_name: string;
+  cluster_uuid: string;
+  version: {
+    number: string;
+    distribution?: string;
+    build_type?: string;
+    build_hash?: string;
+    build_date?: string;
+    build_snapshot?: boolean;
+    lucene_version?: string;
+    minimum_wire_compatibility_version?: string;
+    minimum_index_compatibility_version?: string;
+  };
+  tagline?: string;
+}
+
+export function detectBackend(clusterInfo: ClusterInfoResponse): BackendInfo {
+  const { version } = clusterInfo;
+  const versionNumber = version.number;
+
+  const isOpenSearch =
+    version.distribution?.toLowerCase() === 'opensearch' ||
+    clusterInfo.tagline?.toLowerCase().includes('opensearch');
+
+  const distribution: BackendDistribution = isOpenSearch ? 'opensearch' : 'elasticsearch';
+
+  const parsed = semver.coerce(versionNumber);
+  if (!parsed) {
+    throw new Error(`Unable to parse backend version: ${versionNumber}`);
+  }
+
+  return {
+    distribution,
+    version: versionNumber,
+    majorVersion: parsed.major,
+    minorVersion: parsed.minor,
+    patchVersion: parsed.patch,
+  };
+}

--- a/src/plugins/backend_compatibility/server/transport/compatibility_transport.ts
+++ b/src/plugins/backend_compatibility/server/transport/compatibility_transport.ts
@@ -15,6 +15,7 @@ import * as scrollAdapter from './adapters/scroll_adapter';
 
 const DETECTION_TIMEOUT_MS = 30000;
 const MAX_DETECTION_ATTEMPTS = 3;
+const DETECTION_RETRY_DELAYS_MS = [500, 1000, 2000];
 
 interface RouteEntry {
   name: string;
@@ -172,14 +173,18 @@ export class CompatibilityTransport extends Transport {
       return this.handleResolveIndex(params, options);
     }
 
+    return this.applyES6Request(params, options);
+  }
+
+  private async applyES6Request(params: any, options?: any): Promise<any> {
     const normalized = this.normalizeParams(params);
     const route = this.matchRoute(normalized);
 
-    const translatedParams = route?.request ? route.request(normalized, this.backend) : normalized;
+    const translatedParams = route?.request ? route.request(normalized, this.backend!) : normalized;
 
     const response = await super.request(translatedParams, options);
 
-    return route?.response ? route.response(response, this.backend) : response;
+    return route?.response ? route.response(response, this.backend!) : response;
   }
 
   // ── Route matching ──────────────────────────────────────────────────
@@ -227,11 +232,12 @@ export class CompatibilityTransport extends Transport {
 
   private async performDetection(options?: any): Promise<void> {
     this.detectionAttempts++;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const detectionPromise = super.request({ method: 'GET', path: '/' }, options);
 
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(
+        timer = setTimeout(
           () => reject(new Error(`Backend detection timed out after ${DETECTION_TIMEOUT_MS}ms`)),
           DETECTION_TIMEOUT_MS
         );
@@ -243,6 +249,11 @@ export class CompatibilityTransport extends Transport {
       CompatibilityTransport.lastDetectedBackend = this.backend;
     } catch (error) {
       if (this.detectionAttempts >= MAX_DETECTION_ATTEMPTS) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[backend_compatibility] Failed to detect backend after ${MAX_DETECTION_ATTEMPTS} attempts. ` +
+            `Falling back to OpenSearch pass-through. Last error: ${error}`
+        );
         this.backend = {
           distribution: 'opensearch',
           version: '0.0.0',
@@ -250,7 +261,12 @@ export class CompatibilityTransport extends Transport {
           minorVersion: 0,
           patchVersion: 0,
         };
+      } else {
+        const delay = DETECTION_RETRY_DELAYS_MS[this.detectionAttempts - 1] || 1000;
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 

--- a/src/plugins/backend_compatibility/server/transport/compatibility_transport.ts
+++ b/src/plugins/backend_compatibility/server/transport/compatibility_transport.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Transport } from '@opensearch-project/opensearch';
+import { parse as parseQuerystring } from 'querystring';
+import { BackendInfo } from './types';
+import { detectBackend } from './backend_detector';
+import * as searchAdapter from './adapters/search_adapter';
+import * as documentAdapter from './adapters/document_adapter';
+import * as mappingAdapter from './adapters/mapping_adapter';
+import * as fieldCapsAdapter from './adapters/field_caps_adapter';
+import * as scrollAdapter from './adapters/scroll_adapter';
+
+const DETECTION_TIMEOUT_MS = 30000;
+const MAX_DETECTION_ATTEMPTS = 3;
+
+interface RouteEntry {
+  name: string;
+  pattern: RegExp;
+  guard?: (params: any) => boolean;
+  request?: (params: any, backend: BackendInfo) => any;
+  response?: (response: any, backend: BackendInfo) => any;
+  es7Response?: (response: any, backend: BackendInfo) => any;
+}
+
+function stripTypeFromHits(response: any): any {
+  const body = response?.body || response;
+  if (body?.hits?.hits && Array.isArray(body.hits.hits)) {
+    body.hits.hits = body.hits.hits.map((hit: any) => {
+      if (!hit) return hit;
+      const { _type, ...rest } = hit;
+      return rest;
+    });
+  }
+  return response;
+}
+
+function stripTypeFromMsearchHits(response: any): any {
+  const body = response?.body || response;
+  if (!body?.responses) return response;
+
+  body.responses = body.responses.map((res: any) => {
+    if (res?.hits?.hits && Array.isArray(res.hits.hits)) {
+      res.hits.hits = res.hits.hits.map((hit: any) => {
+        if (!hit) return hit;
+        const { _type, ...rest } = hit;
+        return rest;
+      });
+    }
+    return res;
+  });
+
+  return response;
+}
+
+// ORDER MATTERS — more specific patterns must come before broader ones.
+const ROUTE_TABLE: RouteEntry[] = [
+  // ── Search ────────────────────────────────────────────────────────
+  {
+    name: 'scroll',
+    pattern: /\/_search\/scroll(\/|$)/,
+    request: scrollAdapter.translateRequest,
+    response: scrollAdapter.translateResponse,
+    es7Response: stripTypeFromHits,
+  },
+  {
+    name: 'search',
+    pattern: /\/_search(\/|$)/,
+    request: searchAdapter.translateRequest,
+    response: searchAdapter.translateResponse,
+    es7Response: stripTypeFromHits,
+  },
+  {
+    name: 'msearch',
+    pattern: /\/_msearch(\/|$)/,
+    request: searchAdapter.translateMsearchRequest,
+    response: searchAdapter.translateMsearchResponse,
+    es7Response: stripTypeFromMsearchHits,
+  },
+
+  // ── Documents ─────────────────────────────────────────────────────
+  {
+    name: 'bulk',
+    pattern: /\/_bulk(\/|$)/,
+    request: documentAdapter.translateBulkRequest,
+    response: documentAdapter.translateResponse,
+    es7Response: (res, backend) => documentAdapter.translateResponse(res, backend),
+  },
+  {
+    name: 'create',
+    pattern: /\/_create(\/|$)/,
+    request: documentAdapter.translateCreateRequest,
+    response: documentAdapter.translateResponse,
+  },
+  {
+    name: 'mget',
+    pattern: /\/_mget(\/|$)/,
+    request: documentAdapter.translateMgetRequest,
+    response: documentAdapter.translateResponse,
+    es7Response: (res, backend) => documentAdapter.translateResponse(res, backend),
+  },
+  {
+    name: 'delete_by_query',
+    pattern: /\/_delete_by_query(\/|$)/,
+    request: documentAdapter.translateDeleteByQueryRequest,
+  },
+  {
+    name: 'doc_update',
+    pattern: /\/_update(\/|$)/,
+    request: documentAdapter.translateDocRequest,
+    response: documentAdapter.translateResponse,
+  },
+  {
+    name: 'doc_crud',
+    pattern: /\/_doc(\/|$)/,
+    request: documentAdapter.translateDocRequest,
+    response: documentAdapter.translateResponse,
+    es7Response: (res, backend) => documentAdapter.translateResponse(res, backend),
+  },
+
+  // ── Mappings ──────────────────────────────────────────────────────
+  {
+    name: 'mapping',
+    pattern: /\/_mappings?(\/|$)/,
+    request: mappingAdapter.translateRequest,
+    response: mappingAdapter.translateResponse,
+  },
+  {
+    name: 'index_create',
+    pattern: /^\/[^/]+$/,
+    guard: (params) => params.method === 'PUT' && !!params.body?.mappings,
+    request: mappingAdapter.translateIndexCreateRequest,
+  },
+  {
+    name: 'index_get',
+    pattern: /^\/[^/]+$/,
+    guard: (params) => params.method === 'GET',
+    response: mappingAdapter.translateGetIndexResponse,
+  },
+
+  // ── Metadata ──────────────────────────────────────────────────────
+  {
+    name: 'field_caps',
+    pattern: /\/_field_caps(\/|$)/,
+    request: fieldCapsAdapter.translateRequest,
+    response: fieldCapsAdapter.translateResponse,
+  },
+];
+
+export class CompatibilityTransport extends Transport {
+  static lastDetectedBackend: BackendInfo | null = null;
+
+  private backend: BackendInfo | null = null;
+  private detecting: Promise<void> | null = null;
+  private detectionAttempts = 0;
+
+  async request(params: any, options?: any): Promise<any> {
+    await this.ensureBackendDetected(options);
+
+    if (!this.backend || this.backend.distribution === 'opensearch') {
+      return super.request(params, options);
+    }
+
+    if (this.backend.majorVersion >= 7) {
+      const response = await super.request(params, options);
+      return this.applyES7Response(params, response);
+    }
+
+    if (params.path?.includes('/_resolve/index')) {
+      return this.handleResolveIndex(params, options);
+    }
+
+    const normalized = this.normalizeParams(params);
+    const route = this.matchRoute(normalized);
+
+    const translatedParams = route?.request ? route.request(normalized, this.backend) : normalized;
+
+    const response = await super.request(translatedParams, options);
+
+    return route?.response ? route.response(response, this.backend) : response;
+  }
+
+  // ── Route matching ──────────────────────────────────────────────────
+
+  private matchRoute(params: any): RouteEntry | undefined {
+    const { path } = params;
+    if (!path) return undefined;
+
+    for (const entry of ROUTE_TABLE) {
+      if (entry.pattern.test(path)) {
+        if (!entry.guard || entry.guard(params)) {
+          return entry;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private applyES7Response(params: any, response: any): any {
+    const { path } = params;
+    if (!path) return response;
+
+    for (const entry of ROUTE_TABLE) {
+      if (entry.es7Response && entry.pattern.test(path)) {
+        if (!entry.guard || entry.guard(params)) {
+          return entry.es7Response(response, this.backend!);
+        }
+      }
+    }
+    return response;
+  }
+
+  // ── Backend detection ───────────────────────────────────────────────
+
+  private async ensureBackendDetected(options?: any): Promise<void> {
+    if (this.backend) return;
+    if (this.detecting) {
+      await this.detecting;
+      return;
+    }
+    this.detecting = this.performDetection(options);
+    await this.detecting;
+    this.detecting = null;
+  }
+
+  private async performDetection(options?: any): Promise<void> {
+    this.detectionAttempts++;
+    try {
+      const detectionPromise = super.request({ method: 'GET', path: '/' }, options);
+
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error(`Backend detection timed out after ${DETECTION_TIMEOUT_MS}ms`)),
+          DETECTION_TIMEOUT_MS
+        );
+      });
+
+      const response = await Promise.race([detectionPromise, timeoutPromise]);
+      const info = response?.body || response;
+      this.backend = detectBackend(info);
+      CompatibilityTransport.lastDetectedBackend = this.backend;
+    } catch (error) {
+      if (this.detectionAttempts >= MAX_DETECTION_ATTEMPTS) {
+        this.backend = {
+          distribution: 'opensearch',
+          version: '0.0.0',
+          majorVersion: 0,
+          minorVersion: 0,
+          patchVersion: 0,
+        };
+      }
+    }
+  }
+
+  // ── _resolve/index synthesis (ES 6.x) ──────────────────────────────
+
+  private async handleResolveIndex(params: any, options?: any): Promise<any> {
+    const pathMatch = params.path.match(/\/_resolve\/index\/(.+?)(?:\?|$)/);
+    const pattern = pathMatch ? decodeURIComponent(pathMatch[1]) : '*';
+
+    const [catIndicesRes, catAliasesRes] = await Promise.all([
+      super
+        .request(
+          {
+            method: 'GET',
+            path: `/_cat/indices/${pattern}`,
+            querystring: { format: 'json', h: 'index,status' },
+          },
+          options
+        )
+        .catch(() => ({ body: [] })),
+      super
+        .request(
+          {
+            method: 'GET',
+            path: `/_cat/aliases/${pattern}`,
+            querystring: { format: 'json', h: 'alias,index' },
+          },
+          options
+        )
+        .catch(() => ({ body: [] })),
+    ]);
+
+    const catIndices = catIndicesRes?.body || catIndicesRes || [];
+    const catAliases = catAliasesRes?.body || catAliasesRes || [];
+
+    const indices = Array.isArray(catIndices)
+      ? catIndices.map((item: any) => ({ name: item.index, attributes: [item.status || 'open'] }))
+      : [];
+
+    const aliases = Array.isArray(catAliases)
+      ? catAliases.map((item: any) => ({ name: item.alias, indices: [item.index] }))
+      : [];
+
+    return { body: { indices, aliases, data_streams: [] }, statusCode: 200 };
+  }
+
+  // ── Parameter normalization ─────────────────────────────────────────
+
+  private normalizeParams(params: any): any {
+    let path = params.path;
+    let qs: Record<string, any> =
+      typeof params.querystring === 'object' && params.querystring !== null
+        ? { ...params.querystring }
+        : {};
+
+    if (path && path.includes('?')) {
+      const idx = path.indexOf('?');
+      const pathQs = parseQuerystring(path.substring(idx + 1));
+      qs = { ...qs, ...pathQs };
+      path = path.substring(0, idx);
+    }
+
+    // _source_includes → _source_include (ES 6.x name)
+    if ('_source_includes' in qs) {
+      qs._source_include = qs._source_includes;
+      delete qs._source_includes;
+    }
+    if ('_source_excludes' in qs) {
+      qs._source_exclude = qs._source_excludes;
+      delete qs._source_excludes;
+    }
+
+    return { ...params, path, querystring: qs };
+  }
+}

--- a/src/plugins/backend_compatibility/server/transport/types.ts
+++ b/src/plugins/backend_compatibility/server/transport/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type BackendDistribution = 'opensearch' | 'elasticsearch';
+
+export interface BackendInfo {
+  distribution: BackendDistribution;
+  version: string;
+  majorVersion: number;
+  minorVersion: number;
+  patchVersion: number;
+}
+
+export const DEFAULT_DOCUMENT_TYPE = '_doc';


### PR DESCRIPTION
### Description

   Adds the `backend_compatibility` plugin that enables OpenSearch Dashboards to connect to legacy Elasticsearch 6.x and 7.x clusters.

   The plugin registers a custom `Transport` class with core (via `registerClientTransport` from #11493) that intercepts all HTTP-level communication at the single `transport.request()` convergence point. It applies version-appropriate translations:

   - **ES 6.x**: Full request/response translation — `_type` injection, typed mappings, `interval` syntax, `_seq_no` synthesis, field type downgrades, `/_resolve/index` synthesis
   - **ES 7.x**: Response-only normalization — strip `_type` from document hits
   - **OpenSearch**: Pass-through with zero overhead

   The plugin is experimental and disabled by default: `backendCompatibility.enabled: true`

   **Key design decisions:**
   - Single interception point via Transport subclass (not per-method Proxy wrapping)
   - Declarative route table for path-based dispatch
   - Lazy backend detection on first request via `GET /`
   - Zero core knowledge of Elasticsearch — all logic lives in the plugin

   **Scope:** This PR covers the new opensearch-js client path, which handles core OSD functionality (saved objects, search, index patterns, visualizations, dashboards). Code paths still using the legacy elasticsearch-js client (index patterns field
   discovery, autocomplete, usage collection) bypass the Transport and are not covered. Full legacy client compatibility is planned as a follow-up via either migrating remaining legacy client usage to opensearch-js (preferred) or adding a
   `legacyRequestInterceptor` hook (prototype exists).

   **References:**
   - RFC: #11470
   - Core Transport extension: #11493

   ### Issues Resolved

   closes #11492

   ## Screenshot

   N/A — server-only plugin with no UI changes.

   ## Testing the changes

   **Unit tests:**

   `yarn test:jest src/plugins/backend_compatibility --no-cache`

   **Manual validation against ES 6.8 / 7.10.2:**

   1. Start an ES cluster:

   `docker run -d -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23`

   Or for ES 7.10.2:

   `docker run -d -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2`

   2. Add to `opensearch_dashboards.yml`:
      - `opensearch.hosts: ["http://localhost:9200"]`
      - `backendCompatibility.enabled: true`

   3. Start OSD: `yarn start`

   4. Verify core functionality works: saved objects, index patterns, search, visualizations, dashboards.

   ### Check List

   - [x] All tests pass
     - [x] `yarn test:jest`
     - [x] `yarn test:jest_integration`
   - [x] New functionality includes testing.
   - [x] New functionality has been documented.
   - [x] Commits are signed per the DCO using --signoff