### PR TITLE
[Chat] Fix chat_interaction_success telemetry sent after run error

### DIFF
--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -1441,6 +1441,41 @@ describe('ChatEventHandler', () => {
       // Restore Date.now
       Date.now = originalDateNow;
     });
+
+    it('should not record success telemetry when run finishes after an error', async () => {
+      // Start run
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.RUN_STARTED,
+        threadId: 'test-thread',
+        runId: 'test-run',
+      });
+
+      // Error occurs
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.RUN_ERROR,
+        message: 'Something went wrong',
+        code: 'ERR_001',
+      });
+
+      // Clear mocks to isolate what handleRunFinished records
+      mockTelemetryRecorder.recordEvent.mockClear();
+      mockTelemetryRecorder.recordMetric.mockClear();
+
+      // Run finished after error
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.RUN_FINISHED,
+        threadId: 'test-thread',
+        runId: 'test-run',
+      });
+
+      // Verify success event was NOT recorded
+      expect(mockTelemetryRecorder.recordEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'chat_interaction_success' })
+      );
+
+      // Verify success duration metric was NOT recorded
+      expect(mockTelemetryRecorder.recordMetric).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendToolResultToAssistant skip handling (duplicate tool result)', () => {

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -68,6 +68,7 @@ export class ChatEventHandler {
 
   // Telemetry tracking
   private interactionStartTime: number | null = null;
+  private runErrorOccurred = false;
 
   constructor(config: ChatEventHandlerConfig) {
     this.assistantActionService = config.assistantActionService;
@@ -140,6 +141,7 @@ export class ChatEventHandler {
 
     // Start timing for telemetry
     this.interactionStartTime = Date.now();
+    this.runErrorOccurred = false;
   }
 
   /**
@@ -154,9 +156,8 @@ export class ChatEventHandler {
       (this.chatService as any).resetConnection();
     }
 
-    // Record success telemetry
-    if (this.telemetryRecorder) {
-      // Record successful interaction event
+    // Record success telemetry only if no error occurred during this run
+    if (this.telemetryRecorder && !this.runErrorOccurred) {
       this.telemetryRecorder.recordEvent({
         name: 'chat_interaction_success',
         data: {
@@ -514,6 +515,7 @@ export class ChatEventHandler {
    * Handle run errors and record failure telemetry
    */
   private handleRunError(event: any): void {
+    this.runErrorOccurred = true;
     const errorMessage: SystemMessage = {
       id: `error-${Date.now()}`,
       role: 'system',


### PR DESCRIPTION
### Description

   Fix a bug where `chat_interaction_success` telemetry event was incorrectly sent after a `chat_interaction_failure`. This happened because `RUN_FINISHED` is always emitted after a run completes — including after a `RUN_ERROR`. The success
   telemetry in `handleRunFinished` fired unconditionally, resulting in both failure and success events being recorded for the same failed interaction.

   The fix adds a `runErrorOccurred` flag that is:
   - Reset to `false` on `RUN_STARTED`
   - Set to `true` on `RUN_ERROR`
   - Checked in `handleRunFinished` to skip success telemetry

   ## Testing the changes

   1. Run unit tests: `node scripts/jest --testPathPattern='chat_event_handler.test' --no-coverage`
   2. All 46 tests pass, including the new test that verifies `RUN_ERROR` → `RUN_FINISHED` does not emit `chat_interaction_success`.

   ### Check List

   - [x] All tests pass
     - [x] `yarn test:jest`
     - [ ] `yarn test:jest_integration`
   - [x] New functionality includes testing.
   - [ ] New functionality has been documented.
   - [x] Commits are signed per the DCO using --signoff