### PR TITLE
fix(explore): show time filter and run button in embed mode

### DIFF
--- a/src/plugins/agent_traces/public/application/pages/agent_traces_page.scss
+++ b/src/plugins/agent_traces/public/application/pages/agent_traces_page.scss
@@ -4,9 +4,11 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
   height: calc(100vh - #{$osdHeaderOffset * 1});
 
   &__page-body {
-    // within Agent Traces we do not use the globalQueryEditor
-    // Although this element is empty the way we configure props, it contributes to extra padding
-    & .globalQueryEditor {
+    // Empty wrapper adds padding when controls are portaled to the header, so
+    // hide it. In embed mode (`?embed=true`) the controls render inline here,
+    // so keep it visible.
+    // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+    .app-wrapper:not(.hidden-chrome) & .globalQueryEditor {
       display: none;
     }
   }

--- a/src/plugins/agent_traces/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/agent_traces/public/components/top_nav/top_nav.tsx
@@ -5,6 +5,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
+import { useObservable } from 'react-use';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { useSelector as useNewStateSelector, useDispatch } from 'react-redux';
 import { useSyncQueryStateWithUrl } from '../../../../data/public';
@@ -267,16 +268,23 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedAgentTraces }: Top
     );
   }, [handleCustomButtonClick, shouldShowCancelButton, handleQueryCancel, isQueryRunning]);
 
+  // When chrome is hidden (e.g. `?embed=true`) the header portal isn't
+  // rendered, so render the search bar + date picker inline instead.
+  const isEmbedded = !useObservable(services.chrome.getIsVisible$(), true);
+  const datePickerMode = isEmbedded
+    ? TopNavMenuItemRenderType.IN_PLACE
+    : showDatePicker && TopNavMenuItemRenderType.IN_PORTAL;
+
   return (
     <TopNavMenu
       appName={PLUGIN_ID}
-      config={topNavLinks}
+      config={isEmbedded ? [] : topNavLinks}
       data={data}
       showSearchBar={TopNavMenuItemRenderType.IN_PLACE}
-      showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
+      showDatePicker={datePickerMode}
       showSaveQuery={false}
       useDefaultBehaviors={false}
-      setMenuMountPoint={setHeaderActionMenu}
+      setMenuMountPoint={isEmbedded ? undefined : setHeaderActionMenu}
       indexPatterns={dataset ? [dataset] : undefined}
       savedQueryId={undefined}
       onSavedQueryIdChange={() => {}}

--- a/src/plugins/explore/public/application/pages/explore_page.scss
+++ b/src/plugins/explore/public/application/pages/explore_page.scss
@@ -17,9 +17,11 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
   }
 
   &__page-body {
-    // within Explore we do not use the globalQueryEditor
-    // Although this element is empty the way we configure props, it contributes to extra padding
-    & .globalQueryEditor {
+    // Empty wrapper adds padding when controls are portaled to the header, so
+    // hide it. In embed mode (`?embed=true`) the controls render inline here,
+    // so keep it visible.
+    // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
+    .app-wrapper:not(.hidden-chrome) & .globalQueryEditor {
       display: none;
     }
   }

--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -5,6 +5,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
+import { useObservable } from 'react-use';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { useSelector as useNewStateSelector, useDispatch } from 'react-redux';
 import { useSyncQueryStateWithUrl } from '../../../../data/public';
@@ -269,17 +270,24 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
     );
   }, [handleCustomButtonClick, shouldShowCancelButton, handleQueryCancel, isQueryRunning]);
 
+  // When chrome is hidden (e.g. `?embed=true`) the header portal isn't
+  // rendered, so render the search bar + date picker inline instead.
+  const isEmbedded = !useObservable(services.chrome.getIsVisible$(), true);
+  const datePickerMode = isEmbedded
+    ? TopNavMenuItemRenderType.IN_PLACE
+    : showDatePicker && TopNavMenuItemRenderType.IN_PORTAL;
+
   return (
     <TopNavMenu
       appName={PLUGIN_ID}
-      config={topNavLinks}
+      config={isEmbedded ? [] : topNavLinks}
       data={data}
       showSearchBar={TopNavMenuItemRenderType.IN_PLACE}
-      showDatePicker={showDatePicker && TopNavMenuItemRenderType.IN_PORTAL}
+      showDatePicker={datePickerMode}
       showSaveQuery={false}
       useDefaultBehaviors={false}
       disableTimeRangeTool={true}
-      setMenuMountPoint={setHeaderActionMenu}
+      setMenuMountPoint={isEmbedded ? undefined : setHeaderActionMenu}
       indexPatterns={dataset ? [dataset] : undefined}
       savedQueryId={undefined}
       onSavedQueryIdChange={() => {}}


### PR DESCRIPTION
### Description

Currently the time range filter and run query button are inside the top chrome bar, and they are not rendered on UI using `?embed=true` mode. This makes explore not usable when in embed mode.

This PR renders them in embed mode. Note that other contents in the same bar are still hidden, such as side nav hamburger menu, open saved search, breadcrumbs, etc.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="4024" height="2298" alt="image" src="https://github.com/user-attachments/assets/676e8298-99d0-4a44-92d1-4350d44c32b0" />


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
