### PR TITLE
refactor(csp): expose strict and loose rule sets on CspConfig

### DIFF
--- a/src/core/server/csp/csp_config.test.ts
+++ b/src/core/server/csp/csp_config.test.ts
@@ -49,6 +49,12 @@ describe('CspConfig', () => {
       CspConfig {
         "enable": false,
         "header": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "looseRules": Array [
+          "script-src 'unsafe-eval' 'self'",
+          "worker-src blob: 'self'",
+          "style-src 'unsafe-inline' 'self'",
+        ],
         "loosenCspDirectives": Array [],
         "nonceDirectives": Array [
           "style-src-elem",
@@ -59,6 +65,25 @@ describe('CspConfig', () => {
           "style-src 'unsafe-inline' 'self'",
         ],
         "strict": false,
+        "strictRules": Array [
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
+        ],
         "warnLegacyBrowsers": true,
       }
     `);
@@ -69,6 +94,12 @@ describe('CspConfig', () => {
       CspConfig {
         "enable": false,
         "header": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "looseRules": Array [
+          "script-src 'unsafe-eval' 'self'",
+          "worker-src blob: 'self'",
+          "style-src 'unsafe-inline' 'self'",
+        ],
         "loosenCspDirectives": Array [],
         "nonceDirectives": Array [
           "style-src-elem",
@@ -79,6 +110,25 @@ describe('CspConfig', () => {
           "style-src 'unsafe-inline' 'self'",
         ],
         "strict": false,
+        "strictRules": Array [
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
+        ],
         "warnLegacyBrowsers": true,
       }
     `);
@@ -89,6 +139,12 @@ describe('CspConfig', () => {
       CspConfig {
         "enable": true,
         "header": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
+        "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "looseRules": Array [
+          "script-src 'unsafe-eval' 'self'",
+          "worker-src blob: 'self'",
+          "style-src 'unsafe-inline' 'self'",
+        ],
         "loosenCspDirectives": Array [],
         "nonceDirectives": Array [
           "style-src-elem",
@@ -113,6 +169,25 @@ describe('CspConfig', () => {
           "frame-ancestors 'self'",
         ],
         "strict": true,
+        "strictRules": Array [
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
+        ],
         "warnLegacyBrowsers": false,
       }
     `);
@@ -125,6 +200,12 @@ describe('CspConfig', () => {
       CspConfig {
         "enable": false,
         "header": "alpha; beta; gamma",
+        "looseHeader": "alpha; beta; gamma",
+        "looseRules": Array [
+          "alpha",
+          "beta",
+          "gamma",
+        ],
         "loosenCspDirectives": Array [],
         "nonceDirectives": Array [
           "style-src-elem",
@@ -135,6 +216,25 @@ describe('CspConfig', () => {
           "gamma",
         ],
         "strict": false,
+        "strictRules": Array [
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
+        ],
         "warnLegacyBrowsers": true,
       }
     `);
@@ -222,6 +322,12 @@ describe('CspConfig', () => {
         CspConfig {
           "enable": false,
           "header": "default-src 'self'; script-src 'unsafe-eval' 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
+          "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+          "looseRules": Array [
+            "script-src 'unsafe-eval' 'self'",
+            "worker-src blob: 'self'",
+            "style-src 'unsafe-inline' 'self'",
+          ],
           "loosenCspDirectives": Array [
             "script-src",
             "worker-src",
@@ -249,6 +355,25 @@ describe('CspConfig', () => {
             "frame-ancestors 'self'",
           ],
           "strict": false,
+          "strictRules": Array [
+            "default-src 'self'",
+            "script-src 'unsafe-eval' 'self'",
+            "script-src-attr 'none'",
+            "style-src 'self'",
+            "style-src-elem 'self'",
+            "style-src-attr 'self' 'unsafe-inline'",
+            "child-src 'none'",
+            "worker-src blob: 'self'",
+            "frame-src 'none'",
+            "object-src 'none'",
+            "manifest-src 'self'",
+            "media-src 'none'",
+            "font-src 'self'",
+            "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+            "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+            "form-action 'self'",
+            "frame-ancestors 'self'",
+          ],
           "warnLegacyBrowsers": true,
         }
       `);

--- a/src/core/server/csp/csp_config.ts
+++ b/src/core/server/csp/csp_config.ts
@@ -39,9 +39,26 @@ const DEFAULT_CONFIG = Object.freeze(config.schema.validate({}));
  */
 export interface ICspConfig {
   /**
-   * The CSP rules used for OpenSearch Dashboards.
+   * The CSP rules used for OpenSearch Dashboards. Reflects the rules
+   * selected at startup based on `enable`/`strict` (strict rules if either
+   * is true, otherwise loose rules).
    */
   readonly rules: string[];
+
+  /**
+   * The STRICT CSP rules, always computed — includes allowed sources
+   * (frame-ancestors, connect-src, img-src) and any loosened directives.
+   * Use together with `buildStrictHeaderWithNonce` to emit the strict
+   * header at request time regardless of the startup `enable` value.
+   */
+  readonly strictRules: string[];
+
+  /**
+   * The LOOSE CSP rules, always available. These come from the
+   * schema default (`LOOSE_CSP_RULES_DEFAULT_VALUE`) unless overridden
+   * via `csp.rules` in the config.
+   */
+  readonly looseRules: string[];
 
   /**
    * Specify whether browsers that do not support CSP should be
@@ -91,9 +108,17 @@ export interface ICspConfig {
 
   /**
    * The CSP rules in a formatted directives string for use
-   * in a `Content-Security-Policy` header.
+   * in a `Content-Security-Policy` header. Reflects the startup
+   * `enable`/`strict` selection.
    */
   readonly header: string;
+
+  /**
+   * The LOOSE CSP header, always available — the loose rules joined
+   * with '; '. Use at request time when dynamic config disables CSP
+   * hardening, independent of the startup config.
+   */
+  readonly looseHeader: string;
 
   /**
    * Directives that should have a nonce value appended when building the header.
@@ -103,10 +128,21 @@ export interface ICspConfig {
 
   /**
    * Builds the CSP header with nonce values inserted into configured directives.
+   * Uses whichever rule set was selected at startup (strict or loose).
    * @param nonce - The nonce value to insert (without 'nonce-' prefix)
    * @returns The complete CSP header string with nonces
    */
   buildHeaderWithNonce(nonce: string): string;
+
+  /**
+   * Builds the STRICT CSP header with nonce values inserted — always uses
+   * the strict rule set (with allowed sources applied), regardless of the
+   * startup `enable`/`strict` value. Use when dynamic configuration enables
+   * CSP hardening at request time.
+   * @param nonce - The nonce value to insert (without 'nonce-' prefix)
+   * @returns The complete strict CSP header string with nonces
+   */
+  buildStrictHeaderWithNonce(nonce: string): string;
 }
 
 /**
@@ -117,37 +153,57 @@ export class CspConfig implements ICspConfig {
   static readonly DEFAULT = new CspConfig();
 
   public readonly rules: string[];
+  public readonly strictRules: string[];
+  public readonly looseRules: string[];
   public readonly nonceDirectives: string[];
   /** @deprecated Use `enable` instead. */
   public readonly strict: boolean;
   public readonly enable: boolean;
   public readonly warnLegacyBrowsers: boolean;
   public readonly header: string;
+  public readonly looseHeader: string;
   public readonly loosenCspDirectives: string[];
 
   /**
    * Returns the default CSP configuration when passed with no config
    * @internal
    */
-  constructor(rawCspConfig: Partial<Omit<ICspConfig, 'header'>> = {}) {
+  constructor(
+    rawCspConfig: Partial<
+      Omit<ICspConfig, 'header' | 'looseHeader' | 'strictRules' | 'looseRules'>
+    > = {}
+  ) {
     const source = { ...DEFAULT_CONFIG, ...rawCspConfig };
 
-    this.rules = source.rules;
     this.enable = source.enable;
     this.strict = source.enable;
-    const isCspEnabled = source.enable || source.strict;
     this.warnLegacyBrowsers = source.warnLegacyBrowsers;
     this.nonceDirectives = source.nonceDirectives;
     this.loosenCspDirectives = source.loosenCspDirectives || [];
 
-    if (isCspEnabled) {
-      this.rules = this.applyLoosenCspRules(
-        this.applyAllowedSources(STRICT_CSP_RULES_DEFAULT_VALUE, source)
-      );
+    // Always compute both rule sets so the strict/loose choice can be made
+    // dynamically at request time regardless of the startup config.
+    // Note: `applyLoosenCspRules` references `this.rules` to look up the
+    // "original" loose directive when a rule is loosened, so the loose
+    // rules must be stored on `this.rules` before calling it.
+    this.looseRules = source.rules;
+    this.rules = source.rules;
+
+    this.strictRules = this.applyLoosenCspRules(
+      this.applyAllowedSources(STRICT_CSP_RULES_DEFAULT_VALUE, source)
+    );
+
+    this.looseHeader = this.looseRules.join('; ');
+
+    // Startup-time selection — preserves existing behavior for consumers
+    // that read `this.rules` or `this.header` directly.
+    const isCspEnabledAtStartup = source.enable || source.strict;
+    if (isCspEnabledAtStartup) {
+      this.rules = this.strictRules;
       this.header = this.buildHeaderInternal();
     } else {
-      this.rules = source.rules;
-      this.header = source.rules.join('; ');
+      this.rules = this.looseRules;
+      this.header = this.looseHeader;
     }
   }
 
@@ -167,11 +223,23 @@ export class CspConfig implements ICspConfig {
 
   /**
    * Builds the CSP header with nonce values inserted into configured directives.
+   * Uses whichever rule set was selected at startup (strict or loose).
    * @param nonce - The nonce value to insert (without 'nonce-' prefix)
    * @returns The complete CSP header string with nonces
    */
   public buildHeaderWithNonce(nonce: string): string {
     return this.buildHeaderInternal(nonce);
+  }
+
+  /**
+   * Builds the STRICT CSP header with nonce values inserted — always uses
+   * the strict rule set (with allowed sources applied), regardless of the
+   * startup `enable`/`strict` value.
+   * @param nonce - The nonce value to insert (without 'nonce-' prefix)
+   * @returns The complete strict CSP header string with nonces
+   */
+  public buildStrictHeaderWithNonce(nonce: string): string {
+    return this.applyNonces(this.strictRules, nonce).join('; ');
   }
 
   /**


### PR DESCRIPTION
### Description


Always compute both strict and loose rule sets in the constructor and expose them as strictRules, and buildStrictHeaderWithNonce(nonce). Startup-time behavior of rules and header is preserved.

This enables consumers to choose between strict and loose CSP at request time without depending on the constructor-time enable/strict decision.


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
