### PR TITLE
Pin jest-canvas-mock to 2.5.1 to mitigate supply chain risk

### DIFF
--- a/package.json
+++ b/package.json
@@ -506,7 +506,7 @@
     "immer": "^9.0.6",
     "intl-messageformat-parser": "^1.4.0",
     "jest": "^28.1.3",
-    "jest-canvas-mock": "^2.5.1",
+    "jest-canvas-mock": "2.5.1",
     "jest-raw-loader": "^1.0.1",
     "jimp": "^0.22.12",
     "jquery": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14144,7 +14144,7 @@ javascript-natural-sort@^0.7.1:
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
   integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
 
-jest-canvas-mock@^2.5.1:
+jest-canvas-mock@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.5.1.tgz#81509af658ef485e9a1bf39c64e06761517bdbcb"
   integrity sha512-IVnRiz+v4EYn3ydM/pBo8GW/J+nU/Hg5gHBQQOUQhdRyNfvHnabB8ReqARLO0p+kvQghqr4V0tA92CF3JcUSRg==


### PR DESCRIPTION
### Description

Pins jest-canvas-mock from ^2.5.1 to 2.5.1 to prevent resolution to compromised versions (2.5.3, 2.6.3, 2.7.3) identified in the Mini Shai-Hulud supply chain campaign on 2026-05-19.

### What was changed

Removed caret (^) from jest-canvas-mock version specifier in root package.json

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
