### PR TITLE
[Fix] Dashboard table visualization displays stale data instead of error when PPL query fails

### DIFF
--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -69,6 +69,7 @@ export interface SearchProps {
   indexPattern?: IndexPattern;
   hits?: number;
   isLoading?: boolean;
+  error?: ExpressionRenderError;
   services: ExploreServices;
   chartRender?: () => any;
   sharedItemTitle?: string;
@@ -406,14 +407,15 @@ export class ExploreEmbeddable
       try {
         await this.fetch();
       } catch (error: any) {
+        this.searchProps.isLoading = false;
+        this.searchProps.error = {
+          name: error?.body?.error || error?.name || 'Error',
+          message: error?.body?.message || error?.message || 'An error occurred',
+        };
         this.updateOutput({
           loading: false,
-          error: {
-            name: error?.body?.error,
-            message: error?.body?.message,
-          },
+          error: this.searchProps.error,
         });
-        throw error;
       }
     } else if (searchProps) {
       this.searchProps = searchProps;
@@ -450,6 +452,7 @@ export class ExploreEmbeddable
     });
     this.updateOutput({ loading: true, error: undefined });
     this.searchProps.isLoading = true;
+    this.searchProps.error = undefined;
     const query = searchSource.getField('query');
     const languageConfig = this.services.data.query.queryString
       .getLanguageService()

--- a/src/plugins/explore/public/embeddable/explore_embeddable_component.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable_component.test.tsx
@@ -49,6 +49,9 @@ jest.mock('../components/visualizations/table/table_vis', () => ({
 
 jest.mock('../../../visualizations/public', () => ({
   VisualizationNoResults: jest.fn(() => <div data-test-subj="mockNoResults">No results</div>),
+  VisualizationRequestError: jest.fn(({ error }) => (
+    <div data-test-subj="mockRequestError">{error}</div>
+  )),
 }));
 
 describe('ExploreEmbeddableComponent', () => {
@@ -144,5 +147,44 @@ describe('ExploreEmbeddableComponent', () => {
     render(<ExploreEmbeddableComponent searchProps={minimalProps as any} />);
 
     expect(screen.getByTestId('osdExploreContainer')).toBeInTheDocument();
+  });
+
+  test('renders error message when searchProps.error is present', () => {
+    const errorProps: SearchProps = {
+      ...mockSearchProps,
+      error: {
+        name: 'QueryError',
+        message: 'PPL query failed: syntax error',
+      },
+    };
+
+    render(<ExploreEmbeddableComponent searchProps={errorProps} />);
+
+    expect(screen.getByTestId('mockRequestError')).toBeInTheDocument();
+    expect(screen.getByTestId('mockRequestError')).toHaveTextContent(
+      'PPL query failed: syntax error'
+    );
+  });
+
+  test('shows error instead of old data when error occurs', () => {
+    const errorPropsWithOldData: SearchProps = {
+      ...mockSearchProps,
+      error: {
+        name: 'Error',
+        message: 'Failed to execute query',
+      },
+      rows: [{ _id: '1', _source: { field1: 'value1' } }],
+      tableData: {
+        rows: [{ col1: 'val1' }],
+        columns: [],
+      },
+    };
+
+    render(<ExploreEmbeddableComponent searchProps={errorPropsWithOldData} />);
+
+    // Should show error, not the table or old data
+    expect(screen.getByTestId('mockRequestError')).toBeInTheDocument();
+    expect(screen.queryByTestId('mockDataGridTable')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mockTableVis')).not.toBeInTheDocument();
   });
 });

--- a/src/plugins/explore/public/embeddable/explore_embeddable_component.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable_component.tsx
@@ -6,7 +6,7 @@
 import { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { SearchProps } from './explore_embeddable';
-import { VisualizationNoResults } from '../../../visualizations/public';
+import { VisualizationNoResults, VisualizationRequestError } from '../../../visualizations/public';
 // TODO: refactor it to now use legacy getServices
 import {
   getDocViewsRegistry,
@@ -77,6 +77,16 @@ export const ExploreEmbeddableComponent = ({ searchProps }: ExploreEmbeddablePro
   }, [searchProps]);
 
   const getEmbeddableContent = () => {
+    if (searchProps?.error) {
+      return (
+        <EuiFlexItem>
+          <VisualizationRequestError
+            error={searchProps.error.message || searchProps.error.name || 'An error occurred'}
+          />
+        </EuiFlexItem>
+      );
+    }
+
     if (searchProps?.rows?.length === 0) {
       return (
         <EuiFlexItem>

--- a/src/plugins/visualizations/public/components/index.ts
+++ b/src/plugins/visualizations/public/components/index.ts
@@ -31,3 +31,4 @@
 export { Visualization } from './visualization';
 export { VisualizationContainer } from './visualization_container';
 export { VisualizationNoResults } from './visualization_noresults';
+export { VisualizationRequestError } from './visualization_requesterror';

--- a/src/plugins/visualizations/public/index.ts
+++ b/src/plugins/visualizations/public/index.ts
@@ -47,7 +47,11 @@ export {
   VisualizeEmbeddable,
   DisabledLabEmbeddable,
 } from './embeddable';
-export { VisualizationContainer, VisualizationNoResults } from './components';
+export {
+  VisualizationContainer,
+  VisualizationNoResults,
+  VisualizationRequestError,
+} from './components';
 export {
   getSchemas as getVisSchemas,
   buildVislibDimensions,


### PR DESCRIPTION
### Description

When a table visualization created by the in-context query editor in a dashboard encounters a PPL query error, the table continues to display the previous successful query results instead of showing any error message. This behavior is inconsistent with other visualization types and editors, which properly display error states.

Root Cause:
The issue stems from incomplete error state management in the `ExploreEmbeddable` class:

1. Missing error propagation to component: When `fetch()` fails, the catch block only updates the embeddable's output state via `updateOutput()`, but doesn't set `searchProps.error`
2. searchProps not updated: The React component `ExploreEmbeddableComponent` only receives data through `searchProps` and has no way to access the embeddable's output state
3. Loading state not cleared: `searchProps.isLoading` remained `true` after error
4. Error thrown breaks flow: The throw error in the catch block prevented `renderComponent()` from being called, so the component never re-rendered with error state
5. Stale data persists: Without error information in `searchProps`, the component continues rendering cached `tableData` from the previous successful query

### Issues Resolved

## Screenshot
before:
<img width="1023" height="480" alt="image" src="https://github.com/user-attachments/assets/eac4e7bd-bbc7-453a-b8c1-6fee176b0948" />

after:
<img width="965" height="430" alt="image" src="https://github.com/user-attachments/assets/f9044fc7-58a1-4815-9ba8-d008187717e7" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
