### PR TITLE
[Variable] Dashboard panels reset when switching variables in VIEW mode

### DIFF
--- a/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.test.tsx
+++ b/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.test.tsx
@@ -200,3 +200,188 @@ describe('updateStateUrl', () => {
     expect(replaceSpy).toHaveBeenCalledWith({ ...location, state: someState });
   });
 });
+
+describe('panels preservation logic in URL sync', () => {
+  /**
+   * This test suite verifies the fix for the bug where panels were being reset
+   * when switching variables in VIEW mode.
+   *
+   * The bug occurred because:
+   * 1. In VIEW mode, toUrlState() excludes panels from URL
+   * 2. When syncing back from URL, stateDefaults (with initial panels) was merged
+   * 3. This caused panels to revert to their initial state
+   *
+   * The fix: `panels: state.panels ?? stateContainer.getState().panels`
+   * This preserves current panels when URL state doesn't include them.
+   */
+
+  // Helper to simulate the set function logic from createDashboardGlobalAndAppState
+  const simulateSetFunction = (state: any, stateDefaults: any, currentPanels: any[]) => {
+    if (!state) {
+      return null; // Don't set anything for null state
+    }
+
+    // This simulates the logic in create_dashboard_app_state.tsx lines 105-109
+    return {
+      ...stateDefaults,
+      ...state,
+      panels: state.panels ?? currentPanels, // The bug fix
+    };
+  };
+
+  test('should preserve current panels when URL state has no panels field (VIEW mode)', () => {
+    const initialPanels = [{ panelIndex: 'old-panel', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const currentPanels = [{ panelIndex: 'new-panel', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    // URL state in VIEW mode (panels excluded)
+    const urlState = {
+      viewMode: ViewMode.VIEW,
+      title: 'Test Dashboard',
+      variables: [{ id: 'var1', name: 'test', current: ['value1'] }],
+      // panels field is missing
+    };
+
+    const result = simulateSetFunction(urlState, stateDefaults, currentPanels);
+
+    // Should use current panels, not initial panels from stateDefaults
+    expect(result?.panels).toEqual(currentPanels);
+    expect(result?.panels).not.toEqual(initialPanels);
+    expect(result?.viewMode).toBe(ViewMode.VIEW);
+    expect(result?.variables).toEqual(urlState.variables);
+  });
+
+  test('should use panels from URL state when explicitly provided (EDIT mode)', () => {
+    const initialPanels = [{ panelIndex: 'initial', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const currentPanels = [{ panelIndex: 'current', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const urlPanels = [
+      { panelIndex: 'url-panel-1', gridData: { x: 0, y: 0, w: 5, h: 5 } },
+      { panelIndex: 'url-panel-2', gridData: { x: 5, y: 0, w: 5, h: 5 } },
+    ];
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    // URL state with explicit panels (EDIT mode)
+    const urlState = {
+      viewMode: ViewMode.EDIT,
+      title: 'Test Dashboard',
+      panels: urlPanels,
+    };
+
+    const result = simulateSetFunction(urlState, stateDefaults, currentPanels);
+
+    // Should use panels from URL, not current panels
+    expect(result?.panels).toEqual(urlPanels);
+    expect(result?.panels).not.toEqual(currentPanels);
+  });
+
+  test('should handle the complete bug scenario: add/delete panels, save, change variable', () => {
+    // Initial state: dashboard loaded with old panel that will be deleted
+    const initialPanels = [{ panelIndex: 'deleted-panel', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+
+    // Current state: user added new panel and deleted old one
+    const currentPanels = [{ panelIndex: 'added-panel', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    // After save, user switches variable in VIEW mode
+    const urlStateAfterVariableChange = {
+      viewMode: ViewMode.VIEW,
+      title: 'Test Dashboard',
+      variables: [{ id: 'var1', name: 'region', current: ['us-west'] }],
+      // panels field is missing (VIEW mode excludes them from URL)
+    };
+
+    const result = simulateSetFunction(urlStateAfterVariableChange, stateDefaults, currentPanels);
+
+    // Verify panels are preserved (bug fix verification)
+    expect(result?.panels).toEqual(currentPanels);
+    expect(result?.panels).not.toEqual(initialPanels);
+    expect(result?.panels[0].panelIndex).toBe('added-panel');
+    expect(result?.panels[0].panelIndex).not.toBe('deleted-panel');
+  });
+
+  test('should handle undefined panels field correctly', () => {
+    const initialPanels = [{ panelIndex: 'initial', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const currentPanels = [{ panelIndex: 'current', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    const urlState = {
+      viewMode: ViewMode.VIEW,
+      title: 'Test',
+      panels: undefined, // Explicitly undefined
+    };
+
+    const result = simulateSetFunction(urlState, stateDefaults, currentPanels);
+
+    expect(result?.panels).toEqual(currentPanels);
+  });
+
+  test('should handle null panels field correctly', () => {
+    const initialPanels = [{ panelIndex: 'initial', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const currentPanels = [{ panelIndex: 'current', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    const urlState = {
+      viewMode: ViewMode.VIEW,
+      title: 'Test',
+      panels: null as any, // Explicitly null
+    };
+
+    const result = simulateSetFunction(urlState, stateDefaults, currentPanels);
+
+    expect(result?.panels).toEqual(currentPanels);
+  });
+
+  test('should not return anything when state is null', () => {
+    const currentPanels = [{ panelIndex: 'test', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const stateDefaults = { ...dashboardAppStateStub, panels: [] };
+
+    const result = simulateSetFunction(null, stateDefaults, currentPanels);
+
+    expect(result).toBeNull();
+  });
+
+  test('should use empty array when explicitly provided (not preserve current)', () => {
+    const initialPanels = [{ panelIndex: 'initial', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const currentPanels = [{ panelIndex: 'current', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    const urlState = {
+      viewMode: ViewMode.VIEW,
+      title: 'Test',
+      panels: [], // Empty array (valid state for empty dashboard)
+    };
+
+    const result = simulateSetFunction(urlState, stateDefaults, currentPanels);
+
+    // Empty array should be used as-is (it's a valid state, not undefined/null)
+    expect(result?.panels).toEqual([]);
+  });
+
+  test('should preserve panels across multiple variable changes', () => {
+    const initialPanels = [{ panelIndex: 'initial', gridData: { x: 0, y: 0, w: 10, h: 10 } }];
+    const modifiedPanels = [
+      { panelIndex: 'panel-1', gridData: { x: 0, y: 0, w: 5, h: 5 } },
+      { panelIndex: 'panel-2', gridData: { x: 5, y: 0, w: 5, h: 5 } },
+      { panelIndex: 'panel-3', gridData: { x: 0, y: 5, w: 5, h: 5 } },
+    ];
+    const stateDefaults = { ...dashboardAppStateStub, panels: initialPanels };
+
+    // First variable change
+    const urlState1 = {
+      viewMode: ViewMode.VIEW,
+      variables: [{ id: 'var1', current: ['value1'] }],
+    };
+    const result1 = simulateSetFunction(urlState1, stateDefaults, modifiedPanels);
+    expect(result1?.panels).toEqual(modifiedPanels);
+
+    // Second variable change - panels should still be preserved
+    const urlState2 = {
+      viewMode: ViewMode.VIEW,
+      variables: [{ id: 'var1', current: ['value2'] }],
+    };
+    const result2 = simulateSetFunction(urlState2, stateDefaults, modifiedPanels);
+    expect(result2?.panels).toEqual(modifiedPanels);
+    expect(result2?.panels).not.toEqual(initialPanels);
+  });
+});

--- a/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx
@@ -102,9 +102,13 @@ export const createDashboardGlobalAndAppState = ({
           const currentDashboardIdInUrl = getDashboardIdFromUrl(history.location.pathname);
           if (currentDashboardIdInUrl !== savedDashboardInstance.id) return;
 
+          // In VIEW mode, toUrlState() excludes panels from URL to keep URLs clean.
+          // When syncing URL back to state, preserve current panels if URL state doesn't include them.
+          // This prevents panels from being reset to stateDefaults after variable changes in VIEW mode.
           stateContainer.set({
             ...stateDefaults,
             ...state,
+            panels: state.panels ?? stateContainer.getState().panels,
           });
         } else {
           // TODO: This logic was ported over this but can be handled more gracefully and intentionally


### PR DESCRIPTION
### Description

After adding/deleting visualizations in a dashboard and saving, switching a variable value causes deleted visualizations to reappear and newly added visualizations to disappear. Refreshing the page restores the correct panel state.

#### Root Cause

`stateDefaults` is a closure variable computed once at page load time from `savedDashboard.panelsJSON` and never updated afterward. In VIEW mode, `toUrlState()` intentionally strips `panels` from the URL state (`_a` param) to reduce URL length. When variable value selection triggers a URL sync round-trip (state → URL → state), the custom `set()` callback in `create_dashboard_app_state.tsx` falls back to `stateDefaults.panels` because the URL state has no `panels` field:

```typescript
stateContainer.set({
  ...stateDefaults,  // panels from initial page load (stale after save)
  ...state,          // from URL — no panels in VIEW mode
});
```

This overwrites the current in-memory panels with the stale snapshot from page load, causing newly added panels to be removed and previously deleted panels to be restored.

The full trigger chain:
1. User adds/removes viz → saves dashboard → backend `panelsJSON` updated correctly → switches to VIEW mode
2. User selects a different variable option → `updateVariableValue()` → `variables$.next()` → container `updateInput({variables})` → `handleDashboardContainerChanges()` → `appState.transitions.setDashboard({variables})` → URL updated (without panels) → `history.listen` fires → `updateState()` → custom `set()` called with URL state (no panels) → `stateDefaults.panels` (stale) overwrites current panels → `refreshDashboardContainer()` applies stale panels to container → panels mismatch → `maybeUpdateChildren()` removes/adds wrong panels

#### Solution

In the URL sync `set()` callback, when URL state does not include `panels` (VIEW mode), preserve the current in-memory panels instead of falling back to the stale `stateDefaults`:

```typescript
stateContainer.set({
  ...stateDefaults,
  ...state,
  panels: state.panels ?? stateContainer.getState().panels,
});
```

This is safe because:
- In VIEW mode, panels are never stored in the URL, so all panel state changes go through direct `setDashboard()` calls (save, revert, add/remove panel) which update `stateContainer` correctly
- On fresh page load, `stateContainer.getState().panels` equals `stateDefaults.panels` (just initialized)
- When switching dashboards, the entire state sync is torn down and recreated with fresh `stateDefaults`
- Discard changes flow writes panels explicitly via `setDashboard({panels: dashboard.panels})`, not through the URL sync callback


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
