### PR TITLE
fix(osd-optimizer): anchor tailwind source scan to each scss file's dir

### DIFF
--- a/packages/osd-optimizer/postcss.config.js
+++ b/packages/osd-optimizer/postcss.config.js
@@ -28,6 +28,8 @@
  * under the License.
  */
 
+const Path = require('path');
+
 /**
  * Strips dependency messages from @tailwindcss/postcss.
  *
@@ -65,13 +67,15 @@ function normalizeTailwindImports() {
 }
 normalizeTailwindImports.postcss = true;
 
-module.exports = {
+module.exports = (ctx) => ({
   plugins: [
     /*require('autoprefixer')()*/
     normalizeTailwindImports(),
     // Safe to include unconditionally. Bails out for files without Tailwind directives.
     // eslint-disable-next-line import/no-unresolved -- package uses `exports` field; resolver lacks support
-    require('@tailwindcss/postcss')(),
+    require('@tailwindcss/postcss')({
+      base: ctx && ctx.file ? Path.dirname(ctx.file) : process.cwd(),
+    }),
     stripTailwindDeps(),
   ],
-};
+});


### PR DESCRIPTION
### Description

Tailwind v4's @tailwindcss/postcss auto-detects source files from process.cwd() when no `base` option is provided. This works for in-tree builds where cwd is the OSD repo root, but third-party plugins run their own build from the plugin directory so that Tailwind never sees classes shipped by workspace packages they consume, and emits an empty utilities stylesheet.

Switching postcss.config.js to function form lets us read the resource's path from the postcss-loader context and pin Tailwind's `base` to the SCSS file's directory.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
