### PR TITLE
[Explore vis]delete query action registry for in-context vis editor

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/component/query_panel_widget.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/query_panel_widget.tsx
@@ -3,19 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { ExploreServices } from '../../../types';
 import { LanguageToggle } from './lauguage_toggle';
-import { QueryPanelActions } from '../../../components/query_panel/query_panel_widgets/query_panel_actions';
 
 import { DatasetSelectWidget } from './dataset_select';
 import '../visualization_editor.scss';
 import { SaveQueryButton } from './save_query_button';
 
 export const QueryPanelWidgets = () => {
-  const { services } = useOpenSearchDashboards<ExploreServices>();
-  const { queryPanelActionsRegistry } = services;
-
   return (
     <div className="exploreQueryPanelWidgets">
       {/* Left Section */}
@@ -24,12 +18,6 @@ export const QueryPanelWidgets = () => {
         <DatasetSelectWidget />
         <div className="exploreQueryPanelWidgets__verticalSeparator" />
         <SaveQueryButton />
-        {!queryPanelActionsRegistry.isEmpty() ? (
-          <>
-            <div className="exploreQueryPanelWidgets__verticalSeparator" />
-            <QueryPanelActions registry={queryPanelActionsRegistry} />
-          </>
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
### Description

In context editor doesn't support query action. 

This is also fixed in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11753/changes#diff-ce2ae5e7ae4e4dbc460c3bf3e4cbff850003b973cf50d22f834868e91abb75f9. which haven't be reviewed.


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12022

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
