### PR TITLE
[Fix] Preserve chart type when data changes in visualization editor

### DIFF
--- a/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
@@ -424,6 +424,137 @@ describe('VisualizationBuilder', () => {
       });
       expect(setVisConfigSpy).not.toHaveBeenCalled();
     });
+
+    test('should try to preserve current chart type using reuseAxesMapping', () => {
+      const builder = new VisualizationBuilder({});
+      const reuseAxesMappingSpy = jest
+        .spyOn(visualizationRegistry, 'reuseAxesMapping')
+        .mockReturnValue({ x: 'name-numerical-0', y: 'name-numerical-1' });
+
+      builder.visConfig$.next({
+        type: 'line',
+        axesMapping: { x: 'name-date-0', y: 'name-numerical-0' },
+      });
+
+      builder.onDataChange({
+        numericalColumns: createMockVisColumns(2, VisFieldType.Numerical),
+        categoricalColumns: [],
+        dateColumns: [],
+        transformedData: [],
+        unknownColumns: [],
+      });
+
+      expect(reuseAxesMappingSpy).toHaveBeenCalledWith(
+        'line',
+        { x: 'name-date-0', y: 'name-numerical-0' },
+        expect.any(Array)
+      );
+      expect(builder.visConfig$.value?.type).toBe('line');
+      reuseAxesMappingSpy.mockRestore();
+    });
+
+    test('should try to create auto vis with current chart type when reuseAxesMapping fails', () => {
+      const builder = new VisualizationBuilder({});
+      jest.spyOn(visualizationRegistry, 'reuseAxesMapping').mockReturnValue(undefined);
+      const createAutoVisSpy = jest.spyOn(builder, 'createAutoVis');
+
+      builder.visConfig$.next({
+        type: 'line',
+        axesMapping: { x: 'name-date-0', y: 'name-numerical-0' },
+      });
+
+      builder.onDataChange({
+        numericalColumns: createMockVisColumns(2, VisFieldType.Numerical),
+        categoricalColumns: [],
+        dateColumns: [],
+        transformedData: [],
+        unknownColumns: [],
+      });
+
+      // Should call createAutoVis with the current chart type
+      expect(createAutoVisSpy).toHaveBeenCalledWith(expect.anything(), 'line');
+    });
+
+    test('should preserve custom styles when preserving chart type', () => {
+      const builder = new VisualizationBuilder({});
+      const customStyles = { addLegend: true, title: 'My Chart' } as any;
+      jest
+        .spyOn(visualizationRegistry, 'reuseAxesMapping')
+        .mockReturnValue({ x: 'name-numerical-0', y: 'name-numerical-1' });
+
+      builder.visConfig$.next({
+        type: 'line',
+        axesMapping: { x: 'name-date-0', y: 'name-numerical-0' },
+        styles: customStyles,
+      });
+
+      builder.onDataChange({
+        numericalColumns: createMockVisColumns(2, VisFieldType.Numerical),
+        categoricalColumns: [],
+        dateColumns: [],
+        transformedData: [],
+        unknownColumns: [],
+      });
+
+      expect(builder.visConfig$.value?.type).toBe('line');
+      expect(builder.visConfig$.value?.styles).toBe(customStyles);
+    });
+
+    test('should reset styles when falling back to any chart type', () => {
+      const builder = new VisualizationBuilder({});
+      const customStyles = { addLegend: true, title: 'My Chart' } as any;
+      jest.spyOn(visualizationRegistry, 'reuseAxesMapping').mockReturnValue(undefined);
+      jest.spyOn(builder, 'createAutoVis').mockImplementation((data, chartType) => {
+        if (chartType) return undefined; // Fail for specific chart type
+        return { chartType: 'bar', axesMapping: { x: 'field0', y: 'field1' } };
+      });
+
+      builder.visConfig$.next({
+        type: 'line',
+        axesMapping: { x: 'name-date-0', y: 'name-numerical-0' },
+        styles: customStyles,
+      });
+
+      builder.onDataChange({
+        numericalColumns: createMockVisColumns(2, VisFieldType.Numerical),
+        categoricalColumns: [],
+        dateColumns: [],
+        transformedData: [],
+        unknownColumns: [],
+      });
+
+      expect(builder.visConfig$.value?.type).toBe('bar');
+      const defaultStyles = visualizationRegistry.getVisualization('bar')?.ui.style.defaults;
+      expect(builder.visConfig$.value?.styles).toEqual(defaultStyles);
+      expect(builder.visConfig$.value?.styles).not.toBe(customStyles);
+    });
+
+    test('should preserve splitField configuration across data changes', () => {
+      const builder = new VisualizationBuilder({});
+      jest
+        .spyOn(visualizationRegistry, 'reuseAxesMapping')
+        .mockReturnValue({ x: 'name-numerical-0', y: 'name-numerical-1' });
+
+      builder.visConfig$.next({
+        type: 'line',
+        axesMapping: { x: 'name-date-0', y: 'name-numerical-0' },
+        splitField: 'category',
+        splitLayout: 'horizontal',
+        showSplitLabel: true,
+      });
+
+      builder.onDataChange({
+        numericalColumns: createMockVisColumns(2, VisFieldType.Numerical),
+        categoricalColumns: [{ name: 'category', schema: 'categorical' } as any],
+        dateColumns: [],
+        transformedData: [],
+        unknownColumns: [],
+      });
+
+      expect(builder.visConfig$.value?.splitField).toBe('category');
+      expect(builder.visConfig$.value?.splitLayout).toBe('horizontal');
+      expect(builder.visConfig$.value?.showSplitLabel).toBe(true);
+    });
   });
 
   test('should update with normalized data', () => {
@@ -533,6 +664,78 @@ describe('VisualizationBuilder', () => {
 
     expect(builder.data$.value).toBe(undefined);
     expect(builder.visConfig$.value).toBe(undefined);
+  });
+
+  describe('applyVisConfig()', () => {
+    test('should apply valid config and return true', () => {
+      const builder = new VisualizationBuilder({});
+      const result = (builder as any).applyVisConfig('line', { x: 'field0', y: 'field1' }, false);
+
+      expect(result).toBe(true);
+      expect(builder.visConfig$.value?.type).toBe('line');
+      expect(builder.visConfig$.value?.axesMapping).toEqual({ x: 'field0', y: 'field1' });
+    });
+
+    test('should return false for invalid chart type', () => {
+      const builder = new VisualizationBuilder({});
+      // Mock invalid chart type
+      const getVisualizationSpy = jest
+        .spyOn(visualizationRegistry, 'getVisualization')
+        .mockReturnValue(undefined);
+
+      const result = (builder as any).applyVisConfig('invalid-type', {}, false);
+
+      expect(result).toBe(false);
+      expect(builder.visConfig$.value).toBe(undefined);
+      getVisualizationSpy.mockRestore();
+    });
+
+    test('should preserve split field configuration', () => {
+      const builder = new VisualizationBuilder({});
+      builder.visConfig$.next({
+        type: 'bar',
+        splitField: 'category',
+        splitLayout: 'horizontal',
+        showSplitLabel: true,
+      });
+
+      const result = (builder as any).applyVisConfig('line', { x: 'field0', y: 'field1' }, false);
+
+      expect(result).toBe(true);
+      expect(builder.visConfig$.value?.splitField).toBe('category');
+      expect(builder.visConfig$.value?.splitLayout).toBe('horizontal');
+      expect(builder.visConfig$.value?.showSplitLabel).toBe(true);
+    });
+
+    test('should preserve styles when preserveStyles is true', () => {
+      const builder = new VisualizationBuilder({});
+      const customStyles = { addLegend: true, title: 'Custom Title' } as any;
+      builder.visConfig$.next({
+        type: 'bar',
+        styles: customStyles,
+      });
+
+      const result = (builder as any).applyVisConfig('line', { x: 'field0', y: 'field1' }, true);
+
+      expect(result).toBe(true);
+      expect(builder.visConfig$.value?.styles).toBe(customStyles);
+    });
+
+    test('should use default styles when preserveStyles is false', () => {
+      const builder = new VisualizationBuilder({});
+      const customStyles = { addLegend: true, title: 'Custom Title' } as any;
+      builder.visConfig$.next({
+        type: 'bar',
+        styles: customStyles,
+      });
+
+      const result = (builder as any).applyVisConfig('line', { x: 'field0', y: 'field1' }, false);
+      const defaultStyles = visualizationRegistry.getVisualization('line')?.ui.style.defaults;
+
+      expect(result).toBe(true);
+      expect(builder.visConfig$.value?.styles).toEqual(defaultStyles);
+      expect(builder.visConfig$.value?.styles).not.toBe(customStyles);
+    });
   });
 });
 

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.ts
@@ -296,6 +296,37 @@ export class VisualizationBuilder {
   }
 
   /**
+   * Helper method to create a vis config with split fields and apply it.
+   * Returns true if successful, false otherwise.
+   */
+  private applyVisConfig(
+    chartType: ChartType,
+    axesMapping: AxisFieldNameMappings,
+    preserveStyles = false
+  ): boolean {
+    const chartTypeConfig = visualizationRegistry.getVisualization(chartType);
+    if (!chartTypeConfig) {
+      return false;
+    }
+
+    const currentConfig = this.visConfig$.value;
+    const newVisConfig: ChartConfig = {
+      type: chartType,
+      styles:
+        preserveStyles && currentConfig?.styles
+          ? currentConfig.styles
+          : chartTypeConfig.ui.style.defaults,
+      axesMapping,
+      splitField: currentConfig?.splitField,
+      splitLayout: currentConfig?.splitLayout,
+      showSplitLabel: currentConfig?.showSplitLabel,
+    };
+
+    this.setVisConfig(newVisConfig);
+    return true;
+  }
+
+  /**
    * For the given data, we need to check if the current chart type and axes mapping can be applied
    */
   onDataChange(data?: VisData) {
@@ -315,52 +346,43 @@ export class VisualizationBuilder {
 
     const columns = [...data.numericalColumns, ...data.categoricalColumns, ...data.dateColumns];
 
-    // We cannot apply the current chart type and axes mapping if:
-    // 1. It has axes mapping, but the mapping is incompatible with the received data
-    // 2. No current axes mapping
-    // For these cases, we will create auto vis based on the rules. If not auto vis can be created,
-    // reset chart type and axes mapping to empty, this will let user to choose.
-    if (isEmpty(axesMapping) || !isValidMapping(axesMapping ?? {}, columns)) {
-      const autoVis = this.createAutoVis(data);
-      const currentConfig = this.visConfig$.value;
-      if (autoVis) {
-        const chartTypeConfig = visualizationRegistry.getVisualization(autoVis.chartType);
-        if (chartTypeConfig) {
-          const newVisConfig: ChartConfig = {
-            type: autoVis.chartType,
-            styles: chartTypeConfig.ui.style.defaults,
-            axesMapping: autoVis.axesMapping,
-            splitField: currentConfig?.splitField,
-            splitLayout: currentConfig?.splitLayout,
-            showSplitLabel: currentConfig?.showSplitLabel,
-          };
-          this.setVisConfig(newVisConfig);
-        }
-      } else {
-        const chartTypeConfig = visualizationRegistry.getVisualization('table');
-        if (!chartTypeConfig) {
-          this.setVisConfig(undefined);
-        }
-        const newVisConfig: ChartConfig = {
-          type: 'table',
-          styles: chartTypeConfig?.ui.style.defaults,
-          splitField: currentConfig?.splitField,
-          splitLayout: currentConfig?.splitLayout,
-          showSplitLabel: currentConfig?.showSplitLabel,
-        };
-        this.setVisConfig(newVisConfig);
+    // If current axes mapping is valid, no changes needed
+    if (!isEmpty(axesMapping) && isValidMapping(axesMapping ?? {}, columns)) {
+      return;
+    }
+
+    // Current axes mapping is invalid or empty - try different strategies to rebuild
+
+    // Strategy 1: Try to reuse current axes mapping with the same chart type
+    if (currentChartType && !isEmpty(axesMapping)) {
+      const reusedMapping = visualizationRegistry.reuseAxesMapping(
+        currentChartType,
+        axesMapping ?? {},
+        columns
+      );
+      if (reusedMapping && this.applyVisConfig(currentChartType, reusedMapping, true)) {
+        return;
       }
+    }
+
+    // Strategy 2: Try to create auto vis for the current chart type
+    if (currentChartType) {
+      const autoVis = this.createAutoVis(data, currentChartType);
+      if (autoVis && this.applyVisConfig(autoVis.chartType, autoVis.axesMapping, true)) {
+        return;
+      }
+    }
+
+    // Strategy 3: Try to create auto vis with any chart type
+    const autoVis = this.createAutoVis(data);
+    if (autoVis && this.applyVisConfig(autoVis.chartType, autoVis.axesMapping, false)) {
       return;
     }
 
-    // The current axes mappings can be applied to the data,
-    // it will just use the current chart type and axes mapping
-    if (isValidMapping(axesMapping ?? {}, columns)) {
-      return;
+    // Strategy 4: Fallback to table, or set undefined if table config unavailable
+    if (!this.applyVisConfig('table', {}, false)) {
+      this.setVisConfig(undefined);
     }
-
-    // All other cases will fallback to reset vis state and let user to choose
-    this.setVisConfig(undefined);
   }
 
   /**


### PR DESCRIPTION
### Description

Fix the visualization editor to preserve the user's selected chart type when data changes, providing a more consistent user experience.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
