### PR TITLE
Pin actions/github-script to exact commit SHA

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check if issue author is a collaborator
         id: check-collaborator
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const issueAuthor = context.payload.issue.user.login;
@@ -59,7 +59,7 @@ jobs:
 
       - name: Apply label if not a collaborator
         if: steps.check-collaborator.outputs.is_collaborator == 'false'
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             console.log('Attempting to add "untriaged" label');


### PR DESCRIPTION
## Summary
- Pin `actions/github-script` from `v6` tag to exact commit SHA (`3a2844b7e9c422d3c10d287c895573f7108da1b3`),  which points to v9.

## Context
Mutable tags can be overwritten. Pinning to a specific commit SHA ensures the action code cannot change without a corresponding PR update.
