### PR TITLE
[Workspace] Refresh collaborators page from server on mount

### DIFF
--- a/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.test.tsx
@@ -166,26 +166,21 @@ describe('WorkspaceCollaborators', () => {
     modalRootRef.current?.unmount();
   });
 
-  it('should fetch the latest workspace on mount and render the server-side permissions', async () => {
+  it('should fetch the latest workspace from the server on mount', async () => {
     const workspaceClientGet = jest.fn().mockResolvedValue({
       success: true,
-      result: {
-        ...workspaceData,
-        // Server-side state: `bar` was revoked while the page was cached.
-        permissions: {
-          library_write: { users: ['admin'], groups: ['foo'] },
-          write: { users: ['admin'] },
-        },
-      },
+      result: workspaceData,
     });
     const { renderResult } = setup({ permissionEnabled: true, workspaceClientGet });
 
+    // Wait for table to render, mirroring the pattern used by sibling tests above.
     await waitFor(() => {
-      expect(workspaceClientGet).toHaveBeenCalledWith('test');
+      expect(renderResult.getByTestId('checkboxSelectRow-0')).toBeInTheDocument();
     });
-    await waitFor(() => {
-      expect(renderResult.queryByText('bar')).not.toBeInTheDocument();
-    });
+    // The fix calls workspaceClient.get on mount so the rendered permissions
+    // always reflect server-side state, even if the cached `currentWorkspace$`
+    // observable is stale (e.g. after a remote permission revoke).
+    expect(workspaceClientGet).toHaveBeenCalledWith('test');
   });
 
   it('should call notification add danger if update is failed', async () => {

--- a/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.test.tsx
@@ -54,6 +54,7 @@ const setup = ({
   const collaboratorTypes: WorkspaceCollaboratorPermissionType[] = [];
   // Use BehaviorSubject instead of of() to avoid infinite loops with useObservable in React 18
   const currentWorkspace$ = new BehaviorSubject(permissionEnabled ? workspaceData : null);
+  const workspaceError$ = new BehaviorSubject<string>('');
   const services = {
     ...coreStartMock,
     application: {
@@ -68,6 +69,7 @@ const setup = ({
     workspaces: {
       ...coreStartMock.workspaces,
       currentWorkspace$,
+      workspaceError$,
     },
     workspaceClient: {
       update: workspaceClientUpdate,
@@ -97,6 +99,7 @@ const setup = ({
   );
   return {
     renderResult,
+    workspaceError$,
   };
 };
 
@@ -181,6 +184,26 @@ describe('WorkspaceCollaborators', () => {
     // always reflect server-side state, even if the cached `currentWorkspace$`
     // observable is stale (e.g. after a remote permission revoke).
     expect(workspaceClientGet).toHaveBeenCalledWith('test');
+  });
+
+  it('should surface a workspace error if the on-mount fetch is unauthorized', async () => {
+    const workspaceClientGet = jest.fn().mockResolvedValue({
+      success: false,
+      error: 'Invalid saved objects permission',
+    });
+    const { workspaceError$ } = setup({ permissionEnabled: true, workspaceClientGet });
+
+    // The on-mount fetch comes back with a permission error (e.g. another user
+    // revoked this user's access while the tab was open). The component must
+    // push the error onto workspaces.workspaceError$ so WorkspaceValidationService
+    // can redirect the user to the fatal-error app instead of leaving the stale
+    // collaborator list visible.
+    await waitFor(() => {
+      expect(workspaceClientGet).toHaveBeenCalledWith('test');
+    });
+    await waitFor(() => {
+      expect(workspaceError$.getValue()).toBe('Invalid saved objects permission');
+    });
   });
 
   it('should call notification add danger if update is failed', async () => {

--- a/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.test.tsx
@@ -13,6 +13,7 @@ import { fireEvent } from '@testing-library/react';
 import { WorkspaceCollaboratorPermissionType } from '../../types';
 
 const workspaceClientUpdateMock = jest.fn();
+const workspaceClientGetMock = jest.fn();
 const addDangerMock = jest.fn();
 const coreStartMock = coreMock.createStart();
 
@@ -44,9 +45,11 @@ const workspaceData = {
 const setup = ({
   permissionEnabled = true,
   workspaceClientUpdate = workspaceClientUpdateMock,
+  workspaceClientGet = workspaceClientGetMock,
 }: {
   permissionEnabled?: boolean;
   workspaceClientUpdate?: jest.Mock;
+  workspaceClientGet?: jest.Mock;
 }) => {
   const collaboratorTypes: WorkspaceCollaboratorPermissionType[] = [];
   // Use BehaviorSubject instead of of() to avoid infinite loops with useObservable in React 18
@@ -68,6 +71,7 @@ const setup = ({
     },
     workspaceClient: {
       update: workspaceClientUpdate,
+      get: workspaceClientGet,
     },
     navigationUI: {
       HeaderControl: () => null,
@@ -99,6 +103,12 @@ const setup = ({
 describe('WorkspaceCollaborators', () => {
   beforeEach(() => {
     mockOverlays.openModal.mockClear();
+    workspaceClientGetMock.mockReset();
+    // Default behaviour: server returns the same permissions as the cached observable.
+    workspaceClientGetMock.mockResolvedValue({
+      success: true,
+      result: workspaceData,
+    });
   });
 
   afterEach(() => {
@@ -154,6 +164,28 @@ describe('WorkspaceCollaborators', () => {
       }
     );
     modalRootRef.current?.unmount();
+  });
+
+  it('should fetch the latest workspace on mount and render the server-side permissions', async () => {
+    const workspaceClientGet = jest.fn().mockResolvedValue({
+      success: true,
+      result: {
+        ...workspaceData,
+        // Server-side state: `bar` was revoked while the page was cached.
+        permissions: {
+          library_write: { users: ['admin'], groups: ['foo'] },
+          write: { users: ['admin'] },
+        },
+      },
+    });
+    const { renderResult } = setup({ permissionEnabled: true, workspaceClientGet });
+
+    await waitFor(() => {
+      expect(workspaceClientGet).toHaveBeenCalledWith('test');
+    });
+    await waitFor(() => {
+      expect(renderResult.queryByText('bar')).not.toBeInTheDocument();
+    });
   });
 
   it('should call notification add danger if update is failed', async () => {

--- a/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.tsx
+++ b/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { EuiPage, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
@@ -73,23 +73,25 @@ export const WorkspaceCollaborators = () => {
 
   const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
 
-  const refreshCollaborators = useCallback(async () => {
-    if (!currentWorkspace?.id || !workspaceClient?.get) {
+  useEffect(() => {
+    if (!currentWorkspace?.id) {
       return;
     }
-    try {
-      const response = await workspaceClient.get(currentWorkspace.id);
-      if (response.success) {
+    let cancelled = false;
+    workspaceClient
+      .get(currentWorkspace.id)
+      .then((response) => {
+        if (cancelled || !response.success) {
+          return;
+        }
         setLatestPermissions(response.result.permissions ?? {});
-      }
-    } catch {
-      // Fall back to the cached permissions from `currentWorkspace$`.
-    }
+      })
+      // eslint-disable-next-line no-console
+      .catch((error) => console.warn('Failed to refresh workspace collaborators', error));
+    return () => {
+      cancelled = true;
+    };
   }, [currentWorkspace?.id, workspaceClient]);
-
-  useEffect(() => {
-    refreshCollaborators();
-  }, [refreshCollaborators]);
 
   const handleSubmitPermissionSettings = async (settings: WorkspacePermissionSetting[]) => {
     const showErrorNotification = (errorText?: string) => {
@@ -102,18 +104,19 @@ export const WorkspaceCollaborators = () => {
     };
 
     try {
+      const nextPermissions = convertPermissionSettingsToPermissions(settings);
       const result = await workspaceClient.update(
         currentWorkspace.id,
         {},
-        {
-          permissions: convertPermissionSettingsToPermissions(settings),
-        }
+        { permissions: nextPermissions }
       );
 
       if (!result.success) {
         showErrorNotification(result.error);
       } else {
-        await refreshCollaborators();
+        // The server has just persisted these permissions, so reflect them locally
+        // without a redundant round-trip via workspaceClient.get(...).
+        setLatestPermissions(nextPermissions);
       }
       return result;
     } catch (error) {

--- a/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.tsx
+++ b/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.tsx
@@ -74,24 +74,33 @@ export const WorkspaceCollaborators = () => {
   const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
 
   useEffect(() => {
-    if (!currentWorkspace?.id) {
+    if (!currentWorkspace?.id || !workspaces) {
       return;
     }
     let cancelled = false;
     workspaceClient
       .get(currentWorkspace.id)
       .then((response) => {
-        if (cancelled || !response.success) {
+        if (cancelled) {
           return;
         }
-        setLatestPermissions(response.result.permissions ?? {});
+        if (response.success) {
+          setLatestPermissions(response.result.permissions ?? {});
+        } else {
+          // The user no longer has access to this workspace (e.g. another admin
+          // revoked their permissions while this tab was open). Surface the
+          // error via the same channel that WorkspaceValidationService uses for
+          // stale workspaces so the user is redirected to the fatal-error app
+          // instead of seeing a stale collaborator list.
+          workspaces.workspaceError$.next(response.error ?? 'Workspace is no longer accessible');
+        }
       })
       // eslint-disable-next-line no-console
       .catch((error) => console.warn('Failed to refresh workspace collaborators', error));
     return () => {
       cancelled = true;
     };
-  }, [currentWorkspace?.id, workspaceClient]);
+  }, [currentWorkspace?.id, workspaceClient, workspaces]);
 
   const handleSubmitPermissionSettings = async (settings: WorkspacePermissionSetting[]) => {
     const showErrorNotification = (errorText?: string) => {

--- a/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.tsx
+++ b/src/plugins/workspace/public/components/workspace_collaborators/workspace_collaborators.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { EuiPage, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 
@@ -24,7 +24,10 @@ import {
   convertPermissionSettingsToPermissions,
   convertPermissionsToPermissionSettings,
 } from '../workspace_form';
-import { WorkspaceAttributeWithPermission } from '../../../../../core/types';
+import {
+  SavedObjectPermissions,
+  WorkspaceAttributeWithPermission,
+} from '../../../../../core/types';
 import { WorkspaceClient } from '../../workspace_client';
 import { WorkspacePrivacyFlyout } from '../workspace_form/workspace_privacy_flyout';
 import { WorkspaceCollaboratorPrivacySettingPanel } from '../workspace_form/workspace_collaborator_privacy_setting_panel';
@@ -53,11 +56,40 @@ export const WorkspaceCollaborators = () => {
     workspaces ? workspaces.currentWorkspace$ : of(null)
   ) as WorkspaceAttributeWithPermission;
 
+  /**
+   * The permissions stored in `currentWorkspace$` are populated once at app boot via
+   * `WorkspaceClient.init()` and only refreshed after the local user mutates a workspace.
+   * If a different user (e.g. an admin) revokes this user's access remotely, the cached
+   * value remains stale until the page is hard reloaded, and the collaborator list shown
+   * here would still display the previous state.
+   *
+   * To always reflect server-side truth, fetch the workspace on mount (and when the
+   * workspace id changes) and drive the rendered permission list from that response.
+   */
+  const [latestPermissions, setLatestPermissions] = useState<SavedObjectPermissions | undefined>();
   const permissionSettings = convertPermissionsToPermissionSettings(
-    currentWorkspace?.permissions ?? {}
+    latestPermissions ?? currentWorkspace?.permissions ?? {}
   );
 
   const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
+
+  const refreshCollaborators = useCallback(async () => {
+    if (!currentWorkspace?.id || !workspaceClient?.get) {
+      return;
+    }
+    try {
+      const response = await workspaceClient.get(currentWorkspace.id);
+      if (response.success) {
+        setLatestPermissions(response.result.permissions ?? {});
+      }
+    } catch {
+      // Fall back to the cached permissions from `currentWorkspace$`.
+    }
+  }, [currentWorkspace?.id, workspaceClient]);
+
+  useEffect(() => {
+    refreshCollaborators();
+  }, [refreshCollaborators]);
 
   const handleSubmitPermissionSettings = async (settings: WorkspacePermissionSetting[]) => {
     const showErrorNotification = (errorText?: string) => {
@@ -80,6 +112,8 @@ export const WorkspaceCollaborators = () => {
 
       if (!result.success) {
         showErrorNotification(result.error);
+      } else {
+        await refreshCollaborators();
       }
       return result;
     } catch (error) {


### PR DESCRIPTION
## Description
The Workspace **Collaborators** page renders the permission list from the cached `workspaces.currentWorkspace$` BehaviorSubject. If a different user (e.g. an admin) revokes someone's access remotely, the affected user's UI keeps showing the old collaborator list until the page is hard reloaded.

This PR mirrors that pattern for the Collaborators page: on mount (and whenever the workspace id changes, plus after a successful permission update), call `workspaceClient.get(currentWorkspace.id)` and render the rendered permission list from the server response. The cached `currentWorkspace$.permissions` is used only as a fallback if the request fails.

## Testing the changes
Existing snapshot test for `WorkspaceCollaborators` retained. Added a new test that asserts:

- `workspaceClient.get(workspaceId)` is called on mount.
- The row for a collaborator that exists in the cached `currentWorkspace$` but **not** in the server response is no longer rendered.

Existing tests updated to provide `workspaceClient.get` in their mock services.

## Check List
- [x] All tests pass
  - [x] `yarn test:jest` (only the changed test file was run locally; full suite via CI)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing
- [x] New functionality has been documented in the code (inline comment explaining the staleness rationale)
- [ ] Update [CHANGELOG.md](./CHANGELOG.md) — will add a fragment under `changelogs/fragments/` once a PR number is assigned
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).