### PR TITLE
fix(query_enhancements): bound assist/languages probe timeout

### DIFF
--- a/src/plugins/query_enhancements/server/routes/query_assist/routes.test.ts
+++ b/src/plugins/query_enhancements/server/routes/query_assist/routes.test.ts
@@ -144,6 +144,30 @@ describe('Query Assist Routes', () => {
         configuredLanguages: [],
       });
     });
+
+    it('returns empty languages with a timeout error when the agent probe hangs', async () => {
+      mockGetAgentIdByConfig.mockReturnValue(new Promise(() => {}));
+
+      const realSetTimeout = global.setTimeout;
+      const setTimeoutSpy = jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation(((fn: (...args: any[]) => void, ms?: number, ...args: any[]) =>
+          realSetTimeout(fn, ms === 5000 ? 0 : ms, ...args)) as typeof setTimeout);
+
+      try {
+        const httpSetup = await testSetup();
+        const result = await supertest(httpSetup.server.listener)
+          .get(API.QUERY_ASSIST.LANGUAGES)
+          .expect(200);
+
+        expect(result.body).toEqual({
+          configuredLanguages: [],
+          error: 'assist/languages probe timed out',
+        });
+      } finally {
+        setTimeoutSpy.mockRestore();
+      }
+    });
   });
 
   describe('POST /api/query_assist/generate', () => {

--- a/src/plugins/query_enhancements/server/routes/query_assist/routes.ts
+++ b/src/plugins/query_enhancements/server/routes/query_assist/routes.ts
@@ -44,15 +44,20 @@ export function registerQueryAssistRoutes(router: IRouter) {
         }
 
         // Check other languages via ML Commons agent config
-        await Promise.allSettled(
-          // @ts-expect-error TS7006 TODO(ts-error): fixme
-          config.queryAssist.supportedLanguages.map((languageConfig) =>
-            // if the call does not throw any error, then the agent is properly configured
-            getAgentIdByConfig(client, languageConfig.agentConfig).then(() =>
-              configuredLanguages.push(languageConfig.language)
+        await Promise.race([
+          Promise.allSettled(
+            // @ts-expect-error TS7006 TODO(ts-error): fixme
+            config.queryAssist.supportedLanguages.map((languageConfig) =>
+              // if the call does not throw any error, then the agent is properly configured
+              getAgentIdByConfig(client, languageConfig.agentConfig).then(() =>
+                configuredLanguages.push(languageConfig.language)
+              )
             )
-          )
-        );
+          ),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('assist/languages probe timed out')), 5000)
+          ),
+        ]);
         return response.ok({ body: { configuredLanguages } });
       } catch (error) {
         return response.ok({ body: { configuredLanguages, error: error.message } });


### PR DESCRIPTION
### Description

Add 5s timeout to `Promise.race` in `GET /api/enhancements/assist/languages` so an unreachable data source cannot pin the request open indefinitely. When the probe times out, return empty configuredLanguages array as expected by frontend, allowing app to mount normally.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

UT

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
