### PR TITLE
[Chat] Refactor: Extract streaming logic into useChatStreaming hook

### DIFF
--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -75,6 +75,7 @@ describe('ChatWindow', () => {
       newThread: jest.fn(),
       getThreadId: jest.fn().mockReturnValue('mock-thread-id'),
       abort: jest.fn(),
+      resetConnection: jest.fn(),
       setChatWindowInstance: jest.fn(),
       clearChatWindowInstance: jest.fn(),
       getCurrentDataSourceId: jest.fn().mockResolvedValue(undefined),

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -99,6 +99,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     eventHandler,
     subscribeToMessageStream,
     stopStreaming,
+    sendToolResult,
   } = useChatStreaming({
     chatService,
     confirmationService,
@@ -296,17 +297,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     subscribeToMessageStream(textContent, [...truncatedTimeline,...additionalMessages]);
   }, [timeline, subscribeToMessageStream, setInput, setTimeline]);
 
-  const handleResendToolResult = useCallback(
-    async ({ messageId, toolCallId, toolResult }: { messageId: string; toolCallId: string; toolResult: any }) => {
-      // Avoid concurrent resends while streaming or already sending a tool result
-      if (isStreamingRef.current || hasActiveToolCallsRef.current) return;
-      // Remove the error message from timeline
-      setTimeline((prev) => prev.filter((msg) => msg.id !== messageId));
-      await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
-    },
-    [eventHandler, setTimeline]
-  );
-
   const handleNewChat = useCallback(() => {
     // Stop any ongoing streaming before starting a new chat
     stopStreaming();
@@ -500,7 +490,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             timeline={timeline}
             isStreaming={isStreaming}
             onResendMessage={resendAvailable ? handleResendMessage : undefined}
-            onResendToolResult={handleResendToolResult}
+            onResendToolResult={sendToolResult}
             onApproveConfirmation={handleApproveConfirmation}
             onRejectConfirmation={handleRejectConfirmation}
             onFillInput={setInput}

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -11,13 +11,8 @@ import moment from "moment";
 import { i18n } from '@osd/i18n';
 import { EuiButton, EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
 import { useChatContext } from '../contexts/chat_context';
-import { ChatEventHandler } from '../services/chat_event_handler';
 import { AssistantActionService } from '../../../context_provider/public';
 import { ConfirmationRequest } from '../services/confirmation_service';
-import {
-  // eslint-disable-next-line prettier/prettier
-  type Event as ChatEvent,
-} from '../../common/events';
 import type {
   Message,
   SystemMessage,
@@ -30,6 +25,7 @@ import { ChatMessages } from './chat_messages';
 import { ChatInput } from './chat_input';
 import { slashCommandRegistry } from '../services/slash_commands';
 import { usePageContainerCapture, PageContainerImageData } from '../hooks/use_page_container_capture';
+import { useChatStreaming } from '../hooks/use_chat_streaming';
 import { ConversationHistoryPanel } from './conversation_history_panel';
 import type { SavedConversation } from '../services/conversation_history_service';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
@@ -63,22 +59,16 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   const { chatService, confirmationService } = useChatContext();
   const { services } = useOpenSearchDashboards<{ core: CoreStart }>();
   const toasts = services.core?.notifications?.toasts;
-  const [timeline, setTimeline] = useState<Message[]>([]);
   const [input, setInput] = useState('');
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const [pendingConfirmation, setPendingConfirmation] = useState<ConfirmationRequest | null>(null);
   const [showHistory, setShowHistory] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const handleSendRef = useRef<typeof handleSend>();
-  const currentSubscriptionRef = useRef<any>(null);
   const conversationLoadAbortControllerRef = useRef<AbortController | null>(null);
   const {screenshotFeatureEnabled,isCapturing, capturePageContainer} = usePageContainerCapture();
   const [screenshotData, setScreenshotData] = useState<{pageTitle: string, createdAt: moment.Moment} & PageContainerImageData>();
   const [toolCallStates, setToolCallStates] = useState<Map<string, any>>(new Map());
   const resendAvailable = !!chatService.conversationHistoryService.getMemoryProvider().includeFullHistory;
-  const [startResponse, setStartResponse] = useState(false);
-
   const hasActiveToolCalls = useMemo(() => {
     if (toolCallStates instanceof Map) {
       for (const state of toolCallStates.values()) {
@@ -90,20 +80,36 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   const hasActiveToolCallsRef = useRef(false);
   hasActiveToolCallsRef.current = hasActiveToolCalls;
 
+  // Get telemetry recorder from core services
+  const telemetryRecorder = useMemo(
+    () => services.core?.telemetry?.getPluginRecorder('chat'),
+    [services.core?.telemetry]
+  );
+
+  // Use the streaming hook
+  const {
+    timeline,
+    setTimeline,
+    isStreaming,
+    isStreamingRef,
+    isSendingToolResult,
+    isSendingToolResultRef,
+    startResponse,
+    setCurrentRunId,
+    eventHandler,
+    subscribeToMessageStream,
+    stopStreaming,
+  } = useChatStreaming({
+    chatService,
+    confirmationService,
+    telemetryRecorder,
+    onMessageSent: () => setScreenshotData(undefined),
+  });
+
   const hasPendingResend = useMemo(
     () => timeline.some((msg) => msg.role === 'system' && (msg as SystemMessage).canResend),
     [timeline]
   );
-
-  // Use ref to track streaming state synchronously for React 18 compatibility
-  // React 18 batches state updates, so we need a ref for immediate checks
-  const isStreamingRef = useRef(false);
-
-  const timelineRef = React.useRef<Message[]>(timeline);
-
-  React.useEffect(() => {
-    timelineRef.current = timeline;
-  }, [timeline]);
 
   // Subscribe to pending confirmations
   useEffect(() => {
@@ -119,29 +125,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     return () => subscription.unsubscribe();
   }, [confirmationService]);
 
-  // Get telemetry recorder from core services
-  const telemetryRecorder = useMemo(
-    () => services.core?.telemetry?.getPluginRecorder('chat'),
-    [services.core?.telemetry]
-  );
-
-  // Create the event handler using useMemo
-  const eventHandler = useMemo(
-    () =>
-      new ChatEventHandler({
-        assistantActionService: service,
-        chatService,
-        confirmationService,
-        telemetryRecorder,
-        callbacks: {
-          onTimelineUpdate: setTimeline,
-          onStreamingStateChange: setIsStreaming,
-          onStartResponse: setStartResponse,
-          getTimeline: () => timelineRef.current,
-        },
-      }),
-    [service, chatService, confirmationService, telemetryRecorder]
-  );
 
   // Subscribe to tool updates from the service
   useEffect(() => {
@@ -156,13 +139,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     return () => subscription.unsubscribe();
   }, [service, chatService]);
-
-  // Clean up event handler on component unmount
-  useEffect(() => {
-    return () => {
-      eventHandler.clearState();
-    };
-  }, [eventHandler]);
 
   // Initialize with fresh conversation on mount
   useMount(() => {
@@ -207,89 +183,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     }
   }, [chatService, services.core?.savedObjects?.client]);
 
-  // Helper function to handle message streaming with observable subscription
-  const subscribeToMessageStream = useCallback(async (
-    messageContent: string,
-    messages: Message[],
-    rawMessage?: string
-  ) => {
-    // Block AI features for unsupported data sources
-    if (await isUnsupportedDataSource()) {
-      const userMsg: UserMessage = {
-        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        role: 'user',
-        content: messageContent,
-        rawMessage: rawMessage || messageContent,
-      };
-      const systemMsg: SystemMessage = {
-        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        role: 'system',
-        content: i18n.translate('chat.dataSourceUnsupported', {
-          defaultMessage: 'The current data source does not support AI features.',
-        }),
-      };
-      setTimeline((prev) => [...prev, userMsg, systemMsg]);
-      return;
-    }
-
-    isStreamingRef.current = true;
-    setIsStreaming(true);
-    setStartResponse(false);
-
-    try {
-      const { observable, userMessage } = await chatService.sendMessage(
-        messageContent,
-        messages
-      );
-
-      const timelineUserMessage: UserMessage = {
-        id: userMessage.id,
-        role: 'user',
-        content: userMessage.content,
-        rawMessage: Array.isArray(userMessage.content) ? undefined : rawMessage || messageContent,  // For regular messages, raw and content are the same
-      };
-
-      setTimeline((prev) => [...prev, timelineUserMessage]);
-      setScreenshotData(undefined);
-
-      // Subscribe to streaming response
-      const subscription = observable.subscribe({
-        next: async (event: ChatEvent) => {
-          // Update runId if we get it from the event
-          if ('runId' in event && event.runId && event.runId !== currentRunId) {
-            setCurrentRunId(event.runId);
-          }
-
-          // Handle all events through the event handler service
-          await eventHandler.handleEvent(event);
-        },
-        error: (error: any) => {
-          console.error('Subscription error:', error);
-          isStreamingRef.current = false;
-          setStartResponse(false);
-          setIsStreaming(false);
-          currentSubscriptionRef.current = null;
-        },
-        complete: () => {
-          isStreamingRef.current = false;
-          setStartResponse(false);
-          setIsStreaming(false);
-          currentSubscriptionRef.current = null;
-        },
-      });
-
-      // Store subscription for potential cancellation
-      currentSubscriptionRef.current = subscription;
-
-      return () => subscription.unsubscribe();
-    } catch (error) {
-      console.error('Failed to send message:', error);
-      isStreamingRef.current = false;
-      setIsStreaming(false);
-      currentSubscriptionRef.current = null;
-    }
-  }, [chatService, currentRunId, eventHandler, isUnsupportedDataSource]);
-
   const handleSend = async (options?: {input?: string, messages?: Message[]}) => {
     const messageContent = options?.input ?? input.trim();
     // Use ref for immediate check since React 18 batches state updates
@@ -326,6 +219,25 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       if (commandResult.message) {
         return subscribeToMessageStream(commandResult.message, messagesToSend, messageContent);
       }
+      return;
+    }
+
+    // Block AI features for unsupported data sources
+    if (await isUnsupportedDataSource()) {
+      const userMsg: UserMessage = {
+        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        role: 'user',
+        content: messageContent,
+        rawMessage: messageContent,
+      };
+      const systemMsg: SystemMessage = {
+        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        role: 'system',
+        content: i18n.translate('chat.dataSourceUnsupported', {
+          defaultMessage: 'The current data source does not support AI features.',
+        }),
+      };
+      setTimeline((prev) => [...prev, userMsg, systemMsg]);
       return;
     }
 
@@ -394,25 +306,6 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     },
     [eventHandler, setTimeline]
   );
-
-  // Helper function to stop streaming and clean up subscriptions
-  const stopStreaming = useCallback(() => {
-    // Abort the current streaming request
-    chatService.abort();
-    // Unsubscribe from current observable if exists
-    if (currentSubscriptionRef.current) {
-      currentSubscriptionRef.current.unsubscribe();
-      currentSubscriptionRef.current = null;
-    }
-
-    // Cancel any in-flight tool result dispatch
-    eventHandler.cancelToolResultDispatch();
-
-    // Update streaming state (both ref and state for React 18 compatibility)
-    isStreamingRef.current = false;
-    setIsStreaming(false);
-    setStartResponse(false);
-  }, [chatService, eventHandler]);
 
   const handleNewChat = useCallback(() => {
     // Stop any ongoing streaming before starting a new chat

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -1,13 +1,18 @@
 /*
-* Copyright OpenSearch Contributors
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-/* eslint-disable no-console */
-
-import React, { useState, useEffect, useMemo, useImperativeHandle, useCallback, useRef } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useImperativeHandle,
+  useCallback,
+  useRef,
+} from 'react';
 import { useUnmount, useMount } from 'react-use';
-import moment from "moment";
+import moment from 'moment';
 import { i18n } from '@osd/i18n';
 import { EuiButton, EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
 import { useChatContext } from '../contexts/chat_context';
@@ -24,23 +29,26 @@ import { ChatHeader } from './chat_header';
 import { ChatMessages } from './chat_messages';
 import { ChatInput } from './chat_input';
 import { slashCommandRegistry } from '../services/slash_commands';
-import { usePageContainerCapture, PageContainerImageData } from '../hooks/use_page_container_capture';
+import {
+  usePageContainerCapture,
+  PageContainerImageData,
+} from '../hooks/use_page_container_capture';
 import { useChatStreaming } from '../hooks/use_chat_streaming';
 import { ConversationHistoryPanel } from './conversation_history_panel';
 import type { SavedConversation } from '../services/conversation_history_service';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../core/public';
 import { ChatSessionErrorBoundary } from './chat_session_error_boundary';
-import "./chat_window.scss"
+import './chat_window.scss';
 
 export interface ChatWindowInstance {
-  startNewChat: ()=>void;
-  sendMessage: (options:{content: string; messages?: Message[]})=>Promise<unknown>;
+  startNewChat: () => void;
+  sendMessage: (options: { content: string; messages?: Message[] }) => Promise<unknown>;
 }
 
 interface ChatWindowProps {
   layoutMode?: ChatLayoutMode;
-  onClose: ()=>void;
+  onClose: () => void;
 }
 
 /**
@@ -50,150 +58,155 @@ export const ChatWindow = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   return <ChatWindowContent ref={ref} {...props} />;
 });
 
-const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(({
-  layoutMode = ChatLayoutMode.SIDECAR,
-  onClose,
-}, ref) => {
-
-  const service = AssistantActionService.getInstance();
-  const { chatService, confirmationService } = useChatContext();
-  const { services } = useOpenSearchDashboards<{ core: CoreStart }>();
-  const toasts = services.core?.notifications?.toasts;
-  const [input, setInput] = useState('');
-  const [pendingConfirmation, setPendingConfirmation] = useState<ConfirmationRequest | null>(null);
-  const [showHistory, setShowHistory] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const handleSendRef = useRef<typeof handleSend>();
-  const conversationLoadAbortControllerRef = useRef<AbortController | null>(null);
-  const {screenshotFeatureEnabled,isCapturing, capturePageContainer} = usePageContainerCapture();
-  const [screenshotData, setScreenshotData] = useState<{pageTitle: string, createdAt: moment.Moment} & PageContainerImageData>();
-  const [toolCallStates, setToolCallStates] = useState<Map<string, any>>(new Map());
-  const resendAvailable = !!chatService.conversationHistoryService.getMemoryProvider().includeFullHistory;
-  const hasActiveToolCalls = useMemo(() => {
-    if (toolCallStates instanceof Map) {
-      for (const state of toolCallStates.values()) {
-        if (state.status === 'pending' || state.status === 'executing') return true;
+const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
+  ({ layoutMode = ChatLayoutMode.SIDECAR, onClose }, ref) => {
+    const service = AssistantActionService.getInstance();
+    const { chatService, confirmationService } = useChatContext();
+    const { services } = useOpenSearchDashboards<{ core: CoreStart }>();
+    const toasts = services.core?.notifications?.toasts;
+    const [input, setInput] = useState('');
+    const [pendingConfirmation, setPendingConfirmation] = useState<ConfirmationRequest | null>(
+      null
+    );
+    const [showHistory, setShowHistory] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const handleSendRef = useRef<typeof handleSend>();
+    const conversationLoadAbortControllerRef = useRef<AbortController | null>(null);
+    const {
+      screenshotFeatureEnabled,
+      isCapturing,
+      capturePageContainer,
+    } = usePageContainerCapture();
+    const [screenshotData, setScreenshotData] = useState<
+      { pageTitle: string; createdAt: moment.Moment } & PageContainerImageData
+    >();
+    const [toolCallStates, setToolCallStates] = useState<Map<string, any>>(new Map());
+    const resendAvailable = !!chatService.conversationHistoryService.getMemoryProvider()
+      .includeFullHistory;
+    const hasActiveToolCalls = useMemo(() => {
+      if (toolCallStates instanceof Map) {
+        for (const state of toolCallStates.values()) {
+          if (state.status === 'pending' || state.status === 'executing') return true;
+        }
       }
-    }
-    return false;
-  }, [toolCallStates]);
-  const hasActiveToolCallsRef = useRef(false);
-  hasActiveToolCallsRef.current = hasActiveToolCalls;
-
-  // Get telemetry recorder from core services
-  const telemetryRecorder = useMemo(
-    () => services.core?.telemetry?.getPluginRecorder('chat'),
-    [services.core?.telemetry]
-  );
-
-  // Use the streaming hook
-  const {
-    timeline,
-    setTimeline,
-    isStreaming,
-    isStreamingRef,
-    isSendingToolResult,
-    isSendingToolResultRef,
-    startResponse,
-    setCurrentRunId,
-    eventHandler,
-    subscribeToMessageStream,
-    stopStreaming,
-    sendToolResult,
-  } = useChatStreaming({
-    chatService,
-    confirmationService,
-    telemetryRecorder,
-    onMessageSent: () => setScreenshotData(undefined),
-  });
-
-  const hasPendingResend = useMemo(
-    () => timeline.some((msg) => msg.role === 'system' && (msg as SystemMessage).canResend),
-    [timeline]
-  );
-
-  // Subscribe to pending confirmations
-  useEffect(() => {
-    const subscription = confirmationService.getPendingConfirmations$().subscribe((requests) => {
-      // Show the first pending confirmation in the timeline
-      if (requests.length > 0) {
-        setPendingConfirmation(requests[0]);
-      } else {
-        setPendingConfirmation(null);
-      }
-    });
-
-    return () => subscription.unsubscribe();
-  }, [confirmationService]);
-
-
-  // Subscribe to tool updates from the service
-  useEffect(() => {
-    const subscription = service.getState$().subscribe((state) => {
-      if (chatService && state.toolDefinitions.length > 0) {
-        // Store tools for when we send messages
-        (chatService as any).availableTools = state.toolDefinitions;
-      }
-      // Update tool call states
-      setToolCallStates(state.toolCallStates);
-    });
-
-    return () => subscription.unsubscribe();
-  }, [service, chatService]);
-
-  // Initialize with fresh conversation on mount
-  useMount(() => {
-    chatService.newThread();
-  });
-
-  // Save conversation to history whenever timeline changes
-  useEffect(() => {
-    if (timeline.length > 0 && !isLoading) {
-      chatService.saveConversation(timeline);
-    }
-  }, [timeline, chatService, isLoading]);
-
-  // Clear thread ID on unmount to start fresh next time
-  useUnmount(() => {
-    services.core.chat.resetThreadId()
-  });
-
-  // Cache data source compatibility check to avoid network call on every message
-  const unsupportedDataSourceRef = useRef<{ dataSourceId: string | undefined; result: boolean } | null>(null);
-
-  const isUnsupportedDataSource = useCallback(async (): Promise<boolean> => {
-    try {
-      const dataSourceId = await chatService.getCurrentDataSourceId();
-      if (!dataSourceId) return false;
-      // Return cached result if data source hasn't changed
-      if (unsupportedDataSourceRef.current?.dataSourceId === dataSourceId) {
-        return unsupportedDataSourceRef.current.result;
-      }
-      const savedObjectsClient = services.core?.savedObjects?.client;
-      if (!savedObjectsClient) return false;
-      const ds = await savedObjectsClient.get<{ dataSourceEngineType?: string }>(
-        'data-source',
-        dataSourceId
-      );
-      const result = ds?.attributes?.dataSourceEngineType === 'AnalyticEngine';
-      unsupportedDataSourceRef.current = { dataSourceId, result };
-      return result;
-    } catch {
-      // Fail-open: transient errors should not block AI features
       return false;
-    }
-  }, [chatService, services.core?.savedObjects?.client]);
+    }, [toolCallStates]);
+    const hasActiveToolCallsRef = useRef(false);
+    hasActiveToolCallsRef.current = hasActiveToolCalls;
 
-  const handleSend = async (options?: {input?: string, messages?: Message[]}) => {
-    const messageContent = options?.input ?? input.trim();
-    // Use ref for immediate check since React 18 batches state updates
-    if (!messageContent || isStreamingRef.current || hasPendingResend) return;
+    // Get telemetry recorder from core services
+    const telemetryRecorder = useMemo(() => services.core?.telemetry?.getPluginRecorder('chat'), [
+      services.core?.telemetry,
+    ]);
 
-    // Prepare additional messages for sending (but don't add to timeline yet)
-    let additionalMessages = options?.messages ?? [];
+    // Use the streaming hook
+    const {
+      timeline,
+      setTimeline,
+      isStreaming,
+      isStreamingRef,
+      startResponse,
+      setCurrentRunId,
+      eventHandler,
+      subscribeToMessageStream,
+      stopStreaming,
+      sendToolResult,
+    } = useChatStreaming({
+      chatService,
+      confirmationService,
+      telemetryRecorder,
+      onMessageSent: () => setScreenshotData(undefined),
+    });
 
-    // Only add screenshot data if messages not provided
-    if (!options?.messages && screenshotData) {
+    const hasPendingResend = useMemo(
+      () => timeline.some((msg) => msg.role === 'system' && (msg as SystemMessage).canResend),
+      [timeline]
+    );
+
+    // Subscribe to pending confirmations
+    useEffect(() => {
+      const subscription = confirmationService.getPendingConfirmations$().subscribe((requests) => {
+        // Show the first pending confirmation in the timeline
+        if (requests.length > 0) {
+          setPendingConfirmation(requests[0]);
+        } else {
+          setPendingConfirmation(null);
+        }
+      });
+
+      return () => subscription.unsubscribe();
+    }, [confirmationService]);
+
+    // Subscribe to tool updates from the service
+    useEffect(() => {
+      const subscription = service.getState$().subscribe((state) => {
+        if (chatService && state.toolDefinitions.length > 0) {
+          // Store tools for when we send messages
+          (chatService as any).availableTools = state.toolDefinitions;
+        }
+        // Update tool call states
+        setToolCallStates(state.toolCallStates);
+      });
+
+      return () => subscription.unsubscribe();
+    }, [service, chatService]);
+
+    // Initialize with fresh conversation on mount
+    useMount(() => {
+      chatService.newThread();
+    });
+
+    // Save conversation to history whenever timeline changes
+    useEffect(() => {
+      if (timeline.length > 0 && !isLoading) {
+        chatService.saveConversation(timeline);
+      }
+    }, [timeline, chatService, isLoading]);
+
+    // Clear thread ID on unmount to start fresh next time
+    useUnmount(() => {
+      services.core.chat.resetThreadId();
+    });
+
+    // Cache data source compatibility check to avoid network call on every message
+    const unsupportedDataSourceRef = useRef<{
+      dataSourceId: string | undefined;
+      result: boolean;
+    } | null>(null);
+
+    const isUnsupportedDataSource = useCallback(async (): Promise<boolean> => {
+      try {
+        const dataSourceId = await chatService.getCurrentDataSourceId();
+        if (!dataSourceId) return false;
+        // Return cached result if data source hasn't changed
+        if (unsupportedDataSourceRef.current?.dataSourceId === dataSourceId) {
+          return unsupportedDataSourceRef.current.result;
+        }
+        const savedObjectsClient = services.core?.savedObjects?.client;
+        if (!savedObjectsClient) return false;
+        const ds = await savedObjectsClient.get<{ dataSourceEngineType?: string }>(
+          'data-source',
+          dataSourceId
+        );
+        const result = ds?.attributes?.dataSourceEngineType === 'AnalyticEngine';
+        unsupportedDataSourceRef.current = { dataSourceId, result };
+        return result;
+      } catch {
+        // Fail-open: transient errors should not block AI features
+        return false;
+      }
+    }, [chatService, services.core?.savedObjects?.client]);
+
+    const handleSend = async (options?: { input?: string; messages?: Message[] }) => {
+      const messageContent = options?.input ?? input.trim();
+      // Use ref for immediate check since React 18 batches state updates
+      if (!messageContent || isStreamingRef.current || hasPendingResend) return;
+
+      // Prepare additional messages for sending (but don't add to timeline yet)
+      let additionalMessages = options?.messages ?? [];
+
+      // Only add screenshot data if messages not provided
+      if (!options?.messages && screenshotData) {
         additionalMessages = [
           {
             role: 'user' as const,
@@ -205,364 +218,394 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
                 data: screenshotData.base64,
               },
             ],
-        }]
-    }
-
-    setInput('');
-
-    // Merge additional messages with current timeline for sending
-    const messagesToSend = [...timeline, ...additionalMessages];
-
-    // Check if this is a slash command
-    const commandResult = await slashCommandRegistry.execute(messageContent);
-    if (commandResult.handled) {
-      // If command was handled and returned a message, send it to the AI
-      if (commandResult.message) {
-        return subscribeToMessageStream(commandResult.message, messagesToSend, messageContent);
+          },
+        ];
       }
-      return;
-    }
 
-    // Block AI features for unsupported data sources
-    if (await isUnsupportedDataSource()) {
-      const userMsg: UserMessage = {
-        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        role: 'user',
-        content: messageContent,
-        rawMessage: messageContent,
-      };
-      const systemMsg: SystemMessage = {
-        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-        role: 'system',
-        content: i18n.translate('chat.dataSourceUnsupported', {
-          defaultMessage: 'The current data source does not support AI features.',
-        }),
-      };
-      setTimeline((prev) => [...prev, userMsg, systemMsg]);
-      return;
-    }
+      setInput('');
 
-    // Normal message flow
-    return subscribeToMessageStream(messageContent, messagesToSend);
-  };
+      // Merge additional messages with current timeline for sending
+      const messagesToSend = [...timeline, ...additionalMessages];
 
-  handleSendRef.current = handleSend;
+      // Check if this is a slash command
+      const commandResult = await slashCommandRegistry.execute(messageContent);
+      if (commandResult.handled) {
+        // If command was handled and returned a message, send it to the AI
+        if (commandResult.message) {
+          return subscribeToMessageStream(commandResult.message, messagesToSend, messageContent);
+        }
+        return;
+      }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  };
+      // Block AI features for unsupported data sources
+      if (await isUnsupportedDataSource()) {
+        const userMsg: UserMessage = {
+          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+          role: 'user',
+          content: messageContent,
+          rawMessage: messageContent,
+        };
+        const systemMsg: SystemMessage = {
+          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+          role: 'system',
+          content: i18n.translate('chat.dataSourceUnsupported', {
+            defaultMessage: 'The current data source does not support AI features.',
+          }),
+        };
+        setTimeline((prev) => [...prev, userMsg, systemMsg]);
+        return;
+      }
 
-  const handleResendMessage = useCallback(async (message: Message) => {
-    // Use ref for immediate check since React 18 batches state updates
-    if (isStreamingRef.current) return;
+      // Normal message flow
+      return subscribeToMessageStream(messageContent, messagesToSend);
+    };
 
-    // Only user messages can be resent
-    if (message.role !== 'user') return;
+    handleSendRef.current = handleSend;
 
-    // Find the index of this message in the timeline
-    const messageIndex = timeline.findIndex(
-      (item) => item.id === message.id
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    };
+
+    const handleResendMessage = useCallback(
+      async (message: Message) => {
+        // Use ref for immediate check since React 18 batches state updates
+        if (isStreamingRef.current) return;
+
+        // Only user messages can be resent
+        if (message.role !== 'user') return;
+
+        // Find the index of this message in the timeline
+        const messageIndex = timeline.findIndex((item) => item.id === message.id);
+
+        if (messageIndex === -1) return;
+
+        let textContent = typeof message.content === 'string' ? message.content : '';
+        const additionalMessages: Message[] = [];
+
+        if (Array.isArray(message.content)) {
+          const lastMessageContent = message.content[message.content.length - 1];
+          if (lastMessageContent.type === 'text') {
+            textContent = lastMessageContent.text;
+            additionalMessages.push({
+              ...message,
+              content: message.content.slice(0, message.content.length - 1),
+            });
+          }
+        }
+
+        if (textContent === '') {
+          return;
+        }
+
+        // Remove this message and everything after it from the timeline
+        const truncatedTimeline = timeline.slice(0, messageIndex);
+        setTimeline(truncatedTimeline);
+
+        // Clear any streaming state and input
+        setInput('');
+
+        subscribeToMessageStream(textContent, [...truncatedTimeline, ...additionalMessages]);
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [timeline, subscribeToMessageStream, setInput, setTimeline]
     );
 
-    if (messageIndex === -1) return;
+    const handleNewChat = useCallback(() => {
+      // Stop any ongoing streaming before starting a new chat
+      stopStreaming();
 
-    let textContent = typeof message.content === "string" ? message.content : "";
-    const additionalMessages: Message[] = [];
+      chatService.newThread();
+      setTimeline([]);
+      setCurrentRunId(null);
+      setPendingConfirmation(null);
+      confirmationService.cleanAll();
+      setShowHistory(false);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [chatService, confirmationService, stopStreaming]);
 
-    if (Array.isArray(message.content)) {
-      const lastMessageContent =  message.content[message.content.length - 1];
-      if (lastMessageContent.type === "text") {
-        textContent = lastMessageContent.text;
-        additionalMessages.push({
-          ...message,
-          content: message.content.slice(0, message.content.length - 1),
-        });
+    const handleStop = useCallback(() => {
+      stopStreaming();
+    }, [stopStreaming]);
+
+    const handleApproveConfirmation = useCallback(() => {
+      if (pendingConfirmation) {
+        confirmationService.approve(pendingConfirmation.id);
       }
-    }
+    }, [pendingConfirmation, confirmationService]);
 
-    if (textContent === "") {
-        return;
-    }
-
-    // Remove this message and everything after it from the timeline
-    const truncatedTimeline = timeline.slice(0, messageIndex);
-    setTimeline(truncatedTimeline);
-
-    // Clear any streaming state and input
-    setInput('');
-
-    subscribeToMessageStream(textContent, [...truncatedTimeline,...additionalMessages]);
-  }, [timeline, subscribeToMessageStream, setInput, setTimeline]);
-
-  const handleNewChat = useCallback(() => {
-    // Stop any ongoing streaming before starting a new chat
-    stopStreaming();
-
-    chatService.newThread();
-    setTimeline([]);
-    setCurrentRunId(null);
-    setPendingConfirmation(null);
-    confirmationService.cleanAll();
-    setShowHistory(false);
-  }, [chatService, confirmationService, stopStreaming]);
-
-  const handleStop = useCallback(() => {
-    stopStreaming();
-  }, [stopStreaming]);
-
-  const handleApproveConfirmation = useCallback(() => {
-    if (pendingConfirmation) {
-      confirmationService.approve(pendingConfirmation.id);
-    }
-  }, [pendingConfirmation, confirmationService]);
-
-  const handleRejectConfirmation = useCallback(() => {
-    if (pendingConfirmation) {
-      confirmationService.reject(pendingConfirmation.id);
-    }
-  }, [pendingConfirmation, confirmationService]);
-
-  const handleCaptureScreenshot = useCallback(async ()=>{
-    setScreenshotData(undefined);
-    const imageData = await capturePageContainer();
-    if(imageData){
-      setScreenshotData({...imageData, pageTitle: document.title, createdAt: moment()});
-    }
-
-  }, [capturePageContainer]);
-
-  const enhancedProps = useMemo(() => {
-    return {
-      toolCallStates,
-      getActionRenderer: service.getActionRenderer,
-    };
-  }, [toolCallStates, service.getActionRenderer]);
-
-  // Get conversation name from first user message with text content
-  const conversationName = useMemo(() => {
-    // Find first user message that has text content
-    for (const msg of timeline) {
-      if (msg.role !== 'user') continue;
-
-      // Handle string content
-      if (typeof msg.content === 'string' && msg.content.trim()) {
-        return msg.content;
+    const handleRejectConfirmation = useCallback(() => {
+      if (pendingConfirmation) {
+        confirmationService.reject(pendingConfirmation.id);
       }
+    }, [pendingConfirmation, confirmationService]);
 
-      // Handle array content - look for text content
-      if (Array.isArray(msg.content)) {
-        const textContent = msg.content.find((item) => item.type === 'text');
-        if (textContent?.text && textContent.text.trim()) {
-          return textContent.text;
+    const handleCaptureScreenshot = useCallback(async () => {
+      setScreenshotData(undefined);
+      const imageData = await capturePageContainer();
+      if (imageData) {
+        setScreenshotData({ ...imageData, pageTitle: document.title, createdAt: moment() });
+      }
+    }, [capturePageContainer]);
+
+    const enhancedProps = useMemo(() => {
+      return {
+        toolCallStates,
+        getActionRenderer: service.getActionRenderer,
+      };
+    }, [toolCallStates, service.getActionRenderer]);
+
+    // Get conversation name from first user message with text content
+    const conversationName = useMemo(() => {
+      // Find first user message that has text content
+      for (const msg of timeline) {
+        if (msg.role !== 'user') continue;
+
+        // Handle string content
+        if (typeof msg.content === 'string' && msg.content.trim()) {
+          return msg.content;
+        }
+
+        // Handle array content - look for text content
+        if (Array.isArray(msg.content)) {
+          const textContent = msg.content.find((item) => item.type === 'text');
+          if (textContent?.text && textContent.text.trim()) {
+            return textContent.text;
+          }
         }
       }
-    }
 
-    return '';
-  }, [timeline]);
+      return '';
+    }, [timeline]);
 
-  const handleShowHistory = useCallback(() => {
-    setShowHistory(true);
-  }, []);
+    const handleShowHistory = useCallback(() => {
+      setShowHistory(true);
+    }, []);
 
-  const handleCloseHistory = useCallback(() => {
-    setShowHistory(false);
-  }, []);
+    const handleCloseHistory = useCallback(() => {
+      setShowHistory(false);
+    }, []);
 
-  const handleSelectConversation = useCallback(async (conversation: SavedConversation) => {
-    // Stop any ongoing streaming before switching conversations
-    stopStreaming();
+    const handleSelectConversation = useCallback(
+      async (conversation: SavedConversation) => {
+        // Stop any ongoing streaming before switching conversations
+        stopStreaming();
 
-    // Abort any ongoing conversation loading
-    if (conversationLoadAbortControllerRef.current) {
-      conversationLoadAbortControllerRef.current.abort();
-    }
+        // Abort any ongoing conversation loading
+        if (conversationLoadAbortControllerRef.current) {
+          conversationLoadAbortControllerRef.current.abort();
+        }
 
-    // Create new abort controller for this load operation
-    const abortController = new AbortController();
-    conversationLoadAbortControllerRef.current = abortController;
+        // Create new abort controller for this load operation
+        const abortController = new AbortController();
+        conversationLoadAbortControllerRef.current = abortController;
 
-    setIsLoading(true);
+        setIsLoading(true);
 
-    try {
-      // Load the conversation and get AG-UI event array
-      const events = await chatService.loadConversation(conversation.threadId);
+        try {
+          // Load the conversation and get AG-UI event array
+          const events = await chatService.loadConversation(conversation.threadId);
 
-      // Check if this load was aborted (user switched to another conversation)
-      if (abortController.signal.aborted) {
-        return;
-      }
-
-      if (events) {
-        // Reset UI state
-        eventHandler.clearState();
-        setCurrentRunId(null);
-        setPendingConfirmation(null);
-        confirmationService.cleanAll();
-        setShowHistory(false);
-        setIsLoading(false);
-
-        // Replay all events to reconstruct the conversation
-        for (const event of events) {
-          // Check abort signal during replay
+          // Check if this load was aborted (user switched to another conversation)
           if (abortController.signal.aborted) {
             return;
           }
-          await eventHandler.handleEvent(event);
+
+          if (events) {
+            // Reset UI state
+            eventHandler.clearState();
+            setCurrentRunId(null);
+            setPendingConfirmation(null);
+            confirmationService.cleanAll();
+            setShowHistory(false);
+            setIsLoading(false);
+
+            // Replay all events to reconstruct the conversation
+            for (const event of events) {
+              // Check abort signal during replay
+              if (abortController.signal.aborted) {
+                return;
+              }
+              await eventHandler.handleEvent(event);
+            }
+          }
+        } catch (error: any) {
+          if (!abortController.signal.aborted) {
+            toasts?.addWarning({
+              title: i18n.translate('chat.window.loadConversationErrorTitle', {
+                defaultMessage: 'Failed to load conversation',
+              }),
+              text:
+                error instanceof Error
+                  ? error.message
+                  : i18n.translate('chat.window.loadConversationErrorMessage', {
+                      defaultMessage:
+                        'An unexpected error occurred while loading the conversation.',
+                    }),
+            });
+          }
+        } finally {
+          if (!abortController.signal.aborted) {
+            setIsLoading(false);
+          }
+          // Clear abort controller reference
+          if (conversationLoadAbortControllerRef.current === abortController) {
+            conversationLoadAbortControllerRef.current = null;
+          }
         }
-      }
-    } catch (error: any) {
-      if (!abortController.signal.aborted) {
-        toasts?.addWarning({
-          title: i18n.translate('chat.window.loadConversationErrorTitle', {
-            defaultMessage: 'Failed to load conversation',
-          }),
-          text:
-            error instanceof Error
-              ? error.message
-              : i18n.translate('chat.window.loadConversationErrorMessage', {
-                  defaultMessage: 'An unexpected error occurred while loading the conversation.',
-                }),
-        });
-      }
-    } finally {
-      if (!abortController.signal.aborted) {
-        setIsLoading(false);
-      }
-      // Clear abort controller reference
-      if (conversationLoadAbortControllerRef.current === abortController) {
-        conversationLoadAbortControllerRef.current = null;
-      }
-    }
-  }, [chatService, eventHandler, confirmationService, toasts, stopStreaming]);
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [chatService, eventHandler, confirmationService, toasts, stopStreaming]
+    );
 
-  const windowInstance = useMemo<ChatWindowInstance>(() => ({
-    startNewChat: () => handleNewChat(),
-    sendMessage: async ({content, messages}) => (await handleSendRef.current?.({input:content, messages}))
-  }), [handleNewChat]);
+    const windowInstance = useMemo<ChatWindowInstance>(
+      () => ({
+        startNewChat: () => handleNewChat(),
+        sendMessage: async ({ content, messages }) =>
+          await handleSendRef.current?.({ input: content, messages }),
+      }),
+      [handleNewChat]
+    );
 
-  // Expose instance methods via ref
-  useImperativeHandle(ref, () => windowInstance, [windowInstance]);
+    // Expose instance methods via ref
+    useImperativeHandle(ref, () => windowInstance, [windowInstance]);
 
-  // Register with chatService and clean up on unmount
-  useEffect(() => {
-    chatService.setChatWindowInstance(windowInstance);
+    // Register with chatService and clean up on unmount
+    useEffect(() => {
+      chatService.setChatWindowInstance(windowInstance);
 
-    return () => {
-      chatService.clearChatWindowInstance();
-    };
-  }, [chatService, windowInstance]);
+      return () => {
+        chatService.clearChatWindowInstance();
+      };
+    }, [chatService, windowInstance]);
 
-  return (
-    <ChatContainer layoutMode={layoutMode}>
-      <ChatHeader
-        conversationName={conversationName}
-        isStreaming={isStreaming}
-        onNewChat={handleNewChat}
-        onClose={onClose}
-        onShowHistory={showHistory ? undefined : handleShowHistory}
-        showBackButton={showHistory}
-        onBack={showHistory ? handleCloseHistory : undefined}
-        title={showHistory ? 'All conversations' : undefined}
-      />
-
-      {isLoading ? (
-        <div className="chatWindow__loadingContainer">
-          <EuiLoadingSpinner size="xl" />
-          <EuiText color="subdued">
-            {i18n.translate('chat.window.loadingMessage', {
-              defaultMessage: 'Loading conversation...',
-            })}
-          </EuiText>
-        </div>
-      ) : showHistory ? (
-        <ConversationHistoryPanel
-          conversationHistoryService={chatService.conversationHistoryService}
-          onSelectConversation={handleSelectConversation}
+    return (
+      <ChatContainer layoutMode={layoutMode}>
+        <ChatHeader
+          conversationName={conversationName}
+          isStreaming={isStreaming}
+          onNewChat={handleNewChat}
+          onClose={onClose}
+          onShowHistory={showHistory ? undefined : handleShowHistory}
+          showBackButton={showHistory}
+          onBack={showHistory ? handleCloseHistory : undefined}
+          title={showHistory ? 'All conversations' : undefined}
         />
-      ) : (
-        <ChatSessionErrorBoundary onStartNewSession={handleNewChat}>
-          <ChatMessages
-            layoutMode={layoutMode}
-            timeline={timeline}
-            isStreaming={isStreaming}
-            onResendMessage={resendAvailable ? handleResendMessage : undefined}
-            onResendToolResult={sendToolResult}
-            onApproveConfirmation={handleApproveConfirmation}
-            onRejectConfirmation={handleRejectConfirmation}
-            onFillInput={setInput}
-            threadId={chatService.getThreadId()}
-            onShowHistory={handleShowHistory}
+
+        {isLoading ? (
+          <div className="chatWindow__loadingContainer">
+            <EuiLoadingSpinner size="xl" />
+            <EuiText color="subdued">
+              {i18n.translate('chat.window.loadingMessage', {
+                defaultMessage: 'Loading conversation...',
+              })}
+            </EuiText>
+          </div>
+        ) : showHistory ? (
+          <ConversationHistoryPanel
             conversationHistoryService={chatService.conversationHistoryService}
             onSelectConversation={handleSelectConversation}
-            {...enhancedProps}
-            startResponse={startResponse}
           />
+        ) : (
+          <ChatSessionErrorBoundary onStartNewSession={handleNewChat}>
+            <ChatMessages
+              layoutMode={layoutMode}
+              timeline={timeline}
+              isStreaming={isStreaming}
+              onResendMessage={resendAvailable ? handleResendMessage : undefined}
+              onResendToolResult={sendToolResult}
+              onApproveConfirmation={handleApproveConfirmation}
+              onRejectConfirmation={handleRejectConfirmation}
+              onFillInput={setInput}
+              threadId={chatService.getThreadId()}
+              onShowHistory={handleShowHistory}
+              conversationHistoryService={chatService.conversationHistoryService}
+              onSelectConversation={handleSelectConversation}
+              {...enhancedProps}
+              startResponse={startResponse}
+            />
 
-          {
-            (isCapturing || screenshotData) && (
-              <div className={`chatWindow__screenshotRow ${!screenshotData && isCapturing ? 'capturing' : ''}`}>
-                {
-                  screenshotData && (
-                    <>
-                      <img src={`data:${screenshotData.mimeType || 'image/jpeg'};base64,${screenshotData.base64}`} alt={`Screenshot of ${screenshotData.pageTitle}`} />
-                      <div className='chatWindow__screenshotRow__right'>
-                        <div className='chatWindow__screenshotRow__right__pageTitle'>
-                          <EuiText size='xs'>{screenshotData.pageTitle}</EuiText>
-                        </div>
-                        <div className='chatWindow__screenshotRow__right__timeAndButtons'>
-                          <div />
-                          <div>
-                            <EuiButtonIcon disabled={isStreaming} color='text' onClick={handleCaptureScreenshot} iconType="refresh" size='xs' aria-label='Recapture' />
-                            <EuiButtonIcon disabled={isStreaming} color='text' onClick={()=>{setScreenshotData(undefined)}} iconType="cross" size='xs' aria-label='Remove screenshot' />
-                          </div>
+            {(isCapturing || screenshotData) && (
+              <div
+                className={`chatWindow__screenshotRow ${
+                  !screenshotData && isCapturing ? 'capturing' : ''
+                }`}
+              >
+                {screenshotData && (
+                  <>
+                    <img
+                      src={`data:${screenshotData.mimeType || 'image/jpeg'};base64,${
+                        screenshotData.base64
+                      }`}
+                      alt={`Screenshot of ${screenshotData.pageTitle}`}
+                    />
+                    <div className="chatWindow__screenshotRow__right">
+                      <div className="chatWindow__screenshotRow__right__pageTitle">
+                        <EuiText size="xs">{screenshotData.pageTitle}</EuiText>
+                      </div>
+                      <div className="chatWindow__screenshotRow__right__timeAndButtons">
+                        <div />
+                        <div>
+                          <EuiButtonIcon
+                            disabled={isStreaming}
+                            color="text"
+                            onClick={handleCaptureScreenshot}
+                            iconType="refresh"
+                            size="xs"
+                            aria-label="Recapture"
+                          />
+                          <EuiButtonIcon
+                            disabled={isStreaming}
+                            color="text"
+                            onClick={() => {
+                              setScreenshotData(undefined);
+                            }}
+                            iconType="cross"
+                            size="xs"
+                            aria-label="Remove screenshot"
+                          />
                         </div>
                       </div>
-                    </>
-                  )
-                }
-                {
-                  isCapturing && !screenshotData && (
-                    <EuiLoadingSpinner size='m' />
-                  )
-                }
+                    </div>
+                  </>
+                )}
+                {isCapturing && !screenshotData && <EuiLoadingSpinner size="m" />}
               </div>
-            )
-          }
+            )}
 
-          <ChatInput
-            layoutMode={layoutMode}
-            input={input}
-            isCapturing={isCapturing}
-            isStreaming={isStreaming}
-            disabled={hasActiveToolCalls || hasPendingResend || !!pendingConfirmation}
-            placeholder={
-              pendingConfirmation
-                ? i18n.translate('chat.input.waitingForConfirmation', {
-                    defaultMessage: 'Waiting for confirmation...',
-                  })
-                : hasPendingResend
-                ? i18n.translate('chat.input.pendingResend', {
-                    defaultMessage: 'Resend the tool result to continue...',
-                  })
-                : hasActiveToolCalls
-                ? i18n.translate('chat.input.waitingForToolExecution', {
-                    defaultMessage: 'Waiting for tool execution...',
-                  })
-                : undefined
-            }
-            onInputChange={setInput}
-            onSend={handleSend}
-            onStop={handleStop}
-            onKeyDown={handleKeyDown}
-            includeScreenShotEnabled={screenshotFeatureEnabled}
-            onCaptureScreenshot={handleCaptureScreenshot}
-          />
-        </ChatSessionErrorBoundary>
-      )}
-    </ChatContainer>
-  );
-});
+            <ChatInput
+              layoutMode={layoutMode}
+              input={input}
+              isCapturing={isCapturing}
+              isStreaming={isStreaming}
+              disabled={hasActiveToolCalls || hasPendingResend || !!pendingConfirmation}
+              placeholder={
+                pendingConfirmation
+                  ? i18n.translate('chat.input.waitingForConfirmation', {
+                      defaultMessage: 'Waiting for confirmation...',
+                    })
+                  : hasPendingResend
+                  ? i18n.translate('chat.input.pendingResend', {
+                      defaultMessage: 'Resend the tool result to continue...',
+                    })
+                  : hasActiveToolCalls
+                  ? i18n.translate('chat.input.waitingForToolExecution', {
+                      defaultMessage: 'Waiting for tool execution...',
+                    })
+                  : undefined
+              }
+              onInputChange={setInput}
+              onSend={handleSend}
+              onStop={handleStop}
+              onKeyDown={handleKeyDown}
+              includeScreenShotEnabled={screenshotFeatureEnabled}
+              onCaptureScreenshot={handleCaptureScreenshot}
+            />
+          </ChatSessionErrorBoundary>
+        )}
+      </ChatContainer>
+    );
+  }
+);

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -18,11 +18,7 @@ import { EuiButton, EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/e
 import { useChatContext } from '../contexts/chat_context';
 import { AssistantActionService } from '../../../context_provider/public';
 import { ConfirmationRequest } from '../services/confirmation_service';
-import type {
-  Message,
-  SystemMessage,
-  UserMessage,
-} from '../../common/types';
+import type { Message, SystemMessage, UserMessage } from '../../common/types';
 import { ChatLayoutMode } from '../types';
 import { ChatContainer } from './chat_container';
 import { ChatHeader } from './chat_header';

--- a/src/plugins/chat/public/hooks/use_chat_streaming.ts
+++ b/src/plugins/chat/public/hooks/use_chat_streaming.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { AssistantActionService } from '../../../context_provider/public';
+import { ChatEventHandler } from '../services/chat_event_handler';
+import { ChatService } from '../services/chat_service';
+import { ConfirmationService } from '../services/confirmation_service';
+import type { PluginTelemetryRecorder } from '../../../../core/public';
+import type { Event as ChatEvent } from '../../common/events';
+import type { Message, UserMessage } from '../../common/types';
+
+interface UseChatStreamingOptions {
+  chatService: ChatService;
+  confirmationService: ConfirmationService;
+  telemetryRecorder?: PluginTelemetryRecorder;
+  onMessageSent?: () => void;
+}
+
+export const useChatStreaming = ({
+  chatService,
+  confirmationService,
+  telemetryRecorder,
+  onMessageSent,
+}: UseChatStreamingOptions) => {
+  const service = AssistantActionService.getInstance();
+
+  const [timeline, setTimeline] = useState<Message[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [startResponse, setStartResponse] = useState(false);
+  const [isSendingToolResult, setIsSendingToolResult] = useState(false);
+  const [currentRunId, setCurrentRunId] = useState<string | null>(null);
+
+  // Use ref to track streaming state synchronously for React 18 compatibility
+  const isStreamingRef = useRef(false);
+  const isSendingToolResultRef = useRef(false);
+  const timelineRef = useRef<Message[]>(timeline);
+  const currentSubscriptionRef = useRef<any>(null);
+
+  isSendingToolResultRef.current = isSendingToolResult;
+
+  useEffect(() => {
+    timelineRef.current = timeline;
+  }, [timeline]);
+
+  // Create the event handler
+  const eventHandler = useMemo(
+    () =>
+      new ChatEventHandler({
+        assistantActionService: service,
+        chatService,
+        confirmationService,
+        telemetryRecorder,
+        callbacks: {
+          onTimelineUpdate: setTimeline,
+          onStreamingStateChange: setIsStreaming,
+          onStartResponse: setStartResponse,
+          onSendToolResultStateChange: setIsSendingToolResult,
+          getTimeline: () => timelineRef.current,
+        },
+      }),
+    [service, chatService, confirmationService, telemetryRecorder]
+  );
+
+  // Clean up event handler on unmount
+  useEffect(() => {
+    return () => {
+      eventHandler.clearState();
+    };
+  }, [eventHandler]);
+
+  // Subscribe to message stream and handle events
+  const subscribeToMessageStream = useCallback(
+    async (messageContent: string, messages: Message[], rawMessage?: string) => {
+      isStreamingRef.current = true;
+      setIsStreaming(true);
+      setStartResponse(false);
+
+      try {
+        const { observable, userMessage } = await chatService.sendMessage(messageContent, messages);
+
+        const timelineUserMessage: UserMessage = {
+          id: userMessage.id,
+          role: 'user',
+          content: userMessage.content,
+          rawMessage: Array.isArray(userMessage.content)
+            ? undefined
+            : rawMessage || messageContent,
+        };
+
+        setTimeline((prev) => [...prev, timelineUserMessage]);
+
+        onMessageSent?.();
+
+        const subscription = observable.subscribe({
+          next: async (event: ChatEvent) => {
+            if ('runId' in event && event.runId && event.runId !== currentRunId) {
+              setCurrentRunId(event.runId);
+            }
+            await eventHandler.handleEvent(event);
+          },
+          error: (error: any) => {
+            // eslint-disable-next-line no-console
+            console.error('Subscription error:', error);
+            isStreamingRef.current = false;
+            setStartResponse(false);
+            setIsStreaming(false);
+            currentSubscriptionRef.current = null;
+          },
+          complete: () => {
+            isStreamingRef.current = false;
+            setStartResponse(false);
+            setIsStreaming(false);
+            currentSubscriptionRef.current = null;
+          },
+        });
+
+        currentSubscriptionRef.current = subscription;
+        return () => subscription.unsubscribe();
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to send message:', error);
+        isStreamingRef.current = false;
+        setIsStreaming(false);
+        currentSubscriptionRef.current = null;
+      }
+    },
+    [chatService, currentRunId, eventHandler, onMessageSent]
+  );
+
+  // Stop streaming and clean up
+  const stopStreaming = useCallback(() => {
+    chatService.abort();
+    if (currentSubscriptionRef.current) {
+      currentSubscriptionRef.current.unsubscribe();
+      currentSubscriptionRef.current = null;
+    }
+    eventHandler.cancelToolResultDispatch();
+    isStreamingRef.current = false;
+    setIsStreaming(false);
+    setStartResponse(false);
+  }, [chatService, eventHandler]);
+
+  return {
+    timeline,
+    setTimeline,
+    isStreaming,
+    isStreamingRef,
+    isSendingToolResult,
+    isSendingToolResultRef,
+    startResponse,
+    currentRunId,
+    setCurrentRunId,
+    eventHandler,
+    subscribeToMessageStream,
+    stopStreaming,
+  };
+};

--- a/src/plugins/chat/public/hooks/use_chat_streaming.ts
+++ b/src/plugins/chat/public/hooks/use_chat_streaming.ts
@@ -39,6 +39,10 @@ export const useChatStreaming = ({
 
   // Use ref to track streaming state synchronously for React 18 compatibility
   const isStreamingRef = useRef(false);
+
+  useEffect(() => {
+    isStreamingRef.current = isStreaming;
+  }, [isStreaming]);
   const isSendingToolResultRef = useRef(false);
   const timelineRef = useRef<Message[]>(timeline);
   const currentSubscriptionRef = useRef<any>(null);
@@ -126,7 +130,6 @@ export const useChatStreaming = ({
   // Subscribe to message stream and handle events
   const subscribeToMessageStream = useCallback(
     async (messageContent: string, messages: Message[], rawMessage?: string) => {
-      isStreamingRef.current = true;
       setIsMainStreaming(true);
       setMainStartResponse(false);
 
@@ -137,9 +140,7 @@ export const useChatStreaming = ({
           id: userMessage.id,
           role: 'user',
           content: userMessage.content,
-          rawMessage: Array.isArray(userMessage.content)
-            ? undefined
-            : rawMessage || messageContent,
+          rawMessage: Array.isArray(userMessage.content) ? undefined : rawMessage || messageContent,
         };
 
         setTimeline((prev) => [...prev, timelineUserMessage]);
@@ -147,7 +148,6 @@ export const useChatStreaming = ({
         onMessageSent?.();
 
         const onStreamEnd = () => {
-          isStreamingRef.current = false;
           setIsMainStreaming(false);
           setMainStartResponse(false);
           currentSubscriptionRef.current = null;
@@ -173,7 +173,6 @@ export const useChatStreaming = ({
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Failed to send message:', error);
-        isStreamingRef.current = false;
         setIsMainStreaming(false);
         currentSubscriptionRef.current = null;
       }
@@ -185,6 +184,7 @@ export const useChatStreaming = ({
   const stopStreaming = useCallback(() => {
     chatService.abort();
     chatService.resetConnection();
+    eventHandler.cancelToolResultDispatch();
     if (currentSubscriptionRef.current) {
       currentSubscriptionRef.current.unsubscribe();
       currentSubscriptionRef.current = null;
@@ -193,18 +193,28 @@ export const useChatStreaming = ({
       toolResultSubscriptionRef.current.unsubscribe();
       toolResultSubscriptionRef.current = null;
     }
-    eventHandler.cancelToolResultDispatch();
-    isStreamingRef.current = false;
     setIsMainStreaming(false);
     setIsToolResultStreaming(false);
+    // Synchronously reset ref so that handleSend called immediately after
+    // stopStreaming (e.g. from nav search "start new chat + send") isn't blocked.
+    // The useEffect will also sync it, but that's async (React 18 batching).
+    isStreamingRef.current = false;
     setMainStartResponse(false);
     setToolResultStartResponse(false);
   }, [chatService, eventHandler]);
 
   // Resend a tool result to the assistant
   const sendToolResult = useCallback(
-    async ({ messageId, toolCallId, toolResult }: { messageId: string; toolCallId: string; toolResult: any }) => {
-      if (isStreamingRef.current || isSendingToolResultRef.current) return;
+    async ({
+      messageId,
+      toolCallId,
+      toolResult,
+    }: {
+      messageId: string;
+      toolCallId: string;
+      toolResult: any;
+    }) => {
+      if (isStreamingRef.current) return;
       setTimeline((prev) => prev.filter((msg) => msg.id !== messageId));
       await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
     },

--- a/src/plugins/chat/public/hooks/use_chat_streaming.ts
+++ b/src/plugins/chat/public/hooks/use_chat_streaming.ts
@@ -28,8 +28,12 @@ export const useChatStreaming = ({
   const service = AssistantActionService.getInstance();
 
   const [timeline, setTimeline] = useState<Message[]>([]);
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [startResponse, setStartResponse] = useState(false);
+  const [isMainStreaming, setIsMainStreaming] = useState(false);
+  const [isToolResultStreaming, setIsToolResultStreaming] = useState(false);
+  const isStreaming = isMainStreaming || isToolResultStreaming;
+  const [mainStartResponse, setMainStartResponse] = useState(false);
+  const [toolResultStartResponse, setToolResultStartResponse] = useState(false);
+  const startResponse = mainStartResponse || toolResultStartResponse;
   const [isSendingToolResult, setIsSendingToolResult] = useState(false);
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
 
@@ -38,12 +42,52 @@ export const useChatStreaming = ({
   const isSendingToolResultRef = useRef(false);
   const timelineRef = useRef<Message[]>(timeline);
   const currentSubscriptionRef = useRef<any>(null);
+  const toolResultSubscriptionRef = useRef<any>(null);
 
   isSendingToolResultRef.current = isSendingToolResult;
 
   useEffect(() => {
     timelineRef.current = timeline;
   }, [timeline]);
+
+  // Handle tool result stream subscription (called by ChatEventHandler)
+  const toolResultRunIdRef = useRef<string | null>(null);
+  const handleToolResultStream = useCallback(
+    (observable: any, abortController: AbortController) => {
+      setIsToolResultStreaming(true);
+
+      const subscription = observable.subscribe({
+        next: (event: ChatEvent) => {
+          // Capture the tool result stream's runId
+          if ('runId' in event && event.runId) {
+            toolResultRunIdRef.current = event.runId;
+          }
+          eventHandlerRef.current?.handleEvent(event);
+        },
+        error: (error: Error) => {
+          if (error?.name !== 'AbortError') {
+            // eslint-disable-next-line no-console
+            console.error('Tool result response error:', error);
+          }
+        },
+      });
+      subscription.add(() => {
+        setIsToolResultStreaming(false);
+        setToolResultStartResponse(false);
+        toolResultRunIdRef.current = null;
+        toolResultSubscriptionRef.current = null;
+        if (abortController) {
+          eventHandlerRef.current?.releaseToolResultController(abortController);
+        }
+      });
+
+      toolResultSubscriptionRef.current = subscription;
+    },
+    []
+  );
+
+  // Ref to access eventHandler inside handleToolResultStream without circular dep
+  const eventHandlerRef = useRef<ChatEventHandler | null>(null);
 
   // Create the event handler
   const eventHandler = useMemo(
@@ -55,14 +99,22 @@ export const useChatStreaming = ({
         telemetryRecorder,
         callbacks: {
           onTimelineUpdate: setTimeline,
-          onStreamingStateChange: setIsStreaming,
-          onStartResponse: setStartResponse,
+          onStartResponse: (runId?: string) => {
+            if (runId && runId === toolResultRunIdRef.current) {
+              setToolResultStartResponse(true);
+            } else {
+              setMainStartResponse(true);
+            }
+          },
           onSendToolResultStateChange: setIsSendingToolResult,
+          onSubscribeToToolResultStream: handleToolResultStream,
           getTimeline: () => timelineRef.current,
         },
       }),
-    [service, chatService, confirmationService, telemetryRecorder]
+    [service, chatService, confirmationService, telemetryRecorder, handleToolResultStream]
   );
+
+  eventHandlerRef.current = eventHandler;
 
   // Clean up event handler on unmount
   useEffect(() => {
@@ -75,8 +127,8 @@ export const useChatStreaming = ({
   const subscribeToMessageStream = useCallback(
     async (messageContent: string, messages: Message[], rawMessage?: string) => {
       isStreamingRef.current = true;
-      setIsStreaming(true);
-      setStartResponse(false);
+      setIsMainStreaming(true);
+      setMainStartResponse(false);
 
       try {
         const { observable, userMessage } = await chatService.sendMessage(messageContent, messages);
@@ -94,6 +146,13 @@ export const useChatStreaming = ({
 
         onMessageSent?.();
 
+        const onStreamEnd = () => {
+          isStreamingRef.current = false;
+          setIsMainStreaming(false);
+          setMainStartResponse(false);
+          currentSubscriptionRef.current = null;
+        };
+
         const subscription = observable.subscribe({
           next: async (event: ChatEvent) => {
             if ('runId' in event && event.runId && event.runId !== currentRunId) {
@@ -104,17 +163,9 @@ export const useChatStreaming = ({
           error: (error: any) => {
             // eslint-disable-next-line no-console
             console.error('Subscription error:', error);
-            isStreamingRef.current = false;
-            setStartResponse(false);
-            setIsStreaming(false);
-            currentSubscriptionRef.current = null;
+            onStreamEnd();
           },
-          complete: () => {
-            isStreamingRef.current = false;
-            setStartResponse(false);
-            setIsStreaming(false);
-            currentSubscriptionRef.current = null;
-          },
+          complete: onStreamEnd,
         });
 
         currentSubscriptionRef.current = subscription;
@@ -123,7 +174,7 @@ export const useChatStreaming = ({
         // eslint-disable-next-line no-console
         console.error('Failed to send message:', error);
         isStreamingRef.current = false;
-        setIsStreaming(false);
+        setIsMainStreaming(false);
         currentSubscriptionRef.current = null;
       }
     },
@@ -133,15 +184,32 @@ export const useChatStreaming = ({
   // Stop streaming and clean up
   const stopStreaming = useCallback(() => {
     chatService.abort();
+    chatService.resetConnection();
     if (currentSubscriptionRef.current) {
       currentSubscriptionRef.current.unsubscribe();
       currentSubscriptionRef.current = null;
     }
+    if (toolResultSubscriptionRef.current) {
+      toolResultSubscriptionRef.current.unsubscribe();
+      toolResultSubscriptionRef.current = null;
+    }
     eventHandler.cancelToolResultDispatch();
     isStreamingRef.current = false;
-    setIsStreaming(false);
-    setStartResponse(false);
+    setIsMainStreaming(false);
+    setIsToolResultStreaming(false);
+    setMainStartResponse(false);
+    setToolResultStartResponse(false);
   }, [chatService, eventHandler]);
+
+  // Resend a tool result to the assistant
+  const sendToolResult = useCallback(
+    async ({ messageId, toolCallId, toolResult }: { messageId: string; toolCallId: string; toolResult: any }) => {
+      if (isStreamingRef.current || isSendingToolResultRef.current) return;
+      setTimeline((prev) => prev.filter((msg) => msg.id !== messageId));
+      await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
+    },
+    [eventHandler]
+  );
 
   return {
     timeline,
@@ -156,5 +224,6 @@ export const useChatStreaming = ({
     eventHandler,
     subscribeToMessageStream,
     stopStreaming,
+    sendToolResult,
   };
 };

--- a/src/plugins/chat/public/hooks/use_chat_streaming.ts
+++ b/src/plugins/chat/public/hooks/use_chat_streaming.ts
@@ -130,6 +130,7 @@ export const useChatStreaming = ({
   // Subscribe to message stream and handle events
   const subscribeToMessageStream = useCallback(
     async (messageContent: string, messages: Message[], rawMessage?: string) => {
+      isStreamingRef.current = true;
       setIsMainStreaming(true);
       setMainStartResponse(false);
 
@@ -173,6 +174,7 @@ export const useChatStreaming = ({
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Failed to send message:', error);
+        isStreamingRef.current = false;
         setIsMainStreaming(false);
         currentSubscriptionRef.current = null;
       }
@@ -184,7 +186,7 @@ export const useChatStreaming = ({
   const stopStreaming = useCallback(() => {
     chatService.abort();
     chatService.resetConnection();
-    eventHandler.cancelToolResultDispatch();
+    eventHandler.clearState();
     if (currentSubscriptionRef.current) {
       currentSubscriptionRef.current.unsubscribe();
       currentSubscriptionRef.current = null;
@@ -199,6 +201,7 @@ export const useChatStreaming = ({
     // stopStreaming (e.g. from nav search "start new chat + send") isn't blocked.
     // The useEffect will also sync it, but that's async (React 18 batching).
     isStreamingRef.current = false;
+    setCurrentRunId(null);
     setMainStartResponse(false);
     setToolResultStartResponse(false);
   }, [chatService, eventHandler]);

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -477,7 +477,6 @@ describe('ChatEventHandler', () => {
         threadId: 'test-thread',
         runId: 'test-run',
       });
-
     });
 
     it('should handle run finished', async () => {
@@ -486,7 +485,6 @@ describe('ChatEventHandler', () => {
         threadId: 'test-thread',
         runId: 'test-run',
       });
-
     });
 
     it('should handle run error', async () => {
@@ -494,7 +492,6 @@ describe('ChatEventHandler', () => {
         type: EventType.RUN_ERROR,
         message: 'Something went wrong',
       });
-
 
       const errorMessage = timeline.find((msg) => msg.role === 'system');
       expect(errorMessage).toBeDefined();
@@ -843,7 +840,6 @@ describe('ChatEventHandler', () => {
       // Verify onSubscribeToToolResultStream was called with the observable and an AbortController
       expect(mockOnSubscribe).toHaveBeenCalledWith(mockObservable, expect.any(AbortController));
     });
-
   });
 
   describe('handleMessagesSnapshot', () => {
@@ -872,7 +868,6 @@ describe('ChatEventHandler', () => {
         messages,
         timestamp: Date.now(),
       });
-
     });
 
     it('should handle empty messages array', async () => {
@@ -1090,7 +1085,7 @@ describe('ChatEventHandler', () => {
       expect(sendToolResultCalled).toBe(true);
     });
 
-    it('should call onSendToolResultStateChange(false) after sending tool result succeeds', async () => {
+    it('should not call onSendToolResultStateChange(false) immediately on success (stream still active)', async () => {
       const toolCallId = 'tool-123';
       const mockResult = { success: true, data: 'test result' };
 
@@ -1130,15 +1125,10 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
-      // Verify the callback sequence: true before, false after
+      // true is called at the start
       expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(true);
-      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
-
-      // Verify the order: true was called before false
-      const calls = mockOnSendToolResultStateChange.mock.calls;
-      const trueCallIndex = calls.findIndex((call: any) => call[0] === true);
-      const falseCallIndex = calls.findIndex((call: any) => call[0] === false);
-      expect(trueCallIndex).toBeLessThan(falseCallIndex);
+      // false is NOT called immediately — stream is still active (hook handles it)
+      expect(mockOnSendToolResultStateChange).not.toHaveBeenCalledWith(false);
     });
 
     it('should call onSendToolResultStateChange(false) when sendToolResult fails', async () => {
@@ -1589,7 +1579,6 @@ describe('ChatEventHandler', () => {
         skipped: { reason: 'result_already_exists' },
       });
 
-
       await chatEventHandler.handleEvent({
         type: EventType.TOOL_CALL_START,
         toolCallId,
@@ -1674,7 +1663,9 @@ describe('ChatEventHandler', () => {
         toolCallId,
       };
 
-      const observable = { subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }) };
+      const observable = {
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+      };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
         observable,
@@ -2027,8 +2018,8 @@ describe('ChatEventHandler', () => {
       // The first send's finally block should NOT have emitted (false) because
       // the controller was already replaced by the second send.
       const falseCalls = mockOnSendToolResultStateChange.mock.calls.filter((c) => c[0] === false);
-      // Only the second send should have emitted (false) — exactly once.
-      expect(falseCalls.length).toBe(1);
+      // Neither send emits (false): first is superseded, second delegates to stream hook
+      expect(falseCalls.length).toBe(0);
     });
 
     it('should append a non-resendable system message when sendToolResult returns skipped reason no_thread_id', async () => {

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -46,7 +46,6 @@ const mockConfirmationService = {
 describe('ChatEventHandler', () => {
   let chatEventHandler: ChatEventHandler;
   let mockOnTimelineUpdate: jest.Mock;
-  let mockOnStreamingStateChange: jest.Mock;
   let mockOnStartResponse: jest.Mock;
   let mockGetTimeline: jest.Mock;
   let timeline: Message[];
@@ -64,7 +63,6 @@ describe('ChatEventHandler', () => {
     mockOnTimelineUpdate = jest.fn((updater) => {
       timeline = updater(timeline);
     });
-    mockOnStreamingStateChange = jest.fn();
     mockOnStartResponse = jest.fn();
     mockGetTimeline = jest.fn(() => timeline);
 
@@ -75,9 +73,9 @@ describe('ChatEventHandler', () => {
       confirmationService: mockConfirmationService,
       callbacks: {
         onTimelineUpdate: mockOnTimelineUpdate,
-        onStreamingStateChange: mockOnStreamingStateChange,
         onStartResponse: mockOnStartResponse,
         getTimeline: mockGetTimeline,
+        onSubscribeToToolResultStream: jest.fn(),
       },
     });
   });
@@ -102,8 +100,6 @@ describe('ChatEventHandler', () => {
       }
 
       // Verify streaming state changes
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(true); // RUN_STARTED
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false); // RUN_FINISHED and RUN_ERROR
     });
   });
 
@@ -482,7 +478,6 @@ describe('ChatEventHandler', () => {
         runId: 'test-run',
       });
 
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(true);
     });
 
     it('should handle run finished', async () => {
@@ -492,7 +487,6 @@ describe('ChatEventHandler', () => {
         runId: 'test-run',
       });
 
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false);
     });
 
     it('should handle run error', async () => {
@@ -501,7 +495,6 @@ describe('ChatEventHandler', () => {
         message: 'Something went wrong',
       });
 
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false);
 
       const errorMessage = timeline.find((msg) => msg.role === 'system');
       expect(errorMessage).toBeDefined();
@@ -775,7 +768,7 @@ describe('ChatEventHandler', () => {
       } as TextMessageStartEvent);
 
       // Verify onStartResponse was called with true
-      expect(mockOnStartResponse).toHaveBeenCalledWith(true);
+      expect(mockOnStartResponse).toHaveBeenCalledWith(undefined);
     });
 
     it('should call onStartResponse(true) when TOOL_CALL_START event is handled', async () => {
@@ -788,16 +781,15 @@ describe('ChatEventHandler', () => {
       } as ToolCallStartEvent);
 
       // Verify onStartResponse was called with true
-      expect(mockOnStartResponse).toHaveBeenCalledWith(true);
+      expect(mockOnStartResponse).toHaveBeenCalledWith(undefined);
     });
 
-    it('should call onStartResponse(false) when tool result response completes', async () => {
+    it('should call onSubscribeToToolResultStream when tool result response is ready', async () => {
       const toolCallId = 'tool-123';
       const mockResult = { success: true, data: 'test result' };
 
       mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
 
-      // Mock sendToolResult to return observable that completes
       const mockToolMessage: ToolMessage = {
         id: `tool-result-${toolCallId}`,
         role: 'tool',
@@ -805,16 +797,11 @@ describe('ChatEventHandler', () => {
         toolCallId,
       };
 
-      const teardowns: Array<() => void> = [];
       const mockObservable = {
-        subscribe: jest.fn(() => {
-          return {
-            unsubscribe: jest.fn(),
-            add: jest.fn((fn: () => void) => {
-              teardowns.push(fn);
-            }),
-          };
-        }),
+        subscribe: jest.fn(() => ({
+          unsubscribe: jest.fn(),
+          add: jest.fn(),
+        })),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -822,95 +809,41 @@ describe('ChatEventHandler', () => {
         toolMessage: mockToolMessage,
       });
 
-      // Trigger tool call flow
-      await chatEventHandler.handleEvent({
-        type: EventType.TOOL_CALL_START,
-        toolCallId,
-        toolCallName: 'test_action',
-      } as ToolCallStartEvent);
-
-      await chatEventHandler.handleEvent({
-        type: EventType.TOOL_CALL_ARGS,
-        toolCallId,
-        delta: '{}',
-      } as ToolCallArgsEvent);
-
-      await chatEventHandler.handleEvent({
-        type: EventType.TOOL_CALL_END,
-        toolCallId,
-      } as ToolCallEndEvent);
-
-      // Clear previous calls to focus on the teardown
-      mockOnStartResponse.mockClear();
-
-      // Trigger teardown (simulates subscription completing in RxJS)
-      teardowns.forEach((fn) => fn());
-
-      // Verify onStartResponse was called with false on completion
-      expect(mockOnStartResponse).toHaveBeenCalledWith(false);
-    });
-
-    it('should call onStartResponse(false) when tool result response errors', async () => {
-      const toolCallId = 'tool-123';
-      const mockResult = { success: true, data: 'test result' };
-
-      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
-
-      // Mock sendToolResult to return observable that errors
-      const mockToolMessage: ToolMessage = {
-        id: `tool-result-${toolCallId}`,
-        role: 'tool',
-        content: JSON.stringify(mockResult),
-        toolCallId,
-      };
-
-      let errorCallback: any;
-      const teardowns: Array<() => void> = [];
-      const mockObservable = {
-        subscribe: jest.fn((callbacks) => {
-          errorCallback = callbacks.error;
-          return {
-            unsubscribe: jest.fn(),
-            add: jest.fn((fn: () => void) => {
-              teardowns.push(fn);
-            }),
-          };
-        }),
-      };
-
-      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
-        observable: mockObservable,
-        toolMessage: mockToolMessage,
+      const mockOnSubscribe = jest.fn();
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2322 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSubscribeToToolResultStream: mockOnSubscribe,
+          getTimeline: mockGetTimeline,
+        },
       });
 
-      // Trigger tool call flow
-      await chatEventHandler.handleEvent({
+      await handler.handleEvent({
         type: EventType.TOOL_CALL_START,
         toolCallId,
         toolCallName: 'test_action',
       } as ToolCallStartEvent);
 
-      await chatEventHandler.handleEvent({
+      await handler.handleEvent({
         type: EventType.TOOL_CALL_ARGS,
         toolCallId,
         delta: '{}',
       } as ToolCallArgsEvent);
 
-      await chatEventHandler.handleEvent({
+      await handler.handleEvent({
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
 
-      // Clear previous calls to focus on the error callback
-      mockOnStartResponse.mockClear();
-
-      // Trigger error and teardown (simulates RxJS behavior)
-      errorCallback(new Error('Test error'));
-      teardowns.forEach((fn) => fn());
-
-      // Verify onStartResponse was called with false on error
-      expect(mockOnStartResponse).toHaveBeenCalledWith(false);
+      // Verify onSubscribeToToolResultStream was called with the observable and an AbortController
+      expect(mockOnSubscribe).toHaveBeenCalledWith(mockObservable, expect.any(AbortController));
     });
+
   });
 
   describe('handleMessagesSnapshot', () => {
@@ -940,7 +873,6 @@ describe('ChatEventHandler', () => {
         timestamp: Date.now(),
       });
 
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false);
     });
 
     it('should handle empty messages array', async () => {
@@ -951,7 +883,6 @@ describe('ChatEventHandler', () => {
       });
 
       expect(timeline).toEqual([]);
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false);
     });
 
     it('should handle messages with tool calls', async () => {
@@ -1087,14 +1018,35 @@ describe('ChatEventHandler', () => {
     });
   });
 
-  describe('cancelToolResultDispatch', () => {
-    it('should stop active tool result streaming and reset state', async () => {
+  describe('onSendToolResultStateChange callback', () => {
+    let mockOnSendToolResultStateChange: jest.Mock;
+    let chatEventHandlerWithCallback: ChatEventHandler;
+
+    beforeEach(() => {
+      mockOnSendToolResultStateChange = jest.fn();
+
+      chatEventHandlerWithCallback = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2322 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+          onSubscribeToToolResultStream: jest.fn(),
+        },
+      });
+    });
+
+    it('should call onSendToolResultStateChange(true) before sending tool result', async () => {
       const toolCallId = 'tool-123';
       const mockResult = { success: true, data: 'test result' };
 
       mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
 
-      // Mock sendToolResult to return observable with unsubscribe
+      // Mock sendToolResult to capture when it's called
       const mockToolMessage: ToolMessage = {
         id: `tool-result-${toolCallId}`,
         role: 'tool',
@@ -1102,18 +1054,57 @@ describe('ChatEventHandler', () => {
         toolCallId,
       };
 
-      const mockUnsubscribe = jest.fn();
-      const teardowns: Array<() => void> = [];
+      let sendToolResultCalled = false;
       const mockObservable = {
-        subscribe: jest.fn().mockReturnValue({
-          unsubscribe: jest.fn(() => {
-            mockUnsubscribe();
-            teardowns.forEach((fn) => fn());
-          }),
-          add: jest.fn((fn: () => void) => {
-            teardowns.push(fn);
-          }),
-        }),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+      };
+
+      mockChatService.sendToolResult = jest.fn().mockImplementation(async () => {
+        // Verify onSendToolResultStateChange(true) was called before sendToolResult
+        expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(true);
+        sendToolResultCalled = true;
+        return {
+          observable: mockObservable,
+          toolMessage: mockToolMessage,
+        };
+      });
+
+      // Trigger tool call flow
+      await chatEventHandlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_action',
+      } as ToolCallStartEvent);
+
+      await chatEventHandlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      expect(sendToolResultCalled).toBe(true);
+    });
+
+    it('should call onSendToolResultStateChange(false) after sending tool result succeeds', async () => {
+      const toolCallId = 'tool-123';
+      const mockResult = { success: true, data: 'test result' };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      const mockToolMessage: ToolMessage = {
+        id: `tool-result-${toolCallId}`,
+        role: 'tool',
+        content: JSON.stringify(mockResult),
+        toolCallId,
+      };
+
+      const mockObservable = {
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
       };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
@@ -1121,40 +1112,193 @@ describe('ChatEventHandler', () => {
         toolMessage: mockToolMessage,
       });
 
-      // Trigger tool call flow to start streaming
-      await chatEventHandler.handleEvent({
+      // Trigger tool call flow
+      await chatEventHandlerWithCallback.handleEvent({
         type: EventType.TOOL_CALL_START,
         toolCallId,
         toolCallName: 'test_action',
       } as ToolCallStartEvent);
 
-      await chatEventHandler.handleEvent({
+      await chatEventHandlerWithCallback.handleEvent({
         type: EventType.TOOL_CALL_ARGS,
         toolCallId,
         delta: '{}',
       } as ToolCallArgsEvent);
 
-      await chatEventHandler.handleEvent({
+      await chatEventHandlerWithCallback.handleEvent({
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
 
-      // Verify streaming was started
-      expect(mockObservable.subscribe).toHaveBeenCalled();
+      // Verify the callback sequence: true before, false after
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(true);
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
 
-      // Clear previous calls
-      mockOnStreamingStateChange.mockClear();
-      mockOnStartResponse.mockClear();
+      // Verify the order: true was called before false
+      const calls = mockOnSendToolResultStateChange.mock.calls;
+      const trueCallIndex = calls.findIndex((call: any) => call[0] === true);
+      const falseCallIndex = calls.findIndex((call: any) => call[0] === false);
+      expect(trueCallIndex).toBeLessThan(falseCallIndex);
+    });
+
+    it('should call onSendToolResultStateChange(false) when sendToolResult fails', async () => {
+      const toolCallId = 'tool-123';
+      const mockResult = { success: true, data: 'test result' };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      // Mock sendToolResult to throw an error
+      mockChatService.sendToolResult = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      // Suppress console.error for this test
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      // Trigger tool call flow
+      await chatEventHandlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_action',
+      } as ToolCallStartEvent);
+
+      await chatEventHandlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await chatEventHandlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      // Verify onSendToolResultStateChange(false) was called even on error
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(true);
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should work without onSendToolResultStateChange callback', async () => {
+      // Use the original chatEventHandler without the callback
+      const toolCallId = 'tool-123';
+      const mockResult = { success: true, data: 'test result' };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      const mockToolMessage: ToolMessage = {
+        id: `tool-result-${toolCallId}`,
+        role: 'tool',
+        content: JSON.stringify(mockResult),
+        toolCallId,
+      };
+
+      const mockObservable = {
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+      };
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: mockObservable,
+        toolMessage: mockToolMessage,
+      });
+
+      // Should not throw when callback is not provided
+      await expect(
+        chatEventHandler.handleEvent({
+          type: EventType.TOOL_CALL_START,
+          toolCallId,
+          toolCallName: 'test_action',
+        } as ToolCallStartEvent)
+      ).resolves.not.toThrow();
+
+      await expect(
+        chatEventHandler.handleEvent({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId,
+          delta: '{}',
+        } as ToolCallArgsEvent)
+      ).resolves.not.toThrow();
+
+      await expect(
+        chatEventHandler.handleEvent({
+          type: EventType.TOOL_CALL_END,
+          toolCallId,
+        } as ToolCallEndEvent)
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('cancelToolResultDispatch', () => {
+    it('should stop active tool result streaming and reset state', async () => {
+      const toolCallId = 'tool-123';
+      const mockResult = { success: true, data: 'test result' };
+
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(mockResult);
+
+      const mockToolMessage: ToolMessage = {
+        id: `tool-result-${toolCallId}`,
+        role: 'tool',
+        content: JSON.stringify(mockResult),
+        toolCallId,
+      };
+
+      const mockObservable = {
+        subscribe: jest.fn(() => ({
+          unsubscribe: jest.fn(),
+          add: jest.fn(),
+        })),
+      };
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: mockObservable,
+        toolMessage: mockToolMessage,
+      });
+
+      let capturedAbortController: AbortController | null = null;
+      const mockOnSubscribe = jest.fn((obs, ac) => {
+        capturedAbortController = ac;
+      });
+
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2322 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSubscribeToToolResultStream: mockOnSubscribe,
+          getTimeline: mockGetTimeline,
+        },
+      });
+
+      // Trigger tool call flow to start streaming
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_action',
+      } as ToolCallStartEvent);
+
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      // Verify onSubscribeToToolResultStream was called
+      expect(mockOnSubscribe).toHaveBeenCalled();
+      expect(capturedAbortController).not.toBeNull();
+      expect(capturedAbortController!.signal.aborted).toBe(false);
 
       // Stop the streaming
-      chatEventHandler.cancelToolResultDispatch();
+      handler.cancelToolResultDispatch();
 
-      // Verify unsubscribe was called
-      expect(mockUnsubscribe).toHaveBeenCalled();
-
-      // Verify state was reset
-      expect(mockOnStreamingStateChange).toHaveBeenCalledWith(false);
-      expect(mockOnStartResponse).toHaveBeenCalledWith(false);
+      // Verify abort controller was aborted
+      expect(capturedAbortController!.signal.aborted).toBe(true);
     });
 
     it('should handle cancelToolResultDispatch when no streaming is active', () => {
@@ -1164,7 +1308,6 @@ describe('ChatEventHandler', () => {
       }).not.toThrow();
 
       // State callbacks should not be called when there's no active streaming
-      expect(mockOnStreamingStateChange).not.toHaveBeenCalled();
       expect(mockOnStartResponse).not.toHaveBeenCalled();
     });
   });
@@ -1192,9 +1335,9 @@ describe('ChatEventHandler', () => {
         telemetryRecorder: mockTelemetryRecorder,
         callbacks: {
           onTimelineUpdate: mockOnTimelineUpdate,
-          onStreamingStateChange: mockOnStreamingStateChange,
           onStartResponse: mockOnStartResponse,
           getTimeline: mockGetTimeline,
+          onSubscribeToToolResultStream: jest.fn(),
         },
       });
     });
@@ -1245,6 +1388,7 @@ describe('ChatEventHandler', () => {
       // Error occurs
       await chatEventHandlerWithTelemetry.handleEvent({
         type: EventType.RUN_ERROR,
+        runId: 'test-run',
         message: 'Something went wrong',
         code: 'ERR_001',
       });
@@ -1344,6 +1488,7 @@ describe('ChatEventHandler', () => {
       // Error occurs
       await chatEventHandlerWithTelemetry.handleEvent({
         type: EventType.RUN_ERROR,
+        runId: 'test-run',
         message: 'Something went wrong',
         code: 'ERR_001',
       });
@@ -1444,7 +1589,6 @@ describe('ChatEventHandler', () => {
         skipped: { reason: 'result_already_exists' },
       });
 
-      mockOnStreamingStateChange.mockClear();
 
       await chatEventHandler.handleEvent({
         type: EventType.TOOL_CALL_START,
@@ -1464,7 +1608,57 @@ describe('ChatEventHandler', () => {
       } as ToolCallEndEvent);
 
       expect(subscribeSpy).not.toHaveBeenCalled();
-      expect(mockOnStreamingStateChange).not.toHaveBeenCalledWith(true);
+    });
+
+    it('should still call onSendToolResultStateChange(true) then (false) when skipped', async () => {
+      const mockOnSendToolResultStateChange = jest.fn();
+      const handlerWithCallback = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2740 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+          onSubscribeToToolResultStream: jest.fn(),
+        },
+      });
+
+      const toolCallId = 'tool-skip-3';
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue({ ok: true });
+
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: { subscribe: jest.fn() },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'result_already_exists' },
+      });
+
+      await handlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'test_tool',
+      } as ToolCallStartEvent);
+
+      await handlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      await handlerWithCallback.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(true);
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
     });
 
     it('should follow the normal dispatch path when skipped is undefined', async () => {
@@ -1480,27 +1674,40 @@ describe('ChatEventHandler', () => {
         toolCallId,
       };
 
-      const subscribeSpy = jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() });
-      const observable = { subscribe: subscribeSpy };
+      const observable = { subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }) };
 
       mockChatService.sendToolResult = jest.fn().mockResolvedValue({
         observable,
         toolMessage: constructedToolMessage,
       });
 
-      await chatEventHandler.handleEvent({
+      const mockOnSubscribe = jest.fn();
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2322 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSubscribeToToolResultStream: mockOnSubscribe,
+          getTimeline: mockGetTimeline,
+        },
+      });
+
+      await handler.handleEvent({
         type: EventType.TOOL_CALL_START,
         toolCallId,
         toolCallName: 'test_tool',
       } as ToolCallStartEvent);
 
-      await chatEventHandler.handleEvent({
+      await handler.handleEvent({
         type: EventType.TOOL_CALL_ARGS,
         toolCallId,
         delta: '{}',
       } as ToolCallArgsEvent);
 
-      await chatEventHandler.handleEvent({
+      await handler.handleEvent({
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
@@ -1508,7 +1715,7 @@ describe('ChatEventHandler', () => {
       expect(timeline).toContainEqual(constructedToolMessage);
       const skipInfoMessage = timeline.find((m) => (m as any).id?.startsWith('tool-skipped-'));
       expect(skipInfoMessage).toBeUndefined();
-      expect(subscribeSpy).toHaveBeenCalledTimes(1);
+      expect(mockOnSubscribe).toHaveBeenCalledWith(observable, expect.any(AbortController));
     });
   });
 
@@ -1604,12 +1811,74 @@ describe('ChatEventHandler', () => {
       await pipelinePromise;
     });
 
+    it('should fire onSendToolResultStateChange(true) once at dispatch and (false) on stop', async () => {
+      const mockOnSendToolResultStateChange = jest.fn();
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2740 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+          onSubscribeToToolResultStream: jest.fn(),
+        },
+      });
+
+      const toolCallId = 'tool-state-change-on-stop';
+
+      let resolveSend: (v: any) => void = () => {};
+      mockChatService.sendToolResult = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSend = resolve;
+          })
+      );
+
+      const pipelinePromise = runToolCallPipeline(handler, toolCallId);
+      await new Promise((r) => setImmediate(r));
+
+      // Only the initial `(true)` should have been emitted so far.
+      const trueCallsBeforeStop = mockOnSendToolResultStateChange.mock.calls.filter(
+        (c) => c[0] === true
+      ).length;
+      expect(trueCallsBeforeStop).toBe(1);
+
+      handler.cancelToolResultDispatch();
+
+      resolveSend({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: `tool-result-${toolCallId}`,
+          role: 'tool',
+          content: '{"ok":true}',
+          toolCallId,
+        },
+        skipped: { reason: 'aborted' },
+      });
+
+      await pipelinePromise;
+
+      // The `finally` block emits (false) once the awaited promise resolves.
+      expect(mockOnSendToolResultStateChange).toHaveBeenCalledWith(false);
+
+      // `(true)` should still have been emitted exactly once — stop() must
+      // not re-emit `(true)`.
+      const finalTrueCallCount = mockOnSendToolResultStateChange.mock.calls.filter(
+        (c) => c[0] === true
+      ).length;
+      expect(finalTrueCallCount).toBe(1);
+    });
+
     it('should be a no-op when no send is in flight and no subscription is active', () => {
       // Fresh handler with no active send.
       chatEventHandler.cancelToolResultDispatch();
 
       // Both branches are null on a fresh handler, so no callbacks fire.
-      expect(mockOnStreamingStateChange).not.toHaveBeenCalled();
       expect(mockOnStartResponse).not.toHaveBeenCalled();
     });
 
@@ -1691,6 +1960,75 @@ describe('ChatEventHandler', () => {
       // No tool message should have been appended since dispatch was skipped.
       const toolMessages = timeline.filter((m) => m.role === 'tool');
       expect(toolMessages).toHaveLength(0);
+    });
+
+    it('should not emit onSendToolResultStateChange(false) from a superseded send', async () => {
+      const mockOnSendToolResultStateChange = jest.fn();
+      const handler = new ChatEventHandler({
+        assistantActionService: mockAssistantActionService,
+        chatService: mockChatService,
+        // @ts-expect-error TS2740 TODO(ts-error): fixme
+        confirmationService: mockConfirmationService,
+        callbacks: {
+          onTimelineUpdate: mockOnTimelineUpdate,
+          onStartResponse: mockOnStartResponse,
+          onSendToolResultStateChange: mockOnSendToolResultStateChange,
+          getTimeline: mockGetTimeline,
+          onSubscribeToToolResultStream: jest.fn(),
+        },
+      });
+
+      // First send will be held pending so we can start a second send.
+      let resolveFirst: (v: any) => void = () => {};
+      const sendMock = jest.fn();
+      sendMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+      );
+      sendMock.mockImplementationOnce(() =>
+        Promise.resolve({
+          observable: {
+            subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+          },
+          toolMessage: {
+            id: 'tool-result-second',
+            role: 'tool',
+            content: '{}',
+            toolCallId: 'tool-second',
+          },
+        })
+      );
+      mockChatService.sendToolResult = sendMock;
+
+      // Start first send (stays pending)
+      const firstPromise = runToolCallPipeline(handler, 'tool-first');
+      await new Promise((r) => setImmediate(r));
+
+      // Start second send — this aborts the first controller and replaces it
+      await runToolCallPipeline(handler, 'tool-second');
+
+      // Now resolve the first send so its finally block runs
+      resolveFirst({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+        },
+        toolMessage: {
+          id: 'tool-result-first',
+          role: 'tool',
+          content: '{}',
+          toolCallId: 'tool-first',
+        },
+        skipped: { reason: 'aborted' },
+      });
+      await firstPromise;
+
+      // The first send's finally block should NOT have emitted (false) because
+      // the controller was already replaced by the second send.
+      const falseCalls = mockOnSendToolResultStateChange.mock.calls.filter((c) => c[0] === false);
+      // Only the second send should have emitted (false) — exactly once.
+      expect(falseCalls.length).toBe(1);
     });
 
     it('should append a non-resendable system message when sendToolResult returns skipped reason no_thread_id', async () => {

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -840,6 +840,7 @@ export class ChatEventHandler {
     this.activeAssistantMessages.clear();
     this.pendingToolCalls.clear();
     this.toolExecutor.clearAllPendingTools();
+    this.runStartTimes.clear();
     this.lastTextMessageStartId = null;
     // Drain the process-wide AssistantActionService tool call states so
     // stale pending/executing entries from a previous run do not bleed

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { i18n } from '@osd/i18n';
 import { EventType } from '../../common/events';
 import { TOOL_EXECUTION_ERROR_PREFIX } from '../../common';
@@ -41,8 +41,12 @@ export interface ChatEventHandlerConfig {
   telemetryRecorder?: PluginTelemetryRecorder;
   callbacks: {
     onTimelineUpdate: (updater: (prev: Message[]) => Message[]) => void;
-    onStreamingStateChange: (isStreaming: boolean) => void;
-    onStartResponse: (flag: boolean) => void;
+    onStartResponse: (runId?: string) => void;
+    onSendToolResultStateChange?: (isSending: boolean) => void;
+    onSubscribeToToolResultStream: (
+      observable: Observable<ChatEvent>,
+      abortController: AbortController
+    ) => void;
     getTimeline: () => Message[];
   };
 }
@@ -61,10 +65,13 @@ export class ChatEventHandler {
   private chatService: ChatService;
   private telemetryRecorder?: PluginTelemetryRecorder;
   private onTimelineUpdate: (updater: (prev: Message[]) => Message[]) => void;
-  private onStreamingStateChange: (isStreaming: boolean) => void;
-  private onStartResponse: (flag: boolean) => void;
+  private onStartResponse: (runId?: string) => void;
+  private onSendToolResultStateChange?: (isSending: boolean) => void;
+  private onSubscribeToToolResultStream: (
+    observable: Observable<ChatEvent>,
+    abortController: AbortController
+  ) => void;
   private getTimeline: () => Message[];
-  private toolResultSubscription: Subscription | null = null;
 
   // Controls the currently in-flight tool result send (polling + agent stream).
   // When aborted, `waitForToolCallSync` bails out with reason 'aborted' and the
@@ -72,16 +79,18 @@ export class ChatEventHandler {
   private toolResultAbortController: AbortController | null = null;
 
   // Telemetry tracking
-  private interactionStartTime: number | null = null;
+  private runStartTimes = new Map<string, number>();
   private runErrorOccurred = false;
+  private currentRunId: string | null = null;
 
   constructor(config: ChatEventHandlerConfig) {
     this.assistantActionService = config.assistantActionService;
     this.chatService = config.chatService;
     this.telemetryRecorder = config.telemetryRecorder;
     this.onTimelineUpdate = config.callbacks.onTimelineUpdate;
-    this.onStreamingStateChange = config.callbacks.onStreamingStateChange;
     this.onStartResponse = config.callbacks.onStartResponse;
+    this.onSendToolResultStateChange = config.callbacks.onSendToolResultStateChange;
+    this.onSubscribeToToolResultStream = config.callbacks.onSubscribeToToolResultStream;
     this.getTimeline = config.callbacks.getTimeline;
     this.toolExecutor = new ToolExecutor(config.assistantActionService, config.confirmationService);
   }
@@ -141,10 +150,12 @@ export class ChatEventHandler {
    * Handle run started - set streaming state and start timing
    */
   private handleRunStarted(event: any): void {
-    this.onStreamingStateChange(true);
-
-    // Start timing for telemetry
-    this.interactionStartTime = Date.now();
+    // Track current run for routing callbacks
+    this.currentRunId = event.runId || null;
+    // Start timing for telemetry (keyed by runId to avoid race conditions)
+    if (event.runId) {
+      this.runStartTimes.set(event.runId, Date.now());
+    }
     this.runErrorOccurred = false;
   }
 
@@ -152,11 +163,6 @@ export class ChatEventHandler {
    * Handle run finished - clear streaming state, cleanup, and record success telemetry
    */
   private handleRunFinished(event: any): void {
-    this.onStreamingStateChange(false);
-    // Clear any remaining active messages (cleanup)
-    this.activeAssistantMessages.clear();
-    // Reset the connection state to allow new chats
-    this.chatService.resetConnection();
 
     // Record success telemetry only if no error occurred during this run
     if (this.telemetryRecorder && !this.runErrorOccurred) {
@@ -168,9 +174,10 @@ export class ChatEventHandler {
         },
       });
 
-      // Record duration metric if we have a start time
-      if (this.interactionStartTime !== null) {
-        const duration = Date.now() - this.interactionStartTime;
+      // Record duration metric if we have a start time for this run
+      const startTime = event.runId ? this.runStartTimes.get(event.runId) : undefined;
+      if (startTime !== undefined) {
+        const duration = Date.now() - startTime;
         this.telemetryRecorder.recordMetric({
           name: 'chat_interaction_duration_ms',
           value: duration,
@@ -179,7 +186,7 @@ export class ChatEventHandler {
             status: 'success',
           },
         });
-        this.interactionStartTime = null;
+        this.runStartTimes.delete(event.runId);
       }
     }
   }
@@ -188,7 +195,7 @@ export class ChatEventHandler {
    * Handle start of a text message
    */
   private handleTextMessageStart(event: TextMessageStartEvent): void {
-    this.onStartResponse(true);
+    this.onStartResponse(this.currentRunId || undefined);
     // Track this as the last TEXT_MESSAGE_START for tool call association
     this.lastTextMessageStartId = event.messageId;
 
@@ -287,7 +294,7 @@ export class ChatEventHandler {
    * in the conversation timeline, maintaining proper message ordering.
    */
   private handleToolCallStart(event: ToolCallStartEvent): void {
-    this.onStartResponse(true);
+    this.onStartResponse(this.currentRunId || undefined);
     const { toolCallId, toolCallName, parentMessageId } = event;
 
     // Update tool call state in AssistantActionService
@@ -538,7 +545,6 @@ export class ChatEventHandler {
     };
 
     this.onTimelineUpdate((prev) => [...prev, errorMessage]);
-    this.onStreamingStateChange(false);
 
     // Record failure telemetry
     if (this.telemetryRecorder) {
@@ -563,8 +569,9 @@ export class ChatEventHandler {
       });
 
       // Record duration metric if we have a start time (with failure status)
-      if (this.interactionStartTime !== null) {
-        const duration = Date.now() - this.interactionStartTime;
+      const startTime = event.runId ? this.runStartTimes.get(event.runId) : undefined;
+      if (startTime !== undefined) {
+        const duration = Date.now() - startTime;
         this.telemetryRecorder.recordMetric({
           name: 'chat_interaction_duration_ms',
           value: duration,
@@ -573,7 +580,7 @@ export class ChatEventHandler {
             status: 'failure',
           },
         });
-        this.interactionStartTime = null;
+        this.runStartTimes.delete(event.runId);
       }
     }
   }
@@ -794,32 +801,8 @@ export class ChatEventHandler {
 
     this.onTimelineUpdate((prev) => [...prev, toolMessage]);
 
-    // Set streaming state and subscribe to the response stream
-    this.onStreamingStateChange(true);
-
-    const subscription = observable.subscribe({
-      next: (event: ChatEvent) => {
-        // Handle the assistant's response to the tool result
-        this.handleEvent(event);
-      },
-      error: (error: Error) => {
-        // A deliberate abort surfaces as AbortError — treat it as a quiet
-        // cancellation rather than a real error.
-        if (error?.name !== 'AbortError') {
-          // eslint-disable-next-line no-console
-          console.error('Tool result response error:', error);
-        }
-      },
-    });
-    subscription.add(() => {
-      this.onStreamingStateChange(false);
-      this.onStartResponse(false);
-      this.toolResultSubscription = null;
-      releaseController();
-    });
-
-    // Store subscription so it can be unsubscribed in clearState
-    this.toolResultSubscription = subscription;
+    // Delegate stream subscription to the hook
+    this.onSubscribeToToolResultStream(observable, abortController);
   }
 
   // timelineToMessages method removed - timeline is now directly AG-UI compatible
@@ -831,9 +814,6 @@ export class ChatEventHandler {
   private async handleMessagesSnapshot(event: MessagesSnapshotEvent): Promise<void> {
     // Set timeline to snapshot messages
     this.onTimelineUpdate(() => event.messages || []);
-
-    // Reset streaming state
-    this.onStreamingStateChange(false);
   }
 
   /**
@@ -869,9 +849,15 @@ export class ChatEventHandler {
       this.toolResultAbortController.abort();
       this.toolResultAbortController = null;
     }
-    if (this.toolResultSubscription) {
-      this.toolResultSubscription.unsubscribe();
-      this.toolResultSubscription = null;
+  }
+
+  /**
+   * Release the tool result abort controller if it matches the given one.
+   * Called by the hook when the tool result stream subscription completes.
+   */
+  releaseToolResultController(abortController: AbortController): void {
+    if (this.toolResultAbortController === abortController) {
+      this.toolResultAbortController = null;
     }
   }
 }

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -163,7 +163,6 @@ export class ChatEventHandler {
    * Handle run finished - clear streaming state, cleanup, and record success telemetry
    */
   private handleRunFinished(event: any): void {
-
     // Record success telemetry only if no error occurred during this run
     if (this.telemetryRecorder && !this.runErrorOccurred) {
       this.telemetryRecorder.recordEvent({
@@ -686,6 +685,8 @@ export class ChatEventHandler {
    * what failed, and that is surfaced via the system message.
    */
   async sendToolResultToAssistant(toolCallId: string, result: any): Promise<void> {
+    this.onSendToolResultStateChange?.(true);
+
     // Abort any in-flight tool result send so we don't leak controllers or
     // race two dispatches against the same toolCallId.
     if (this.toolResultAbortController) {
@@ -693,6 +694,17 @@ export class ChatEventHandler {
     }
     const abortController = new AbortController();
     this.toolResultAbortController = abortController;
+
+    // Only emit (false) if this send is still the active one — a superseded
+    // send must not reset the flag that the newer send owns.
+    const notifySendDone = () => {
+      if (
+        this.toolResultAbortController === abortController ||
+        this.toolResultAbortController === null
+      ) {
+        this.onSendToolResultStateChange?.(false);
+      }
+    };
 
     // Release our claim on the shared slot — but only if it's still ours.
     // A later send may have already replaced it.
@@ -722,6 +734,7 @@ export class ChatEventHandler {
       // eslint-disable-next-line no-console
       console.error('Failed to send tool result:', error);
       releaseController();
+      notifySendDone();
 
       // Surface the failure in the timeline so the user can tell the
       // conversation is out of sync (the assistant never received the
@@ -743,6 +756,7 @@ export class ChatEventHandler {
         // User initiated the abort (e.g. via cancelToolResultDispatch). No
         // user-facing system message — the cancellation is intentional.
         releaseController();
+        notifySendDone();
         return;
       }
 
@@ -763,6 +777,7 @@ export class ChatEventHandler {
         };
         this.onTimelineUpdate((prev) => [...prev, timeoutMessage]);
         releaseController();
+        notifySendDone();
         return;
       }
 
@@ -781,6 +796,7 @@ export class ChatEventHandler {
         };
         this.onTimelineUpdate((prev) => [...prev, noThreadMessage]);
         releaseController();
+        notifySendDone();
         return;
       }
 
@@ -796,6 +812,7 @@ export class ChatEventHandler {
       };
       this.onTimelineUpdate((prev) => [...prev, infoMessage]);
       releaseController();
+      notifySendDone();
       return;
     }
 


### PR DESCRIPTION
### Description

Extracts streaming state management from `chat_window.tsx` into a dedicated `useChatStreaming` hook, separating the main message stream from the tool result stream for clearer ownership and independent lifecycle management.

**Key changes:**

1. **New `useChatStreaming` hook** — manages dual-stream state (`isMainStreaming` / `isToolResultStreaming`), owns `subscribeToMessageStream`, `stopStreaming`, and `sendToolResult`
2. **Simplified `ChatEventHandler`** — removed `onStreamingStateChange` callback, added `onSubscribeToToolResultStream` to delegate stream subscription to the hook, replaced single `interactionStartTime` with `runStartTimes` Map for concurrent run tracking
3. **Slimmed `chat_window.tsx`** — removed ~170 lines of inline streaming logic, preserves `hasActiveToolCalls` from #11982

### Issues Resolved

N/A (refactor for maintainability)

## Screenshot

N/A (no UI changes — internal refactor only)

## Testing the changes

1. Verify chat streaming works normally (send message, get streamed response)
2. Verify tool execution triggers correctly (`execute_ppl_query` shows "Running" state)
3. Verify "New Chat" during tool result streaming properly aborts and cleans up
4. Verify send button stays disabled during active streaming
5. Run existing unit tests: `yarn test:jest --testPathPattern=chat`

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff