### PR TITLE
[Fix] Limit variable feature to Observability workspace and add tooltip for DSL filter

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -90,9 +90,7 @@ export const DashboardEditor = () => {
       .then((ws) => {
         const features = ws?.features;
         setIsExploreWorkspace(
-          (features &&
-            (isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.observability.id, features) ||
-              isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.all.id, features))) ??
+          (features && isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.observability.id, features)) ??
             false
         );
       });

--- a/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_editor/index.tsx
@@ -43,6 +43,7 @@ import {
   EuiSpacer,
   EuiCompressedSwitch,
   EuiSwitchEvent,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@osd/i18n/react';
@@ -119,23 +120,33 @@ class FilterEditorUI extends Component<Props, State> {
             </EuiFlexItem>
             <EuiFlexItem grow={false} className="filterEditor__hiddenItem" />
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                size="xs"
-                data-test-subj="editQueryDSL"
-                onClick={this.toggleCustomEditor}
+              <EuiToolTip
+                content={
+                  this.state.isCustomEditorOpen
+                    ? undefined
+                    : i18n.translate('data.filter.filterEditor.editQueryDslTooltip', {
+                        defaultMessage: 'Raw DSL input only applies to DSL-based visualizations',
+                      })
+                }
               >
-                {this.state.isCustomEditorOpen ? (
-                  <FormattedMessage
-                    id="data.filter.filterEditor.editFilterValuesButtonLabel"
-                    defaultMessage="Edit filter values"
-                  />
-                ) : (
-                  <FormattedMessage
-                    id="data.filter.filterEditor.editQueryDslButtonLabel"
-                    defaultMessage="Edit as Query DSL"
-                  />
-                )}
-              </EuiButtonEmpty>
+                <EuiButtonEmpty
+                  size="xs"
+                  data-test-subj="editQueryDSL"
+                  onClick={this.toggleCustomEditor}
+                >
+                  {this.state.isCustomEditorOpen ? (
+                    <FormattedMessage
+                      id="data.filter.filterEditor.editFilterValuesButtonLabel"
+                      defaultMessage="Edit filter values"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="data.filter.filterEditor.editQueryDslButtonLabel"
+                      defaultMessage="Edit as Query DSL"
+                    />
+                  )}
+                </EuiButtonEmpty>
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPopoverTitle>
@@ -299,6 +310,7 @@ class FilterEditorUI extends Component<Props, State> {
           isClearable={false}
           className="globalFilterEditor__fieldInput"
           data-test-subj="filterFieldSuggestionList"
+          autoFocus
         />
       </EuiCompressedFormRow>
     );


### PR DESCRIPTION
### Description

1. **Restrict variable feature to Observability workspace only** - Previously enabled in both Observability and All workspaces (All workspace should not enable variable feature), now limited to Observability only
2. **Add tooltip for Edit as Query DSL button**
<img width="526" height="164" alt="image" src="https://github.com/user-attachments/assets/77e82a51-a5d6-4e0b-aa43-e106f60135e1" />


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
