### PR TITLE
fix: refresh active workspace metadata when switching pages

### DIFF
--- a/src/plugins/workspace/public/services/workspace_validation.service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_validation.service.test.ts
@@ -190,6 +190,33 @@ describe('WorkspaceValidationService', () => {
       expect(core.chrome.setIsVisible).not.toHaveBeenCalled();
     });
 
+    it('should not refresh workspace when navigating to fatal error page', async () => {
+      const core = coreMock.createStart();
+      const service = new WorkspaceValidationService();
+      workspaceClientMock.refreshWorkspace.mockClear();
+
+      const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+      core.application.currentAppId$ = currentAppId$;
+      core.application.capabilities = {
+        ...core.application.capabilities,
+        workspaces: { permissionEnabled: true },
+      };
+
+      workspaceClientMock.refreshWorkspace.mockResolvedValue({ success: true, result: {} });
+
+      const coreSetup = coreMock.createSetup();
+      await service.setup(coreSetup, 'test-workspace');
+      service.start(core);
+
+      // Clear calls from initial subscription emission
+      workspaceClientMock.refreshWorkspace.mockClear();
+
+      // Simulate navigation to fatal error page
+      currentAppId$.next(WORKSPACE_FATAL_ERROR_APP_ID);
+
+      expect(workspaceClientMock.refreshWorkspace).not.toHaveBeenCalled();
+    });
+
     it('should redirect from error page to workspace detail when workspace becomes valid', async () => {
       const core = coreMock.createStart();
       const service = new WorkspaceValidationService();

--- a/src/plugins/workspace/public/services/workspace_validation.service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_validation.service.test.ts
@@ -71,6 +71,85 @@ describe('WorkspaceValidationService', () => {
       });
     });
 
+    it('should show fatal error page when refreshWorkspace returns permission error on page switch', async () => {
+      const core = coreMock.createStart();
+      const service = new WorkspaceValidationService();
+
+      const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+      core.application.currentAppId$ = currentAppId$;
+
+      workspaceClientMock.refreshWorkspace.mockResolvedValue({
+        success: false,
+        error: 'Invalid saved objects permission',
+      });
+
+      const coreSetup = coreMock.createSetup();
+      await service.setup(coreSetup, 'test-workspace');
+      service.start(core);
+
+      // Simulate page switch
+      currentAppId$.next('some-app');
+
+      await waitFor(() => {
+        expect(workspaceClientMock.refreshWorkspace).toHaveBeenCalledWith('test-workspace');
+        expect(core.chrome.setIsVisible).toHaveBeenCalledWith(false);
+        expect(core.application.navigateToApp).toHaveBeenCalledWith(WORKSPACE_FATAL_ERROR_APP_ID, {
+          replace: true,
+          state: { error: expect.any(String) },
+        });
+      });
+    });
+
+    it('should not show fatal error page when refreshWorkspace succeeds on page switch', async () => {
+      const core = coreMock.createStart();
+      const service = new WorkspaceValidationService();
+
+      const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+      core.application.currentAppId$ = currentAppId$;
+
+      workspaceClientMock.refreshWorkspace.mockResolvedValue({
+        success: true,
+        result: { id: 'test-workspace', name: 'Test' },
+      });
+
+      const coreSetup = coreMock.createSetup();
+      await service.setup(coreSetup, 'test-workspace');
+      service.start(core);
+
+      // Simulate page switch
+      currentAppId$.next('some-app');
+
+      await waitFor(() => {
+        expect(workspaceClientMock.refreshWorkspace).toHaveBeenCalledWith('test-workspace');
+      });
+      expect(core.chrome.setIsVisible).not.toHaveBeenCalled();
+    });
+
+    it('should not show fatal error page when refreshWorkspace returns non-permission error', async () => {
+      const core = coreMock.createStart();
+      const service = new WorkspaceValidationService();
+
+      const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+      core.application.currentAppId$ = currentAppId$;
+
+      workspaceClientMock.refreshWorkspace.mockResolvedValue({
+        success: false,
+        error: 'Network error',
+      });
+
+      const coreSetup = coreMock.createSetup();
+      await service.setup(coreSetup, 'test-workspace');
+      service.start(core);
+
+      // Simulate page switch
+      currentAppId$.next('some-app');
+
+      await waitFor(() => {
+        expect(workspaceClientMock.refreshWorkspace).toHaveBeenCalledWith('test-workspace');
+      });
+      expect(core.chrome.setIsVisible).not.toHaveBeenCalled();
+    });
+
     it('should redirect from error page to workspace detail when workspace becomes valid', async () => {
       const core = coreMock.createStart();
       const service = new WorkspaceValidationService();

--- a/src/plugins/workspace/public/services/workspace_validation.service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_validation.service.test.ts
@@ -77,6 +77,10 @@ describe('WorkspaceValidationService', () => {
 
       const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
       core.application.currentAppId$ = currentAppId$;
+      core.application.capabilities = {
+        ...core.application.capabilities,
+        workspaces: { permissionEnabled: true },
+      };
 
       workspaceClientMock.refreshWorkspace.mockResolvedValue({
         success: false,
@@ -106,6 +110,10 @@ describe('WorkspaceValidationService', () => {
 
       const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
       core.application.currentAppId$ = currentAppId$;
+      core.application.capabilities = {
+        ...core.application.capabilities,
+        workspaces: { permissionEnabled: true },
+      };
 
       workspaceClientMock.refreshWorkspace.mockResolvedValue({
         success: true,
@@ -131,6 +139,10 @@ describe('WorkspaceValidationService', () => {
 
       const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
       core.application.currentAppId$ = currentAppId$;
+      core.application.capabilities = {
+        ...core.application.capabilities,
+        workspaces: { permissionEnabled: true },
+      };
 
       workspaceClientMock.refreshWorkspace.mockResolvedValue({
         success: false,
@@ -147,6 +159,34 @@ describe('WorkspaceValidationService', () => {
       await waitFor(() => {
         expect(workspaceClientMock.refreshWorkspace).toHaveBeenCalledWith('test-workspace');
       });
+      expect(core.chrome.setIsVisible).not.toHaveBeenCalled();
+    });
+
+    it('should not show fatal error page on page switch when permission control is disabled', async () => {
+      const core = coreMock.createStart();
+      const service = new WorkspaceValidationService();
+      workspaceClientMock.refreshWorkspace.mockClear();
+
+      const currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+      core.application.currentAppId$ = currentAppId$;
+      // permissionEnabled is falsy by default
+
+      workspaceClientMock.refreshWorkspace.mockResolvedValue({
+        success: false,
+        error: 'Invalid saved objects permission',
+      });
+
+      const coreSetup = coreMock.createSetup();
+      await service.setup(coreSetup, 'test-workspace');
+      service.start(core);
+
+      // Simulate page switch
+      currentAppId$.next('some-app');
+
+      await waitFor(() => {
+        expect(workspaceClientMock.refreshWorkspace).toHaveBeenCalledWith('test-workspace');
+      });
+      // Should not show error page when permission control is disabled
       expect(core.chrome.setIsVisible).not.toHaveBeenCalled();
     });
 

--- a/src/plugins/workspace/public/services/workspace_validation_service.ts
+++ b/src/plugins/workspace/public/services/workspace_validation_service.ts
@@ -66,23 +66,29 @@ export class WorkspaceValidationService {
     if (isPermissionEnabled) {
       this.workspaceClient?.setPermissionEnabled(true);
     }
-    this.currentAppIdSubscription = application.currentAppId$.subscribe(() => {
+    this.currentAppIdSubscription = application.currentAppId$.subscribe((appId) => {
+      if (appId === WORKSPACE_FATAL_ERROR_APP_ID) {
+        return;
+      }
       if (this.workspaceClient && this.workspaceId) {
-        this.workspaceClient.refreshWorkspace(this.workspaceId)?.then((resp) => {
-          if (
-            isPermissionEnabled &&
-            !resp.success &&
-            resp.error === 'Invalid saved objects permission'
-          ) {
-            this.handleFatalError(
-              application,
-              chrome,
-              i18n.translate('workspace.error.noPermission', {
-                defaultMessage: 'You do not have permission to access this workspace',
-              })
-            );
-          }
-        });
+        this.workspaceClient
+          .refreshWorkspace(this.workspaceId)
+          ?.then((resp) => {
+            if (
+              isPermissionEnabled &&
+              !resp.success &&
+              resp.error === 'Invalid saved objects permission'
+            ) {
+              this.handleFatalError(
+                application,
+                chrome,
+                i18n.translate('workspace.error.noPermission', {
+                  defaultMessage: 'You do not have permission to access this workspace',
+                })
+              );
+            }
+          })
+          .catch(() => {});
       }
     });
 

--- a/src/plugins/workspace/public/services/workspace_validation_service.ts
+++ b/src/plugins/workspace/public/services/workspace_validation_service.ts
@@ -30,6 +30,7 @@ export class WorkspaceValidationService {
   private workspaceClient?: WorkspaceClient;
   private workspaceId: string | undefined;
   private workspaceValidationSubscription?: Subscription;
+  private currentAppIdSubscription?: Subscription;
 
   /**
    * Fatal error service does not support customized actions
@@ -58,6 +59,24 @@ export class WorkspaceValidationService {
 
   async start(core: CoreStart) {
     const { workspaces, application, chrome } = core;
+
+    // Refresh the active workspace when switching pages to ensure fresh data;
+    // show error page if the user no longer has permission.
+    this.currentAppIdSubscription = application.currentAppId$.subscribe(() => {
+      if (this.workspaceClient && this.workspaceId) {
+        this.workspaceClient.refreshWorkspace(this.workspaceId).then((resp) => {
+          if (!resp.success && resp.error === 'Invalid saved objects permission') {
+            this.handleFatalError(
+              application,
+              chrome,
+              i18n.translate('workspace.error.noPermission', {
+                defaultMessage: 'You do not have permission to access this workspace',
+              })
+            );
+          }
+        });
+      }
+    });
 
     this.workspaceValidationSubscription = combineLatest([
       workspaces.workspaceError$,
@@ -94,5 +113,6 @@ export class WorkspaceValidationService {
 
   stop() {
     this.workspaceValidationSubscription?.unsubscribe();
+    this.currentAppIdSubscription?.unsubscribe();
   }
 }

--- a/src/plugins/workspace/public/services/workspace_validation_service.ts
+++ b/src/plugins/workspace/public/services/workspace_validation_service.ts
@@ -59,13 +59,21 @@ export class WorkspaceValidationService {
 
   async start(core: CoreStart) {
     const { workspaces, application, chrome } = core;
+    const isPermissionEnabled = core.application.capabilities.workspaces.permissionEnabled;
 
     // Refresh the active workspace when switching pages to ensure fresh data;
     // show error page if the user no longer has permission.
+    if (isPermissionEnabled) {
+      this.workspaceClient?.setPermissionEnabled(true);
+    }
     this.currentAppIdSubscription = application.currentAppId$.subscribe(() => {
       if (this.workspaceClient && this.workspaceId) {
-        this.workspaceClient.refreshWorkspace(this.workspaceId).then((resp) => {
-          if (!resp.success && resp.error === 'Invalid saved objects permission') {
+        this.workspaceClient.refreshWorkspace(this.workspaceId)?.then((resp) => {
+          if (
+            isPermissionEnabled &&
+            !resp.success &&
+            resp.error === 'Invalid saved objects permission'
+          ) {
             this.handleFatalError(
               application,
               chrome,

--- a/src/plugins/workspace/public/workspace_client.mock.ts
+++ b/src/plugins/workspace/public/workspace_client.mock.ts
@@ -20,6 +20,7 @@ export const createMockWorkspaceClient = (): jest.Mocked<
     enterWorkspace: (id: string) => Promise<IResponse<null>>;
     init: () => {};
     refreshWorkspace: (id: string) => Promise<IResponse<any>>;
+    setPermissionEnabled: (enabled: boolean) => void;
   }
 > => ({
   getCurrentWorkspaceId: jest.fn(),
@@ -37,6 +38,7 @@ export const createMockWorkspaceClient = (): jest.Mocked<
   init: jest.fn(),
   batchDelete: jest.fn(),
   refreshWorkspace: jest.fn(),
+  setPermissionEnabled: jest.fn(),
 });
 
 export const workspaceClientMock = createMockWorkspaceClient();

--- a/src/plugins/workspace/public/workspace_client.mock.ts
+++ b/src/plugins/workspace/public/workspace_client.mock.ts
@@ -16,7 +16,11 @@ type IResponse<T> =
     };
 
 export const createMockWorkspaceClient = (): jest.Mocked<
-  IWorkspaceClient & { enterWorkspace: (id: string) => Promise<IResponse<null>>; init: () => {} }
+  IWorkspaceClient & {
+    enterWorkspace: (id: string) => Promise<IResponse<null>>;
+    init: () => {};
+    refreshWorkspace: (id: string) => Promise<IResponse<any>>;
+  }
 > => ({
   getCurrentWorkspaceId: jest.fn(),
   getCurrentWorkspace: jest.fn(),
@@ -32,6 +36,7 @@ export const createMockWorkspaceClient = (): jest.Mocked<
   enterWorkspace: jest.fn(),
   init: jest.fn(),
   batchDelete: jest.fn(),
+  refreshWorkspace: jest.fn(),
 });
 
 export const workspaceClientMock = createMockWorkspaceClient();

--- a/src/plugins/workspace/public/workspace_client.test.ts
+++ b/src/plugins/workspace/public/workspace_client.test.ts
@@ -289,28 +289,79 @@ describe('#WorkspaceClient', () => {
 });
 
 describe('WorkspaceClient.refreshWorkspace', () => {
-  it('should update workspace in workspaceList$ on success', async () => {
+  it('should update workspace in workspaceList$ with readonly/owner flags from permissionMode', async () => {
     const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceClient.setPermissionEnabled(true);
     workspaceMock.workspaceList$.next([
-      { id: 'foo', name: 'old-name' },
+      { id: 'foo', name: 'old-name', readonly: true, owner: false },
       { id: 'bar', name: 'bar' },
     ]);
     httpSetupMock.fetch.mockResolvedValueOnce({
       success: true,
-      result: { id: 'foo', name: 'new-name' },
+      result: { id: 'foo', name: 'new-name', permissionMode: 'owner' },
     });
 
     const resp = await workspaceClient.refreshWorkspace('foo');
 
     expect(resp.success).toBe(true);
     expect(workspaceMock.workspaceList$.getValue()).toEqual([
-      { id: 'foo', name: 'new-name' },
+      { id: 'foo', name: 'new-name', readonly: false, owner: true },
       { id: 'bar', name: 'bar' },
+    ]);
+  });
+
+  it('should set readonly true when permissionMode is read', async () => {
+    const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceClient.setPermissionEnabled(true);
+    workspaceMock.workspaceList$.next([{ id: 'foo', name: 'old-name', readonly: false }]);
+    httpSetupMock.fetch.mockResolvedValueOnce({
+      success: true,
+      result: { id: 'foo', name: 'new-name', permissionMode: 'read' },
+    });
+
+    await workspaceClient.refreshWorkspace('foo');
+
+    expect(workspaceMock.workspaceList$.getValue()).toEqual([
+      { id: 'foo', name: 'new-name', readonly: true, owner: false },
+    ]);
+  });
+
+  it('should set readonly false and owner false when permissionMode is read+write', async () => {
+    const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceClient.setPermissionEnabled(true);
+    workspaceMock.workspaceList$.next([{ id: 'foo', name: 'old-name' }]);
+    httpSetupMock.fetch.mockResolvedValueOnce({
+      success: true,
+      result: { id: 'foo', name: 'new-name', permissionMode: 'read+write' },
+    });
+
+    await workspaceClient.refreshWorkspace('foo');
+
+    expect(workspaceMock.workspaceList$.getValue()).toEqual([
+      { id: 'foo', name: 'new-name', readonly: false, owner: false },
+    ]);
+  });
+
+  it('should set readonly false and owner true when permission is disabled', async () => {
+    const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceMock.workspaceList$.next([
+      { id: 'foo', name: 'old-name', readonly: true, owner: false },
+    ]);
+    httpSetupMock.fetch.mockResolvedValueOnce({
+      success: true,
+      result: { id: 'foo', name: 'new-name' },
+    });
+
+    await workspaceClient.refreshWorkspace('foo');
+
+    expect(workspaceMock.workspaceList$.getValue()).toEqual([
+      { id: 'foo', name: 'new-name', readonly: false, owner: true },
     ]);
   });
 
   it('should not update workspaceList$ on failure', async () => {
     const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceClient.setPermissionEnabled(true);
     workspaceMock.workspaceList$.next([{ id: 'foo', name: 'old-name' }]);
     httpSetupMock.fetch.mockResolvedValueOnce({
       success: false,
@@ -320,7 +371,9 @@ describe('WorkspaceClient.refreshWorkspace', () => {
     const resp = await workspaceClient.refreshWorkspace('foo');
 
     expect(resp.success).toBe(false);
-    expect(resp.error).toBe('Invalid saved objects permission');
+    if (!resp.success) {
+      expect(resp.error).toBe('Invalid saved objects permission');
+    }
     expect(workspaceMock.workspaceList$.getValue()).toEqual([{ id: 'foo', name: 'old-name' }]);
   });
 });

--- a/src/plugins/workspace/public/workspace_client.test.ts
+++ b/src/plugins/workspace/public/workspace_client.test.ts
@@ -288,6 +288,43 @@ describe('#WorkspaceClient', () => {
   });
 });
 
+describe('WorkspaceClient.refreshWorkspace', () => {
+  it('should update workspace in workspaceList$ on success', async () => {
+    const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceMock.workspaceList$.next([
+      { id: 'foo', name: 'old-name' },
+      { id: 'bar', name: 'bar' },
+    ]);
+    httpSetupMock.fetch.mockResolvedValueOnce({
+      success: true,
+      result: { id: 'foo', name: 'new-name' },
+    });
+
+    const resp = await workspaceClient.refreshWorkspace('foo');
+
+    expect(resp.success).toBe(true);
+    expect(workspaceMock.workspaceList$.getValue()).toEqual([
+      { id: 'foo', name: 'new-name' },
+      { id: 'bar', name: 'bar' },
+    ]);
+  });
+
+  it('should not update workspaceList$ on failure', async () => {
+    const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
+    workspaceMock.workspaceList$.next([{ id: 'foo', name: 'old-name' }]);
+    httpSetupMock.fetch.mockResolvedValueOnce({
+      success: false,
+      error: 'Invalid saved objects permission',
+    });
+
+    const resp = await workspaceClient.refreshWorkspace('foo');
+
+    expect(resp.success).toBe(false);
+    expect(resp.error).toBe('Invalid saved objects permission');
+    expect(workspaceMock.workspaceList$.getValue()).toEqual([{ id: 'foo', name: 'old-name' }]);
+  });
+});
+
 describe('WorkspaceClient.batchDelete', () => {
   it('should delete all workspaces successfully', async () => {
     const { workspaceClient, httpSetupMock } = getWorkspaceClient();

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -415,6 +415,21 @@ export class WorkspaceClient implements IWorkspaceClient {
     };
   }
 
+  /**
+   * Refresh a workspace by fetching the latest data from the server
+   * and updating it in the workspace list.
+   */
+  public async refreshWorkspace(id: string): Promise<IResponse<WorkspaceAttributeWithPermission>> {
+    const resp = await this.get(id);
+    if (resp.success) {
+      const workspaceList = this.workspaces.workspaceList$.getValue();
+      this.workspaces.workspaceList$.next(
+        workspaceList.map((ws) => (ws.id === id ? { ...ws, ...resp.result } : ws))
+      );
+    }
+    return resp;
+  }
+
   public stop() {
     this.workspaces.workspaceList$.unsubscribe();
     this.workspaces.currentWorkspaceId$.unsubscribe();

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -16,7 +16,11 @@ import {
   WorkspaceFindOptions,
   WorkspacePermissionMode,
 } from '../../../core/public';
-import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
+import {
+  SavedObjectPermissions,
+  WorkspaceAttributeWithPermission,
+  PermissionModeId,
+} from '../../../core/types';
 import { DataSourceAssociation } from './components/data_source_association/data_source_association';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
@@ -36,10 +40,15 @@ const join = (...uriComponents: Array<string | undefined>) =>
 export class WorkspaceClient implements IWorkspaceClient {
   private http: HttpSetup;
   private workspaces: WorkspacesSetup;
+  private isPermissionEnabled: boolean = false;
 
   constructor(http: HttpSetup, workspaces: WorkspacesSetup) {
     this.http = http;
     this.workspaces = workspaces;
+  }
+
+  public setPermissionEnabled(enabled: boolean) {
+    this.isPermissionEnabled = enabled;
   }
 
   /**
@@ -417,14 +426,26 @@ export class WorkspaceClient implements IWorkspaceClient {
 
   /**
    * Refresh a workspace by fetching the latest data from the server
-   * and updating it in the workspace list.
+   * and updating it in the workspace list, including readonly/owner flags.
    */
   public async refreshWorkspace(id: string): Promise<IResponse<WorkspaceAttributeWithPermission>> {
     const resp = await this.get(id);
     if (resp.success) {
+      const { permissionMode, ...workspaceAttributes } = resp.result;
       const workspaceList = this.workspaces.workspaceList$.getValue();
       this.workspaces.workspaceList$.next(
-        workspaceList.map((ws) => (ws.id === id ? { ...ws, ...resp.result } : ws))
+        workspaceList.map((ws) =>
+          ws.id === id
+            ? {
+                ...ws,
+                ...workspaceAttributes,
+                readonly: this.isPermissionEnabled
+                  ? permissionMode === PermissionModeId.Read
+                  : false,
+                owner: this.isPermissionEnabled ? permissionMode === PermissionModeId.Owner : true,
+              }
+            : ws
+        )
       );
     }
     return resp;

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -15,12 +15,9 @@ import {
   SavedObjectsImportResponse,
   WorkspaceFindOptions,
   WorkspacePermissionMode,
-} from '../../../core/public';
-import {
-  SavedObjectPermissions,
-  WorkspaceAttributeWithPermission,
   PermissionModeId,
-} from '../../../core/types';
+} from '../../../core/public';
+import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
 import { DataSourceAssociation } from './components/data_source_association/data_source_association';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';

--- a/src/plugins/workspace/server/routes/index.test.ts
+++ b/src/plugins/workspace/server/routes/index.test.ts
@@ -65,6 +65,29 @@ describe(`Workspace routes`, () => {
     );
   });
 
+  /**
+   * This test verifies that the get route returns the exact error message
+   * "Invalid saved objects permission" when a user lacks access to a workspace.
+   * The public-side code in workspace_validation_service.ts relies on this exact
+   * error string to redirect the user to the fatal error page. If this error
+   * message changes, the client-side check must be updated accordingly.
+   */
+  it('get should return permission error when workspace client returns permission error', async () => {
+    (mockedWorkspaceClient.get as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      error: 'Invalid saved objects permission',
+    });
+
+    const result = await supertest(httpSetup.server.listener)
+      .get(`${WORKSPACES_API_BASE_URL}/mock-workspace-id`)
+      .expect(200);
+
+    expect(result.body).toEqual({
+      success: false,
+      error: 'Invalid saved objects permission',
+    });
+  });
+
   describe('feature validation', () => {
     it('returns 400 when no features is provided during workspace creation', async () => {
       await supertest(httpSetup.server.listener)

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -191,6 +191,15 @@ export function registerRoutes({
         id
       );
 
+      if (result.success) {
+        const principals = permissionControlClient?.getPrincipalsFromRequest(req);
+        (result.result as WorkspaceAttributeWithPermission).permissionMode = translatePermissionsToRole(
+          isPermissionControlEnabled,
+          (result.result as WorkspaceAttributeWithPermission).permissions,
+          principals
+        );
+      }
+
       return res.ok({
         body: result,
       });


### PR DESCRIPTION
### Description

The Workspace Collaborators page renders permission data from the cached `currentWorkspace$` BehaviorSubject. If another user (e.g. an admin) revokes access, the affected user's UI keeps showing stale data until a hard reload.

This PR fixes the issue by refreshing the active workspace from the server on every page navigation. If the refresh API returns a permission error (`"Invalid saved objects permission"`), the user is redirected to the fatal error page.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

#12067 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

https://github.com/user-attachments/assets/88d4d883-01a9-4815-9cb0-6d069059badf

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

1. Open a workspace as User A
2. As User B (admin), revoke User A's access to the workspace
3. As User A, navigate to a different page within the workspace
4. Verify User A is redirected to the error page

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
