### PR TITLE
fix: hide AI features for AnalyticEngine data sources

### DIFF
--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -77,6 +77,7 @@ describe('ChatWindow', () => {
       abort: jest.fn(),
       setChatWindowInstance: jest.fn(),
       clearChatWindowInstance: jest.fn(),
+      getCurrentDataSourceId: jest.fn().mockResolvedValue(undefined),
       conversationHistoryService: {
         getMemoryProvider: jest.fn().mockReturnValue({
           includeFullHistory: true,

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -181,12 +181,49 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     services.core.chat.resetThreadId()
   });
 
+  // Check if the current data source is AnalyticEngine (unsupported for AI features)
+  const isUnsupportedDataSource = useCallback(async (): Promise<boolean> => {
+    try {
+      const dataSourceId = await chatService.getCurrentDataSourceId();
+      if (!dataSourceId) return false;
+      const savedObjectsClient = services.core?.savedObjects?.client;
+      if (!savedObjectsClient) return false;
+      const ds = await savedObjectsClient.get<{ dataSourceEngineType?: string }>(
+        'data-source',
+        dataSourceId
+      );
+      return ds?.attributes?.dataSourceEngineType === 'AnalyticEngine';
+    } catch {
+      // Data source not found or inaccessible — treat as unsupported
+      return true;
+    }
+  }, [chatService, services.core?.savedObjects?.client]);
+
   // Helper function to handle message streaming with observable subscription
   const subscribeToMessageStream = useCallback(async (
     messageContent: string,
     messages: Message[],
     rawMessage?: string
   ) => {
+    // Block AI features for unsupported data sources
+    if (await isUnsupportedDataSource()) {
+      const userMsg: UserMessage = {
+        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        role: 'user',
+        content: messageContent,
+        rawMessage: rawMessage || messageContent,
+      };
+      const systemMsg: SystemMessage = {
+        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        role: 'system',
+        content: i18n.translate('chat.dataSourceUnsupported', {
+          defaultMessage: 'The current data source does not support AI features.',
+        }),
+      };
+      setTimeline((prev) => [...prev, userMsg, systemMsg]);
+      return;
+    }
+
     isStreamingRef.current = true;
     setIsStreaming(true);
     setStartResponse(false);
@@ -243,7 +280,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       setIsStreaming(false);
       currentSubscriptionRef.current = null;
     }
-  }, [chatService, currentRunId, eventHandler]);
+  }, [chatService, currentRunId, eventHandler, isUnsupportedDataSource]);
 
   const handleSend = async (options?: {input?: string, messages?: Message[]}) => {
     const messageContent = options?.input ?? input.trim();

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -181,21 +181,29 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     services.core.chat.resetThreadId()
   });
 
-  // Check if the current data source is AnalyticEngine (unsupported for AI features)
+  // Cache data source compatibility check to avoid network call on every message
+  const unsupportedDataSourceRef = useRef<{ dataSourceId: string | undefined; result: boolean } | null>(null);
+
   const isUnsupportedDataSource = useCallback(async (): Promise<boolean> => {
     try {
       const dataSourceId = await chatService.getCurrentDataSourceId();
       if (!dataSourceId) return false;
+      // Return cached result if data source hasn't changed
+      if (unsupportedDataSourceRef.current?.dataSourceId === dataSourceId) {
+        return unsupportedDataSourceRef.current.result;
+      }
       const savedObjectsClient = services.core?.savedObjects?.client;
       if (!savedObjectsClient) return false;
       const ds = await savedObjectsClient.get<{ dataSourceEngineType?: string }>(
         'data-source',
         dataSourceId
       );
-      return ds?.attributes?.dataSourceEngineType === 'AnalyticEngine';
+      const result = ds?.attributes?.dataSourceEngineType === 'AnalyticEngine';
+      unsupportedDataSourceRef.current = { dataSourceId, result };
+      return result;
     } catch {
-      // Data source not found or inaccessible — treat as unsupported
-      return true;
+      // Fail-open: transient errors should not block AI features
+      return false;
     }
   }, [chatService, services.core?.savedObjects?.client]);
 

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -248,6 +248,13 @@ export class ChatService {
     return contextValue?.dataset?.dataSource?.id;
   }
 
+  private getDataSourceFromPageContext() {
+    const contextStore = (window as any).assistantContextStore;
+    const allContexts = contextStore ? contextStore.getAllContexts() : [];
+
+    return this.extractDataSourceIdFromPageContext(allContexts);
+  }
+
   /**
    * Get workspace-aware data source ID
    * Determines the correct data source based on current workspace context
@@ -255,10 +262,7 @@ export class ChatService {
   private async getWorkspaceAwareDataSourceId(): Promise<string | undefined> {
     try {
       // Try to get data source from page context first
-      const contextStore = (window as any).assistantContextStore;
-      const allContexts = contextStore ? contextStore.getAllContexts() : [];
-
-      const pageDataSourceId = this.extractDataSourceIdFromPageContext(allContexts);
+      const pageDataSourceId = this.getDataSourceFromPageContext();
       if (pageDataSourceId) {
         this.cachedDataSourceId = pageDataSourceId;
         return pageDataSourceId;
@@ -303,7 +307,11 @@ export class ChatService {
    * Returns the datasourceId that was last retrieved
    */
   public async getCurrentDataSourceId(): Promise<string | undefined> {
-    return this.cachedDataSourceId || (await this.getWorkspaceAwareDataSourceId());
+    return (
+      this.getDataSourceFromPageContext() ||
+      this.cachedDataSourceId ||
+      (await this.getWorkspaceAwareDataSourceId())
+    );
   }
 
   public async sendMessage(

--- a/src/plugins/explore/public/actions/ask_ai_action.test.ts
+++ b/src/plugins/explore/public/actions/ask_ai_action.test.ts
@@ -52,6 +52,7 @@ describe('createAskAiAction', () => {
     const mockContext = {
       document: { message: 'test log' },
       query: 'test query',
+      metadata: { dataSourceEngineType: 'OpenSearch' },
     };
 
     it('should return true when chatService is available', () => {
@@ -66,6 +67,24 @@ describe('createAskAiAction', () => {
       };
       const action = createAskAiAction(unavailableChatService);
       expect(action.isCompatible(mockContext)).toBe(false);
+    });
+
+    it('should return false when dataSourceEngineType is AnalyticEngine', () => {
+      const action = createAskAiAction(mockChatService);
+      const context = {
+        document: { message: 'test' },
+        metadata: { dataSourceEngineType: 'AnalyticEngine' },
+      };
+      expect(action.isCompatible(context)).toBe(false);
+    });
+
+    it('should return true when dataSourceEngineType is not AnalyticEngine', () => {
+      const action = createAskAiAction(mockChatService);
+      const context = {
+        document: { message: 'test' },
+        metadata: { dataSourceEngineType: 'OpenSearch' },
+      };
+      expect(action.isCompatible(context)).toBe(true);
     });
   });
 

--- a/src/plugins/explore/public/actions/ask_ai_action.ts
+++ b/src/plugins/explore/public/actions/ask_ai_action.ts
@@ -17,12 +17,12 @@ export function createAskAiAction(chatService: ChatServiceStart): LogActionDefin
     iconType: 'generate',
     order: 1,
 
-    isCompatible: () => {
-      return chatService.isAvailable();
+    isCompatible: (context) => {
+      if (!chatService.isAvailable()) return false;
+      return context.metadata?.dataSourceEngineType !== 'AnalyticEngine';
     },
 
     component: (props) => {
-      // chatService is always defined since we're using core service
       return AskAIActionItem({ ...props, chatService });
     },
   };

--- a/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
@@ -60,7 +60,15 @@ export class AskAIEmbeddableAction implements Action<EmbeddableContext> {
   public async isCompatible({ embeddable }: EmbeddableContext) {
     // Check if this is an explore embeddable and if context provider is available
     const hasContextProvider = this.contextProvider !== undefined;
-    return embeddable.type === 'explore' && hasContextProvider && this.core.chat.isAvailable();
+    if (!(embeddable.type === 'explore' && hasContextProvider && this.core.chat.isAvailable())) {
+      return false;
+    }
+    // Check if the embeddable's data source is AnalyticEngine
+    const visEmbeddable = embeddable as DiscoverVisualizationEmbeddable;
+    const dsType = visEmbeddable.savedExplore?.searchSource?.getFields()?.query?.dataset?.dataSource
+      ?.type;
+    if (dsType === 'AnalyticEngine') return false;
+    return true;
   }
 
   public async execute({ embeddable }: EmbeddableContext) {

--- a/src/plugins/explore/public/components/data_table/table_cell/non_filterable_table_cell.tsx
+++ b/src/plugins/explore/public/components/data_table/table_cell/non_filterable_table_cell.tsx
@@ -48,7 +48,7 @@ export const NonFilterableTableCell: React.FC<NonFilterableTableCellProps> = ({
                 document={rowData._source}
                 query={undefined}
                 indexPattern={dataset?.title}
-                metadata={{ index }}
+                metadata={{ index, dataSourceEngineType: dataset?.dataSource?.type }}
                 iconType="generate"
                 size="xs"
               />

--- a/src/plugins/explore/public/components/data_table/table_cell/table_cell.tsx
+++ b/src/plugins/explore/public/components/data_table/table_cell/table_cell.tsx
@@ -78,7 +78,7 @@ export const TableCellUI = ({
             document={rowData._source}
             query={undefined}
             indexPattern={dataset?.title}
-            metadata={{ index }}
+            metadata={{ index, dataSourceEngineType: dataset?.dataSource?.type }}
             iconType="generate"
             size="xs"
           />

--- a/src/plugins/explore/public/components/tabs/action_bar/action_bar.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/action_bar.tsx
@@ -41,6 +41,11 @@ const ActionBarComponent = ({ filteredRowsCount }: ActionBarProps = {}) => {
   }, [slotRegistry]);
   const slotItems = useObservable(sortedSlotItems$, []);
 
+  const compatibleSlotItems = useMemo(() => {
+    const context = { dataSourceEngineType: dataset?.dataSourceRef?.type };
+    return slotItems.filter((item) => !item.isCompatible || item.isCompatible(context));
+  }, [slotItems, dataset?.dataSourceRef?.type]);
+
   const openInspector = () => {
     if (inspector) {
       inspector.open(inspectorAdapters, {
@@ -69,7 +74,7 @@ const ActionBarComponent = ({ filteredRowsCount }: ActionBarProps = {}) => {
       elapsedMs={elapsedMs}
       dataset={dataset}
       inspectionHanlder={openInspector}
-      extraActions={slotItems}
+      extraActions={compatibleSlotItems}
       rowsCountOverride={filteredRowsCount}
     />
   );

--- a/src/plugins/explore/public/services/slot_registry/slot_registry_service.ts
+++ b/src/plugins/explore/public/services/slot_registry/slot_registry_service.ts
@@ -12,6 +12,7 @@ import { map } from 'rxjs/operators';
 export interface SlotTypeDefinitions {
   resultsActionBar: {
     render: () => React.ReactElement;
+    isCompatible?: (context: { dataSourceEngineType?: string }) => boolean;
   };
   // Add more slot types as needed
 }

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
@@ -63,6 +63,7 @@ describe('AskAIVisualizeEmbeddableAction', () => {
             }),
           },
           indexPattern: {
+            id: 'test-index-pattern-id',
             title: 'test-index',
           },
         },
@@ -71,7 +72,10 @@ describe('AskAIVisualizeEmbeddableAction', () => {
     } as unknown) as VisualizeEmbeddable;
 
     // Create action instance
-    action = new AskAIVisualizeEmbeddableAction(mockCore, mockContextProvider);
+    const mockIndexPatterns = {
+      getCache: jest.fn().mockResolvedValue([{ id: 'test-index-pattern-id' }]),
+    } as any;
+    action = new AskAIVisualizeEmbeddableAction(mockCore, mockIndexPatterns, mockContextProvider);
   });
 
   afterEach(() => {
@@ -106,12 +110,14 @@ describe('AskAIVisualizeEmbeddableAction', () => {
     });
 
     it('should return false when context provider is not available', async () => {
-      const actionWithoutContext = new AskAIVisualizeEmbeddableAction(mockCore, undefined);
+      const mockIp = { getCache: jest.fn().mockResolvedValue([]) } as any;
+      const actionWithoutContext = new AskAIVisualizeEmbeddableAction(mockCore, mockIp, undefined);
       const result = await actionWithoutContext.isCompatible({ embeddable: mockEmbeddable });
       expect(result).toBe(false);
     });
 
     it('should return false when chat is not available', async () => {
+      const mockIp = { getCache: jest.fn().mockResolvedValue([]) } as any;
       const actionWithoutContext = new AskAIVisualizeEmbeddableAction(
         {
           ...mockCore,
@@ -119,6 +125,7 @@ describe('AskAIVisualizeEmbeddableAction', () => {
             isAvailable: () => false,
           },
         },
+        mockIp,
         undefined
       );
       const result = await actionWithoutContext.isCompatible({ embeddable: mockEmbeddable });

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
@@ -11,6 +11,7 @@ import { EmbeddableContext, IEmbeddable } from '../../../embeddable/public';
 import { Action, IncompatibleActionError } from '../../../ui_actions/public';
 import { CoreStart } from '../../../../core/public';
 import { ContextProviderStart } from '../../../context_provider/public';
+import { IndexPatternsContract } from '../../../data/public';
 import { Vis } from '../vis';
 
 interface VisualizeEmbeddable extends IEmbeddable {
@@ -44,6 +45,7 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
 
   constructor(
     private readonly core: CoreStart,
+    private readonly indexPatterns: IndexPatternsContract,
     private readonly contextProvider?: ContextProviderStart
   ) {}
 
@@ -60,9 +62,23 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
   public async isCompatible({ embeddable }: EmbeddableContext) {
     // Check if this is a visualization embeddable and if context provider is available
     const hasContextProvider = this.contextProvider !== undefined;
-    return (
-      embeddable.type === 'visualization' && hasContextProvider && this.core.chat.isAvailable()
-    );
+    if (
+      !(embeddable.type === 'visualization' && hasContextProvider && this.core.chat.isAvailable())
+    ) {
+      return false;
+    }
+    // Hide for AnalyticEngine data sources
+    const visEmbeddable = embeddable as VisualizeEmbeddable;
+    const indexPatternId = visEmbeddable.vis.data.indexPattern?.id;
+    if (indexPatternId) {
+      const cache = await this.indexPatterns.getCache({
+        excludeEngineTypes: ['AnalyticEngine'],
+      });
+      if (cache && !cache.find((ip) => ip.id === indexPatternId)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public async execute({ embeddable }: EmbeddableContext) {

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -217,7 +217,11 @@ export class VisualizationsPlugin
     });
 
     // Register Ask AI action for visualizations
-    const askAIAction = new AskAIVisualizeEmbeddableAction(core, contextProvider);
+    const askAIAction = new AskAIVisualizeEmbeddableAction(
+      core,
+      data.indexPatterns,
+      contextProvider
+    );
     uiActions.addTriggerAction(CONTEXT_MENU_TRIGGER, askAIAction);
 
     setDataStart(data);


### PR DESCRIPTION
### Description

Fix AI-related features showing for AnalyticEngine data sources which don't support OpenSearch DSL.

**Chat plugin:**
- Chat window shows system message when data source is AnalyticEngine (fetches saved object since page context may not have the type)

**Explore plugin:**
- Ask AI log action checks `context.metadata.dataSourceEngineType` passed from table cell
- Ask AI embeddable action checks `savedExplore.searchSource.getFields().query.dataset.dataSource.type`
- Table cells pass `dataSourceEngineType` via metadata from `dataset.dataSource.type`
- Slot registry supports optional `isCompatible(context)` for `resultsActionBar` items
- Action bar filters slot items by `isCompatible({ dataSourceEngineType: dataset?.dataSourceRef?.type })`

**Visualizations plugin:**
- Ask AI embeddable action uses `indexPatterns.getCache({ excludeEngineTypes: ['AnalyticEngine'] })` to check compatibility

### Issues Resolved

Refs opensearch-project/OpenSearch-Dashboards#11882

### Related PRs
- opensearch-project/dashboards-investigation#379
- opensearch-project/dashboards-assistant#689

## Screenshot

N/A - feature hiding, no new UI

## Testing the changes

1. Connect to an AnalyticEngine data source
2. Verify the Ask AI button in log row context menu is hidden
3. Verify the Ask AI embeddable action is hidden on dashboards (both explore and visualization panels)
4. Verify the chat window shows system message when sending a message
5. Verify slot registry `isCompatible` filters out items for AnalyticEngine

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff