### PR TITLE
[Backport 2.19] Align input handling across saved-objects import and data_source routes

### DIFF
--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -157,6 +157,17 @@ describe('#importSavedObjectsFromStream', () => {
       attributes: { title: 'some-title' },
     };
   };
+
+  const createConfigObject = (): SavedObject<{
+    title: string;
+  }> => {
+    return {
+      type: 'config',
+      id: uuidv4(),
+      references: [],
+      attributes: { title: 'some-title' },
+    };
+  };
   const createError = (): SavedObjectsImportError => {
     const title = 'some-title';
     return {
@@ -749,6 +760,82 @@ describe('#importSavedObjectsFromStream', () => {
       const result = await importSavedObjectsFromStream(options);
       const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
       expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
+    });
+
+    test('early return if import contains config type object', async () => {
+      const options = setupOptions();
+      const configObj = createConfigObject();
+      const collectedObjects = [configObj];
+
+      const errors = [
+        {
+          type: configObj.type,
+          id: configObj.id,
+          title: configObj.id,
+          meta: { title: configObj.id },
+          error: { type: 'unsupported_type' },
+        },
+      ];
+      getMockFn(collectSavedObjects).mockResolvedValue({
+        errors: [],
+        collectedObjects,
+        importIdMap: new Map(),
+      });
+      const result = await importSavedObjectsFromStream(options);
+      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
+      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
+      expect(createSavedObjects).not.toHaveBeenCalled();
+    });
+
+    test('early return if import contains config type mixed with valid objects', async () => {
+      const options = setupOptions();
+      const configObj = createConfigObject();
+      const validObj = createObject();
+      const collectedObjects = [validObj, configObj];
+
+      const errors = [
+        {
+          type: configObj.type,
+          id: configObj.id,
+          title: configObj.id,
+          meta: { title: configObj.id },
+          error: { type: 'unsupported_type' },
+        },
+      ];
+      getMockFn(collectSavedObjects).mockResolvedValue({
+        errors: [],
+        collectedObjects,
+        importIdMap: new Map(),
+      });
+      const result = await importSavedObjectsFromStream(options);
+      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
+      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
+      expect(createSavedObjects).not.toHaveBeenCalled();
+    });
+
+    test('early return if import contains config type in workspace-scoped import', async () => {
+      const options = setupOptions(false, undefined, true, ['workspace-1']);
+      const configObj = createConfigObject();
+      const collectedObjects = [configObj];
+
+      const errors = [
+        {
+          type: configObj.type,
+          id: configObj.id,
+          title: configObj.id,
+          meta: { title: configObj.id },
+          error: { type: 'unsupported_type' },
+        },
+      ];
+      getMockFn(collectSavedObjects).mockResolvedValue({
+        errors: [],
+        collectedObjects,
+        importIdMap: new Map(),
+      });
+      const result = await importSavedObjectsFromStream(options);
+      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
+      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
+      expect(createSavedObjects).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -74,8 +74,6 @@ export async function importSavedObjectsFromStream({
     supportedTypes,
     dataSourceId,
   });
-  // Block config type from being imported — config objects control global UI settings
-  // (e.g. defaultRoute, banners) and must only be modified via the advancedSettings API.
   const configErrors: SavedObjectsImportError[] = collectSavedObjectsResult.collectedObjects
     .filter((obj) => obj.type === 'config')
     .map((obj) => ({

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -74,6 +74,25 @@ export async function importSavedObjectsFromStream({
     supportedTypes,
     dataSourceId,
   });
+  // Block config type from being imported — config objects control global UI settings
+  // (e.g. defaultRoute, banners) and must only be modified via the advancedSettings API.
+  const configErrors: SavedObjectsImportError[] = collectSavedObjectsResult.collectedObjects
+    .filter((obj) => obj.type === 'config')
+    .map((obj) => ({
+      error: { type: 'unsupported_type' } as SavedObjectsImportUnsupportedTypeError,
+      type: obj.type,
+      id: obj.id,
+      title: obj.id,
+      meta: { title: obj.id },
+    }));
+  if (configErrors.length > 0) {
+    return {
+      successCount: 0,
+      success: false,
+      errors: configErrors,
+    };
+  }
+
   // if dataSource is not enabled, but object type is data-source, or saved object id contains datasource id
   // return unsupported type error
   if (!dataSourceEnabled) {

--- a/src/core/server/saved_objects/import/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.test.ts
@@ -144,6 +144,17 @@ describe('#importSavedObjectsFromStream', () => {
       attributes: { title: 'some-title' },
     };
   };
+
+  const createConfigObject = (): SavedObject<{
+    title: string;
+  }> => {
+    return {
+      type: 'config',
+      id: uuidv4(),
+      references: [],
+      attributes: { title: 'some-title' },
+    };
+  };
   const createError = (): SavedObjectsImportError => {
     const title = 'some-title';
     return {
@@ -525,6 +536,33 @@ describe('#importSavedObjectsFromStream', () => {
       const result = await resolveSavedObjectsImportErrors(options);
       const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
       expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
+    });
+
+    test('early return if resolve contains config type object', async () => {
+      const configObj = createConfigObject();
+      const options = setupOptions([
+        { type: 'config', id: configObj.id, overwrite: true, replaceReferences: [] },
+      ]);
+      const collectedObjects = [configObj];
+
+      const errors = [
+        {
+          type: configObj.type,
+          id: configObj.id,
+          title: configObj.id,
+          meta: { title: configObj.id },
+          error: { type: 'unsupported_type' },
+        },
+      ];
+      getMockFn(collectSavedObjects).mockResolvedValue({
+        errors: [],
+        collectedObjects,
+        importIdMap: new Map(),
+      });
+      const result = await resolveSavedObjectsImportErrors(options);
+      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
+      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
+      expect(createSavedObjects).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -85,7 +85,6 @@ export async function resolveSavedObjectsImportErrors({
   );
   errorAccumulator = [...errorAccumulator, ...collectorErrors];
 
-  // Block config type from being imported via retry/resolve path
   const configErrors: SavedObjectsImportError[] = objectsToResolve
     .filter((obj) => obj.type === 'config')
     .map((obj) => ({

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -36,6 +36,7 @@ import {
   SavedObjectsImportResponse,
   SavedObjectsResolveImportErrorsOptions,
   SavedObjectsImportSuccess,
+  SavedObjectsImportUnsupportedTypeError,
 } from './types';
 import { regenerateIds } from './regenerate_ids';
 import { validateReferences } from './validate_references';
@@ -83,6 +84,24 @@ export async function resolveSavedObjectsImportErrors({
     }
   );
   errorAccumulator = [...errorAccumulator, ...collectorErrors];
+
+  // Block config type from being imported via retry/resolve path
+  const configErrors: SavedObjectsImportError[] = objectsToResolve
+    .filter((obj) => obj.type === 'config')
+    .map((obj) => ({
+      error: { type: 'unsupported_type' } as SavedObjectsImportUnsupportedTypeError,
+      type: obj.type,
+      id: obj.id,
+      title: obj.id,
+      meta: { title: obj.id },
+    }));
+  if (configErrors.length > 0) {
+    return {
+      successCount: 0,
+      success: false,
+      errors: configErrors,
+    };
+  }
 
   // Create a map of references to replace for each object to avoid iterating through
   // retries for every object to resolve

--- a/src/core/server/saved_objects/routes/utils.test.ts
+++ b/src/core/server/saved_objects/routes/utils.test.ts
@@ -114,6 +114,50 @@ describe('createSavedObjectsStreamFromNdJson', () => {
       },
     ]);
   });
+
+  it('rejects objects with __proto__ keys', async () => {
+    await expect(
+      createSavedObjectsStreamFromNdJson(
+        new Readable({
+          read() {
+            this.push('{"id": "foo", "type": "foo-type", "__proto__": {"polluted": true}}\n');
+            this.push(null);
+          },
+        })
+      )
+    ).rejects.toThrowError(/invalid key/i);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('rejects objects with constructor.prototype keys', async () => {
+    await expect(
+      createSavedObjectsStreamFromNdJson(
+        new Readable({
+          read() {
+            this.push(
+              '{"id": "foo", "type": "foo-type", "constructor": {"prototype": {"bad": true}}}\n'
+            );
+            this.push(null);
+          },
+        })
+      )
+    ).rejects.toThrowError(/invalid key/i);
+  });
+
+  it('rejects objects with __proto__ in nested attributes', async () => {
+    await expect(
+      createSavedObjectsStreamFromNdJson(
+        new Readable({
+          read() {
+            this.push(
+              '{"id": "foo", "type": "foo-type", "attributes": {"title": "safe", "__proto__": {"x": 1}}}\n'
+            );
+            this.push(null);
+          },
+        })
+      )
+    ).rejects.toThrowError(/invalid key/i);
+  });
 });
 
 describe('validateTypes', () => {

--- a/src/core/server/saved_objects/routes/utils.ts
+++ b/src/core/server/saved_objects/routes/utils.ts
@@ -38,6 +38,7 @@ import {
   createListStream,
   createConcatStream,
 } from '../../utils/streams';
+import { validateObject } from '../../http/prototype_pollution/validate_object';
 
 export async function createSavedObjectsStreamFromNdJson(ndJsonStream: Readable) {
   const savedObjects = await createPromiseFromStreams([
@@ -45,7 +46,15 @@ export async function createSavedObjectsStreamFromNdJson(ndJsonStream: Readable)
     createSplitStream('\n'),
     createMapStream((str: string) => {
       if (str && str.trim() !== '') {
-        return JSON.parse(str);
+        const parsed = JSON.parse(str);
+        try {
+          validateObject(parsed);
+        } catch (e) {
+          throw new Error(
+            `Invalid object in import stream: ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+        return parsed;
       }
     }),
     createFilterStream<SavedObject | SavedObjectsExportResultDetails>(

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -128,19 +128,31 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     );
 
     const router = core.http.createRouter();
+    const endpointDeniedIPs = config.endpointDeniedIPs ?? [
+      '127.0.0.0/8',
+      '::1/128',
+      '169.254.0.0/16',
+      'fe80::/10',
+    ];
     registerTestConnectionRoute(
       router,
       dataSourceService,
       cryptographyServiceSetup,
       authRegistryPromise,
-      customApiSchemaRegistryPromise
+      customApiSchemaRegistryPromise,
+      this.logger.get('test-connection'),
+      endpointDeniedIPs,
+      config.endpointAllowlistedSuffixes
     );
     registerFetchDataSourceMetaDataRoute(
       router,
       dataSourceService,
       cryptographyServiceSetup,
       authRegistryPromise,
-      customApiSchemaRegistryPromise
+      customApiSchemaRegistryPromise,
+      this.logger.get('fetch-data-source-metadata'),
+      endpointDeniedIPs,
+      config.endpointAllowlistedSuffixes
     );
 
     const registerCredentialProvider = (method: AuthenticationMethod) => {

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -128,11 +128,6 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     );
 
     const router = core.http.createRouter();
-    // Default deny list covers cloud metadata (IMDS) and IPv6 link-local —
-    // the network ranges the SSRF report flagged. Loopback is intentionally
-    // excluded so OSD deployed alongside OpenSearch on the same host (and
-    // Cypress test runs) keep working; operators that want stricter blocking
-    // can configure `data_source.endpointDeniedIPs` explicitly.
     const endpointDeniedIPs = config.endpointDeniedIPs ?? ['169.254.0.0/16', 'fe80::/10'];
     registerTestConnectionRoute(
       router,

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -128,12 +128,12 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
     );
 
     const router = core.http.createRouter();
-    const endpointDeniedIPs = config.endpointDeniedIPs ?? [
-      '127.0.0.0/8',
-      '::1/128',
-      '169.254.0.0/16',
-      'fe80::/10',
-    ];
+    // Default deny list covers cloud metadata (IMDS) and IPv6 link-local —
+    // the network ranges the SSRF report flagged. Loopback is intentionally
+    // excluded so OSD deployed alongside OpenSearch on the same host (and
+    // Cypress test runs) keep working; operators that want stricter blocking
+    // can configure `data_source.endpointDeniedIPs` explicitly.
+    const endpointDeniedIPs = config.endpointDeniedIPs ?? ['169.254.0.0/16', 'fe80::/10'];
     registerTestConnectionRoute(
       router,
       dataSourceService,

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
@@ -530,9 +530,7 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
       })
       .expect(400);
 
-    expect(result.body.message).toEqual(
-      'Fetch data source metadata endpoint validation failed'
-    );
+    expect(result.body.message).toEqual('Fetch data source metadata endpoint validation failed');
     expect(dataSourceServiceSetupMock.getDataSourceClient).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
@@ -18,7 +18,6 @@ import { AuthType } from '../../common/data_sources';
 import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
 import { dynamicConfigServiceMock } from '../../../../../src/core/server/mocks';
 
-// Mock the endpoint validator
 jest.mock('../util/endpoint_validator', () => ({
   isValidURL: jest.fn(),
 }));
@@ -174,7 +173,6 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
       getDataSourceLegacyClient: jest.fn(),
     };
 
-    // Mock endpoint validator to allow by default; individual SSRF cases override.
     mockedIsValidURL.mockResolvedValue({ valid: true });
 
     const router = httpSetup.createRouter('');
@@ -405,10 +403,6 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
       installedPlugins: ['opensearch-ml', 'opensearch-sql'],
     });
   });
-
-  // ---------------------------------------------------------------------------
-  // SSRF endpoint validation tests
-  // ---------------------------------------------------------------------------
 
   it('should fail when endpoint is invalid', async () => {
     mockedIsValidURL.mockResolvedValue({

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
@@ -18,9 +18,18 @@ import { AuthType } from '../../common/data_sources';
 import { opensearchClientMock } from '../../../../../src/core/server/opensearch/client/mocks';
 import { dynamicConfigServiceMock } from '../../../../../src/core/server/mocks';
 
+// Mock the endpoint validator
+jest.mock('../util/endpoint_validator', () => ({
+  isValidURL: jest.fn(),
+}));
+
+import { isValidURL } from '../util/endpoint_validator';
+const mockedIsValidURL = isValidURL as jest.MockedFunction<typeof isValidURL>;
+
 type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 
 const URL = '/internal/data-source-management/fetchDataSourceMetaData';
+const BLOCKED_IP_RANGES = ['127.0.0.0/8', '169.254.0.0/16'];
 
 describe(`Fetch DataSource MetaData ${URL}`, () => {
   let server: SetupServerReturn['server'];
@@ -165,6 +174,9 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
       getDataSourceLegacyClient: jest.fn(),
     };
 
+    // Mock endpoint validator to allow by default; individual SSRF cases override.
+    mockedIsValidURL.mockResolvedValue({ valid: true });
+
     const router = httpSetup.createRouter('');
     dataSourceClient.info.mockImplementationOnce(() =>
       opensearchClientMock.createSuccessTransportRequestPromise({
@@ -180,12 +192,25 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
       opensearchClientMock.createSuccessTransportRequestPromise(installedPlugins)
     );
 
+    const mockLogger: any = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+      fatal: jest.fn(),
+      log: jest.fn(),
+      get: jest.fn().mockReturnThis(),
+    };
+
     registerFetchDataSourceMetaDataRoute(
       router,
       dataSourceServiceSetupMock,
       cryptographyMock,
       authRegistryPromiseMock,
-      customApiSchemaRegistryPromise
+      customApiSchemaRegistryPromise,
+      mockLogger as any,
+      BLOCKED_IP_RANGES
     );
 
     await server.start({ dynamicConfigService: dynamicConfigServiceStart });
@@ -193,6 +218,7 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
 
   afterEach(async () => {
     await server.stop();
+    mockedIsValidURL.mockReset();
   });
 
   it('shows successful response', async () => {
@@ -378,5 +404,135 @@ describe(`Fetch DataSource MetaData ${URL}`, () => {
       dataSourceEngineType: 'OpenSearch',
       installedPlugins: ['opensearch-ml', 'opensearch-sql'],
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // SSRF endpoint validation tests
+  // ---------------------------------------------------------------------------
+
+  it('should fail when endpoint is invalid', async () => {
+    mockedIsValidURL.mockResolvedValue({
+      valid: false,
+      error: 'Invalid URL format',
+      userMessage: 'Invalid URL format',
+    });
+
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: {
+          endpoint: 'invalid-endpoint',
+          auth: {
+            type: AuthType.NoAuth,
+            credentials: {},
+          },
+        },
+      })
+      .expect(400);
+
+    expect(result.body.message).toContain('Invalid URL format');
+    expect(mockedIsValidURL).toHaveBeenCalledWith('invalid-endpoint', BLOCKED_IP_RANGES, undefined);
+    expect(dataSourceServiceSetupMock.getDataSourceClient).not.toHaveBeenCalled();
+  });
+
+  it('should succeed when endpoint is valid', async () => {
+    mockedIsValidURL.mockResolvedValue({ valid: true });
+
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr,
+      })
+      .expect(200);
+
+    expect(result.body).toEqual({
+      dataSourceVersion: '2.11.0',
+      dataSourceEngineType: 'OpenSearch',
+      installedPlugins: ['opensearch-ml', 'opensearch-sql'],
+    });
+    expect(mockedIsValidURL).toHaveBeenCalledWith('https://test.com', BLOCKED_IP_RANGES, undefined);
+    expect(dataSourceServiceSetupMock.getDataSourceClient).toHaveBeenCalled();
+  });
+
+  it('should fail when endpoint resolves to a blocked IP range', async () => {
+    mockedIsValidURL.mockResolvedValue({
+      valid: false,
+      error: 'IP 127.0.0.1 is blocked by denied range 127.0.0.0/8',
+      userMessage: 'Endpoint IP address is not allowed',
+    });
+
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: {
+          endpoint: 'http://127.0.0.1:9200',
+          auth: {
+            type: AuthType.NoAuth,
+            credentials: {},
+          },
+        },
+      })
+      .expect(400);
+
+    expect(result.body.message).toContain('Endpoint IP address is not allowed');
+    expect(mockedIsValidURL).toHaveBeenCalledWith(
+      'http://127.0.0.1:9200',
+      BLOCKED_IP_RANGES,
+      undefined
+    );
+    expect(dataSourceServiceSetupMock.getDataSourceClient).not.toHaveBeenCalled();
+  });
+
+  it('should fail when endpoint targets the cloud metadata IP', async () => {
+    mockedIsValidURL.mockResolvedValue({
+      valid: false,
+      error: 'IP 169.254.169.254 is blocked by denied range 169.254.0.0/16',
+      userMessage: 'Endpoint IP address is not allowed',
+    });
+
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr: {
+          endpoint: 'http://169.254.169.254/latest/meta-data/',
+          auth: {
+            type: AuthType.NoAuth,
+            credentials: {},
+          },
+        },
+      })
+      .expect(400);
+
+    expect(result.body.message).toContain('Endpoint IP address is not allowed');
+    expect(mockedIsValidURL).toHaveBeenCalledWith(
+      'http://169.254.169.254/latest/meta-data/',
+      BLOCKED_IP_RANGES,
+      undefined
+    );
+    expect(dataSourceServiceSetupMock.getDataSourceClient).not.toHaveBeenCalled();
+  });
+
+  it('should use a generic message when validator returns no userMessage', async () => {
+    mockedIsValidURL.mockResolvedValue({
+      valid: false,
+      error: 'unexpected validator failure',
+    });
+
+    const result = await supertest(httpSetup.server.listener)
+      .post(URL)
+      .send({
+        id: 'testId',
+        dataSourceAttr,
+      })
+      .expect(400);
+
+    expect(result.body.message).toEqual(
+      'Fetch data source metadata endpoint validation failed'
+    );
+    expect(dataSourceServiceSetupMock.getDataSourceClient).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
@@ -83,7 +83,11 @@ export const registerFetchDataSourceMetaDataRoute = async (
       // Validate endpoint before attempting connection
       const { endpoint } = dataSourceAttr;
 
-      const validationResult = await isValidURL(endpoint, endpointDeniedIPs, endpointAllowlistedSuffixes);
+      const validationResult = await isValidURL(
+        endpoint,
+        endpointDeniedIPs,
+        endpointAllowlistedSuffixes
+      );
       if (!validationResult.valid) {
         // Log detailed error for server-side debugging
         logger.error(`Endpoint validation failed for ${endpoint}: ${validationResult.error}`);

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
@@ -80,7 +80,6 @@ export const registerFetchDataSourceMetaDataRoute = async (
     async (context, request, response) => {
       const { dataSourceAttr, id: dataSourceId } = request.body;
 
-      // Validate endpoint before attempting connection
       const { endpoint } = dataSourceAttr;
 
       const validationResult = await isValidURL(
@@ -89,10 +88,8 @@ export const registerFetchDataSourceMetaDataRoute = async (
         endpointAllowlistedSuffixes
       );
       if (!validationResult.valid) {
-        // Log detailed error for server-side debugging
         logger.error(`Endpoint validation failed for ${endpoint}: ${validationResult.error}`);
 
-        // Return safe message to client
         return response.customError({
           statusCode: 400,
           body: {

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
@@ -4,20 +4,24 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { IRouter, OpenSearchClient } from 'opensearch-dashboards/server';
+import { IRouter, Logger, OpenSearchClient } from 'opensearch-dashboards/server';
 import { AuthType, DataSourceAttributes, SigV4ServiceName } from '../../common/data_sources';
 import { DataSourceConnectionValidator } from './data_source_connection_validator';
 import { DataSourceServiceSetup } from '../data_source_service';
 import { CryptographyServiceSetup } from '../cryptography_service';
 import { IAuthenticationMethodRegistry } from '../auth_registry';
 import { CustomApiSchemaRegistry } from '../schema_registry/custom_api_schema_registry';
+import { isValidURL } from '../util/endpoint_validator';
 
 export const registerFetchDataSourceMetaDataRoute = async (
   router: IRouter,
   dataSourceServiceSetup: DataSourceServiceSetup,
   cryptography: CryptographyServiceSetup,
   authRegistryPromise: Promise<IAuthenticationMethodRegistry>,
-  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>
+  customApiSchemaRegistryPromise: Promise<CustomApiSchemaRegistry>,
+  logger: Logger,
+  endpointDeniedIPs?: string[],
+  endpointAllowlistedSuffixes?: string[]
 ) => {
   const authRegistry = await authRegistryPromise;
   router.post(
@@ -75,6 +79,25 @@ export const registerFetchDataSourceMetaDataRoute = async (
     },
     async (context, request, response) => {
       const { dataSourceAttr, id: dataSourceId } = request.body;
+
+      // Validate endpoint before attempting connection
+      const { endpoint } = dataSourceAttr;
+
+      const validationResult = await isValidURL(endpoint, endpointDeniedIPs, endpointAllowlistedSuffixes);
+      if (!validationResult.valid) {
+        // Log detailed error for server-side debugging
+        logger.error(`Endpoint validation failed for ${endpoint}: ${validationResult.error}`);
+
+        // Return safe message to client
+        return response.customError({
+          statusCode: 400,
+          body: {
+            message:
+              validationResult.userMessage ||
+              'Fetch data source metadata endpoint validation failed',
+          },
+        });
+      }
 
       try {
         const dataSourceClient: OpenSearchClient = await dataSourceServiceSetup.getDataSourceClient(


### PR DESCRIPTION
### Description

backport of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12014


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
