### PR TITLE
[Security]Enable CSP enforcement by default (csp.enable: true)

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -40,6 +40,18 @@
 # It requires the application config plugin as its dependency.
 # csp_handler.enabled: true
 
+# Content Security Policy (CSP) configuration.
+# csp.enable: false
+# csp.allowedFrameAncestorSources: []
+# csp.allowedConnectSources: []
+# csp.allowedImgSources: []
+#
+# Content-Security-Policy-Report-Only settings.
+# csp-report-only.isEmitting: false
+# csp-report-only.allowedFrameAncestorSources: []
+# csp-report-only.allowedConnectSources: []
+# csp-report-only.allowedImgSources: []
+
 # The default application to load.
 # opensearchDashboards.defaultAppId: "home"
 

--- a/src/core/server/csp/config.ts
+++ b/src/core/server/csp/config.ts
@@ -44,7 +44,7 @@ export const config = {
     rules: schema.arrayOf(schema.string(), {
       defaultValue: LOOSE_CSP_RULES_DEFAULT_VALUE,
     }),
-    enable: schema.boolean({ defaultValue: false }),
+    enable: schema.boolean({ defaultValue: true }),
     /** @deprecated Use `enable` instead. */
     strict: schema.boolean({ defaultValue: false }),
     warnLegacyBrowsers: schema.boolean({ defaultValue: true }),

--- a/src/core/server/csp/csp_config.test.ts
+++ b/src/core/server/csp/csp_config.test.ts
@@ -47,8 +47,8 @@ describe('CspConfig', () => {
   test('DEFAULT', () => {
     expect(CspConfig.DEFAULT).toMatchInlineSnapshot(`
       CspConfig {
-        "enable": false,
-        "header": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "enable": true,
+        "header": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
         "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
         "looseRules": Array [
           "script-src 'unsafe-eval' 'self'",
@@ -60,11 +60,25 @@ describe('CspConfig', () => {
           "style-src-elem",
         ],
         "rules": Array [
-          "script-src 'unsafe-eval' 'self'",
-          "worker-src blob: 'self'",
-          "style-src 'unsafe-inline' 'self'",
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
         ],
-        "strict": false,
+        "strict": true,
         "strictRules": Array [
           "default-src 'self'",
           "script-src 'self'",
@@ -92,8 +106,8 @@ describe('CspConfig', () => {
   test('defaults from config', () => {
     expect(new CspConfig()).toMatchInlineSnapshot(`
       CspConfig {
-        "enable": false,
-        "header": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+        "enable": true,
+        "header": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
         "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
         "looseRules": Array [
           "script-src 'unsafe-eval' 'self'",
@@ -105,11 +119,25 @@ describe('CspConfig', () => {
           "style-src-elem",
         ],
         "rules": Array [
-          "script-src 'unsafe-eval' 'self'",
-          "worker-src blob: 'self'",
-          "style-src 'unsafe-inline' 'self'",
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
         ],
-        "strict": false,
+        "strict": true,
         "strictRules": Array [
           "default-src 'self'",
           "script-src 'self'",
@@ -198,8 +226,8 @@ describe('CspConfig', () => {
 
     expect(cspConfig).toMatchInlineSnapshot(`
       CspConfig {
-        "enable": false,
-        "header": "alpha; beta; gamma",
+        "enable": true,
+        "header": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
         "looseHeader": "alpha; beta; gamma",
         "looseRules": Array [
           "alpha",
@@ -211,11 +239,25 @@ describe('CspConfig', () => {
           "style-src-elem",
         ],
         "rules": Array [
-          "alpha",
-          "beta",
-          "gamma",
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-attr 'none'",
+          "style-src 'self'",
+          "style-src-elem 'self'",
+          "style-src-attr 'self' 'unsafe-inline'",
+          "child-src 'none'",
+          "worker-src 'self'",
+          "frame-src 'none'",
+          "object-src 'none'",
+          "manifest-src 'self'",
+          "media-src 'none'",
+          "font-src 'self'",
+          "connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org",
+          "form-action 'self'",
+          "frame-ancestors 'self'",
         ],
-        "strict": false,
+        "strict": true,
         "strictRules": Array [
           "default-src 'self'",
           "script-src 'self'",
@@ -320,7 +362,7 @@ describe('CspConfig', () => {
 
       expect(config).toMatchInlineSnapshot(`
         CspConfig {
-          "enable": false,
+          "enable": true,
           "header": "default-src 'self'; script-src 'unsafe-eval' 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src blob: 'self'; frame-src 'none'; object-src 'none'; manifest-src 'self'; media-src 'none'; font-src 'self'; connect-src 'self' https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; img-src 'self' data: https://opensearch.org https://docs.opensearch.org https://maps.opensearch.org https://vectors.maps.opensearch.org https://tiles.maps.opensearch.org; form-action 'self'; frame-ancestors 'self'",
           "looseHeader": "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
           "looseRules": Array [
@@ -354,7 +396,7 @@ describe('CspConfig', () => {
             "form-action 'self'",
             "frame-ancestors 'self'",
           ],
-          "strict": false,
+          "strict": true,
           "strictRules": Array [
             "default-src 'self'",
             "script-src 'unsafe-eval' 'self'",
@@ -382,6 +424,7 @@ describe('CspConfig', () => {
     test('has no effect in non-strict mode', () => {
       const config = new CspConfig({
         strict: false,
+        enable: false,
         loosenCspDirectives: ['script-src', 'worker-src'],
         rules: ["script-src 'self'", "worker-src 'self'"],
       });
@@ -432,6 +475,7 @@ describe('CspConfig', () => {
     test('has no effect in non-strict mode without custom rules', () => {
       const config = new CspConfig({
         strict: false,
+        enable: false,
         allowedImgSources: ['https://images.example.com'],
       });
 

--- a/src/core/server/http_resources/http_resources_service.test.ts
+++ b/src/core/server/http_resources/http_resources_service.test.ts
@@ -112,8 +112,7 @@ describe('HttpResources service', () => {
             body: '<body />',
             headers: {
               'x-opensearch-dashboards': '42',
-              'content-security-policy':
-                "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+              'content-security-policy': expect.stringContaining("default-src 'self'"),
             },
           });
         });
@@ -162,8 +161,7 @@ describe('HttpResources service', () => {
             body: '<body />',
             headers: {
               'x-opensearch-dashboards': '42',
-              'content-security-policy':
-                "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+              'content-security-policy': expect.stringContaining("default-src 'self'"),
             },
           });
         });
@@ -185,8 +183,7 @@ describe('HttpResources service', () => {
             body: htmlBody,
             headers: {
               'content-type': 'text/html',
-              'content-security-policy':
-                "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+              'content-security-policy': expect.stringContaining("default-src 'self'"),
             },
           });
         });
@@ -217,8 +214,7 @@ describe('HttpResources service', () => {
             headers: {
               'content-type': 'text/html',
               'x-opensearch-dashboards': '42',
-              'content-security-policy':
-                "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+              'content-security-policy': expect.stringContaining("default-src 'self'"),
             },
           });
         });
@@ -240,8 +236,7 @@ describe('HttpResources service', () => {
             body: jsBody,
             headers: {
               'content-type': 'text/javascript',
-              'content-security-policy':
-                "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+              'content-security-policy': expect.stringContaining("default-src 'self'"),
             },
           });
         });
@@ -272,8 +267,7 @@ describe('HttpResources service', () => {
             headers: {
               'content-type': 'text/javascript',
               'x-opensearch-dashboards': '42',
-              'content-security-policy':
-                "script-src 'unsafe-eval' 'self'; worker-src blob: 'self'; style-src 'unsafe-inline' 'self'",
+              'content-security-policy': expect.stringContaining("default-src 'self'"),
             },
           });
         });

--- a/src/core/server/http_resources/integration_tests/http_resources_service.test.ts
+++ b/src/core/server/http_resources/integration_tests/http_resources_service.test.ts
@@ -39,6 +39,7 @@ describe('http resources service', () => {
       root = osdTestServer.createRoot({
         csp: {
           rules: [defaultCspRules],
+          enable: false,
         },
         plugins: { initialize: false },
       });

--- a/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/csp_collector.test.ts
+++ b/src/plugins/opensearch_dashboards_usage_collection/server/collectors/csp/csp_collector.test.ts
@@ -47,10 +47,10 @@ describe('csp collector', () => {
   test('fetches whether strict mode is enabled', async () => {
     const collector = createCspCollector(httpMock);
 
-    expect((await collector.fetch(mockCallCluster)).strict).toEqual(false);
-
-    updateCsp({ enable: true });
     expect((await collector.fetch(mockCallCluster)).strict).toEqual(true);
+
+    updateCsp({ enable: false });
+    expect((await collector.fetch(mockCallCluster)).strict).toEqual(false);
   });
 
   test('fetches whether the legacy browser warning is enabled', async () => {
@@ -67,7 +67,7 @@ describe('csp collector', () => {
 
     expect((await collector.fetch(mockCallCluster)).rulesChangedFromDefault).toEqual(false);
 
-    updateCsp({ rules: ['not', 'default'] });
+    updateCsp({ enable: false, rules: ['not', 'default'] });
     expect((await collector.fetch(mockCallCluster)).rulesChangedFromDefault).toEqual(true);
   });
 
@@ -83,7 +83,7 @@ describe('csp collector', () => {
     expect(await collector.fetch(mockCallCluster)).toMatchInlineSnapshot(`
       Object {
         "rulesChangedFromDefault": false,
-        "strict": false,
+        "strict": true,
         "warnLegacyBrowsers": true,
       }
     `);


### PR DESCRIPTION
### Description


  Enable CSP enforcement by default (csp.enable: true). Previously, OSD shipped with CSP disabled, requiring operators to explicitly opt in. This change makes the strict CSP policy active out of the box, improving security posture for all deployments.

Adds commented-out CSP configuration flags to opensearch_dashboards.yml operators can set csp.enable: false to revert to the previous behavior.

## Testing the changes
<img width="1508" height="947" alt="image" src="https://github.com/user-attachments/assets/457ebe48-ed5a-4011-ba7a-538db9088f29" />

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
