### PR TITLE
Upgrade dompurify to 3.4.7 to fix CVE-2025-15599

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "core-js": "^3.6.5",
     "deep-freeze-strict": "^1.1.1",
     "del": "^6.1.1",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.7",
     "echarts": "^6.0.0",
     "elastic-apm-node": "^4.10.0",
     "elasticsearch": "^16.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10265,10 +10265,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
-  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
+dompurify@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.7.tgz#e2702ea4fd5d83467f1baef62309466ce7d44a82"
+  integrity sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
### Description

Upgrades `dompurify` from `^3.4.0` (resolved 3.4.0) to `^3.4.7` (resolved 3.4.7) to remediate [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599).

**CVE-2025-15599** is an XSS vulnerability in DOMPurify versions 3.1.3–3.2.6 that allows attackers to bypass attribute sanitization by exploiting missing `textarea` rawtext element validation in the `SAFE_FOR_XML` regex. The fix was released in DOMPurify 3.2.7.

### Issues Resolved

- Resolves CVE-2025-15599

### Check List

- [x] All tests pass (`yarn osd bootstrap` succeeds)
- [x] New functionality includes testing
- [x] Commits are signed (DCO)
