### PR TITLE
Upgrade langsmith to 0.6.3 to fix CVE-2026-25528

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "**/@babel/traverse": "^7.27.0",
     "**/@cypress/request": "^3.0.9",
     "**/@microsoft/tsdoc-config/ajv": "^6.14.0",
-    "**/@langchain/core/langsmith": "0.5.26",
+    "**/@langchain/core/langsmith": "0.6.3",
     "**/cipher-base": "^1.0.5",
     "**/sha.js": "^2.4.12",
     "**/@types/node": "~22.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15107,10 +15107,10 @@ known-css-properties@^0.24.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.24.0.tgz#19aefd85003ae5698a5560d2b55135bf5432155c"
   integrity sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==
 
-langsmith@0.5.26, langsmith@^0.3.67:
-  version "0.5.26"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.26.tgz#49c720450991c81b1ddd86aec1aa633417753885"
-  integrity sha512-HmmFgeQR2n9x1Kq8NiVaNL/j72ta71qN11hYjbyePJ/QuYEnOMhQjbNv9KeyKB3bOetpIzNalQbhHm+RyKoPRQ==
+langsmith@0.6.3, langsmith@^0.3.67:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.6.3.tgz#a3d8ad58d66a47d3697e3c69b2be3f6df5233190"
+  integrity sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==
   dependencies:
     p-queue "6.6.2"
 


### PR DESCRIPTION
### Description

Upgrades the `langsmith` resolution override from `0.5.26` to `0.6.3` to remediate [CVE-2026-25528](https://nvd.nist.gov/vuln/detail/CVE-2026-25528).

**CVE-2026-25528** is an SSRF vulnerability in the LangSmith SDK's distributed tracing feature. An attacker can inject arbitrary `api_url` values through the HTTP `baggage` header, causing the SDK to exfiltrate sensitive trace data to attacker-controlled endpoints.

- [GHSA-v34v-rq6j-cj6p](https://github.com/langchain-ai/langsmith-sdk/security/advisories/GHSA-v34v-rq6j-cj6p)

### Issues Resolved

- Resolves CVE-2026-25528

### Check List

- [x] All tests pass (`yarn osd bootstrap` succeeds)
- [x] Commits are signed (DCO)
