### PR TITLE
fix: saved visualization reset immediately after save on discover page

### DIFF
--- a/src/plugins/explore/public/helpers/save_explore.test.ts
+++ b/src/plugins/explore/public/helpers/save_explore.test.ts
@@ -110,6 +110,52 @@ describe('saveSavedExplore', () => {
     expect(services.store.dispatch).toHaveBeenCalledWith(setSavedSearch('456'));
   });
 
+  it('should preserve hash search params when navigating to new explore id', async () => {
+    savedExplore.save.mockResolvedValue('456');
+    const pushMock = jest.fn();
+    services.scopedHistory = {
+      location: {
+        hash: '#?_v=(chartType:bar,axesMapping:(x:field1,y:field2))&_q=(query:test)&_a=(tab:vis)',
+      },
+      push: pushMock,
+    };
+
+    await saveSavedExplore({
+      savedExplore,
+      newTitle: 'New Title',
+      saveOptions,
+      searchContext,
+      services,
+      startSyncingQueryStateWithUrl: jest.fn(),
+      openAfterSave: true,
+    });
+
+    expect(pushMock).toHaveBeenCalledWith(
+      '#/view/456?_v=(chartType:bar,axesMapping:(x:field1,y:field2))&_q=(query:test)&_a=(tab:vis)'
+    );
+  });
+
+  it('should navigate without search params when hash has no query string', async () => {
+    savedExplore.save.mockResolvedValue('456');
+    const pushMock = jest.fn();
+    services.scopedHistory = {
+      location: { hash: '#/' },
+      push: pushMock,
+    };
+
+    await saveSavedExplore({
+      savedExplore,
+      newTitle: 'New Title',
+      saveOptions,
+      searchContext,
+      services,
+      startSyncingQueryStateWithUrl: jest.fn(),
+      openAfterSave: true,
+    });
+
+    expect(pushMock).toHaveBeenCalledWith('#/view/456');
+  });
+
   it('should handle save failure', async () => {
     savedExplore.save.mockRejectedValue(new Error('Save failed'));
 

--- a/src/plugins/explore/public/helpers/save_explore.ts
+++ b/src/plugins/explore/public/helpers/save_explore.ts
@@ -77,7 +77,10 @@ export async function saveSavedExplore({
       });
 
       if (id !== originalId) {
-        services.scopedHistory?.push(`#/view/${encodeURIComponent(id)}`);
+        const currentHash = services.scopedHistory?.location.hash || '';
+        const hashSearch =
+          currentHash.indexOf('?') >= 0 ? currentHash.substring(currentHash.indexOf('?')) : '';
+        services.scopedHistory?.push(`#/view/${encodeURIComponent(id)}${hashSearch}`);
       } else {
         // Update browser title and breadcrumbs
         chrome.docTitle.change(newTitle);


### PR DESCRIPTION
### Description
Fixed an issue that visualization get reset immediately after save on discover page

#### Before

https://github.com/user-attachments/assets/f78cf93d-40ac-4112-92e8-d702f9d9d11a


#### After

https://github.com/user-attachments/assets/71c20b33-b890-4c1c-80b8-8607fdfc3c95


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
