### PR TITLE
[Explore metrics] fix and improve chart with long series

### DIFF
--- a/src/plugins/explore/public/components/tabs/metrics_vis_tab.scss
+++ b/src/plugins/explore/public/components/tabs/metrics_vis_tab.scss
@@ -78,4 +78,28 @@
     flex: 1 0 auto;
     min-height: 500px;
   }
+
+  // Override custom legend defaults for metrics charts: stack one series per
+  // line with both horizontal and vertical scrolling so long Prometheus-style
+  // labels stay legible.
+  .customLegend--horizontal {
+    flex-flow: column nowrap;
+    align-items: flex-start;
+    max-height: 120px;
+    overflow: auto;
+  }
+
+  .customLegend__item {
+    flex-shrink: 0;
+  }
+
+  .customLegend--vertical .customLegend__item {
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .customLegend--vertical .customLegend__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/src/plugins/explore/public/components/tabs/metrics_vis_tab.test.tsx
+++ b/src/plugins/explore/public/components/tabs/metrics_vis_tab.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+
+const mockHandleData = jest.fn();
+const mockVisualizationBuilder = {
+  handleData: mockHandleData,
+  data$: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })), pipe: jest.fn() },
+  visConfig$: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })), pipe: jest.fn() },
+  setCurrentChartType: jest.fn(),
+  renderStylePanel: jest.fn(() => null),
+};
+
+jest.mock('../visualizations/visualization_builder', () => ({
+  getVisualizationBuilder: () => mockVisualizationBuilder,
+}));
+
+const mockResults: {
+  hits: { hits: Array<{ _source: Record<string, unknown> }> };
+  fieldSchema: Array<{ name: string; type: string }>;
+} = {
+  hits: {
+    hits: Array.from({ length: 25 }, (_, i) => ({
+      _source: { Series: `series-${i}`, Time: 1000 + i, Value: i },
+    })),
+  },
+  fieldSchema: [
+    { name: 'Time', type: 'time' },
+    { name: 'Series', type: 'string' },
+    { name: 'Value', type: 'number' },
+  ],
+};
+
+jest.mock('../../application/utils/hooks/use_tab_results', () => ({
+  useTabResults: () => ({ results: mockResults }),
+}));
+
+jest.mock('react-use', () => ({
+  useObservable: (obs: unknown) => {
+    if (obs === mockVisualizationBuilder.data$) return [{}];
+    if (obs === mockVisualizationBuilder.visConfig$) return { type: 'line' };
+    return undefined;
+  },
+}));
+
+const mockQuery = {};
+jest.mock('react-redux', () => ({
+  useSelector: () => mockQuery,
+}));
+
+jest.mock('../../application/utils/state_management/actions/query_actions', () => ({
+  shouldSkipQueryExecution: () => false,
+}));
+
+jest.mock('../visualizations/visualization_container', () => ({
+  VisualizationContainer: () => <div data-testid="vis-container" />,
+}));
+
+jest.mock('../data_table/explore_metrics_raw_table', () => ({
+  ExploreMetricsRawTable: () => <div data-testid="raw-table" />,
+}));
+
+jest.mock('./action_bar/action_bar', () => ({
+  ActionBar: () => null,
+}));
+
+jest.mock('./tabs', () => ({
+  EXPLORE_ACTION_BAR_SLOT_ID: 'action-bar-slot',
+}));
+
+jest.mock('../../components/data_transformations', () => ({
+  TransformPanel: () => null,
+  useTransformationService: () => ({}),
+}));
+
+import { MetricsVisTab } from './metrics_vis_tab';
+
+describe('MetricsVisTab handleData with showAllSeries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls handleData with limited rows on initial render', () => {
+    render(<MetricsVisTab />);
+
+    expect(mockHandleData).toHaveBeenCalled();
+    // Should be limited to 20 series (DEFAULT_SERIES_LIMIT)
+    const rows = mockHandleData.mock.calls[mockHandleData.mock.calls.length - 1][0];
+    const series = new Set(rows.map((r: { _source: { Series: string } }) => r._source.Series));
+    expect(series.size).toBe(20);
+  });
+
+  it('calls handleData with all rows when showAllSeries is clicked', () => {
+    const { getByTestId } = render(<MetricsVisTab />);
+
+    mockHandleData.mockClear();
+    act(() => {
+      fireEvent.click(getByTestId('showAllSeriesButton'));
+    });
+
+    expect(mockHandleData).toHaveBeenCalled();
+    const rows = mockHandleData.mock.calls[mockHandleData.mock.calls.length - 1][0];
+    expect(rows).toHaveLength(25);
+  });
+});

--- a/src/plugins/explore/public/components/tabs/metrics_vis_tab.tsx
+++ b/src/plugins/explore/public/components/tabs/metrics_vis_tab.tsx
@@ -112,9 +112,10 @@ export const MetricsVisTab = React.memo(() => {
 
   // Override VisualizationContainer's handleData with limited rows.
   // React fires child effects before parent effects, so this runs after
-  // VisualizationContainer's own handleData(allRows) call.
+  // VisualizationContainer's own handleData(allRows) call. Must also re-fire
+  // when showAllSeries toggles, since VisualizationContainer doesn't depend on it.
   useEffect(() => {
-    if (results && limitedRows !== (results.hits?.hits || [])) {
+    if (results) {
       const fieldSchema = results.fieldSchema || [];
       visualizationBuilder.handleData(limitedRows, fieldSchema);
     }


### PR DESCRIPTION
### Description

This PR
1. fixes a bug where clicking 'Showing 20 of 133 available series `Show 133`' may not work
2. improves legend styling to put each series on one line with scrolling

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="1462" height="814" alt="image" src="https://github.com/user-attachments/assets/55deaaf3-bb14-4dfa-9ade-517bb4ea6741" />

## Testing the changes

- UT

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
