### PR TITLE
fix: increase index pattern fetch limit from 100 to 10000 in dataset service

### DIFF
--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
@@ -157,7 +157,7 @@ describe('indexPatternTypeConfig', () => {
         fields: ['title', 'displayName', 'timeFieldName', 'references'],
         search: '*',
         searchFields: ['title', 'displayName'],
-        perPage: 100,
+        perPage: 10000,
       });
 
       expect(client.bulkGet).toHaveBeenCalledWith([{ id: 'datasource-abc', type: 'data-source' }]);

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -103,7 +103,7 @@ const fetchIndexPatterns = async (client: SavedObjectsClientContract): Promise<D
     fields: ['title', 'displayName', 'timeFieldName', 'references'],
     search: `*`,
     searchFields: ['title', 'displayName'],
-    perPage: 100,
+    perPage: 10000,
   });
 
   // Get all unique data source ids from both references and index pattern IDs


### PR DESCRIPTION
### Description

The fetchIndexPatterns function in index_pattern_type.ts used perPage: 100 when fetching index patterns for the classic Discover selector. Workspaces with more than 100 index patterns would silently drop the rest, causing patterns visible in Index Patterns management to be missing from Discover.

### Issues Resolved

Resolves #11255

## Screenshot

Before:
<img width="1728" height="961" alt="Screenshot 2026-05-28 at 6 43 32 PM" src="https://github.com/user-attachments/assets/7706e750-91f4-40f3-9629-fa48a41d30b1" />

After: 
<img width="1728" height="961" alt="Screenshot 2026-05-28 at 6 57 01 PM" src="https://github.com/user-attachments/assets/77136c9e-7614-4f17-81d8-00e9b2d1b540" />

## Testing the changes



<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
