### PR TITLE
fix(vis): prevent bar gauge items from being squeezed in vertical mode

### DIFF
--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_component.scss
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_component.scss
@@ -24,7 +24,14 @@ $bar-gauge-radius: 2px;
 .bar-gauge-item-tooltip {
   flex: 1;
   display: flex;
-  min-width: 0;
+
+  .vertical & {
+    min-width: 40px;
+  }
+
+  .horizontal & {
+    min-height: 24px;
+  }
 }
 
 // bar gauge item


### PR DESCRIPTION
### Description
root cause:
The .bar-gauge-item-tooltip (EuiToolTip anchor element) had min-width: 0, which overrides the default min-width for flex items, resulting in items being squeezed instead of triggering container scroll.

before:
<img width="1645" height="662" alt="截屏2026-06-01 10 49 40" src="https://github.com/user-attachments/assets/68d17fd4-1cfb-4cd3-8d54-731c1714c7b7" />


after:

<img width="970" height="420" alt="截屏2026-06-01 10 50 41" src="https://github.com/user-attachments/assets/fa75394b-8d02-4c11-8ce0-023f25b79a7c" />



### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff

