### PR TITLE
[Explore] Fix explore panels showing abort error when cloning dashboard panels

### DIFF
--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -449,6 +449,9 @@ export class ExploreEmbeddable
       try {
         await this.fetch();
       } catch (error: any) {
+        if (error?.name === 'AbortError' || this.abortController?.signal?.aborted) {
+          return;
+        }
         this.searchProps.isLoading = false;
         this.searchProps.error = {
           name: error?.body?.error || error?.name || 'Error',


### PR DESCRIPTION
### Description
Fixes a bug where cloning any panel on a dashboard causes all Explore embeddable panels to display the error "signal is aborted without reason".

This issue was introduced in #12004 which improved error propagation for failed PPL queries.
The change correctly surfaces real query errors to the panel UI, but inadvertently also
surfaces AbortError (which is expected when a new fetch aborts a stale in-flight request).

### Issues Resolved

When a panel is cloned, DashboardContainer.replacePanel() sets lastReloadRequestTime to force all panels to reload (a workaround for container infrastructure limitations). This triggers ExploreEmbeddable.reload() → fetch(), which first aborts any in-flight request via this.abortController.abort(). The aborted fetch's promise rejects with an AbortError, which bubbles up to the catch block in updateHandler(). The catch block does not distinguish AbortError from real errors, so it displays the abort as a panel error message.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
