### PR TITLE
Fix bar gauge value text overflow in vertical mode

### DIFF
--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_component.scss
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_component.scss
@@ -10,7 +10,7 @@ $bar-gauge-radius: 2px;
   &.horizontal {
     flex-direction: column;
     padding: 4% 2%;
-    gap: 2%;
+    gap: 40px; // fixed to 40px, min height for horizontal bar
   }
 
   &.vertical {
@@ -30,7 +30,7 @@ $bar-gauge-radius: 2px;
   }
 
   .horizontal & {
-    min-height: 24px;
+    min-height: 40px;
   }
 }
 
@@ -43,7 +43,7 @@ $bar-gauge-radius: 2px;
     flex-direction: row;
     align-items: center;
     width: 100%;
-    min-height: 24px; // don't shrink below this — container scrolls
+    min-height: 40px; // don't shrink below this — container scrolls
   }
 
   &.vertical {

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_item.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_item.tsx
@@ -104,6 +104,7 @@ export const BarGaugeItem: React.FC<BarGaugeItemProps> = ({
     left: '50%',
     transform: 'translateX(-50%)',
     marginBottom: '4px',
+    maxWidth: '100%',
   };
 
   const bar = (

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.tsx
@@ -188,12 +188,12 @@ export const BarGaugeRender = ({ data, styles, isHorizontal }: BarGaugeRenderPro
     const leftWidth = size * (1 - 0.04 * 2) - size * 0.02 * (barCount - 1);
     const computedThickness = (leftWidth / barCount) * 0.7;
 
-    // when bars overflow and scroll, each bar is clamped to the min-height/min-width
-    const minThickness = isHorizontal ? 24 : 40;
+    // when bars overflow and scroll, each bar is clamped to the min-height/min-width(40px)
+    const minThickness = 40;
     const barThickness = Math.max(computedThickness, minThickness);
 
     const maxValueLen = items.reduce((max, item) => Math.max(max, item.displayValue.length), 1);
-    const fontSize = isHorizontal ? barThickness / 3 : barThickness / (maxValueLen * 0.5);
+    const fontSize = isHorizontal ? barThickness / 2 : barThickness / (maxValueLen * 0.5);
     return Math.min(24, fontSize);
   }, [containerDimensions, data.length, isHorizontal, items]);
 


### PR DESCRIPTION
### Description

Fix text overflow for the bar gauge value label, ensuring long values are properly truncated with ellipsis instead of overflowing the container.

https://github.com/user-attachments/assets/fdffd701-a94f-47e2-9c9d-10dde32cb10d

Tweak horizontal bar style by increasing the bar height

<img width="2478" height="816" alt="截屏2026-06-01 15 50 10" src="https://github.com/user-attachments/assets/d73fd372-6d31-4e98-831b-5d2aef5a9422" />

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
