### PR TITLE
fix: stale custom legend displayed for unsupported chart type

### DIFF
--- a/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
@@ -6,7 +6,7 @@
 import { render, screen } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import dateMath from '@elastic/datemath';
-import { VisualizationRender } from './visualization_render';
+import { VisualizationRender, CommonVisualizationRender } from './visualization_render';
 import { VisData } from './visualization_builder.types';
 import { VisFieldType, Positions, RenderChartConfig } from './types';
 import { defaultBarChartStyles } from './bar/bar_vis_config';
@@ -30,6 +30,10 @@ jest.mock('./visualization_empty_state', () => ({
   VisualizationEmptyState: jest.fn(() => (
     <div data-test-subj="visualizationEmptyState">Empty State</div>
   )),
+}));
+
+jest.mock('./custom_legend', () => ({
+  CustomLegend: jest.fn(() => <div data-test-subj="customLegend">Custom Legend</div>),
 }));
 
 jest.mock('../../services/services', () => ({
@@ -240,5 +244,94 @@ describe('VisualizationRender', () => {
     );
 
     expect(screen.queryByTestId('echartsRender')).not.toBeInTheDocument();
+  });
+
+  describe('custom legend visibility', () => {
+    it.each(['area', 'line', 'bar', 'pie', 'scatter', 'state_timeline'])(
+      'renders custom legend for %s chart type when addLegend is true',
+      (chartType) => {
+        const config: RenderChartConfig = {
+          type: chartType,
+          styles: {
+            ...defaultBarChartStyles,
+            addLegend: true,
+            legendPosition: Positions.BOTTOM,
+          },
+          axesMapping: { x: 'field1', y: 'count' },
+        };
+
+        const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+        const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(config);
+        const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+        render(
+          <VisualizationRender data$={data$} config$={visConfig$} showRawTable$={showRawTable$} />
+        );
+
+        expect(screen.getByTestId('customLegend')).toBeInTheDocument();
+      }
+    );
+
+    it('does not render custom legend when addLegend is false', () => {
+      const config: RenderChartConfig = {
+        type: 'bar',
+        styles: {
+          ...defaultBarChartStyles,
+          addLegend: false,
+          legendPosition: Positions.BOTTOM,
+        },
+        axesMapping: { x: 'field1', y: 'count' },
+      };
+
+      const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+      const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(config);
+      const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+      render(
+        <VisualizationRender data$={data$} config$={visConfig$} showRawTable$={showRawTable$} />
+      );
+
+      expect(screen.queryByTestId('customLegend')).not.toBeInTheDocument();
+    });
+
+    it('clears legend$ when chart type does not support custom legend', () => {
+      const barConfig: RenderChartConfig = {
+        type: 'bar',
+        styles: { ...defaultBarChartStyles, addLegend: true, legendPosition: Positions.BOTTOM },
+        axesMapping: { x: 'field1', y: 'count' },
+      };
+
+      const metricConfig: RenderChartConfig = {
+        type: 'metric',
+        styles: {
+          ...defaultMetricChartStyles,
+          addLegend: true,
+          legendPosition: Positions.BOTTOM,
+        },
+        axesMapping: { value: 'count' },
+      };
+
+      const { rerender } = render(
+        <CommonVisualizationRender
+          visualizationData={mockVisData}
+          visConfig={barConfig}
+          showRawTable={false}
+        />
+      );
+
+      // Legend renders for bar chart
+      expect(screen.getByTestId('customLegend')).toBeInTheDocument();
+
+      // Switch to metric — legend still renders (addLegend is true) but legend$ data is cleared
+      rerender(
+        <CommonVisualizationRender
+          visualizationData={mockVisData}
+          visConfig={metricConfig}
+          showRawTable={false}
+        />
+      );
+
+      expect(screen.getByTestId('customLegend')).toBeInTheDocument();
+    });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/visualization_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { useObservable } from 'react-use';
 import dateMath from '@elastic/datemath';
@@ -60,6 +60,20 @@ export const CommonVisualizationRender = ({
   const legendSelected$ = useRef(new BehaviorSubject<Record<string, boolean>>({})).current;
   const highlightedSeries$ = useRef(new BehaviorSubject<string | undefined>(undefined)).current;
   const legend$ = useRef(new BehaviorSubject<Record<string, ColorMap>>({})).current;
+
+  useEffect(() => {
+    const visSupportCustomLegend = [
+      'area',
+      'line',
+      'bar',
+      'pie',
+      'scatter',
+      'state_timeline',
+    ].includes(visConfig?.type ?? '');
+    if (!visSupportCustomLegend) {
+      legend$.next({});
+    }
+  }, [visConfig?.type, legend$]);
 
   const timeRange = useMemo(() => {
     return {


### PR DESCRIPTION
### Description

Fix stale custom legend being displayed on chart types that don't support it (e.g., metric) when switching between visualization types

#### Before
Legend displayed for Heatmap incorrectly, it's stable component state from previous Bar chart
<img width="1160" height="626" alt="Screenshot 2026-06-01 at 13 11 10" src="https://github.com/user-attachments/assets/52af926b-3ea3-48f1-8216-cd41eee239e1" />

#### After
<img width="1163" height="628" alt="Screenshot 2026-06-01 at 16 37 30" src="https://github.com/user-attachments/assets/1e0d6098-27be-4546-8df2-2a8b64304a7f" />


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
