### PR TITLE
[Backport 3.7] fix: dashboard admin user gets correct Owner permissionMode for workspaces (#12126)

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -216,6 +216,7 @@
     - [Opensearch dashboards.release notes 3.4.0](../release-notes/opensearch-dashboards.release-notes-3.4.0.md)
     - [Opensearch dashboards.release notes 3.5.0](../release-notes/opensearch-dashboards.release-notes-3.5.0.md)
     - [Opensearch dashboards.release notes 3.6.0](../release-notes/opensearch-dashboards.release-notes-3.6.0.md)
+    - [Opensearch dashboards.release notes 3.7.0](../release-notes/opensearch-dashboards.release-notes-3.7.0.md)
   - scripts
     - [README](../scripts/README.md)
   - [DOCS_README](DOCS_README.md)

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -19,7 +19,7 @@ import {
 import { IWorkspaceClientImpl, WorkspaceAttributeWithPermission } from '../types';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
 import { registerDuplicateRoute } from './duplicate';
-import { transferCurrentUserInPermissions, translatePermissionsToRole } from '../utils';
+import { getPermissionMode, transferCurrentUserInPermissions } from '../utils';
 import { validateWorkspaceColor } from '../../common/utils';
 import { getUseCaseFeatureConfig } from '../../../../core/server';
 
@@ -158,14 +158,13 @@ export function registerRoutes({
       const { workspaces } = result.result;
 
       // enrich workspace permissionMode
-      const principals = permissionControlClient?.getPrincipalsFromRequest(req);
       workspaces.forEach((workspace) => {
-        const permissionMode = translatePermissionsToRole(
+        workspace.permissionMode = getPermissionMode({
           isPermissionControlEnabled,
-          workspace.permissions,
-          principals
-        );
-        workspace.permissionMode = permissionMode;
+          request: req,
+          permissionControlClient,
+          permissions: workspace.permissions,
+        });
       });
 
       return res.ok({
@@ -192,12 +191,12 @@ export function registerRoutes({
       );
 
       if (result.success) {
-        const principals = permissionControlClient?.getPrincipalsFromRequest(req);
-        (result.result as WorkspaceAttributeWithPermission).permissionMode = translatePermissionsToRole(
+        (result.result as WorkspaceAttributeWithPermission).permissionMode = getPermissionMode({
           isPermissionControlEnabled,
-          (result.result as WorkspaceAttributeWithPermission).permissions,
-          principals
-        );
+          request: req,
+          permissionControlClient,
+          permissions: (result.result as WorkspaceAttributeWithPermission).permissions,
+        });
       }
 
       return res.ok({

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -8,15 +8,16 @@ import {
   savedObjectsClientMock,
   uiSettingsServiceMock,
 } from '../../../core/server/mocks';
-import { UiSettingScope } from '../../../core/server';
+import { PermissionModeId, UiSettingScope } from '../../../core/server';
 import {
   generateRandomId,
+  getPermissionMode,
   updateDashboardAdminStateForRequest,
   transferCurrentUserInPermissions,
   getDataSourcesList,
   checkAndSetDefaultDataSource,
 } from './utils';
-import { getWorkspaceState } from '../../../core/server/utils';
+import { getWorkspaceState, updateWorkspaceState } from '../../../core/server/utils';
 import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../data_source_management/common';
 import { OSD_ADMIN_WILDCARD_MATCH_ALL } from '../common/constants';
 
@@ -191,5 +192,60 @@ describe('workspace utils', () => {
       undefined,
       UiSettingScope.WORKSPACE
     );
+  });
+});
+
+describe('getPermissionMode', () => {
+  it('should return Owner when user is dashboard admin', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(mockRequest, { isDashboardAdmin: true });
+
+    const result = getPermissionMode({
+      request: mockRequest,
+      isPermissionControlEnabled: true,
+      permissionControlClient: { getPrincipalsFromRequest: jest.fn() } as any,
+      permissions: { read: { users: ['user1'] } },
+    });
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should fall back to translatePermissionsToRole when user is not dashboard admin', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(mockRequest, { isDashboardAdmin: false });
+
+    const mockPermissionControlClient = {
+      getPrincipalsFromRequest: jest.fn().mockReturnValue({ users: ['user1'], groups: [] }),
+    } as any;
+
+    const result = getPermissionMode({
+      request: mockRequest,
+      isPermissionControlEnabled: true,
+      permissionControlClient: mockPermissionControlClient,
+      permissions: {
+        write: { users: ['user1'] },
+        library_write: { users: ['user1'] },
+      },
+    });
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should return Read when non-admin user only has read permission', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(mockRequest, { isDashboardAdmin: false });
+
+    const mockPermissionControlClient = {
+      getPrincipalsFromRequest: jest.fn().mockReturnValue({ users: ['user1'], groups: [] }),
+    } as any;
+
+    const result = getPermissionMode({
+      request: mockRequest,
+      isPermissionControlEnabled: true,
+      permissionControlClient: mockPermissionControlClient,
+      permissions: { read: { users: ['user1'] } },
+    });
+
+    expect(result).toBe(PermissionModeId.Read);
   });
 });

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -13,7 +13,7 @@ import {
   WorkspacePermissionMode,
   UiSettingScope,
 } from '../../../core/server';
-import { updateWorkspaceState } from '../../../core/server/utils';
+import { getWorkspaceState, updateWorkspaceState } from '../../../core/server/utils';
 import { DEFAULT_DATA_SOURCE_UI_SETTINGS_ID } from '../../data_source_management/common';
 import {
   CURRENT_USER_PLACEHOLDER,
@@ -21,6 +21,7 @@ import {
   OSD_ADMIN_WILDCARD_MATCH_ALL,
 } from '../common/constants';
 import { PermissionModeId } from '../../../core/server';
+import { SavedObjectsPermissionControlContract } from './permission_control/client';
 
 /**
  * Generate URL friendly random ID
@@ -180,5 +181,33 @@ export const translatePermissionsToRole = (
   } else {
     permissionMode = PermissionModeId.Read;
   }
+  return permissionMode;
+};
+
+/**
+ * get workspace permission mode
+ * @param req OSD request
+ * @param permissions workspace permission object
+ * @returns PermissionModeId
+ */
+export const getPermissionMode = (props: {
+  request: OpenSearchDashboardsRequest;
+  isPermissionControlEnabled: boolean;
+  permissionControlClient?: SavedObjectsPermissionControlContract;
+  permissions?: Permissions;
+}) => {
+  const { isDashboardAdmin } = getWorkspaceState(props.request);
+  let permissionMode: PermissionModeId = PermissionModeId.Read;
+  if (isDashboardAdmin) {
+    permissionMode = PermissionModeId.Owner;
+  } else {
+    const principals = props.permissionControlClient?.getPrincipalsFromRequest(props.request);
+    permissionMode = translatePermissionsToRole(
+      props.isPermissionControlEnabled,
+      props.permissions,
+      principals
+    );
+  }
+
   return permissionMode;
 };


### PR DESCRIPTION
Backport #12126 
