### PR TITLE
fix(dashboard): scripted field filter displays full script when value is 0

### DIFF
--- a/src/plugins/data/common/opensearch_query/filters/phrase_filter.test.ts
+++ b/src/plugins/data/common/opensearch_query/filters/phrase_filter.test.ts
@@ -32,6 +32,7 @@ import {
   buildInlineScriptForPhraseFilter,
   buildPhraseFilter,
   getPhraseFilterField,
+  isScriptedPhraseFilter,
 } from './phrase_filter';
 import { fields, getField } from '../../index_patterns/mocks';
 import { IIndexPattern } from '../../index_patterns';
@@ -121,5 +122,85 @@ describe('getPhraseFilterField', function () {
     const filter = buildPhraseFilter(field!, 'jpg', indexPattern);
     const result = getPhraseFilterField(filter);
     expect(result).toBe('extension');
+  });
+});
+
+describe('isScriptedPhraseFilter', () => {
+  it('should return true for a scripted phrase filter with value 0', () => {
+    const filter = {
+      meta: { field: 'script number' },
+      script: {
+        script: {
+          lang: 'painless',
+          params: { value: 0 },
+          source: 'boolean compare(Supplier s, def v) {return s.get() == v;}',
+        },
+      },
+    };
+    expect(isScriptedPhraseFilter(filter)).toBe(true);
+  });
+
+  it('should return true for a scripted phrase filter with value false', () => {
+    const filter = {
+      meta: { field: 'script boolean' },
+      script: {
+        script: {
+          lang: 'painless',
+          params: { value: false },
+          source: 'boolean compare(Supplier s, def v) {return s.get() == v;}',
+        },
+      },
+    };
+    expect(isScriptedPhraseFilter(filter)).toBe(true);
+  });
+
+  it('should return true for a scripted phrase filter with empty string value', () => {
+    const filter = {
+      meta: { field: 'script string' },
+      script: {
+        script: {
+          lang: 'painless',
+          params: { value: '' },
+          source: 'boolean compare(Supplier s, def v) {return s.get() == v;}',
+        },
+      },
+    };
+    expect(isScriptedPhraseFilter(filter)).toBe(true);
+  });
+
+  it('should return true for a scripted phrase filter with a truthy value', () => {
+    const filter = {
+      meta: { field: 'script number' },
+      script: {
+        script: {
+          lang: 'expression',
+          params: { value: 5 },
+          source: '(1234) == value',
+        },
+      },
+    };
+    expect(isScriptedPhraseFilter(filter)).toBe(true);
+  });
+
+  it('should return false for a filter without script params value', () => {
+    const filter = {
+      meta: { index: 'logstash-*' },
+      query: { match_phrase: { extension: 'jpg' } },
+    };
+    expect(isScriptedPhraseFilter(filter)).toBe(false);
+  });
+
+  it('should return false for a filter with null script params value', () => {
+    const filter = {
+      meta: { field: 'script number' },
+      script: {
+        script: {
+          lang: 'painless',
+          params: { value: null },
+          source: 'boolean compare(Supplier s, def v) {return s.get() == v;}',
+        },
+      },
+    };
+    expect(isScriptedPhraseFilter(filter)).toBe(false);
   });
 });

--- a/src/plugins/data/common/opensearch_query/filters/phrase_filter.ts
+++ b/src/plugins/data/common/opensearch_query/filters/phrase_filter.ts
@@ -66,7 +66,7 @@ export const isPhraseFilter = (filter: any): filter is PhraseFilter => {
 };
 
 export const isScriptedPhraseFilter = (filter: any): filter is PhraseFilter =>
-  Boolean(get(filter, 'script.script.params.value'));
+  get(filter, 'script.script.params.value') != null;
 
 export const getPhraseFilterField = (filter: PhraseFilter) => {
   const queryConfig = filter.query.match_phrase || filter.query.match;

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.test.ts
@@ -63,5 +63,77 @@ describe('filter manager utilities', () => {
         done();
       }
     });
+
+    test('should return the key and value for scripted phrase filters with value 0', () => {
+      const filter = ({
+        meta: { index: 'logstash-*', field: 'script_number' },
+        script: {
+          script: {
+            lang: 'painless',
+            params: { value: 0 },
+            source:
+              'boolean compare(Supplier s, def v) {return s.get() == v;}compare(() -> { doc["bytes"].value }, params.value);',
+          },
+        },
+      } as unknown) as PhraseFilter;
+
+      const result = mapPhrase(filter);
+
+      expect(result).toHaveProperty('key', 'script_number');
+      expect(result).toHaveProperty('type', 'phrase');
+
+      if (result.value) {
+        const displayName = result.value();
+        expect(displayName).toBe(0);
+      }
+    });
+
+    test('should return the key and value for scripted phrase filters with value false', () => {
+      const filter = ({
+        meta: { index: 'logstash-*', field: 'script_boolean' },
+        script: {
+          script: {
+            lang: 'painless',
+            params: { value: false },
+            source:
+              'boolean compare(Supplier s, def v) {return s.get() == v;}compare(() -> { doc["is_active"].value }, params.value);',
+          },
+        },
+      } as unknown) as PhraseFilter;
+
+      const result = mapPhrase(filter);
+
+      expect(result).toHaveProperty('key', 'script_boolean');
+      expect(result).toHaveProperty('type', 'phrase');
+
+      if (result.value) {
+        const displayName = result.value();
+        expect(displayName).toBe(false);
+      }
+    });
+
+    test('should return the key and value for scripted phrase filters with empty string value', () => {
+      const filter = ({
+        meta: { index: 'logstash-*', field: 'script_string' },
+        script: {
+          script: {
+            lang: 'painless',
+            params: { value: '' },
+            source:
+              'boolean compare(Supplier s, def v) {return s.get() == v;}compare(() -> { doc["status"].value }, params.value);',
+          },
+        },
+      } as unknown) as PhraseFilter;
+
+      const result = mapPhrase(filter);
+
+      expect(result).toHaveProperty('key', 'script_string');
+      expect(result).toHaveProperty('type', 'phrase');
+
+      if (result.value) {
+        const displayName = result.value();
+        expect(displayName).toBe('');
+      }
+    });
   });
 });

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
@@ -51,9 +51,9 @@ const getFormattedValueFn = (value: any) => {
 
 const getParams = (filter: PhraseFilter) => {
   const scriptedPhraseValue = getScriptedPhraseValue(filter);
-  const isScriptedFilter = Boolean(scriptedPhraseValue);
+  const isScriptedFilter = scriptedPhraseValue != null;
   const key = isScriptedFilter ? filter.meta.field || '' : getPhraseFilterField(filter);
-  const query = scriptedPhraseValue || getPhraseFilterValue(filter);
+  const query = scriptedPhraseValue ?? getPhraseFilterValue(filter);
   const params = { query };
 
   return {


### PR DESCRIPTION
### Description
Replace truthiness checks with nullish checks so that falsy values like 0, "", and false are correctly handled for scripted phrase filters.

Resolves #11966
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
Script field filter with 0 now correctly displayed
<img width="400" height="86" alt="Screenshot 2026-06-02 at 11 40 02" src="https://github.com/user-attachments/assets/98b0f861-b3fa-4ce2-89d9-66f41287db92" />

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
