### PR TITLE
[Workspace]Remove AOSS restriction that limits workspace type to Essential

### DIFF
--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PublicAppInfo, UseCaseId } from 'opensearch-dashboards/public';
+import { PublicAppInfo } from 'opensearch-dashboards/public';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { coreMock } from '../../../../../core/public/mocks';
@@ -164,9 +164,6 @@ const WorkspaceCreator = ({
       dataSourceManagement: dataSourceEnabled ? {} : undefined,
       navigationUI: {
         HeaderControl: () => null,
-      },
-      useCaseService: {
-        supportedUseCasesForServerless: [UseCaseId.ESSENTIAL_USE_CASE_ID],
       },
     },
   });

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -36,7 +36,6 @@ import { navigateToAppWithinWorkspace } from '../utils/workspace';
 import { WorkspaceCreatorForm } from './workspace_creator_form';
 import { optionIdToWorkspacePermissionModesMap } from '../workspace_form/constants';
 import { getUseCaseFeatureConfig } from '../../../../../core/public';
-import { UseCaseService } from '../../services';
 import { detectTraceData, createAutoDetectedDatasets } from '../../../../explore/public';
 
 export interface WorkspaceCreatorProps {
@@ -54,14 +53,12 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
       savedObjects,
       dataSourceManagement,
       navigationUI: { HeaderControl },
-      useCaseService,
       data: dataPlugin,
     },
   } = useOpenSearchDashboards<{
     workspaceClient: WorkspaceClient;
     dataSourceManagement?: DataSourceManagementPluginSetup;
     navigationUI: NavigationPublicPluginStart['ui'];
-    useCaseService: UseCaseService;
     data: DataPublicPluginStart;
   }>();
   const [isFormSubmitting, setIsFormSubmitting] = useState(false);
@@ -69,9 +66,7 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
   const isPermissionEnabled = application?.capabilities.workspaces.permissionEnabled;
 
   const { availableUseCases } = useFormAvailableUseCases({
-    savedObjects,
     registeredUseCases$,
-    useCaseService,
   });
 
   const location = useLocation();

--- a/src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.test.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.test.ts
@@ -2,27 +2,14 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { WorkspaceUseCase } from '../../types';
-import { DEFAULT_NAV_GROUPS, UseCaseId } from '../../../../../core/public';
-import { savedObjectsServiceMock } from '../../../../../core/public/mocks';
-import { areAllDataSourcesOpenSearchServerless } from '../../utils';
-import { UseCaseService } from '../../services';
+import { DEFAULT_NAV_GROUPS } from '../../../../../core/public';
 
 import { useFormAvailableUseCases } from './use_form_available_use_cases';
 
-jest.mock('../../utils', () => ({
-  areAllDataSourcesOpenSearchServerless: jest.fn(),
-}));
-
 describe('useFormAvailableUseCases', () => {
-  const mockSavedObjectsClient = savedObjectsServiceMock.createStartContract();
-
-  const mockUseCaseService = {
-    supportedUseCasesForServerless: [UseCaseId.ESSENTIAL_USE_CASE_ID],
-  } as UseCaseService;
-
   const mockUseCases: WorkspaceUseCase[] = [
     {
       id: 'useCase1',
@@ -48,113 +35,15 @@ describe('useFormAvailableUseCases', () => {
     },
   ];
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should return available use cases when data sources are not serverless', () => {
+  it('should return non-systematic use cases and ALL use case', () => {
     const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockResolvedValue(false);
 
     const { result } = renderHook(() =>
       useFormAvailableUseCases({
-        savedObjects: mockSavedObjectsClient,
         registeredUseCases$,
-        useCaseService: mockUseCaseService,
       })
     );
 
-    expect(result.current.availableUseCases).toEqual([
-      expect.objectContaining({
-        id: 'useCase1',
-        title: 'Use Case 1',
-        systematic: false,
-      }),
-      expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
-      expect.objectContaining(DEFAULT_NAV_GROUPS.all),
-    ]);
-  });
-
-  it('should return only supported serverless use cases when all data sources are serverless', async () => {
-    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockResolvedValue(true);
-
-    const { result } = renderHook(() =>
-      useFormAvailableUseCases({
-        savedObjects: mockSavedObjectsClient,
-        registeredUseCases$,
-        useCaseService: mockUseCaseService,
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current.availableUseCases).toEqual([
-        expect.objectContaining({
-          ...DEFAULT_NAV_GROUPS.essentials,
-          disabled: true,
-        }),
-      ]);
-    });
-  });
-
-  it('should handle error when fetching serverless status and default to non-serverless behavior', async () => {
-    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockRejectedValue(
-      new Error('Failed to fetch')
-    );
-
-    const { result } = renderHook(() =>
-      useFormAvailableUseCases({
-        savedObjects: mockSavedObjectsClient,
-        registeredUseCases$,
-        useCaseService: mockUseCaseService,
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current.availableUseCases).toEqual([
-        expect.objectContaining({
-          id: 'useCase1',
-          title: 'Use Case 1',
-          systematic: false,
-        }),
-        expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
-        expect.objectContaining(DEFAULT_NAV_GROUPS.all),
-      ]);
-    });
-  });
-
-  it('should not update serverless status after unmount', async () => {
-    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    const areAllDataSourcesServerlessMock = (areAllDataSourcesOpenSearchServerless as jest.Mock).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(() => resolve(true), 0);
-        })
-    );
-    const { unmount, result } = renderHook(() =>
-      useFormAvailableUseCases({
-        savedObjects: mockSavedObjectsClient,
-        registeredUseCases$,
-        useCaseService: mockUseCaseService,
-      })
-    );
-
-    // Initially should show non-serverless behavior (all use cases)
-    expect(result.current.availableUseCases).toEqual([
-      expect.objectContaining({
-        id: 'useCase1',
-        title: 'Use Case 1',
-        systematic: false,
-      }),
-      expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
-      expect.objectContaining(DEFAULT_NAV_GROUPS.all),
-    ]);
-
-    unmount();
-    await areAllDataSourcesServerlessMock.mock.results[0].value;
-
-    // After unmount, the result should remain unchanged
     expect(result.current.availableUseCases).toEqual([
       expect.objectContaining({
         id: 'useCase1',
@@ -171,65 +60,10 @@ describe('useFormAvailableUseCases', () => {
 
     const { result } = renderHook(() =>
       useFormAvailableUseCases({
-        savedObjects: mockSavedObjectsClient,
         registeredUseCases$,
-        useCaseService: mockUseCaseService,
       })
     );
 
     expect(result.current.availableUseCases).toBeUndefined();
-  });
-
-  it('should work without savedObjects parameter', () => {
-    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-
-    const { result } = renderHook(() =>
-      useFormAvailableUseCases({
-        registeredUseCases$,
-        useCaseService: mockUseCaseService,
-      })
-    );
-
-    // Should default to non-serverless behavior when no savedObjects provided
-    expect(result.current.availableUseCases).toEqual([
-      expect.objectContaining({
-        id: 'useCase1',
-        title: 'Use Case 1',
-        systematic: false,
-      }),
-      expect.objectContaining(DEFAULT_NAV_GROUPS.essentials),
-      expect.objectContaining(DEFAULT_NAV_GROUPS.all),
-    ]);
-  });
-
-  it('should handle multiple supported serverless use cases', async () => {
-    const multiServerlessUseCaseService = {
-      supportedUseCasesForServerless: [UseCaseId.ESSENTIAL_USE_CASE_ID, 'useCase1' as UseCaseId],
-    } as UseCaseService;
-
-    const registeredUseCases$ = new BehaviorSubject(mockUseCases);
-    (areAllDataSourcesOpenSearchServerless as jest.Mock).mockResolvedValue(true);
-
-    const { result } = renderHook(() =>
-      useFormAvailableUseCases({
-        savedObjects: mockSavedObjectsClient,
-        registeredUseCases$,
-        useCaseService: multiServerlessUseCaseService,
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current.availableUseCases).toEqual([
-        expect.objectContaining({
-          id: 'useCase1',
-          title: 'Use Case 1',
-          disabled: false, // Should not be disabled when multiple use cases are supported
-        }),
-        expect.objectContaining({
-          ...DEFAULT_NAV_GROUPS.essentials,
-          disabled: false, // Should not be disabled when multiple use cases are supported
-        }),
-      ]);
-    });
   });
 });

--- a/src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.ts
+++ b/src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.ts
@@ -3,73 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 import { BehaviorSubject } from 'rxjs';
 
-import { ALL_USE_CASE_ID, SavedObjectsStart, UseCaseId } from '../../../../../core/public';
+import { ALL_USE_CASE_ID } from '../../../../../core/public';
 import { WorkspaceUseCase } from '../../types';
-import { areAllDataSourcesOpenSearchServerless } from '../../utils';
 import { AvailableUseCaseItem } from './types';
-import { UseCaseService } from '../../services';
 
 interface UseFormAvailableUseCasesOptions {
-  savedObjects?: SavedObjectsStart;
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
-  useCaseService: UseCaseService;
 }
 
 export const useFormAvailableUseCases = ({
-  savedObjects,
   registeredUseCases$,
-  useCaseService,
 }: UseFormAvailableUseCasesOptions) => {
-  const [areAllDatasourcesServerless, setAreAllDatasourcesServerless] = useState(false);
   const registeredUseCases = useObservable(registeredUseCases$, undefined);
-
-  useEffect(() => {
-    let shouldUpdate = true;
-    if (!savedObjects) {
-      return;
-    }
-    const updateEssential = (payload: boolean) => {
-      if (shouldUpdate) {
-        setAreAllDatasourcesServerless(payload);
-      }
-    };
-    (async () => {
-      try {
-        const result = await areAllDataSourcesOpenSearchServerless(savedObjects.client);
-        updateEssential(result);
-      } catch (e) {
-        updateEssential(false);
-      }
-    })();
-    return () => {
-      shouldUpdate = false;
-    };
-  }, [savedObjects]);
 
   const availableUseCases = useMemo<AvailableUseCaseItem[] | undefined>(() => {
     if (!registeredUseCases) {
       return undefined;
     }
-    if (areAllDatasourcesServerless) {
-      const useCaseOptionDisabled = useCaseService.supportedUseCasesForServerless.length === 1;
-      return registeredUseCases.flatMap((useCase) =>
-        useCaseService.supportedUseCasesForServerless.includes(useCase.id as UseCaseId)
-          ? [{ ...useCase, disabled: useCaseOptionDisabled }]
-          : []
-      );
-    }
     return registeredUseCases.filter(
       (useCase) => !useCase.systematic || useCase.id === ALL_USE_CASE_ID
     );
-  }, [
-    registeredUseCases,
-    areAllDatasourcesServerless,
-    useCaseService.supportedUseCasesForServerless,
-  ]);
+  }, [registeredUseCases]);
 
   return {
     availableUseCases,

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -601,8 +601,6 @@ export class WorkspacePlugin
       ui: {
         AddCollaboratorsModal,
       },
-      registerSupportedUseCasesForServerlessCollections: this.useCase
-        .registerSupportedUseCasesForServerlessCollections,
     };
   }
 

--- a/src/plugins/workspace/public/services/use_case_service.ts
+++ b/src/plugins/workspace/public/services/use_case_service.ts
@@ -15,7 +15,6 @@ import {
   WorkspacesSetup,
   DEFAULT_NAV_GROUPS,
   ALL_USE_CASE_ID,
-  UseCaseId,
 } from '../../../../core/public';
 import {
   WORKSPACE_DETAIL_APP_ID,
@@ -37,13 +36,6 @@ export interface UseCaseServiceSetupDeps {
 
 export class UseCaseService {
   private workspaceAndManageWorkspaceCategorySubscription?: Subscription;
-  private supportedUseCasesForServerlessCollections = new Set<UseCaseId>([
-    UseCaseId.ESSENTIAL_USE_CASE_ID,
-  ]);
-
-  public get supportedUseCasesForServerless(): UseCaseId[] {
-    return Array.from(this.supportedUseCasesForServerlessCollections);
-  }
 
   constructor() {}
 
@@ -234,8 +226,4 @@ export class UseCaseService {
   stop() {
     this.workspaceAndManageWorkspaceCategorySubscription?.unsubscribe();
   }
-
-  registerSupportedUseCasesForServerlessCollections = (useCaseIds: UseCaseId[]) => {
-    useCaseIds.forEach((id) => this.supportedUseCasesForServerlessCollections.add(id));
-  };
 }

--- a/src/plugins/workspace/public/types.ts
+++ b/src/plugins/workspace/public/types.ts
@@ -56,5 +56,4 @@ export interface WorkspacePluginSetup {
   ui: {
     AddCollaboratorsModal: typeof AddCollaboratorsModal;
   };
-  registerSupportedUseCasesForServerlessCollections: UseCaseService['registerSupportedUseCasesForServerlessCollections'];
 }

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -13,7 +13,6 @@ import {
   convertNavGroupToWorkspaceUseCase,
   isEqualWorkspaceUseCase,
   prependWorkspaceToBreadcrumbs,
-  areAllDataSourcesOpenSearchServerless,
   mergeDataSourcesWithConnections,
   fetchDataSourceConnections,
   getUseCaseUrl,
@@ -22,10 +21,7 @@ import {
 import { WORKSPACE_USE_CASE_PREFIX, WorkspaceAvailability } from '../../../core/public';
 import { coreMock } from '../../../core/public/mocks';
 import { AssociationDataSourceModalMode } from '../common/constants';
-import {
-  SigV4ServiceName,
-  DataSourceEngineType,
-} from '../../../plugins/data_source/common/data_sources';
+import { DataSourceEngineType } from '../../../plugins/data_source/common/data_sources';
 import { createMockedRegisteredUseCases } from './mocks';
 import {
   DATA_SOURCE_SAVED_OBJECT_TYPE,
@@ -486,56 +482,6 @@ describe('workspace utils: getDataSourcesList', () => {
   it('should return empty array if no saved objects responded', async () => {
     mockedSavedObjectClient.find = jest.fn().mockResolvedValue({});
     expect(await getDataSourcesList(mockedSavedObjectClient, [])).toStrictEqual([]);
-  });
-});
-
-describe('workspace utils: getIsOnlyAllowEssentialUseCase', () => {
-  const mockedSavedObjectClient = startMock.savedObjects.client;
-
-  it('should return true when all data sources are serverless', async () => {
-    mockedSavedObjectClient.find = jest.fn().mockResolvedValue({
-      savedObjects: [
-        {
-          id: 'id1',
-          get: () => {
-            return {
-              credentials: {
-                service: SigV4ServiceName.OpenSearchServerless,
-              },
-            };
-          },
-        },
-      ],
-    });
-    expect(await areAllDataSourcesOpenSearchServerless(mockedSavedObjectClient)).toBe(true);
-  });
-
-  it('should return false when not all data sources are serverless', async () => {
-    mockedSavedObjectClient.find = jest.fn().mockResolvedValue({
-      savedObjects: [
-        {
-          id: 'id1',
-          get: () => {
-            return {
-              credentials: {
-                service: SigV4ServiceName.OpenSearchServerless,
-              },
-            };
-          },
-        },
-        {
-          id: 'id2',
-          get: () => {
-            return {
-              credentials: {
-                service: SigV4ServiceName.OpenSearch,
-              },
-            };
-          },
-        },
-      ],
-    });
-    expect(await areAllDataSourcesOpenSearchServerless(mockedSavedObjectClient)).toBe(false);
   });
 });
 

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -33,10 +33,7 @@ import {
 } from '../common/constants';
 import { WorkspaceUseCase, WorkspaceUseCaseFeature } from './types';
 import { formatUrlWithWorkspaceId } from '../../../core/public/utils';
-import {
-  DataSourceEngineType,
-  SigV4ServiceName,
-} from '../../../plugins/data_source/common/data_sources';
+import { DataSourceEngineType } from '../../../plugins/data_source/common/data_sources';
 import {
   DATACONNECTIONS_BASE,
   DatasourceTypeToDisplayName,
@@ -397,19 +394,6 @@ export const mergeDataSourcesWithConnections = (
   }
 
   return result;
-};
-
-// If all connected data sources are serverless, will use the list of registered use cases specifically for serverless collections.
-export const areAllDataSourcesOpenSearchServerless = async (
-  client: SavedObjectsStart['client']
-) => {
-  const allDataSources = await getDataSourcesList(client);
-  if (allDataSources.length > 0) {
-    return allDataSources.every(
-      (ds) => ds?.auth?.credentials?.service === SigV4ServiceName.OpenSearchServerless
-    );
-  }
-  return false;
 };
 
 export const convertNavGroupToWorkspaceUseCase = ({


### PR DESCRIPTION
### Description

Remove the logic that restricts workspace type to Essential when all datasources are OpenSearch Serverless (AOSS).

Previously, during workspace creation, if all connected data sources used AOSS auth, the workspace type selector was restricted to only allow "Essential". This restriction is no longer needed.

**Changes:**
- Removed `areAllDataSourcesOpenSearchServerless` utility function
- Removed `supportedUseCasesForServerless` tracking in `UseCaseService`
- Removed `registerSupportedUseCasesForServerlessCollections` from plugin setup API
- Simplified `useFormAvailableUseCases` hook to always show all non-systematic use cases

### Issues Resolved

<!-- closes # -->

## Screenshot

<!-- TODO: Add screenshot showing workspace creation with all use case options available when connected to AOSS datasources -->

**Before**
<img width="957" height="498" alt="image" src="https://github.com/user-attachments/assets/5264297f-643a-4f47-a938-a7cb59fb4593" />

----

**After**
<img width="1227" height="772" alt="image" src="https://github.com/user-attachments/assets/11d5b190-b9df-4758-8bb3-33f136112894" />


## Testing the changes

1. Set up an environment with only AOSS datasources connected
2. Navigate to workspace creation
3. Verify that all workspace types (not just Essential) are available for selection
4. Run tests: `yarn test:jest src/plugins/workspace/public/components/workspace_form/use_form_available_use_cases.test.ts`
5. Run tests: `yarn test:jest src/plugins/workspace/public/utils.test.ts`
6. Run tests: `yarn test:jest src/plugins/workspace/public/components/workspace_creator/workspace_creator.test.tsx`

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff