### PR TITLE
[Chat] Support local-only responses from slash commands

### DIFF
--- a/src/plugins/chat/common/types.ts
+++ b/src/plugins/chat/common/types.ts
@@ -63,6 +63,7 @@ export const DeveloperMessageSchema = BaseMessageSchema.extend({
 export const SystemMessageSchema = BaseMessageSchema.extend({
   role: z.literal('system'),
   content: z.string(),
+  title: z.string().optional(),
   toolCallId: z.string().optional(),
   canResend: z.boolean().optional(),
   toolResult: z.any().optional(),

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -216,13 +216,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     // Block AI features for unsupported data sources
     if (await isUnsupportedDataSource()) {
       const userMsg: UserMessage = {
-        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        id: chatService.generateMessageId(),
         role: 'user',
         content: messageContent,
         rawMessage: rawMessage || messageContent,
       };
       const systemMsg: SystemMessage = {
-        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        id: chatService.generateMessageId(),
         role: 'system',
         content: i18n.translate('chat.dataSourceUnsupported', {
           defaultMessage: 'The current data source does not support AI features.',
@@ -303,7 +303,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         additionalMessages = [
           {
             role: 'user' as const,
-            id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+            id: chatService.generateMessageId(),
             content: [
               {
                 type: 'binary' as const,
@@ -322,6 +322,22 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     // Check if this is a slash command
     const commandResult = await slashCommandRegistry.execute(messageContent);
     if (commandResult.handled) {
+      if (commandResult.localMessage) {
+        const userMsg: UserMessage = {
+          id: chatService.generateMessageId(),
+          role: 'user',
+          content: messageContent,
+          rawMessage: messageContent,
+        };
+        const systemMsg: SystemMessage = {
+          id: chatService.generateMessageId(),
+          role: 'system',
+          content: commandResult.localMessage,
+          ...(commandResult.title && { title: commandResult.title }),
+        };
+        setTimeline((prev) => [...prev, userMsg, systemMsg]);
+        return;
+      }
       // If command was handled and returned a message, send it to the AI
       if (commandResult.message) {
         return subscribeToMessageStream(commandResult.message, messagesToSend, messageContent);

--- a/src/plugins/chat/public/components/error_row.tsx
+++ b/src/plugins/chat/public/components/error_row.tsx
@@ -46,9 +46,10 @@ export const ErrorRow: React.FC<ErrorRowProps> = ({ error, onResendToolResult })
       <div className="errorRow__content">
         <div className="errorRow__info">
           <EuiText size="s" style={{ fontWeight: 600, color: '#BD271E' }}>
-            {i18n.translate('chat.errorRow.title', {
-              defaultMessage: 'Something went wrong',
-            })}
+            {error.title ||
+              i18n.translate('chat.errorRow.title', {
+                defaultMessage: 'Something went wrong',
+              })}
           </EuiText>
         </div>
         <div className="errorRow__message">

--- a/src/plugins/chat/public/index.ts
+++ b/src/plugins/chat/public/index.ts
@@ -16,5 +16,5 @@ export function plugin(initializerContext: PluginInitializerContext) {
   return new ChatPlugin(initializerContext);
 }
 export { ChatPluginSetup, ChatPluginStart } from './types';
-export { SlashCommand } from './services/slash_commands';
+export { SlashCommand, SlashCommandResult } from './services/slash_commands';
 export { ChatService } from './services/chat_service';

--- a/src/plugins/chat/public/services/slash_commands.test.ts
+++ b/src/plugins/chat/public/services/slash_commands.test.ts
@@ -470,6 +470,46 @@ describe('SlashCommandRegistry', () => {
     });
   });
 
+  describe('localMessage support', () => {
+    it('should return localMessage when handler returns object with localMessage', async () => {
+      slashCommandRegistry.register({
+        command: 'local',
+        description: 'Local response command',
+        handler: () => ({ localMessage: 'This is shown locally' }),
+      });
+
+      const result = await slashCommandRegistry.execute('/local');
+      expect(result.handled).toBe(true);
+      expect(result.localMessage).toBe('This is shown locally');
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should return message when handler returns a string', async () => {
+      slashCommandRegistry.register({
+        command: 'remote',
+        description: 'Remote response command',
+        handler: () => 'sent to agent',
+      });
+
+      const result = await slashCommandRegistry.execute('/remote');
+      expect(result.handled).toBe(true);
+      expect(result.message).toBe('sent to agent');
+      expect(result.localMessage).toBeUndefined();
+    });
+
+    it('should pass args to handler that returns localMessage', async () => {
+      slashCommandRegistry.register({
+        command: 'info',
+        description: 'Info command',
+        handler: (args) => ({ localMessage: `Info: ${args}` }),
+      });
+
+      const result = await slashCommandRegistry.execute('/info some details');
+      expect(result.handled).toBe(true);
+      expect(result.localMessage).toBe('Info: some details');
+    });
+  });
+
   describe('integration scenarios', () => {
     it('should handle complete workflow: register, execute, unregister', async () => {
       const command: SlashCommand = {

--- a/src/plugins/chat/public/services/slash_commands.ts
+++ b/src/plugins/chat/public/services/slash_commands.ts
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export type SlashCommandResult = string | { localMessage: string; title?: string };
+
 export interface SlashCommand {
   command: string;
   description: string;
   usage?: string;
   hint?: string; // Placeholder hint text shown after the command
-  handler: (args: string) => Promise<string> | string;
+  handler: (args: string) => Promise<SlashCommandResult> | SlashCommandResult;
 }
 
 class SlashCommandRegistry {
@@ -42,7 +44,9 @@ class SlashCommandRegistry {
     return this.getAll().filter((cmd) => cmd.command.toLowerCase().startsWith(query));
   }
 
-  async execute(input: string): Promise<{ handled: boolean; message?: string }> {
+  async execute(
+    input: string
+  ): Promise<{ handled: boolean; message?: string; localMessage?: string; title?: string }> {
     if (!input.startsWith('/')) {
       return { handled: false };
     }
@@ -57,8 +61,11 @@ class SlashCommandRegistry {
     }
 
     try {
-      const message = await command.handler(args);
-      return { handled: true, message };
+      const result = await command.handler(args);
+      if (typeof result === 'object' && result !== null && 'localMessage' in result) {
+        return { handled: true, localMessage: result.localMessage, title: result.title };
+      }
+      return { handled: true, message: result };
     } catch (error) {
       return {
         handled: true,


### PR DESCRIPTION
### Description

Extend the slash command infrastructure to support local-only responses that display immediately in the chat without invoking the AI agent.

**Changes:**
- Add `SlashCommandResult` type: handlers can return `string` (sent to agent) or `{ localMessage: string; title?: string }` (displayed locally as a system message)
- Add optional `title` field to `SystemMessage` schema for custom message titles
- `ErrorRow` renders `message.title` when present, falls back to "Something went wrong"
- Export `SlashCommandResult` type from chat plugin public API

This enables slash commands to show informational messages (e.g., workspace incompatibility warnings) with custom titles without involving the AI agent.

### Issues Resolved

N/A - Infrastructure enhancement for slash command system

## Screenshot

N/A - No visual change without consuming plugins

## Testing the changes

1. Register a slash command returning `{ localMessage: "test", title: "Custom Title" }`
2. Type the command in chat
3. Verify the system message shows "Custom Title" instead of "Something went wrong"

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff