### PR TITLE
fix: standardize index pattern saved-object ID separator to underscore

### DIFF
--- a/src/plugins/data/common/index_patterns/utils.ts
+++ b/src/plugins/data/common/index_patterns/utils.ts
@@ -140,5 +140,13 @@ export const getDataSourceIdFromIndexPattern = (indexPattern: {
   if (indexPattern.id?.includes('::')) {
     return indexPattern.id.split('::')[0];
   }
+  // Check _ format: <dataSourceId>_<uuid> where prefix is a valid UUID
+  const uIdx = indexPattern.id?.indexOf('_');
+  if (uIdx !== undefined && uIdx > 0) {
+    const prefix = indexPattern.id.substring(0, uIdx);
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(prefix)) {
+      return prefix;
+    }
+  }
   return undefined;
 };

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
@@ -322,7 +322,7 @@ describe('DatasetService', () => {
     } as Dataset;
 
     const mockCreatedDataView = {
-      id: 'data-source-123::generated-uuid-5678',
+      id: 'data-source-123_generated-uuid-5678',
     };
 
     const mockDataViews = {
@@ -343,7 +343,7 @@ describe('DatasetService', () => {
     // Should call createAndSave with data source prefixed ID
     expect(mockDataViews.createAndSave).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: expect.stringMatching(/^data-source-123::[0-9a-f-]{36}$/), // Should match data-source-id::uuid pattern
+        id: expect.stringMatching(/^data-source-123_[0-9a-f-]{36}$/), // Should match data-source-id_uuid pattern
         title: 'Test Dataset',
         displayName: 'My Dataset',
         description: 'Test description',
@@ -362,7 +362,7 @@ describe('DatasetService', () => {
     );
 
     // Should update the dataset with the generated UUID
-    expect(mockDataset.id).toBe('data-source-123::generated-uuid-5678');
+    expect(mockDataset.id).toBe('data-source-123_generated-uuid-5678');
   });
 
   test('saveDataset does not save index pattern datasets', async () => {

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -193,7 +193,7 @@ export class DatasetService {
           : await type?.fetchFields(dataset, services);
         const spec = {
           // Generate ID with data source prefix if data source exists, otherwise allow UUID generation
-          id: dataset.dataSource?.id ? `${dataset.dataSource.id}::${uuidv4()}` : undefined,
+          id: dataset.dataSource?.id ? `${dataset.dataSource.id}_${uuidv4()}` : undefined,
           type: dataset.type,
           displayName: dataset.displayName,
           title: dataset.title,

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -121,6 +121,14 @@ const fetchIndexPatterns = async (client: SavedObjectsClientContract): Promise<D
           if (savedObject.id.includes('::')) {
             return savedObject.id.split('::')[0];
           }
+          // Check _ format: <dataSourceId>_<uuid> where prefix is a valid UUID
+          const uIdx = savedObject.id.indexOf('_');
+          if (uIdx > 0) {
+            const prefix = savedObject.id.substring(0, uIdx);
+            if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(prefix)) {
+              return prefix;
+            }
+          }
           return undefined;
         })
         .filter(Boolean)
@@ -146,6 +154,16 @@ const fetchIndexPatterns = async (client: SavedObjectsClientContract): Promise<D
       // If not in references, check if the ID contains :: (namespaced format)
       if (!dataSourceId && savedObject.id.includes('::')) {
         dataSourceId = savedObject.id.split('::')[0];
+      }
+      // Check _ format: <dataSourceId>_<uuid> where prefix is a valid UUID
+      if (!dataSourceId) {
+        const uIdx = savedObject.id.indexOf('_');
+        if (uIdx > 0) {
+          const prefix = savedObject.id.substring(0, uIdx);
+          if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(prefix)) {
+            dataSourceId = prefix;
+          }
+        }
       }
 
       const dataSource = dataSourceId ? dataSourceMap[dataSourceId] : undefined;


### PR DESCRIPTION
### Description
`saveDataset()` in dataset_service.ts uses :: as the separator when minting index-pattern saved-object IDs `<dataSourceId>::<uuid>`, but the _import handler in `regenerate_ids.ts` uses _ `<dataSourceId>_<uuid>`. 
This causes duplicate index patterns in the UI because OSD does exact string matching on saved-object IDs — the same logical index pattern gets two different IDs depending on which code path created it.

Additionally, :: is reserved for cross-cluster search notation in OpenSearch `cluster_alias::index_name`, so using it in saved-object IDs creates parsing ambiguity.

Backward compatibility: Existing :: format IDs continue to work — all read paths still check for :: first, then fall back to _. Only newly created IDs will use _.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
