### PR TITLE
fix: rewrite inline dataset.id in searchSourceJSON during import

### DIFF
--- a/src/core/server/saved_objects/import/create_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.test.ts
@@ -894,7 +894,13 @@ describe('#createSavedObjects', () => {
             }),
           },
         },
-        references: [{ name: 'kibanaSavedObjectMeta.searchSourceJSON.index', type: 'index-pattern', id: 'old-ip-id' }],
+        references: [
+          {
+            name: 'kibanaSavedObjectMeta.searchSourceJSON.index',
+            type: 'index-pattern',
+            id: 'old-ip-id',
+          },
+        ],
       };
 
       importIdMap.set('index-pattern:old-ip-id', { id: 'ds-123_new-ip-uuid' });
@@ -914,6 +920,7 @@ describe('#createSavedObjects', () => {
 
       expect(bulkCreate).toHaveBeenCalledTimes(1);
       const createdObj = bulkCreate.mock.calls[0][0][0];
+      // @ts-expect-error
       const searchSource = JSON.parse(createdObj.attributes.kibanaSavedObjectMeta.searchSourceJSON);
       expect(searchSource.query.dataset.id).toBe('ds-123_new-ip-uuid');
     });
@@ -955,6 +962,7 @@ describe('#createSavedObjects', () => {
       await createSavedObjects(options);
 
       const createdObj = bulkCreate.mock.calls[0][0][0];
+      // @ts-expect-error
       const searchSource = JSON.parse(createdObj.attributes.kibanaSavedObjectMeta.searchSourceJSON);
       expect(searchSource.query.dataset.id).toBe('unknown-ip-id');
     });
@@ -999,6 +1007,7 @@ describe('#createSavedObjects', () => {
       await createSavedObjects(options);
 
       const createdObj = bulkCreate.mock.calls[0][0][0];
+      // @ts-expect-error
       const searchSource = JSON.parse(createdObj.attributes.kibanaSavedObjectMeta.searchSourceJSON);
       expect(searchSource.query.dataset.id).toBe('ds-123_new-ip-uuid');
     });

--- a/src/core/server/saved_objects/import/create_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.test.ts
@@ -870,4 +870,137 @@ describe('#createSavedObjects', () => {
       expect(bulkCreate.mock.calls[0][1]?.hasOwnProperty('workspaces')).toEqual(false);
     });
   });
+
+  describe('inline dataset.id rewriting', () => {
+    test('rewrites searchSourceJSON.query.dataset.id using importIdMap when dataSourceId is provided', async () => {
+      const exploreObj: SavedObject = {
+        type: 'explore',
+        id: 'explore-1',
+        attributes: {
+          title: 'My Explore',
+          kibanaSavedObjectMeta: {
+            searchSourceJSON: JSON.stringify({
+              query: {
+                query: 'source = logs-*',
+                language: 'PPL',
+                dataset: {
+                  id: 'old-ip-id',
+                  title: 'logs-*',
+                  type: 'INDEX_PATTERN',
+                  timeFieldName: '@timestamp',
+                },
+              },
+              filter: [],
+            }),
+          },
+        },
+        references: [{ name: 'kibanaSavedObjectMeta.searchSourceJSON.index', type: 'index-pattern', id: 'old-ip-id' }],
+      };
+
+      importIdMap.set('index-pattern:old-ip-id', { id: 'ds-123_new-ip-uuid' });
+      importIdMap.set('explore:explore-1', { id: 'ds-123_new-explore-uuid' });
+
+      const options = setupParams({
+        objects: [exploreObj],
+        dataSourceId: 'ds-123',
+        dataSourceTitle: 'My Data Source',
+      });
+
+      savedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [{ ...exploreObj, id: 'ds-123_new-explore-uuid' }],
+      });
+
+      await createSavedObjects(options);
+
+      expect(bulkCreate).toHaveBeenCalledTimes(1);
+      const createdObj = bulkCreate.mock.calls[0][0][0];
+      const searchSource = JSON.parse(createdObj.attributes.kibanaSavedObjectMeta.searchSourceJSON);
+      expect(searchSource.query.dataset.id).toBe('ds-123_new-ip-uuid');
+    });
+
+    test('does not modify searchSourceJSON when dataset.id is not in importIdMap', async () => {
+      const exploreObj: SavedObject = {
+        type: 'explore',
+        id: 'explore-2',
+        attributes: {
+          title: 'My Explore',
+          kibanaSavedObjectMeta: {
+            searchSourceJSON: JSON.stringify({
+              query: {
+                query: 'source = logs-*',
+                language: 'PPL',
+                dataset: {
+                  id: 'unknown-ip-id',
+                  title: 'logs-*',
+                  type: 'INDEX_PATTERN',
+                },
+              },
+            }),
+          },
+        },
+        references: [],
+      };
+
+      importIdMap.set('explore:explore-2', { id: 'ds-123_new-explore-uuid' });
+
+      const options = setupParams({
+        objects: [exploreObj],
+        dataSourceId: 'ds-123',
+      });
+
+      savedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [{ ...exploreObj, id: 'ds-123_new-explore-uuid' }],
+      });
+
+      await createSavedObjects(options);
+
+      const createdObj = bulkCreate.mock.calls[0][0][0];
+      const searchSource = JSON.parse(createdObj.attributes.kibanaSavedObjectMeta.searchSourceJSON);
+      expect(searchSource.query.dataset.id).toBe('unknown-ip-id');
+    });
+
+    test('rewrites dataset.id for dashboard type as well', async () => {
+      const dashboardObj: SavedObject = {
+        type: 'dashboard',
+        id: 'dashboard-1',
+        attributes: {
+          title: 'My Dashboard',
+          kibanaSavedObjectMeta: {
+            searchSourceJSON: JSON.stringify({
+              query: {
+                query: '',
+                language: 'kuery',
+                dataset: {
+                  id: 'old-ip-id',
+                  title: 'logs-*',
+                  type: 'INDEX_PATTERN',
+                  timeFieldName: '@timestamp',
+                },
+              },
+              filter: [],
+            }),
+          },
+        },
+        references: [],
+      };
+
+      importIdMap.set('index-pattern:old-ip-id', { id: 'ds-123_new-ip-uuid' });
+      importIdMap.set('dashboard:dashboard-1', { id: 'ds-123_new-dashboard-uuid' });
+
+      const options = setupParams({
+        objects: [dashboardObj],
+        dataSourceId: 'ds-123',
+      });
+
+      savedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [{ ...dashboardObj, id: 'ds-123_new-dashboard-uuid' }],
+      });
+
+      await createSavedObjects(options);
+
+      const createdObj = bulkCreate.mock.calls[0][0][0];
+      const searchSource = JSON.parse(createdObj.attributes.kibanaSavedObjectMeta.searchSourceJSON);
+      expect(searchSource.query.dataset.id).toBe('ds-123_new-ip-uuid');
+    });
+  });
 });

--- a/src/core/server/saved_objects/import/create_saved_objects.ts
+++ b/src/core/server/saved_objects/import/create_saved_objects.ts
@@ -207,6 +207,31 @@ export const createSavedObjects = async <T>({
             object.attributes.visState = JSON.stringify(visState);
           }
         }
+
+        // Rewrite inline dataset.id inside searchSourceJSON for all SO types that embed it.
+        // The references[] rewriter (below) handles the official pointer, but the inline copy
+        // at searchSourceJSON.query.dataset.id is opaque to the references walker and must be
+        // rewritten separately using importIdMap.
+        // @ts-expect-error
+        const ssJSON = object.attributes?.kibanaSavedObjectMeta?.searchSourceJSON;
+        if (ssJSON) {
+          try {
+            const searchSource = JSON.parse(ssJSON);
+            const inlineDatasetId = searchSource?.query?.dataset?.id;
+            if (typeof inlineDatasetId === 'string') {
+              const newId = importIdMap.get(`index-pattern:${inlineDatasetId}`)?.id;
+              if (newId) {
+                searchSource.query.dataset.id = newId;
+                // @ts-expect-error
+                object.attributes.kibanaSavedObjectMeta.searchSourceJSON = JSON.stringify(
+                  searchSource
+                );
+              }
+            }
+          } catch (e) {
+            // If searchSourceJSON is malformed, leave it untouched
+          }
+        }
       }
 
       // use the import ID map to ensure that each reference is being created with the correct ID


### PR DESCRIPTION
### Description
When importing saved objects with _import?createNewCopies=true&dataSourceId=..., the handler rewrites references[].id to point at the newly-minted index pattern IDs, but does not rewrite the inline copy of the same ID embedded at searchSourceJSON.query.dataset.id. This leaves the imported saved object with two inconsistent pointers — the official references[] points to a real ID, while the inline copy points to a non-existent one.

On cold load, the client reads the stale inline dataset.id from URL state, calls dataViews.get() which 404s, dataset becomes undefined, and the time picker disappears.

### Root cause
create_saved_objects.ts has an existing searchSourceJSON rewrite block, but:

It only runs for visualization and search types — not explore or dashboard
It only rewrites the legacy searchSource.index field — not the new searchSource.query.dataset.id format

### Fix
Added a new block (outside the type whitelist) that parses searchSourceJSON, finds query.dataset.id, looks it up in importIdMap (the same mapping used for references[]), and rewrites it. This runs for all saved-object types since explore, dashboard, and search SOs all can embed dataset.id.

### Backward compatibility
No impact on existing saved objects. This only affects objects being imported going forward — they'll now have consistent inline and reference pointers.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
