### PR TITLE
chore(deps): upgrade axios from 1.15.2 to 1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -554,7 +554,6 @@
     "vega-schema-url-parser": "^2.1.0",
     "vega-tooltip": "^0.30.0",
     "vinyl-fs": "^3.0.3",
-    "wait-on": "^8.0.2",
     "webpack": "^5.104.1",
     "xml2js": "^0.5.0",
     "xmlbuilder": "13.0.2",

--- a/packages/osd-dev-utils/package.json
+++ b/packages/osd-dev-utils/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@babel/core": "^7.22.9",
     "@osd/utils": "1.0.0",
-    "axios": "^1.15.2",
+    "axios": "^1.17.0",
     "chalk": "^4.1.0",
     "cheerio": "1.0.0-rc.1",
     "dedent": "^0.7.0",

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -15,7 +15,7 @@
     "@opensearch/datemath": "5.0.3",
     "@osd/i18n": "1.0.0",
     "@osd/monaco": "1.0.0",
-    "axios": "^1.15.2",
+    "axios": "^1.17.0",
     "compression-webpack-plugin": "^11.1.0",
     "core-js": "^3.6.5",
     "jquery": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7605,13 +7605,14 @@ axe-core@^4.0.2, axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axios@^1.15.2, axios@^1.6.5, axios@^1.8.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
-  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
+axios@^1.17.0, axios@^1.6.5:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
 axobject-query@^2.2.0:
@@ -11968,7 +11969,7 @@ focus-lock@^0.10.2:
   dependencies:
     tslib "^2.0.3"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.11, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0, follow-redirects@^1.15.6, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -14860,7 +14861,7 @@ joi@^14.3.1:
     isemail "3.x.x"
     topo "3.x.x"
 
-joi@^17.13.3, joi@^17.3.0:
+joi@^17.3.0:
   version "17.13.3"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
   integrity sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==
@@ -19219,13 +19220,6 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.1, rxjs@^6.5.5, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.8.2:
-  version "7.8.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
-  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
-  dependencies:
-    tslib "^2.1.0"
-
 safe-array-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c"
@@ -22349,17 +22343,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-wait-on@^8.0.2:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.3.tgz#a23c684115d68059d739ce4eb18a3f88088d2d16"
-  integrity sha512-nQFqAFzZDeRxsu7S3C7LbuxslHhk+gnJZHyethuGKAn2IVleIbTB9I3vJSQiSR+DifUqmdzfPMoMPJfLqMF2vw==
-  dependencies:
-    axios "^1.8.2"
-    joi "^17.13.3"
-    lodash "^4.17.21"
-    minimist "^1.2.8"
-    rxjs "^7.8.2"
 
 walker@^1.0.7, walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
### Description

This PR upgrades axios from version 1.15.2 to 1.17.0 and removes the unused `wait-on` dependency to address multiple critical security vulnerabilities. I suggest to backport this to 3.7.0.

#### Changes

- Upgraded `axios` from `^1.15.2` to `^1.17.0` in:
  - [`packages/osd-dev-utils/package.json`](packages/osd-dev-utils/package.json:18)
  - [`packages/osd-ui-shared-deps/package.json`](packages/osd-ui-shared-deps/package.json:18)
- Removed unused `wait-on` dependency from [`package.json`](package.json:557)
  - Originally added in [#9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304) but ultimately not used
- Updated [`yarn.lock`](yarn.lock) with new dependency resolutions

#### Security Impact

This upgrade resolves multiple high-severity CVEs in axios 1.15.2:

- **[CVE-2026-44492](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12120)** (High, CVSS 8.6) - IPv4-mapped IPv6 addresses bypass NO_PROXY settings, enabling SSRF attacks against internal services and cloud metadata endpoints
- **[CVE-2026-44494](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12121)** (High, CVSS 8.7) - Prototype pollution gadget in `config.proxy` allows full Man-in-the-Middle attacks, intercepting all HTTP traffic including credentials
- **[CVE-2026-44490](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12122)** (Medium, CVSS 4.8) - Prototype pollution enables arbitrary HTTP header injection and crash DoS via malformed property descriptors
- **[CVE-2026-44489](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12123)** (Low, CVSS 3.7) - Proxy-Authorization header injection via prototype pollution in nested proxy configuration objects

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

closes #12120  
closes #12121  
closes #12122  
closes #12123 

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
