### PR TITLE
[Dashboard] Lazy load panel data queries based on viewport visibility

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/13/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/13/inspect.spec.js
@@ -124,6 +124,8 @@ const inspectTestSuite = () => {
         'dashboardListingTitleLink-[Flights]-Global-Flight-Dashboard'
       ).click();
 
+      cy.scrollTo('bottom', { duration: 3000 });
+
       cy.getElementByTestId('visualizationLoader').should(
         'have.length',
         NUMBER_OF_VISUALIZATIONS_IN_FLIGHTS_DASHBOARD

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/13/inspect.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/13/inspect.spec.js
@@ -130,6 +130,8 @@ const inspectTestSuite = () => {
         'dashboardListingTitleLink-[Flights]-Global-Flight-Dashboard'
       ).click();
 
+      cy.scrollTo('bottom', { duration: 3000 });
+
       cy.getElementByTestId('visualizationLoader').should(
         'have.length',
         NUMBER_OF_VISUALIZATIONS_IN_FLIGHTS_DASHBOARD

--- a/src/dev/jest/mocks/intersection_observer_mock.js
+++ b/src/dev/jest/mocks/intersection_observer_mock.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// jsdom does not implement IntersectionObserver. Tests get a mock that
+// immediately fires the callback with isIntersecting: true so components
+// that defer rendering until visible work out of the box.
+// Tests that need fine-grained control should override this with
+// jest.spyOn or reassign window.IntersectionObserver in beforeEach.
+
+class IntersectionObserver {
+  constructor(callback) {
+    this._callback = callback;
+  }
+
+  observe(element) {
+    // Immediately report the element as intersecting
+    this._callback([{ isIntersecting: true, target: element }], this);
+  }
+
+  unobserve() {}
+  disconnect() {}
+}
+
+module.exports = IntersectionObserver;

--- a/src/dev/jest/setup/polyfills.js
+++ b/src/dev/jest/setup/polyfills.js
@@ -57,3 +57,8 @@ global.React = require('react');
 // component constructors don't throw. Individual tests can spy on this global
 // to assert observe/unobserve behavior.
 global.ResizeObserver = require('../mocks/resize_observer_mock');
+
+// jsdom does not implement IntersectionObserver. Provide a mock that immediately
+// reports elements as intersecting so lazy-loading components render in tests.
+// Tests that need fine-grained control can override window.IntersectionObserver.
+global.IntersectionObserver = require('../mocks/intersection_observer_mock');

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -364,11 +364,14 @@ export class SearchSource {
     const indexPattern = this.getField('index');
 
     let response;
-    if (getConfig(UI_SETTINGS.COURIER_BATCH_SEARCHES)) {
+
+    // Unsupported queries' type will be processed as unsupported and legacyFetch cannot parse {type: 'unsupported'} correctly
+    // need to call fetchExternalSearch before COURIER_BATCH_SEARCHES check
+    if (this.isUnsupportedRequest(searchRequest)) {
+      response = await this.fetchExternalSearch(searchRequest, options);
+    } else if (getConfig(UI_SETTINGS.COURIER_BATCH_SEARCHES)) {
       searchRequest.dataSourceId = indexPattern?.dataSourceRef?.id;
       response = await this.legacyFetch(searchRequest, options);
-    } else if (this.isUnsupportedRequest(searchRequest)) {
-      response = await this.fetchExternalSearch(searchRequest, options);
     } else {
       searchRequest.dataSourceId = indexPattern?.dataSourceRef?.id;
       response = await this.fetchSearch(searchRequest, options);

--- a/src/plugins/discover/public/embeddable/search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/search_embeddable.tsx
@@ -191,6 +191,7 @@ export class SearchEmbeddable
     }
     this.node = node;
     this.root = createRoot(node);
+    this.pushContainerStateParamsToProps(this.searchProps);
   }
 
   public destroy() {
@@ -300,7 +301,7 @@ export class SearchEmbeddable
       });
     };
 
-    this.pushContainerStateParamsToProps(searchProps);
+    this.searchProps = searchProps;
   }
 
   public reload() {
@@ -376,12 +377,14 @@ export class SearchEmbeddable
   }
 
   private async pushContainerStateParamsToProps(searchProps: SearchProps, force: boolean = false) {
+    // no fetch until the panel is mounted in the viewport and render(node) sets this.node.
     const isFetchRequired =
-      force ||
-      !opensearchFilters.onlyDisabledFiltersChanged(this.input.filters, this.prevFilters) ||
-      !isEqual(this.prevQuery, this.input.query) ||
-      !isEqual(this.prevTimeRange, this.input.timeRange) ||
-      !isEqual(searchProps.sort, this.input.sort || this.savedSearch.sort);
+      this.node &&
+      (force ||
+        !opensearchFilters.onlyDisabledFiltersChanged(this.input.filters, this.prevFilters) ||
+        !isEqual(this.prevQuery, this.input.query) ||
+        !isEqual(this.prevTimeRange, this.input.timeRange) ||
+        !isEqual(searchProps.sort, this.input.sort || this.savedSearch.sort));
 
     // If there is column or sort data on the panel, that means the original columns or sort settings have
     // been overridden in a dashboard.

--- a/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.test.tsx
+++ b/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.test.tsx
@@ -42,7 +42,28 @@ import { inspectorPluginMock } from '../../../../inspector/public/mocks';
 import { mount } from 'enzyme';
 import { embeddablePluginMock, createEmbeddablePanelMock } from '../../mocks';
 
-test('EmbeddableChildPanel renders an embeddable when it is done loading', async () => {
+let intersectionCallback: (entries: Array<{ isIntersecting: boolean }>) => void;
+let mockDisconnect: jest.Mock;
+const originalIO = window.IntersectionObserver;
+
+beforeEach(() => {
+  mockDisconnect = jest.fn();
+  const MockIntersectionObserver = jest.fn().mockImplementation((callback) => {
+    intersectionCallback = callback;
+    return {
+      observe: jest.fn(),
+      disconnect: mockDisconnect,
+      unobserve: jest.fn(),
+    };
+  });
+  window.IntersectionObserver = MockIntersectionObserver as any;
+});
+
+afterEach(() => {
+  window.IntersectionObserver = originalIO;
+});
+
+test('EmbeddableChildPanel renders an embeddable when it is done loading and visible', async () => {
   const inspector = inspectorPluginMock.createStartContract();
   const { setup, doStart } = embeddablePluginMock.createInstance();
   setup.registerEmbeddableFactory(
@@ -84,14 +105,159 @@ test('EmbeddableChildPanel renders an embeddable when it is done loading', async
   await nextTick();
   component.update();
 
-  // Due to the way embeddables mount themselves on the dom node, they are not forced to be
-  // react components, and hence, we can't use the usual
-  // findTestSubject(component, 'embeddablePanelHeading-HelloTheonGreyjoy');
+  // Simulate panel entering viewport
+  intersectionCallback([{ isIntersecting: true }]);
+  await nextTick();
+  component.update();
+
   expect(
     component
       .getDOMNode()
       .querySelectorAll('[data-test-subj="embeddablePanelHeading-HelloTheonGreyjoy"]').length
   ).toBe(1);
+});
+
+test('EmbeddableChildPanel does not mount PanelComponent when not visible', async () => {
+  const inspector = inspectorPluginMock.createStartContract();
+  const { setup, doStart } = embeddablePluginMock.createInstance();
+  setup.registerEmbeddableFactory(
+    CONTACT_CARD_EMBEDDABLE,
+    new SlowContactCardEmbeddableFactory({ execAction: (() => null) as any })
+  );
+  const start = doStart();
+  const getEmbeddableFactory = start.getEmbeddableFactory;
+
+  const container = new HelloWorldContainer({ id: 'hello', panels: {} }, {
+    getEmbeddableFactory,
+  } as any);
+  await container.addNewEmbeddable<
+    ContactCardEmbeddableInput,
+    ContactCardEmbeddableOutput,
+    ContactCardEmbeddable
+  >(CONTACT_CARD_EMBEDDABLE, {
+    firstName: 'Theon',
+    lastName: 'Greyjoy',
+    id: '123',
+  });
+
+  const testPanel = createEmbeddablePanelMock({
+    getAllEmbeddableFactories: start.getEmbeddableFactories,
+    getEmbeddableFactory,
+    inspector,
+  });
+
+  const component = mount(
+    <EmbeddableChildPanel container={container} embeddableId={'123'} PanelComponent={testPanel} />
+  );
+
+  await nextTick();
+  component.update();
+
+  // Observer has not fired isIntersecting=true, so panel should show loading
+  expect(component.find('EuiLoadingChart').length).toBe(1);
+  expect(
+    component
+      .getDOMNode()
+      .querySelectorAll('[data-test-subj="embeddablePanelHeading-HelloTheonGreyjoy"]').length
+  ).toBe(0);
+});
+
+test('EmbeddableChildPanel mounts PanelComponent when it becomes visible', async () => {
+  const inspector = inspectorPluginMock.createStartContract();
+  const { setup, doStart } = embeddablePluginMock.createInstance();
+  setup.registerEmbeddableFactory(
+    CONTACT_CARD_EMBEDDABLE,
+    new SlowContactCardEmbeddableFactory({ execAction: (() => null) as any })
+  );
+  const start = doStart();
+  const getEmbeddableFactory = start.getEmbeddableFactory;
+
+  const container = new HelloWorldContainer({ id: 'hello', panels: {} }, {
+    getEmbeddableFactory,
+  } as any);
+  const newEmbeddable = await container.addNewEmbeddable<
+    ContactCardEmbeddableInput,
+    ContactCardEmbeddableOutput,
+    ContactCardEmbeddable
+  >(CONTACT_CARD_EMBEDDABLE, {
+    firstName: 'Theon',
+    lastName: 'Greyjoy',
+    id: '123',
+  });
+
+  const testPanel = createEmbeddablePanelMock({
+    getAllEmbeddableFactories: start.getEmbeddableFactories,
+    getEmbeddableFactory,
+    inspector,
+  });
+
+  const component = mount(
+    <EmbeddableChildPanel
+      container={container}
+      embeddableId={newEmbeddable.id}
+      PanelComponent={testPanel}
+    />
+  );
+
+  await nextTick();
+  component.update();
+
+  // Initially not visible
+  expect(component.find('EuiLoadingChart').length).toBe(1);
+
+  // Simulate scrolling into view
+  intersectionCallback([{ isIntersecting: true }]);
+  await nextTick();
+  component.update();
+
+  // Now PanelComponent should be mounted
+  expect(component.find('EuiLoadingChart').length).toBe(0);
+  expect(
+    component
+      .getDOMNode()
+      .querySelectorAll('[data-test-subj="embeddablePanelHeading-HelloTheonGreyjoy"]').length
+  ).toBe(1);
+  expect(mockDisconnect).toHaveBeenCalled();
+});
+
+test('EmbeddableChildPanel disconnects observer on unmount', async () => {
+  const inspector = inspectorPluginMock.createStartContract();
+  const { setup, doStart } = embeddablePluginMock.createInstance();
+  setup.registerEmbeddableFactory(
+    CONTACT_CARD_EMBEDDABLE,
+    new SlowContactCardEmbeddableFactory({ execAction: (() => null) as any })
+  );
+  const start = doStart();
+  const getEmbeddableFactory = start.getEmbeddableFactory;
+
+  const container = new HelloWorldContainer({ id: 'hello', panels: {} }, {
+    getEmbeddableFactory,
+  } as any);
+  await container.addNewEmbeddable<
+    ContactCardEmbeddableInput,
+    ContactCardEmbeddableOutput,
+    ContactCardEmbeddable
+  >(CONTACT_CARD_EMBEDDABLE, {
+    firstName: 'Arya',
+    lastName: 'Stark',
+    id: '456',
+  });
+
+  const testPanel = createEmbeddablePanelMock({
+    getAllEmbeddableFactories: start.getEmbeddableFactories,
+    getEmbeddableFactory,
+    inspector,
+  });
+
+  const component = mount(
+    <EmbeddableChildPanel container={container} embeddableId={'456'} PanelComponent={testPanel} />
+  );
+
+  await nextTick();
+  component.update();
+
+  component.unmount();
+  expect(mockDisconnect).toHaveBeenCalled();
 });
 
 test(`EmbeddableChildPanel renders an error message if the factory doesn't exist`, async () => {
@@ -110,6 +276,11 @@ test(`EmbeddableChildPanel renders an error message if the factory doesn't exist
     <EmbeddableChildPanel container={container} embeddableId={'1'} PanelComponent={testPanel} />
   );
 
+  await nextTick();
+  component.update();
+
+  // Simulate visibility so the error panel can mount
+  intersectionCallback([{ isIntersecting: true }]);
   await nextTick();
   component.update();
 

--- a/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.tsx
+++ b/src/plugins/embeddable/public/lib/containers/embeddable_child_panel.tsx
@@ -46,11 +46,13 @@ export interface EmbeddableChildPanelProps {
 
 interface State {
   loading: boolean;
+  visible: boolean;
 }
 
 /**
  * This component can be used by embeddable containers using react to easily render children. It waits
  * for the child to be initialized, showing a loading indicator until that is complete.
+ * Panels that are not in the viewport will defer mounting the PanelComponent until they scroll into view.
  */
 
 export class EmbeddableChildPanel extends React.Component<EmbeddableChildPanelProps, State> {
@@ -58,17 +60,34 @@ export class EmbeddableChildPanel extends React.Component<EmbeddableChildPanelPr
   public mounted: boolean;
   public embeddable!: IEmbeddable | ErrorEmbeddable;
   private subscription?: Subscription;
+  private panelRef = React.createRef<HTMLDivElement>();
+  private observer?: IntersectionObserver;
 
   constructor(props: EmbeddableChildPanelProps) {
     super(props);
     this.state = {
       loading: true,
+      visible: false,
     };
 
     this.mounted = false;
   }
 
   public async componentDidMount() {
+    const el = this.panelRef.current;
+    if (el) {
+      this.observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting && this.mounted) {
+            this.observer?.disconnect();
+            this.setState({ visible: true });
+          }
+        },
+        { rootMargin: '200px' }
+      );
+      this.observer.observe(el);
+    }
+
     this.mounted = true;
     const { container } = this.props;
 
@@ -80,6 +99,7 @@ export class EmbeddableChildPanel extends React.Component<EmbeddableChildPanelPr
 
   public componentWillUnmount() {
     this.mounted = false;
+    this.observer?.disconnect();
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
@@ -88,12 +108,12 @@ export class EmbeddableChildPanel extends React.Component<EmbeddableChildPanelPr
   public render() {
     const { PanelComponent } = this.props;
     const classes = classNames('embPanel', {
-      'embPanel-isLoading': this.state.loading,
+      'embPanel-isLoading': this.state.loading || !this.state.visible,
     });
 
     return (
-      <div className={classes}>
-        {this.state.loading || !this.embeddable ? (
+      <div className={classes} ref={this.panelRef}>
+        {this.state.loading || !this.embeddable || !this.state.visible ? (
           <EuiLoadingChart size="l" mono />
         ) : (
           <PanelComponent embeddable={this.embeddable} />

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -420,16 +420,18 @@ export class ExploreEmbeddable
       });
     };
 
-    this.updateHandler(searchProps);
+    this.searchProps = searchProps;
   }
 
   private async updateHandler(searchProps: SearchProps, force = false) {
     const { filters, query, timeRange } = this.input;
+    // no fetch until the panel is mounted in the viewport and render(node) sets this.node.
     const needFetch =
-      force ||
-      !opensearchFilters.onlyDisabledFiltersChanged(filters, this.prevState.filters) ||
-      !isEqual(query, this.prevState.query) ||
-      !isEqual(timeRange, this.prevState.timeRange);
+      this.node &&
+      (force ||
+        !opensearchFilters.onlyDisabledFiltersChanged(filters, this.prevState.filters) ||
+        !isEqual(query, this.prevState.query) ||
+        !isEqual(timeRange, this.prevState.timeRange));
 
     // If there is column or sort data on the panel, that means the original columns or sort settings have
     // been overridden in a dashboard.
@@ -726,6 +728,7 @@ export class ExploreEmbeddable
     this.node = node;
     this.node.style.height = '100%';
     this.root = createRoot(node);
+    this.updateHandler(this.searchProps);
   }
 
   public getInspectorAdapters() {

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -36,6 +36,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const find = getService('find');
   const log = getService('log');
+  const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
   const security = getService('security');
   const pieChart = getService('pieChart');
   const renderable = getService('renderable');
@@ -108,6 +110,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should launch sample flights data set dashboard', async () => {
         await PageObjects.home.launchSampleDashboard('flights');
         await PageObjects.header.waitUntilLoadingHasFinished();
+        const panels = await testSubjects.findAll('dashboardPanel');
+        for (const panel of panels) {
+          await panel.scrollIntoViewIfNecessary();
+        }
+        await browser.scrollTop();
         await renderable.waitForRender();
         const todayYearMonthDay = moment().format('MMM D, YYYY');
         const fromTime = `${todayYearMonthDay} @ 00:00:00.000`;
@@ -120,6 +127,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should render visualizations', async () => {
         await PageObjects.home.launchSampleDashboard('flights');
         await PageObjects.header.waitUntilLoadingHasFinished();
+        const panels = await testSubjects.findAll('dashboardPanel');
+        for (const panel of panels) {
+          await panel.scrollIntoViewIfNecessary();
+        }
         await renderable.waitForRender();
         log.debug('Checking pie charts rendered');
         await pieChart.expectPieSliceCount(4);
@@ -140,6 +151,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should launch sample logs data set dashboard', async () => {
         await PageObjects.home.launchSampleDashboard('logs');
         await PageObjects.header.waitUntilLoadingHasFinished();
+        const panels = await testSubjects.findAll('dashboardPanel');
+        for (const panel of panels) {
+          await panel.scrollIntoViewIfNecessary();
+        }
+        await browser.scrollTop();
         await renderable.waitForRender();
         const todayYearMonthDay = moment().format('MMM D, YYYY');
         const fromTime = `${todayYearMonthDay} @ 00:00:00.000`;
@@ -152,6 +168,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should launch sample ecommerce data set dashboard', async () => {
         await PageObjects.home.launchSampleDashboard('ecommerce');
         await PageObjects.header.waitUntilLoadingHasFinished();
+        const panels = await testSubjects.findAll('dashboardPanel');
+        for (const panel of panels) {
+          await panel.scrollIntoViewIfNecessary();
+        }
+        await browser.scrollTop();
         await renderable.waitForRender();
         const todayYearMonthDay = moment().format('MMM D, YYYY');
         const fromTime = `${todayYearMonthDay} @ 00:00:00.000`;

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -484,7 +484,16 @@ export function DashboardPageProvider({ getService, getPageObjects }: FtrProvide
       log.debug('waitForRenderComplete');
       const count = await this.getSharedItemsCount();
       // eslint-disable-next-line radix
-      await renderable.waitForRender(parseInt(count));
+      const panelCount = parseInt(count);
+
+      // Scroll each panel into view to trigger lazy loading via IntersectionObserver
+      const panels = await testSubjects.findAll('dashboardPanel');
+      for (const panel of panels) {
+        await panel.scrollIntoViewIfNecessary();
+      }
+      await browser.scrollTop();
+
+      await renderable.waitForRender(panelCount);
     }
 
     public async getSharedContainerData() {


### PR DESCRIPTION
### Description
Support dashboard lazy loading for 

- Defer data fetch (PPL/DSL /PromQl queries) for dashboard panels until they scroll into the viewport 
- Panels above the fold load immediately; panels below the fold show a loading indicator until visible
- Reduces concurrent query pressure on OpenSearch clusters for dashboards with many visualizations


## Test plan
- [ ] Open a dashboard with 10+ panels where some are below the fold
- [ ] Verify above-fold panels load immediately
- [ ] Verify below-fold panels show loading spinner and only fetch data when scrolled into view
- [ ] Check Network tab: PPL/DSL requests should fire incrementally as panels scroll into view, not all at once


## Screenshot

https://github.com/user-attachments/assets/7a0beee1-826c-4836-9d8a-0940162c2fc3



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
