### PR TITLE
fix: hide Ask AI for AnalyticEngine data sources across all visualization types

### DIFF
--- a/src/plugins/explore/public/components/data_table/table_cell/non_filterable_table_cell.tsx
+++ b/src/plugins/explore/public/components/data_table/table_cell/non_filterable_table_cell.tsx
@@ -48,7 +48,7 @@ export const NonFilterableTableCell: React.FC<NonFilterableTableCellProps> = ({
                 document={rowData._source}
                 query={undefined}
                 indexPattern={dataset?.title}
-                metadata={{ index, dataSourceEngineType: dataset?.dataSource?.type }}
+                metadata={{ index, dataSourceEngineType: dataset?.dataSourceRef?.type }}
                 iconType="generate"
                 size="xs"
               />

--- a/src/plugins/explore/public/components/data_table/table_cell/table_cell.tsx
+++ b/src/plugins/explore/public/components/data_table/table_cell/table_cell.tsx
@@ -78,7 +78,7 @@ export const TableCellUI = ({
             document={rowData._source}
             query={undefined}
             indexPattern={dataset?.title}
-            metadata={{ index, dataSourceEngineType: dataset?.dataSource?.type }}
+            metadata={{ index, dataSourceEngineType: dataset?.dataSourceRef?.type }}
             iconType="generate"
             size="xs"
           />

--- a/src/plugins/vis_type_timeseries/public/request_handler.js
+++ b/src/plugins/vis_type_timeseries/public/request_handler.js
@@ -31,6 +31,7 @@
 import { getTimezone, validateInterval } from './application';
 import { getUISettings, getDataStart, getCoreStart } from './services';
 import { MAX_BUCKETS_SETTING } from '../common/constants';
+import { AnalyticEngineError } from '../../data/public';
 
 export const metricsRequestHandler = async ({
   uiState,
@@ -74,6 +75,9 @@ export const metricsRequestHandler = async ({
         ...resp,
       };
     } catch (error) {
+      if (error?.body?.attributes?.title === 'AnalyticEngineError') {
+        throw new AnalyticEngineError();
+      }
       return Promise.reject(error);
     }
   }

--- a/src/plugins/vis_type_timeseries/public/request_handler_raw.js
+++ b/src/plugins/vis_type_timeseries/public/request_handler_raw.js
@@ -7,6 +7,7 @@ import { getTimezone, validateInterval } from './application';
 import { getUISettings, getDataStart, getCoreStart } from './services';
 import { MAX_BUCKETS_SETTING } from '../common/constants';
 import { evaluateMathExpressions } from './lib/process_math_series';
+import { AnalyticEngineError } from '../../data/public';
 
 /**
  * Request handler for TSVB visualizations with client-side math evaluation.
@@ -70,6 +71,9 @@ export const metricsRequestHandlerRaw = async ({
         ...processedResp,
       };
     } catch (error) {
+      if (error?.body?.attributes?.title === 'AnalyticEngineError') {
+        throw new AnalyticEngineError();
+      }
       return Promise.reject(error);
     }
   }

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data.js
@@ -88,7 +88,7 @@ export async function getSeriesData(req, panel) {
       },
     };
   } catch (err) {
-    if (err.body || err.name === 'DQLSyntaxError' || err.name === 'AnalyticEngineError') {
+    if (err.body || err.name === 'DQLSyntaxError') {
       err.response = err.body;
 
       return {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data_raw.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data_raw.js
@@ -88,7 +88,7 @@ export async function getSeriesDataRaw(req, panel) {
       },
     };
   } catch (err) {
-    if (err.body || err.name === 'DQLSyntaxError' || err.name === 'AnalyticEngineError') {
+    if (err.body || err.name === 'DQLSyntaxError') {
       err.response = err.body;
 
       return {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.js
@@ -84,7 +84,11 @@ export async function getTableData(req, panel) {
       series: buckets.map(processBucket(panel)),
     };
   } catch (err) {
-    if (err.body || err.name === 'DQLSyntaxError' || err.name === 'AnalyticEngineError') {
+    if (err.name === 'AnalyticEngineError') {
+      throw err;
+    }
+
+    if (err.body || err.name === 'DQLSyntaxError') {
       err.response = err.body;
 
       return {

--- a/src/plugins/vis_type_timeseries/server/routes/vis.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/vis.ts
@@ -71,7 +71,10 @@ export const visDataRoutes = (
         return response.ok({ body: results });
       } catch (error) {
         return response.internalError({
-          body: error.message,
+          body: {
+            ...(error?.name === 'AnalyticEngineError' && { attributes: { title: error?.name } }),
+            message: error.message,
+          },
         });
       }
     }

--- a/src/plugins/vis_type_timeseries/server/routes/vis_raw.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/vis_raw.ts
@@ -71,7 +71,10 @@ export const visDataRawRoutes = (
         return response.ok({ body: results });
       } catch (error) {
         return response.internalError({
-          body: error.message,
+          body: {
+            ...(error?.name === 'AnalyticEngineError' && { attributes: { title: error?.name } }),
+            message: error.message,
+          },
         });
       }
     }

--- a/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.test.ts
@@ -14,6 +14,14 @@ jest.mock('rxjs', () => ({
 
 jest.mock('../../../data/public', () => ({
   getSearchParamsFromRequest: jest.fn().mockImplementation((obj, _) => obj),
+  AnalyticEngineError: class AnalyticEngineError extends Error {
+    constructor() {
+      super(
+        'This data source uses Analytic Engine which does not support DSL queries. Use PPL-compatible features or switch to a standard OpenSearch data source.'
+      );
+      this.name = 'AnalyticEngineError';
+    }
+  },
 }));
 
 interface MockSearch {

--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -40,6 +40,7 @@ import {
   DataPublicPluginStart,
   IOpenSearchSearchResponse,
   IOpenSearchSearchRequest,
+  AnalyticEngineError,
 } from '../../../data/public';
 import { search as dataPluginSearch } from '../../../data/public';
 import { VegaInspectorAdapters } from '../vega_inspector';
@@ -140,12 +141,7 @@ export class SearchAPI {
       dataSource?.attributes?.dataSourceEngineType &&
       UNSUPPORTED_ENGINE_TYPES.includes(dataSource?.attributes?.dataSourceEngineType)
     ) {
-      throw new Error(
-        i18n.translate('visTypeVega.search.analyticEngineNotSupported', {
-          defaultMessage:
-            'This data source uses Analytic Engine which does not support DSL queries. Use PPL-compatible features or switch to a standard OpenSearch data source.',
-        })
-      );
+      throw new AnalyticEngineError();
     }
 
     return dataSource.id;

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -126,6 +126,12 @@ export class VegaParser {
     try {
       await this._parseAsync();
     } catch (err) {
+      // Let AnalyticEngine errors propagate so they surface through the unified embeddable error
+      // path (output.error.name === 'AnalyticEngineError') and render via ErrorEmbeddable, instead
+      // of being shown inline as a Vega warning.
+      if (err.name === 'AnalyticEngineError') {
+        throw err;
+      }
       // if we reject current promise, it will use the standard OpenSearch Dashboards error handling
       this.error = Utils.formatErrorToStr(err);
     }

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
@@ -33,6 +33,12 @@ describe('AskAIVisualizeEmbeddableAction', () => {
         isAvailable: () => true,
         sendMessageWithWindow: jest.fn().mockResolvedValue(undefined),
       },
+      savedObjects: {
+        client: {
+          get: jest.fn().mockResolvedValue({ attributes: {} }),
+          find: jest.fn().mockResolvedValue({ savedObjects: [] }),
+        },
+      },
     };
 
     // Mock context provider
@@ -100,6 +106,20 @@ describe('AskAIVisualizeEmbeddableAction', () => {
       expect(result).toBe(true);
     });
 
+    it('should memoize the index pattern lookup for a normal visualization', async () => {
+      const getCache = jest.fn().mockResolvedValue([{ id: 'test-index-pattern-id' }]);
+      const memoAction = new AskAIVisualizeEmbeddableAction(
+        mockCore,
+        { getCache } as any,
+        mockContextProvider
+      );
+      await memoAction.isCompatible({ embeddable: mockEmbeddable });
+      await memoAction.isCompatible({ embeddable: mockEmbeddable });
+      await memoAction.isCompatible({ embeddable: mockEmbeddable });
+      // The index pattern classification is cached after the first lookup.
+      expect(getCache).toHaveBeenCalledTimes(1);
+    });
+
     it('should return false for non-VisualizeEmbeddable', async () => {
       const nonVisualizeEmbeddable = {
         type: 'other_type',
@@ -130,6 +150,138 @@ describe('AskAIVisualizeEmbeddableAction', () => {
       );
       const result = await actionWithoutContext.isCompatible({ embeddable: mockEmbeddable });
       expect(result).toBe(false);
+    });
+
+    const buildEmbeddable = (vis: any) =>
+      (({ ...mockEmbeddable, vis } as unknown) as VisualizeEmbeddable);
+
+    it('should hide for TSVB (metrics) backed by an AnalyticEngine data source', async () => {
+      mockCore.savedObjects.client.get.mockResolvedValue({
+        attributes: { dataSourceEngineType: 'AnalyticEngine' },
+      });
+      const embeddable = buildEmbeddable({
+        type: { name: 'metrics' },
+        params: { data_source_id: 'ae-id' },
+        data: {},
+      });
+      const result = await action.isCompatible({ embeddable });
+      expect(result).toBe(false);
+      expect(mockCore.savedObjects.client.get).toHaveBeenCalledWith('data-source', 'ae-id');
+    });
+
+    it('should memoize the data source lookup across repeated isCompatible calls', async () => {
+      mockCore.savedObjects.client.get.mockResolvedValue({
+        attributes: { dataSourceEngineType: 'AnalyticEngine' },
+      });
+      const embeddable = buildEmbeddable({
+        type: { name: 'metrics' },
+        params: { data_source_id: 'ae-id' },
+        data: {},
+      });
+      await action.isCompatible({ embeddable });
+      await action.isCompatible({ embeddable });
+      await action.isCompatible({ embeddable });
+      // The engine type is cached after the first lookup, so the API is only hit once.
+      expect(mockCore.savedObjects.client.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show for TSVB (metrics) backed by a non-AnalyticEngine data source', async () => {
+      mockCore.savedObjects.client.get.mockResolvedValue({
+        attributes: { dataSourceEngineType: 'OpenSearch' },
+      });
+      const embeddable = buildEmbeddable({
+        type: { name: 'metrics' },
+        params: { data_source_id: 'os-id' },
+        data: {},
+      });
+      expect(await action.isCompatible({ embeddable })).toBe(true);
+    });
+
+    it('should hide for Vega referencing an AnalyticEngine data source by name', async () => {
+      mockCore.savedObjects.client.find.mockResolvedValue({
+        savedObjects: [
+          { attributes: { title: 'my source', dataSourceEngineType: 'AnalyticEngine' } },
+        ],
+      });
+      const embeddable = buildEmbeddable({
+        type: { name: 'vega' },
+        params: { spec: JSON.stringify({ data: { url: { data_source_name: 'my source' } } }) },
+        data: {},
+      });
+      expect(await action.isCompatible({ embeddable })).toBe(false);
+    });
+
+    it('should hide for Vega when the spec is authored in HJSON (unquoted keys)', async () => {
+      mockCore.savedObjects.client.find.mockResolvedValue({
+        savedObjects: [
+          { attributes: { title: 'my source', dataSourceEngineType: 'AnalyticEngine' } },
+        ],
+      });
+      // HJSON: unquoted keys and a comment, which strict JSON.parse cannot handle.
+      const hjsonSpec = `{
+        // an hjson spec
+        data: {
+          url: {
+            index: my-index
+            data_source_name: my source
+          }
+        }
+      }`;
+      const embeddable = buildEmbeddable({
+        type: { name: 'vega' },
+        params: { spec: hjsonSpec },
+        data: {},
+      });
+      expect(await action.isCompatible({ embeddable })).toBe(false);
+    });
+
+    it('should hide for Timeline referencing an AnalyticEngine data source by name', async () => {
+      mockCore.savedObjects.client.find.mockResolvedValue({
+        savedObjects: [
+          { attributes: { title: 'my source', dataSourceEngineType: 'AnalyticEngine' } },
+        ],
+      });
+      const embeddable = buildEmbeddable({
+        type: { name: 'timelion' },
+        params: { expression: '.opensearch(index=*, data_source_name="my source")' },
+        data: {},
+      });
+      expect(await action.isCompatible({ embeddable })).toBe(false);
+    });
+
+    it('should hide for input controls whose index pattern is AnalyticEngine-backed', async () => {
+      const mockIndexPatterns = {
+        // 'ae-ip' is intentionally excluded from the engine-filtered cache.
+        getCache: jest.fn().mockResolvedValue([{ id: 'os-ip' }]),
+      } as any;
+      const controlsAction = new AskAIVisualizeEmbeddableAction(
+        mockCore,
+        mockIndexPatterns,
+        mockContextProvider
+      );
+      const embeddable = buildEmbeddable({
+        type: { name: 'input_control_vis' },
+        params: { controls: [{ indexPattern: 'ae-ip' }] },
+        data: {},
+      });
+      expect(await controlsAction.isCompatible({ embeddable })).toBe(false);
+    });
+
+    it('should show for input controls whose index pattern is allowed', async () => {
+      const mockIndexPatterns = {
+        getCache: jest.fn().mockResolvedValue([{ id: 'os-ip' }]),
+      } as any;
+      const controlsAction = new AskAIVisualizeEmbeddableAction(
+        mockCore,
+        mockIndexPatterns,
+        mockContextProvider
+      );
+      const embeddable = buildEmbeddable({
+        type: { name: 'input_control_vis' },
+        params: { controls: [{ indexPattern: 'os-ip' }] },
+        data: {},
+      });
+      expect(await controlsAction.isCompatible({ embeddable })).toBe(true);
     });
   });
 

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
@@ -16,6 +16,7 @@ describe('AskAIVisualizeEmbeddableAction', () => {
   let mockCore: any;
   let mockContextProvider: any;
   let mockEmbeddable: any;
+  let mockIndexPatterns: any;
 
   beforeEach(() => {
     // Mock core
@@ -75,12 +76,13 @@ describe('AskAIVisualizeEmbeddableAction', () => {
         },
       },
       domNode: document.createElement('div'),
+      getOutput: jest.fn().mockReturnValue({ usesUnsupportedEngineDataSource: false }),
     } as unknown) as VisualizeEmbeddable;
 
     // Create action instance
-    const mockIndexPatterns = {
+    mockIndexPatterns = {
       getCache: jest.fn().mockResolvedValue([{ id: 'test-index-pattern-id' }]),
-    } as any;
+    };
     action = new AskAIVisualizeEmbeddableAction(mockCore, mockIndexPatterns, mockContextProvider);
   });
 
@@ -101,43 +103,48 @@ describe('AskAIVisualizeEmbeddableAction', () => {
   });
 
   describe('isCompatible', () => {
-    it('should return true for VisualizeEmbeddable', async () => {
-      const result = await action.isCompatible({ embeddable: mockEmbeddable });
+    const withOutput = (usesUnsupportedEngineDataSource?: boolean) =>
+      (({
+        ...mockEmbeddable,
+        getOutput: jest.fn().mockReturnValue({ usesUnsupportedEngineDataSource }),
+      } as unknown) as VisualizeEmbeddable);
+
+    it('should return true when the data source engine is supported', async () => {
+      const result = await action.isCompatible({ embeddable: withOutput(false) });
       expect(result).toBe(true);
     });
 
-    it('should memoize the index pattern lookup for a normal visualization', async () => {
-      const getCache = jest.fn().mockResolvedValue([{ id: 'test-index-pattern-id' }]);
-      const memoAction = new AskAIVisualizeEmbeddableAction(
-        mockCore,
-        { getCache } as any,
-        mockContextProvider
-      );
-      await memoAction.isCompatible({ embeddable: mockEmbeddable });
-      await memoAction.isCompatible({ embeddable: mockEmbeddable });
-      await memoAction.isCompatible({ embeddable: mockEmbeddable });
-      // The index pattern classification is cached after the first lookup.
-      expect(getCache).toHaveBeenCalledTimes(1);
+    it('should fail open (return true) while engine resolution is still in flight', async () => {
+      const result = await action.isCompatible({ embeddable: withOutput(undefined) });
+      expect(result).toBe(true);
+    });
+
+    it('should return false when the data source engine is unsupported', async () => {
+      const result = await action.isCompatible({ embeddable: withOutput(true) });
+      expect(result).toBe(false);
     });
 
     it('should return false for non-VisualizeEmbeddable', async () => {
       const nonVisualizeEmbeddable = {
         type: 'other_type',
         getInput: jest.fn(),
+        getOutput: jest.fn().mockReturnValue({}),
       };
       const result = await action.isCompatible({ embeddable: nonVisualizeEmbeddable as any });
       expect(result).toBe(false);
     });
 
     it('should return false when context provider is not available', async () => {
-      const mockIp = { getCache: jest.fn().mockResolvedValue([]) } as any;
-      const actionWithoutContext = new AskAIVisualizeEmbeddableAction(mockCore, mockIp, undefined);
+      const actionWithoutContext = new AskAIVisualizeEmbeddableAction(
+        mockCore,
+        mockIndexPatterns,
+        undefined
+      );
       const result = await actionWithoutContext.isCompatible({ embeddable: mockEmbeddable });
       expect(result).toBe(false);
     });
 
     it('should return false when chat is not available', async () => {
-      const mockIp = { getCache: jest.fn().mockResolvedValue([]) } as any;
       const actionWithoutContext = new AskAIVisualizeEmbeddableAction(
         {
           ...mockCore,
@@ -145,143 +152,46 @@ describe('AskAIVisualizeEmbeddableAction', () => {
             isAvailable: () => false,
           },
         },
-        mockIp,
-        undefined
+        mockIndexPatterns,
+        mockContextProvider
       );
       const result = await actionWithoutContext.isCompatible({ embeddable: mockEmbeddable });
       expect(result).toBe(false);
     });
 
-    const buildEmbeddable = (vis: any) =>
-      (({ ...mockEmbeddable, vis } as unknown) as VisualizeEmbeddable);
+    describe('input controls (resolved via index-pattern cache, not the render-error flag)', () => {
+      const buildInputControlEmbeddable = (indexPattern: string) =>
+        (({
+          ...mockEmbeddable,
+          vis: { type: { name: 'input_control_vis' }, params: { controls: [{ indexPattern }] } },
+          // Output flag is irrelevant for input controls; ensure it isn't read.
+          getOutput: jest.fn().mockReturnValue({ usesUnsupportedEngineDataSource: undefined }),
+        } as unknown) as VisualizeEmbeddable);
 
-    it('should hide for TSVB (metrics) backed by an AnalyticEngine data source', async () => {
-      mockCore.savedObjects.client.get.mockResolvedValue({
-        attributes: { dataSourceEngineType: 'AnalyticEngine' },
-      });
-      const embeddable = buildEmbeddable({
-        type: { name: 'metrics' },
-        params: { data_source_id: 'ae-id' },
-        data: {},
-      });
-      const result = await action.isCompatible({ embeddable });
-      expect(result).toBe(false);
-      expect(mockCore.savedObjects.client.get).toHaveBeenCalledWith('data-source', 'ae-id');
-    });
-
-    it('should memoize the data source lookup across repeated isCompatible calls', async () => {
-      mockCore.savedObjects.client.get.mockResolvedValue({
-        attributes: { dataSourceEngineType: 'AnalyticEngine' },
-      });
-      const embeddable = buildEmbeddable({
-        type: { name: 'metrics' },
-        params: { data_source_id: 'ae-id' },
-        data: {},
-      });
-      await action.isCompatible({ embeddable });
-      await action.isCompatible({ embeddable });
-      await action.isCompatible({ embeddable });
-      // The engine type is cached after the first lookup, so the API is only hit once.
-      expect(mockCore.savedObjects.client.get).toHaveBeenCalledTimes(1);
-    });
-
-    it('should show for TSVB (metrics) backed by a non-AnalyticEngine data source', async () => {
-      mockCore.savedObjects.client.get.mockResolvedValue({
-        attributes: { dataSourceEngineType: 'OpenSearch' },
-      });
-      const embeddable = buildEmbeddable({
-        type: { name: 'metrics' },
-        params: { data_source_id: 'os-id' },
-        data: {},
-      });
-      expect(await action.isCompatible({ embeddable })).toBe(true);
-    });
-
-    it('should hide for Vega referencing an AnalyticEngine data source by name', async () => {
-      mockCore.savedObjects.client.find.mockResolvedValue({
-        savedObjects: [
-          { attributes: { title: 'my source', dataSourceEngineType: 'AnalyticEngine' } },
-        ],
-      });
-      const embeddable = buildEmbeddable({
-        type: { name: 'vega' },
-        params: { spec: JSON.stringify({ data: { url: { data_source_name: 'my source' } } }) },
-        data: {},
-      });
-      expect(await action.isCompatible({ embeddable })).toBe(false);
-    });
-
-    it('should hide for Vega when the spec is authored in HJSON (unquoted keys)', async () => {
-      mockCore.savedObjects.client.find.mockResolvedValue({
-        savedObjects: [
-          { attributes: { title: 'my source', dataSourceEngineType: 'AnalyticEngine' } },
-        ],
-      });
-      // HJSON: unquoted keys and a comment, which strict JSON.parse cannot handle.
-      const hjsonSpec = `{
-        // an hjson spec
-        data: {
-          url: {
-            index: my-index
-            data_source_name: my source
-          }
-        }
-      }`;
-      const embeddable = buildEmbeddable({
-        type: { name: 'vega' },
-        params: { spec: hjsonSpec },
-        data: {},
-      });
-      expect(await action.isCompatible({ embeddable })).toBe(false);
-    });
-
-    it('should hide for Timeline referencing an AnalyticEngine data source by name', async () => {
-      mockCore.savedObjects.client.find.mockResolvedValue({
-        savedObjects: [
-          { attributes: { title: 'my source', dataSourceEngineType: 'AnalyticEngine' } },
-        ],
-      });
-      const embeddable = buildEmbeddable({
-        type: { name: 'timelion' },
-        params: { expression: '.opensearch(index=*, data_source_name="my source")' },
-        data: {},
-      });
-      expect(await action.isCompatible({ embeddable })).toBe(false);
-    });
-
-    it('should hide for input controls whose index pattern is AnalyticEngine-backed', async () => {
-      const mockIndexPatterns = {
+      it('should hide when a control index pattern is AnalyticEngine-backed', async () => {
         // 'ae-ip' is intentionally excluded from the engine-filtered cache.
-        getCache: jest.fn().mockResolvedValue([{ id: 'os-ip' }]),
-      } as any;
-      const controlsAction = new AskAIVisualizeEmbeddableAction(
-        mockCore,
-        mockIndexPatterns,
-        mockContextProvider
-      );
-      const embeddable = buildEmbeddable({
-        type: { name: 'input_control_vis' },
-        params: { controls: [{ indexPattern: 'ae-ip' }] },
-        data: {},
+        mockIndexPatterns.getCache.mockResolvedValue([{ id: 'os-ip' }]);
+        const result = await action.isCompatible({
+          embeddable: buildInputControlEmbeddable('ae-ip'),
+        });
+        expect(result).toBe(false);
       });
-      expect(await controlsAction.isCompatible({ embeddable })).toBe(false);
-    });
 
-    it('should show for input controls whose index pattern is allowed', async () => {
-      const mockIndexPatterns = {
-        getCache: jest.fn().mockResolvedValue([{ id: 'os-ip' }]),
-      } as any;
-      const controlsAction = new AskAIVisualizeEmbeddableAction(
-        mockCore,
-        mockIndexPatterns,
-        mockContextProvider
-      );
-      const embeddable = buildEmbeddable({
-        type: { name: 'input_control_vis' },
-        params: { controls: [{ indexPattern: 'os-ip' }] },
-        data: {},
+      it('should show when all control index patterns are allowed', async () => {
+        mockIndexPatterns.getCache.mockResolvedValue([{ id: 'os-ip' }]);
+        const result = await action.isCompatible({
+          embeddable: buildInputControlEmbeddable('os-ip'),
+        });
+        expect(result).toBe(true);
       });
-      expect(await controlsAction.isCompatible({ embeddable })).toBe(true);
+
+      it('should fail open when the index-pattern cache is unavailable', async () => {
+        mockIndexPatterns.getCache.mockResolvedValue(undefined);
+        const result = await action.isCompatible({
+          embeddable: buildInputControlEmbeddable('ae-ip'),
+        });
+        expect(result).toBe(true);
+      });
     });
   });
 

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
@@ -6,7 +6,6 @@
 import { i18n } from '@osd/i18n';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import { get } from 'lodash';
-import { parse as parseHjson } from 'hjson';
 import html2canvas from 'html2canvas-pro';
 import { EmbeddableContext, IEmbeddable } from '../../../embeddable/public';
 import { Action, IncompatibleActionError } from '../../../ui_actions/public';
@@ -45,15 +44,6 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
     },
   ];
 
-  // `isCompatible` is invoked frequently (panel renders, context-menu opens), so resolved engine
-  // types are memoized to avoid repeating saved-object lookups for the same data source. A data
-  // source's engine type does not change within a session.
-  private readonly engineTypeByIdCache = new Map<string, string | undefined>();
-  private readonly engineTypeByNameCache = new Map<string, string | undefined>();
-  // Whether a given index pattern is backed by an unsupported engine. Memoized for the same
-  // reason; the underlying `getCache` call otherwise re-fetches data sources on every call.
-  private readonly analyticEngineByIndexPatternCache = new Map<string, boolean>();
-
   constructor(
     private readonly core: CoreStart,
     private readonly indexPatterns: IndexPatternsContract,
@@ -78,128 +68,45 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
     ) {
       return false;
     }
-    // Hide the action when the visualization is backed by an AnalyticEngine data source.
+
     const visEmbeddable = embeddable as VisualizeEmbeddable;
-    const usesAnalyticEngine = await this.usesAnalyticEngineDataSource(visEmbeddable.vis);
-    return !usesAnalyticEngine;
+
+    // Input controls never produce a render error for an AnalyticEngine data source — the
+    // unsupported index patterns are silently filtered out at render time — so there is no error
+    // signal to rely on. Resolve their engine type directly from the index-pattern cache instead.
+    if (visEmbeddable.vis?.type?.name === 'input_control_vis') {
+      const controlIndexPatternIds: string[] = ((visEmbeddable.vis.params as any)?.controls || [])
+        .map((control: { indexPattern?: string }) => control.indexPattern)
+        .filter(Boolean);
+      const usesAnalyticEngine = await this.hasAnalyticEngineIndexPattern(controlIndexPatternIds);
+      return !usesAnalyticEngine;
+    }
+
+    // Every other visualization type surfaces an AnalyticEngine data source as a render error, which
+    // the VisualizeEmbeddable captures and publishes on its output. Read it synchronously here.
+    // While the value is still `undefined` (not yet rendered) we fail open and keep the action.
+    const output = embeddable.getOutput() as { usesUnsupportedEngineDataSource?: boolean };
+    return output.usesUnsupportedEngineDataSource !== true;
   }
 
   /**
-   * Resolves whether a visualization uses an AnalyticEngine data source. Each visualization type
-   * references its data source differently, so they are handled by type here. We fail open
-   * (return false) whenever the data source cannot be resolved, so the action stays available.
+   * Whether any of the given index patterns is backed by an unsupported (AnalyticEngine) engine.
+   * Index patterns backed by an unsupported engine are excluded from the engine-filtered cache, so
+   * any id missing from it is unsupported-engine-backed. Fails open (false) if the cache is
+   * unavailable so the action stays visible.
    */
-  private async usesAnalyticEngineDataSource(vis: Vis): Promise<boolean> {
-    const params: any = vis.params || {};
-
-    switch (vis.type?.name) {
-      // TSVB references the data source directly by id.
-      case 'metrics':
-        return this.isAnalyticEngineById(params.data_source_id);
-
-      // Vega references one or more data sources by name inside its spec.
-      case 'vega':
-        return this.isAnalyticEngineByNames(extractVegaDataSourceNames(params.spec));
-
-      // Timeline references data sources by name inside its expression string.
-      case 'timelion':
-        return this.isAnalyticEngineByNames(extractTimelineDataSourceNames(params.expression));
-
-      // Input controls reference index patterns per control; an AnalyticEngine-backed index
-      // pattern is excluded from the engine-filtered cache.
-      case 'input_control_vis': {
-        const indexPatternIds: string[] = (params.controls || [])
-          .map((control: { indexPattern?: string }) => control.indexPattern)
-          .filter(Boolean);
-        return this.hasAnalyticEngineIndexPattern(indexPatternIds);
-      }
-
-      // Default: aggregation-based visualizations expose `vis.data.indexPattern`.
-      default: {
-        const indexPatternId = vis.data.indexPattern?.id;
-        return indexPatternId ? this.hasAnalyticEngineIndexPattern([indexPatternId]) : false;
-      }
-    }
-  }
-
-  private async isAnalyticEngineById(dataSourceId?: string): Promise<boolean> {
-    if (!dataSourceId) {
-      return false;
-    }
-    if (!this.engineTypeByIdCache.has(dataSourceId)) {
-      try {
-        const dataSource = await this.core.savedObjects.client.get<{
-          dataSourceEngineType?: string;
-        }>('data-source', dataSourceId);
-        this.engineTypeByIdCache.set(dataSourceId, dataSource?.attributes?.dataSourceEngineType);
-      } catch {
-        // Do not cache failures so a transient error can be retried later.
-        return false;
-      }
-    }
-    const engineType = this.engineTypeByIdCache.get(dataSourceId);
-    return !!engineType && UNSUPPORTED_ENGINE_TYPES.includes(engineType);
-  }
-
-  private async isAnalyticEngineByNames(dataSourceNames: string[]): Promise<boolean> {
-    if (dataSourceNames.length === 0) {
-      return false;
-    }
-    for (const name of dataSourceNames) {
-      if (!this.engineTypeByNameCache.has(name)) {
-        try {
-          const response = await this.core.savedObjects.client.find<{
-            title?: string;
-            dataSourceEngineType?: string;
-          }>({
-            type: 'data-source',
-            perPage: 10,
-            search: `"${name}"`,
-            searchFields: ['title'],
-            fields: ['title', 'dataSourceEngineType'],
-          });
-          // `data_source_name` could be a prefix of another name, so match exactly.
-          const match = response.savedObjects.find((obj) => obj.attributes?.title === name);
-          this.engineTypeByNameCache.set(name, match?.attributes?.dataSourceEngineType);
-        } catch {
-          // Do not cache failures; skip this name and keep the action available.
-          continue;
-        }
-      }
-      const engineType = this.engineTypeByNameCache.get(name);
-      if (engineType && UNSUPPORTED_ENGINE_TYPES.includes(engineType)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private async hasAnalyticEngineIndexPattern(indexPatternIds: string[]): Promise<boolean> {
     if (indexPatternIds.length === 0) {
       return false;
     }
-
-    // Resolve any ids we have not classified yet via a single engine-filtered cache lookup.
-    const uncachedIds = indexPatternIds.filter(
-      (id) => !this.analyticEngineByIndexPatternCache.has(id)
-    );
-    if (uncachedIds.length > 0) {
-      const cache = await this.indexPatterns.getCache({
-        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-      });
-      if (!cache) {
-        // Cache unavailable — fail open without memoizing so it can be retried later.
-        return false;
-      }
-      // Index patterns backed by an unsupported engine are excluded from the cache, so any id
-      // missing from it is AnalyticEngine-backed.
-      const allowedIds = new Set(cache.map((ip) => ip.id));
-      for (const id of uncachedIds) {
-        this.analyticEngineByIndexPatternCache.set(id, !allowedIds.has(id));
-      }
+    const cache = await this.indexPatterns.getCache({
+      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+    });
+    if (!cache) {
+      return false;
     }
-
-    return indexPatternIds.some((id) => this.analyticEngineByIndexPatternCache.get(id));
+    const allowedIds = new Set(cache.map((ip) => ip.id));
+    return indexPatternIds.some((id) => !allowedIds.has(id));
   }
 
   public async execute({ embeddable }: EmbeddableContext) {
@@ -289,52 +196,4 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
       });
     }
   }
-}
-
-/**
- * Extracts every `data_source_name` referenced by a Vega spec. The spec's `data` field may be a
- * single object or an array of objects, each optionally carrying a `url.data_source_name`.
- */
-function extractVegaDataSourceNames(spec: unknown): string[] {
-  if (typeof spec !== 'string' || !spec.trim()) {
-    return [];
-  }
-  let parsed: any;
-  try {
-    parsed = parseHjson(spec, { legacyRoot: false, keepWsc: true });
-  } catch {
-    // If we cannot parse the spec, skip the name-based check and fail open.
-    return [];
-  }
-  const dataField = parsed?.data;
-  const dataObjects = Array.isArray(dataField) ? dataField : dataField ? [dataField] : [];
-  const names = new Set<string>();
-  for (const dataObject of dataObjects) {
-    const name = dataObject?.url?.data_source_name;
-    if (typeof name === 'string' && name) {
-      names.add(name);
-    }
-  }
-  return Array.from(names);
-}
-
-/**
- * Extracts every `data_source_name` referenced by a Timeline expression, e.g.
- * `.opensearch(index=*, data_source_name="my source")`. Names may be quoted (to allow spaces)
- * or unquoted.
- */
-function extractTimelineDataSourceNames(expression: unknown): string[] {
-  if (typeof expression !== 'string' || !expression) {
-    return [];
-  }
-  const names = new Set<string>();
-  const regex = /data_source_name\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s,)]+))/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(expression)) !== null) {
-    const name = match[1] ?? match[2] ?? match[3];
-    if (name) {
-      names.add(name);
-    }
-  }
-  return Array.from(names);
 }

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
@@ -6,6 +6,7 @@
 import { i18n } from '@osd/i18n';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import { get } from 'lodash';
+import { parse as parseHjson } from 'hjson';
 import html2canvas from 'html2canvas-pro';
 import { EmbeddableContext, IEmbeddable } from '../../../embeddable/public';
 import { Action, IncompatibleActionError } from '../../../ui_actions/public';
@@ -13,6 +14,7 @@ import { CoreStart } from '../../../../core/public';
 import { ContextProviderStart } from '../../../context_provider/public';
 import { IndexPatternsContract } from '../../../data/public';
 import { Vis } from '../vis';
+import { UNSUPPORTED_ENGINE_TYPES } from '../../../data/common';
 
 interface VisualizeEmbeddable extends IEmbeddable {
   vis: Vis;
@@ -43,6 +45,15 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
     },
   ];
 
+  // `isCompatible` is invoked frequently (panel renders, context-menu opens), so resolved engine
+  // types are memoized to avoid repeating saved-object lookups for the same data source. A data
+  // source's engine type does not change within a session.
+  private readonly engineTypeByIdCache = new Map<string, string | undefined>();
+  private readonly engineTypeByNameCache = new Map<string, string | undefined>();
+  // Whether a given index pattern is backed by an unsupported engine. Memoized for the same
+  // reason; the underlying `getCache` call otherwise re-fetches data sources on every call.
+  private readonly analyticEngineByIndexPatternCache = new Map<string, boolean>();
+
   constructor(
     private readonly core: CoreStart,
     private readonly indexPatterns: IndexPatternsContract,
@@ -67,18 +78,128 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
     ) {
       return false;
     }
-    // Hide for AnalyticEngine data sources
+    // Hide the action when the visualization is backed by an AnalyticEngine data source.
     const visEmbeddable = embeddable as VisualizeEmbeddable;
-    const indexPatternId = visEmbeddable.vis.data.indexPattern?.id;
-    if (indexPatternId) {
-      const cache = await this.indexPatterns.getCache({
-        excludeEngineTypes: ['AnalyticEngine'],
-      });
-      if (cache && !cache.find((ip) => ip.id === indexPatternId)) {
+    const usesAnalyticEngine = await this.usesAnalyticEngineDataSource(visEmbeddable.vis);
+    return !usesAnalyticEngine;
+  }
+
+  /**
+   * Resolves whether a visualization uses an AnalyticEngine data source. Each visualization type
+   * references its data source differently, so they are handled by type here. We fail open
+   * (return false) whenever the data source cannot be resolved, so the action stays available.
+   */
+  private async usesAnalyticEngineDataSource(vis: Vis): Promise<boolean> {
+    const params: any = vis.params || {};
+
+    switch (vis.type?.name) {
+      // TSVB references the data source directly by id.
+      case 'metrics':
+        return this.isAnalyticEngineById(params.data_source_id);
+
+      // Vega references one or more data sources by name inside its spec.
+      case 'vega':
+        return this.isAnalyticEngineByNames(extractVegaDataSourceNames(params.spec));
+
+      // Timeline references data sources by name inside its expression string.
+      case 'timelion':
+        return this.isAnalyticEngineByNames(extractTimelineDataSourceNames(params.expression));
+
+      // Input controls reference index patterns per control; an AnalyticEngine-backed index
+      // pattern is excluded from the engine-filtered cache.
+      case 'input_control_vis': {
+        const indexPatternIds: string[] = (params.controls || [])
+          .map((control: { indexPattern?: string }) => control.indexPattern)
+          .filter(Boolean);
+        return this.hasAnalyticEngineIndexPattern(indexPatternIds);
+      }
+
+      // Default: aggregation-based visualizations expose `vis.data.indexPattern`.
+      default: {
+        const indexPatternId = vis.data.indexPattern?.id;
+        return indexPatternId ? this.hasAnalyticEngineIndexPattern([indexPatternId]) : false;
+      }
+    }
+  }
+
+  private async isAnalyticEngineById(dataSourceId?: string): Promise<boolean> {
+    if (!dataSourceId) {
+      return false;
+    }
+    if (!this.engineTypeByIdCache.has(dataSourceId)) {
+      try {
+        const dataSource = await this.core.savedObjects.client.get<{
+          dataSourceEngineType?: string;
+        }>('data-source', dataSourceId);
+        this.engineTypeByIdCache.set(dataSourceId, dataSource?.attributes?.dataSourceEngineType);
+      } catch {
+        // Do not cache failures so a transient error can be retried later.
         return false;
       }
     }
-    return true;
+    const engineType = this.engineTypeByIdCache.get(dataSourceId);
+    return !!engineType && UNSUPPORTED_ENGINE_TYPES.includes(engineType);
+  }
+
+  private async isAnalyticEngineByNames(dataSourceNames: string[]): Promise<boolean> {
+    if (dataSourceNames.length === 0) {
+      return false;
+    }
+    for (const name of dataSourceNames) {
+      if (!this.engineTypeByNameCache.has(name)) {
+        try {
+          const response = await this.core.savedObjects.client.find<{
+            title?: string;
+            dataSourceEngineType?: string;
+          }>({
+            type: 'data-source',
+            perPage: 10,
+            search: `"${name}"`,
+            searchFields: ['title'],
+            fields: ['title', 'dataSourceEngineType'],
+          });
+          // `data_source_name` could be a prefix of another name, so match exactly.
+          const match = response.savedObjects.find((obj) => obj.attributes?.title === name);
+          this.engineTypeByNameCache.set(name, match?.attributes?.dataSourceEngineType);
+        } catch {
+          // Do not cache failures; skip this name and keep the action available.
+          continue;
+        }
+      }
+      const engineType = this.engineTypeByNameCache.get(name);
+      if (engineType && UNSUPPORTED_ENGINE_TYPES.includes(engineType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private async hasAnalyticEngineIndexPattern(indexPatternIds: string[]): Promise<boolean> {
+    if (indexPatternIds.length === 0) {
+      return false;
+    }
+
+    // Resolve any ids we have not classified yet via a single engine-filtered cache lookup.
+    const uncachedIds = indexPatternIds.filter(
+      (id) => !this.analyticEngineByIndexPatternCache.has(id)
+    );
+    if (uncachedIds.length > 0) {
+      const cache = await this.indexPatterns.getCache({
+        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+      });
+      if (!cache) {
+        // Cache unavailable — fail open without memoizing so it can be retried later.
+        return false;
+      }
+      // Index patterns backed by an unsupported engine are excluded from the cache, so any id
+      // missing from it is AnalyticEngine-backed.
+      const allowedIds = new Set(cache.map((ip) => ip.id));
+      for (const id of uncachedIds) {
+        this.analyticEngineByIndexPatternCache.set(id, !allowedIds.has(id));
+      }
+    }
+
+    return indexPatternIds.some((id) => this.analyticEngineByIndexPatternCache.get(id));
   }
 
   public async execute({ embeddable }: EmbeddableContext) {
@@ -168,4 +289,52 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
       });
     }
   }
+}
+
+/**
+ * Extracts every `data_source_name` referenced by a Vega spec. The spec's `data` field may be a
+ * single object or an array of objects, each optionally carrying a `url.data_source_name`.
+ */
+function extractVegaDataSourceNames(spec: unknown): string[] {
+  if (typeof spec !== 'string' || !spec.trim()) {
+    return [];
+  }
+  let parsed: any;
+  try {
+    parsed = parseHjson(spec, { legacyRoot: false, keepWsc: true });
+  } catch {
+    // If we cannot parse the spec, skip the name-based check and fail open.
+    return [];
+  }
+  const dataField = parsed?.data;
+  const dataObjects = Array.isArray(dataField) ? dataField : dataField ? [dataField] : [];
+  const names = new Set<string>();
+  for (const dataObject of dataObjects) {
+    const name = dataObject?.url?.data_source_name;
+    if (typeof name === 'string' && name) {
+      names.add(name);
+    }
+  }
+  return Array.from(names);
+}
+
+/**
+ * Extracts every `data_source_name` referenced by a Timeline expression, e.g.
+ * `.opensearch(index=*, data_source_name="my source")`. Names may be quoted (to allow spaces)
+ * or unquoted.
+ */
+function extractTimelineDataSourceNames(expression: unknown): string[] {
+  if (typeof expression !== 'string' || !expression) {
+    return [];
+  }
+  const names = new Set<string>();
+  const regex = /data_source_name\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s,)]+))/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(expression)) !== null) {
+    const name = match[1] ?? match[2] ?? match[3];
+    if (name) {
+      names.add(name);
+    }
+  }
+  return Array.from(names);
 }

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -109,6 +109,13 @@ export interface VisualizeOutput extends EmbeddableOutput {
   editUrl: string;
   indexPatterns?: IIndexPattern[];
   visTypeName: string;
+  /**
+   * Whether the visualization is backed by a data source whose engine type is unsupported by
+   * features that require a DSL-queryable data source (e.g. "Ask AI"). Resolved asynchronously
+   * once after construction; `undefined` until resolution completes, in which case consumers
+   * should fail open.
+   */
+  usesUnsupportedEngineDataSource?: boolean;
 }
 
 export type VisualizeSavedObjectAttributes = SavedObjectAttributes & {
@@ -297,7 +304,9 @@ export class VisualizeEmbeddable
 
   onContainerRender = () => {
     this.renderComplete.dispatchComplete();
-    this.updateOutput({ loading: false, error: undefined });
+    // A successful render means the data source is DSL-queryable, so it is not an unsupported
+    // (e.g. AnalyticEngine) engine. Clear any previously-set flag.
+    this.updateOutput({ loading: false, error: undefined, usesUnsupportedEngineDataSource: false });
   };
 
   onContainerError = (error: ExpressionRenderError) => {
@@ -305,7 +314,15 @@ export class VisualizeEmbeddable
       this.abortController.abort();
     }
     this.renderComplete.dispatchError();
-    this.updateOutput({ loading: false, error });
+    // Visualizations backed by an unsupported (AnalyticEngine / PPL-only) data source fail to render
+    // as DSL. Detect that here and publish it on the output so actions (e.g. "Ask AI") can gate
+    // synchronously without their own data-source lookups. Covers any viz type whose AnalyticEngine
+    // failure surfaces as a render error (agg-based, Timeline, Vega, TSVB).
+    this.updateOutput({
+      loading: false,
+      error,
+      usesUnsupportedEngineDataSource: error?.name === 'AnalyticEngineError',
+    });
   };
 
   /**


### PR DESCRIPTION
### Description
The "Ask AI" action only supports DSL-queryable data sources, but it was still offered for visualizations backed by an **AnalyticEngine** (PPL-only) data source. The previous gating only inspected `vis.data.indexPattern`, which is `undefined` for several visualization types (TSVB, Vega, Timeline, input controls), so the action was incorrectly shown for them.

Rather than re-implementing per–visualization-type data-source resolution inside the action, this PR reuses the signal each visualization already produces — an AnalyticEngine data source makes the visualization fail to render — and routes it through the unified embeddable error path introduced in #12103 (`output.error.name === 'AnalyticEngineError'`).

#### How it works

**Unified gating via embeddable output**
- `VisualizeEmbeddable.onContainerError` sets a new `output.usesUnsupportedEngineDataSource` flag when the render error is an  `AnalyticEngineError`; `onContainerRender` clears it on a successful render.
- `AskAIVisualizeEmbeddableAction.isCompatible` reads that flag **synchronously** —  no saved-object lookups, no spec parsing, no per-type branching. While the flag is still `undefined` (panel not yet rendered) it fails open and keeps the action.

**Making every visualization surface `AnalyticEngineError` consistently**
- **Agg-based & Timeline**: already throw `AnalyticEngineError` — no change.
- **Vega**: `search_api` now throws the typed `AnalyticEngineError` (was a generic `Error`), and `vega_parser.parseAsync` re-throws it instead of swallowing it into an inline message.
- **TSVB**: the server data layer (`get_series_data`, `get_series_data_raw`, `get_table_data`) propagates `AnalyticEngineError` instead of returning it as an inline per-panel error; the client request handlers (`request_handler`, `request_handler_raw`) detect it from the response and rethrow it as a typed  `AnalyticEngineError`.
- **Input controls**: intentionally **not** routed through the error path. A control with an AnalyticEngine index pattern is *disabled individually* (the panel still renders), so there is no render error to key off — and forcing an error would break panels that also contain valid controls. The action resolves these via the same engine-filtered index-pattern cache (`getCache({ excludeEngineTypes })`) used by the control factories.

**Explore log action**
- `dataSourceEngineType` for the per-row "Ask AI" log action was read from the wrong field; it now reads `dataset?.dataSourceRef?.type`, so the action is correctly hidden for AnalyticEngine data sources in Explore.

**Side effect (intended):** Vega and TSVB AnalyticEngine errors now render through the shared `ErrorEmbeddable` like agg/Timeline, instead of their own inline error UI — closing two inconsistencies left by #12103.

### Issues Resolved

<!-- Add the issue link, e.g. closes #XXXX -->

## Screenshot

<!-- Add before/after screenshots showing the Ask AI action hidden on an
AnalyticEngine-backed TSVB / Vega / Timeline / input-control panel -->

## Testing the changes

1. Configure an **AnalyticEngine** data source and an **OpenSearch** data source.
2. Create a dashboard panel with each visualization type (TSVB, Vega, Timeline, input control, plus a standard agg-based viz) against the AnalyticEngine data source.
3. Open each panel's context menu and confirm **Ask AI does not appear**.
4. Repeat against the OpenSearch data source and confirm **Ask AI appears**.
5. In Explore, view a results table on an AnalyticEngine data source and confirm the per-row "Ask AI" log action is hidden.

Unit tests:

```bash
yarn test:jest src/plugins/visualizations/public/actions/ask_ai_embeddable_action.test.tsx
