### PR TITLE
fix: treat parse failure the same as non-whitelisted referrer (#11677)

### DIFF
--- a/src/core/server/http/http_server.test.ts
+++ b/src/core/server/http/http_server.test.ts
@@ -905,6 +905,21 @@ describe('conditional compression', () => {
 
       expect(response.header).not.toHaveProperty('content-encoding');
     });
+
+    test.each([
+      ['bare IP with port', '192.168.1.1:5601'],
+      ['hostname without protocol', 'intranet-server/dashboard'],
+      ['malformed protocol', 'http:///missing-host'],
+      ['empty string-like value', '://example.com'],
+    ])('disables compression for malformed referer (%s)', async (_label, referer) => {
+      const response = await supertest(listener)
+        .get('/')
+        .set('accept-encoding', 'gzip')
+        .set('referer', referer);
+
+      expect(response.status).toBe(200);
+      expect(response.header).not.toHaveProperty('content-encoding');
+    });
   });
 
   describe('response headers', () => {

--- a/src/core/server/http/http_server.ts
+++ b/src/core/server/http/http_server.ts
@@ -299,7 +299,12 @@ export class HttpServer {
       this.server.ext('onRequest', (request, h) => {
         const { referrer } = request.info;
         if (referrer !== '') {
-          const { hostname } = new URL('', referrer);
+          let hostname: string | undefined;
+          try {
+            ({ hostname } = new URL('', referrer));
+          } catch {
+            // Malformed referer header — treat as non-allowlisted and disable compression
+          }
           if (!hostname || !list.includes(hostname)) {
             request.info.acceptEncoding = '';
           }


### PR DESCRIPTION
### Description

Wrap new URL() in try-catch, so malformed Referer header won't throw a 500 Internal Server Error — treat parse failure the same as non-whitelisted referrer.

### Issues Resolved

fix #11677 

## Screenshot


## Testing the changes

```
$ curl -i http://localhost:5601/ -H "Referer: 192.168.1.1:5601"
HTTP/1.1 302 Found
location: /app/home
osd-name: DESKTOP-OUIAUK5
cache-control: private, no-cache, no-store, must-revalidate
content-length: 0
Date: Sat, 06 Jun 2026 13:35:37 GMT
Connection: keep-alive
Keep-Alive: timeout=120

$ curl -i http://localhost:5601/ -H "Referer: intranet-server/dashboard"
HTTP/1.1 302 Found
location: /app/home
osd-name: DESKTOP-OUIAUK5
cache-control: private, no-cache, no-store, must-revalidate
content-length: 0
Date: Sat, 06 Jun 2026 13:35:37 GMT
Connection: keep-alive
Keep-Alive: timeout=120

$ curl -i -H "Accept-Encoding: gzip" -H "Referer: http://foo:1234" http://localhost:5601/app/home
HTTP/1.1 200 OK
content-encoding: gzip
```

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
