### PR TITLE
fix(deps): stop forcing @tootallnate/once to 3.x (breaks jsdom/jest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "**/lodash-es": "^4.18.0",
     "**/lodash": "^4.18.0",
     "**/body-parser": "^2.2.1",
-    "**/@tootallnate/once": "^3.0.1",
     "**/fast-xml-parser": "^5.7.0",
     "**/grunt/minimatch": "^3.1.5",
     "**/@hapi/content": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5273,10 +5273,10 @@
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
   integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
-"@tootallnate/once@1", "@tootallnate/once@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-3.0.1.tgz#d580decb59cb41a15856387a86800838102daf44"
-  integrity sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"


### PR DESCRIPTION
### Description

`@tootallnate/once` is force-pinned to the ESM-only `3.0.1` by a global resolution in
`package.json` (`"**/@tootallnate/once": "^3.0.1"`, added in #11501 during a CVE bump).
`jsdom`'s transitive `http-proxy-agent@4` requires the **CommonJS** `@tootallnate/once@1`;
forced onto the ESM build, Jest's `require()` throws `ERR_REQUIRE_ESM` and the jsdom test
environment fails to initialize — so every jsdom-based Jest suite reports `Tests: 0 total`
on a fresh `yarn osd bootstrap`.

`@tootallnate/once` is a zero-dependency utility reachable only through the test toolchain
(`jest → jest-environment-jsdom → jsdom → http-proxy-agent`); it is never bundled into a
shipped OpenSearch Dashboards artifact. The `1.x → 3.x` change is a CommonJS→ESM packaging
migration, not a security patch, so the resolution provided no production benefit while
breaking the test runner.

This PR removes the over-broad resolution so `@tootallnate/once` resolves naturally to the
CommonJS `1.1.2` that `http-proxy-agent@4` needs. All other CVE-driven resolutions from
#11501 (`body-parser`, `fast-xml-parser`, `minimatch`, `dompurify`) are unchanged.

Why it stayed latent: #11501 merged 2026-03-12, but the broken resolution only materializes
on a fresh install. Environments whose `node_modules` predates that date keep a leftover
CommonJS `@tootallnate/once@1.1.2` (yarn 1 doesn't prune stale nested deps), so tests keep
passing until the next bootstrap.

Reviewer note: if an SCA scan flags `@tootallnate/once@1.1.2` again, prefer upgrading the
`jest-environment-jsdom`/`jsdom` chain (so it natively uses `@tootallnate/once@3`) over a
global `**/` force — that is what broke things here.

### Issues Resolved

N/A (no tracking issue) — restores the jsdom Jest environment broken by the
`**/@tootallnate/once` resolution introduced in #11501.

## Screenshot

N/A — build/test tooling only.

## Testing the changes

On a fresh install:
```
yarn osd bootstrap
yarn test:jest src/plugins/vis_type_timeseries/public/lib/process_math_series.test.js
```
- Before: `ERR_REQUIRE_ESM: require() of ES Module @tootallnate/once/dist/index.js from
  jsdom/node_modules/http-proxy-agent/dist/agent.js` → `Tests: 0 total`.
- After: `@tootallnate/once@1.1.2` (CommonJS) installs under jsdom's `http-proxy-agent`, the
  jsdom environment initializes, suites run normally.

`yarn why @tootallnate/once` shows only the test path (`jest → … → jsdom → http-proxy-agent`),
confirming no production code path is affected.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest` (jsdom suites load again)
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing. (N/A — dependency fix)
- [ ] New functionality has been documented. (N/A)
- [x] Commits are signed per the DCO using --signoff
