### PR TITLE
fix(tsvb): correct client-side math evaluation for split, percentile, and ordering

### DIFF
--- a/src/plugins/vis_type_timeseries/public/lib/post_process_raw_series.js
+++ b/src/plugins/vis_type_timeseries/public/lib/post_process_raw_series.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Post-math processing for the TSVB raw flow.
+ *
+ * timeShift and dropLastBucket must run AFTER math (evaluated in the browser by
+ * process_math_series.js), so they are applied here once the math is computed. This
+ * keeps `params._all` / `params._timestamp` derived from the full, un-shifted bucket
+ * set: dropping the last bucket or shifting timestamps before math would change them.
+ */
+
+import moment from 'moment';
+import { TIME_RANGE_DATA_MODES, TIME_RANGE_MODE_KEY } from '../../common/timerange_data_modes';
+import { PANEL_TYPES } from '../../common/panel_types';
+
+const OFFSET_TIME_RE = /^([+-]?[\d]+)([shmdwMy]|ms)$/;
+const OVERRIDE_INDEX_PATTERN_KEY = 'override_index_pattern';
+
+const hasOverriddenIndexPattern = (series) => Boolean(series[OVERRIDE_INDEX_PATTERN_KEY]);
+
+/**
+ * Timeseries panels are never "entire time range" (so they ARE last-value mode and
+ * drop the trailing, potentially-incomplete bucket by default). Other panel types
+ * decide via the panel/series time range mode: "entire time range" => no drop.
+ */
+const isEntireTimeRangeMode = (panel, series = {}) => {
+  if (panel.type === PANEL_TYPES.TIMESERIES) {
+    return false;
+  }
+
+  const timeRangeMode = hasOverriddenIndexPattern(series)
+    ? series[TIME_RANGE_MODE_KEY]
+    : panel[TIME_RANGE_MODE_KEY];
+
+  return timeRangeMode === TIME_RANGE_DATA_MODES.ENTIRE_TIME_RANGE;
+};
+
+const isLastValueTimerangeMode = (panel, series) => !isEntireTimeRangeMode(panel, series);
+
+/**
+ * Applies each series' `offset_time` to its result rows. Preserves any extra values
+ * per row (e.g. band series carry [time, y1, y0]).
+ *
+ * @param {Object} response - The processed panel response ({ [panelId]: { series } })
+ * @param {Object} panel - The panel configuration
+ * @returns {Object} The same response with timestamps shifted in place
+ */
+export function applyTimeShift(response, panel) {
+  const panelData = response[panel.id];
+  if (!panelData || !panelData.series) {
+    return response;
+  }
+
+  panel.series.forEach((series) => {
+    if (!series.offset_time || !OFFSET_TIME_RE.test(series.offset_time)) {
+      return;
+    }
+
+    const matches = series.offset_time.match(OFFSET_TIME_RE);
+    const offset = moment.duration(Number(matches[1]), matches[2]).valueOf();
+
+    panelData.series.forEach((item) => {
+      if (item.id && item.id.startsWith(series.id) && Array.isArray(item.data)) {
+        item.data = item.data.map(([time, ...rest]) => [time + offset, ...rest]);
+      }
+    });
+  });
+
+  return response;
+}
+
+/**
+ * Drops the trailing bucket for series in "last value" time range mode. Runs after
+ * math so the math context sees the full bucket set.
+ *
+ * @param {Object} response - The processed panel response ({ [panelId]: { series } })
+ * @param {Object} panel - The panel configuration
+ * @returns {Object} The same response with trailing buckets dropped in place
+ */
+export function applyDropLastBucket(response, panel) {
+  const panelData = response[panel.id];
+  if (!panelData || !panelData.series) {
+    return response;
+  }
+
+  panel.series.forEach((series) => {
+    if (!isLastValueTimerangeMode(panel, series)) {
+      return;
+    }
+
+    // panel.drop_last_bucket overrides the per-series override_drop_last_bucket;
+    // both default to 1 (drop) when undefined.
+    const seriesDropLastBucket =
+      series.override_drop_last_bucket != null ? series.override_drop_last_bucket : 1;
+    const dropLastBucket =
+      panel.drop_last_bucket != null ? panel.drop_last_bucket : seriesDropLastBucket;
+
+    if (!dropLastBucket) {
+      return;
+    }
+
+    panelData.series.forEach((item) => {
+      if (item.id && item.id.startsWith(series.id) && Array.isArray(item.data)) {
+        item.data = item.data.slice(0, item.data.length - 1);
+      }
+    });
+  });
+
+  return response;
+}

--- a/src/plugins/vis_type_timeseries/public/lib/post_process_raw_series.test.js
+++ b/src/plugins/vis_type_timeseries/public/lib/post_process_raw_series.test.js
@@ -1,0 +1,227 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { applyTimeShift, applyDropLastBucket } from './post_process_raw_series';
+
+describe('post_process_raw_series', () => {
+  describe('applyTimeShift', () => {
+    const makeResponse = () => ({
+      'panel-1': {
+        series: [
+          {
+            id: 'series-1:metric-a',
+            data: [
+              [1000, 10],
+              [2000, 20],
+            ],
+          },
+          {
+            id: 'series-2:metric-b',
+            data: [
+              [1000, 30],
+              [2000, 40],
+            ],
+          },
+        ],
+      },
+    });
+
+    test('shifts timestamps of matching series by the parsed offset', () => {
+      const response = makeResponse();
+      const panel = {
+        id: 'panel-1',
+        series: [{ id: 'series-1', offset_time: '1m' }],
+      };
+
+      const result = applyTimeShift(response, panel);
+
+      // series-1 shifted by +60s, series-2 untouched
+      expect(result['panel-1'].series[0].data).toEqual([
+        [1000 + 60000, 10],
+        [2000 + 60000, 20],
+      ]);
+      expect(result['panel-1'].series[1].data).toEqual([
+        [1000, 30],
+        [2000, 40],
+      ]);
+    });
+
+    test('supports negative offsets', () => {
+      const response = makeResponse();
+      const panel = {
+        id: 'panel-1',
+        series: [{ id: 'series-1', offset_time: '-1m' }],
+      };
+
+      const result = applyTimeShift(response, panel);
+
+      expect(result['panel-1'].series[0].data).toEqual([
+        [1000 - 60000, 10],
+        [2000 - 60000, 20],
+      ]);
+    });
+
+    test('preserves extra row values (band series y0/y1)', () => {
+      const response = {
+        'panel-1': {
+          series: [{ id: 'series-1:band', data: [[1000, 5, 1]] }],
+        },
+      };
+      const panel = { id: 'panel-1', series: [{ id: 'series-1', offset_time: '1s' }] };
+
+      const result = applyTimeShift(response, panel);
+
+      expect(result['panel-1'].series[0].data).toEqual([[1000 + 1000, 5, 1]]);
+    });
+
+    test('is a no-op when offset_time is absent or invalid', () => {
+      const response = makeResponse();
+      const panel = {
+        id: 'panel-1',
+        series: [{ id: 'series-1' }, { id: 'series-2', offset_time: 'not-an-offset' }],
+      };
+
+      const result = applyTimeShift(response, panel);
+
+      expect(result['panel-1'].series[0].data).toEqual([
+        [1000, 10],
+        [2000, 20],
+      ]);
+      expect(result['panel-1'].series[1].data).toEqual([
+        [1000, 30],
+        [2000, 40],
+      ]);
+    });
+
+    test('returns response unchanged when panel data is missing', () => {
+      const response = {};
+      expect(applyTimeShift(response, { id: 'panel-1', series: [] })).toBe(response);
+    });
+  });
+
+  describe('applyDropLastBucket', () => {
+    const makeResponse = () => ({
+      'panel-1': {
+        series: [
+          {
+            id: 'series-1:metric-a',
+            data: [
+              [1000, 10],
+              [2000, 20],
+              [3000, 30],
+            ],
+          },
+        ],
+      },
+    });
+
+    test('drops the last bucket for timeseries panels by default (last-value mode)', () => {
+      const response = makeResponse();
+      const panel = { id: 'panel-1', type: 'timeseries', series: [{ id: 'series-1' }] };
+
+      const result = applyDropLastBucket(response, panel);
+
+      // Timeseries panels are last-value mode, so the trailing (often partial) bucket
+      // is dropped unless drop_last_bucket is explicitly disabled.
+      expect(result['panel-1'].series[0].data).toEqual([
+        [1000, 10],
+        [2000, 20],
+      ]);
+    });
+
+    test('drops the last bucket in last-value mode (non-timeseries panel)', () => {
+      const response = makeResponse();
+      const panel = { id: 'panel-1', type: 'metric', series: [{ id: 'series-1' }] };
+
+      const result = applyDropLastBucket(response, panel);
+
+      expect(result['panel-1'].series[0].data).toEqual([
+        [1000, 10],
+        [2000, 20],
+      ]);
+    });
+
+    test('does not drop in entire-time-range mode', () => {
+      const response = makeResponse();
+      const panel = {
+        id: 'panel-1',
+        type: 'metric',
+        time_range_mode: 'entire_time_range',
+        series: [{ id: 'series-1' }],
+      };
+
+      const result = applyDropLastBucket(response, panel);
+
+      expect(result['panel-1'].series[0].data).toHaveLength(3);
+    });
+
+    test('respects panel.drop_last_bucket = 0', () => {
+      const response = makeResponse();
+      const panel = {
+        id: 'panel-1',
+        type: 'metric',
+        drop_last_bucket: 0,
+        series: [{ id: 'series-1' }],
+      };
+
+      const result = applyDropLastBucket(response, panel);
+
+      expect(result['panel-1'].series[0].data).toHaveLength(3);
+    });
+
+    test('respects per-series override_drop_last_bucket = 0 when panel value absent', () => {
+      const response = makeResponse();
+      const panel = {
+        id: 'panel-1',
+        type: 'metric',
+        series: [{ id: 'series-1', override_drop_last_bucket: 0 }],
+      };
+
+      const result = applyDropLastBucket(response, panel);
+
+      expect(result['panel-1'].series[0].data).toHaveLength(3);
+    });
+
+    test('only drops series belonging to the matching series config', () => {
+      const response = {
+        'panel-1': {
+          series: [
+            {
+              id: 'series-1:m',
+              data: [
+                [1, 1],
+                [2, 2],
+              ],
+            },
+            {
+              id: 'series-2:m',
+              data: [
+                [1, 1],
+                [2, 2],
+              ],
+            },
+          ],
+        },
+      };
+      const panel = {
+        id: 'panel-1',
+        type: 'metric',
+        series: [
+          { id: 'series-1' },
+          { id: 'series-2', time_range_mode: 'entire_time_range', override_index_pattern: true },
+        ],
+      };
+
+      const result = applyDropLastBucket(response, panel);
+
+      // series-1 is last-value -> dropped; series-2 overrides to entire range -> kept
+      expect(result['panel-1'].series[0].data).toEqual([[1, 1]]);
+      expect(result['panel-1'].series[1].data).toEqual([
+        [1, 1],
+        [2, 2],
+      ]);
+    });
+  });
+});

--- a/src/plugins/vis_type_timeseries/public/lib/process_math_series.js
+++ b/src/plugins/vis_type_timeseries/public/lib/process_math_series.js
@@ -27,7 +27,7 @@
  *   // processedResponse now contains evaluated math series ready for rendering
  */
 
-import { last, first, flatten, values, startsWith } from 'lodash';
+import { last, first, flatten, values } from 'lodash';
 import { evaluate, configureMathJs } from './mathjs_wrapper';
 
 // Configure Math.js with security restrictions
@@ -128,13 +128,20 @@ export function evaluateMathExpressions(response, panel) {
   mathSeriesConfigs.forEach((seriesConfig) => {
     const mathMetric = last(seriesConfig.metrics);
 
-    // Find component metrics for this math series
-    // Component metrics have IDs like "series-1:metric-a", "series-1:metric-b"
+    // Find component metrics for this math series.
+    // Component metric series have IDs like "series-1:metric-a" (no split) or
+    // "series-1:<splitKey>:metric-a" (when the series is split by terms/filters).
     const componentSeries = panelData.series.filter((s) => s.id.startsWith(seriesConfig.id + ':'));
 
     if (componentSeries.length > 0) {
-      const evaluatedSerie = evaluateMathSeries(seriesConfig, mathMetric, componentSeries);
-      evaluatedSeries.push(evaluatedSerie);
+      // Group the component series by split bucket so a split-by-terms math series
+      // produces one evaluated series per split. Without this, a split series emits a
+      // single empty series and the visualization renders no data.
+      const splits = groupComponentSeriesBySplit(seriesConfig, mathMetric, componentSeries);
+
+      splits.forEach((split) => {
+        evaluatedSeries.push(evaluateMathSplit(seriesConfig, mathMetric, split));
+      });
 
       // Mark component series as processed
       componentSeries.forEach((s) => processedIds.add(s.id));
@@ -163,41 +170,103 @@ export function evaluateMathExpressions(response, panel) {
 }
 
 /**
- * Evaluates a single math series by combining component metrics.
- * This replicates the logic from server/lib/vis_data/response_processors/series/math.js:54-136
+ * Groups a math series' component metrics by their split bucket.
+ *
+ * The raw endpoint appends the metric id to each series id. A non-split
+ * ("everything") series has the form `${seriesId}:${metricId}`, while a series
+ * split by terms/filters has the form `${seriesId}:${splitKey}:${metricId}`.
+ * Stripping the trailing `:${metricId}` yields the split id, which we use to
+ * group the component metrics that belong to the same split bucket (one evaluated
+ * math series per split).
+ *
+ * @param {Object} seriesConfig - The series configuration from the panel
+ * @param {Object} mathMetric - The math metric definition (for variable field tokens)
+ * @param {Array} componentSeries - Component metric series for this math series
+ * @returns {Array} One entry per split: { id, label, color, metrics: { [token]: serie } }
+ */
+function groupComponentSeriesBySplit(seriesConfig, mathMetric, componentSeries) {
+  // Tokens are the possible id suffixes a component series can carry: a plain metric
+  // id (e.g. "metric-a") or a percentile-value reference used by a math variable
+  // (e.g. "metric-a[95]"). Variables are resolved by these same tokens. Longest-first
+  // so the most specific token wins.
+  const tokens = [
+    ...seriesConfig.metrics.map((m) => m.id),
+    ...(mathMetric.variables || []).map((v) => v.field),
+  ]
+    .filter((t) => typeof t === 'string' && t.length > 0)
+    .sort((a, b) => b.length - a.length);
+
+  const splitsById = new Map();
+
+  componentSeries.forEach((serie) => {
+    // Match the trailing `:${token}` to recover both the split id (everything before
+    // it) and the token under which the variable will look this series up.
+    const token = tokens.find((t) => serie.id.endsWith(`:${t}`));
+    if (!token) return;
+
+    // Everything before the `:${token}` suffix is the split id. For a non-split
+    // series this equals seriesConfig.id; for a terms/filters split it is
+    // `${seriesConfig.id}:${splitKey}`.
+    const splitId = serie.id.slice(0, serie.id.length - `:${token}`.length);
+
+    if (!splitsById.has(splitId)) {
+      splitsById.set(splitId, {
+        id: splitId,
+        label: serie.label,
+        color: serie.color,
+        metrics: {},
+      });
+    }
+    splitsById.get(splitId).metrics[token] = serie;
+  });
+
+  return Array.from(splitsById.values());
+}
+
+/**
+ * Evaluates the math expression for a single split bucket.
  *
  * @param {Object} seriesConfig - The series configuration from the panel
  * @param {Object} mathMetric - The math metric definition
- * @param {Array} componentSeries - Array of component metric series
+ * @param {Object} split - A split bucket from groupComponentSeriesBySplit
  * @returns {Object} Evaluated series with computed data
  */
-function evaluateMathSeries(seriesConfig, mathMetric, componentSeries) {
+function evaluateMathSplit(seriesConfig, mathMetric, split) {
   const decoration = getDefaultDecoration(seriesConfig);
+
+  // For a non-split ("everything") series the split id equals the series id, and we
+  // keep the configured series label/color. For a terms/filters split, each bucket
+  // carries its own label (the term value) and color.
+  const isSplit = split.id !== seriesConfig.id;
+  const label = isSplit
+    ? split.label || seriesConfig.label || 'Math'
+    : seriesConfig.label || 'Math';
+  const color = isSplit ? split.color : seriesConfig.color;
+
+  const emptySeries = {
+    id: split.id,
+    label,
+    color,
+    data: [],
+    ...decoration,
+  };
+
   if (!mathMetric.variables || mathMetric.variables.length === 0) {
-    return {
-      id: seriesConfig.id,
-      label: seriesConfig.label || 'Math',
-      data: [],
-      ...decoration,
-    };
+    return emptySeries;
   }
 
-  // Build splitData structure mapping variable names to [timestamp, value] arrays
-  // This mirrors math.js:57-70
+  // Build splitData mapping variable names to [timestamp, value] arrays. Components
+  // are keyed by the variable field (the metric id, or "${metricId}[${percentile}]"
+  // for percentile references), so each variable resolves directly to its component.
   const splitData = {};
   mathMetric.variables.forEach((variable) => {
-    const metric = seriesConfig.metrics.find((m) => startsWith(variable.field, m.id));
-    if (!metric) return;
-
-    // Find the component series for this variable
-    const componentSerie = componentSeries.find((s) => s.id === `${seriesConfig.id}:${metric.id}`);
+    const componentSerie = split.metrics[variable.field];
     if (componentSerie) {
       splitData[variable.name] = componentSerie.data;
     }
   });
 
   // Build params._all structure
-  // This mirrors math.js:73-79
   const all = Object.keys(splitData).reduce((acc, key) => {
     acc[key] = {
       values: splitData[key].map((x) => x[1]),
@@ -207,24 +276,18 @@ function evaluateMathSeries(seriesConfig, mathMetric, componentSeries) {
   }, {});
 
   // Get timestamps from first variable
-  // This mirrors math.js:83-92
   const firstVar = first(mathMetric.variables);
   if (!splitData[firstVar.name]) {
-    return {
-      id: seriesConfig.id,
-      label: seriesConfig.label || 'Math',
-      data: [],
-      ...decoration,
-    };
+    return emptySeries;
   }
 
   const timestamps = splitData[firstVar.name].map((r) => first(r));
 
-  // Get bucket size from component series metadata
-  const bucketSize = componentSeries[0].meta?.bucketSize || 0;
+  // Get bucket size from any component series metadata for this split
+  const componentForMeta = values(split.metrics)[0];
+  const bucketSize = componentForMeta?.meta?.bucketSize || 0;
 
   // Evaluate expression for each timestamp
-  // This mirrors math.js:96-128
   const data = timestamps.map((ts, index) => {
     // Build params object for this timestamp
     const params = mathMetric.variables.reduce((acc, v) => {
@@ -237,8 +300,6 @@ function evaluateMathSeries(seriesConfig, mathMetric, componentSeries) {
     if (someNull) return [ts, null];
 
     try {
-      // Evaluate expression with full context
-      // Context matches server exactly (math.js:107-114)
       const result = evaluate(mathMetric.script, {
         params: {
           ...params,
@@ -269,9 +330,9 @@ function evaluateMathSeries(seriesConfig, mathMetric, componentSeries) {
   });
 
   return {
-    id: seriesConfig.id,
-    label: seriesConfig.label || 'Math',
-    color: seriesConfig.color,
+    id: split.id,
+    label,
+    color,
     data,
     ...decoration,
   };

--- a/src/plugins/vis_type_timeseries/public/lib/process_math_series.test.js
+++ b/src/plugins/vis_type_timeseries/public/lib/process_math_series.test.js
@@ -546,4 +546,216 @@ describe('process_math_series - evaluateMathExpressions', () => {
       ]);
     });
   });
+
+  describe('Split by terms math series', () => {
+    // Regression test: a math metric on a series split by terms/filters. The raw
+    // endpoint returns one component series per split bucket with ids of the form
+    // `${seriesId}:${splitKey}:${metricId}`. The evaluator must group by split and
+    // emit one math series per bucket, mirroring the server-side mathAgg. Before the
+    // fix, the exact-match lookup `s.id === seriesId:metricId` found nothing for split
+    // series, collapsing the panel to a single empty series (TSVB rendered no data).
+    beforeEach(() => {
+      panel.series = [
+        {
+          id: 'series-1',
+          label: 'Temperature',
+          color: '#0000FF',
+          chart_type: 'line',
+          line_width: 1,
+          fill: '0',
+          point_size: '1',
+          stacked: 'none',
+          split_mode: 'terms',
+          terms_field: 'sensor_name.keyword',
+          metrics: [
+            { id: 'metric-a', type: 'avg', field: 'sensor_temperature' },
+            {
+              id: 'math-1',
+              type: 'math',
+              script: 'params.temp * 0.1',
+              variables: [{ name: 'temp', field: 'metric-a' }],
+            },
+          ],
+        },
+      ];
+
+      response = {
+        'panel-1': {
+          series: [
+            {
+              id: 'series-1:Sensor-A:metric-a',
+              label: 'Sensor-A',
+              data: [
+                [1000, 200],
+                [2000, 210],
+              ],
+              meta: { bucketSize: 600 },
+            },
+            {
+              id: 'series-1:Sensor-B:metric-a',
+              label: 'Sensor-B',
+              data: [
+                [1000, 150],
+                [2000, 160],
+              ],
+              meta: { bucketSize: 600 },
+            },
+          ],
+        },
+      };
+    });
+
+    test('should emit one evaluated math series per split bucket', () => {
+      const result = evaluateMathExpressions(response, panel);
+
+      expect(result['panel-1'].series).toHaveLength(2);
+
+      expect(result['panel-1'].series[0]).toEqual(
+        expect.objectContaining({
+          id: 'series-1:Sensor-A',
+          label: 'Sensor-A',
+          data: [
+            [1000, 20], // 200 * 0.1
+            [2000, 21], // 210 * 0.1
+          ],
+        })
+      );
+
+      expect(result['panel-1'].series[1]).toEqual(
+        expect.objectContaining({
+          id: 'series-1:Sensor-B',
+          label: 'Sensor-B',
+          data: [
+            [1000, 15], // 150 * 0.1
+            [2000, 16], // 160 * 0.1
+          ],
+        })
+      );
+    });
+
+    test('should not leave any raw component series in the output', () => {
+      const result = evaluateMathExpressions(response, panel);
+
+      const ids = result['panel-1'].series.map((s) => s.id);
+      expect(ids).not.toContain('series-1:Sensor-A:metric-a');
+      expect(ids).not.toContain('series-1:Sensor-B:metric-a');
+    });
+
+    test('should default color to undefined for opensearchDashboards split mode (client maps by label)', () => {
+      // With split_color_mode "opensearchDashboards" the server returns no per-term
+      // color (getSplitColors yields []), so component series have no color and the
+      // client palette maps colors by label. This matches the server-side data flow.
+      const result = evaluateMathExpressions(response, panel);
+
+      expect(result['panel-1'].series[0].color).toBeUndefined();
+      expect(result['panel-1'].series[1].color).toBeUndefined();
+    });
+
+    test('should preserve per-split colors when the server assigns them (rainbow/gradient)', () => {
+      // For rainbow/gradient split color modes the raw endpoint sets an explicit
+      // color on each component series. Each evaluated math series should carry the
+      // color of its own split bucket, matching the server-side mathAgg output.
+      response['panel-1'].series[0].color = '#68BC00';
+      response['panel-1'].series[1].color = '#009CE0';
+
+      const result = evaluateMathExpressions(response, panel);
+
+      expect(result['panel-1'].series[0]).toEqual(
+        expect.objectContaining({ id: 'series-1:Sensor-A', color: '#68BC00' })
+      );
+      expect(result['panel-1'].series[1]).toEqual(
+        expect.objectContaining({ id: 'series-1:Sensor-B', color: '#009CE0' })
+      );
+    });
+  });
+
+  describe('Percentile values as math variables', () => {
+    // A math metric whose variable references a percentile value, e.g. params.p95.
+    // The server (percentileRaw) emits component series with ids of the form
+    // `${seriesId}:${metricId}[${value}]`, matching the variable field exactly, so
+    // the client resolves them directly. Before percentileRaw + token lookup, the
+    // percentile component was never produced/matched and the series rendered empty.
+    beforeEach(() => {
+      panel.series = [
+        {
+          id: 'series-1',
+          label: 'P95 ratio',
+          color: '#FF0000',
+          chart_type: 'line',
+          line_width: 1,
+          fill: '0',
+          point_size: '0',
+          stacked: 'none',
+          metrics: [
+            { id: 'pct-1', type: 'percentile', field: 'latency', percentiles: [{ value: 95 }] },
+            {
+              id: 'math-1',
+              type: 'math',
+              script: 'params.p95 / 2',
+              variables: [{ name: 'p95', field: 'pct-1[95]' }],
+            },
+          ],
+        },
+      ];
+
+      response = {
+        'panel-1': {
+          series: [
+            {
+              id: 'series-1:pct-1[95]',
+              data: [
+                [1000, 200],
+                [2000, 400],
+              ],
+              meta: { bucketSize: 10 },
+            },
+          ],
+        },
+      };
+    });
+
+    test('should resolve a percentile-value math variable', () => {
+      const result = evaluateMathExpressions(response, panel);
+
+      expect(result['panel-1'].series).toHaveLength(1);
+      expect(result['panel-1'].series[0]).toEqual(
+        expect.objectContaining({
+          id: 'series-1',
+          label: 'P95 ratio',
+          data: [
+            [1000, 100], // 200 / 2
+            [2000, 200], // 400 / 2
+          ],
+        })
+      );
+    });
+
+    test('should resolve percentile-value math variables split by terms', () => {
+      response = {
+        'panel-1': {
+          series: [
+            {
+              id: 'series-1:Host-A:pct-1[95]',
+              label: 'Host-A',
+              data: [[1000, 200]],
+              meta: { bucketSize: 10 },
+            },
+            {
+              id: 'series-1:Host-B:pct-1[95]',
+              label: 'Host-B',
+              data: [[1000, 80]],
+              meta: { bucketSize: 10 },
+            },
+          ],
+        },
+      };
+
+      const result = evaluateMathExpressions(response, panel);
+
+      expect(result['panel-1'].series.map((s) => [s.id, s.data])).toEqual([
+        ['series-1:Host-A', [[1000, 100]]],
+        ['series-1:Host-B', [[1000, 40]]],
+      ]);
+    });
+  });
 });

--- a/src/plugins/vis_type_timeseries/public/request_handler_raw.js
+++ b/src/plugins/vis_type_timeseries/public/request_handler_raw.js
@@ -7,6 +7,7 @@ import { getTimezone, validateInterval } from './application';
 import { getUISettings, getDataStart, getCoreStart } from './services';
 import { MAX_BUCKETS_SETTING } from '../common/constants';
 import { evaluateMathExpressions } from './lib/process_math_series';
+import { applyTimeShift, applyDropLastBucket } from './lib/post_process_raw_series';
 import { AnalyticEngineError } from '../../data/public';
 
 /**
@@ -61,8 +62,13 @@ export const metricsRequestHandlerRaw = async ({
         }),
       });
 
-      // Evaluate math expressions client-side
-      const processedResp = evaluateMathExpressions(rawResp, visParams);
+      // Evaluate math expressions client-side, then apply the post-math processors
+      // (timeShift, dropLastBucket) in the same order the server `data` flow uses.
+      // These run AFTER math so that params._all / params._timestamp are computed
+      // from the full, un-shifted bucket set (matching the server-side mathAgg).
+      let processedResp = evaluateMathExpressions(rawResp, visParams);
+      processedResp = applyTimeShift(processedResp, visParams);
+      processedResp = applyDropLastBucket(processedResp, visParams);
 
       return {
         dateFormat,

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index_raw.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index_raw.js
@@ -30,27 +30,27 @@
 
 import { percentile } from './percentile';
 import { percentileRank } from './percentile_rank';
+import { percentileRaw } from './percentile_raw';
 
 import { seriesAgg } from './series_agg';
 import { stdDeviationBands } from './std_deviation_bands';
 import { stdDeviationSibling } from './std_deviation_sibling';
 import { stdMetricRaw } from './std_metric_raw';
 import { stdSiblingRaw } from './std_sibling_raw';
-import { timeShift } from './time_shift';
-import { dropLastBucket } from './drop_last_bucket';
-// NOTE: mathAgg is intentionally NOT imported for raw data endpoint
-// NOTE: Using stdMetricRaw and stdSiblingRaw instead of stdMetric/stdSibling
-//       to append metric IDs to series IDs for client-side processing
+// math is evaluated in the browser (process_math_series.js); timeShift and
+// dropLastBucket must run AFTER math, so they are applied client-side in
+// post_process_raw_series.js. stdMetricRaw/stdSiblingRaw append metric ids to series
+// ids for client-side math; percentileRaw emits percentile component series so math
+// can reference percentile values (e.g. params.x where x = `${metricId}[95]`).
 
 export const processorsRaw = [
   percentile,
   percentileRank,
+  percentileRaw,
   stdDeviationBands,
   stdDeviationSibling,
   stdMetricRaw,
   stdSiblingRaw,
-  // mathAgg, // EXCLUDED - client will handle math evaluation
   seriesAgg,
-  timeShift,
-  dropLastBucket,
+  // mathAgg, timeShift, dropLastBucket are applied client-side (after math)
 ];

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index_raw.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index_raw.test.js
@@ -3,29 +3,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { processors } from './index';
 import { processorsRaw } from './index_raw';
 
 describe('processorsRaw (for /api/metrics/vis/data-raw endpoint)', () => {
-  test('should exclude mathAgg processor', () => {
+  test('should exclude mathAgg processor (math is evaluated client-side)', () => {
     const processorNames = processorsRaw.map((p) => p.name);
     expect(processorNames).not.toContain('mathAgg');
   });
 
-  test('should have same number of processors as standard list (excluding mathAgg)', () => {
-    // processorsRaw should have exactly one fewer processor than standard (mathAgg is excluded)
-    expect(processorsRaw.length).toBe(processors.length - 1);
+  test('should exclude timeShift and dropLastBucket (applied client-side after math)', () => {
+    const processorNames = processorsRaw.map((p) => p.name);
+    // These must run AFTER math, which happens in the browser, so they are applied
+    // client-side in public/lib/post_process_raw_series.js instead.
+    expect(processorNames).not.toContain('timeShift');
+    expect(processorNames).not.toContain('dropLastBucket');
   });
 
   test('should include expected processors', () => {
     const processorNames = processorsRaw.map((p) => p.name);
 
-    // Verify key processors are present
     expect(processorNames).toContain('percentile');
     expect(processorNames).toContain('percentileRank');
+    expect(processorNames).toContain('percentileRaw');
     expect(processorNames).toContain('seriesAgg');
-    expect(processorNames).toContain('timeShift');
-    expect(processorNames).toContain('dropLastBucket');
     expect(processorNames).toContain('stdDeviationBands');
     expect(processorNames).toContain('stdDeviationSibling');
   });
@@ -45,16 +45,16 @@ describe('processorsRaw (for /api/metrics/vis/data-raw endpoint)', () => {
   test('should maintain expected processor order', () => {
     const processorNames = processorsRaw.map((p) => p.name);
 
-    // Verify processors are in expected order
-    expect(processorNames[0]).toBe('percentile');
-    expect(processorNames[1]).toBe('percentileRank');
-    expect(processorNames[2]).toBe('stdDeviationBands');
-    expect(processorNames[3]).toBe('stdDeviationSibling');
-    expect(processorNames[4]).toBe('stdMetricRaw');
-    expect(processorNames[5]).toBe('stdSiblingRaw');
-    // Note: mathAgg would be here in standard processors but is excluded
-    expect(processorNames[6]).toBe('seriesAgg');
-    expect(processorNames[7]).toBe('timeShift');
-    expect(processorNames[8]).toBe('dropLastBucket');
+    expect(processorNames).toEqual([
+      'percentile',
+      'percentileRank',
+      'percentileRaw',
+      'stdDeviationBands',
+      'stdDeviationSibling',
+      'stdMetricRaw',
+      'stdSiblingRaw',
+      // mathAgg excluded (client-side); timeShift + dropLastBucket excluded (client-side after math)
+      'seriesAgg',
+    ]);
   });
 });

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_raw.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_raw.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getDefaultDecoration } from '../../helpers/get_default_decoration';
+import { getSplits } from '../../helpers/get_splits';
+import { getLastMetric } from '../../helpers/get_last_metric';
+import { mapBucket } from '../../helpers/map_bucket';
+import { METRIC_TYPES } from '../../../../../common/metric_types';
+
+const PERCENTILE_VALUE_RE = /\[([0-9.]+)\]$/;
+
+/**
+ * Emits percentile component series for a math series so the browser can evaluate
+ * math variables that reference percentile values.
+ *
+ * For each math variable of the form `${percentileMetricId}[${value}]`, emits a
+ * component series id `${split.id}:${percentileMetricId}[${value}]` whose data is the
+ * per-bucket Nth percentile. The math evaluator resolves variables by `variable.field`,
+ * so the id suffix matches the field exactly. Non-math series are left untouched.
+ */
+export function percentileRaw(resp, panel, series, meta) {
+  return (next) => (results) => {
+    const lastMetric = getLastMetric(series);
+    if (lastMetric.type !== 'math') {
+      return next(results);
+    }
+
+    const mathMetric = lastMetric;
+    const variables = mathMetric.variables || [];
+    const decoration = getDefaultDecoration(series);
+
+    series.metrics.forEach((metric) => {
+      if (metric.type !== METRIC_TYPES.PERCENTILE) {
+        return;
+      }
+
+      // Collect the distinct percentile values this math metric references for this
+      // percentile metric, e.g. fields "p[50]" and "p[95]" -> ['50', '95'].
+      const referencedValues = [
+        ...new Set(
+          variables
+            .filter((v) => typeof v.field === 'string' && v.field.startsWith(metric.id))
+            .map((v) => {
+              const match = v.field.match(PERCENTILE_VALUE_RE);
+              return match ? match[1] : null;
+            })
+            .filter((value) => value != null)
+        ),
+      ];
+
+      referencedValues.forEach((value) => {
+        getSplits(resp, panel, series, meta).forEach((split) => {
+          const data = split.timeseries.buckets.map(mapBucket({ ...metric, percent: value }));
+          results.push({
+            id: `${split.id}:${metric.id}[${value}]`,
+            label: split.label,
+            labelFormatted: split.labelFormatted,
+            color: split.color,
+            data,
+            meta: split.meta,
+            ...decoration,
+          });
+        });
+      });
+    });
+
+    return next(results);
+  };
+}

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_raw.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_raw.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { percentileRaw } from './percentile_raw';
+
+describe('percentileRaw(resp, panel, series)', () => {
+  let resp;
+  let panel;
+  let series;
+
+  beforeEach(() => {
+    resp = {
+      aggregations: {
+        'series-1': {
+          meta: { bucketSize: 10, seriesId: 'series-1' },
+          timeseries: {
+            buckets: [
+              { key: 1000, 'pct-1': { values: { '95.0': 200, '50.0': 100 } } },
+              { key: 2000, 'pct-1': { values: { '95.0': 400, '50.0': 150 } } },
+            ],
+          },
+        },
+      },
+    };
+
+    series = {
+      id: 'series-1',
+      color: '#000000',
+      chart_type: 'line',
+      line_width: 1,
+      fill: 0,
+      point_size: 0,
+      stacked: 'none',
+      metrics: [
+        { id: 'pct-1', type: 'percentile', field: 'latency', percentiles: [{ value: 95 }] },
+        {
+          id: 'math-1',
+          type: 'math',
+          script: 'params.p95',
+          variables: [{ name: 'p95', field: 'pct-1[95]' }],
+        },
+      ],
+    };
+
+    panel = { id: 'panel-1', type: 'timeseries', series: [series] };
+  });
+
+  test('emits a percentile component series keyed by the variable field', () => {
+    const next = jest.fn((results) => results);
+    const results = percentileRaw(resp, panel, series)(next)([]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        id: 'series-1:pct-1[95]',
+        data: [
+          [1000, 200],
+          [2000, 400],
+        ],
+      })
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('emits one component per distinct referenced percentile value', () => {
+    series.metrics[1].variables = [
+      { name: 'p95', field: 'pct-1[95]' },
+      { name: 'p50', field: 'pct-1[50]' },
+    ];
+
+    const results = percentileRaw(resp, panel, series)((r) => r)([]);
+
+    const byId = Object.fromEntries(results.map((s) => [s.id, s.data]));
+    expect(byId['series-1:pct-1[95]']).toEqual([
+      [1000, 200],
+      [2000, 400],
+    ]);
+    expect(byId['series-1:pct-1[50]']).toEqual([
+      [1000, 100],
+      [2000, 150],
+    ]);
+  });
+
+  test('is a no-op when the last metric is not math', () => {
+    series.metrics = [series.metrics[0]]; // only the percentile metric, no math
+
+    const results = percentileRaw(resp, panel, series)((r) => r)([]);
+
+    expect(results).toEqual([]);
+  });
+
+  test('ignores percentile values that are not referenced by the math variables', () => {
+    // pct-1 defines [95] but the math only references nothing for it
+    series.metrics[1].variables = [{ name: 'x', field: 'some-other-metric' }];
+
+    const results = percentileRaw(resp, panel, series)((r) => r)([]);
+
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Description

#11129 added client-side math expression evaluation for TSVB (the
`/api/metrics/vis/data-raw` endpoint), evaluating math in the browser instead of on
the server. That client implementation diverged from the server `data` flow in
several cases. The most visible: **a math metric on a series split by terms/filters
renders no data** — the panel collapses to a single empty series — which is why some
TSVB panels stopped loading after #11129.

This PR brings the client (raw) flow back into parity with the server (`data`) flow.
Math is still evaluated only in the browser; no math expression runs on the server.

1. **Split by terms/filters (the reported regression).** For a split series the raw
   endpoint emits component ids `${seriesId}:${splitKey}:${metricId}`, but the client
   looked them up by `${seriesId}:${metricId}` and matched nothing → one empty series.
   Component series are now grouped by split, emitting one evaluated series per split
   (`groupComponentSeriesBySplit` / `evaluateMathSplit`), mirroring the server `getSplits()`.

2. **Percentile values as math variables** (`params.x` where `x = ${metricId}[95]`).
   The server `percentile` processor only emits when the last metric is a percentile, so
   for a math series it produced nothing and the client had no data. A new `percentileRaw`
   processor emits per-value percentile component series, and the client resolves math
   variables by `variable.field`.

3. **`params._all` / `params._timestamp` ordering.** `timeShift` and `dropLastBucket` ran
   *before* math in the raw chain, so `_all` was built from a bucket set with the last
   bucket already dropped and `_timestamp` carried the time-shift offset. Both now run
   client-side *after* math (`post_process_raw_series.js`), matching the server order
   (`math → timeShift → dropLastBucket`).

### Issues Resolved

Fixes the TSVB "visualization does not load" regression for split-by-terms math panels
introduced in #11129.
<!-- Replace with the tracking issue link if one exists. -->

## Screenshot

<!-- Before/after of a split-by-terms math TSVB panel. -->
Before: a TSVB timeseries with a math metric grouped by terms renders no lines.
After: one evaluated line per term.

## Testing the changes

Unit tests (added/updated) — split-by-terms math, percentile-in-math (incl. split),
time-shift `_timestamp`, drop-last-bucket `_all`, and the raw processor list:
```
yarn test:jest src/plugins/vis_type_timeseries/public/lib/process_math_series.test.js
yarn test:jest src/plugins/vis_type_timeseries/public/lib/post_process_raw_series.test.js
yarn test:jest src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/percentile_raw.test.js
yarn test:jest src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/index_raw.test.js
```

Manual (flights sample data) — toggle `metrics:clientSideEvaluation` on/off; output must match:
- `avg(AvgTicketPrice) * 0.9` grouped by terms `Carrier` → 4 lines (empty before this fix).
- 95th-pct `FlightTimeMin` referenced by math `params.p95 / 60`, grouped by `Carrier` → 4 lines.
- Math using `params._all` / `params._timestamp` (with a series time offset) → values match the server flow.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
