### PR TITLE
[Fix][Workspace] Validate collaborator permission combinations and reject invalid ones in workspace APIs

### DIFF
--- a/src/plugins/workspace/common/__tests__/utils.test.ts
+++ b/src/plugins/workspace/common/__tests__/utils.test.ts
@@ -6,7 +6,7 @@
 import {
   validateWorkspaceColor,
   getInvalidWorkspacePermissions,
-  getWorkspacePermissionWarning,
+  getInvalidWorkspacePermissionsError,
   normalizeWorkspacePermissions,
 } from '../utils';
 
@@ -116,10 +116,10 @@ describe('getInvalidWorkspacePermissions', () => {
   });
 });
 
-describe('getWorkspacePermissionWarning', () => {
+describe('getInvalidWorkspacePermissionsError', () => {
   it('should return undefined for valid permissions', () => {
     expect(
-      getWorkspacePermissionWarning({
+      getInvalidWorkspacePermissionsError({
         library_read: { groups: ['obs-users'] },
         read: { groups: ['obs-users'] },
       })
@@ -127,21 +127,19 @@ describe('getWorkspacePermissionWarning', () => {
   });
 
   it('should return undefined when permissions are undefined', () => {
-    expect(getWorkspacePermissionWarning()).toBeUndefined();
+    expect(getInvalidWorkspacePermissionsError()).toBeUndefined();
   });
 
-  it('should return a single message listing each invalid principal once, with guidance appended once', () => {
-    const warning = getWorkspacePermissionWarning({
+  it('should return a message naming each invalid principal with guidance', () => {
+    const error = getInvalidWorkspacePermissionsError({
       library_write: { groups: ['obs-admins'] },
       read: { groups: ['obs-users'] },
     });
-    expect(typeof warning).toBe('string');
-    expect(warning).toContain('obs-admins');
-    expect(warning).toContain('obs-users');
-    // each invalid principal is described exactly once
-    expect(warning!.match(/which is not a recognized workspace access level/g)).toHaveLength(2);
-    // guidance text appears exactly once
-    expect(warning!.match(/Grant one of these permission mode combinations/g)).toHaveLength(1);
+    expect(typeof error).toBe('string');
+    expect(error).toContain('obs-admins');
+    expect(error).toContain('obs-users');
+    expect(error).toContain('Invalid workspace permissions');
+    expect(error).toContain('["library_write", "write"] for admin');
   });
 });
 

--- a/src/plugins/workspace/common/__tests__/utils.test.ts
+++ b/src/plugins/workspace/common/__tests__/utils.test.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { validateWorkspaceColor } from '../utils';
+import {
+  validateWorkspaceColor,
+  getInvalidWorkspacePermissions,
+  getWorkspacePermissionWarning,
+  normalizeWorkspacePermissions,
+} from '../utils';
 
 describe('validateWorkspaceColor', () => {
   it('should return true for a valid 6-digit hex color code', () => {
@@ -34,5 +39,172 @@ describe('validateWorkspaceColor', () => {
   it('should be case-insensitive', () => {
     expect(validateWorkspaceColor('#abcdef')).toBe(true);
     expect(validateWorkspaceColor('#ABC')).toBe(true);
+  });
+});
+
+describe('getInvalidWorkspacePermissions', () => {
+  it('should return an empty array when permissions are undefined or empty', () => {
+    expect(getInvalidWorkspacePermissions()).toEqual([]);
+    expect(getInvalidWorkspacePermissions({})).toEqual([]);
+  });
+
+  it('should accept a valid read only collaborator (library_read + read)', () => {
+    expect(
+      getInvalidWorkspacePermissions({
+        library_read: { groups: ['obs-users'] },
+        read: { groups: ['obs-users'] },
+      })
+    ).toEqual([]);
+  });
+
+  it('should accept a valid read and write collaborator (library_write + read)', () => {
+    expect(
+      getInvalidWorkspacePermissions({
+        library_write: { users: ['user-1'] },
+        read: { users: ['user-1'] },
+      })
+    ).toEqual([]);
+  });
+
+  it('should accept a valid admin collaborator (library_write + write)', () => {
+    expect(
+      getInvalidWorkspacePermissions({
+        library_write: { groups: ['obs-admins'] },
+        write: { groups: ['obs-admins'] },
+      })
+    ).toEqual([]);
+  });
+
+  it('should reject a group granted only "read" (missing library_read)', () => {
+    expect(
+      getInvalidWorkspacePermissions({
+        read: { groups: ['obs-users'] },
+      })
+    ).toEqual([{ type: 'group', name: 'obs-users', modes: ['read'] }]);
+  });
+
+  it('should reject a group granted only "library_write" (missing read/write)', () => {
+    expect(
+      getInvalidWorkspacePermissions({
+        library_write: { groups: ['obs-admins'] },
+      })
+    ).toEqual([{ type: 'group', name: 'obs-admins', modes: ['library_write'] }]);
+  });
+
+  it('should reproduce issue #11996: only the incomplete read-only group is rejected', () => {
+    // payload that "creates nothing" in the bug report
+    const invalid = getInvalidWorkspacePermissions({
+      library_write: { groups: ['obs-admins'] },
+      read: { groups: ['obs-users'] },
+    });
+    expect(invalid).toEqual(
+      expect.arrayContaining([
+        { type: 'group', name: 'obs-admins', modes: ['library_write'] },
+        { type: 'group', name: 'obs-users', modes: ['read'] },
+      ])
+    );
+    expect(invalid).toHaveLength(2);
+  });
+
+  it('should validate users and groups independently across modes', () => {
+    expect(
+      getInvalidWorkspacePermissions({
+        library_read: { users: ['valid-user'], groups: ['invalid-group'] },
+        read: { users: ['valid-user'] },
+      })
+    ).toEqual([{ type: 'group', name: 'invalid-group', modes: ['library_read'] }]);
+  });
+});
+
+describe('getWorkspacePermissionWarning', () => {
+  it('should return undefined for valid permissions', () => {
+    expect(
+      getWorkspacePermissionWarning({
+        library_read: { groups: ['obs-users'] },
+        read: { groups: ['obs-users'] },
+      })
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when permissions are undefined', () => {
+    expect(getWorkspacePermissionWarning()).toBeUndefined();
+  });
+
+  it('should return a single message listing each invalid principal once, with guidance appended once', () => {
+    const warning = getWorkspacePermissionWarning({
+      library_write: { groups: ['obs-admins'] },
+      read: { groups: ['obs-users'] },
+    });
+    expect(typeof warning).toBe('string');
+    expect(warning).toContain('obs-admins');
+    expect(warning).toContain('obs-users');
+    // each invalid principal is described exactly once
+    expect(warning!.match(/which is not a recognized workspace access level/g)).toHaveLength(2);
+    // guidance text appears exactly once
+    expect(warning!.match(/Grant one of these permission mode combinations/g)).toHaveLength(1);
+  });
+});
+
+describe('normalizeWorkspacePermissions', () => {
+  it('should return permissions unchanged when undefined', () => {
+    expect(normalizeWorkspacePermissions()).toBeUndefined();
+  });
+
+  it('should leave a canonical read only collaborator unchanged', () => {
+    expect(
+      normalizeWorkspacePermissions({
+        library_read: { groups: ['obs-users'] },
+        read: { groups: ['obs-users'] },
+      })
+    ).toEqual({
+      library_read: { groups: ['obs-users'] },
+      read: { groups: ['obs-users'] },
+    });
+  });
+
+  it('should collapse a principal granted all four modes to admin (library_write + write)', () => {
+    expect(
+      normalizeWorkspacePermissions({
+        library_write: { users: ['admin'] },
+        write: { users: ['admin'] },
+        library_read: { users: ['admin'] },
+        read: { users: ['admin'] },
+      })
+    ).toEqual({
+      library_write: { users: ['admin'] },
+      write: { users: ['admin'] },
+    });
+  });
+
+  it('should collapse library_write + write + read to admin', () => {
+    expect(
+      normalizeWorkspacePermissions({
+        library_write: { groups: ['obs-admins'] },
+        write: { groups: ['obs-admins'] },
+        read: { groups: ['obs-admins'] },
+      })
+    ).toEqual({
+      library_write: { groups: ['obs-admins'] },
+      write: { groups: ['obs-admins'] },
+    });
+  });
+
+  it('should normalize each principal to its own highest access level', () => {
+    expect(
+      normalizeWorkspacePermissions({
+        library_write: { users: ['admin'], groups: ['obs-rw'] },
+        write: { users: ['admin'] },
+        read: { users: ['admin'], groups: ['obs-rw'] },
+        library_read: { groups: ['obs-ro'] },
+      })
+    ).toEqual({
+      // admin -> admin
+      write: { users: ['admin'] },
+      library_write: { users: ['admin'], groups: ['obs-rw'] },
+      // obs-rw -> read and write
+      read: { groups: ['obs-rw'] },
+      // obs-ro only has library_read -> no access level matches, preserved as-is
+      library_read: { groups: ['obs-ro'] },
+    });
   });
 });

--- a/src/plugins/workspace/common/utils.ts
+++ b/src/plugins/workspace/common/utils.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { SavedObjectPermissions } from '../../../core/types';
 import { WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES } from './constants';
 
 // Reference https://github.com/opensearch-project/oui/blob/main/src/services/color/is_valid_hex.ts
@@ -10,3 +11,138 @@ export const validateWorkspaceColor = (color?: string) =>
 
 export const validateIsWorkspaceDataSourceAndConnectionObjectType = (type: string) =>
   WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES.includes(type);
+
+export const WORKSPACE_ACCESS_LEVEL_MODES: string[][] = [
+  ['library_write', 'write'],
+  ['library_write', 'read'],
+  ['library_read', 'read'],
+];
+
+export interface InvalidWorkspacePermissionPrincipal {
+  type: 'user' | 'group';
+  name: string;
+  modes: string[];
+}
+
+/**
+ * Flatten a workspace `permissions` object (keyed by permission mode) into the
+ * set of permission modes granted to each principal, keyed by principal. Users
+ * and groups are tracked separately because a user and a group can share a name.
+ */
+const collectPrincipalModes = (permissions: SavedObjectPermissions) => {
+  const userModes: { [user: string]: Set<string> } = {};
+  const groupModes: { [group: string]: Set<string> } = {};
+
+  Object.keys(permissions).forEach((mode) => {
+    const principals = permissions[mode];
+    principals?.users?.forEach((user) => {
+      (userModes[user] = userModes[user] ?? new Set<string>()).add(mode);
+    });
+    principals?.groups?.forEach((group) => {
+      (groupModes[group] = groupModes[group] ?? new Set<string>()).add(mode);
+    });
+  });
+
+  return { userModes, groupModes };
+};
+
+/**
+ * Validate that every principal in a workspace `permissions` object forms a
+ * recognized collaborator access level (see {@link WORKSPACE_ACCESS_LEVEL_MODES}).
+ *
+ * Returns the list of principals whose granted permission modes do not contain
+ * all the modes of any access level. An empty array means the permissions are valid.
+ */
+export const getInvalidWorkspacePermissions = (
+  permissions?: SavedObjectPermissions
+): InvalidWorkspacePermissionPrincipal[] => {
+  if (!permissions) {
+    return [];
+  }
+
+  const { userModes, groupModes } = collectPrincipalModes(permissions);
+
+  const isValidCombination = (modes: Set<string>) =>
+    WORKSPACE_ACCESS_LEVEL_MODES.some((requiredModes) =>
+      requiredModes.every((requiredMode) => modes.has(requiredMode))
+    );
+
+  const invalidPrincipals: InvalidWorkspacePermissionPrincipal[] = [];
+
+  Object.keys(userModes).forEach((user) => {
+    if (!isValidCombination(userModes[user])) {
+      invalidPrincipals.push({ type: 'user', name: user, modes: [...userModes[user]] });
+    }
+  });
+  Object.keys(groupModes).forEach((group) => {
+    if (!isValidCombination(groupModes[group])) {
+      invalidPrincipals.push({ type: 'group', name: group, modes: [...groupModes[group]] });
+    }
+  });
+
+  return invalidPrincipals;
+};
+
+/**
+ * Build a single human-readable, non-blocking warning message for any principal
+ * whose granted permission modes do not form a recognized collaborator access level.
+ */
+export const getWorkspacePermissionWarning = (
+  permissions?: SavedObjectPermissions
+): string | undefined => {
+  const invalidPrincipals = getInvalidWorkspacePermissions(permissions);
+  if (invalidPrincipals.length === 0) {
+    return undefined;
+  }
+  const lines = invalidPrincipals.map(
+    ({ type, name, modes }) =>
+      `The ${type} "${name}" was granted [${modes.join(
+        ', '
+      )}], which is not a recognized workspace access level and will not appear as a collaborator.`
+  );
+  lines.push(
+    `Grant one of these permission mode combinations instead: ["library_read", "read"] for read only, ["library_write", "read"] for read and write, or ["library_write", "write"] for admin.`
+  );
+  return lines.join(' ');
+};
+
+/**
+ * Normalize a workspace `permissions` object so that every principal is collapsed
+ * to the single highest access level it qualifies.
+ */
+export const normalizeWorkspacePermissions = (
+  permissions?: SavedObjectPermissions
+): SavedObjectPermissions | undefined => {
+  if (!permissions) {
+    return permissions;
+  }
+
+  const { userModes, groupModes } = collectPrincipalModes(permissions);
+
+  const resolveModes = (modes: Set<string>): string[] => {
+    const matched = WORKSPACE_ACCESS_LEVEL_MODES.find((requiredModes) =>
+      requiredModes.every((requiredMode) => modes.has(requiredMode))
+    );
+    // Fall back to the original modes if no access level matches, to avoid
+    // silently dropping permissions that validation would have already rejected.
+    return matched ?? [...modes];
+  };
+
+  const normalized: SavedObjectPermissions = {};
+  const addPrincipal = (mode: string, key: 'users' | 'groups', name: string) => {
+    const principals = normalized[mode] ?? (normalized[mode] = {});
+    const list = principals[key] ?? (principals[key] = []);
+    if (!list.includes(name)) {
+      list.push(name);
+    }
+  };
+
+  Object.keys(userModes).forEach((user) => {
+    resolveModes(userModes[user]).forEach((mode) => addPrincipal(mode, 'users', user));
+  });
+  Object.keys(groupModes).forEach((group) => {
+    resolveModes(groupModes[group]).forEach((mode) => addPrincipal(mode, 'groups', group));
+  });
+
+  return normalized;
+};

--- a/src/plugins/workspace/common/utils.ts
+++ b/src/plugins/workspace/common/utils.ts
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { SavedObjectPermissions } from '../../../core/types';
+import type { SavedObjectPermissions } from '../../../core/types';
 import { WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES } from './constants';
 
 // Reference https://github.com/opensearch-project/oui/blob/main/src/services/color/is_valid_hex.ts
@@ -48,10 +48,7 @@ const collectPrincipalModes = (permissions: SavedObjectPermissions) => {
 
 /**
  * Validate that every principal in a workspace `permissions` object forms a
- * recognized collaborator access level (see {@link WORKSPACE_ACCESS_LEVEL_MODES}).
- *
- * Returns the list of principals whose granted permission modes do not contain
- * all the modes of any access level. An empty array means the permissions are valid.
+ * recognized collaborator access level.
  */
 export const getInvalidWorkspacePermissions = (
   permissions?: SavedObjectPermissions
@@ -84,26 +81,24 @@ export const getInvalidWorkspacePermissions = (
 };
 
 /**
- * Build a single human-readable, non-blocking warning message for any principal
- * whose granted permission modes do not form a recognized collaborator access level.
+ * Build a single human-readable error message for any principal whose granted
+ * permission modes do not form a recognized collaborator access level.
  */
-export const getWorkspacePermissionWarning = (
+export const getInvalidWorkspacePermissionsError = (
   permissions?: SavedObjectPermissions
 ): string | undefined => {
   const invalidPrincipals = getInvalidWorkspacePermissions(permissions);
   if (invalidPrincipals.length === 0) {
     return undefined;
   }
-  const lines = invalidPrincipals.map(
-    ({ type, name, modes }) =>
-      `The ${type} "${name}" was granted [${modes.join(
-        ', '
-      )}], which is not a recognized workspace access level and will not appear as a collaborator.`
+  const details = invalidPrincipals
+    .map(({ type, name, modes }) => `${type} "${name}" ([${modes.join(', ')}])`)
+    .join('; ');
+  return (
+    `Invalid workspace permissions for: ${details}. Each user or group must be granted one of ` +
+    `the following permission mode combinations: ["library_read", "read"] for read only, ` +
+    `["library_write", "read"] for read and write, or ["library_write", "write"] for admin.`
   );
-  lines.push(
-    `Grant one of these permission mode combinations instead: ["library_read", "read"] for read only, ["library_write", "read"] for read and write, or ["library_write", "write"] for admin.`
-  );
-  return lines.join(' ');
 };
 
 /**
@@ -123,8 +118,6 @@ export const normalizeWorkspacePermissions = (
     const matched = WORKSPACE_ACCESS_LEVEL_MODES.find((requiredModes) =>
       requiredModes.every((requiredMode) => modes.has(requiredMode))
     );
-    // Fall back to the original modes if no access level matches, to avoid
-    // silently dropping permissions that validation would have already rejected.
     return matched ?? [...modes];
   };
 

--- a/src/plugins/workspace/server/integration_tests/routes.test.ts
+++ b/src/plugins/workspace/server/integration_tests/routes.test.ts
@@ -624,7 +624,7 @@ describe('workspace service api integration test when savedObjects.permission.en
         .send({
           attributes: omitId(testWorkspace),
           settings: {
-            permissions: { read: { users: ['foo'] } },
+            permissions: { library_read: { users: ['foo'] }, read: { users: ['foo'] } },
             dataSources: [],
           },
         })
@@ -638,7 +638,7 @@ describe('workspace service api integration test when savedObjects.permission.en
             .createInternalRepository([WORKSPACE_TYPE])
             .get<{ permissions: Permissions }>(WORKSPACE_TYPE, result.body.result.id)
         ).permissions
-      ).toEqual({ read: { users: ['foo'] } });
+      ).toEqual({ library_read: { users: ['foo'] }, read: { users: ['foo'] } });
     });
     it('update', async () => {
       const result: any = await osdTestServer.request
@@ -655,7 +655,7 @@ describe('workspace service api integration test when savedObjects.permission.en
             ...omitId(testWorkspace),
           },
           settings: {
-            permissions: { write: { users: ['foo'] } },
+            permissions: { library_write: { users: ['foo'] }, write: { users: ['foo'] } },
             dataSources: [],
           },
         })
@@ -668,7 +668,117 @@ describe('workspace service api integration test when savedObjects.permission.en
             .createInternalRepository([WORKSPACE_TYPE])
             .get<{ permissions: Permissions }>(WORKSPACE_TYPE, result.body.result.id)
         ).permissions
-      ).toEqual({ write: { users: ['foo'] } });
+      ).toEqual({ library_write: { users: ['foo'] }, write: { users: ['foo'] } });
+    });
+
+    it('create should reject permissions that do not form a recognized access level', async () => {
+      const createResult: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omitId(testWorkspace),
+          settings: {
+            // `library_write` alone (missing read/write) is not a valid collaborator role.
+            permissions: {
+              library_write: { groups: ['obs-admins'] },
+              read: { groups: ['obs-users'] },
+            },
+            dataSources: [],
+          },
+        })
+        .expect(400);
+
+      expect(createResult.body.message).toContain('Invalid workspace permissions');
+      expect(createResult.body.message).toContain('obs-admins');
+      expect(createResult.body.message).toContain('obs-users');
+    });
+
+    it('create should normalize a principal granted redundant permission modes to its highest access level', async () => {
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omitId(testWorkspace),
+          settings: {
+            // All four modes should collapse to admin (library_write + write).
+            permissions: {
+              library_write: { users: ['foo'] },
+              write: { users: ['foo'] },
+              library_read: { users: ['foo'] },
+              read: { users: ['foo'] },
+            },
+            dataSources: [],
+          },
+        })
+        .expect(200);
+
+      expect(result.body.success).toEqual(true);
+      expect(
+        (
+          await osd.coreStart.savedObjects
+            .createInternalRepository([WORKSPACE_TYPE])
+            .get<{ permissions: Permissions }>(WORKSPACE_TYPE, result.body.result.id)
+        ).permissions
+      ).toEqual({ library_write: { users: ['foo'] }, write: { users: ['foo'] } });
+    });
+
+    it('update should reject permissions that do not form a recognized access level', async () => {
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omitId(testWorkspace),
+        })
+        .expect(200);
+
+      const updateResult: any = await osdTestServer.request
+        .put(root, `/api/workspaces/${result.body.result.id}`)
+        .send({
+          attributes: {
+            ...omitId(testWorkspace),
+          },
+          settings: {
+            // `read` alone (missing library_read) is not a valid collaborator role.
+            permissions: { read: { users: ['foo'] } },
+            dataSources: [],
+          },
+        })
+        .expect(400);
+
+      expect(updateResult.body.message).toContain('Invalid workspace permissions');
+      expect(updateResult.body.message).toContain('foo');
+    });
+
+    it('update should normalize a principal granted redundant permission modes to its highest access level', async () => {
+      const result: any = await osdTestServer.request
+        .post(root, `/api/workspaces`)
+        .send({
+          attributes: omitId(testWorkspace),
+        })
+        .expect(200);
+
+      await osdTestServer.request
+        .put(root, `/api/workspaces/${result.body.result.id}`)
+        .send({
+          attributes: {
+            ...omitId(testWorkspace),
+          },
+          settings: {
+            // library_write + write + read should collapse to admin (library_write + write).
+            permissions: {
+              library_write: { groups: ['obs-admins'] },
+              write: { groups: ['obs-admins'] },
+              read: { groups: ['obs-admins'] },
+            },
+            dataSources: [],
+          },
+        })
+        .expect(200);
+
+      expect(
+        (
+          await osd.coreStart.savedObjects
+            .createInternalRepository([WORKSPACE_TYPE])
+            .get<{ permissions: Permissions }>(WORKSPACE_TYPE, result.body.result.id)
+        ).permissions
+      ).toEqual({ library_write: { groups: ['obs-admins'] }, write: { groups: ['obs-admins'] } });
     });
   });
 

--- a/src/plugins/workspace/server/routes/index.test.ts
+++ b/src/plugins/workspace/server/routes/index.test.ts
@@ -153,3 +153,181 @@ describe(`Workspace routes`, () => {
     });
   });
 });
+
+describe(`Workspace routes permission validation`, () => {
+  let server: SetupServerReturn['server'];
+  let httpSetup: SetupServerReturn['httpSetup'];
+  let mockedWorkspaceClient: IWorkspaceClientImpl;
+
+  beforeEach(async () => {
+    ({ server, httpSetup } = await setupServer());
+
+    const router = httpSetup.createRouter('');
+
+    mockedWorkspaceClient = workspaceClientMock.create();
+    (mockedWorkspaceClient.update as jest.Mock).mockResolvedValue({
+      success: true,
+      result: true,
+    });
+
+    registerRoutes({
+      router,
+      client: mockedWorkspaceClient,
+      logger: loggingSystemMock.create().get(),
+      maxImportExportSize: Number.MAX_SAFE_INTEGER,
+      // Permission validation/normalization only runs when permission control is enabled.
+      isPermissionControlEnabled: true,
+      isDataSourceEnabled: true,
+    });
+
+    await server.start({ dynamicConfigService: mockDynamicConfigService });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('create', () => {
+    it('returns a warning but still succeeds when a group has an incomplete permission combination', async () => {
+      const result = await supertest(httpSetup.server.listener)
+        .post(WORKSPACES_API_BASE_URL)
+        .send({
+          attributes: {
+            name: 'Observability',
+            features: ['use-case-observability'],
+          },
+          settings: {
+            permissions: {
+              read: { groups: ['obs-users'] },
+            },
+          },
+        })
+        .expect(200);
+      // Backward compatible: the request succeeds and the permission is persisted as-is...
+      expect(mockedWorkspaceClient.create).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          permissions: { read: { groups: ['obs-users'] } },
+        })
+      );
+      // ...but a non-blocking warning is returned to the caller (visible from the CLI response).
+      expect(typeof result.body.warning).toBe('string');
+      expect(result.body.warning).toContain('obs-users');
+    });
+
+    it('persists a valid read only collaborator unchanged', async () => {
+      await supertest(httpSetup.server.listener)
+        .post(WORKSPACES_API_BASE_URL)
+        .send({
+          attributes: {
+            name: 'Observability',
+            features: ['use-case-observability'],
+          },
+          settings: {
+            permissions: {
+              library_read: { groups: ['obs-users'] },
+              read: { groups: ['obs-users'] },
+            },
+          },
+        })
+        .expect(200);
+      expect(mockedWorkspaceClient.create).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          permissions: {
+            library_read: { groups: ['obs-users'] },
+            read: { groups: ['obs-users'] },
+          },
+        })
+      );
+    });
+
+    it('normalizes a redundant permission combination to a single access level before persisting', async () => {
+      await supertest(httpSetup.server.listener)
+        .post(WORKSPACES_API_BASE_URL)
+        .send({
+          attributes: {
+            name: 'Observability',
+            features: ['use-case-observability'],
+          },
+          settings: {
+            permissions: {
+              library_write: { users: ['admin'] },
+              write: { users: ['admin'] },
+              library_read: { users: ['admin'] },
+              read: { users: ['admin'] },
+            },
+          },
+        })
+        .expect(200);
+      expect(mockedWorkspaceClient.create).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          permissions: {
+            library_write: { users: ['admin'] },
+            write: { users: ['admin'] },
+          },
+        })
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('returns warnings but still succeeds when permissions have incomplete combinations', async () => {
+      const result = await supertest(httpSetup.server.listener)
+        .put(`${WORKSPACES_API_BASE_URL}/mock-workspace-id`)
+        .send({
+          attributes: {},
+          settings: {
+            permissions: {
+              library_write: { groups: ['obs-admins'] },
+              read: { groups: ['obs-users'] },
+            },
+          },
+        })
+        .expect(200);
+      // Backward compatible: the #11996 payload still persists as-is instead of being rejected.
+      expect(mockedWorkspaceClient.update).toHaveBeenCalledWith(
+        expect.any(Object),
+        'mock-workspace-id',
+        expect.objectContaining({
+          permissions: {
+            library_write: { groups: ['obs-admins'] },
+            read: { groups: ['obs-users'] },
+          },
+        })
+      );
+      // Both incomplete principals are reported in a single warning string.
+      expect(typeof result.body.warning).toBe('string');
+      expect(result.body.warning).toContain('obs-admins');
+      expect(result.body.warning).toContain('obs-users');
+    });
+
+    it('normalizes a redundant permission combination before calling the workspace client', async () => {
+      await supertest(httpSetup.server.listener)
+        .put(`${WORKSPACES_API_BASE_URL}/mock-workspace-id`)
+        .send({
+          attributes: {},
+          settings: {
+            permissions: {
+              library_write: { users: ['admin'] },
+              write: { users: ['admin'] },
+              library_read: { users: ['admin'] },
+              read: { users: ['admin'] },
+            },
+          },
+        })
+        .expect(200);
+      expect(mockedWorkspaceClient.update).toHaveBeenCalledWith(
+        expect.any(Object),
+        'mock-workspace-id',
+        expect.objectContaining({
+          permissions: {
+            library_write: { users: ['admin'] },
+            write: { users: ['admin'] },
+          },
+        })
+      );
+    });
+  });
+});

--- a/src/plugins/workspace/server/routes/index.test.ts
+++ b/src/plugins/workspace/server/routes/index.test.ts
@@ -188,7 +188,7 @@ describe(`Workspace routes permission validation`, () => {
   });
 
   describe('create', () => {
-    it('returns a warning but still succeeds when a group has an incomplete permission combination', async () => {
+    it('returns 400 when a group has an incomplete permission combination', async () => {
       const result = await supertest(httpSetup.server.listener)
         .post(WORKSPACES_API_BASE_URL)
         .send({
@@ -202,17 +202,10 @@ describe(`Workspace routes permission validation`, () => {
             },
           },
         })
-        .expect(200);
-      // Backward compatible: the request succeeds and the permission is persisted as-is...
-      expect(mockedWorkspaceClient.create).toHaveBeenCalledWith(
-        expect.any(Object),
-        expect.objectContaining({
-          permissions: { read: { groups: ['obs-users'] } },
-        })
-      );
-      // ...but a non-blocking warning is returned to the caller (visible from the CLI response).
-      expect(typeof result.body.warning).toBe('string');
-      expect(result.body.warning).toContain('obs-users');
+        .expect(400);
+      expect(result.body.message).toContain('Invalid workspace permissions');
+      expect(result.body.message).toContain('obs-users');
+      expect(mockedWorkspaceClient.create).not.toHaveBeenCalled();
     });
 
     it('persists a valid read only collaborator unchanged', async () => {
@@ -273,7 +266,7 @@ describe(`Workspace routes permission validation`, () => {
   });
 
   describe('update', () => {
-    it('returns warnings but still succeeds when permissions have incomplete combinations', async () => {
+    it('returns 400 when permissions have an incomplete combination', async () => {
       const result = await supertest(httpSetup.server.listener)
         .put(`${WORKSPACES_API_BASE_URL}/mock-workspace-id`)
         .send({
@@ -285,22 +278,11 @@ describe(`Workspace routes permission validation`, () => {
             },
           },
         })
-        .expect(200);
-      // Backward compatible: the #11996 payload still persists as-is instead of being rejected.
-      expect(mockedWorkspaceClient.update).toHaveBeenCalledWith(
-        expect.any(Object),
-        'mock-workspace-id',
-        expect.objectContaining({
-          permissions: {
-            library_write: { groups: ['obs-admins'] },
-            read: { groups: ['obs-users'] },
-          },
-        })
-      );
-      // Both incomplete principals are reported in a single warning string.
-      expect(typeof result.body.warning).toBe('string');
-      expect(result.body.warning).toContain('obs-admins');
-      expect(result.body.warning).toContain('obs-users');
+        .expect(400);
+      expect(result.body.message).toContain('Invalid workspace permissions');
+      expect(result.body.message).toContain('obs-admins');
+      expect(result.body.message).toContain('obs-users');
+      expect(mockedWorkspaceClient.update).not.toHaveBeenCalled();
     });
 
     it('normalizes a redundant permission combination before calling the workspace client', async () => {

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -22,7 +22,7 @@ import { registerDuplicateRoute } from './duplicate';
 import { getPermissionMode, transferCurrentUserInPermissions } from '../utils';
 import {
   validateWorkspaceColor,
-  getWorkspacePermissionWarning,
+  getInvalidWorkspacePermissionsError,
   normalizeWorkspacePermissions,
 } from '../../common/utils';
 import { getUseCaseFeatureConfig } from '../../../../core/server';
@@ -226,14 +226,13 @@ export function registerRoutes({
         dataConnections?: string[];
       } = attributes;
 
-      // Non-blocking warning for permission combinations that do not map to a
-      // recognized collaborator access level. The request still succeeds to keep
-      // the API backward compatible.
-      const permissionWarning = isPermissionControlEnabled
-        ? getWorkspacePermissionWarning(settings.permissions)
-        : undefined;
-
+      // Reject permission combinations that do not map to a recognized
+      // collaborator access level (read only, read and write, or admin).
       if (isPermissionControlEnabled) {
+        const invalidPermissionsError = getInvalidWorkspacePermissionsError(settings.permissions);
+        if (invalidPermissionsError) {
+          return res.badRequest({ body: invalidPermissionsError });
+        }
         const normalizedPermissions = normalizeWorkspacePermissions(settings.permissions);
         createPayload.permissions = normalizedPermissions;
         if (!!principals?.users?.length) {
@@ -254,9 +253,7 @@ export function registerRoutes({
         },
         createPayload
       );
-      return res.ok({
-        body: permissionWarning ? { ...result, warning: permissionWarning } : result,
-      });
+      return res.ok({ body: result });
     })
   );
   router.put(
@@ -276,12 +273,14 @@ export function registerRoutes({
       const { id } = req.params;
       const { attributes, settings } = req.body;
 
-      // Non-blocking warning for permission combinations that do not map to a
-      // recognized collaborator access level. The request still succeeds to keep
-      // the API backward compatible.
-      const permissionWarning = isPermissionControlEnabled
-        ? getWorkspacePermissionWarning(settings.permissions)
-        : undefined;
+      // Reject permission combinations that do not map to a recognized
+      // collaborator access level (read only, read and write, or admin).
+      if (isPermissionControlEnabled) {
+        const invalidPermissionsError = getInvalidWorkspacePermissionsError(settings.permissions);
+        if (invalidPermissionsError) {
+          return res.badRequest({ body: invalidPermissionsError });
+        }
+      }
 
       const result = await client.update(
         {
@@ -297,9 +296,7 @@ export function registerRoutes({
           ...{ dataConnections: settings.dataConnections },
         }
       );
-      return res.ok({
-        body: permissionWarning ? { ...result, warning: permissionWarning } : result,
-      });
+      return res.ok({ body: result });
     })
   );
   router.delete(

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -20,7 +20,11 @@ import { IWorkspaceClientImpl, WorkspaceAttributeWithPermission } from '../types
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
 import { registerDuplicateRoute } from './duplicate';
 import { getPermissionMode, transferCurrentUserInPermissions } from '../utils';
-import { validateWorkspaceColor } from '../../common/utils';
+import {
+  validateWorkspaceColor,
+  getWorkspacePermissionWarning,
+  normalizeWorkspacePermissions,
+} from '../../common/utils';
 import { getUseCaseFeatureConfig } from '../../../../core/server';
 
 export const WORKSPACES_API_BASE_URL = '/api/workspaces';
@@ -222,12 +226,20 @@ export function registerRoutes({
         dataConnections?: string[];
       } = attributes;
 
+      // Non-blocking warning for permission combinations that do not map to a
+      // recognized collaborator access level. The request still succeeds to keep
+      // the API backward compatible.
+      const permissionWarning = isPermissionControlEnabled
+        ? getWorkspacePermissionWarning(settings.permissions)
+        : undefined;
+
       if (isPermissionControlEnabled) {
-        createPayload.permissions = settings.permissions;
+        const normalizedPermissions = normalizeWorkspacePermissions(settings.permissions);
+        createPayload.permissions = normalizedPermissions;
         if (!!principals?.users?.length) {
           const currentUserId = principals.users[0];
           const acl = new ACL(
-            transferCurrentUserInPermissions(currentUserId, settings.permissions)
+            transferCurrentUserInPermissions(currentUserId, normalizedPermissions)
           );
           createPayload.permissions = acl.getPermissions();
         }
@@ -242,7 +254,9 @@ export function registerRoutes({
         },
         createPayload
       );
-      return res.ok({ body: result });
+      return res.ok({
+        body: permissionWarning ? { ...result, warning: permissionWarning } : result,
+      });
     })
   );
   router.put(
@@ -262,6 +276,13 @@ export function registerRoutes({
       const { id } = req.params;
       const { attributes, settings } = req.body;
 
+      // Non-blocking warning for permission combinations that do not map to a
+      // recognized collaborator access level. The request still succeeds to keep
+      // the API backward compatible.
+      const permissionWarning = isPermissionControlEnabled
+        ? getWorkspacePermissionWarning(settings.permissions)
+        : undefined;
+
       const result = await client.update(
         {
           request: req,
@@ -269,12 +290,16 @@ export function registerRoutes({
         id,
         {
           ...attributes,
-          ...(isPermissionControlEnabled ? { permissions: settings.permissions } : {}),
+          ...(isPermissionControlEnabled
+            ? { permissions: normalizeWorkspacePermissions(settings.permissions) }
+            : {}),
           ...{ dataSources: settings.dataSources },
           ...{ dataConnections: settings.dataConnections },
         }
       );
-      return res.ok({ body: result });
+      return res.ok({
+        body: permissionWarning ? { ...result, warning: permissionWarning } : result,
+      });
     })
   );
   router.delete(


### PR DESCRIPTION
### Description

The workspace create (`POST /api/workspaces`) and update (`PUT /api/workspaces/{id}`) APIs accepted any `permissions` map and persisted it verbatim. A workspace collaborator role, however, is defined by a *combination* of one workspace-level mode and one library-level mode:

| Access level   | Required modes            |
| -------------- | ------------------------- |
| Read only      | `library_read` + `read`   |
| Read and write | `library_write` + `read`  |
| Admin          | `library_write` + `write` |

- `read` / `write` apply to the **workspace object** (open it / manage it).
- `library_read` / `library_write` apply to the **saved objects inside it**.

When a principal was granted an incomplete combination (e.g. only `read`, or only `library_write`), the value was stored but did not form a usable role: it was silently dropped by the collaborators UI and granted no coherent access (for example, a `write`-only user can open the workspace shell but cannot read any of its saved objects and never appears as a collaborator). This is the cause of #11996 — and the official docs example used exactly such an incomplete combination.

This PR makes the workspace create/update APIs validate permissions:

- **Reject invalid combinations.** When the supplied `permissions` contain a principal whose mode combination does not map to a recognized access level, the request fails with `400 Bad Request` and an error message naming the offending principal and listing the valid combinations. This prevents the silent, unusable state described above.
- **Normalize redundant combinations.** A principal granted a superset of a role (e.g. all four modes) is collapsed to the single highest matching access level before persisting (e.g. `library_write` + `write` for admin). This keeps the stored ACL canonical and prevents the collaborators UI from rendering the same principal once per matching access level.

### Screenshot

Example response when an incomplete combination is supplied:
```
curl ...
  --data-raw '{"attributes":{},"settings":{"permissions":{"library_write":{"users":["admin", "wrongPermission1"]},"write":{"users":["admin"]},"library_read":{"users":["wrongPermission1"]},"read":{"users":["wrongPermission2"]}}}}'

{"statusCode":400,"error":"Bad Request","message":"Invalid workspace permissions for: user \"wrongPermission1\" ([library_write, library_read]); user \"wrongPermission2\" ([read]). Each user or group must be granted one of the following permission mode combinations: [\"library_read\", \"read\"] for read only, [\"library_write\", \"read\"] for read and write, or [\"library_write\", \"write\"] for admin."}% 
```


### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11996

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
