### PR TITLE
Harden HTTP redirect path handling

### DIFF
--- a/src/core/server/http/https_redirect_server.test.ts
+++ b/src/core/server/http/https_redirect_server.test.ts
@@ -115,3 +115,20 @@ test('forwards http requests to https', async () => {
       expect(res.header.location).toEqual(`https://${config.host}:${config.port}/`);
     });
 });
+
+describe('rejects protocol-relative paths to prevent open redirects', () => {
+  beforeEach(async () => {
+    await server.start(config);
+  });
+
+  test.each([
+    ['//attacker.com/aa/'],
+    ['///attacker.com/aa/'],
+    ['/////attacker.com/'],
+    ['/\\attacker.com/aa/'],
+  ])('rejects %s with 404 and no Location header', async (path) => {
+    const res = await supertest(getServerListener(server)).get(path);
+    expect(res.status).toBe(404);
+    expect(res.header.location).toBeUndefined();
+  });
+});

--- a/src/core/server/http/https_redirect_server.ts
+++ b/src/core/server/http/https_redirect_server.ts
@@ -61,6 +61,15 @@ export class HttpsRedirectServer {
     );
 
     this.server.ext('onRequest', (request: Request, responseToolkit: ResponseToolkit) => {
+      // Reject protocol-relative paths (e.g. `//attacker.com/...`). Without this
+      // check, `new URL(request.url.pathname, base)` interprets the leading `//`
+      // as the start of an authority and produces a redirect `Location` pointing
+      // at an attacker-controlled host. Hapi's WHATWG `request.url.pathname`
+      // normalizes `/\` to `//`, so a single startsWith('//') covers both forms.
+      if (request.url.pathname.startsWith('//')) {
+        return responseToolkit.response('Not Found').code(404).takeover();
+      }
+
       const redirectUrl = new URL(request.url.pathname, `https://${config.host}:${config.port}`);
       redirectUrl.search = request.url.search;
       return responseToolkit.redirect(redirectUrl.toString()).takeover();

--- a/src/legacy/server/http/index.js
+++ b/src/legacy/server/http/index.js
@@ -50,6 +50,14 @@ export default async function (osdServer, server) {
         throw Boom.notFound();
       }
 
+      // Reject protocol-relative paths (e.g. `//attacker.com/...` or `/\attacker.com/...`).
+      // Without this check, such a path would be reflected verbatim into the redirect
+      // `Location` header and the browser would treat it as a cross-origin redirect.
+      // (`charAt` returns '' for out-of-range indices, so no length check is needed.)
+      if (path.charAt(1) === '/' || path.charAt(1) === '\\') {
+        throw Boom.notFound();
+      }
+
       const pathPrefix = req.getBasePath() ? `${req.getBasePath()}/` : '';
       return h
         .redirect(

--- a/src/legacy/server/http/integration_tests/open_redirect.test.ts
+++ b/src/legacy/server/http/integration_tests/open_redirect.test.ts
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import * as osdTestServer from '../../../../core/test_helpers/osd_server';
+
+let root;
+beforeAll(async () => {
+  root = osdTestServer.createRoot({
+    migrations: { skip: true },
+    plugins: { initialize: false },
+  });
+
+  await root.setup();
+  await root.start();
+}, 30000);
+
+afterAll(async () => await root.shutdown());
+
+describe('legacy http handler trailing-slash redirect', () => {
+  test('redirects a trailing-slash path to the version without the slash', async () => {
+    await osdTestServer.request
+      .get(root, '/some/path/')
+      .expect(301)
+      .expect('location', '/some/path');
+  });
+
+  test('does not redirect protocol-relative paths starting with `//` (open redirect)', async () => {
+    const response = await osdTestServer.request.get(root, '///attacker.com/aa/');
+    expect(response.status).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+
+  test('does not redirect paths starting with `/\\` (backslash protocol-relative)', async () => {
+    const response = await osdTestServer.request.get(root, '/\\attacker.com/aa/');
+    expect(response.status).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+
+  test('does not redirect paths with many leading slashes', async () => {
+    const response = await osdTestServer.request.get(root, '/////attacker.com/');
+    expect(response.status).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

Adds path validation to the legacy HTTP handler and HTTPS redirect server to reject malformed request paths before constructing redirect responses.

### Issues Resolved

N/A

## Screenshot

N/A

## Testing the changes

Integration and unit tests added covering edge cases in redirect path construction.

### Check List
- [x] All tests pass
  - `yarn test:jest`
  - `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff