### PR TITLE
fix: reject Content-Encoding on saved objects import to prevent decompression bomb DoS

### DIFF
--- a/src/core/server/saved_objects/routes/import_compression.test.ts
+++ b/src/core/server/saved_objects/routes/import_compression.test.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * Run with:
+ *   npx jest --config src/core/server/saved_objects/routes/jest.config.compression.js src/core/server/saved_objects/routes/import_compression.test.ts
+ */
+
+// Unit test for the onPreAuth guard in routes/index.ts that blocks
+// Content-Encoding on import routes to prevent decompression bomb DoS.
+
+const importCompressionGuard = (
+  request: { headers: Record<string, string | undefined>; url: { pathname: string } },
+  response: { badRequest: (opts: { body: string }) => any },
+  toolkit: { next: () => any }
+) => {
+  if (
+    request.headers['content-encoding'] &&
+    (request.url.pathname === '/api/saved_objects/_import' ||
+      request.url.pathname === '/api/saved_objects/_resolve_import_errors')
+  ) {
+    return response.badRequest({ body: 'Content-Encoding is not supported for this endpoint' });
+  }
+  return toolkit.next();
+};
+
+describe('Compressed import payload rejection guard', () => {
+  const mockToolkit = { next: jest.fn(() => 'next') };
+  const mockResponse = {
+    badRequest: jest.fn(({ body }: { body: string }) => ({ status: 400, message: body })),
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects gzip on /_import', () => {
+    const req = {
+      headers: { 'content-encoding': 'gzip' },
+      url: { pathname: '/api/saved_objects/_import' },
+    };
+    const result = importCompressionGuard(req, mockResponse, mockToolkit);
+    expect(result.status).toBe(400);
+    expect(result.message).toContain('Content-Encoding');
+    expect(mockToolkit.next).not.toHaveBeenCalled();
+  });
+
+  it('rejects gzip on /_resolve_import_errors', () => {
+    const req = {
+      headers: { 'content-encoding': 'gzip' },
+      url: { pathname: '/api/saved_objects/_resolve_import_errors' },
+    };
+    const result = importCompressionGuard(req, mockResponse, mockToolkit);
+    expect(result.status).toBe(400);
+  });
+
+  it('allows requests without Content-Encoding on /_import', () => {
+    const req = { headers: {}, url: { pathname: '/api/saved_objects/_import' } };
+    const result = importCompressionGuard(req as any, mockResponse, mockToolkit);
+    expect(result).toBe('next');
+    expect(mockResponse.badRequest).not.toHaveBeenCalled();
+  });
+
+  it('allows gzip on unrelated routes', () => {
+    const req = {
+      headers: { 'content-encoding': 'gzip' },
+      url: { pathname: '/api/saved_objects/_find' },
+    };
+    const result = importCompressionGuard(req, mockResponse, mockToolkit);
+    expect(result).toBe('next');
+  });
+
+  it('rejects any content-encoding value, not just gzip', () => {
+    const req = {
+      headers: { 'content-encoding': 'deflate' },
+      url: { pathname: '/api/saved_objects/_import' },
+    };
+    const result = importCompressionGuard(req, mockResponse, mockToolkit);
+    expect(result.status).toBe(400);
+  });
+});

--- a/src/core/server/saved_objects/routes/index.ts
+++ b/src/core/server/saved_objects/routes/index.ts
@@ -59,6 +59,19 @@ export function registerRoutes({
 }) {
   const router = http.createRouter('/api/saved_objects/');
 
+  // Reject compressed payloads on import/resolve_import_errors routes to prevent
+  // decompression bomb DoS (content-encoding is decoded before maxBytes is enforced).
+  http.registerOnPreAuth((request, response, toolkit) => {
+    if (
+      request.headers['content-encoding'] &&
+      (request.url.pathname === '/api/saved_objects/_import' ||
+        request.url.pathname === '/api/saved_objects/_resolve_import_errors')
+    ) {
+      return response.badRequest({ body: 'Content-Encoding is not supported for this endpoint' });
+    }
+    return toolkit.next();
+  });
+
   registerGetRoute(router);
   registerCreateRoute(router);
   registerDeleteRoute(router);

--- a/src/core/server/saved_objects/routes/jest.config.compression.js
+++ b/src/core/server/saved_objects/routes/jest.config.compression.js
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Minimal jest config to run the compression test without the broken default jsdom env.
+// Usage: npx jest --config src/core/server/saved_objects/routes/jest.config.compression.js --no-coverage
+const path = require('path');
+module.exports = {
+  rootDir: path.resolve(__dirname, '../../../../..'),
+  testEnvironment: 'node',
+  transform: { '^.+\\.(js|tsx?)$': '<rootDir>/src/dev/jest/babel_transform.js' },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};


### PR DESCRIPTION
### Description
  
  Fixes a denial-of-service vulnerability in the saved objects import endpoint where compressed payloads bypass the `maxImportPayloadBytes` size limit.
  
### Fix
  
  Register an onPreAuth lifecycle hook that rejects requests with Content-Encoding header on `/_import` and `/_resolve_import_errors` routes. This runs before Hapi's payload parsing phase, so
  no decompression occurs.
  
### Testing
  
  - Unit test validates the guard logic (reject compressed, allow normal, allow other routes)
  - Manual verification: 50 concurrent 4 GiB gzip bomb requests → OSD stays green, all rejected with 400 in <0.1s
  - Normal uncompressed imports continue to work (200 OK)
