### PR TITLE
Sanitize field formatter output in doc viewer table row

### DIFF
--- a/src/plugins/explore/public/components/doc_viewer/doc_viewer_table/table_row/table_row.test.tsx
+++ b/src/plugins/explore/public/components/doc_viewer/doc_viewer_table/table_row/table_row.test.tsx
@@ -4,7 +4,15 @@
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
+import DOMPurify from 'dompurify';
 import { DocViewTableRow } from './table_row';
+
+jest.mock('dompurify', () => ({
+  __esModule: true,
+  default: {
+    sanitize: jest.fn((input) => input.replace(/<script[^>]*>.*?<\/script>/gi, '')),
+  },
+}));
 
 // Mock child components
 jest.mock('./table_row_btn_filter_add', () => ({
@@ -150,5 +158,25 @@ describe('DocViewTableRow', () => {
 
     const valueElement = screen.getByTestId('tableDocViewRow-test_field-value');
     expect(valueElement).toHaveClass('truncate-by-height');
+  });
+
+  it('sanitizes value using DOMPurify before rendering', () => {
+    const maliciousValue = '<script>alert("xss")</script><p>Safe content</p>';
+
+    render(<DocViewTableRow {...defaultProps} value={maliciousValue} />);
+
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith(maliciousValue);
+  });
+
+  it('does not render dangerous script tags in HTML output', () => {
+    const maliciousValue = '<script>alert("xss")</script><p>Safe content</p>';
+
+    render(<DocViewTableRow {...defaultProps} value={maliciousValue} />);
+
+    const valueElement = screen.getByTestId('tableDocViewRow-test_field-value');
+    const html = valueElement.innerHTML;
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('alert("xss")');
+    expect(html).toContain('Safe content');
   });
 });

--- a/src/plugins/explore/public/components/doc_viewer/doc_viewer_table/table_row/table_row.tsx
+++ b/src/plugins/explore/public/components/doc_viewer/doc_viewer_table/table_row/table_row.tsx
@@ -5,6 +5,7 @@
 
 import classNames from 'classnames';
 import { ReactNode } from 'react';
+import DOMPurify from 'dompurify';
 import { FieldMapping, DocViewFilterFn } from '../../../../types/doc_views_types';
 import { DocViewTableRowBtnFilterAdd } from './table_row_btn_filter_add';
 import { DocViewTableRowBtnFilterRemove } from './table_row_btn_filter_remove';
@@ -86,10 +87,12 @@ export function DocViewTableRow({
           data-test-subj={`tableDocViewRow-${field}-value`}
           /*
            * Justification for dangerouslySetInnerHTML:
-           * We just use values encoded by our field formatters
+           * We just use values encoded by our field formatters. The output is
+           * additionally passed through DOMPurify to defend against any unsafe
+           * HTML that may slip through the formatters.
            */
           // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: value as string }}
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value as string) }}
         />
       </td>
     </tr>


### PR DESCRIPTION
### Description

Passes field formatter output through DOMPurify before rendering in the Explore doc viewer table row component.

### Issues Resolved

N/A

## Screenshot

N/A

## Testing the changes

Unit tests added verifying sanitization behavior.

### Check List
- [x] All tests pass
  - `yarn test:jest`
  - `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff