### PR TITLE
[Backport 2.19] Harden HTTP redirect path handling

### DIFF
--- a/src/core/server/http/https_redirect_server.test.ts
+++ b/src/core/server/http/https_redirect_server.test.ts
@@ -115,3 +115,20 @@ test('forwards http requests to https', async () => {
       expect(res.header.location).toEqual(`https://${config.host}:${config.port}/`);
     });
 });
+
+describe('rejects protocol-relative paths to prevent open redirects', () => {
+  beforeEach(async () => {
+    await server.start(config);
+  });
+
+  test.each([
+    ['//attacker.com/aa/'],
+    ['///attacker.com/aa/'],
+    ['/////attacker.com/'],
+    ['/\\attacker.com/aa/'],
+  ])('rejects %s with 404 and no Location header', async (path) => {
+    const res = await supertest(getServerListener(server)).get(path);
+    expect(res.status).toBe(404);
+    expect(res.header.location).toBeUndefined();
+  });
+});

--- a/src/core/server/http/https_redirect_server.ts
+++ b/src/core/server/http/https_redirect_server.ts
@@ -62,6 +62,13 @@ export class HttpsRedirectServer {
     );
 
     this.server.ext('onRequest', (request: Request, responseToolkit: ResponseToolkit) => {
+      // Reject protocol-relative paths (e.g. `//attacker.com/...`). Without this
+      // check, the pathname is reflected into the redirect Location header and
+      // browsers interpret the leading `//` as a cross-origin redirect.
+      if (request.url.pathname.startsWith('//')) {
+        return responseToolkit.response('Not Found').code(404).takeover();
+      }
+
       return responseToolkit
         .redirect(
           formatUrl({

--- a/src/legacy/server/http/index.js
+++ b/src/legacy/server/http/index.js
@@ -50,6 +50,11 @@ export default async function (osdServer, server) {
         throw Boom.notFound();
       }
 
+      // Reject protocol-relative paths (e.g. `//attacker.com/...` or `/\attacker.com/...`).
+      if (path.charAt(1) === '/' || path.charAt(1) === '\\') {
+        throw Boom.notFound();
+      }
+
       const pathPrefix = req.getBasePath() ? `${req.getBasePath()}/` : '';
       return h
         .redirect(

--- a/src/legacy/server/http/integration_tests/open_redirect.test.ts
+++ b/src/legacy/server/http/integration_tests/open_redirect.test.ts
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import * as osdTestServer from '../../../../core/test_helpers/osd_server';
+
+let root;
+beforeAll(async () => {
+  root = osdTestServer.createRoot({
+    migrations: { skip: true },
+    plugins: { initialize: false },
+  });
+
+  await root.setup();
+  await root.start();
+}, 30000);
+
+afterAll(async () => await root.shutdown());
+
+describe('legacy http handler trailing-slash redirect', () => {
+  test('redirects a trailing-slash path to the version without the slash', async () => {
+    await osdTestServer.request
+      .get(root, '/some/path/')
+      .expect(301)
+      .expect('location', '/some/path');
+  });
+
+  test('does not redirect protocol-relative paths starting with `//` (open redirect)', async () => {
+    const response = await osdTestServer.request.get(root, '///attacker.com/aa/');
+    expect(response.status).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+
+  test('does not redirect paths starting with `/\\` (backslash protocol-relative)', async () => {
+    const response = await osdTestServer.request.get(root, '/\\attacker.com/aa/');
+    expect(response.status).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+
+  test('does not redirect paths with many leading slashes', async () => {
+    const response = await osdTestServer.request.get(root, '/////attacker.com/');
+    expect(response.status).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

Backport of #12188 to 2.19. Adds path validation to the legacy HTTP handler and HTTPS redirect server to reject malformed request paths before constructing redirect responses.

### Issues Resolved

N/A

## Screenshot

N/A

## Testing the changes

Integration and unit tests added covering edge cases in redirect path construction.

### Check List
- [x] All tests pass
  - `yarn test:jest`
  - `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff