### PR TITLE
Fix agent traces trace map latency bar always showing 50%

### DIFF
--- a/packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx
@@ -85,7 +85,7 @@ export const AgentCardNode = ({ data }: NodeProps<AgentCardCustomNode>) => {
         {showStandaloneDuration && (
           <MetricBar
             value={data.duration!}
-            max={data.duration! * 2}
+            max={data.maxDuration ?? data.duration!}
             color={kindConfig.color}
             label={data.latency ?? `${data.duration}ms`}
           />

--- a/packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx
@@ -86,6 +86,7 @@ export const AgentCardNode = ({ data }: NodeProps<AgentCardCustomNode>) => {
           <MetricBar
             value={data.duration!}
             max={data.maxDuration ?? data.duration!}
+            offset={data.startOffset}
             color={kindConfig.color}
             label={data.latency ?? `${data.duration}ms`}
           />

--- a/packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx
@@ -86,7 +86,6 @@ export const AgentCardNode = ({ data }: NodeProps<AgentCardCustomNode>) => {
           <MetricBar
             value={data.duration!}
             max={data.maxDuration ?? data.duration!}
-            offset={data.startOffset}
             color={kindConfig.color}
             label={data.latency ?? `${data.duration}ms`}
           />

--- a/packages/osd-apm-topology/src/components/nodes/metric_bar.test.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/metric_bar.test.tsx
@@ -36,6 +36,19 @@ describe('MetricBar', () => {
     const labelSpans = container.querySelectorAll('.osd\\:text-right');
     expect(labelSpans).toHaveLength(0);
   });
+
+  it('applies marginLeft when offset is provided', () => {
+    const { container } = render(<MetricBar value={50} max={100} offset={25} />);
+    const fillBar = container.querySelector('.osd\\:h-full') as HTMLElement;
+    expect(fillBar.style.marginLeft).toBe('25%');
+    expect(fillBar.style.width).toBe('50%');
+  });
+
+  it('defaults offset to 0 when not provided', () => {
+    const { container } = render(<MetricBar value={50} max={100} />);
+    const fillBar = container.querySelector('.osd\\:h-full') as HTMLElement;
+    expect(fillBar.style.marginLeft).toBe('0%');
+  });
 });
 
 describe('MetricBarGroup', () => {

--- a/packages/osd-apm-topology/src/components/nodes/metric_bar.test.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/metric_bar.test.tsx
@@ -49,6 +49,21 @@ describe('MetricBar', () => {
     const fillBar = container.querySelector('.osd\\:h-full') as HTMLElement;
     expect(fillBar.style.marginLeft).toBe('0%');
   });
+
+  it('applies a minimum width so tiny nonzero values stay visible', () => {
+    const { container } = render(<MetricBar value={1} max={10000} />);
+    const fillBar = container.querySelector('.osd\\:h-full') as HTMLElement;
+    // Real percentage stays honest (sub-pixel), but a minWidth floor keeps it visible.
+    expect(fillBar.style.width).toBe('0.01%');
+    expect(fillBar.style.minWidth).toBe('2px');
+  });
+
+  it('does not apply a minimum width floor when value is 0', () => {
+    const { container } = render(<MetricBar value={0} max={10000} />);
+    const fillBar = container.querySelector('.osd\\:h-full') as HTMLElement;
+    expect(fillBar.style.width).toBe('0%');
+    expect(fillBar.style.minWidth).toBe('');
+  });
 });
 
 describe('MetricBarGroup', () => {

--- a/packages/osd-apm-topology/src/components/nodes/metric_bar.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/metric_bar.tsx
@@ -14,6 +14,8 @@ export interface MetricBarProps {
   color?: string;
   /** Label displayed to the right of the bar */
   label?: string;
+  /** Offset percentage (0–100) to push the bar fill to the right (Gantt-style). */
+  offset?: number;
 }
 
 /**
@@ -24,8 +26,10 @@ export const MetricBar: React.FC<MetricBarProps> = ({
   max,
   color = 'var(--osd-color-cl-blue-450)',
   label,
+  offset = 0,
 }) => {
   const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+  const offsetPct = Math.min(Math.max(offset, 0), 100);
 
   return (
     <div className="osd:flex osd:items-center osd:gap-2 osd:w-full">
@@ -35,7 +39,11 @@ export const MetricBar: React.FC<MetricBarProps> = ({
       >
         <div
           className="osd:h-full osd:rounded-full osd:transition-all osd:duration-300"
-          style={{ width: `${pct}%`, backgroundColor: color }}
+          style={{
+            width: `${pct}%`,
+            marginLeft: `${offsetPct}%`,
+            backgroundColor: color,
+          }}
         />
       </div>
       {label && (

--- a/packages/osd-apm-topology/src/components/nodes/metric_bar.tsx
+++ b/packages/osd-apm-topology/src/components/nodes/metric_bar.tsx
@@ -41,6 +41,10 @@ export const MetricBar: React.FC<MetricBarProps> = ({
           className="osd:h-full osd:rounded-full osd:transition-all osd:duration-300"
           style={{
             width: `${pct}%`,
+            // Guarantee a visible sliver for tiny-but-nonzero values that would
+            // otherwise round to a sub-pixel width and disappear. True zeros stay
+            // empty. The label carries the exact value, so this is not misleading.
+            minWidth: value > 0 ? '2px' : undefined,
             marginLeft: `${offsetPct}%`,
             backgroundColor: color,
           }}

--- a/packages/osd-apm-topology/src/shared/types/agent.types.ts
+++ b/packages/osd-apm-topology/src/shared/types/agent.types.ts
@@ -29,6 +29,8 @@ export type AgentNodeKind =
 export interface AgentNodeData extends BaseNodeData {
   nodeKind: AgentNodeKind;
   duration?: number;
+  /** Maximum duration (e.g., root trace duration) for scaling the latency bar. */
+  maxDuration?: number;
   latency?: string;
   tokens?: { prompt: number; completion: number };
   cost?: number;

--- a/packages/osd-apm-topology/src/shared/types/agent.types.ts
+++ b/packages/osd-apm-topology/src/shared/types/agent.types.ts
@@ -31,6 +31,8 @@ export interface AgentNodeData extends BaseNodeData {
   duration?: number;
   /** Maximum duration (e.g., root trace duration) for scaling the latency bar. */
   maxDuration?: number;
+  /** Start offset as a percentage (0–100) for Gantt-style bar positioning. */
+  startOffset?: number;
   latency?: string;
   tokens?: { prompt: number; completion: number };
   cost?: number;

--- a/packages/osd-apm-topology/src/shared/types/agent.types.ts
+++ b/packages/osd-apm-topology/src/shared/types/agent.types.ts
@@ -31,8 +31,6 @@ export interface AgentNodeData extends BaseNodeData {
   duration?: number;
   /** Maximum duration (e.g., root trace duration) for scaling the latency bar. */
   maxDuration?: number;
-  /** Start offset as a percentage (0–100) for Gantt-style bar positioning. */
-  startOffset?: number;
   latency?: string;
   tokens?: { prompt: number; completion: number };
   cost?: number;

--- a/src/plugins/agent_traces/public/services/flow_transform.test.ts
+++ b/src/plugins/agent_traces/public/services/flow_transform.test.ts
@@ -52,6 +52,7 @@ describe('spansToFlow', () => {
         nodeKind: 'agent',
         duration: 100,
         maxDuration: 100,
+        startOffset: undefined,
         latency: '100ms',
         status: undefined,
       },
@@ -175,5 +176,29 @@ describe('spansToFlow', () => {
 
     expect(spansToFlow([errorSpan]).nodes[0].data.status).toBe('error');
     expect(spansToFlow([successSpan]).nodes[0].data.status).toBeUndefined();
+  });
+
+  it('computes startOffset based on span start time relative to root', () => {
+    const root = makeSpan({
+      id: 'root',
+      spanId: 'root',
+      durationNanos: 1_000_000_000, // 1000ms
+      rawDocument: { startTime: '2025-05-29 03:11:25.000' },
+    });
+    const child = makeSpan({
+      id: 'child',
+      spanId: 'child',
+      category: 'LLM',
+      durationNanos: 200_000_000, // 200ms
+      rawDocument: { startTime: '2025-05-29 03:11:25.500' }, // 500ms after root
+    });
+    root.children = [child];
+
+    const { nodes } = spansToFlow([root]);
+
+    // Root starts at 0%
+    expect(nodes[0].data.startOffset).toBe(0);
+    // Child starts at 500ms / 1000ms = 50%
+    expect(nodes[1].data.startOffset).toBe(50);
   });
 });

--- a/src/plugins/agent_traces/public/services/flow_transform.test.ts
+++ b/src/plugins/agent_traces/public/services/flow_transform.test.ts
@@ -51,6 +51,7 @@ describe('spansToFlow', () => {
         title: 'TestAgent',
         nodeKind: 'agent',
         duration: 100,
+        maxDuration: 100,
         latency: '100ms',
         status: undefined,
       },

--- a/src/plugins/agent_traces/public/services/flow_transform.test.ts
+++ b/src/plugins/agent_traces/public/services/flow_transform.test.ts
@@ -52,7 +52,6 @@ describe('spansToFlow', () => {
         nodeKind: 'agent',
         duration: 100,
         maxDuration: 100,
-        startOffset: undefined,
         latency: '100ms',
         status: undefined,
       },
@@ -176,29 +175,5 @@ describe('spansToFlow', () => {
 
     expect(spansToFlow([errorSpan]).nodes[0].data.status).toBe('error');
     expect(spansToFlow([successSpan]).nodes[0].data.status).toBeUndefined();
-  });
-
-  it('computes startOffset based on span start time relative to root', () => {
-    const root = makeSpan({
-      id: 'root',
-      spanId: 'root',
-      durationNanos: 1_000_000_000, // 1000ms
-      rawDocument: { startTime: '2025-05-29 03:11:25.000' },
-    });
-    const child = makeSpan({
-      id: 'child',
-      spanId: 'child',
-      category: 'LLM',
-      durationNanos: 200_000_000, // 200ms
-      rawDocument: { startTime: '2025-05-29 03:11:25.500' }, // 500ms after root
-    });
-    root.children = [child];
-
-    const { nodes } = spansToFlow([root]);
-
-    // Root starts at 0%
-    expect(nodes[0].data.startOffset).toBe(0);
-    // Child starts at 500ms / 1000ms = 50%
-    expect(nodes[1].data.startOffset).toBe(50);
   });
 });

--- a/src/plugins/agent_traces/public/services/flow_transform.ts
+++ b/src/plugins/agent_traces/public/services/flow_transform.ts
@@ -8,6 +8,7 @@ import type { AgentNodeData, AgentNodeKind } from '@osd/apm-topology';
 // @ts-expect-error TS7016 TODO(ts-error): fixme
 import type { CelestialEdgeStyleData } from '@osd/apm-topology';
 import { CategorizedSpan, SpanCategory } from './span_categorization';
+import { parseTimestampMs } from '../application/pages/traces/trace_details/utils/span_timerange_utils';
 
 interface FlowNode {
   id: string;
@@ -52,10 +53,23 @@ export function spansToFlow(spanTree: CategorizedSpan[]): FlowTransformResult {
       ? spanTree[0].durationNanos / 1_000_000
       : 0;
 
+  // Root span start time for computing Gantt-style offsets
+  const rootStartMs =
+    spanTree.length > 0 ? parseTimestampMs(spanTree[0].rawDocument?.startTime) : 0;
+
   const processSpan = (span: CategorizedSpan, parentId?: string) => {
     const nodeId = span.spanId || span.id;
     const nodeKind = CATEGORY_TO_NODE_KIND[span.category] ?? 'other';
     const durationMs = span.durationNanos > 0 ? span.durationNanos / 1_000_000 : 0;
+
+    // Compute start offset as percentage of root duration
+    let startOffset: number | undefined;
+    if (rootDurationMs > 0 && rootStartMs > 0) {
+      const spanStartMs = parseTimestampMs(span.rawDocument?.startTime);
+      if (spanStartMs > 0) {
+        startOffset = ((spanStartMs - rootStartMs) / rootDurationMs) * 100;
+      }
+    }
 
     nodes.push({
       id: nodeId,
@@ -67,6 +81,7 @@ export function spansToFlow(spanTree: CategorizedSpan[]): FlowTransformResult {
         nodeKind,
         duration: durationMs > 0 ? durationMs : undefined,
         maxDuration: rootDurationMs > 0 ? rootDurationMs : undefined,
+        startOffset,
         latency: span.latency || undefined,
         status: span.status === 'error' ? 'error' : undefined,
       },

--- a/src/plugins/agent_traces/public/services/flow_transform.ts
+++ b/src/plugins/agent_traces/public/services/flow_transform.ts
@@ -46,6 +46,12 @@ export function spansToFlow(spanTree: CategorizedSpan[]): FlowTransformResult {
   const nodes: FlowNode[] = [];
   const edges: FlowEdge[] = [];
 
+  // Compute the root span duration to use as the max for latency bars
+  const rootDurationMs =
+    spanTree.length > 0 && spanTree[0].durationNanos > 0
+      ? spanTree[0].durationNanos / 1_000_000
+      : 0;
+
   const processSpan = (span: CategorizedSpan, parentId?: string) => {
     const nodeId = span.spanId || span.id;
     const nodeKind = CATEGORY_TO_NODE_KIND[span.category] ?? 'other';
@@ -60,6 +66,7 @@ export function spansToFlow(spanTree: CategorizedSpan[]): FlowTransformResult {
         title: span.displayName || span.name || 'Unknown',
         nodeKind,
         duration: durationMs > 0 ? durationMs : undefined,
+        maxDuration: rootDurationMs > 0 ? rootDurationMs : undefined,
         latency: span.latency || undefined,
         status: span.status === 'error' ? 'error' : undefined,
       },

--- a/src/plugins/agent_traces/public/services/flow_transform.ts
+++ b/src/plugins/agent_traces/public/services/flow_transform.ts
@@ -8,7 +8,6 @@ import type { AgentNodeData, AgentNodeKind } from '@osd/apm-topology';
 // @ts-expect-error TS7016 TODO(ts-error): fixme
 import type { CelestialEdgeStyleData } from '@osd/apm-topology';
 import { CategorizedSpan, SpanCategory } from './span_categorization';
-import { parseTimestampMs } from '../application/pages/traces/trace_details/utils/span_timerange_utils';
 
 interface FlowNode {
   id: string;
@@ -53,23 +52,10 @@ export function spansToFlow(spanTree: CategorizedSpan[]): FlowTransformResult {
       ? spanTree[0].durationNanos / 1_000_000
       : 0;
 
-  // Root span start time for computing Gantt-style offsets
-  const rootStartMs =
-    spanTree.length > 0 ? parseTimestampMs(spanTree[0].rawDocument?.startTime) : 0;
-
   const processSpan = (span: CategorizedSpan, parentId?: string) => {
     const nodeId = span.spanId || span.id;
     const nodeKind = CATEGORY_TO_NODE_KIND[span.category] ?? 'other';
     const durationMs = span.durationNanos > 0 ? span.durationNanos / 1_000_000 : 0;
-
-    // Compute start offset as percentage of root duration
-    let startOffset: number | undefined;
-    if (rootDurationMs > 0 && rootStartMs > 0) {
-      const spanStartMs = parseTimestampMs(span.rawDocument?.startTime);
-      if (spanStartMs > 0) {
-        startOffset = ((spanStartMs - rootStartMs) / rootDurationMs) * 100;
-      }
-    }
 
     nodes.push({
       id: nodeId,
@@ -81,7 +67,6 @@ export function spansToFlow(spanTree: CategorizedSpan[]): FlowTransformResult {
         nodeKind,
         duration: durationMs > 0 ? durationMs : undefined,
         maxDuration: rootDurationMs > 0 ? rootDurationMs : undefined,
-        startOffset,
         latency: span.latency || undefined,
         status: span.status === 'error' ? 'error' : undefined,
       },


### PR DESCRIPTION
### Description
Fix the agent traces flyout trace map tab where the latency bar for each span always shows at 50% regardless of actual duration, and add Gantt-style offset positioning.

**Root cause:** The `MetricBar` in `AgentCardNode` used `max={data.duration * 2}`, making the bar fill always `duration / (duration * 2) = 50%`.

**Fix:**
1. Pass the root span's duration as `maxDuration` through the flow transform, so each span's bar correctly shows its duration relative to the total trace duration.
2. Add an `offset` prop to `MetricBar` that pushes the bar fill to the right based on span start time relative to the root span (Gantt-style positioning).

### Issues Resolved
Resolves https://github.com/opensearch-project/dashboards-observability/issues/2720
Resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12196

### Screenshots

**Before (bug):** All bars at 50% regardless of actual span duration
![Before - all bars at 50%](https://github.com/joshuali925-osdbot/images/releases/download/v0/2720-before-trace-map.png)

**After (fix):** Bars proportional to root span duration with Gantt-style offset (bar position shows when span starts, bar width shows duration)
![After - Gantt-style bars with offset](https://github.com/joshuali925-osdbot/images/releases/download/v0/2720-after-ad934f71.png)

### Testing
- Unit tests pass for `flow_transform.test.ts` (12/12 including new offset test)
- Unit tests pass for `metric_bar.test.tsx` (9/9 including new offset tests)
- Unit tests pass for `agent_card_node.test.tsx` (12/12)
- Lint and i18n checks pass

### Changes
- `packages/osd-apm-topology/src/shared/types/agent.types.ts`: Add `maxDuration` and `startOffset` fields to `AgentNodeData`
- `packages/osd-apm-topology/src/components/nodes/metric_bar.tsx`: Add `offset` prop for Gantt-style left margin positioning
- `packages/osd-apm-topology/src/components/nodes/agent_card_node.tsx`: Use `maxDuration` for bar max and pass `startOffset` as offset
- `src/plugins/agent_traces/public/services/flow_transform.ts`: Compute root span duration/start time, pass `maxDuration` and `startOffset` to all nodes
- `src/plugins/agent_traces/public/services/flow_transform.test.ts`: Add test for offset computation
- `packages/osd-apm-topology/src/components/nodes/metric_bar.test.tsx`: Add tests for offset prop
