### PR TITLE
[Chat] Add role field to SlashCommandResult for assistant-style local messages

### DIFF
--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -329,13 +329,14 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           content: messageContent,
           rawMessage: messageContent,
         };
-        const systemMsg: SystemMessage = {
+        const role = commandResult.role ?? 'system';
+        const responseMsg: Message = {
           id: chatService.generateMessageId(),
-          role: 'system',
+          role,
           content: commandResult.localMessage,
-          ...(commandResult.title && { title: commandResult.title }),
+          ...(role === 'system' && commandResult.title && { title: commandResult.title }),
         };
-        setTimeline((prev) => [...prev, userMsg, systemMsg]);
+        setTimeline((prev) => [...prev, userMsg, responseMsg]);
         return;
       }
       // If command was handled and returned a message, send it to the AI

--- a/src/plugins/chat/public/services/slash_commands.test.ts
+++ b/src/plugins/chat/public/services/slash_commands.test.ts
@@ -508,6 +508,32 @@ describe('SlashCommandRegistry', () => {
       expect(result.handled).toBe(true);
       expect(result.localMessage).toBe('Info: some details');
     });
+
+    it('should return role when handler returns object with role', async () => {
+      slashCommandRegistry.register({
+        command: 'welcome',
+        description: 'Welcome command',
+        handler: () => ({ localMessage: 'Welcome!', role: 'assistant' as const }),
+      });
+
+      const result = await slashCommandRegistry.execute('/welcome');
+      expect(result.handled).toBe(true);
+      expect(result.localMessage).toBe('Welcome!');
+      expect(result.role).toBe('assistant');
+    });
+
+    it('should return undefined role when not specified', async () => {
+      slashCommandRegistry.register({
+        command: 'norole',
+        description: 'No role command',
+        handler: () => ({ localMessage: 'Error occurred' }),
+      });
+
+      const result = await slashCommandRegistry.execute('/norole');
+      expect(result.handled).toBe(true);
+      expect(result.localMessage).toBe('Error occurred');
+      expect(result.role).toBeUndefined();
+    });
   });
 
   describe('integration scenarios', () => {

--- a/src/plugins/chat/public/services/slash_commands.ts
+++ b/src/plugins/chat/public/services/slash_commands.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export type SlashCommandResult = string | { localMessage: string; title?: string };
+export type SlashCommandResult =
+  | string
+  | { localMessage: string; title?: string; role?: 'system' | 'assistant' };
 
 export interface SlashCommand {
   command: string;
@@ -46,7 +48,13 @@ class SlashCommandRegistry {
 
   async execute(
     input: string
-  ): Promise<{ handled: boolean; message?: string; localMessage?: string; title?: string }> {
+  ): Promise<{
+    handled: boolean;
+    message?: string;
+    localMessage?: string;
+    title?: string;
+    role?: 'system' | 'assistant';
+  }> {
     if (!input.startsWith('/')) {
       return { handled: false };
     }
@@ -63,7 +71,12 @@ class SlashCommandRegistry {
     try {
       const result = await command.handler(args);
       if (typeof result === 'object' && result !== null && 'localMessage' in result) {
-        return { handled: true, localMessage: result.localMessage, title: result.title };
+        return {
+          handled: true,
+          localMessage: result.localMessage,
+          title: result.title,
+          role: result.role,
+        };
       }
       return { handled: true, message: result };
     } catch (error) {


### PR DESCRIPTION
### Description

Add an optional `role` property to `SlashCommandResult` type to allow slash commands to render local messages as assistant bubbles instead of error rows. When `role='assistant'`, the message renders in the chat timeline as an assistant message. Defaults to `'system'` (error style) for backward compatibility.

**Changes:**
- Extend `SlashCommandResult` type: `{ localMessage: string; title?: string; role?: 'system' | 'assistant' }`
- Update `SlashCommandRegistry.execute()` to pass `role` through in the result
- Update `chat_window.tsx` to use `commandResult.role ?? 'system'` when rendering the local message

This enables slash commands to show informational/welcome messages (e.g., a welcome greeting with sample questions) without the red error styling.

### Issues Resolved

N/A - Enhancement for slash command framework

## Screenshot

N/A - Visual change depends on consuming plugin (dashboards-search-relevance PR #843)

## Testing the changes

1. Register a slash command returning `{ localMessage: "Welcome!", role: "assistant" }`
2. Type the command in chat
3. Verify the message renders as an assistant bubble (not a red error row)
4. Register a command returning `{ localMessage: "Error" }` (no role)
5. Verify it still renders as a red error row (backward compatible)

### Check List

- [x] New functionality includes testing
  - [x] 2 new unit tests for role field in `slash_commands.test.ts`
  - [x] All 42 slash_commands tests pass
  - [x] All 52 chat_window tests pass
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).