### PR TITLE
fix(explore): include data connection meta in metrics tab PromQL query

### DIFF
--- a/src/plugins/explore/public/application/pages/metrics/explore/services/prometheus_client.test.ts
+++ b/src/plugins/explore/public/application/pages/metrics/explore/services/prometheus_client.test.ts
@@ -205,3 +205,45 @@ describe('PrometheusClient resource calls propagate time range', () => {
     expect(rc.getMetrics).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('PrometheusClient.queryRange preserves data connection meta', () => {
+  it('keeps the dataset.dataSource.meta from the live query state', async () => {
+    const setFields = jest.fn();
+    const searchSource = {
+      setFields,
+      fetch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+    };
+    const dataset = {
+      id: 'conn-1',
+      title: 'prometheus',
+      type: 'PROMETHEUS',
+      dataSource: { meta: { name: 'my-prom', sessionId: 'abc' } },
+    };
+    const queryState = { language: 'PROMQL', query: '', dataset };
+    const dataView = { id: 'conn-1', type: 'PROMETHEUS' };
+
+    const services = ({
+      data: {
+        query: {
+          timefilter: { timefilter: { getTime: () => ({ from: 'now-1h', to: 'now' }) } },
+          queryString: { getQuery: () => queryState },
+        },
+        dataViews: {
+          get: jest.fn().mockResolvedValue(dataView),
+          getDefault: jest.fn().mockResolvedValue(dataView),
+          // convertToDataset would strip `meta`; assert it is NOT used to build the query.
+          convertToDataset: jest.fn().mockResolvedValue({ id: 'conn-1', title: 'prometheus' }),
+        },
+        search: { searchSource: { create: jest.fn().mockResolvedValue(searchSource) } },
+      },
+    } as unknown) as ExploreServices;
+
+    const client = new PrometheusClient(services, 'conn-1');
+    await client.queryRange('up');
+
+    expect(setFields).toHaveBeenCalledTimes(1);
+    const passedQuery = setFields.mock.calls[0][0].query;
+    expect(passedQuery.query).toBe('up');
+    expect(passedQuery.dataset.dataSource.meta).toEqual({ name: 'my-prom', sessionId: 'abc' });
+  });
+});

--- a/src/plugins/explore/public/application/pages/metrics/explore/services/prometheus_client.ts
+++ b/src/plugins/explore/public/application/pages/metrics/explore/services/prometheus_client.ts
@@ -249,12 +249,11 @@ export class PrometheusClient {
     if (!dataView) return [];
 
     const queryState = this.services.data.query.queryString.getQuery();
-    const dataset = await this.services.data.dataViews.convertToDataset(dataView);
     const searchSource = await this.services.data.search.searchSource.create();
     searchSource.setFields({
       index: dataView,
       size: 2000,
-      query: { ...queryState, dataset, query: promql },
+      query: { ...queryState, query: promql },
       highlightAll: false,
       version: false,
     });


### PR DESCRIPTION
### Description

Align the metrics tab with the query tab: reuse the live query state's dataset and override only the query string, so the data-connection meta reaches the server-side PromQL search strategy.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

unit tests

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
