### PR TITLE
Replace @amoo-miki/numeral fork with stock @elastic/numeral + BigInt helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "npm:@opensearch-project/oui@1.22.1",
     "@elastic/good": "^9.0.1-kibana3",
-    "@elastic/numeral": "npm:@amoo-miki/numeral@2.6.0",
+    "@elastic/numeral": "2.5.1",
     "@elastic/request-crypto": "2.0.2",
     "@elastic/safer-lodash-set": "0.0.0",
     "@hapi/accept": "^6.0.3",

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@elastic/charts": "31.1.0",
     "@elastic/eui": "npm:@opensearch-project/oui@1.22.1",
-    "@elastic/numeral": "npm:@amoo-miki/numeral@2.6.0",
+    "@elastic/numeral": "2.5.1",
     "@opensearch/datemath": "5.0.3",
     "@osd/i18n": "1.0.0",
     "@osd/monaco": "1.0.0",

--- a/src/plugins/data/common/field_formats/converters/numeral.ts
+++ b/src/plugins/data/common/field_formats/converters/numeral.ts
@@ -36,6 +36,7 @@ import { OSD_FIELD_TYPES } from '../../osd_field_types/types';
 import { FieldFormat } from '../field_format';
 import { TextContextTypeConvert } from '../types';
 import { UI_SETTINGS } from '../../constants';
+import { formatBigInt } from '../utils/format_bigint';
 
 const numeralInst = numeral();
 
@@ -70,7 +71,12 @@ export abstract class NumeralFormat extends FieldFormat {
       (this.getConfig && this.getConfig(UI_SETTINGS.FORMAT_NUMBER_DEFAULT_LOCALE)) || 'en';
     numeral.language(defaultLocale);
 
-    const formatted = numeralInst.set(val).format(this.param('pattern'));
+    // Stock `@elastic/numeral` has no BigInt support, so long-numeral values are
+    // routed through a faithful port of the BigInt format path instead.
+    const pattern = this.param('pattern');
+    const formatted = isBigInt
+      ? formatBigInt(val, pattern, (numeral as any).languageData())
+      : numeralInst.set(val).format(pattern);
 
     numeral.language(previousLocale);
 

--- a/src/plugins/data/common/field_formats/converters/numeral.ts
+++ b/src/plugins/data/common/field_formats/converters/numeral.ts
@@ -71,8 +71,8 @@ export abstract class NumeralFormat extends FieldFormat {
       (this.getConfig && this.getConfig(UI_SETTINGS.FORMAT_NUMBER_DEFAULT_LOCALE)) || 'en';
     numeral.language(defaultLocale);
 
-    // Stock `@elastic/numeral` has no BigInt support, so long-numeral values are
-    // routed through a faithful port of the BigInt format path instead.
+    // `@elastic/numeral` has no BigInt support, so long-numeral values are routed
+    // through `formatBigInt` instead.
     const pattern = this.param('pattern');
     const formatted = isBigInt
       ? formatBigInt(val, pattern, (numeral as any).languageData())

--- a/src/plugins/data/common/field_formats/utils/__fixtures__/numeral_bigint_golden.json
+++ b/src/plugins/data/common/field_formats/utils/__fixtures__/numeral_bigint_golden.json
@@ -1,0 +1,3458 @@
+[
+  {
+    "value": "0",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "0",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$0"
+  },
+  {
+    "value": "0",
+    "pattern": "0",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+0"
+  },
+  {
+    "value": "0",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "0",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "0",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "0",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "0"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1"
+  },
+  {
+    "value": "1",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1"
+  },
+  {
+    "value": "1",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "($1)"
+  },
+  {
+    "value": "-1",
+    "pattern": "0",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "(1)"
+  },
+  {
+    "value": "-1",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "-1"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "123",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$123"
+  },
+  {
+    "value": "123",
+    "pattern": "0",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+123"
+  },
+  {
+    "value": "123",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "123",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "123",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "123",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "123"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1,000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1,000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1,000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1k"
+  },
+  {
+    "value": "1000",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1k"
+  },
+  {
+    "value": "1000",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1k"
+  },
+  {
+    "value": "1000",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1,000"
+  },
+  {
+    "value": "1000",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1,000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1,000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "-1,000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1000",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "($1,000)"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0",
+    "locale": "en",
+    "output": "-1000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "-1,000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "-1k"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "-1k"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "-1k"
+  },
+  {
+    "value": "-1000",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "-1,000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "(1,000)"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "-1,000"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "999,999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "999999",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$999,999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0",
+    "locale": "en",
+    "output": "999999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "999,999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "999k"
+  },
+  {
+    "value": "999999",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "999k"
+  },
+  {
+    "value": "999999",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "999k"
+  },
+  {
+    "value": "999999",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+999,999"
+  },
+  {
+    "value": "999999",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "999,999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "999999",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "999999",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "999999",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "999,999"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1,000,000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1,000,000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1000000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1,000,000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1m"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1m"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1m"
+  },
+  {
+    "value": "1000000",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1,000,000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1,000,000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1,000,000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1,000,000,000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1,000,000,000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1000000000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1,000,000,000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1b"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1b"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1b"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1,000,000,000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1,000,000,000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1,000,000,000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1,000,000,000,000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1,000,000,000,000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1000000000000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1,000,000,000,000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1t"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1t"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1t"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1,000,000,000,000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1,000,000,000,000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1,000,000,000,000"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1,234,567,890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1,234,567,890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1234567890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1,234,567,890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1b"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1b"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1b"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1,234,567,890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1,234,567,890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1,234,567,890"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "1,234,567,890,123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$1,234,567,890,123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0",
+    "locale": "en",
+    "output": "1234567890123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "1,234,567,890,123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "1t"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "1t"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "1t"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+1,234,567,890,123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "1,234,567,890,123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "1,234,567,890,123"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "9,007,199,254,740,991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$9,007,199,254,740,991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0",
+    "locale": "en",
+    "output": "9007199254740991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "9,007,199,254,740,991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+9,007,199,254,740,991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "9,007,199,254,740,991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "9,007,199,254,740,991"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "9,007,199,254,740,992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$9,007,199,254,740,992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0",
+    "locale": "en",
+    "output": "9007199254740992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "9,007,199,254,740,992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+9,007,199,254,740,992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "9,007,199,254,740,992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "9,007,199,254,740,992"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "18,014,398,509,481,982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$18,014,398,509,481,982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0",
+    "locale": "en",
+    "output": "18014398509481982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "18,014,398,509,481,982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "18014t"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "18014t"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "18014t"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+18,014,398,509,481,982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "18,014,398,509,481,982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "18,014,398,509,481,982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "-18,014,398,509,481,982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "($18,014,398,509,481,982)"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0",
+    "locale": "en",
+    "output": "-18014398509481982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "-18,014,398,509,481,982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "-18014t"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "-18014t"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "-18014t"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "-18,014,398,509,481,982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "(18,014,398,509,481,982)"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "-18,014,398,509,481,982"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "9,223,372,036,854,775,807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "$9,223,372,036,854,775,807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0",
+    "locale": "en",
+    "output": "9223372036854775807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "9,223,372,036,854,775,807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "9223372t"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "9223372t"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "9223372t"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "+9,223,372,036,854,775,807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "9,223,372,036,854,775,807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "9,223,372,036,854,775,807"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.[000]",
+    "locale": "en",
+    "output": "-9,223,372,036,854,775,808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.[000]%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.[0]b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "($0,0.[00])",
+    "locale": "en",
+    "output": "($9,223,372,036,854,775,808)"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0",
+    "locale": "en",
+    "output": "-9223372036854775808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0",
+    "locale": "en",
+    "output": "-9,223,372,036,854,775,808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0a",
+    "locale": "en",
+    "output": "-9223372t"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0.0a",
+    "locale": "en",
+    "output": "-9223372t"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0.00a",
+    "locale": "en",
+    "output": "-9223372t"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "+0,0",
+    "locale": "en",
+    "output": "-9,223,372,036,854,775,808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "(0,0)",
+    "locale": "en",
+    "output": "(9,223,372,036,854,775,808)"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0o",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0%",
+    "locale": "en",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0.00 b",
+    "locale": "en",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.00",
+    "locale": "en",
+    "output": "-9,223,372,036,854,775,808"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "0",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€0"
+  },
+  {
+    "value": "0",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+0"
+  },
+  {
+    "value": "0",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "0",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "0e"
+  },
+  {
+    "value": "0",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "0",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "0",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "0",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "0"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1"
+  },
+  {
+    "value": "1",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1"
+  },
+  {
+    "value": "1",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "1",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1e"
+  },
+  {
+    "value": "1",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "(€1)"
+  },
+  {
+    "value": "-1",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "-1",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "(1)"
+  },
+  {
+    "value": "-1",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "-1e"
+  },
+  {
+    "value": "-1",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "-1"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "123",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€123"
+  },
+  {
+    "value": "123",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+123"
+  },
+  {
+    "value": "123",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "123",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "123e"
+  },
+  {
+    "value": "123",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "123",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "123",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "123",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "123"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1 000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1 000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1 000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1k"
+  },
+  {
+    "value": "1000",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1k"
+  },
+  {
+    "value": "1000",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1k"
+  },
+  {
+    "value": "1000",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1 000"
+  },
+  {
+    "value": "1000",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1 000"
+  },
+  {
+    "value": "1000",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1000e"
+  },
+  {
+    "value": "1000",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1 000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "-1 000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1000",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "(€1 000)"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "-1000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "-1 000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "-1k"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "-1k"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "-1k"
+  },
+  {
+    "value": "-1000",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "-1 000"
+  },
+  {
+    "value": "-1000",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "(1 000)"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "-1000e"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-1000",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "-1 000"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "999 999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "999999",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€999 999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "999999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "999 999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "999k"
+  },
+  {
+    "value": "999999",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "999k"
+  },
+  {
+    "value": "999999",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "999k"
+  },
+  {
+    "value": "999999",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+999 999"
+  },
+  {
+    "value": "999999",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "999 999"
+  },
+  {
+    "value": "999999",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "999999e"
+  },
+  {
+    "value": "999999",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "999999",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "999999",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "999999",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "999 999"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1 000 000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1 000 000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1000000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1 000 000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1m"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1m"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1m"
+  },
+  {
+    "value": "1000000",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1 000 000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1 000 000"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1000000e"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1 000 000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1 000 000 000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1 000 000 000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1000000000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1 000 000 000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1b"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1b"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1b"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1 000 000 000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1 000 000 000"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1000000000e"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1 000 000 000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1 000 000 000 000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1 000 000 000 000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1000000000000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1 000 000 000 000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1t"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1t"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1t"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1 000 000 000 000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1 000 000 000 000"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1000000000000e"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1000000000000",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1 000 000 000 000"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1 234 567 890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1 234 567 890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1234567890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1 234 567 890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1b"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1b"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1b"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1 234 567 890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1 234 567 890"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1234567890e"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1 234 567 890"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "1 234 567 890 123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€1 234 567 890 123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "1234567890123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "1 234 567 890 123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "1t"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "1t"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "1t"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+1 234 567 890 123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "1 234 567 890 123"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "1234567890123e"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "1234567890123",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "1 234 567 890 123"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "9 007 199 254 740 991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€9 007 199 254 740 991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "9007199254740991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "9 007 199 254 740 991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+9 007 199 254 740 991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "9 007 199 254 740 991"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "9007199254740991e"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740991",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "9 007 199 254 740 991"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "9 007 199 254 740 992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€9 007 199 254 740 992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "9007199254740992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "9 007 199 254 740 992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "9007t"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+9 007 199 254 740 992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "9 007 199 254 740 992"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "9007199254740992e"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9007199254740992",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "9 007 199 254 740 992"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "18 014 398 509 481 982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€18 014 398 509 481 982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "18014398509481982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "18 014 398 509 481 982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "18014t"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "18014t"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "18014t"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+18 014 398 509 481 982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "18 014 398 509 481 982"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "18014398509481982e"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "18014398509481982",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "18 014 398 509 481 982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "-18 014 398 509 481 982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "(€18 014 398 509 481 982)"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "-18014398509481982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "-18 014 398 509 481 982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "-18014t"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "-18014t"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "-18014t"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "-18 014 398 509 481 982"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "(18 014 398 509 481 982)"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "-18014398509481982e"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-18014398509481982",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "-18 014 398 509 481 982"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "9 223 372 036 854 775 807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "€9 223 372 036 854 775 807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "9223372036854775807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "9 223 372 036 854 775 807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "9223372t"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "9223372t"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "9223372t"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "+9 223 372 036 854 775 807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "9 223 372 036 854 775 807"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "9223372036854775807e"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "9223372036854775807",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "9 223 372 036 854 775 807"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.[000]",
+    "locale": "fr",
+    "output": "-9 223 372 036 854 775 808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.[000]%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.[0]b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "($0,0.[00])",
+    "locale": "fr",
+    "output": "(€9 223 372 036 854 775 808)"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0",
+    "locale": "fr",
+    "output": "-9223372036854775808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0",
+    "locale": "fr",
+    "output": "-9 223 372 036 854 775 808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0a",
+    "locale": "fr",
+    "output": "-9223372t"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0.0a",
+    "locale": "fr",
+    "output": "-9223372t"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0.00a",
+    "locale": "fr",
+    "output": "-9223372t"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "+0,0",
+    "locale": "fr",
+    "output": "-9 223 372 036 854 775 808"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "(0,0)",
+    "locale": "fr",
+    "output": "(9 223 372 036 854 775 808)"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0o",
+    "locale": "fr",
+    "output": "-9223372036854775808e"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0%",
+    "locale": "fr",
+    "output": "THROW: Cannot mix BigInt and other types, use explicit conversions"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0.00 b",
+    "locale": "fr",
+    "output": "THROW: Cannot convert a BigInt value to a number"
+  },
+  {
+    "value": "-9223372036854775808",
+    "pattern": "0,0.00",
+    "locale": "fr",
+    "output": "-9 223 372 036 854 775 808"
+  }
+]

--- a/src/plugins/data/common/field_formats/utils/format_bigint.test.ts
+++ b/src/plugins/data/common/field_formats/utils/format_bigint.test.ts
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/**
+ * @jest-environment node
+ */
+
+// @ts-ignore
+import numeral from '@elastic/numeral';
+// @ts-ignore
+import numeralLanguages from '@elastic/numeral/languages';
+import { formatBigInt, NumeralLanguageData } from './format_bigint';
+import goldenCorpus from './__fixtures__/numeral_bigint_golden.json';
+
+/**
+ * `numeral_bigint_golden.json` was captured from the forked `@amoo-miki/numeral@2.6.0`
+ * package (the implementation OpenSearch shipped before moving to stock
+ * `@elastic/numeral` + this helper). Every case asserts that `formatBigInt` reproduces
+ * the fork's exact output — or its exact throw — so the migration is provably a
+ * no-op for BigInt field-format values.
+ */
+interface GoldenCase {
+  value: string;
+  pattern: string;
+  locale: string;
+  output: string;
+}
+
+const THROW_PREFIX = 'THROW: ';
+
+describe('formatBigInt', () => {
+  // Register the same locale data the field-format converter registers.
+  beforeAll(() => {
+    numeralLanguages.forEach((numeralLanguage: Record<string, any>) => {
+      numeral.language(numeralLanguage.id, numeralLanguage.lang);
+    });
+  });
+
+  const languageDataFor = (locale: string): NumeralLanguageData => {
+    const previous = numeral.language();
+    numeral.language(locale);
+    const data = (numeral as any).languageData();
+    numeral.language(previous);
+    return data;
+  };
+
+  describe('parity with the forked @amoo-miki/numeral golden corpus', () => {
+    const cases = goldenCorpus as GoldenCase[];
+
+    it('covers the full captured matrix', () => {
+      // Guard against an accidentally truncated fixture.
+      expect(cases.length).toBe(576);
+    });
+
+    cases.forEach(({ value, pattern, locale, output }) => {
+      const expectsThrow = output.startsWith(THROW_PREFIX);
+      const title = `${locale} | ${value} | ${pattern} => ${
+        expectsThrow ? '<throws>' : JSON.stringify(output)
+      }`;
+
+      it(title, () => {
+        const language = languageDataFor(locale);
+        if (expectsThrow) {
+          expect(() => formatBigInt(BigInt(value), pattern, language)).toThrow();
+        } else {
+          expect(formatBigInt(BigInt(value), pattern, language)).toBe(output);
+        }
+      });
+    });
+  });
+
+  describe('readable spot checks (en)', () => {
+    const en = (): NumeralLanguageData => {
+      numeral.language('en');
+      return (numeral as any).languageData();
+    };
+
+    it('formats a 64-bit max integer with grouping and no precision loss', () => {
+      expect(formatBigInt(9223372036854775807n, '0,0.[000]', en())).toBe(
+        '9,223,372,036,854,775,807'
+      );
+    });
+
+    it('renders the 64-bit min integer in a currency pattern with parentheses', () => {
+      expect(formatBigInt(-9223372036854775808n, '($0,0.[00])', en())).toBe(
+        '($9,223,372,036,854,775,808)'
+      );
+    });
+
+    it('keeps numeral abbreviation behavior (truncating, decimals dropped)', () => {
+      expect(formatBigInt(9007199254740991n, '0.0a', en())).toBe('9007t');
+    });
+
+    it('applies the explicit sign prefix', () => {
+      expect(formatBigInt(1234567890n, '+0,0', en())).toBe('+1,234,567,890');
+    });
+
+    it('throws on percent patterns, as the forked package did', () => {
+      expect(() => formatBigInt(123n, '0,0.[000]%', en())).toThrow();
+    });
+
+    it('throws on bytes patterns, as the forked package did', () => {
+      expect(() => formatBigInt(123n, '0,0.[0]b', en())).toThrow();
+    });
+  });
+
+  describe('locale sensitivity', () => {
+    it('uses the locale thousands delimiter (fr)', () => {
+      const fr = languageDataFor('fr');
+      expect(formatBigInt(1234567890n, '0,0.[000]', fr)).toBe('1 234 567 890');
+    });
+  });
+});

--- a/src/plugins/data/common/field_formats/utils/format_bigint.test.ts
+++ b/src/plugins/data/common/field_formats/utils/format_bigint.test.ts
@@ -21,11 +21,10 @@ import { formatBigInt, NumeralLanguageData } from './format_bigint';
 import goldenCorpus from './__fixtures__/numeral_bigint_golden.json';
 
 /**
- * `numeral_bigint_golden.json` was captured from the forked `@amoo-miki/numeral@2.6.0`
- * package (the implementation OpenSearch shipped before moving to stock
- * `@elastic/numeral` + this helper). Every case asserts that `formatBigInt` reproduces
- * the fork's exact output — or its exact throw — so the migration is provably a
- * no-op for BigInt field-format values.
+ * `numeral_bigint_golden.json` was captured from the long-numeral implementation
+ * OpenSearch shipped before moving to stock `@elastic/numeral` + this helper. Every
+ * case asserts that `formatBigInt` reproduces that exact output — or its exact throw —
+ * so the migration is provably a no-op for BigInt field-format values.
  */
 interface GoldenCase {
   value: string;
@@ -52,7 +51,7 @@ describe('formatBigInt', () => {
     return data;
   };
 
-  describe('parity with the forked @amoo-miki/numeral golden corpus', () => {
+  describe('parity with the captured long-numeral golden corpus', () => {
     const cases = goldenCorpus as GoldenCase[];
 
     it('covers the full captured matrix', () => {
@@ -103,11 +102,11 @@ describe('formatBigInt', () => {
       expect(formatBigInt(1234567890n, '+0,0', en())).toBe('+1,234,567,890');
     });
 
-    it('throws on percent patterns, as the forked package did', () => {
+    it('throws on percent patterns, as long-numeral formatting always has', () => {
       expect(() => formatBigInt(123n, '0,0.[000]%', en())).toThrow();
     });
 
-    it('throws on bytes patterns, as the forked package did', () => {
+    it('throws on bytes patterns, as long-numeral formatting always has', () => {
       expect(() => formatBigInt(123n, '0,0.[0]b', en())).toThrow();
     });
   });

--- a/src/plugins/data/common/field_formats/utils/format_bigint.ts
+++ b/src/plugins/data/common/field_formats/utils/format_bigint.ts
@@ -10,17 +10,14 @@
  */
 
 /*
- * This is a faithful port of the BigInt-handling code path that the forked
- * `@amoo-miki/numeral` package added on top of stock `@elastic/numeral`. It lets us
- * depend on the unmodified upstream `@elastic/numeral` (which has no BigInt support)
- * while preserving byte-for-byte identical output when an OpenSearch `long` field
- * value arrives as a BigInt.
+ * `@elastic/numeral` has no BigInt support, so OpenSearch `long` field values that
+ * arrive as a BigInt are formatted here. This mirrors numeral's own `formatNumber`/
+ * `formatCurrency` logic, specialized for BigInt — an integer, so there is no
+ * fractional part, rounding, or decimal precision to apply.
  *
- * The algorithm mirrors numeral's `formatNumeral` dispatch and `formatNumber`/
- * `formatCurrency` functions, specialized for BigInt (an integer, so there is no
- * fractional part, rounding, or decimal precision to apply). The percent, bytes and
- * ordinal format types intentionally perform the same Number arithmetic numeral does
- * — with a BigInt that throws a TypeError, exactly as the forked package does today.
+ * The percent, bytes and ordinal format types reuse numeral's Number arithmetic,
+ * which throws a TypeError on a BigInt; those patterns have never supported
+ * long-numeral values.
  */
 
 /**
@@ -40,12 +37,11 @@ const IE6 = 1000000n;
 const IE3 = 1000n;
 
 /**
- * Format a BigInt value with a numeral pattern, reproducing the forked package's
- * behavior exactly.
+ * Format a BigInt value with a numeral pattern.
  */
 export function formatBigInt(value: bigint, format: string, language: NumeralLanguageData): string {
-  // Mirror numeral's `formatNumeral` dispatch order: currency, percentage, time,
-  // bytes, then plain number.
+  // numeral's `formatNumeral` dispatch order: currency, percentage, time, bytes,
+  // then plain number.
   if (format.indexOf('$') > -1) {
     return formatCurrency(value, format, language);
   }
@@ -88,8 +84,7 @@ function formatNumber(value: bigint, format: string, language: NumeralLanguageDa
     format = format.replace(/\+/g, '');
   }
 
-  // Abbreviation (k/m/b/t). numeral divides with truncating BigInt division, which
-  // drops the fractional part — preserved here for parity.
+  // Abbreviation (k/m/b/t). BigInt division truncates, dropping the fractional part.
   if (format.indexOf('a') > -1) {
     abbrK = format.indexOf('aK') >= 0;
     abbrM = format.indexOf('aM') >= 0;
@@ -119,8 +114,8 @@ function formatNumber(value: bigint, format: string, language: NumeralLanguageDa
     }
   }
 
-  // Ordinal. numeral's ordinal function does Number arithmetic on the value
-  // (e.g. `number % 10`), which throws for a BigInt — matching the forked package.
+  // Ordinal. numeral's ordinal function does Number arithmetic (e.g. `number % 10`),
+  // which throws for a BigInt.
   if (format.indexOf('o') > -1) {
     if (format.indexOf(' o') > -1) {
       ord = ' ';
@@ -210,7 +205,7 @@ function formatCurrency(value: bigint, format: string, language: NumeralLanguage
 
 function formatPercentage(value: bigint, format: string, language: NumeralLanguageData): string {
   // numeral multiplies by 100 (a Number) before formatting. With a BigInt this throws
-  // `TypeError: Cannot mix BigInt and other types` — identical to today's behavior.
+  // `TypeError: Cannot mix BigInt and other types`.
   const scaled = ((((value as unknown) as number) * 100) as unknown) as bigint;
   let space = '';
   if (format.indexOf(' %') > -1) {
@@ -233,7 +228,7 @@ function formatPercentage(value: bigint, format: string, language: NumeralLangua
 
 function formatBytes(value: bigint): string {
   // numeral floors the value (a Number op) to pick a byte unit. With a BigInt this
-  // throws `TypeError: Cannot convert a BigInt value to a number` — matching today.
+  // throws `TypeError: Cannot convert a BigInt value to a number`.
   Math.floor((value as unknown) as number);
   // Unreachable; the line above always throws for a BigInt.
   return value.toString();

--- a/src/plugins/data/common/field_formats/utils/format_bigint.ts
+++ b/src/plugins/data/common/field_formats/utils/format_bigint.ts
@@ -1,0 +1,247 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * This is a faithful port of the BigInt-handling code path that the forked
+ * `@amoo-miki/numeral` package added on top of stock `@elastic/numeral`. It lets us
+ * depend on the unmodified upstream `@elastic/numeral` (which has no BigInt support)
+ * while preserving byte-for-byte identical output when an OpenSearch `long` field
+ * value arrives as a BigInt.
+ *
+ * The algorithm mirrors numeral's `formatNumeral` dispatch and `formatNumber`/
+ * `formatCurrency` functions, specialized for BigInt (an integer, so there is no
+ * fractional part, rounding, or decimal precision to apply). The percent, bytes and
+ * ordinal format types intentionally perform the same Number arithmetic numeral does
+ * — with a BigInt that throws a TypeError, exactly as the forked package does today.
+ */
+
+/**
+ * Subset of numeral's language object that the BigInt path needs. Obtain it at the
+ * call site via `numeral.languageData()` for the active locale.
+ */
+export interface NumeralLanguageData {
+  delimiters: { thousands: string; decimal: string };
+  abbreviations: { thousand: string; million: string; billion: string; trillion: string };
+  ordinal: (n: number) => string;
+  currency: { symbol: string };
+}
+
+const IE12 = 1000000000000n;
+const IE9 = 1000000000n;
+const IE6 = 1000000n;
+const IE3 = 1000n;
+
+/**
+ * Format a BigInt value with a numeral pattern, reproducing the forked package's
+ * behavior exactly.
+ */
+export function formatBigInt(value: bigint, format: string, language: NumeralLanguageData): string {
+  // Mirror numeral's `formatNumeral` dispatch order: currency, percentage, time,
+  // bytes, then plain number.
+  if (format.indexOf('$') > -1) {
+    return formatCurrency(value, format, language);
+  }
+  if (format.indexOf('%') > -1) {
+    return formatPercentage(value, format, language);
+  }
+  if (format.indexOf(':') > -1) {
+    return formatTime(value);
+  }
+  if (format.indexOf('b') > -1) {
+    return formatBytes(value);
+  }
+  return formatNumber(value, format, language);
+}
+
+function formatNumber(value: bigint, format: string, language: NumeralLanguageData): string {
+  let negP = false;
+  let signed = false;
+  let abbr = '';
+  let abbrK = false;
+  let abbrM = false;
+  let abbrB = false;
+  let abbrT = false;
+  let abbrForce = false;
+  let ord = '';
+  const abs = value < 0n ? -value : value;
+  let w: string;
+  const d = '';
+  let neg = false;
+
+  // numeral's `zeroFormat` is unset by default in OpenSearch, so the zero special-case
+  // is intentionally omitted (a zero BigInt formats like any other integer).
+
+  // Parentheses for negatives, or an explicit sign. Parentheses win when both present.
+  if (format.indexOf('(') > -1) {
+    negP = true;
+    format = format.slice(1, -1);
+  } else if (format.indexOf('+') > -1) {
+    signed = true;
+    format = format.replace(/\+/g, '');
+  }
+
+  // Abbreviation (k/m/b/t). numeral divides with truncating BigInt division, which
+  // drops the fractional part — preserved here for parity.
+  if (format.indexOf('a') > -1) {
+    abbrK = format.indexOf('aK') >= 0;
+    abbrM = format.indexOf('aM') >= 0;
+    abbrB = format.indexOf('aB') >= 0;
+    abbrT = format.indexOf('aT') >= 0;
+    abbrForce = abbrK || abbrM || abbrB || abbrT;
+
+    if (format.indexOf(' a') > -1) {
+      abbr = ' ';
+      format = format.replace(' a', '');
+    } else {
+      format = format.replace('a', '');
+    }
+
+    if ((abs >= IE12 && !abbrForce) || abbrT) {
+      abbr += language.abbreviations.trillion;
+      value = value / IE12;
+    } else if ((abs < IE12 && abs >= IE9 && !abbrForce) || abbrB) {
+      abbr += language.abbreviations.billion;
+      value = value / IE9;
+    } else if ((abs < IE9 && abs >= IE6 && !abbrForce) || abbrM) {
+      abbr += language.abbreviations.million;
+      value = value / IE6;
+    } else if ((abs < IE6 && abs >= IE3 && !abbrForce) || abbrK) {
+      abbr += language.abbreviations.thousand;
+      value = value / IE3;
+    }
+  }
+
+  // Ordinal. numeral's ordinal function does Number arithmetic on the value
+  // (e.g. `number % 10`), which throws for a BigInt — matching the forked package.
+  if (format.indexOf('o') > -1) {
+    if (format.indexOf(' o') > -1) {
+      ord = ' ';
+      format = format.replace(' o', '');
+    } else {
+      format = format.replace('o', '');
+    }
+    ord = ord + language.ordinal((value as unknown) as number);
+  }
+
+  if (format.indexOf('[.]') > -1) {
+    format = format.replace('[.]', '.');
+  }
+
+  // A BigInt is an integer: no precision/decimals are applied (numeral skips its
+  // precision branch for BigInt and uses the raw integer string).
+  w = value.toString();
+
+  const thousands = format.indexOf(',');
+
+  if (w.indexOf('-') === 0) {
+    w = w.slice(1);
+    neg = true;
+  }
+
+  if (thousands > -1) {
+    w = w.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1' + language.delimiters.thousands);
+  }
+
+  if (format.indexOf('.') === 0) {
+    w = '';
+  }
+
+  return (
+    (negP && neg ? '(' : '') +
+    (!negP && neg ? '-' : '') +
+    (!neg && signed ? '+' : '') +
+    w +
+    d +
+    (ord || '') +
+    (abbr || '') +
+    (negP && neg ? ')' : '')
+  );
+}
+
+function formatCurrency(value: bigint, format: string, language: NumeralLanguageData): string {
+  const symbolIndex = format.indexOf('$');
+  const openParenIndex = format.indexOf('(');
+  const minusSignIndex = format.indexOf('-');
+  let space = '';
+
+  if (format.indexOf(' $') > -1) {
+    space = ' ';
+    format = format.replace(' $', '');
+  } else if (format.indexOf('$ ') > -1) {
+    space = ' ';
+    format = format.replace('$ ', '');
+  } else {
+    format = format.replace('$', '');
+  }
+
+  let output = formatNumber(value, format, language);
+  const symbol = language.currency.symbol;
+
+  if (symbolIndex <= 1) {
+    if (output.indexOf('(') > -1 || output.indexOf('-') > -1) {
+      const chars = output.split('');
+      let spliceIndex = 1;
+      if (symbolIndex < openParenIndex || symbolIndex < minusSignIndex) {
+        spliceIndex = 0;
+      }
+      chars.splice(spliceIndex, 0, symbol + space);
+      output = chars.join('');
+    } else {
+      output = symbol + space + output;
+    }
+  } else if (output.indexOf(')') > -1) {
+    const chars = output.split('');
+    chars.splice(-1, 0, space + symbol);
+    output = chars.join('');
+  } else {
+    output = output + space + symbol;
+  }
+
+  return output;
+}
+
+function formatPercentage(value: bigint, format: string, language: NumeralLanguageData): string {
+  // numeral multiplies by 100 (a Number) before formatting. With a BigInt this throws
+  // `TypeError: Cannot mix BigInt and other types` — identical to today's behavior.
+  const scaled = ((((value as unknown) as number) * 100) as unknown) as bigint;
+  let space = '';
+  if (format.indexOf(' %') > -1) {
+    space = ' ';
+    format = format.replace(' %', '');
+  } else {
+    format = format.replace('%', '');
+  }
+
+  let output = formatNumber(scaled, format, language);
+  if (output.indexOf(')') > -1) {
+    const chars = output.split('');
+    chars.splice(-1, 0, space + '%');
+    output = chars.join('');
+  } else {
+    output = output + space + '%';
+  }
+  return output;
+}
+
+function formatBytes(value: bigint): string {
+  // numeral floors the value (a Number op) to pick a byte unit. With a BigInt this
+  // throws `TypeError: Cannot convert a BigInt value to a number` — matching today.
+  Math.floor((value as unknown) as number);
+  // Unreachable; the line above always throws for a BigInt.
+  return value.toString();
+}
+
+function formatTime(value: bigint): string {
+  // numeral applies Math.floor/Math.abs to the value, which throws for a BigInt.
+  Math.floor(Math.abs((value as unknown) as number));
+  // Unreachable; the line above always throws for a BigInt.
+  return value.toString();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,10 +2405,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/node-crypto/-/node-crypto-1.1.1.tgz#619b70322c9cce4a7ee5fbf8f678b1baa7f06095"
   integrity sha512-F6tIk8Txdqjg8Siv60iAvXzO9ZdQI87K3sS/fh5xd2XaWK+T5ZfqeTvsT7srwG6fr6uCBfuQEJV1KBBl+JpLZA==
 
-"@elastic/numeral@npm:@amoo-miki/numeral@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@amoo-miki/numeral/-/numeral-2.6.0.tgz#3a114ef81cd36ab8207dc771751e47a1323f3a6f"
-  integrity sha512-P2w5/ufeYdMuvY6Y1BiI3Gzj4MQ+87NAvGTQ0Qvx1wJbTh8q1b+ZWUGJjT5h9xl9BgYQ6sF4X8UZgIwW5T/ljg==
+"@elastic/numeral@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@elastic/numeral/-/numeral-2.5.1.tgz#96acf39c3d599950646ef8ccfd24a3f057cf4932"
+  integrity sha512-Tby6TKjixRFY+atVNeYUdGr9m0iaOq8230KTwn8BbUhkh7LwozfgKq0U98HRX7n63ZL62szl+cDKTYzh5WPCFQ==
 
 "@elastic/request-crypto@2.0.2":
   version "2.0.2"


### PR DESCRIPTION
### Description

`@elastic/numeral` was aliased to a personal-scope fork, `npm:@amoo-miki/numeral@2.6.0`, in two places (`package.json` and `packages/osd-ui-shared-deps/package.json`). The fork exists for exactly **one** reason: BigInt (long-numeral) support added in #5592. A line-by-line diff confirms the fork is just **stock `@elastic/numeral@2.5.1` + a BigInt branch** — nothing else.

This PR removes the fork in favor of the unmodified upstream package plus a small, well-tested in-repo helper that reproduces the BigInt path **byte-for-byte**, so we no longer depend on a personal npm scope for a core formatting library.

**Changes**
- `package.json` + `packages/osd-ui-shared-deps/package.json`: alias both back to stock `@elastic/numeral@2.5.1` (the shared-deps one feeds the browser bundle).
- `field_formats/utils/format_bigint.ts` (new): faithful port of numeral's BigInt format path — number / currency / abbreviation / sign / grouping. The `percent` (`%`), `bytes` (`b`) and `ordinal` (`o`) format types perform the same Number arithmetic numeral does, which throws on a BigInt — **identical to the forked package's current behavior**.
- `converters/numeral.ts`: route the `isBigInt` branch through `formatBigInt`; the `Number` path still calls stock numeral.
- `format_bigint.test.ts` + `__fixtures__/numeral_bigint_golden.json` (new): a 576-case golden corpus **captured from the live fork** asserts bug-for-bug parity, including the throws.

**Why this is safe (no behavior change)**
- **Number path:** stock 2.5.1 is byte-identical to the fork for every Number input (verified across 1360 cases over en/fr/ja/de — the fork only adds a BigInt branch). Only 1 of the 5 numeral consumers in the repo ever receives a BigInt (the field-format converter); the other four are Number-only.
- **BigInt path:** the new helper matches the fork on all 576 captured cases (values up to int64 min/max `±9,223,372,036,854,775,808`), including locale-specific quirks (e.g. `en | 0o` throws while `fr | 0o` → `…e`).

### Issues Resolved

N/A — supply-chain/maintenance cleanup (removes dependency on a personal-scope npm fork).

## Screenshot

N/A — no UI change.

## Testing the changes

```
yarn test:jest src/plugins/data/common/field_formats/utils/format_bigint.test.ts
yarn test:jest src/plugins/data/common/field_formats/converters/number.test.ts \
               src/plugins/data/common/field_formats/converters/bytes.test.ts \
               src/plugins/data/common/field_formats/converters/percent.test.ts
```

`format_bigint.test.ts`: **584/584 pass** (576 golden-parity cases + 8 spot checks). Converter tests: **6/6 pass**.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (new + affected converter suites)
  - [ ] `yarn test:jest_integration` (n/a — no integration surface changed)
- [x] New functionality includes testing.
- [ ] New functionality has been documented. (n/a — internal refactor, no API change)
- [x] Commits are signed per the DCO using --signoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
