### PR TITLE
[Workspace] Mark requested IDs not returned by the API as sentinel to avoid re-fetching

### DIFF
--- a/src/core/server/security/identity_source_service.test.ts
+++ b/src/core/server/security/identity_source_service.test.ts
@@ -45,7 +45,7 @@ describe('IdentitySourceService', () => {
 
       expect(() => {
         service.registerIdentitySourceHandler(sourceA, mockHandler2);
-      }).toThrow("Identity source 'sourceA' has already been registered");
+      }).toThrow("Identity source for field 'source' has already been registered");
     });
 
     it('should support registering multiple different sources', () => {
@@ -80,7 +80,7 @@ describe('IdentitySourceService', () => {
 
       expect(() => {
         service.getIdentitySourceHandler(sourceB);
-      }).toThrow("Identity source 'sourceB' has not been registered");
+      }).toThrow("Invalid input for field 'source', no matching identity source handler found");
     });
 
     it('should throw an error with the correct source name in the message', () => {
@@ -90,7 +90,7 @@ describe('IdentitySourceService', () => {
 
       expect(() => {
         service.getIdentitySourceHandler(unknownSource);
-      }).toThrow(`Identity source 'unknown-source' has not been registered`);
+      }).toThrow("Invalid input for field 'source', no matching identity source handler found");
     });
   });
 
@@ -124,7 +124,7 @@ describe('IdentitySourceService', () => {
 
         service.registerIdentitySourceHandler(source, createMockHandler());
         expect(() => service.registerIdentitySourceHandler(source, createMockHandler())).toThrow(
-          `Identity source '${source}' has already been registered`
+          `Identity source for field 'source' has already been registered`
         );
       }
     );
@@ -136,7 +136,7 @@ describe('IdentitySourceService', () => {
         const service = new IdentitySourceService(logger);
 
         expect(() => service.getIdentitySourceHandler(source)).toThrow(
-          `Identity source '${source}' has not been registered`
+          `Invalid input for field 'source', no matching identity source handler found`
         );
       }
     );

--- a/src/core/server/security/identity_source_service.ts
+++ b/src/core/server/security/identity_source_service.ts
@@ -21,7 +21,7 @@ export class IdentitySourceService {
    */
   public registerIdentitySourceHandler(source: string, handler: IdentitySourceHandler): void {
     if (this.identitySource[source]) {
-      throw new Error(`Identity source '${source}' has already been registered`);
+      throw new Error(`Identity source for field 'source' has already been registered`);
     }
     this.identitySource[source] = handler;
     this.logger.info(`Register ${source} type identity source handler`);
@@ -33,7 +33,9 @@ export class IdentitySourceService {
   public getIdentitySourceHandler(source: string): IdentitySourceHandler {
     const handler = this.identitySource[source];
     if (!handler) {
-      throw new Error(`Identity source '${source}' has not been registered`);
+      throw new Error(
+        `Invalid input for field 'source', no matching identity source handler found`
+      );
     }
     return handler;
   }

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.test.tsx
@@ -266,6 +266,62 @@ describe('WorkspaceCollaboratorTable', () => {
     });
   });
 
+  it('should not re-fetch IDs that were requested but not returned by the API', async () => {
+    const httpPostMock = mockCoreStart.http.post as jest.Mock;
+    httpPostMock.mockClear();
+    // API returns nothing for 'unknown-user' — simulating a non-existent ID
+    httpPostMock.mockResolvedValue([]);
+
+    const typesWithIdentitySource: WorkspaceCollaboratorType[] = [
+      {
+        id: 'user',
+        name: 'User',
+        buttonLabel: 'Add Users',
+        onAdd: async () => {},
+        getDisplayedType: ({ permissionType }) => (permissionType === 'user' ? 'User' : undefined),
+        identitySource: { source: 'LDAP', type: 'user' },
+      },
+    ];
+
+    const permissionSettings = [
+      {
+        id: 0,
+        modes: [WorkspacePermissionMode.Read, WorkspacePermissionMode.LibraryRead],
+        type: WorkspacePermissionItemType.User,
+        userId: 'unknown-user',
+      },
+    ];
+
+    const { rerender } = render(
+      <Provider>
+        <WorkspaceCollaboratorTable
+          {...mockProps}
+          permissionSettings={permissionSettings}
+          displayedCollaboratorTypes={typesWithIdentitySource}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => expect(httpPostMock).toHaveBeenCalledTimes(1));
+
+    // Re-render with a new permissionSettings reference (same content) to trigger the effect
+    rerender(
+      <Provider>
+        <WorkspaceCollaboratorTable
+          {...mockProps}
+          permissionSettings={[...permissionSettings]}
+          displayedCollaboratorTypes={typesWithIdentitySource}
+        />
+      </Provider>
+    );
+
+    // Wait a tick to let any potential re-fetch fire
+    await act(async () => {});
+
+    // Should still be 1 — the sentinel prevents re-fetching the unresolvable ID
+    expect(httpPostMock).toHaveBeenCalledTimes(1);
+  });
+
   it('should render empty state when no permission settings', () => {
     const permissionSettings: any[] = [];
 

--- a/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
+++ b/src/plugins/workspace/public/components/workspace_form/workspace_collaborator_table.tsx
@@ -221,6 +221,10 @@ export const WorkspaceCollaboratorTable = ({
                 resp?.forEach(({ id, name, alias }) => {
                   newMap[id] = { name, alias };
                 });
+                // Mark requested IDs not returned by the API as sentinel to avoid re-fetching
+                slice.forEach((id) => {
+                  if (!(id in newMap)) newMap[id] = { name: '' };
+                });
               }
             } catch (e) {
               if ((e as Error).name !== 'AbortError') {


### PR DESCRIPTION
### Description

In the workspace collaborators page, if an user or a group is deleted, we cannot fetch its name by the identity entries API, we need to set the `name` field to a sentinel value for these deleted user or group, to avoid re-fetching its name in next render.

By the way, hide the user input `source` from the error message returned by the identity entries API, to improve security.

### Issues Resolved


## Screenshot
<img width="808" height="96" alt="image" src="https://github.com/user-attachments/assets/0ad93ddc-974f-49af-9a1b-7f74c55072cc" />


## Testing the changes


### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
