### PR TITLE
fix: preserve in-progress query editor input across auto-refresh re-renders

### DIFF
--- a/changelogs/fragments/12212.yml
+++ b/changelogs/fragments/12212.yml
@@ -1,0 +1,2 @@
+fix:
+- Preserve in-progress query editor input across auto-refresh re-renders ([#12212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12212))

--- a/src/plugins/data/public/ui/search_bar/search_bar.test.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.test.tsx
@@ -38,6 +38,7 @@ import { coreMock } from '../../../../../core/public/mocks';
 const startMock = coreMock.createStart();
 
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import { IIndexPattern } from '../..';
 
 const mockTimeHistory = {
@@ -276,6 +277,83 @@ describe('SearchBar', () => {
     expect(component.find(SEARCH_BAR_ROOT).length).toBe(1);
     expect(component.find(FILTER_BAR).length).toBe(1);
     expect(component.find(QUERY_BAR).length).toBe(1);
+  });
+
+  describe('getDerivedStateFromProps', () => {
+    const mountSearchBar = () =>
+      mount(
+        wrapSearchBarInContext({
+          indexPatterns: [mockIndexPattern],
+          screenTitle: 'test screen',
+          onQuerySubmit: noop,
+          query: dqlQuery,
+        })
+      );
+
+    it('Should keep the in-progress draft when re-rendered with an unchanged query prop (auto-refresh tick)', () => {
+      const component = mountSearchBar();
+      const instance = component.find('SearchBarUI').instance() as any;
+
+      // User types a draft without submitting
+      act(() => {
+        instance.onQueryBarChange({
+          query: { query: 'response:404', language: 'kuery' },
+          dateRange: { from: 'now-15m', to: 'now' },
+        });
+      });
+      component.update();
+      expect(instance.state.query.query).toBe('response:404');
+
+      // Auto-refresh re-renders the search bar with a new props object whose
+      // query is still the last submitted one
+      const derived = (instance.constructor as any).getDerivedStateFromProps(
+        { ...instance.props, query: { ...dqlQuery }, isQueryRunning: true },
+        instance.state
+      );
+
+      expect(derived.query).toBeUndefined();
+      expect(instance.state.query.query).toBe('response:404');
+    });
+
+    it('Should replace the draft when the query prop actually changes', () => {
+      const component = mountSearchBar();
+      const instance = component.find('SearchBarUI').instance() as any;
+
+      act(() => {
+        instance.onQueryBarChange({
+          query: { query: 'response:404', language: 'kuery' },
+          dateRange: { from: 'now-15m', to: 'now' },
+        });
+      });
+      component.update();
+
+      const derived = (instance.constructor as any).getDerivedStateFromProps(
+        { ...instance.props, query: { query: 'status:500', language: 'kuery' } },
+        instance.state
+      );
+
+      expect(derived.query).toEqual({
+        query: 'status:500',
+        language: 'kuery',
+        dataset: undefined,
+      });
+    });
+
+    it('Should reset the query when the language prop changes', () => {
+      const component = mountSearchBar();
+      const instance = component.find('SearchBarUI').instance() as any;
+
+      const derived = (instance.constructor as any).getDerivedStateFromProps(
+        { ...instance.props, query: { query: dqlQuery.query, language: 'lucene' } },
+        instance.state
+      );
+
+      expect(derived.query).toEqual({
+        query: '',
+        language: 'lucene',
+        dataset: undefined,
+      });
+    });
   });
 
   describe('Cancel Button Props', () => {

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -140,7 +140,14 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     }
 
     let nextQuery = null;
-    if (nextProps.query && nextProps.query.query !== prevState.query?.query) {
+    if (
+      nextProps.query &&
+      nextProps.query.query !== get(prevState, 'currentProps.query.query') &&
+      nextProps.query.query !== prevState.query?.query
+    ) {
+      // Sync the draft only when the query prop itself changed (e.g. a saved query was loaded).
+      // Re-renders that keep the same submitted query (e.g. auto-refresh ticks) must not
+      // overwrite what the user is currently typing.
       nextQuery = {
         query: nextProps.query.query,
         language: nextProps.query.language,


### PR DESCRIPTION
### Description

With query enhancements enabled (Monaco-based `QueryEditor`) and auto-refresh active, every refresh tick wipes whatever the user is typing in the query editor, reverting it to the last submitted query.

Root cause: each auto-refresh tick re-renders the search bar (query status props change), and `SearchBarUI.getDerivedStateFromProps` compared the incoming `query` prop (last submitted query) against the **local draft** (`prevState.query`). Since an unsubmitted draft always differs from the submitted query, the draft was overwritten on every tick and the value flowed down into the Monaco editor, replacing its content.

Fix: only sync the local draft from props when the `query` prop itself changed relative to the previous props (`prevState.currentProps.query.query`) — e.g. a saved query was loaded or the app updated the query externally. Re-renders that keep the same submitted query (auto-refresh ticks, query status updates) no longer clobber in-progress typing. Local flows (submit, language change, dataset change, saved query load) are unaffected: they either go through `setState` directly or through a real prop change.

### Issues Resolved

fixes #12211

## Screenshot

N/A — behavioral fix; no visual changes. Repro and expected behavior described in #12211.

## Testing the changes

1. Open Discover / Data Explorer with query enhancements enabled (DQL/PPL Monaco editor).
2. Enable auto-refresh with a short interval (e.g. 10 seconds).
3. Start typing a query without submitting it and wait for several refresh ticks.
4. Before this change: the editor content is replaced with the last submitted query on every tick. After this change: the in-progress text is preserved.
5. Verify saved query loading and language switching still update the editor as before.

Unit tests added in `search_bar.test.tsx` cover the three `getDerivedStateFromProps` scenarios (unchanged query prop preserves draft, changed query prop syncs, language change resets). The new draft-preservation test fails against the previous implementation.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (`src/plugins/data/public/ui`: 41 suites, 322 tests passing)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
