### PR TITLE
fix: address AI comment and pass-in correct data source id

### DIFF
--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -84,7 +84,9 @@ describe('ChatWindow', () => {
         content,
         rawMessage: rawMessage || content,
       })),
-      getAvailableDataSources: jest.fn().mockResolvedValue([]),
+      getAvailableDataSources: jest
+        .fn()
+        .mockResolvedValue([{ id: 'mock-ds-id', title: 'Mock DS' }]),
       setDataSourceId: jest.fn(),
       conversationHistoryService: {
         getMemoryProvider: jest.fn().mockReturnValue({
@@ -810,11 +812,8 @@ describe('ChatWindow', () => {
 
   describe('data source validation on send', () => {
     it('should show unsupported message when data source is AnalyticEngine', async () => {
-      // getCurrentDataSourceId returns undefined (validation fails)
-      mockChatService.getCurrentDataSourceId.mockResolvedValue(undefined);
-      // No compatible data sources available
+      mockChatService.getCurrentDataSourceId.mockResolvedValue('ds-analytic');
       mockChatService.getAvailableDataSources.mockResolvedValue([]);
-      // But an unsupported data source exists
       mockCore.savedObjects.client.get = jest.fn().mockResolvedValue({
         attributes: { dataSourceEngineType: 'AnalyticEngine' },
       });
@@ -834,11 +833,34 @@ describe('ChatWindow', () => {
       expect(mockChatService.sendMessage).not.toHaveBeenCalled();
     });
 
+    it('should show selector when current data source is invalid but alternatives exist', async () => {
+      // Current data source is unsupported, but compatible alternatives exist
+      mockChatService.getCurrentDataSourceId.mockResolvedValue('ds-analytic');
+      mockChatService.getAvailableDataSources.mockResolvedValue([
+        { id: 'ds-good', title: 'Good Source' },
+      ]);
+
+      const ref = React.createRef<ChatWindowInstance>();
+      const { getByRole, getByText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'hello' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Should show selector, not unsupported message
+      expect(mockChatService.sendMessage).not.toHaveBeenCalled();
+      expect(getByText('Good Source')).toBeTruthy();
+    });
+
     it('should show no data source message when no data sources exist at all', async () => {
       mockChatService.getCurrentDataSourceId.mockResolvedValue(undefined);
       mockChatService.getAvailableDataSources.mockResolvedValue([]);
-      // No unsupported data source either
-      mockCore.savedObjects.client.get = jest.fn().mockRejectedValue(new Error('Not found'));
 
       const ref = React.createRef<ChatWindowInstance>();
       const { getByRole } = renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -186,13 +186,10 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   });
 
   // Cache data source compatibility check to avoid network call on every message
-  const unsupportedDataSourceRef = useRef<{ dataSourceId: string | undefined; result: boolean } | null>(null);
+  const unsupportedDataSourceRef = useRef<{ dataSourceId: string; result: boolean } | null>(null);
 
-  const isUnsupportedDataSource = useCallback(async (): Promise<boolean> => {
+  const isUnsupportedDataSource = useCallback(async (dataSourceId: string): Promise<boolean> => {
     try {
-      const dataSourceId = await chatService.getCurrentDataSourceId();
-      if (!dataSourceId) return false;
-      // Return cached result if data source hasn't changed
       if (unsupportedDataSourceRef.current?.dataSourceId === dataSourceId) {
         return unsupportedDataSourceRef.current.result;
       }
@@ -206,10 +203,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       unsupportedDataSourceRef.current = { dataSourceId, result };
       return result;
     } catch {
-      // Fail-open: transient errors should not block AI features
       return false;
     }
-  }, [chatService, services.core?.savedObjects?.client]);
+  }, [services.core?.savedObjects?.client]);
 
   // Helper function to handle message streaming with observable subscription
   const subscribeToMessageStream = useCallback(async (
@@ -311,32 +307,37 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     const messagesToSend = [...timeline, ...additionalMessages];
 
     // Validate data source before sending
-    if (!(await chatService.getCurrentDataSourceId())) {
-      const dataSources = await chatService.getAvailableDataSources();
-      if (dataSources.length >= 1) {
-        // Compatible data sources exist but none selected — prompt user to pick one
+    const currentDataSourceId = await chatService.getCurrentDataSourceId();
+
+    // 1. Check if current data source is unsupported
+    if (currentDataSourceId && (await isUnsupportedDataSource(currentDataSourceId))) {
+      const userMsg = chatService.getUserMessage(messageContent);
+      const systemMsg: SystemMessage = {
+        id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        role: 'system',
+        content: i18n.translate('chat.dataSourceUnsupported', {
+          defaultMessage: 'The current data source does not support AI features.',
+        }),
+      };
+      setTimeline((prev) => [...prev, userMsg, systemMsg]);
+      return;
+    }
+
+    // 2. Check if current data source is valid (exists in available list)
+    const compatibleDataSources = await chatService.getAvailableDataSources();
+    const isValid = currentDataSourceId && compatibleDataSources.some((ds) => ds.id === currentDataSourceId);
+
+    if (!isValid) {
+      if (compatibleDataSources.length >= 1) {
+        // Compatible data sources exist — prompt user to pick one
         const userMsg = chatService.getUserMessage(messageContent);
         setPendingMessage(userMsg);
-        setAvailableDataSources(dataSources);
+        setAvailableDataSources(compatibleDataSources);
         setTimeline((prev) => [...prev, userMsg]);
         return;
       }
 
-      // Check if unsupported data sources exist (filtered out by getAvailableDataSources)
-      if (await isUnsupportedDataSource()) {
-        const userMsg = chatService.getUserMessage(messageContent);
-        const systemMsg: SystemMessage = {
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          role: 'system',
-          content: i18n.translate('chat.dataSourceUnsupported', {
-            defaultMessage: 'The current data source does not support AI features.',
-          }),
-        };
-        setTimeline((prev) => [...prev, userMsg, systemMsg]);
-        return;
-      }
-
-      // No data sources associated with this workspace
+      // 3. No data sources associated with this workspace
       const userMsg = chatService.getUserMessage(messageContent);
       const infoMsg: Message = {
         id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -2201,7 +2201,7 @@ describe('ChatService', () => {
       expect(result).toBe('ds-1');
     });
 
-    it('should return undefined when data source ID is not in available data sources', async () => {
+    it('should return data source ID even if not in available data sources', async () => {
       const { getDefaultDataSourceId } = jest.requireMock('../../../data_source_management/public');
       getDefaultDataSourceId.mockResolvedValue('ds-invalid');
 
@@ -2214,10 +2214,10 @@ describe('ChatService', () => {
 
       const result = await service.getCurrentDataSourceId();
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('ds-invalid');
     });
 
-    it('should return undefined when no data sources are available', async () => {
+    it('should return data source ID even when no compatible data sources are available', async () => {
       mockSavedObjectsClient.find.mockResolvedValue({ savedObjects: [] });
       const { getDefaultDataSourceId } = jest.requireMock('../../../data_source_management/public');
       getDefaultDataSourceId.mockResolvedValue('ds-1');
@@ -2231,7 +2231,7 @@ describe('ChatService', () => {
 
       const result = await service.getCurrentDataSourceId();
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('ds-1');
     });
 
     it('should return cachedDataSourceId when it is valid', async () => {
@@ -2248,7 +2248,7 @@ describe('ChatService', () => {
       expect(result).toBe('ds-2');
     });
 
-    it('should return undefined when cachedDataSourceId is not in available data sources', async () => {
+    it('should return cachedDataSourceId even if not in available data sources', async () => {
       const service = new (ChatService as any)(
         mockUiSettings,
         mockCoreChatService,
@@ -2259,7 +2259,7 @@ describe('ChatService', () => {
       service.setDataSourceId('ds-removed');
       const result = await service.getCurrentDataSourceId();
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('ds-removed');
     });
 
     it('should prioritize page context data source when valid', async () => {
@@ -2285,7 +2285,7 @@ describe('ChatService', () => {
       expect(result).toBe('ds-1');
     });
 
-    it('should return undefined when page context data source is not in available list', async () => {
+    it('should return page context data source even if not in available list', async () => {
       (global as any).window.assistantContextStore = {
         getAllContexts: jest.fn().mockReturnValue([
           {
@@ -2305,7 +2305,7 @@ describe('ChatService', () => {
 
       const result = await service.getCurrentDataSourceId();
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('ds-not-in-workspace');
     });
 
     afterEach(() => {

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -315,21 +315,14 @@ export class ChatService {
   }
 
   /**
-   * Get the current data source ID, validated against available data sources in the workspace.
+   * Get the current data source ID from all resolution sources.
    */
   public async getCurrentDataSourceId(): Promise<string | undefined> {
-    const dataSourceId =
+    return (
       this.getDataSourceFromPageContext() ||
       this.cachedDataSourceId ||
-      (await this.getWorkspaceAwareDataSourceId());
-
-    if (!dataSourceId) return undefined;
-
-    const available = await this.getAvailableDataSources();
-    if (available.length === 0) return undefined;
-    if (available.some((ds) => ds.id === dataSourceId)) return dataSourceId;
-
-    return undefined;
+      (await this.getWorkspaceAwareDataSourceId())
+    );
   }
 
   public async sendMessage(
@@ -365,7 +358,7 @@ export class ChatService {
     }
 
     // Get workspace-aware data source ID
-    const dataSourceId = await this.getWorkspaceAwareDataSourceId();
+    const dataSourceId = await this.getCurrentDataSourceId();
 
     // Get all contexts from the assistant context store (static + dynamic)
     const contextStore = (window as any).assistantContextStore;


### PR DESCRIPTION
### Description

Fixes data source validation logic in the chat plugin to correctly handle three distinct scenarios:

1. **Unsupported data source** — When the current data source is an AnalyticEngine type, show a clear "does not support AI features" message.
2. **Invalid/missing data source with alternatives available** — When the resolved data source is not in the compatible list but compatible alternatives exist, show the data source selector for the user to pick one.
3. **No data sources** — When no compatible data sources are associated with the workspace, inform the user to contact their workspace admin.

Key changes:
- `getCurrentDataSourceId()` now returns the raw resolved ID without validation (single responsibility — it resolves, callers validate).
- `isUnsupportedDataSource()` accepts a `dataSourceId` parameter instead of resolving internally, fixing a bug where it was unreachable dead code (it previously called `getCurrentDataSourceId()` inside a block that was only entered when `getCurrentDataSourceId()` returned undefined).
- `sendMessage()` in ChatService now uses `getCurrentDataSourceId()` to pass the correct data source ID to the agent, ensuring the user-selected data source is respected.

### Issues Resolved

fixes #12205 (review comments)

## Screenshot

N/A — no visual changes, logic fix only.

## Testing the changes

1. Configure a workspace with only an AnalyticEngine data source → send a message → verify "does not support AI features" system message appears.
2. Configure a workspace with a stale default data source ID (not matching any current data source) and one valid OpenSearch data source → send a message → verify the data source selector appears.
3. Configure a workspace with no data sources → send a message → verify "no data sources associated" assistant message appears.
4. Configure a workspace with a valid default data source → send a message → verify it sends normally without prompts.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
