### PR TITLE
fix(sample-data): exclude Observability (otel) sample set on AnalyticEngine data sources

### DIFF
--- a/changelogs/fragments/12216.yml
+++ b/changelogs/fragments/12216.yml
@@ -1,0 +1,2 @@
+fix:
+- Exclude the Observability (otel) sample data set on AnalyticEngine data sources, since its nested-field trace mappings cannot be created on a pluggable-dataformat domain ([#12216](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12216))

--- a/src/plugins/home/server/services/sample_data/routes/list.test.ts
+++ b/src/plugins/home/server/services/sample_data/routes/list.test.ts
@@ -274,7 +274,7 @@ describe('sample data list route', () => {
     );
   });
 
-  it('filters sample datasets to only logs and otel for AnalyticEngine data source', async () => {
+  it('filters sample datasets to only logs for AnalyticEngine data source', async () => {
     const mockDataSourceId = 'analyticEngineDataSource';
     const mockClient = jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce({ count: 1 });
 
@@ -342,10 +342,11 @@ describe('sample data list route', () => {
     expect(mockSOClient.get).toHaveBeenCalledWith('data-source', mockDataSourceId);
     expect(mockResponse.ok).toBeCalled();
 
-    // Verify that only logs and otel datasets are returned
+    // Verify that only the logs dataset is returned (otel is excluded because its
+    // nested-field trace mappings cannot be created on an AnalyticEngine domain)
     const responseBody = mockResponse.ok.mock.calls[0]?.[0]?.body as any[];
-    expect(responseBody).toHaveLength(2);
-    expect(responseBody.map((ds) => ds.id).sort()).toEqual(['logs', 'otel']);
+    expect(responseBody).toHaveLength(1);
+    expect(responseBody.map((ds) => ds.id).sort()).toEqual(['logs']);
   });
 
   it('returns all sample datasets for non-AnalyticEngine data source', async () => {

--- a/src/plugins/home/server/services/sample_data/routes/list.ts
+++ b/src/plugins/home/server/services/sample_data/routes/list.ts
@@ -54,7 +54,7 @@ export const createListRoute = (router: IRouter, sampleDatasets: SampleDatasetSc
       const workspaceState = getWorkspaceState(req);
       const workspaceId = workspaceState?.requestWorkspaceId;
 
-      // For AnalyticEngine (Mustang) datasource, only support Sample web logs (logs). The
+      // For AnalyticEngine datasource, only support Sample web logs (logs). The
       // Observability sample set (otel) is excluded because its trace index mappings use
       // `nested` fields (events/links), which the pluggable data format rejects at index
       // creation ("nested type is not supported with pluggable data format"), so installing

--- a/src/plugins/home/server/services/sample_data/routes/list.ts
+++ b/src/plugins/home/server/services/sample_data/routes/list.ts
@@ -54,12 +54,14 @@ export const createListRoute = (router: IRouter, sampleDatasets: SampleDatasetSc
       const workspaceState = getWorkspaceState(req);
       const workspaceId = workspaceState?.requestWorkspaceId;
 
-      // For AnalyticEngine (Mustang) datasource, only support Sample Observability Logs (otel) and Sample web logs (logs)
+      // For AnalyticEngine (Mustang) datasource, only support Sample web logs (logs). The
+      // Observability sample set (otel) is excluded because its trace index mappings use
+      // `nested` fields (events/links), which the pluggable data format rejects at index
+      // creation ("nested type is not supported with pluggable data format"), so installing
+      // it against an AnalyticEngine domain fails with an internal server error.
       let filteredSampleDatasets = sampleDatasets;
       if (await isAnalyticEngineDataSource(dataSourceId, context.core.savedObjects.client)) {
-        filteredSampleDatasets = sampleDatasets.filter(
-          (dataset) => dataset.id === 'logs' || dataset.id === 'otel'
-        );
+        filteredSampleDatasets = sampleDatasets.filter((dataset) => dataset.id === 'logs');
       }
 
       const registeredSampleDatasets = filteredSampleDatasets.map((sampleDataset) => {


### PR DESCRIPTION
## Description

The sample data list route (`GET /api/sample_data`) already restricts the available sample sets when the selected data source is an **AnalyticEngine** domain. It kept both `logs` and `otel`, but the **Observability sample set (`otel`) cannot be installed on a AnalyticEngine domain**.

The otel trace index mappings declare `nested` fields (`events` / `links`), and the pluggable data format rejects `nested` at index creation:

```
mapper_parsing_exception: nested type is not supported with pluggable data format on field [links]
```

So installing the Observability sample set against an AnalyticEngine data source fails with an internal server error — the user sees:

> Unable to install sample data set: Sample Observability Logs, Traces, and Metrics
> Internal Server Error

This change drops `otel` from the AnalyticEngine sample-set list, leaving **`logs` (Sample web logs)**, which has no nested fields and installs cleanly on AnalyticEngine. Non-AnalyticEngine data sources are unaffected and still see all four sample sets.

## Changes

- `src/plugins/home/server/services/sample_data/routes/list.ts` — the AnalyticEngine branch now filters to `dataset.id === 'logs'` (was `'logs' || 'otel'`); comment updated to explain the nested-field constraint.
- `src/plugins/home/server/services/sample_data/routes/list.test.ts` — the AnalyticEngine test now asserts only `['logs']` is returned. The non-AnalyticEngine test (all four sets) is unchanged.

## Testing

`yarn jest src/plugins/home/server/services/sample_data/routes/list.test.ts` — **7/7 pass**, including:
- `filters sample datasets to only logs for AnalyticEngine data source`
- `returns all sample datasets for non-AnalyticEngine data source`
- `returns all sample datasets when no data_source_id is provided`

Reproduced the underlying engine error directly against a local AnalyticEngine (pluggable-dataformat) cluster: creating an index with a `nested` `links` field returns `mapper_parsing_exception: nested type is not supported with pluggable data format on field [links]`.

## Check List
- [x] All tests pass
- [x] Unit tests updated to cover the new behavior
- [x] New functionality has been documented in code comments
- [ ] New functionality has been documented in the [changelog](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CHANGELOG.md) — changelog fragment added (see below)
- [x] Commits are signed per the DCO using `--signoff`
