### PR TITLE
Update opensearch-build workflow references from commit SHA to main

### DIFF
--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Code-Diff-Analyzer:
-    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@main
     if: github.repository == 'opensearch-project/OpenSearch-Dashboards'
     permissions:
       id-token: write  # github oidc to assume aws roles
@@ -18,7 +18,7 @@ jobs:
       update_pr_comment_with_analyzer_report: true
 
   Code-Diff-Reviewer:
-    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@main
     needs: Code-Diff-Analyzer
     if: github.repository == 'opensearch-project/OpenSearch-Dashboards'
     permissions:

--- a/.github/workflows/release_cypress_workflow.yml
+++ b/.github/workflows/release_cypress_workflow.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch-dashboards
 


### PR DESCRIPTION
### Description
This PR replaces SHA-pinned references to `opensearch-project/opensearch-build` reusable workflows with `@main` branch references.

Reusable workflows from `opensearch-build` should track the `main` branch rather than being pinned to specific commit SHAs, as these are internal org workflows that are maintained upstream.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).