### PR TITLE
fix(saved-objects): gate config import on advancedSettings.save capabilities

### DIFF
--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -762,80 +762,84 @@ describe('#importSavedObjectsFromStream', () => {
       expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
     });
 
-    test('early return if import contains config type object', async () => {
+    test('filters out config type objects when canImportConfig is false', async () => {
       const options = setupOptions();
       const configObj = createConfigObject();
       const collectedObjects = [configObj];
 
-      const errors = [
-        {
-          type: configObj.type,
-          id: configObj.id,
-          title: configObj.id,
-          meta: { title: configObj.id },
-          error: { type: 'unsupported_type' },
-        },
-      ];
       getMockFn(collectSavedObjects).mockResolvedValue({
         errors: [],
         collectedObjects,
         importIdMap: new Map(),
       });
+      getMockFn(createSavedObjects).mockResolvedValue({ errors: [], createdObjects: [] });
       const result = await importSavedObjectsFromStream(options);
-      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
-      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
-      expect(createSavedObjects).not.toHaveBeenCalled();
+      expect(result.success).toEqual(false);
+      expect(result.successCount).toEqual(0);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'config', id: configObj.id })])
+      );
     });
 
-    test('early return if import contains config type mixed with valid objects', async () => {
+    test('filters config objects but processes remaining valid objects', async () => {
       const options = setupOptions();
       const configObj = createConfigObject();
       const validObj = createObject();
       const collectedObjects = [validObj, configObj];
 
-      const errors = [
-        {
-          type: configObj.type,
-          id: configObj.id,
-          title: configObj.id,
-          meta: { title: configObj.id },
-          error: { type: 'unsupported_type' },
-        },
-      ];
       getMockFn(collectSavedObjects).mockResolvedValue({
         errors: [],
         collectedObjects,
         importIdMap: new Map(),
       });
+      getMockFn(createSavedObjects).mockResolvedValue({
+        errors: [],
+        createdObjects: [validObj],
+      });
       const result = await importSavedObjectsFromStream(options);
-      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
-      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
-      expect(createSavedObjects).not.toHaveBeenCalled();
+      expect(result.successCount).toEqual(1);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'config', id: configObj.id })])
+      );
+      expect(createSavedObjects).toHaveBeenCalled();
     });
 
-    test('early return if import contains config type in workspace-scoped import', async () => {
+    test('allows config type objects when canImportConfig is true', async () => {
+      const options = { ...setupOptions(), canImportConfig: true };
+      const configObj = createConfigObject();
+      const collectedObjects = [configObj];
+
+      getMockFn(collectSavedObjects).mockResolvedValue({
+        errors: [],
+        collectedObjects,
+        importIdMap: new Map(),
+      });
+      getMockFn(createSavedObjects).mockResolvedValue({
+        errors: [],
+        createdObjects: [configObj],
+      });
+      const result = await importSavedObjectsFromStream(options);
+      expect(result.successCount).toEqual(1);
+      expect(result.success).toEqual(true);
+      expect(createSavedObjects).toHaveBeenCalled();
+    });
+
+    test('filters out config type in workspace-scoped import when canImportConfig is false', async () => {
       const options = setupOptions(false, undefined, true, ['workspace-1']);
       const configObj = createConfigObject();
       const collectedObjects = [configObj];
 
-      const errors = [
-        {
-          type: configObj.type,
-          id: configObj.id,
-          title: configObj.id,
-          meta: { title: configObj.id },
-          error: { type: 'unsupported_type' },
-        },
-      ];
       getMockFn(collectSavedObjects).mockResolvedValue({
         errors: [],
         collectedObjects,
         importIdMap: new Map(),
       });
+      getMockFn(createSavedObjects).mockResolvedValue({ errors: [], createdObjects: [] });
       const result = await importSavedObjectsFromStream(options);
-      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
-      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
-      expect(createSavedObjects).not.toHaveBeenCalled();
+      expect(result.success).toEqual(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'config', id: configObj.id })])
+      );
     });
   });
 });

--- a/src/core/server/saved_objects/import/import_saved_objects.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.ts
@@ -63,6 +63,7 @@ export async function importSavedObjectsFromStream({
   workspaces,
   dataSourceEnabled,
   isCopy,
+  canImportConfig,
 }: SavedObjectsImportOptions): Promise<SavedObjectsImportResponse> {
   let errorAccumulator: SavedObjectsImportError[] = [];
   const supportedTypes = typeRegistry.getImportableAndExportableTypes().map((type) => type.name);
@@ -74,27 +75,26 @@ export async function importSavedObjectsFromStream({
     supportedTypes,
     dataSourceId,
   });
-  const configErrors: SavedObjectsImportError[] = collectSavedObjectsResult.collectedObjects
-    .filter((obj) => obj.type === 'config')
-    .map((obj) => ({
-      error: { type: 'unsupported_type' } as SavedObjectsImportUnsupportedTypeError,
-      type: obj.type,
-      id: obj.id,
-      title: obj.id,
-      meta: { title: obj.id },
-    }));
-  if (configErrors.length > 0) {
-    return {
-      successCount: 0,
-      success: false,
-      errors: configErrors,
-    };
+  let collectedObjects = collectSavedObjectsResult.collectedObjects;
+
+  if (!canImportConfig) {
+    const configErrors: SavedObjectsImportError[] = collectedObjects
+      .filter((obj) => obj.type === 'config')
+      .map((obj) => ({
+        error: { type: 'unsupported_type' } as SavedObjectsImportUnsupportedTypeError,
+        type: obj.type,
+        id: obj.id,
+        title: obj.id,
+        meta: { title: obj.id },
+      }));
+    errorAccumulator = [...errorAccumulator, ...configErrors];
+    collectedObjects = collectedObjects.filter((obj) => obj.type !== 'config');
   }
 
   // if dataSource is not enabled, but object type is data-source, or saved object id contains datasource id
   // return unsupported type error
   if (!dataSourceEnabled) {
-    const notSupportedErrors: SavedObjectsImportError[] = collectSavedObjectsResult.collectedObjects.reduce(
+    const notSupportedErrors: SavedObjectsImportError[] = collectedObjects.reduce(
       (errors: SavedObjectsImportError[], obj) => {
         if (obj.type === 'data-source' || isSavedObjectWithDataSource(obj.id)) {
           const error: SavedObjectsImportUnsupportedTypeError = { type: 'unsupported_type' };
@@ -121,7 +121,7 @@ export async function importSavedObjectsFromStream({
 
   // Validate references
   const validateReferencesResult = await validateReferences(
-    collectSavedObjectsResult.collectedObjects,
+    collectedObjects,
     savedObjectsClient,
     namespace
   );
@@ -129,11 +129,9 @@ export async function importSavedObjectsFromStream({
 
   if (isCopy) {
     // Data sources can only be assigned to workspaces and can not be copied between workspaces.
-    collectSavedObjectsResult.collectedObjects = collectSavedObjectsResult.collectedObjects.filter(
-      (obj) => obj.type !== 'data-source'
-    );
+    collectedObjects = collectedObjects.filter((obj) => obj.type !== 'data-source');
     const validateDataSourcesResult = await validateDataSources(
-      collectSavedObjectsResult.collectedObjects,
+      collectedObjects,
       savedObjectsClient,
       errorAccumulator,
       workspaces
@@ -143,12 +141,12 @@ export async function importSavedObjectsFromStream({
 
   if (createNewCopies) {
     // randomly generated id
-    importIdMap = regenerateIds(collectSavedObjectsResult.collectedObjects, dataSourceId);
+    importIdMap = regenerateIds(collectedObjects, dataSourceId);
   } else {
     // in check conclict and override mode
     // Check single-namespace objects for conflicts in this namespace, and check multi-namespace objects for conflicts across all namespaces
     const checkConflictsParams = {
-      objects: collectSavedObjectsResult.collectedObjects,
+      objects: collectedObjects,
       savedObjectsClient,
       namespace,
       ignoreRegularConflicts: overwrite,
@@ -195,8 +193,8 @@ export async function importSavedObjectsFromStream({
   // Create objects in bulk
   const createSavedObjectsParams = {
     objects: dataSourceId
-      ? collectSavedObjectsResult.collectedObjects.filter((object) => object.type !== 'data-source')
-      : collectSavedObjectsResult.collectedObjects,
+      ? collectedObjects.filter((object) => object.type !== 'data-source')
+      : collectedObjects,
     accumulatedErrors: errorAccumulator,
     savedObjectsClient,
     importIdMap,

--- a/src/core/server/saved_objects/import/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.test.ts
@@ -538,31 +538,49 @@ describe('#importSavedObjectsFromStream', () => {
       expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
     });
 
-    test('early return if resolve contains config type object', async () => {
+    test('filters out config type objects when canImportConfig is false', async () => {
       const configObj = createConfigObject();
       const options = setupOptions([
         { type: 'config', id: configObj.id, overwrite: true, replaceReferences: [] },
       ]);
       const collectedObjects = [configObj];
 
-      const errors = [
-        {
-          type: configObj.type,
-          id: configObj.id,
-          title: configObj.id,
-          meta: { title: configObj.id },
-          error: { type: 'unsupported_type' },
-        },
-      ];
       getMockFn(collectSavedObjects).mockResolvedValue({
         errors: [],
         collectedObjects,
         importIdMap: new Map(),
       });
+      getMockFn(createSavedObjects).mockResolvedValue({ errors: [], createdObjects: [] });
       const result = await resolveSavedObjectsImportErrors(options);
-      const expectedErrors = errors.map(({ type, id }) => expect.objectContaining({ type, id }));
-      expect(result).toEqual({ success: false, successCount: 0, errors: expectedErrors });
-      expect(createSavedObjects).not.toHaveBeenCalled();
+      expect(result.success).toEqual(false);
+      expect(result.successCount).toEqual(0);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'config', id: configObj.id })])
+      );
+    });
+
+    test('allows config type objects when canImportConfig is true', async () => {
+      const configObj = createConfigObject();
+      const options = {
+        ...setupOptions([
+          { type: 'config', id: configObj.id, overwrite: true, replaceReferences: [] },
+        ]),
+        canImportConfig: true,
+      };
+      const collectedObjects = [configObj];
+
+      getMockFn(collectSavedObjects).mockResolvedValue({
+        errors: [],
+        collectedObjects,
+        importIdMap: new Map(),
+      });
+      getMockFn(createSavedObjects)
+        .mockResolvedValueOnce({ errors: [], createdObjects: [configObj] })
+        .mockResolvedValueOnce({ errors: [], createdObjects: [] });
+      const result = await resolveSavedObjectsImportErrors(options);
+      expect(result.successCount).toEqual(1);
+      expect(result.success).toEqual(true);
+      expect(createSavedObjects).toHaveBeenCalled();
     });
   });
 });

--- a/src/core/server/saved_objects/import/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.ts
@@ -63,6 +63,7 @@ export async function resolveSavedObjectsImportErrors({
   dataSourceId,
   dataSourceTitle,
   workspaces,
+  canImportConfig,
 }: SavedObjectsResolveImportErrorsOptions): Promise<SavedObjectsImportResponse> {
   // throw a BadRequest error if we see invalid retries
   validateRetries(retries);
@@ -74,32 +75,28 @@ export async function resolveSavedObjectsImportErrors({
   const filter = createObjectsFilter(retries);
 
   // Get the objects to resolve errors
-  const { errors: collectorErrors, collectedObjects: objectsToResolve } = await collectSavedObjects(
-    {
-      readStream,
-      objectLimit,
-      filter,
-      supportedTypes,
-      dataSourceId,
-    }
-  );
+  const { errors: collectorErrors, collectedObjects } = await collectSavedObjects({
+    readStream,
+    objectLimit,
+    filter,
+    supportedTypes,
+    dataSourceId,
+  });
   errorAccumulator = [...errorAccumulator, ...collectorErrors];
+  let objectsToResolve = collectedObjects;
 
-  const configErrors: SavedObjectsImportError[] = objectsToResolve
-    .filter((obj) => obj.type === 'config')
-    .map((obj) => ({
-      error: { type: 'unsupported_type' } as SavedObjectsImportUnsupportedTypeError,
-      type: obj.type,
-      id: obj.id,
-      title: obj.id,
-      meta: { title: obj.id },
-    }));
-  if (configErrors.length > 0) {
-    return {
-      successCount: 0,
-      success: false,
-      errors: configErrors,
-    };
+  if (!canImportConfig) {
+    const configErrors: SavedObjectsImportError[] = objectsToResolve
+      .filter((obj) => obj.type === 'config')
+      .map((obj) => ({
+        error: { type: 'unsupported_type' } as SavedObjectsImportUnsupportedTypeError,
+        type: obj.type,
+        id: obj.id,
+        title: obj.id,
+        meta: { title: obj.id },
+      }));
+    errorAccumulator = [...errorAccumulator, ...configErrors];
+    objectsToResolve = objectsToResolve.filter((obj) => obj.type !== 'config');
   }
 
   // Create a map of references to replace for each object to avoid iterating through

--- a/src/core/server/saved_objects/import/types.ts
+++ b/src/core/server/saved_objects/import/types.ts
@@ -202,6 +202,8 @@ export interface SavedObjectsImportOptions {
   dataSourceEnabled?: boolean;
   workspaces?: SavedObjectsBaseOptions['workspaces'];
   isCopy?: boolean;
+  /** If true, allows importing config-type saved objects. Requires advancedSettings.save capability. */
+  canImportConfig?: boolean;
 }
 
 /**
@@ -227,6 +229,8 @@ export interface SavedObjectsResolveImportErrorsOptions {
   dataSourceTitle?: string;
   /** if specified, will import in given workspaces */
   workspaces?: SavedObjectsBaseOptions['workspaces'];
+  /** If true, allows importing config-type saved objects. Requires advancedSettings.save capability. */
+  canImportConfig?: boolean;
 }
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };

--- a/src/core/server/saved_objects/routes/import.ts
+++ b/src/core/server/saved_objects/routes/import.ts
@@ -31,7 +31,8 @@
 import { Readable } from 'stream';
 import { extname } from 'path';
 import { schema } from '@osd/config-schema';
-import { IRouter } from '../../http';
+import { IRouter, OpenSearchDashboardsRequest } from '../../http';
+import { Capabilities } from '../../capabilities';
 import { importSavedObjectsFromStream } from '../import';
 import { SavedObjectConfig } from '../saved_objects_config';
 import { createSavedObjectsStreamFromNdJson } from './utils';
@@ -42,7 +43,30 @@ interface FileStream extends Readable {
   };
 }
 
-export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) => {
+export type CapabilitiesResolver = (request: OpenSearchDashboardsRequest) => Promise<Capabilities>;
+
+export async function resolveCanImportConfig(
+  getCapabilities: (() => CapabilitiesResolver | undefined) | undefined,
+  request: OpenSearchDashboardsRequest
+): Promise<boolean> {
+  const resolver = getCapabilities?.();
+  if (resolver) {
+    const capabilities = await resolver(request);
+    return capabilities.advancedSettings?.save === true;
+  }
+  // Resolver is absent (capabilities service not yet started). This cannot
+  // happen during normal request handling because the HTTP server only begins
+  // accepting connections after server.start() completes, which is after
+  // capabilitiesStart is set. Failing closed (blocking config import) is the
+  // safe default.
+  return false;
+}
+
+export const registerImportRoute = (
+  router: IRouter,
+  config: SavedObjectConfig,
+  getCapabilities?: () => CapabilitiesResolver | undefined
+) => {
   const { maxImportExportSize, maxImportPayloadBytes } = config;
 
   router.post(
@@ -119,6 +143,8 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
 
       const dataSourceEnabled = req.query.dataSourceEnabled;
 
+      const canImportConfig = await resolveCanImportConfig(getCapabilities, req);
+
       const result = await importSavedObjectsFromStream({
         savedObjectsClient: context.core.savedObjects.client,
         typeRegistry: context.core.savedObjects.typeRegistry,
@@ -130,6 +156,7 @@ export const registerImportRoute = (router: IRouter, config: SavedObjectConfig) 
         dataSourceTitle,
         workspaces,
         dataSourceEnabled,
+        canImportConfig,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/routes/index.ts
+++ b/src/core/server/saved_objects/routes/index.ts
@@ -42,7 +42,7 @@ import { registerBulkCreateRoute } from './bulk_create';
 import { registerBulkUpdateRoute } from './bulk_update';
 import { registerLogLegacyImportRoute } from './log_legacy_import';
 import { registerExportRoute } from './export';
-import { registerImportRoute } from './import';
+import { registerImportRoute, CapabilitiesResolver } from './import';
 import { registerResolveImportErrorsRoute } from './resolve_import_errors';
 import { registerMigrateRoute } from './migrate';
 
@@ -51,11 +51,13 @@ export function registerRoutes({
   logger,
   config,
   migratorPromise,
+  getCapabilities,
 }: {
   http: InternalHttpServiceSetup;
   logger: Logger;
   config: SavedObjectConfig;
   migratorPromise: Promise<IOpenSearchDashboardsMigrator>;
+  getCapabilities?: () => CapabilitiesResolver | undefined;
 }) {
   const router = http.createRouter('/api/saved_objects/');
 
@@ -82,8 +84,8 @@ export function registerRoutes({
   registerBulkUpdateRoute(router);
   registerLogLegacyImportRoute(router, logger);
   registerExportRoute(router, config);
-  registerImportRoute(router, config);
-  registerResolveImportErrorsRoute(router, config);
+  registerImportRoute(router, config, getCapabilities);
+  registerResolveImportErrorsRoute(router, config, getCapabilities);
 
   const internalRouter = http.createRouter('/internal/saved_objects/');
 

--- a/src/core/server/saved_objects/routes/integration_tests/import.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/import.test.ts
@@ -558,4 +558,107 @@ describe(`POST ${URL}`, () => {
       );
     });
   });
+
+  describe('config type capability gating', () => {
+    const configObject =
+      '{"type":"config","id":"test-config","attributes":{"dismissedAt":"2026-01-01T00:00:00Z"}}';
+    const dashboardObject =
+      '{"type":"dashboard","id":"my-dashboard","attributes":{"title":"Look at my dashboard"}}';
+
+    const makeRequest = (...lines: string[]) =>
+      supertest(httpSetup.server.listener)
+        .post(URL)
+        .set('content-Type', 'multipart/form-data; boundary=BOUNDARY')
+        .send(
+          [
+            '--BOUNDARY',
+            'Content-Disposition: form-data; name="file"; filename="export.ndjson"',
+            'Content-Type: application/ndjson',
+            '',
+            ...lines,
+            '--BOUNDARY--',
+          ].join('\r\n')
+        );
+
+    describe('when getCapabilities resolver is absent (fail-safe)', () => {
+      it('blocks config objects', async () => {
+        const result = await makeRequest(configObject).expect(200);
+        expect(result.body.success).toBe(false);
+        expect(result.body.errors[0]).toEqual(
+          expect.objectContaining({ type: 'config', error: { type: 'unsupported_type' } })
+        );
+      });
+    });
+
+    describe('when resolver returns advancedSettings.save=false', () => {
+      beforeEach(async () => {
+        await server.stop();
+        ({ server, httpSetup, handlerContext } = await setupServer());
+        handlerContext.savedObjects.typeRegistry.getImportableAndExportableTypes.mockReturnValue(
+          [...allowedTypes, 'config'].map(createExportableType)
+        );
+        handlerContext.savedObjects.typeRegistry.getType.mockImplementation(
+          (type: string) => ({ management: { icon: `${type}-icon` } } as any)
+        );
+        savedObjectsClient = handlerContext.savedObjects.client;
+        savedObjectsClient.find.mockResolvedValue(emptyResponse);
+        savedObjectsClient.checkConflicts.mockResolvedValue({ errors: [] });
+
+        const router = httpSetup.createRouter('/internal/saved_objects/');
+        const mockResolver = jest.fn().mockResolvedValue({ advancedSettings: { save: false } });
+        registerImportRoute(router, config, () => mockResolver);
+
+        const dynamicConfigService = dynamicConfigServiceMock.createInternalStartContract();
+        await server.start({ dynamicConfigService });
+      });
+
+      it('blocks config objects and processes other objects', async () => {
+        savedObjectsClient.bulkCreate.mockResolvedValueOnce({
+          saved_objects: [mockDashboard],
+        });
+
+        const result = await makeRequest(configObject, dashboardObject).expect(200);
+        expect(result.body.successCount).toBe(1);
+        expect(result.body.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: 'config', error: { type: 'unsupported_type' } }),
+          ])
+        );
+      });
+    });
+
+    describe('when resolver returns advancedSettings.save=true', () => {
+      beforeEach(async () => {
+        await server.stop();
+        ({ server, httpSetup, handlerContext } = await setupServer());
+        handlerContext.savedObjects.typeRegistry.getImportableAndExportableTypes.mockReturnValue(
+          [...allowedTypes, 'config'].map(createExportableType)
+        );
+        handlerContext.savedObjects.typeRegistry.getType.mockImplementation(
+          (type: string) => ({ management: { icon: `${type}-icon` } } as any)
+        );
+        savedObjectsClient = handlerContext.savedObjects.client;
+        savedObjectsClient.find.mockResolvedValue(emptyResponse);
+        savedObjectsClient.checkConflicts.mockResolvedValue({ errors: [] });
+
+        const router = httpSetup.createRouter('/internal/saved_objects/');
+        const mockResolver = jest.fn().mockResolvedValue({ advancedSettings: { save: true } });
+        registerImportRoute(router, config, () => mockResolver);
+
+        const dynamicConfigService = dynamicConfigServiceMock.createInternalStartContract();
+        await server.start({ dynamicConfigService });
+      });
+
+      it('allows config objects through', async () => {
+        savedObjectsClient.bulkCreate.mockResolvedValueOnce({
+          saved_objects: [{ type: 'config', id: 'test-config', attributes: {}, references: [] }],
+        });
+
+        const result = await makeRequest(configObject).expect(200);
+        expect(result.body.success).toBe(true);
+        expect(result.body.successCount).toBe(1);
+        expect(result.body.errors).toBeUndefined();
+      });
+    });
+  });
 });

--- a/src/core/server/saved_objects/routes/integration_tests/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/routes/integration_tests/resolve_import_errors.test.ts
@@ -36,6 +36,7 @@ import { savedObjectsClientMock } from '../../../../../core/server/mocks';
 import { setupServer, createExportableType } from '../test_utils';
 import { SavedObjectConfig } from '../../saved_objects_config';
 import { dynamicConfigServiceMock } from '../../../config/dynamic_config_service.mock';
+import { SavedObjectsImportRetry } from '../../import';
 
 type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 
@@ -403,6 +404,110 @@ describe(`POST ${URL}`, () => {
         ],
         expect.any(Object) // options
       );
+    });
+  });
+
+  describe('config type capability gating', () => {
+    const configObject =
+      '{"type":"config","id":"test-config","attributes":{"dismissedAt":"2026-01-01T00:00:00Z"},"references":[]}';
+
+    const makeRequest = (ndjson: string, retries: SavedObjectsImportRetry[]) =>
+      supertest(httpSetup.server.listener)
+        .post(URL)
+        .set('content-Type', 'multipart/form-data; boundary=BOUNDARY')
+        .send(
+          [
+            '--BOUNDARY',
+            'Content-Disposition: form-data; name="file"; filename="export.ndjson"',
+            'Content-Type: application/ndjson',
+            '',
+            ndjson,
+            '--BOUNDARY',
+            'Content-Disposition: form-data; name="retries"',
+            '',
+            JSON.stringify(retries),
+            '--BOUNDARY--',
+          ].join('\r\n')
+        );
+
+    describe('when getCapabilities resolver is absent (fail-safe)', () => {
+      it('blocks config objects', async () => {
+        const result = await makeRequest(configObject, [
+          { type: 'config', id: 'test-config', overwrite: false, replaceReferences: [] },
+        ]).expect(200);
+        expect(result.body.success).toBe(false);
+        expect(result.body.errors[0]).toEqual(
+          expect.objectContaining({ type: 'config', error: { type: 'unsupported_type' } })
+        );
+      });
+    });
+
+    describe('when resolver returns advancedSettings.save=false', () => {
+      beforeEach(async () => {
+        await server.stop();
+        ({ server, httpSetup, handlerContext } = await setupServer());
+        handlerContext.savedObjects.typeRegistry.getImportableAndExportableTypes.mockReturnValue(
+          [...allowedTypes, 'config'].map(createExportableType)
+        );
+        handlerContext.savedObjects.typeRegistry.getType.mockImplementation(
+          (type: string) => ({ management: { icon: `${type}-icon` } } as any)
+        );
+        savedObjectsClient = handlerContext.savedObjects.client;
+        savedObjectsClient.checkConflicts.mockResolvedValue({ errors: [] });
+
+        const router = httpSetup.createRouter('/api/saved_objects/');
+        const mockResolver = jest.fn().mockResolvedValue({ advancedSettings: { save: false } });
+        registerResolveImportErrorsRoute(router, config, () => mockResolver);
+
+        const dynamicConfigService = dynamicConfigServiceMock.createInternalStartContract();
+        await server.start({ dynamicConfigService });
+      });
+
+      it('blocks config objects', async () => {
+        const result = await makeRequest(configObject, [
+          { type: 'config', id: 'test-config', overwrite: false, replaceReferences: [] },
+        ]).expect(200);
+        expect(result.body.success).toBe(false);
+        expect(result.body.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: 'config', error: { type: 'unsupported_type' } }),
+          ])
+        );
+      });
+    });
+
+    describe('when resolver returns advancedSettings.save=true', () => {
+      beforeEach(async () => {
+        await server.stop();
+        ({ server, httpSetup, handlerContext } = await setupServer());
+        handlerContext.savedObjects.typeRegistry.getImportableAndExportableTypes.mockReturnValue(
+          [...allowedTypes, 'config'].map(createExportableType)
+        );
+        handlerContext.savedObjects.typeRegistry.getType.mockImplementation(
+          (type: string) => ({ management: { icon: `${type}-icon` } } as any)
+        );
+        savedObjectsClient = handlerContext.savedObjects.client;
+        savedObjectsClient.checkConflicts.mockResolvedValue({ errors: [] });
+        savedObjectsClient.bulkCreate.mockResolvedValueOnce({
+          saved_objects: [{ type: 'config', id: 'test-config', attributes: {}, references: [] }],
+        });
+
+        const router = httpSetup.createRouter('/api/saved_objects/');
+        const mockResolver = jest.fn().mockResolvedValue({ advancedSettings: { save: true } });
+        registerResolveImportErrorsRoute(router, config, () => mockResolver);
+
+        const dynamicConfigService = dynamicConfigServiceMock.createInternalStartContract();
+        await server.start({ dynamicConfigService });
+      });
+
+      it('allows config objects through', async () => {
+        const result = await makeRequest(configObject, [
+          { type: 'config', id: 'test-config', overwrite: true, replaceReferences: [] },
+        ]).expect(200);
+        expect(result.body.success).toBe(true);
+        expect(result.body.successCount).toBe(1);
+        expect(result.body.errors).toBeUndefined();
+      });
     });
   });
 });

--- a/src/core/server/saved_objects/routes/resolve_import_errors.ts
+++ b/src/core/server/saved_objects/routes/resolve_import_errors.ts
@@ -35,6 +35,7 @@ import { IRouter } from '../../http';
 import { resolveSavedObjectsImportErrors } from '../import';
 import { SavedObjectConfig } from '../saved_objects_config';
 import { createSavedObjectsStreamFromNdJson } from './utils';
+import { CapabilitiesResolver, resolveCanImportConfig } from './import';
 
 interface FileStream extends Readable {
   hapi: {
@@ -42,7 +43,11 @@ interface FileStream extends Readable {
   };
 }
 
-export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedObjectConfig) => {
+export const registerResolveImportErrorsRoute = (
+  router: IRouter,
+  config: SavedObjectConfig,
+  getCapabilities?: () => CapabilitiesResolver | undefined
+) => {
   const { maxImportExportSize, maxImportPayloadBytes } = config;
 
   router.post(
@@ -125,6 +130,8 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         workspaces = [workspaces];
       }
 
+      const canImportConfig = await resolveCanImportConfig(getCapabilities, req);
+
       const result = await resolveSavedObjectsImportErrors({
         typeRegistry: context.core.savedObjects.typeRegistry,
         savedObjectsClient: context.core.savedObjects.client,
@@ -135,6 +142,7 @@ export const registerResolveImportErrorsRoute = (router: IRouter, config: SavedO
         workspaces,
         dataSourceId,
         dataSourceTitle,
+        canImportConfig,
       });
 
       return res.ok({ body: result });

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -104,6 +104,7 @@ const createSavedObjectsServiceMock = () => {
     setup: jest.fn(),
     start: jest.fn(),
     stop: jest.fn(),
+    setCapabilitiesResolver: jest.fn(),
   };
 
   mocked.setup.mockResolvedValue(createInternalSetupContractMock());

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -53,6 +53,7 @@ import {
   SavedObjectConfig,
 } from './saved_objects_config';
 import { OpenSearchDashboardsRequest, InternalHttpServiceSetup } from '../http';
+import { Capabilities } from '../capabilities';
 import { SavedObjectsClientContract, SavedObjectsType, SavedObjectStatusMeta } from './types';
 import { ISavedObjectsRepository, SavedObjectsRepository } from './service/lib/repository';
 import {
@@ -308,6 +309,7 @@ export class SavedObjectsService
 
   private migrator$ = new Subject<IOpenSearchDashboardsMigrator>();
   private typeRegistry = new SavedObjectTypeRegistry();
+  private capabilitiesResolver?: (request: OpenSearchDashboardsRequest) => Promise<Capabilities>;
   private started = false;
 
   private respositoryFactoryProvider?: SavedObjectRepositoryFactoryProvider;
@@ -322,6 +324,12 @@ export class SavedObjectsService
 
   constructor(private readonly coreContext: CoreContext) {
     this.logger = coreContext.logger.get('savedobjects-service');
+  }
+
+  public setCapabilitiesResolver(
+    resolver: (request: OpenSearchDashboardsRequest) => Promise<Capabilities>
+  ) {
+    this.capabilitiesResolver = resolver;
   }
 
   public async setup(setupDeps: SavedObjectsSetupDeps): Promise<InternalSavedObjectsServiceSetup> {
@@ -371,6 +379,7 @@ export class SavedObjectsService
       logger: this.logger,
       config: this.config,
       migratorPromise: this.migrator$.pipe(first()).toPromise(),
+      getCapabilities: () => this.capabilitiesResolver,
     });
 
     return {

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -294,6 +294,9 @@ export class Server {
     });
     soStartSpan?.end();
     const capabilitiesStart = this.capabilities.start();
+    this.savedObjects.setCapabilitiesResolver((request) =>
+      capabilitiesStart.resolveCapabilities(request)
+    );
     const uiSettingsStart = await this.uiSettings.start();
     const workspaceStart = await this.workspace.start();
     const metricsStart = await this.metrics.start();


### PR DESCRIPTION


### Description

The config type block introduced in #12014 rejected all config-type objects unconditionally and failed the entire import when any were present.

This change:
- Gates config import on the advancedSettings.save capability: admin users with this capability can import config objects; non-admin users still receive unsupported_type errors for config objects.
- Changes from fail-all to filter-and-continue: when config objects are rejected, remaining valid objects in the same import are still processed. Config objects are reported as errors in the response alongside any successful imports.
### Issues Resolved

Resolves #12201

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
