### PR TITLE
fix: it should not store flavor as explore object type when creating visualization snapshot

### DIFF
--- a/src/plugins/agent_traces/public/components/add_to_dashboard/add_to_dashboard_button.tsx
+++ b/src/plugins/agent_traces/public/components/add_to_dashboard/add_to_dashboard_button.tsx
@@ -25,7 +25,6 @@ import { saveStateToSavedObject } from '../../saved_agent_traces/transforms';
 import { addToDashboard } from './add_to_dashboard';
 import { saveSavedAgentTraces } from '../../helpers/save_agent_traces';
 import { useCurrentAgentTracesId } from '../../application/utils/hooks/use_current_agent_traces_id';
-import { AgentTracesFlavor } from '../../../common';
 import { AgentTracesServices } from '../../types';
 import { getVisualizationBuilder } from '../visualizations/visualization_builder_singleton';
 import { ExecutionContextSearch } from '../../../../expressions/common';
@@ -82,7 +81,6 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
   const tabDefinition = services.tabRegistry?.getTab?.(uiState.activeTabId);
 
   const savedAgentTracesIdFromUrl = useCurrentAgentTracesId();
-  const flavorId = AgentTracesFlavor.Traces;
 
   const saveObjectsClient = savedObjects.client;
 
@@ -103,8 +101,9 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
   }: OnSaveProps) => {
     const savedAgentTracesWithState = saveStateToSavedObject(
       savedAgentTraces,
-      flavorId,
       tabDefinition!,
+      // Don't store flavor for visualization snapshot
+      undefined,
       {
         chartType: chartConfig?.type,
         axesMapping: chartConfig?.axesMapping,

--- a/src/plugins/agent_traces/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.tsx
+++ b/src/plugins/agent_traces/public/components/top_nav/top_nav_links/top_nav_save/top_nav_save.tsx
@@ -64,8 +64,8 @@ export const getSaveButtonRun = (
   }: OnSaveProps): Promise<SaveResult | undefined> => {
     const savedAgentTracesWithState = saveStateToSavedObject(
       savedAgentTraces,
-      saveStateProps.flavorId ?? 'logs',
       saveStateProps.tabDefinition!,
+      saveStateProps.flavorId ?? 'logs',
       {},
       saveStateProps.dataset,
       saveStateProps.activeTabId

--- a/src/plugins/agent_traces/public/saved_agent_traces/transforms.ts
+++ b/src/plugins/agent_traces/public/saved_agent_traces/transforms.ts
@@ -24,8 +24,8 @@ interface VisState {
 
 export const saveStateToSavedObject = (
   obj: SavedAgentTraces,
-  flavorId: string,
   tabDefinition: TabDefinition,
+  flavorId?: string,
   visState?: VisState,
   dataset?: IndexPattern | Dataset,
   activeTabId?: string

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
@@ -25,7 +25,6 @@ import { saveStateToSavedObject } from '../../saved_explore/transforms';
 import { addToDashboard } from './utils/add_to_dashboard';
 import { saveSavedExplore } from '../../helpers/save_explore';
 import { useCurrentExploreId } from '../../application/utils/hooks/use_current_explore_id';
-import { useFlavorId } from '../../../public/helpers/use_flavor_id';
 import { useSearchContext } from '../query_panel/utils/use_search_context';
 import { ExploreServices } from '../../types';
 import { getVisualizationBuilder } from './visualization_builder';
@@ -84,7 +83,6 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
   const tabDefinition = services.tabRegistry?.getTab?.(activeTabId);
 
   const savedExploreIdFromUrl = useCurrentExploreId();
-  const flavorId = useFlavorId();
 
   const saveObjectsClient = savedObjects.client;
 
@@ -104,7 +102,8 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
 
     const savedExploreWithState = saveStateToSavedObject(
       savedExplore,
-      flavorId ?? 'logs',
+      // Don't store flavor for visualization snapshot
+      undefined,
       tabDefinition,
       {
         chartType: chartConfig?.type,

--- a/src/plugins/explore/public/saved_explore/transforms.ts
+++ b/src/plugins/explore/public/saved_explore/transforms.ts
@@ -34,7 +34,7 @@ interface VisState {
 
 export const saveStateToSavedObject = (
   obj: SavedExplore,
-  flavorId: string,
+  flavorId?: string,
   tabDefinition?: TabDefinition,
   visState?: VisState,
   dataset?: IndexPattern | Dataset,


### PR DESCRIPTION
### Description

It should not store flavor as explore object type when creating visualization snapshot

<!-- Describe what this change achieves-->

### Issues Resolved
#12025
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
