### PR TITLE
[Explore Vis]sync languageType to queryEditorState from saved query on init

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/query_builder/query_builder.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/query_builder/query_builder.ts
@@ -176,9 +176,7 @@ export class QueryBuilder {
       preferredDataset
     );
 
-    if (queryEditorStateFromUrl?.languageType) {
-      this.updateQueryEditorState({ languageType: queryEditorStateFromUrl.languageType });
-    }
+    this.updateQueryEditorState({ languageType: languageType as SupportLanguageType });
 
     if (queryEditorStateFromUrl?.activeBottomPanelTab) {
       this.updateQueryEditorState({


### PR DESCRIPTION
### Description

Bug:
When reopening a saved PromQL visualization from a dashboard, both the dataset selector and language toggle incorrectly showed PPL state instead of PromQL.

fix:

https://github.com/user-attachments/assets/41d0c83a-1aa8-46ec-8762-07acc8ef8f2e




### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
