### PR TITLE
Fix missing osd-ui-framework dist CSS in production build

### DIFF
--- a/packages/osd-ui-framework/package.json
+++ b/packages/osd-ui-framework/package.json
@@ -3,11 +3,6 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "scripts": {},
-  "opensearchDashboards": {
-    "build": {
-      "intermediateBuildDirectory": "target"
-    }
-  },
   "dependencies": {
     "classnames": "^2.3.1",
     "lodash": "^4.18.0",


### PR DESCRIPTION
### Description

After grunt was removed, `packages/osd-ui-framework/package.json` still declares:

```json
"opensearchDashboards": { "build": { "intermediateBuildDirectory": "target" } }
```

but its `build` script (`grunt prodBuild`) — the only thing that populated `target/` — was deleted (`scripts` is now empty).

In the production build (`@osd/pm` `buildProductionProjects`) the per-project flow is:

1. `deleteTarget()` wipes `target/`
2. `buildProject()` is now a no-op (no `build` script, no build targets)
3. `copyToBuild()` copies from the now-empty `target/`

So only `package.json` ships and the committed `dist/kui_*.css` files are dropped from `node_modules/@osd/ui-framework`. At runtime `core_app.ts` serves `/node_modules/@osd/ui-framework/dist/{path*}` from disk, so the missing `kui_*.css` returns a JSON 404 and the browser blocks it on an `X-Content-Type-Options: nosniff` MIME-type mismatch, briefly flashing the fatal-error (red) banner on initial load.

### Fix

The KUI stylesheets are now pre-compiled and committed in `dist/`, so no build step is required. Removing the stale `intermediateBuildDirectory` makes the package ship from its source root (which contains `dist/`). `copyToBuild` then copies the committed `dist/*.css` into `node_modules/@osd/ui-framework/dist/`, and the build's `CleanExtraBuildFiles` task strips source `.scss`/tests/docs from `node_modules` while preserving `.css`.

### Check List

- [x] All tests pass
- [x] Verified with a full distributable build: `build/opensearch-dashboards-*/node_modules/@osd/ui-framework/dist/` now contains all six `kui_*.css` files (`kui_v9_light.css` included); before the fix only `package.json` shipped.
- [x] Commit changes are listed out in CHANGELOG.md? — N/A (build-only fix)
