### PR TITLE
fix(data-explorer): fields sidebar collapse button not working in Safari

### DIFF
--- a/src/plugins/data_explorer/public/components/app_container.tsx
+++ b/src/plugins/data_explorer/public/components/app_container.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { memo, useRef } from 'react';
+import React, { memo, useCallback, useRef } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -37,6 +37,19 @@ export const AppContainer = React.memo(
     const topLinkRef = useRef<HTMLDivElement>(null);
     const datasetSelectorRef = useRef<HTMLDivElement>(null);
     const datePickerRef = useRef<HTMLDivElement>(null);
+
+    // In Safari, mousedown on the collapse toggle moves focus away from the resizer,
+    // triggering a re-render that hides the button before the click event fires.
+    // Preventing default on mousedown preserves the resizer's focus state.
+    const handleResizableMouseDown = useCallback((e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.closest('.ouiResizableToggleButton') ||
+        target.closest('.euiResizableToggleButton')
+      ) {
+        e.preventDefault();
+      }
+    }, []);
 
     if (!view) {
       return <NoView />;
@@ -90,7 +103,10 @@ export const AppContainer = React.memo(
           {/* TODO: improve fallback state */}
           <Suspense fallback={<div>Loading...</div>}>
             <Context {...params}>
-              <EuiResizableContainer direction={isMobile ? 'vertical' : 'horizontal'}>
+              <EuiResizableContainer
+                direction={isMobile ? 'vertical' : 'horizontal'}
+                onMouseDown={handleResizableMouseDown}
+              >
                 {(EuiResizablePanel, EuiResizableButton) => (
                   <>
                     <EuiResizablePanel


### PR DESCRIPTION
### Description
In Safari, mousedown on the collapse toggle moves focus away from the resizer, triggering a re-render that hides the button before the click event fires. Preventing default on mousedown preserves the resizer's focus state.
<!-- Describe what this change achieves-->

### Issues Resolved
Partialy resolved https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12230
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/4638f13d-3a83-44ce-85c2-a6f2b744996c


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
