### PR TITLE
[Chat] auto-open chat window on first visit

### DIFF
--- a/src/plugins/chat/public/plugin.test.ts
+++ b/src/plugins/chat/public/plugin.test.ts
@@ -372,6 +372,13 @@ describe('ChatPlugin', () => {
       });
     });
 
+    it('should open chat window by default when no stored state exists', () => {
+      // No localStorage state set (first visit)
+      plugin.start(mockCoreStart, mockDeps);
+
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
+    });
+
     it('should persist window state changes to localStorage', () => {
       const windowStateSubject = new BehaviorSubject({
         isWindowOpen: false,
@@ -405,8 +412,9 @@ describe('ChatPlugin', () => {
       plugin.start(mockCoreStart, mockDeps);
 
       // Should not call setWindowState with invalid data from localStorage
-      // but will be called with paddingSize from sidecar config subscription
-      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(1);
+      // but will be called with default open state + paddingSize from sidecar config subscription
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(2);
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
       expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ paddingSize: 400 });
     });
   });

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -80,6 +80,9 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
 
     if (isValidChatWindowState(storeState)) {
       chat.setWindowState(storeState);
+    } else {
+      // First visit or no stored state — open chat by default
+      chat.setWindowState({ isWindowOpen: true });
     }
 
     this.paddingSizeSubscription = overlays.sidecar


### PR DESCRIPTION
### Description

Auto-open the chat window by default when a user visits a page with chat enabled for the first time. If the user explicitly closes the chat window, that preference is persisted via localStorage and the window will remain closed on subsequent page loads/refreshes.

This improves discoverability of the AI chat feature for new users while still respecting user preference once they dismiss it.

### Issues Resolved

N/A - feature enhancement

## Screenshot

N/A - behavioral change only, no visual UI change

## Testing the changes

1. Clear `chat.windowState` from localStorage (or use incognito)
2. Navigate to any page with chat enabled (e.g. `/app/home` inside a workspace)
3. Verify the chat panel opens automatically
4. Close the chat panel
5. Refresh the page
6. Verify the chat panel remains closed

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (chat plugin tests: 20/20 passing)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff