### PR TITLE
[Bug] Side-nav applications

### DIFF
--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -10,7 +10,7 @@ import { BehaviorSubject } from 'rxjs';
 import { useLocation } from 'react-router-dom';
 
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { PermissionModeId, PublicAppInfo } from '../../../../../core/public';
+import { PermissionModeId } from '../../../../../core/public';
 import {
   CURRENT_USER_PLACEHOLDER,
   WORKSPACE_COLLABORATORS_APP_ID,
@@ -28,7 +28,11 @@ import { WorkspaceClient } from '../../workspace_client';
 import { DataSourceManagementPluginSetup } from '../../../../../plugins/data_source_management/public';
 import { DataPublicPluginStart } from '../../../../data/public';
 import { WorkspaceUseCase } from '../../types';
-import { getFirstUseCaseOfFeatureConfigs, pickUseCaseLandingAppId } from '../../utils';
+import {
+  getApplicationsSnapshot,
+  getFirstUseCaseOfFeatureConfigs,
+  pickUseCaseLandingAppId,
+} from '../../utils';
 import { useFormAvailableUseCases } from '../workspace_form/use_form_available_use_cases';
 import { NavigationPublicPluginStart } from '../../../../../plugins/navigation/public';
 import { DataSourceConnectionType } from '../../../common/types';
@@ -145,11 +149,7 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
             const newWorkspaceId = result.result.id;
             const useCaseId = getFirstUseCaseOfFeatureConfigs(attributes.features);
             const matchedUseCase = availableUseCases?.find(({ id }) => useCaseId === id);
-            let apps: ReadonlyMap<string, PublicAppInfo> | undefined;
-            const appsSub = application.applications$.subscribe((value) => {
-              apps = value;
-            });
-            appsSub.unsubscribe();
+            const apps = getApplicationsSnapshot(application);
             const useCaseLandingAppId = pickUseCaseLandingAppId(matchedUseCase?.features, apps);
 
             // For observability workspaces, run trace detection and create datasets if found

--- a/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
+++ b/src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx
@@ -10,7 +10,7 @@ import { BehaviorSubject } from 'rxjs';
 import { useLocation } from 'react-router-dom';
 
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { PermissionModeId } from '../../../../../core/public';
+import { PermissionModeId, PublicAppInfo } from '../../../../../core/public';
 import {
   CURRENT_USER_PLACEHOLDER,
   WORKSPACE_COLLABORATORS_APP_ID,
@@ -28,7 +28,7 @@ import { WorkspaceClient } from '../../workspace_client';
 import { DataSourceManagementPluginSetup } from '../../../../../plugins/data_source_management/public';
 import { DataPublicPluginStart } from '../../../../data/public';
 import { WorkspaceUseCase } from '../../types';
-import { getFirstUseCaseOfFeatureConfigs } from '../../utils';
+import { getFirstUseCaseOfFeatureConfigs, pickUseCaseLandingAppId } from '../../utils';
 import { useFormAvailableUseCases } from '../workspace_form/use_form_available_use_cases';
 import { NavigationPublicPluginStart } from '../../../../../plugins/navigation/public';
 import { DataSourceConnectionType } from '../../../common/types';
@@ -144,8 +144,13 @@ export const WorkspaceCreator = (props: WorkspaceCreatorProps) => {
           if (application && http) {
             const newWorkspaceId = result.result.id;
             const useCaseId = getFirstUseCaseOfFeatureConfigs(attributes.features);
-            const useCaseLandingAppId = availableUseCases?.find(({ id }) => useCaseId === id)
-              ?.features[0].id;
+            const matchedUseCase = availableUseCases?.find(({ id }) => useCaseId === id);
+            let apps: ReadonlyMap<string, PublicAppInfo> | undefined;
+            const appsSub = application.applications$.subscribe((value) => {
+              apps = value;
+            });
+            appsSub.unsubscribe();
+            const useCaseLandingAppId = pickUseCaseLandingAppId(matchedUseCase?.features, apps);
 
             // For observability workspaces, run trace detection and create datasets if found
             const isObservabilityWorkspace = useCaseId === 'observability';

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -1027,6 +1027,21 @@ describe('workspace utils: pickUseCaseLandingAppId', () => {
     ]);
     expect(pickUseCaseLandingAppId([{ id: 'a' }, { id: 'b' }], apps)).toBe('a');
   });
+
+  it('treats a feature id absent from the apps map as selectable', () => {
+    // Load-bearing for the transient-load case: feature ids come from
+    // `convertNavGroupToWorkspaceUseCase` over real nav links, so an
+    // absent lookup means the apps snapshot hasn't propagated yet, not
+    // that the app is missing. Skipping such features would silently
+    // skip the entire list during early page load.
+    const apps = new Map<string, PublicAppInfo>([['known-feature-flag-off', featureFlagDisabled]]);
+    expect(
+      pickUseCaseLandingAppId(
+        [{ id: 'known-feature-flag-off' }, { id: 'not-yet-in-apps-map' }],
+        apps
+      )
+    ).toBe('not-yet-in-apps-map');
+  });
 });
 
 describe('workspace utils: getUseCaseUrl', () => {

--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AppNavLinkStatus, NavGroupType, PublicAppInfo } from '../../../core/public';
+import { BehaviorSubject } from 'rxjs';
+import { AppNavLinkStatus, AppStatus, NavGroupType, PublicAppInfo } from '../../../core/public';
 import {
   featureMatchesConfig,
   filterWorkspaceConfigurableApps,
@@ -12,6 +13,7 @@ import {
   getDataSourcesList,
   convertNavGroupToWorkspaceUseCase,
   isEqualWorkspaceUseCase,
+  pickUseCaseLandingAppId,
   prependWorkspaceToBreadcrumbs,
   mergeDataSourcesWithConnections,
   fetchDataSourceConnections,
@@ -967,6 +969,66 @@ describe('workspace utils: mergeDataSourcesWithConnections', () => {
   });
 });
 
+describe('workspace utils: pickUseCaseLandingAppId', () => {
+  const accessibleVisible = ({
+    status: AppStatus.accessible,
+    navLinkStatus: AppNavLinkStatus.default,
+  } as Partial<PublicAppInfo>) as PublicAppInfo;
+  const featureFlagDisabled = ({
+    status: AppStatus.accessible,
+    navLinkStatus: AppNavLinkStatus.hidden,
+  } as Partial<PublicAppInfo>) as PublicAppInfo;
+  const outsideWorkspaceHidden = ({
+    // Mirrors the state read on the workspace creator page for an
+    // `insideWorkspace`-only app: workspace plugin pushed `inaccessible`,
+    // some other path pushed `navLinkStatus: hidden` — both flip back
+    // once the user enters the workspace, so the picker must keep them.
+    status: AppStatus.inaccessible,
+    navLinkStatus: AppNavLinkStatus.hidden,
+  } as Partial<PublicAppInfo>) as PublicAppInfo;
+
+  it('returns undefined when the use case has no features', () => {
+    expect(pickUseCaseLandingAppId(undefined, new Map())).toBeUndefined();
+    expect(pickUseCaseLandingAppId([], new Map())).toBeUndefined();
+  });
+
+  it('falls back to features[0] when no apps snapshot is provided', () => {
+    expect(pickUseCaseLandingAppId([{ id: 'first' }, { id: 'second' }], undefined)).toBe('first');
+  });
+
+  it('skips feature-flag-disabled apps (hidden + accessible)', () => {
+    const apps = new Map<string, PublicAppInfo>([
+      ['alerting', featureFlagDisabled],
+      ['dashboards', accessibleVisible],
+    ]);
+    expect(pickUseCaseLandingAppId([{ id: 'alerting' }, { id: 'dashboards' }], apps)).toBe(
+      'dashboards'
+    );
+  });
+
+  it('keeps apps that are transiently hidden outside a workspace (hidden + inaccessible)', () => {
+    // Repro of the bug we shipped this for: workspace creator runs outside
+    // any workspace, so `insideWorkspace` apps look hidden — but we must
+    // still pick the first one as the landing target, because it'll be
+    // accessible immediately after the redirect.
+    const apps = new Map<string, PublicAppInfo>([
+      ['dashboards', outsideWorkspaceHidden],
+      ['explore/logs', outsideWorkspaceHidden],
+    ]);
+    expect(pickUseCaseLandingAppId([{ id: 'dashboards' }, { id: 'explore/logs' }], apps)).toBe(
+      'dashboards'
+    );
+  });
+
+  it('falls back to features[0] when every feature is feature-flag-disabled', () => {
+    const apps = new Map<string, PublicAppInfo>([
+      ['a', featureFlagDisabled],
+      ['b', featureFlagDisabled],
+    ]);
+    expect(pickUseCaseLandingAppId([{ id: 'a' }, { id: 'b' }], apps)).toBe('a');
+  });
+});
+
 describe('workspace utils: getUseCaseUrl', () => {
   it('should get use case url', () => {
     startMock.application.getUrlForApp.mockImplementation((id) => `http://localhost/${id}`);
@@ -978,6 +1040,32 @@ describe('workspace utils: getUseCaseUrl', () => {
     startMock.application.getUrlForApp.mockImplementation((id) => `http://localhost/${id}`);
     const url = getUseCaseUrl(undefined, 'foo', startMock.application, startMock.http);
     expect(url).toEqual('http://localhost/w/foo/workspace_detail');
+  });
+
+  it('should skip feature-flag-disabled features when picking the landing app', () => {
+    startMock.application.getUrlForApp.mockImplementation((id) => `http://localhost/${id}`);
+    (startMock.application.applications$ as BehaviorSubject<Map<string, PublicAppInfo>>).next(
+      new Map<string, PublicAppInfo>([
+        // `bar` is the first feature of `useCaseMock`. Flag it off so the
+        // picker has to fall through to the next feature.
+        [
+          'bar',
+          ({
+            status: AppStatus.accessible,
+            navLinkStatus: AppNavLinkStatus.hidden,
+          } as Partial<PublicAppInfo>) as PublicAppInfo,
+        ],
+        [
+          'baz',
+          ({
+            status: AppStatus.accessible,
+            navLinkStatus: AppNavLinkStatus.default,
+          } as Partial<PublicAppInfo>) as PublicAppInfo,
+        ],
+      ])
+    );
+    const url = getUseCaseUrl(useCaseMock, 'foo', startMock.application, startMock.http);
+    expect(url).toEqual('http://localhost/w/foo/baz');
   });
 });
 

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -11,6 +11,7 @@ import {
   AppCategory,
   ApplicationStart,
   AppNavLinkStatus,
+  AppStatus,
   ChromeBreadcrumb,
   CoreStart,
   DEFAULT_APP_CATEGORIES,
@@ -526,13 +527,52 @@ export function prependWorkspaceToBreadcrumbs(
   }
 }
 
+/**
+ * Pick the landing app for a use case. Skips features that are
+ * **feature-flag-disabled** — i.e. `navLinkStatus === hidden` *and*
+ * `status === accessible`. An app gated by a feature flag is still
+ * accessible in principle, the plugin just hides the nav link to suppress
+ * the UI; an app that's transiently inaccessible (e.g. an
+ * `insideWorkspace`-only app read from outside any workspace, which the
+ * workspace plugin marks `inaccessible` and which therefore renders as
+ * `hidden` too) will become available once the user enters the workspace
+ * and must not be filtered out here.
+ *
+ * Reading both fields lets us distinguish "hidden by config" (skip) from
+ * "hidden because of where we are" (keep — it'll come back).
+ */
+export const pickUseCaseLandingAppId = (
+  features: WorkspaceUseCaseFeature[] | undefined,
+  apps: ReadonlyMap<string, PublicAppInfo> | undefined
+): string | undefined => {
+  if (!features?.length) {
+    return undefined;
+  }
+  if (!apps) {
+    return features[0].id;
+  }
+  const isFeatureFlagDisabled = (app: PublicAppInfo | undefined) =>
+    app?.navLinkStatus === AppNavLinkStatus.hidden && app?.status === AppStatus.accessible;
+  const firstSelectable = features.find((feature) => !isFeatureFlagDisabled(apps.get(feature.id)));
+  return (firstSelectable ?? features[0]).id;
+};
+
 export const getUseCaseUrl = (
   useCase: WorkspaceUseCase | undefined,
   workspaceId: string,
   application: ApplicationStart,
   http: HttpSetup
 ): string => {
-  const appId = useCase?.features?.[0]?.id || WORKSPACE_DETAIL_APP_ID;
+  let apps: ReadonlyMap<string, PublicAppInfo> | undefined;
+  // `applications$` is wrapped in `shareReplay(1)` upstream, so a
+  // synchronous subscribe-then-unsubscribe yields the current snapshot
+  // without leaking the subscription.
+  const sub = application.applications$.subscribe((value) => {
+    apps = value;
+  });
+  sub.unsubscribe();
+
+  const appId = pickUseCaseLandingAppId(useCase?.features, apps) || WORKSPACE_DETAIL_APP_ID;
   const useCaseURL = formatUrlWithWorkspaceId(
     application.getUrlForApp(appId, {
       absolute: false,

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -528,6 +528,29 @@ export function prependWorkspaceToBreadcrumbs(
 }
 
 /**
+ * Read the current value of `application.applications$` synchronously.
+ *
+ * Load-bearing assumption: `applications$` is wrapped in `shareReplay(1)`
+ * upstream (see `application_service.tsx`), so subscribing then immediately
+ * unsubscribing emits the latest cached value without leaking the
+ * subscription. If a future refactor drops `shareReplay`, this returns
+ * `undefined` instead of throwing — callers that branch on snapshot
+ * presence (e.g. `pickUseCaseLandingAppId`) will silently regress to
+ * pre-fix behavior. Keep this helper as the single source of truth so the
+ * regression has one place to surface rather than many.
+ */
+export const getApplicationsSnapshot = (
+  application: ApplicationStart
+): ReadonlyMap<string, PublicAppInfo> | undefined => {
+  let apps: ReadonlyMap<string, PublicAppInfo> | undefined;
+  const sub = application.applications$.subscribe((value) => {
+    apps = value;
+  });
+  sub.unsubscribe();
+  return apps;
+};
+
+/**
  * Pick the landing app for a use case. Skips features that are
  * **feature-flag-disabled** — i.e. `navLinkStatus === hidden` *and*
  * `status === accessible`. An app gated by a feature flag is still
@@ -539,7 +562,11 @@ export function prependWorkspaceToBreadcrumbs(
  * and must not be filtered out here.
  *
  * Reading both fields lets us distinguish "hidden by config" (skip) from
- * "hidden because of where we are" (keep — it'll come back).
+ * "hidden because of where we are" (keep — it'll come back). A feature id
+ * with no entry in `apps` is treated as selectable: feature ids come from
+ * `convertNavGroupToWorkspaceUseCase` over real registered nav links, so
+ * an absent lookup means the applications snapshot hasn't propagated yet,
+ * not that the app doesn't exist.
  */
 export const pickUseCaseLandingAppId = (
   features: WorkspaceUseCaseFeature[] | undefined,
@@ -563,15 +590,7 @@ export const getUseCaseUrl = (
   application: ApplicationStart,
   http: HttpSetup
 ): string => {
-  let apps: ReadonlyMap<string, PublicAppInfo> | undefined;
-  // `applications$` is wrapped in `shareReplay(1)` upstream, so a
-  // synchronous subscribe-then-unsubscribe yields the current snapshot
-  // without leaking the subscription.
-  const sub = application.applications$.subscribe((value) => {
-    apps = value;
-  });
-  sub.unsubscribe();
-
+  const apps = getApplicationsSnapshot(application);
   const appId = pickUseCaseLandingAppId(useCase?.features, apps) || WORKSPACE_DETAIL_APP_ID;
   const useCaseURL = formatUrlWithWorkspaceId(
     application.getUrlForApp(appId, {


### PR DESCRIPTION
### Description

Corrected Behavior no longer goes to hidden page.


https://github.com/user-attachments/assets/55f9825a-910e-4c4a-834a-840eed7b0ce6




## Summary

When a workspace was created with `opensearchDashboards.enableIconSideNav: true`, the post-creation redirect could land on the wrong app — most visibly, on the alerting app when `observability.alertManager.enabled: false`, or on Metrics after that was filtered out.

The redirect now picks the first feature whose nav-link is not feature-flag-disabled, falling back to `features[0]` when no better candidate exists.

## Why this was specific to icon side nav

The two nav-registration paths in dashboards-observability use different orderings:

- Default side nav (`registerDefaultNavGroups`): Alerting is registered with `order: 30`, ahead of nearly everything else.
- Icon side nav (`registerIconSideNavGroups`): Alerting is registered with `order: 50`, also ahead of Notebooks, APM services, and so on.

In both modes, `features[0]` was Alerting whenever its nav link was registered. With `enableIconSideNav: true`, this combined with the icon-side-nav-specific category and ordering decisions to make the problem visible and reproducible. The fix is mode-agnostic but the bug was first reported in icon-side-nav environments.

## Why `features[0]` was wrong

dashboards-observability uses a register-then-hide pattern: the alerting app and its nav-group entry are registered unconditionally at `setup()`, then hidden in `start()` via `AppNavLinkStatus.hidden` when `observability.alertManager.enabled` is false. This is the supported OSD pattern for dynamic config flags.

But `getUseCaseUrl` and the post-create redirect in `workspace_creator.tsx` both consume `useCase.features[0]` directly, with no awareness of which features are actually visible. So a hidden-but-registered feature could still be picked as the landing app.

## Why the filter has to inspect both `navLinkStatus` and `status`

A naive filter on `navLinkStatus === hidden` or on the computed `ChromeNavLink.hidden` over-filters: it also drops `WorkspaceAvailability.insideWorkspace` apps when read from the workspace creator page, which runs outside any workspace.

The workspace plugin's global app updater marks those apps inaccessible while you're outside a workspace; that inaccessibility flips back to accessible the moment the redirect lands inside the new workspace.

We separate the two using both fields together:

| navLinkStatus | status | Meaning | Skip? |
| --- | --- | --- | --- |
| `hidden` | `accessible` | Feature-flag-disabled by the plugin | Yes |
| `hidden` | `inaccessible` | Transiently hidden because we're outside a workspace | No |
| `visible/default` | `inaccessible` | Same — workspace plugin marked it inaccessible | No |
| `visible/default` | `accessible` | Normal case | No |

`isFeatureFlagDisabled = navLinkStatus === hidden && status === accessible` is the discriminator.

A feature-flagged-off app is still notionally accessible — the plugin just hides the UI — so the status stays accessible. A workspace-availability-restricted app has its status flipped to inaccessible, which we treat as a transient state and ignore.

## Changes

### `src/plugins/workspace/public/utils.ts`

- New exported helper `pickUseCaseLandingAppId(features, apps)` that scans features for the first whose registered app is not feature-flag-disabled, falling back to `features[0]` if none qualify or no apps snapshot is available.
- `getUseCaseUrl` now reads a synchronous snapshot from `application.applications$` — safe because the upstream pipe uses `shareReplay(1)` — and delegates to `pickUseCaseLandingAppId`.

### `src/plugins/workspace/public/components/workspace_creator/workspace_creator.tsx`

- Post-create redirect uses `pickUseCaseLandingAppId` against a synchronous `applications$` snapshot instead of indexing `features[0]` directly.

### `src/plugins/workspace/public/utils.test.ts`

- 5 unit tests for `pickUseCaseLandingAppId` covering: empty/undefined inputs, missing apps snapshot, feature-flag-disabled skip, transient-outside-workspace keep, all-disabled fallback.
- 1 integration test on `getUseCaseUrl` verifying the filter is applied end-to-end through the public API.

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
