### PR TITLE
[Backport 2.19] Pin GitHub Actions to commit SHAs (#12041)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -34,7 +34,7 @@ jobs:
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v2.2.0
+        uses: VachaShah/backport@142d3b8a8c70dc54db515e653e5ed3c3fac64100 # v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/build_and_test_workflow.yml
+++ b/.github/workflows/build_and_test_workflow.yml
@@ -55,24 +55,24 @@ jobs:
 
       - name: Configure pagefile size (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67 # v1.3
         with:
           minimum-size: 16GB
           maximum-size: 64GB
           disk-root: "C:"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup JDK (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: '11'
           distribution: 'adopt'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -88,7 +88,7 @@ jobs:
         run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
 
       - name: Initialize Yarn Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: matrix.os != 'windows-latest'
         with:
           path: ${{ env.YARN_CACHE_LOCATION }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload Code Coverage
         id: upload-code-coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/opensearch-dashboards-coverage
@@ -133,10 +133,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -151,7 +151,7 @@ jobs:
         run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
 
       - name: Initialize Yarn Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ${{ env.YARN_CACHE_LOCATION }}
           key: yarn-${{ hashFiles('**/yarn.lock') }}
@@ -196,24 +196,24 @@ jobs:
 
       - name: Configure pagefile size (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67 # v1.3
         with:
           minimum-size: 16GB
           maximum-size: 64GB
           disk-root: "C:"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup JDK (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: '11'
           distribution: 'adopt'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -229,7 +229,7 @@ jobs:
         run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
 
       - name: Initialize Yarn Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: matrix.os != 'windows-latest'
         with:
           path: ${{ env.YARN_CACHE_LOCATION }}
@@ -240,7 +240,7 @@ jobs:
       # Lock Chrome version until ChromeDriver's release pipeline is fixed
       - name: Download Chrome
         id: download-chrome
-        uses: abhi1693/setup-browser@v0.3.5
+        uses: abhi1693/setup-browser@311d294ea9c5d710f61204ba3c4c3d31fa62443e # v0.3.5
         with:
           browser: chrome
           # v122
@@ -282,7 +282,7 @@ jobs:
           JOB: ci${{ matrix.group }}
           CACHE_DIR: ciGroup${{ matrix.group }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: failure-artifacts-ci${{ matrix.group }}
@@ -312,24 +312,24 @@ jobs:
 
       - name: Configure pagefile size (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67 # v1.3
         with:
           minimum-size: 16GB
           maximum-size: 64GB
           disk-root: "C:"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup JDK (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: '11'
           distribution: 'adopt'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -345,7 +345,7 @@ jobs:
         run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
 
       - name: Initialize Yarn Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: matrix.os != 'windows-latest'
         with:
           path: ${{ env.YARN_CACHE_LOCATION }}
@@ -356,7 +356,7 @@ jobs:
       # Lock Chrome version until ChromeDriver's release pipeline is fixed
       - name: Download Chrome
         id: download-chrome
-        uses: abhi1693/setup-browser@v0.3.5
+        uses: abhi1693/setup-browser@311d294ea9c5d710f61204ba3c4c3d31fa62443e # v0.3.5
         with:
           browser: chrome
           # v122
@@ -393,7 +393,7 @@ jobs:
         id: plugin-ftr-tests
         run: node scripts/functional_tests.js --config test/plugin_functional/config.ts
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: failure-artifacts-plugin-functional-${{ matrix.os }}
@@ -444,19 +444,19 @@ jobs:
 
       - name: Configure pagefile size (Windows only)
         if: matrix.os == 'windows-latest'
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67 # v1.3
         with:
           minimum-size: 16GB
           maximum-size: 64GB
           disk-root: "C:"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           path: ./artifacts
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: './artifacts/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -472,7 +472,7 @@ jobs:
         run: echo "YARN_CACHE_LOCATION=$(yarn cache dir)" >> $GITHUB_ENV
 
       - name: Initialize Yarn Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: matrix.os != 'windows-latest'
         with:
           path: ${{ env.YARN_CACHE_LOCATION }}
@@ -506,7 +506,7 @@ jobs:
       - name: Build `${{ matrix.name }}`
         run: yarn ${{ matrix.script }} --release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: success()
         with:
           name: ${{ matrix.suffix }}-${{ env.VERSION }}
@@ -528,7 +528,7 @@ jobs:
         version: [osd-2.0.0, osd-2.1.0, osd-2.2.0, osd-2.3.0, osd-2.4.0, osd-2.5.0, osd-2.6.0, osd-2.7.0, osd-2.8.0, osd-2.9.0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           path: ./artifacts
 
@@ -536,7 +536,7 @@ jobs:
       - run: echo [NOTE] These tests will be ran using Linux x64 release builds without security
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: './artifacts/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -571,7 +571,7 @@ jobs:
         run: echo "BWC_VERSIONS=${{ matrix.version }}" >> $GITHUB_ENV
 
       - name: Download OpenSearch Dashboards
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         id: download
         with:
           name: linux-x64-${{ env.VERSION }}
@@ -583,7 +583,7 @@ jobs:
         run: |
           yarn test:bwc -s false -o ${{ env.OPENSEARCH_URL }} -d ${{ steps.download.outputs.download-path }}/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz -v ${{ matrix.version }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ failure() && steps.verify-opensearch-exists.outputs.version-exists == 'true' }}
         with:
           name: ${{ matrix.version }}-test-failures

--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Get source information from PR number
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number != '' }}
         id: get_pr_info
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const { data: result } = await github.rest.pulls.get({
@@ -130,13 +130,13 @@ jobs:
           echo "SOURCE_BRANCH=${{ steps.get_pr_info.outputs.head_ref }}" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{ env.SOURCE_REPO }}
           ref: '${{ env.SOURCE_BRANCH }}'
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -153,7 +153,7 @@ jobs:
         run: node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers 12
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: ${{ env.FTR_PATH }}
           repository: ${{ env.TEST_REPO }}
@@ -193,7 +193,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -205,7 +205,7 @@ jobs:
       # Run tests based on configuration
       - name: Run FT repo tests
         if: matrix.test_location == 'ftr'
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: ${{ env.FTR_PATH }}
           start: ${{ env.OPENSEARCH_SNAPSHOT_CMD }}, ${{ env.START_CMD }}
@@ -214,7 +214,7 @@ jobs:
 
       - name: Download OpenSearch
         if: matrix.config == 'query_enhanced'
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@15306412d2c75df56b46844362b86b65235b7db1 # v1.4.0
         with:
           url: https://artifacts.opensearch.org/releases/bundle/opensearch/${{ env.LATEST_VERSION }}/opensearch-${{ env.LATEST_VERSION }}-linux-x64.tar.gz
 
@@ -246,7 +246,7 @@ jobs:
       # Run Dashboards Cypress tests within the source repo
       - name: Run Dashboards Cypress tests with query enhancements
         if: matrix.test_location == 'source' && matrix.config == 'query_enhanced'
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6
         with:
           install-command: npx cypress install --force
           start: ${{ env.START_CMD }}
@@ -254,7 +254,7 @@ jobs:
           command: yarn cypress:run-without-security --browser ${{ env.CYPRESS_BROWSER }} --spec ${{ env.DASHBOARDS_SPEC }}
       - name: Run Dashboards Cypress tests without query enhancements
         if: matrix.test_location == 'source' && matrix.config == 'dashboard'
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6
         with:
           install-command: npx cypress install --force
           start: ${{ env.OPENSEARCH_SNAPSHOT_CMD }}, ${{ env.START_CMD }}
@@ -263,7 +263,7 @@ jobs:
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - name: Upload FT repo screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure() && matrix.test_location == 'ftr'
         with:
           name: ftr-cypress-screenshots-${{ matrix.group }}
@@ -271,7 +271,7 @@ jobs:
           retention-days: 1
 
       - name: Upload FT repo videos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always() && matrix.test_location == 'ftr'
         with:
           name: ftr-cypress-videos-${{ matrix.group }}
@@ -279,7 +279,7 @@ jobs:
           retention-days: 1
 
       - name: Upload FT repo results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always() && matrix.test_location == 'ftr'
         with:
           name: ftr-cypress-results-${{ matrix.group }}
@@ -288,14 +288,14 @@ jobs:
 
       - name: Upload Dashboards screenshots
         if: failure() && matrix.test_location == 'source'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dashboards-cypress-screenshots
           path: cypress/screenshots
           retention-days: 1
 
       - name: Upload Dashboards repo videos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always() && matrix.test_location == 'source'
         with:
           name: dashboards-cypress-videos
@@ -303,7 +303,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Dashboards repo results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always() && matrix.test_location == 'source'
         with:
           name: dashboards-cypress-results
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2
         id: fc
         with:
           issue-number: ${{ inputs.pr_number }}
@@ -326,7 +326,7 @@ jobs:
           body-includes: '${{ env.COMMENT_TAG }}'
 
       - name: Add comment on the PR
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ inputs.pr_number }}

--- a/.github/workflows/cypress_workflow_with_s3.yml
+++ b/.github/workflows/cypress_workflow_with_s3.yml
@@ -52,10 +52,10 @@ jobs:
     name: Run cypress tests (osd:ciGroup10)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -72,7 +72,7 @@ jobs:
         run: node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers 12
 
       - name: Checkout FT repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: ${{ env.FTR_PATH }}
           repository: ${{ env.TEST_REPO }}
@@ -87,7 +87,7 @@ jobs:
           echo "DASHBOARDS_SPEC=${DASHBOARDS_SPEC}"
 
       - name: Download OpenSearch
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@15306412d2c75df56b46844362b86b65235b7db1 # v1.4.0
         with:
           url: https://artifacts.opensearch.org/releases/bundle/opensearch/${{ env.LATEST_VERSION }}/opensearch-${{ env.LATEST_VERSION }}-linux-x64.tar.gz
 
@@ -112,7 +112,7 @@ jobs:
         run: npx cypress cache clear
 
       - name: Run Dashboards Cypress tests with query enhancements
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6
         env:
           S3_CONNECTION_URL: ${{ secrets.S3_CONNECTION_URL }}
           S3_CONNECTION_USERNAME: ${{ secrets.S3_CONNECTION_USERNAME }}
@@ -125,14 +125,14 @@ jobs:
 
       - name: Upload Dashboards screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dashboards-cypress-screenshots-10
           path: cypress/screenshots
           retention-days: 1
 
       - name: Upload Dashboards repo videos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: dashboards-cypress-videos-10
@@ -140,7 +140,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Dashboards repo results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: dashboards-cypress-results-10

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -12,7 +12,7 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
     - name: Delete merged branch
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           github.rest.git.deleteRef({

--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -13,9 +13,9 @@ jobs:
   linkchecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Lychee Link Checker
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1
         with:
           fail: true
           args: --accept=200,403,429 --base . --retry-wait-time=15 --max-retries=5 --exclude-path cypress/fixtures "**/*.html" "**/*.md" "**/*.txt" "**/*.json" "**/*.js" "**/*.ts" "**/*.tsx"

--- a/.github/workflows/opensearch_changelog_workflow.yml
+++ b/.github/workflows/opensearch_changelog_workflow.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Parse changelog entries and submit request for changset creation
-        uses: BigSamu/OpenSearch_Changelog_Workflow@1.0.0-alpha1
+        uses: BigSamu/OpenSearch_Changelog_Workflow@876b13d8d58b18b130b47c86e437291b284de212 # 1.0.0-alpha1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           CHANGELOG_PR_BRIDGE_URL_DOMAIN: ${{secrets.CHANGELOG_PR_BRIDGE_URL_DOMAIN}}

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'
@@ -75,7 +75,7 @@ jobs:
         echo "Target branch: $TARGET_BRANCH"
 
     - name: Checkout target branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: "${{ steps.parse_tag.outputs.target_branch }}"
 
@@ -97,7 +97,7 @@ jobs:
         echo "Updated package.json version to $NEXT_VERSION"
 
     - name: Create PR for target branch
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         base: ${{ env.BASE_BRANCH }}
         branch: 'create-pull-request/patch-${{ env.BASE_BRANCH }}'


### PR DESCRIPTION
Backport of #12041 to `2.19`.

## What
Pins every GitHub Actions `uses:` reference in the workflow files to a full commit SHA (with the version retained as a trailing comment), hardening CI against supply-chain tag-mutation attacks. This unblocks the 2.19 CI check that fails when actions are not pinned to SHAs.

## Why this is a manual port (not a clean cherry-pick)
`2.19`'s workflows have diverged from `main`:
- **9 of the 16 workflow files in #12041 do not exist on 2.19** (they are main-only), so they are intentionally excluded.
- **2.19 has `opensearch_changelog_workflow.yml`**, which main lacks — it is included here.
- Several actions are at **older major versions on 2.19** than on main.

So instead of cherry-picking, the pinning was applied directly to the **8 workflow files present on 2.19** (68 references total).

## SHA sourcing
- For action versions shared with `main`, the exact SHAs from #12041 are reused.
- For versions unique to 2.19, SHAs were resolved from each action's upstream tag: `actions/checkout` v2/v3, `actions/setup-node` v2/v3, `actions/setup-java` v3, `actions/cache` v3, `actions/download-artifact` v4.1.7, `cypress-io/github-action` v2, and `BigSamu/OpenSearch_Changelog_Workflow` 1.0.0-alpha1.

## Testing
- All 8 workflow files validate as YAML.
- Verified every `uses:` reference across `.github/workflows/` is now SHA-pinned (0 remaining tag refs).
- Diff is a symmetric 68 insertions / 68 deletions (reference pinning only; no logic changes).