### PR TITLE
[Enhancement] Sort datasets alphabetically in dataset pickers

### DIFF
--- a/src/plugins/data/public/ui/dataset_select/dataset_select.test.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { coreMock } from '../../../../../core/public/mocks';
 import { DataPublicPluginStart, IDataPluginServices } from '../..';
@@ -1113,6 +1113,67 @@ describe('DatasetSelect', () => {
 
       // Verify that the modal was opened
       expect(mockCore.overlays.openModal).toHaveBeenCalled();
+    });
+
+    it('renders ViewDatasetsModal rows sorted alphabetically by display name', async () => {
+      // Return datasets in non-alphabetical fetch order so sorting is observable
+      const displayNameById: Record<string, string> = {
+        'z-id': 'Zebra',
+        'a-id': 'Apple',
+        'm-id': 'Mango',
+      };
+      mockDataViews.getIds = jest.fn().mockResolvedValue(['z-id', 'a-id', 'm-id']);
+      mockDataViews.getMultiple = jest.fn().mockImplementation((ids) =>
+        Promise.resolve(
+          ids.map((id: string) => ({
+            id,
+            title: `title-${id}`,
+            displayName: displayNameById[id],
+            timeFieldName: '@timestamp',
+          }))
+        )
+      );
+      mockDataViews.convertToDataset = jest.fn().mockImplementation((dataView) =>
+        Promise.resolve({
+          id: dataView.id,
+          title: dataView.title,
+          type: DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+        })
+      );
+      mockDataViews.getDefault = jest.fn().mockResolvedValue(null);
+      mockQueryService.queryString.getQuery = jest.fn().mockReturnValue({ dataset: null });
+
+      renderWithContext();
+
+      await waitFor(() => {
+        expect(mockDataViews.getIds).toHaveBeenCalled();
+      });
+
+      fireEvent.click(screen.getByTestId('datasetSelectButton'));
+      await waitFor(() => {
+        expect(screen.getByTestId('datasetSelectViewDatasetsButton')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('datasetSelectViewDatasetsButton'));
+
+      // The modal mounts via the overlays mount point rather than this render tree,
+      // so render the captured mount point into the DOM to inspect the table rows.
+      const mountPoint = (mockCore.overlays.openModal as jest.Mock).mock.calls[0][0];
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      await act(async () => {
+        mountPoint(container);
+      });
+
+      // EuiModal portals into document.body. The "Dataset" column renders the display
+      // name inside a <strong>, so the strongs reflect the rendered row order.
+      await waitFor(() => {
+        const names = Array.from(document.body.querySelectorAll('strong')).map(
+          (el) => el.textContent
+        );
+        expect(names).toEqual(['Apple', 'Mango', 'Zebra']);
+      });
+
+      document.body.removeChild(container);
     });
   });
 

--- a/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
@@ -143,23 +143,32 @@ const ViewDatasetsModal: React.FC<ViewDatasetsModalProps> = ({
   const datasetService = queryString.getDatasetService();
 
   const filteredDatasets = useMemo(() => {
-    if (!searchQuery) return datasets;
     const lowerSearch = searchQuery.toLowerCase();
-    return datasets.filter((dataset) => {
-      const displayName = (dataset.displayName || dataset.title).toLowerCase();
-      const description = dataset.description?.toLowerCase() || '';
-      const signalType = dataset.signalType?.toLowerCase() || '';
-      const dataSourceName = dataset.dataSource?.title?.toLowerCase() || 'local cluster';
-      const indexPattern = dataset.title.toLowerCase();
+    const matched = searchQuery
+      ? datasets.filter((dataset) => {
+          const displayName = (dataset.displayName || dataset.title).toLowerCase();
+          const description = dataset.description?.toLowerCase() || '';
+          const signalType = dataset.signalType?.toLowerCase() || '';
+          const dataSourceName = dataset.dataSource?.title?.toLowerCase() || 'local cluster';
+          const indexPattern = dataset.title.toLowerCase();
 
-      return (
-        displayName.includes(lowerSearch) ||
-        description.includes(lowerSearch) ||
-        signalType.includes(lowerSearch) ||
-        dataSourceName.includes(lowerSearch) ||
-        indexPattern.includes(lowerSearch)
-      );
-    });
+          return (
+            displayName.includes(lowerSearch) ||
+            description.includes(lowerSearch) ||
+            signalType.includes(lowerSearch) ||
+            dataSourceName.includes(lowerSearch) ||
+            indexPattern.includes(lowerSearch)
+          );
+        })
+      : datasets;
+
+    // Sort alphabetically by the displayed name (displayName || title).
+    // Copy first so we don't mutate the datasets prop.
+    return [...matched].sort((a, b) =>
+      (a.displayName || a.title).localeCompare(b.displayName || b.title, undefined, {
+        sensitivity: 'base',
+      })
+    );
   }, [datasets, searchQuery]);
 
   const handleDatasetClick = useCallback(
@@ -634,6 +643,9 @@ const DatasetSelect: React.FC<DatasetSelectProps> = ({
       ) : undefined,
     };
   });
+
+  // Sort options alphabetically by their displayed label (displayName || title)
+  options.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
 
   const handleOptionChange = useCallback(
     async (newOptions: EuiSelectableOption[]) => {

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -132,26 +132,32 @@ export const DatasetSelector = ({
     const buildDatasetOptions = (
       groupLabel: string,
       ds: Dataset[],
-      selectedDatasetId: string | undefined
+      selectedDatasetId: string | undefined,
+      sort: boolean = false
     ): EuiSelectableOption[] => {
-      const datasetOptions: EuiSelectableOption[] = [
-        {
-          label: groupLabel,
-          isGroupLabel: true,
-        },
-      ];
-      ds.forEach(({ id, title, type, dataSource, displayName }) => {
-        const displayLabel = displayName || title;
-        const label = dataSource ? `${dataSource.title}::${displayLabel}` : displayLabel;
-        datasetOptions.push({
-          label,
-          checked: id === selectedDatasetId ? 'on' : undefined,
-          key: id,
-          prepend: <EuiIcon type={datasetService.getType(type)!.meta.icon.type} />,
-          'data-test-subj': `datasetSelectorOption-${id}`,
-        });
-      });
-      return datasetOptions.length > 1 ? datasetOptions : [];
+      const groupLabelOption: EuiSelectableOption = {
+        label: groupLabel,
+        isGroupLabel: true,
+      };
+      const datasetOptions: EuiSelectableOption[] = ds.map(
+        ({ id, title, type, dataSource, displayName }) => {
+          const displayLabel = displayName || title;
+          const label = dataSource ? `${dataSource.title}::${displayLabel}` : displayLabel;
+          return {
+            label,
+            checked: id === selectedDatasetId ? 'on' : undefined,
+            key: id,
+            prepend: <EuiIcon type={datasetService.getType(type)!.meta.icon.type} />,
+            'data-test-subj': `datasetSelectorOption-${id}`,
+          };
+        }
+      );
+      if (sort) {
+        datasetOptions.sort((a, b) =>
+          a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+        );
+      }
+      return datasetOptions.length > 0 ? [groupLabelOption, ...datasetOptions] : [];
     };
     const recentDatasetOptions = buildDatasetOptions(
       i18n.translate('data.dataSelector.recentDatasetsGroupLabel', {
@@ -167,7 +173,8 @@ export const DatasetSelector = ({
       indexPatterns.filter(
         (dataset) => !recentDatasets.some((recentDataset) => recentDataset.id === dataset.id)
       ),
-      selectedDataset?.id
+      selectedDataset?.id,
+      true
     );
 
     return [...recentDatasetOptions, ...indexPatternOptions];


### PR DESCRIPTION
## Description

The dataset pickers in both the **Explore** (`DatasetSelect`) and **Discover** (`DatasetSelector`) plugins previously rendered datasets in whatever order the saved-objects `find` query returned them (no `sortField` is passed, so effectively backend/relevance order — not alphabetical). This makes datasets hard to scan as the list grows.

This PR sorts datasets alphabetically across all three surfaces. All comparisons are case-insensitive (`localeCompare` with `sensitivity: 'base'`).

### Sort keys (intentionally differ per picker)

The two pickers sort on different keys **by design**, because their option labels are constructed differently:

- **Explore dropdown** and **Explore "View datasets" modal** — sort by the displayed name `displayName || title`. Explore renders the data source in a *subtitle*, not in the label, so the sort key is just the name. (The modal sorts a copy so the `datasets` prop isn't mutated.)
- **Discover dropdown** — Discover's option label *is* the prefixed string `dataSource.title::name`, and we sort on that full label. The effect is that datasets are grouped by **data source first, then by name** — the intended grouping for Discover's multi-cluster list. The **Recently selected** group intentionally keeps its recency order (only the **Index patterns** group is sorted).

In short: Explore orders purely by display name; Discover orders by data-source-prefixed label (cluster-grouped). This divergence is deliberate and matches how each picker presents the data source.

## Issues Resolved

N/A

## Testing

- Added a unit test asserting the "View datasets" modal renders rows in alphabetical order regardless of fetch order.
- `yarn test:jest src/plugins/data/public/ui/dataset_select/dataset_select.test.tsx` — 29 passed, 1 skipped.
- `yarn test:jest src/plugins/data/public/ui/dataset_selector/dataset_selector.test.tsx` — 3 passed.

## Check List

- [x] All tests pass
- [x] New functionality includes unit tests
- [x] Commits are signed per the DCO using `--signoff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)