### PR TITLE
feat(discover): register page context for AI chatbot in classic Disco…

### DIFF
--- a/src/plugins/discover/opensearch_dashboards.json
+++ b/src/plugins/discover/opensearch_dashboards.json
@@ -16,7 +16,7 @@
     "visualizations",
     "usageCollection"
   ],
-  "optionalPlugins": ["home", "share", "explore"],
+  "optionalPlugins": ["home", "share", "explore", "contextProvider"],
   "requiredBundles": [
     "home",
     "opensearchDashboardsUtils",

--- a/src/plugins/discover/public/application/view_components/context/index.test.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '@testing-library/react';
+import { ViewProps } from '../../../../../data_explorer/public';
+
+import DiscoverContext from './index';
+
+// Mock the heavy dependencies so we can focus on the page-context registration logic.
+jest.mock('../utils/use_search', () => ({
+  useSearch: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
+  useOpenSearchDashboards: () => ({ services: {} }),
+  OpenSearchDashboardsContextProvider: () => null,
+}));
+
+const mockUsePageContext = jest.fn();
+const mockGetServices = jest.fn();
+jest.mock('../../../opensearch_dashboards_services', () => ({
+  getServices: () => mockGetServices(),
+}));
+
+// DiscoverContext is mounted by the router with full ViewProps (AppMountParameters);
+// for these unit tests we only care about the page-context side effect, so we cast a
+// minimal props object and let the mocked hooks handle the rest.
+const renderContext = () =>
+  render(
+    <DiscoverContext {...({} as ViewProps)}>
+      <div>child</div>
+    </DiscoverContext>
+  );
+
+describe('DiscoverContext page context registration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers page context with the contextProvider hook when available', () => {
+    mockGetServices.mockReturnValue({
+      contextProvider: { hooks: { usePageContext: mockUsePageContext } },
+    });
+
+    renderContext();
+
+    expect(mockUsePageContext).toHaveBeenCalledTimes(1);
+    const options = mockUsePageContext.mock.calls[0][0];
+    expect(options.description).toBe('Discover application page context');
+    expect(options.categories).toEqual(['page', 'static']);
+    expect(typeof options.convert).toBe('function');
+  });
+
+  it('maps url state to the expected page context shape via convert', () => {
+    mockGetServices.mockReturnValue({
+      contextProvider: { hooks: { usePageContext: mockUsePageContext } },
+    });
+
+    renderContext();
+
+    const { convert } = mockUsePageContext.mock.calls[0][0];
+
+    const dataset = { id: 'logs-*', title: 'logs-*', type: 'INDEX_PATTERN' };
+    const result = convert({
+      _g: { time: { from: 'now-15m', to: 'now' } },
+      _q: { query: { query: 'status:200', language: 'PPL', dataset } },
+    });
+
+    expect(result).toEqual({
+      appId: 'discover',
+      timeRange: { from: 'now-15m', to: 'now' },
+      query: { query: 'status:200', language: 'PPL' },
+      dataset,
+    });
+  });
+
+  it('falls back to safe defaults when url state is empty', () => {
+    mockGetServices.mockReturnValue({
+      contextProvider: { hooks: { usePageContext: mockUsePageContext } },
+    });
+
+    renderContext();
+
+    const { convert } = mockUsePageContext.mock.calls[0][0];
+    const result = convert({});
+
+    expect(result).toEqual({
+      appId: 'discover',
+      timeRange: undefined,
+      query: { query: '', language: 'kuery' },
+      dataset: undefined,
+    });
+  });
+
+  it('does not throw when the contextProvider plugin is unavailable (NOOP fallback)', () => {
+    mockGetServices.mockReturnValue({});
+
+    expect(() => renderContext()).not.toThrow();
+    expect(mockUsePageContext).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -14,6 +14,10 @@ import { useSearch, SearchContextValue } from '../utils/use_search';
 
 const SearchContext = React.createContext<SearchContextValue>({} as SearchContextValue);
 
+// NOOP fallback used when the contextProvider plugin is not available
+// (e.g. AI features disabled). Keeps the hook call unconditional.
+const NOOP_PAGE_CONTEXT_HOOK = (_options?: any): string => '';
+
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverContext({ children }: React.PropsWithChildren<ViewProps>) {
   const { services: deServices } = useOpenSearchDashboards<DataExplorerServices>();
@@ -21,6 +25,24 @@ export default function DiscoverContext({ children }: React.PropsWithChildren<Vi
   const searchParams = useSearch({
     ...deServices,
     ...services,
+  });
+
+  // Register page context so the AI chatbot is aware of the current query,
+  // language, dataset and time range in classic Discover. Classic Discover
+  // stores the query one level deeper under `_q.query` (vs `_q` in Explore).
+  const usePageContext = services.contextProvider?.hooks?.usePageContext || NOOP_PAGE_CONTEXT_HOOK;
+  usePageContext({
+    description: 'Discover application page context',
+    convert: (urlState: any) => ({
+      appId: 'discover',
+      timeRange: urlState?._g?.time,
+      query: {
+        query: urlState?._q?.query?.query || '',
+        language: urlState?._q?.query?.language || 'kuery',
+      },
+      dataset: urlState?._q?.query?.dataset,
+    }),
+    categories: ['page', 'static'],
   });
 
   return (

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -60,6 +60,7 @@ import { UrlForwardingStart } from '../../url_forwarding/public';
 import { NavigationPublicPluginStart } from '../../navigation/public';
 import { DataExplorerServices } from '../../data_explorer/public';
 import { Storage } from '../../opensearch_dashboards_utils/public';
+import { ContextProviderStart } from '../../context_provider/public';
 
 export interface DiscoverServices {
   addBasePath: (path: string) => string;
@@ -86,6 +87,7 @@ export interface DiscoverServices {
   visualizations: VisualizationsStart;
   storage: Storage;
   uiActions: UiActionsStart;
+  contextProvider?: ContextProviderStart;
 }
 
 export function buildServices(
@@ -130,6 +132,7 @@ export function buildServices(
     visualizations: plugins.visualizations,
     storage,
     uiActions: plugins.uiActions,
+    contextProvider: plugins.contextProvider,
   };
 }
 

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -79,6 +79,7 @@ declare module '../../share/public' {
 }
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { ExplorePluginSetup } from '../../explore/public';
+import { ContextProviderStart } from '../../context_provider/public';
 
 /**
  * @public
@@ -150,6 +151,7 @@ export interface DiscoverStartPlugins {
   urlForwarding: UrlForwardingStart;
   inspector: InspectorPublicPluginStart;
   visualizations: VisualizationsStart;
+  contextProvider?: ContextProviderStart;
 }
 
 /**


### PR DESCRIPTION
### Description
This change wires the `contextProvider` plugin into the classic Discover page so the
AI chatbot becomes aware of the user's current page state.

When Discover renders, it now registers a page context describing the current query,
query language, dataset, and time range. This brings classic Discover to parity with
the Explore experience, where the chatbot can already reason about the active query
context.

Implementation notes:
- `contextProvider` is added as an optional plugin/dependency of Discover, so the
  feature degrades gracefully when AI features are disabled. A NOOP fallback hook is
  used when the plugin is unavailable, keeping the hook call unconditional (no
  conditional-hook violations).
- Classic Discover stores its query one level deeper (`_q.query`) compared to Explore
  (`_q`), which the `convert` mapping accounts for.

### Issues Resolved
<!-- closes #<issue-number> -->
N/A

## Screenshot
<!-- Attach a screenshot showing the chatbot responding with awareness of the current
     Discover query/dataset/time range -->
N/A

## Testing the changes
1. Build/run OpenSearch Dashboards with AI/chat features enabled.
2. Open the classic Discover page and set a query, pick a dataset, and adjust the time range.
3. **Open the AI chatbot and confirm it can reference the current query, language, dataset,
   and time range**.
4. Disable the `contextProvider` (AI features off) and confirm Discover still loads and
   functions normally (NOOP fallback path).

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using --signoff
