### PR TITLE
fix(vis_type_table): register Data Table vis type during setup

### DIFF
--- a/src/plugins/vis_type_table/public/plugin.ts
+++ b/src/plugins/vis_type_table/public/plugin.ts
@@ -30,10 +30,11 @@ const setupTableVis = async (
   core: CoreSetup,
   { expressions, visualizations }: TableVisPluginSetupDependencies
 ) => {
+  // Register visualization at setup, it should not wait for plugin start
+  visualizations.createBaseVisualization(getTableVisTypeDefinition());
   const [coreStart] = await core.getStartServices();
   expressions.registerFunction(createTableVisFn);
   expressions.registerRenderer(getTableVisRenderer(coreStart));
-  visualizations.createBaseVisualization(getTableVisTypeDefinition());
 };
 export class TableVisPlugin implements Plugin<void, void> {
   initializerContext: PluginInitializerContext<ConfigSchema>;


### PR DESCRIPTION
### Description
The Data Table visualization was missing from the "Create New Visualization" type picker. createBaseVisualization() was being called after `await core.getStartServices()`, which only resolves once the plugin's start phase runs. There is a race condition, and the type was registered too late and silently never appeared.

Move createBaseVisualization() ahead of the getStartServices() await so registration happens synchronously during setup. The expressions renderer registration still awaits start services since it genuinely needs the CoreStart contract.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
