### PR TITLE
fix(explore): update traces flyout when a different trace is selected while open

### DIFF
--- a/src/plugins/explore/public/application/pages/traces/trace_flyout/trace_flyout.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_flyout/trace_flyout.test.tsx
@@ -3,14 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TraceFlyout } from './trace_flyout';
 import { useTraceFlyoutContext } from './trace_flyout_context';
 
 jest.mock('./trace_flyout_context');
-jest.mock('../trace_details/trace_view', () => ({
-  TraceDetails: () => <div data-test-subj="traceDetails">Trace Details</div>,
-}));
+jest.mock('../trace_details/trace_view', () => {
+  // require inside the factory: jest.mock is hoisted above imports, so the top-level React
+  // import is out of scope here.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const react = require('react');
+  return {
+    // Replicate the real TraceDetails behavior: it captures trace/span only on mount and does
+    // not react to changed props. The test only sees an updated trace if TraceFlyout remounts
+    // it (via its key), which is exactly the behavior under test.
+    TraceDetails: ({ defaultTraceId, defaultSpanId }: any) => {
+      const [mounted] = react.useState(`${defaultTraceId}:${defaultSpanId}`);
+      return react.createElement('div', { 'data-test-subj': 'traceDetails' }, mounted);
+    },
+  };
+});
 
 const mockUseTraceFlyoutContext = useTraceFlyoutContext as jest.MockedFunction<
   typeof useTraceFlyoutContext
@@ -87,5 +100,30 @@ describe('TraceFlyout', () => {
     fireEvent.click(closeButton);
 
     expect(mockCloseTraceFlyout).toHaveBeenCalled();
+  });
+
+  it('updates the rendered trace when a different trace is selected while open', () => {
+    mockUseTraceFlyoutContext.mockReturnValue({
+      closeTraceFlyout: mockCloseTraceFlyout,
+      // @ts-expect-error TS2322 TODO(ts-error): fixme
+      flyoutData: mockFlyoutData,
+      isFlyoutOpen: true,
+      openTraceFlyout: jest.fn(),
+    });
+
+    const { rerender } = render(<TraceFlyout />);
+    expect(screen.getByTestId('traceDetails')).toHaveTextContent('test-trace-id:test-span-id');
+
+    // Simulate selecting a different trace row while the flyout stays open.
+    mockUseTraceFlyoutContext.mockReturnValue({
+      closeTraceFlyout: mockCloseTraceFlyout,
+      // @ts-expect-error TS2322 TODO(ts-error): fixme
+      flyoutData: { ...mockFlyoutData, traceId: 'other-trace-id', spanId: 'other-span-id' },
+      isFlyoutOpen: true,
+      openTraceFlyout: jest.fn(),
+    });
+    rerender(<TraceFlyout />);
+
+    expect(screen.getByTestId('traceDetails')).toHaveTextContent('other-trace-id:other-span-id');
   });
 });

--- a/src/plugins/explore/public/application/pages/traces/trace_flyout/trace_flyout.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_flyout/trace_flyout.tsx
@@ -23,6 +23,8 @@ export const TraceFlyout: React.FC = () => {
   return (
     <EuiFlyout data-test-subj="traceFlyout" onClose={closeTraceFlyout} ownFocus={false}>
       <TraceDetails
+        // Remount when the selected trace/span changes so re-selection updates the flyout.
+        key={`${dataset.id}:${flyoutData.traceId}:${flyoutData.spanId}`}
         isFlyout={true}
         defaultDataset={dataset}
         defaultTraceId={flyoutData.traceId}


### PR DESCRIPTION
### Description

Fixes the Explore traces flyout not updating when a different trace/span row is selected while the flyout is already open.

TraceDetails initializes its state container once on mount (the useMemo is keyed only on [osdUrlStateStorage, isFlyout], and app state via a useState initializer) and does not react to changed defaultTraceId/defaultSpanId props. So re-selecting a row reused the same instance and kept showing the original trace. Adding a key of dataset.id:traceId:spanId to <TraceDetails> forces a remount when the selection changes.

Note: the agent_traces plugin has its own separate flyout that already derives from its trace prop reactively, so it is unaffected. A more thorough fix would make Explore's TraceDetails react to its props instead of relying on a remount; the key change is the minimal, low-risk fix.

### Issues Resolved

N/A

## Screenshot

Before:

https://github.com/user-attachments/assets/3afb02f3-1b81-4bfd-8726-922a104d67df

After:

https://github.com/user-attachments/assets/72e4df89-334c-40d4-bca1-84ba3ef477ce

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
