### PR TITLE
[2.19] Resolve CVE-2026-6951, CVE-2026-40175, and CVE-2026-34043

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     "**/@microsoft/tsdoc-config/ajv": "^6.14.0",
     "**/grunt/minimatch": "^3.1.5",
     "**/lodash-es": "^4.18.0",
-    "**/lodash": "^4.18.0"
+    "**/lodash": "^4.18.0",
+    "**/axios": "^1.15.0"
   },
   "workspaces": {
     "packages": [
@@ -499,7 +500,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^5.0.10",
     "selenium-webdriver": "^4.0.0-alpha.7",
-    "simple-git": "^3.32.3",
+    "simple-git": "^3.36.0",
     "sinon": "^7.4.2",
     "strip-ansi": "^6.0.0",
     "stylelint": "^14.5.2",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     "**/grunt/minimatch": "^3.1.5",
     "**/lodash-es": "^4.18.0",
     "**/lodash": "^4.18.0",
-    "**/axios": "^1.15.0"
+    "**/axios": "^1.15.0",
+    "**/serialize-javascript": "^7.0.5"
   },
   "workspaces": {
     "packages": [

--- a/packages/osd-dev-utils/package.json
+++ b/packages/osd-dev-utils/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@babel/core": "^7.22.9",
     "@osd/utils": "1.0.0",
-    "axios": "^1.13.3",
+    "axios": "^1.15.0",
     "chalk": "^4.1.0",
     "cheerio": "1.0.0-rc.1",
     "dedent": "^0.7.0",

--- a/packages/osd-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/osd-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -132,7 +132,7 @@ export class CiStatsReporter {
           baseURL: this.config.apiUrl,
           headers: {
             Authorization: `token ${this.config.apiToken}`,
-          },
+          } as any,
           data: {
             buildId: this.config.buildId,
             metrics,

--- a/packages/osd-dev-utils/src/osd_client/osd_client_requester.ts
+++ b/packages/osd-dev-utils/src/osd_client/osd_client_requester.ts
@@ -125,7 +125,7 @@ export class OsdClientRequester {
           params: options.query,
           headers: {
             'osd-xsrf': 'osd-client',
-          },
+          } as any,
           httpsAgent: this.httpsAgent,
         });
 

--- a/packages/osd-opensearch/package.json
+++ b/packages/osd-opensearch/package.json
@@ -22,7 +22,6 @@
     "getopts": "^2.2.5",
     "glob": "^7.1.7",
     "node-fetch": "^2.6.7",
-    "simple-git": "^3.32.3",
     "tar-fs": "^2.1.4",
     "tree-kill": "^1.2.2",
     "yauzl": "^2.10.0"

--- a/packages/osd-opensearch/package.json
+++ b/packages/osd-opensearch/package.json
@@ -22,6 +22,7 @@
     "getopts": "^2.2.5",
     "glob": "^7.1.7",
     "node-fetch": "^2.6.7",
+    "simple-git": "^3.36.0",
     "tar-fs": "^2.1.4",
     "tree-kill": "^1.2.2",
     "yauzl": "^2.10.0"

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -16,7 +16,7 @@
     "@osd/i18n": "1.0.0",
     "@osd/monaco": "1.0.0",
     "abortcontroller-polyfill": "^1.4.0",
-    "axios": "^1.13.3",
+    "axios": "^1.15.0",
     "compression-webpack-plugin": "npm:@amoo-miki/compression-webpack-plugin@4.0.1-rc.1",
     "core-js": "^3.6.5",
     "custom-event-polyfill": "^0.3.0",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -108,6 +108,15 @@ const run = async () => {
     ])
   );
 
+  // serialize-javascript 7.x uses globalThis.crypto which is not available in
+  // webpack 4 worker contexts. Patch to use Node.js require('crypto') instead.
+  promises.push(
+    patchFile('node_modules/serialize-javascript/index.js', {
+      from: 'var bytes = crypto.getRandomValues(new Uint8Array(UID_LENGTH));',
+      to: "var bytes = require('crypto').randomBytes(UID_LENGTH);",
+    })
+  );
+
   await Promise.all(promises);
 };
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -87,10 +87,25 @@ const run = async () => {
 
   //Axios's type definition is far too advanced for OSD
   promises.push(
-    patchFile('node_modules/axios/index.d.ts', {
-      from: '[Key in Method as Lowercase<Key>]: AxiosHeaders;',
-      to: '[Key in Method]: AxiosHeaders;',
-    })
+    patchFile('node_modules/axios/index.d.ts', [
+      {
+        from: '[Key in Method as Lowercase<Key>]: AxiosHeaders;',
+        to: '[Key in Method]: AxiosHeaders;',
+      },
+      {
+        from:
+          'type CommonResponseHeaderKey = CommonResponseHeadersList | Lowercase<CommonResponseHeadersList>;',
+        to: 'type CommonResponseHeaderKey = CommonResponseHeadersList | string;',
+      },
+      {
+        from: 'export type Method = (UppercaseMethod | Lowercase<UppercaseMethod>) & {};',
+        to: 'export type Method = UppercaseMethod | string;',
+      },
+      {
+        from: '| Lowercase<UppercaseResponseEncoding>',
+        to: '| string',
+      },
+    ])
   );
 
   await Promise.all(promises);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15098,7 +15098,7 @@ randexp@0.4.6:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -16430,26 +16430,10 @@ send@^1.1.0, send@^1.2.0:
     range-parser "^1.2.1"
     statuses "^2.0.1"
 
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
-  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@^4.0.0, serialize-javascript@^5.0.1, serialize-javascript@^6.0.2, serialize-javascript@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.6.tgz#f2f20c8af0757e4d8fa329d0210636da0682ddef"
+  integrity sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==
 
 serve-static@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,6 +3096,18 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@simple-git/args-pathspec@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz#9ef4a2ad5f49ab4056362d03f93f775b93118ca5"
+  integrity sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==
+
+"@simple-git/argv-parser@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz#275b839c6eeb5030872c73b1ea839a416885da9d"
+  integrity sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==
+  dependencies:
+    "@simple-git/args-pathspec" "^1.0.3"
+
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
@@ -5268,14 +5280,15 @@ axe-core@^4.0.2, axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
-axios@^1.1.3, axios@^1.13.3:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
-  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
+axios@^1.1.3, axios@^1.15.0:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.1.tgz#d63f9863bcd8938815c86f9e2abd380189d96dfe"
+  integrity sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -9370,7 +9383,7 @@ focus-lock@^0.10.2:
   dependencies:
     tslib "^2.0.3"
 
-follow-redirects@^1.15.11, follow-redirects@^1.15.4, follow-redirects@^1.15.6:
+follow-redirects@^1.15.4, follow-redirects@^1.15.6, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -13593,9 +13606,9 @@ nano-css@^5.2.1:
     stylis "^4.0.6"
 
 nanoid@^3.3.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
+  integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -14918,6 +14931,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -16618,13 +16636,15 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-simple-git@^3.32.3:
-  version "3.33.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.33.0.tgz#b903dc70f5b93535a4f64ff39172da43058cfb88"
-  integrity sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==
+simple-git@^3.36.0:
+  version "3.36.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.36.0.tgz#019b28c0a35847ee34299c6fb63770ab1b2dffb7"
+  integrity sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
+    "@simple-git/args-pathspec" "^1.0.3"
+    "@simple-git/argv-parser" "^1.1.0"
     debug "^4.4.0"
 
 simple-swizzle@^0.2.2:
@@ -16725,9 +16745,9 @@ source-list-map@^2.0.0:
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
 source-map-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-resolve@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
## Description

Resolves three dependency CVEs:

### CVE-2026-6951 — simple-git RCE
- **Affected versions**: simple-git < 3.36.0
- **Fix**: Upgrade from `^3.32.3` → `^3.36.0`
- Also removes the duplicate `simple-git` dependency from `packages/osd-opensearch` (it uses the hoisted root version)

### CVE-2026-40175 — Axios Header Injection
- **Affected versions**: axios < 1.15.0
- **Fix**: Upgrade from `^1.13.3` → `^1.15.0` in osd-dev-utils and osd-ui-shared-deps
- Adds `**/axios` resolution to force transitive dependencies (chromedriver) to ^1.15.0
- Updates the axios postinstall type patch to handle additional `Lowercase` usages in axios 1.18.x (TS 4.0.2 compatibility)
- Fixes header type incompatibilities in osd-dev-utils source files

### CVE-2026-34043 — serialize-javascript DoS
- **Affected versions**: serialize-javascript < 7.0.5
- **Fix**: Add `**/serialize-javascript` resolution to force ^7.0.5 (resolves to 7.0.6)
- Adds a postinstall patch to replace `crypto.getRandomValues` with `require('crypto').randomBytes` since webpack 4 worker contexts do not expose `globalThis.crypto`

## Testing

- `yarn osd bootstrap` passes cleanly
- All package tsc compilations succeed
- All postinstall patches apply correctly

## Issues Resolved

- https://advisories.opensearch.org/advisory/CVE-2026-6951
- https://advisories.opensearch.org/advisory/CVE-2026-40175
- https://advisories.opensearch.org/advisory/CVE-2026-34043