### PR TITLE
feat(chat): hide /investigate suggestion card when tool is unavailable

### DIFF
--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { ChatMessages } from './chat_messages';
 import { ChatLayoutMode } from '../types';
 import type { Message, AssistantMessage, ToolMessage, UserMessage } from '../../common/types';
@@ -89,12 +89,48 @@ describe('ChatMessages', () => {
         <ChatMessages {...defaultProps} onShowHistory={onShowHistory} />
       );
 
-      // Verify all starter suggestions are still present
+      // Verify non-tool-gated starter suggestions are present
       expect(getByText('Ask questions about your data')).toBeTruthy();
-      expect(getByText('/investigate an issue')).toBeTruthy();
       expect(getByText('Explain a concept')).toBeTruthy();
+      // /investigate card is hidden when create_investigation tool is not registered
+      expect(queryByText('/investigate an issue')).toBeNull();
       // RecentSessions should not render without required props
       expect(queryByText('RECENT')).toBeNull();
+    });
+
+    it('should show /investigate card when create_investigation tool is registered', () => {
+      const service = AssistantActionService.getInstance();
+      service.registerAction({
+        name: 'create_investigation',
+        description: 'Create an investigation',
+        parameters: { type: 'object', properties: {}, required: [] },
+      });
+
+      const { getByText } = render(<ChatMessages {...defaultProps} />);
+
+      expect(getByText('/investigate an issue')).toBeTruthy();
+
+      // Cleanup
+      service.unregisterAction('create_investigation');
+    });
+
+    it('should hide /investigate card when create_investigation tool is unregistered', () => {
+      const service = AssistantActionService.getInstance();
+      service.registerAction({
+        name: 'create_investigation',
+        description: 'Create an investigation',
+        parameters: { type: 'object', properties: {}, required: [] },
+      });
+
+      const { queryByText } = render(<ChatMessages {...defaultProps} />);
+      expect(queryByText('/investigate an issue')).toBeTruthy();
+
+      // Unregister the tool within act() to flush state updates
+      act(() => {
+        service.unregisterAction('create_investigation');
+      });
+
+      expect(queryByText('/investigate an issue')).toBeNull();
     });
 
     it('should render RecentSessions component when all required props are provided', async () => {

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -79,6 +79,8 @@ interface SuggestionItem {
   text: string;
   prompt?: string;
   action?: () => void;
+  /** When set, this suggestion is only shown if the named tool is registered. */
+  requiredTool?: string;
 }
 
 const STARTER_SUGGESTIONS: SuggestionItem[] = [
@@ -93,6 +95,7 @@ const STARTER_SUGGESTIONS: SuggestionItem[] = [
     iconColor: 'danger',
     text: '/investigate an issue',
     prompt: '/investigate ',
+    requiredTool: 'create_investigation',
   },
   {
     icon: 'help',
@@ -329,6 +332,29 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
     assistantActionService.getCurrentState().toolCallStates
   );
 
+  // Subscribe to tool definitions to conditionally show/hide suggestion cards
+  const toolDefinitions$ = useMemo(
+    () => assistantActionService.getState$().pipe(map((state) => state.toolDefinitions)),
+    [assistantActionService]
+  );
+  const toolDefinitions = useObservable(
+    toolDefinitions$,
+    assistantActionService.getCurrentState().toolDefinitions
+  );
+
+  // Filter starter suggestions based on tool availability
+  const visibleSuggestions = useMemo(() => {
+    return STARTER_SUGGESTIONS.filter((suggestion) => {
+      if (suggestion.requiredTool) {
+        if (!toolDefinitions) {
+          return false;
+        }
+        return toolDefinitions.some((tool) => tool.name === suggestion.requiredTool);
+      }
+      return true;
+    });
+  }, [toolDefinitions]);
+
   // Context is now handled by RFC hooks and context pills
   // No need for separate context display here
 
@@ -502,7 +528,7 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
               </EuiText>
             </div>
             <div className="chatMessages__suggestions">
-              {STARTER_SUGGESTIONS.map((suggestion, index) => (
+              {visibleSuggestions.map((suggestion, index) => (
                 <EuiPanel
                   key={index}
                   paddingSize="m"


### PR DESCRIPTION
### Description

Conditionally show/hide the `/investigate` starter suggestion card based on whether the `create_investigation` tool is registered by the dashboards-investigation plugin.

### Changes

- Added `requiredTool?: string` field to `SuggestionItem` interface — a generic mechanism to gate any suggestion card on tool availability.
- The `/investigate` card entry now declares `requiredTool: 'create_investigation'`.
- `ChatMessages` subscribes to `toolDefinitions` from `AssistantActionService` and filters `STARTER_SUGGESTIONS` reactively.
- When the investigation plugin is not installed or disables the tool (e.g. on the search-relevance page), the card is hidden.

### Testing

- 3 unit tests added covering: card hidden by default, shown when tool registered, hidden when tool unregistered.
- All 47 tests in `chat_messages.test.tsx` pass.
- Manual testing with TDD stack (investigation plugin enabled/disabled).

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed off (DCO).
- [x] All tests pass locally.