### PR TITLE
[Bug fix]Fix dashboard save failing with strict_dynamic_mapping_exception on variablesJSON

### DIFF
--- a/src/plugins/dashboard/public/application/utils/update_saved_dashboard.test.ts
+++ b/src/plugins/dashboard/public/application/utils/update_saved_dashboard.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { updateSavedDashboard } from './update_saved_dashboard';
+import { SavedObjectDashboard } from '../../saved_dashboards';
+import { DashboardAppState } from '../../types';
+import { Dashboard } from '../../dashboard';
+
+const createServices = () => {
+  const savedDashboard = ({
+    searchSource: {
+      setField: jest.fn(),
+    },
+  } as unknown) as SavedObjectDashboard;
+
+  const timeFilter = {
+    getTime: jest.fn(() => ({ from: 'now-15m', to: 'now' })),
+    getRefreshInterval: jest.fn(() => ({ pause: true, value: 0 })),
+  } as any;
+
+  const dashboard = ({
+    setState: jest.fn(),
+  } as unknown) as Dashboard;
+
+  const baseAppState = ({
+    title: 'My dashboard',
+    description: '',
+    timeRestore: false,
+    panels: [],
+    options: {},
+    query: { query: '', language: 'kuery' },
+    filters: [],
+  } as unknown) as DashboardAppState;
+
+  return { savedDashboard, timeFilter, dashboard, baseAppState };
+};
+
+describe('updateSavedDashboard - variablesJSON', () => {
+  it('leaves variablesJSON undefined when there are no variables', () => {
+    const { savedDashboard, timeFilter, dashboard, baseAppState } = createServices();
+
+    updateSavedDashboard(savedDashboard, { ...baseAppState, variables: [] }, timeFilter, dashboard);
+
+    // Must stay undefined (not '') so the field is omitted from the full-document overwrite
+    // and never written to indices that lack a `variablesJSON` strict mapping. See issue #12287.
+    expect(savedDashboard.variablesJSON).toBeUndefined();
+  });
+
+  it('leaves variablesJSON undefined when variables is not provided', () => {
+    const { savedDashboard, timeFilter, dashboard, baseAppState } = createServices();
+
+    updateSavedDashboard(savedDashboard, { ...baseAppState }, timeFilter, dashboard);
+
+    expect(savedDashboard.variablesJSON).toBeUndefined();
+  });
+
+  it('serializes variablesJSON when variables exist', () => {
+    const { savedDashboard, timeFilter, dashboard, baseAppState } = createServices();
+    const variables = [{ name: 'foo', type: 'custom', value: 'bar' }];
+
+    updateSavedDashboard(
+      savedDashboard,
+      ({ ...baseAppState, variables } as unknown) as DashboardAppState,
+      timeFilter,
+      dashboard
+    );
+
+    expect(savedDashboard.variablesJSON).toBe(JSON.stringify({ variables }));
+  });
+});

--- a/src/plugins/dashboard/public/application/utils/update_saved_dashboard.ts
+++ b/src/plugins/dashboard/public/application/utils/update_saved_dashboard.ts
@@ -50,7 +50,7 @@ export function updateSavedDashboard(
   savedDashboard.variablesJSON =
     appState.variables && appState.variables.length > 0
       ? JSON.stringify({ variables: appState.variables })
-      : '';
+      : undefined;
 
   const timeFrom = savedDashboard.timeRestore
     ? FilterUtils.convertTimeToUTCString(timeFilter.getTime().from)


### PR DESCRIPTION
### Description

**Problem**
After upgrading to a version that includes Dashboard Variables (#11646), saving any dashboard on a security multi-tenancy deployment fails with `strict_dynamic_mapping_exception: dynamic introduction of [variablesJSON] within [dashboard]`.

**Root cause**
On upgrade, the saved-object migration does not add the new `variablesJSON` field to pre-existing `dynamic: strict` tenant indices (`.kibana_<hash>_<tenant>_N`) in security multi-tenancy deployments, so the index has no mapping for it. This is amplified by `updateSavedDashboard()` persisting `variablesJSON` on *every* save — even as `''` when the dashboard has no variables — which turns a narrow problem ("dashboards that use variables") into "every dashboard save fails", because `strict` rejects the unmapped field.

**Fix (write-side mitigation)**
In the full-save path, omit the field when there are no variables (write `undefined` instead of `''`). `serializeSavedObject` drops `null`/`undefined` attributes, and dashboard save uses `create(..., { overwrite: true })` (full replace), so the field is simply absent from the document when unused — `strict` has nothing to reject — and it is still cleared on full save when all variables are deleted. This makes the failure not occur regardless of whether the tenant-index migration ran.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12287

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

```

opensearch.hosts: ["https://localhost:9200"]
opensearch.ssl.verificationMode: none
opensearch.username: kibanaserver
opensearch.password: kibanaserver
opensearch.requestHeadersWhitelist: ["authorization", "securitytenant"]
opensearch_security.multitenancy.enabled: true
opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
```

Put dashboard mapping without variableJSON into your tenant kibana index
```
PUT restore_kibana_varjson_test
{
  "mappings": {
    "dynamic": "strict",
    "properties": {
      "type": { "type": "keyword" },
      "updated_at": { "type": "date" },
      "migrationVersion": { "dynamic": "true", "type": "object" },
      "references": { "type": "nested", "properties": {
        "id": { "type": "keyword" }, "name": { "type": "keyword" }, "type": { "type": "keyword" }
      }},
      "dashboard": { "properties": {
        "description": { "type": "text" },
        "hits": { "type": "integer", "index": false, "doc_values": false },
        "kibanaSavedObjectMeta": { "properties": { "searchSourceJSON": { "type": "text", "index": false } } },
        "optionsJSON": { "type": "text", "index": false },
        "panelsJSON": { "type": "text", "index": false },
        "refreshInterval": { "properties": {
          "display": { "type": "keyword", "index": false, "doc_values": false },
          "pause": { "type": "boolean", "index": false, "doc_values": false },
          "section": { "type": "integer", "index": false, "doc_values": false },
          "value": { "type": "integer", "index": false, "doc_values": false }
        }},
        "timeFrom": { "type": "keyword", "index": false, "doc_values": false },
        "timeRestore": { "type": "boolean", "index": false, "doc_values": false },
        "timeTo": { "type": "keyword", "index": false, "doc_values": false },
        "title": { "type": "text" },
        "version": { "type": "integer" }
      }}
    }
  }
}
```

Create and save a new dashboard form ui / devtool.
```

{
    "type": "dashboard",
    "id": "3b445fb0-746d-11f1-bb8a-27cb870aab0c",
    "attributes": {
        "title": "aaatest",
        "hits": 0,
        "description": "",
        "panelsJSON": "[]",
        "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
        "version": 1,
        "timeRestore": false,
        "kibanaSavedObjectMeta": {
            "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
        }
    },
    "references": [],
    "migrationVersion": {
        "dashboard": "7.9.3"
    },
    "updated_at": "2026-06-30T10:19:51.979Z",
    "version": "WzgsMV0=",
    "namespaces": [
        "default"
    ]
}
```


```
POST restore_kibana_varjson_test/_doc/dashboard:fix
{
  "type": "dashboard",
  "dashboard": { "title": "fix (no variablesJSON)", "description": "", "panelsJSON": "[]", "optionsJSON": "{}", "version": 1, "timeRestore": false },
  "references": [],
  "migrationVersion": { "dashboard": "7.9.3" },
  "updated_at": "2026-06-30T00:00:00.000Z"
}
```

Find it from index
```
GET *kibana*/_search?filter_path=hits.hits._index,hits.hits._source.dashboard.title
{
  "query": { "match": { "dashboard.title": "fix" } }
}
```

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
