### PR TITLE
Revert "feat(chat): auto-open chat window on first visit (#12233)"

### DIFF
--- a/src/plugins/chat/public/plugin.test.ts
+++ b/src/plugins/chat/public/plugin.test.ts
@@ -372,13 +372,6 @@ describe('ChatPlugin', () => {
       });
     });
 
-    it('should open chat window by default when no stored state exists', () => {
-      // No localStorage state set (first visit)
-      plugin.start(mockCoreStart, mockDeps);
-
-      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
-    });
-
     it('should persist window state changes to localStorage', () => {
       const windowStateSubject = new BehaviorSubject({
         isWindowOpen: false,
@@ -412,9 +405,8 @@ describe('ChatPlugin', () => {
       plugin.start(mockCoreStart, mockDeps);
 
       // Should not call setWindowState with invalid data from localStorage
-      // but will be called with default open state + paddingSize from sidecar config subscription
-      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(2);
-      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
+      // but will be called with paddingSize from sidecar config subscription
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(1);
       expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ paddingSize: 400 });
     });
   });

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -80,9 +80,6 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
 
     if (isValidChatWindowState(storeState)) {
       chat.setWindowState(storeState);
-    } else {
-      // First visit or no stored state — open chat by default
-      chat.setWindowState({ isWindowOpen: true });
     }
 
     this.paddingSizeSubscription = overlays.sidecar


### PR DESCRIPTION
### Description

The chat window currently overlaps with fixed-position elements on the page such as flyouts, footers and toasts. These layout conflicts should be resolved before enabling auto-open behavior.

This reverts commit 4f5a6837e77.

### Changes

- `plugin.ts`: Remove the `else` branch that called `chat.setWindowState({ isWindowOpen: true })` when no stored state existed.
- `plugin.test.ts`: Remove the corresponding test case and update assertion counts.

### Testing

- All 19 chat plugin tests pass.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed off (DCO).
- [x] All tests pass locally.