### PR TITLE
add feature flag for variableJSON

### DIFF
--- a/src/plugins/dashboard/config.ts
+++ b/src/plugins/dashboard/config.ts
@@ -32,6 +32,9 @@ import { schema, TypeOf } from '@osd/config-schema';
 
 export const configSchema = schema.object({
   allowByValueEmbeddables: schema.boolean({ defaultValue: false }),
+  variables: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -27,6 +27,10 @@ export const DashboardEditor = () => {
   const { id: dashboardIdFromUrl } = useParams<{ id: string }>();
   const { services } = useOpenSearchDashboards<DashboardServices>();
   const { chrome, uiSettings, keyboardShortcut, workspaces } = services;
+  // Master switch for the Dashboard Variables feature (dashboard.variables.enabled, default false).
+  const variablesEnabled =
+    services.pluginInitializerContext.config.get<{ variables?: { enabled?: boolean } }>()?.variables
+      ?.enabled ?? false;
   const { setHeaderVariant } = chrome;
   const isChromeVisible = useChromeVisibility({ chrome });
   const [eventEmitter] = useState(new EventEmitter());
@@ -113,8 +117,9 @@ export const DashboardEditor = () => {
               dashboardIdFromUrl={dashboardIdFromUrl}
               eventEmitter={eventEmitter}
             />
-            {/* Variables are only available in explore-enabled workspaces (observability / analytics) */}
-            {isExploreWorkspace && currentContainer.variableService && (
+            {/* Variables are only available when the feature flag is enabled and in
+                observability workspaces */}
+            {variablesEnabled && isExploreWorkspace && currentContainer.variableService && (
               <DashboardVariables
                 variableService={currentContainer.variableService}
                 interpolationService={currentContainer.variableInterpolationService}

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -140,6 +140,7 @@ export type DashboardUrlGenerator = UrlGeneratorContract<typeof DASHBOARD_APP_UR
 
 export interface DashboardFeatureFlagConfig {
   allowByValueEmbeddables: boolean;
+  variables: { enabled: boolean };
 }
 
 interface SetupDependencies {

--- a/src/plugins/dashboard/server/index.ts
+++ b/src/plugins/dashboard/server/index.ts
@@ -35,6 +35,7 @@ import { configSchema, ConfigSchema } from '../config';
 export const config: PluginConfigDescriptor<ConfigSchema> = {
   exposeToBrowser: {
     allowByValueEmbeddables: true,
+    variables: true,
   },
   schema: configSchema,
 };

--- a/src/plugins/dashboard/server/plugin.ts
+++ b/src/plugins/dashboard/server/plugin.ts
@@ -28,6 +28,7 @@
  * under the License.
  */
 
+import { first } from 'rxjs/operators';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -36,22 +37,31 @@ import {
   Logger,
 } from '../../../core/server';
 
-import { dashboardSavedObjectType } from './saved_objects';
+import { getDashboardSavedObjectType } from './saved_objects';
 import { capabilitiesProvider } from './capabilities_provider';
 
 import { DashboardPluginSetup, DashboardPluginStart } from './types';
+import { ConfigSchema } from '../config';
 
 export class DashboardPlugin implements Plugin<DashboardPluginSetup, DashboardPluginStart> {
   private readonly logger: Logger;
+  private readonly initializerContext: PluginInitializerContext;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
+    this.initializerContext = initializerContext;
   }
 
-  public setup(core: CoreSetup) {
+  public async setup(core: CoreSetup) {
     this.logger.debug('dashboard: Setup');
 
-    core.savedObjects.registerType(dashboardSavedObjectType);
+    const { variables } = await this.initializerContext.config
+      .create<ConfigSchema>()
+      .pipe(first())
+      .toPromise();
+    // Only register the `variablesJSON` mapping field when the Variables feature
+    // is enabled. When disabled, the field is absent.
+    core.savedObjects.registerType(getDashboardSavedObjectType(variables.enabled));
     core.capabilities.registerProvider(capabilitiesProvider);
     core.capabilities.registerSwitcher(async (request, capabilites) => {
       return await core.security.readonlyService().hideForReadonly(request, capabilites, {

--- a/src/plugins/dashboard/server/saved_objects/dashboard.test.ts
+++ b/src/plugins/dashboard/server/saved_objects/dashboard.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getDashboardSavedObjectType } from './dashboard';
+
+describe('getDashboardSavedObjectType - variablesJSON feature flag', () => {
+  it('is a dashboard type with the common fields regardless of the flag', () => {
+    const type = getDashboardSavedObjectType(false);
+    expect(type.name).toBe('dashboard');
+    const props = type.mappings.properties as Record<string, unknown>;
+    expect(props.title).toBeDefined();
+    expect(props.panelsJSON).toBeDefined();
+    expect(props.optionsJSON).toBeDefined();
+  });
+
+  it('does NOT register variablesJSON in the mapping when the feature is disabled', () => {
+    const type = getDashboardSavedObjectType(false);
+    const props = type.mappings.properties as Record<string, unknown>;
+    // Field absent -> upgrades do not change the dashboard mapping hash ->
+    // no saved-object migration is triggered for it (safe for multi-tenancy / AOS).
+    expect(props.variablesJSON).toBeUndefined();
+  });
+
+  it('registers variablesJSON (text, index:false) when the feature is enabled', () => {
+    const type = getDashboardSavedObjectType(true);
+    const props = type.mappings.properties as Record<string, unknown>;
+    expect(props.variablesJSON).toEqual({ type: 'text', index: false });
+  });
+});

--- a/src/plugins/dashboard/server/saved_objects/dashboard.ts
+++ b/src/plugins/dashboard/server/saved_objects/dashboard.ts
@@ -31,7 +31,17 @@
 import { SavedObjectsType } from 'opensearch-dashboards/server';
 import { dashboardSavedObjectTypeMigrations } from './dashboard_migrations';
 
-export const dashboardSavedObjectType: SavedObjectsType = {
+/**
+ * Builds the `dashboard` saved-object type.
+ *
+ * The `variablesJSON` field (Dashboard Variables) is only registered when the
+ * feature is enabled. When disabled, the field is absent from the mapping, so
+ * upgrading does NOT change the dashboard mapping hash and therefore does NOT
+ * trigger a saved-object index migration for it. This is important for
+ * multi-tenancy deployments (e.g. Amazon OpenSearch Service domains), where
+ * tenant-index migration is fragile and the Variables feature is never used.
+ */
+export const getDashboardSavedObjectType = (variablesEnabled: boolean): SavedObjectsType => ({
   name: 'dashboard',
   hidden: false,
   namespaceType: 'single',
@@ -63,7 +73,7 @@ export const dashboardSavedObjectType: SavedObjectsType = {
       },
       optionsJSON: { type: 'text', index: false },
       panelsJSON: { type: 'text', index: false },
-      variablesJSON: { type: 'text', index: false },
+      ...(variablesEnabled ? { variablesJSON: { type: 'text', index: false } } : {}),
       refreshInterval: {
         properties: {
           display: { type: 'keyword', index: false, doc_values: false },
@@ -80,4 +90,4 @@ export const dashboardSavedObjectType: SavedObjectsType = {
     },
   },
   migrations: dashboardSavedObjectTypeMigrations,
-};
+});

--- a/src/plugins/dashboard/server/saved_objects/index.ts
+++ b/src/plugins/dashboard/server/saved_objects/index.ts
@@ -28,4 +28,4 @@
  * under the License.
  */
 
-export { dashboardSavedObjectType } from './dashboard';
+export { getDashboardSavedObjectType } from './dashboard';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7750,14 +7750,14 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001759:
-  version "1.0.30001766"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz#b6f6b55cb25a2d888d9393104d14751c6a7d6f7a"
-  integrity sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==
+  version "1.0.30001800"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz"
+  integrity sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001797"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz#1332709e1439f01ff92085dd17001e0a45897ec0"
-  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
+  version "1.0.30001800"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz"
+  integrity sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
### Description

Introduces a new dashboard.variables.enabled feature flag (default false) that acts as the master switch for the Dashboard Variables feature. When the flag is off, the variablesJSON field is not registered in the dashboard saved-object mapping, and the Variables UI is gated off.

Call-out — local dev with the flag OFF
Because the flag defaults to false, variablesJSON is dropped from the dashboard mapping. If your local .kibana index was previously created by a build that registered variablesJSON (e.g. main, or a flag-on run), starting OSD triggers a saved-object migration (Detected mapping change in "properties.dashboard"), which can either get stuck in a polling loop (resource_already_exists_exception on a leftover .kibana_2) or fail with strict_dynamic_mapping_exception if existing dashboards contain a variablesJSON value.

This is a local-dev-only effect of toggling the field off on an index that already has it. To develop/test the Variables feature locally, set dashboard.variables.enabled: true in config/opensearch_dashboards.dev.yml (or clear the affected local .kibana_* indices). Fresh installs and deployments that never registered the field are unaffected.
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
