### PR TITLE
fix(chat): resolve slash commands after data source selection

### DIFF
--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -84,6 +84,9 @@ describe('ChatWindow', () => {
         content,
         rawMessage: rawMessage || content,
       })),
+      generateMessageId: jest.fn(
+        () => `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
+      ),
       getAvailableDataSources: jest
         .fn()
         .mockResolvedValue([{ id: 'mock-ds-id', title: 'Mock DS' }]),
@@ -940,6 +943,113 @@ describe('ChatWindow', () => {
         expect.any(Array),
         expect.any(Object)
       );
+    });
+
+    it('should execute slash command after user selects a data source', async () => {
+      // Register a slash command for this test
+      const { slashCommandRegistry } = jest.requireActual('../services/slash_commands');
+      const mockHandler = jest.fn().mockReturnValue('resolved command message');
+      slashCommandRegistry.register({
+        command: 'test-cmd',
+        description: 'Test command',
+        handler: mockHandler,
+      });
+
+      mockChatService.getCurrentDataSourceId.mockResolvedValue(undefined);
+      mockChatService.getAvailableDataSources.mockResolvedValue([
+        { id: 'ds-1', title: 'Source One' },
+      ]);
+
+      const ref = React.createRef<ChatWindowInstance>();
+      const { getByRole, getByText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      // Type a slash command and send
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: '/test-cmd some args' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Data source selector should be shown
+      expect(getByText('Source One')).toBeTruthy();
+      // Command should NOT have been executed yet
+      expect(mockHandler).not.toHaveBeenCalled();
+
+      // Select the data source
+      fireEvent.click(getByText('Source One'));
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // After data source selection, the slash command should be executed
+      expect(mockChatService.setDataSourceId).toHaveBeenCalledWith('ds-1');
+      expect(mockHandler).toHaveBeenCalledWith('some args');
+      // The command returns a message to send to the agent
+      expect(mockChatService.sendMessage).toHaveBeenCalledWith(
+        'resolved command message',
+        expect.any(Array),
+        expect.any(Object)
+      );
+
+      // Clean up registered command
+      slashCommandRegistry.unregister('test-cmd');
+    });
+
+    it('should handle local-only slash command after data source selection', async () => {
+      // Register a slash command that returns a local message
+      const { slashCommandRegistry } = jest.requireActual('../services/slash_commands');
+      const mockHandler = jest.fn().mockReturnValue({
+        localMessage: 'Local response from command',
+        title: 'Command Result',
+      });
+      slashCommandRegistry.register({
+        command: 'local-cmd',
+        description: 'Local command',
+        handler: mockHandler,
+      });
+
+      mockChatService.getCurrentDataSourceId.mockResolvedValue(undefined);
+      mockChatService.getAvailableDataSources.mockResolvedValue([
+        { id: 'ds-1', title: 'Source One' },
+      ]);
+
+      const ref = React.createRef<ChatWindowInstance>();
+      const { getByRole, getByText } = renderWithContext(
+        <ChatWindow ref={ref} onClose={jest.fn()} />
+      );
+
+      // Type a local slash command and send (include trailing space to bypass autocomplete menu)
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: '/local-cmd ' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Data source selector should be shown
+      expect(getByText('Source One')).toBeTruthy();
+
+      // Select the data source
+      fireEvent.click(getByText('Source One'));
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // After data source selection, the slash command should be executed locally
+      expect(mockChatService.setDataSourceId).toHaveBeenCalledWith('ds-1');
+      expect(mockHandler).toHaveBeenCalled();
+      // Should NOT send to the agent since it's a local command
+      expect(mockChatService.sendMessage).not.toHaveBeenCalled();
+
+      // Clean up registered command
+      slashCommandRegistry.unregister('local-cmd');
     });
   });
 

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -265,17 +265,81 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     }
   }, [chatService, currentRunId, eventHandler]);
 
-  // Handler for when user selects a data source from the prompt
-  const handleDataSourceSelect = useCallback(async (id: string) => {
-    chatService.setDataSourceId(id);
-    setAvailableDataSources([]);
-    const pending = pendingMessage;
-    setPendingMessage(null);
-    if (!pending) return;
+  /**
+   * Execute a slash command and update the timeline accordingly.
+   * @param messageContent - The raw user input (e.g. "/search-relevance query")
+   * @param messagesToSend - The message history (excluding the user message) to pass to subscribeToMessageStream
+   * @param pendingUserMessage - The user message already in the timeline (data source selection flow).
+   *   When provided, it is replaced (by id) with the resolved command message; otherwise a fresh
+   *   user message is inserted.
+   * @returns true if the command was handled, false otherwise
+   */
+  const executeSlashCommand = useCallback(
+    async (
+      messageContent: string,
+      messagesToSend: Message[],
+      pendingUserMessage?: UserMessage
+    ): Promise<boolean> => {
+      const commandResult = await slashCommandRegistry.execute(messageContent);
+      if (!commandResult.handled) return false;
 
-    // User message already in timeline from handleSend; pass history without it
-    subscribeToMessageStream(timeline.slice(0, -1), pending);
-  }, [chatService, pendingMessage, subscribeToMessageStream, timeline]);
+      if (commandResult.localMessage) {
+        const role = commandResult.role ?? 'system';
+        const responseMsg: Message = {
+          id: chatService.generateMessageId(),
+          role,
+          content: commandResult.localMessage,
+          ...(role === 'system' && commandResult.title && { title: commandResult.title }),
+        };
+        if (pendingUserMessage) {
+          // User message already in timeline (data source selection flow) — append response
+          setTimeline((prev) => [...prev, responseMsg]);
+        } else {
+          const userMsg = chatService.getUserMessage(messageContent);
+          setTimeline((prev) => [...prev, userMsg, responseMsg]);
+        }
+        setScreenshotData(undefined);
+        return true;
+      }
+      if (commandResult.message) {
+        const userMsg = chatService.getUserMessage(commandResult.message, messageContent);
+        if (pendingUserMessage) {
+          // Replace the pending user message (by id) with the resolved command message
+          setTimeline((prev) =>
+            prev.map((msg) => (msg.id === pendingUserMessage.id ? userMsg : msg))
+          );
+        } else {
+          setTimeline((prev) => [...prev, userMsg]);
+        }
+        subscribeToMessageStream(messagesToSend, userMsg);
+        return true;
+      }
+      return true;
+    },
+    [chatService, subscribeToMessageStream]
+  );
+
+  // Handler for when user selects a data source from the prompt
+  const handleDataSourceSelect = useCallback(
+    async (id: string) => {
+      chatService.setDataSourceId(id);
+      setAvailableDataSources([]);
+      const pending = pendingMessage;
+      setPendingMessage(null);
+      if (!pending) return;
+
+      const messageContent = typeof pending.content === 'string' ? pending.content : '';
+      const historyMessages = timeline.slice(0, -1);
+
+      // Pending user message is already in the timeline — replace it if a slash command
+      const handled = await executeSlashCommand(messageContent, historyMessages, pending);
+      if (handled) return;
+
+      // Normal message: user message already in timeline, just stream
+      subscribeToMessageStream(historyMessages, pending);
+    },
+    [chatService, pendingMessage, executeSlashCommand, subscribeToMessageStream, timeline]
+  );
 
   const handleSend = async (options?: {input?: string, messages?: Message[]}) => {
     const messageContent = options?.input ?? input.trim();
@@ -329,7 +393,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     if (!isValid) {
       if (compatibleDataSources.length >= 1) {
-        // Compatible data sources exist — prompt user to pick one
+        // Compatible data sources exist — prompt user to pick one.
+        // The user message is added to the timeline now so it stays visible while the
+        // selector is shown; handleDataSourceSelect replaces it once a source is chosen.
         const userMsg = chatService.getUserMessage(messageContent);
         setPendingMessage(userMsg);
         setAvailableDataSources(compatibleDataSources);
@@ -351,27 +417,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     }
 
     // Check if this is a slash command
-    const commandResult = await slashCommandRegistry.execute(messageContent);
-    if (commandResult.handled) {
-      if (commandResult.localMessage) {
-        const userMsg = chatService.getUserMessage(messageContent);
-        const role = commandResult.role ?? 'system';
-        const responseMsg: Message = {
-          id: chatService.generateMessageId(),
-          role,
-          content: commandResult.localMessage,
-          ...(role === 'system' && commandResult.title && { title: commandResult.title }),
-        };
-        setTimeline((prev) => [...prev, userMsg, responseMsg]);
-        return;
-      }
-      if (commandResult.message) {
-        const userMsg = chatService.getUserMessage(commandResult.message, messageContent);
-        setTimeline((prev) => [...prev, userMsg]);
-        return subscribeToMessageStream(messagesToSend, userMsg);
-      }
-      return;
-    }
+    const handled = await executeSlashCommand(messageContent, messagesToSend);
+    if (handled) return;
 
     // Normal message flow — add user message to timeline then stream
     const userMsg = chatService.getUserMessage(messageContent);


### PR DESCRIPTION
### Description

When the chat window is opened with an invalid/absent data source and compatible data sources exist, the user is prompted to select one before their message is sent. Previously, after the user selected a data source, the pending message was always streamed to the AI agent verbatim — so a queued slash command (e.g. `/search-relevance query`) was sent as raw text instead of being resolved through the slash command registry.

This change makes the data source selection flow resolve slash commands the same way `handleSend` does:

- Extracted the slash command handling in `handleSend` into a shared `executeSlashCommand` helper.
- `handleDataSourceSelect` now runs the pending message through `executeSlashCommand` before falling back to normal streaming. Because the pending user message is already in the timeline, the helper replaces it (by message id) with the resolved command message, or appends the local response for local-only commands.
- Local-command responses clear any stale screenshot data, matching the normal send path.

### Issues Resolved

N/A

## Screenshot

N/A — behavioral fix, no UI changes.

## Testing the changes

1. Open a workspace where the chat window shows the data source selector (no valid data source set, but at least one compatible data source available).
2. Type a slash command (e.g. `/search-relevance test`) and send.
3. The data source selector appears with your message visible above it.
4. Select a data source.
5. Verify the slash command is resolved and executed (its handler runs), rather than the raw `/command` text being sent to the agent.
6. Repeat with a local-only slash command and confirm the local response is rendered without contacting the agent.

Unit tests added in `chat_window.test.tsx`:
- executes an agent-forwarded slash command after data source selection
- handles a local-only slash command after data source selection

All 947 chat plugin unit tests pass.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
