### PR TITLE
fix(chrome): guard useOpenOnUrlMarker against undefined window.location.hash

### DIFF
--- a/src/plugins/opensearch_dashboards_utils/public/react/use_open_on_url_marker.test.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/react/use_open_on_url_marker.test.ts
@@ -119,4 +119,18 @@ describe('useOpenOnUrlMarker', () => {
     expect(onOpen).toHaveBeenCalledTimes(1);
     expect(window.location.hash).toBe('#/');
   });
+
+  it('does not throw when window.location.hash is undefined (partial mock)', () => {
+    // Some component tests stub window.location without a `hash` property; the
+    // hook must default to '' rather than call .indexOf on undefined.
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+    // @ts-expect-error intentionally partial mock, mirroring how apm tests stub it
+    delete window.location;
+    // @ts-expect-error assign a hash-less location
+    window.location = { pathname: '/', search: '' };
+    const onOpen = jest.fn();
+    expect(() => renderHook(() => useOpenOnUrlMarker('_openSaved', onOpen))).not.toThrow();
+    expect(onOpen).not.toHaveBeenCalled();
+    if (originalDescriptor) Object.defineProperty(window, 'location', originalDescriptor);
+  });
 });

--- a/src/plugins/opensearch_dashboards_utils/public/react/use_open_on_url_marker.ts
+++ b/src/plugins/opensearch_dashboards_utils/public/react/use_open_on_url_marker.ts
@@ -38,7 +38,9 @@ import { useEffect } from 'react';
 export function useOpenOnUrlMarker(marker: string, onOpen: () => void) {
   useEffect(() => {
     const openIfMarked = () => {
-      const hash = window.location.hash; // e.g. "#/?_openSaved=true&_g=..."
+      // Default to '' so the hook is safe under partial `window.location` mocks
+      // (some component tests stub `window.location` without a `hash`).
+      const hash = window.location.hash || ''; // e.g. "#/?_openSaved=true&_g=..."
       const qIndex = hash.indexOf('?');
       if (qIndex === -1) return;
       if (new URLSearchParams(hash.slice(qIndex + 1)).get(marker) !== 'true') return;


### PR DESCRIPTION
## Description

Follow-up to #12285. The `useOpenOnUrlMarker` hook reads `window.location.hash` and calls `.indexOf('?')` on it. Some component tests (e.g. `dashboards-observability`'s `public/components/apm/__tests__/services.test.tsx`) stub `window.location` **without** a `hash` property, so `.indexOf` was called on `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'indexOf')
  at openIfMarked (…/use_open_on_url_marker.ts)
```

The simplification in #12285 dropped the defensive default that previously guarded this. This restores it: `const hash = window.location.hash || '';`.

## Changes
- Default `window.location.hash` to `''` in `useOpenOnUrlMarker` so the hook is safe under partial `window.location` mocks.
- Add a regression test asserting the hook does not throw when `window.location` has no `hash`.

Refs: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11545

## Testing
- `yarn test:jest src/plugins/opensearch_dashboards_utils/public/react/use_open_on_url_marker.test.ts` — 11/11 pass.
- Verified the new test reproduces the crash without the guard and passes with it.

## Check List
- [x] All tests pass
- [x] New functionality includes testing
- [ ] New functionality has been documented (n/a)
- [x] Commit changes are signed off (DCO)