### PR TITLE
Sidenav Info Tooltip

### DIFF
--- a/src/core/public/chrome/nav_group/nav_group_service.ts
+++ b/src/core/public/chrome/nav_group/nav_group_service.ts
@@ -78,6 +78,14 @@ export interface ChromeRegistrationNavLink {
    * services ({@link NavPopoverServices}) so plugins do not re-resolve them.
    */
   navPopover?: NavPopoverConfig;
+
+  /**
+   * Optional informational text. When set, a right-aligned info icon is shown
+   * on the nav link in the expanded side navigation; hovering it reveals this
+   * text in a tooltip. Use it to explain what a newly introduced or
+   * multi-purpose destination covers (e.g. what a consolidated hub spans).
+   */
+  infoTooltip?: string;
 }
 
 export type NavGroupItemInMap = ChromeNavGroup & {

--- a/src/core/public/chrome/ui/header/collapsed_side_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsed_side_nav.tsx
@@ -165,6 +165,7 @@ function CollapsedLeafIcon({
           navPopover={link.navPopover}
           services={popoverServices}
           navigateToApp={navigateToApp}
+          infoTooltip={link.infoTooltip}
         />
       ) : (
         <div className="obsNavPopover obsNavPopover--titleOnly" data-test-subj="obsNavPopover">

--- a/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.scss
+++ b/src/core/public/chrome/ui/header/collapsible_nav_group_enabled.scss
@@ -605,6 +605,22 @@ $osd-sidebar-top-min-height: 116px;
   transform: translateX(-8px);
 }
 
+// Right-aligned info affordance (an "i" icon with a hover tooltip). Fades out
+// with the label when the rail collapses, since only the leading icon shows
+// in the collapsed rail.
+.obs-nav-info {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  transition: opacity $osd-sidebar-transition;
+  opacity: 1;
+}
+
+.osd-sidebar[data-state="collapsed"] .obs-nav-info {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .obs-nav-icon {
   // Match collapsed icon sizing (28x28 button, 16x16 icon)
   width: 28px;

--- a/src/core/public/chrome/ui/header/expanded_side_nav.test.tsx
+++ b/src/core/public/chrome/ui/header/expanded_side_nav.test.tsx
@@ -142,6 +142,33 @@ describe('<ExpandedSideNav />', () => {
     expect(container.querySelector('.obs-nav-item-row--no-icon')).toBeInTheDocument();
   });
 
+  describe('info tooltip', () => {
+    it('renders a right-aligned info icon when infoTooltip is set', () => {
+      const navLinks = [
+        makeLink({
+          id: 'alerting',
+          title: 'Alerts',
+          euiIconType: 'navAlerting',
+          infoTooltip: 'New alerting hub — alerts, anomaly detection, and SLOs together.',
+        }),
+      ];
+      const { container, getByLabelText } = render(
+        <ExpandedSideNav {...defaultProps} navLinks={navLinks} />
+      );
+      expect(container.querySelector('.obs-nav-info')).toBeInTheDocument();
+      // EuiIconTip exposes the content as the icon's aria-label.
+      expect(
+        getByLabelText('New alerting hub — alerts, anomaly detection, and SLOs together.')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render an info icon when infoTooltip is absent', () => {
+      const navLinks = [makeLink({ id: 'logs', title: 'Logs', euiIconType: 'logsApp' })];
+      const { container } = render(<ExpandedSideNav {...defaultProps} navLinks={navLinks} />);
+      expect(container.querySelector('.obs-nav-info')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders collapsible section for collapsible categories', () => {
     const collapsibleCategory = {
       id: 'tools',

--- a/src/core/public/chrome/ui/header/expanded_side_nav.tsx
+++ b/src/core/public/chrome/ui/header/expanded_side_nav.tsx
@@ -104,7 +104,12 @@ function NavLeafItem({
           <EuiText size="s">{link.title}</EuiText>
         </EuiFlexItem>
         {link.infoTooltip && (
-          <EuiFlexItem grow={false} className="obs-nav-info">
+          <EuiFlexItem
+            grow={false}
+            className="obs-nav-info"
+            // Stop clicks on the info icon from triggering the row's navigation.
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          >
             <EuiIconTip
               type="iInCircle"
               size="s"
@@ -112,8 +117,6 @@ function NavLeafItem({
               aria-label={link.infoTooltip}
               content={link.infoTooltip}
               position="right"
-              // Stop the tooltip's icon from triggering navigation on the row.
-              anchorProps={{ onClick: (e: React.MouseEvent) => e.stopPropagation() }}
             />
           </EuiFlexItem>
         )}

--- a/src/core/public/chrome/ui/header/expanded_side_nav.tsx
+++ b/src/core/public/chrome/ui/header/expanded_side_nav.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiIconTip, EuiText } from '@elastic/eui';
 import { InternalApplicationStart } from '../../../application/types';
 import { HttpStart } from '../../../http';
 import { ChromeNavLink } from '../../nav_links';
@@ -103,6 +103,20 @@ function NavLeafItem({
         <EuiFlexItem className="obs-nav-label">
           <EuiText size="s">{link.title}</EuiText>
         </EuiFlexItem>
+        {link.infoTooltip && (
+          <EuiFlexItem grow={false} className="obs-nav-info">
+            <EuiIconTip
+              type="iInCircle"
+              size="s"
+              color="subdued"
+              aria-label={link.infoTooltip}
+              content={link.infoTooltip}
+              position="right"
+              // Stop the tooltip's icon from triggering navigation on the row.
+              anchorProps={{ onClick: (e: React.MouseEvent) => e.stopPropagation() }}
+            />
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </a>
   );

--- a/src/core/public/chrome/ui/header/nav_item_popover.test.tsx
+++ b/src/core/public/chrome/ui/header/nav_item_popover.test.tsx
@@ -71,6 +71,41 @@ describe('<NavItemPopover />', () => {
     expect(navigateToApp).toHaveBeenCalledWith('alerts');
   });
 
+  it('renders a right-aligned info icon in the title when infoTooltip is set', () => {
+    const { container, getByLabelText } = render(
+      <NavItemPopover
+        title="Alerts"
+        services={makeServices()}
+        navigateToApp={jest.fn()}
+        infoTooltip="New alerting hub — alerts, anomaly detection, and SLOs together."
+      />
+    );
+    expect(container.querySelector('.obsNavPopover-titleInfo')).toBeInTheDocument();
+    expect(
+      getByLabelText('New alerting hub — alerts, anomaly detection, and SLOs together.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders no title info icon when infoTooltip is absent', () => {
+    const { container } = render(
+      <NavItemPopover title="Alerts" services={makeServices()} navigateToApp={jest.fn()} />
+    );
+    expect(container.querySelector('.obsNavPopover-titleInfo')).not.toBeInTheDocument();
+  });
+
+  it('renders no title info icon when the title is hidden (showTitle=false)', () => {
+    const { container } = render(
+      <NavItemPopover
+        title="Alerts"
+        services={makeServices()}
+        navigateToApp={jest.fn()}
+        showTitle={false}
+        infoTooltip="Some info"
+      />
+    );
+    expect(container.querySelector('.obsNavPopover-titleInfo')).not.toBeInTheDocument();
+  });
+
   it('renders no action buttons when there are no actions', () => {
     const { container } = render(
       <NavItemPopover title="Logs" services={makeServices()} navigateToApp={jest.fn()} />

--- a/src/core/public/chrome/ui/header/nav_item_popover.tsx
+++ b/src/core/public/chrome/ui/header/nav_item_popover.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiIcon, EuiPopoverTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiIconTip, EuiPopoverTitle } from '@elastic/eui';
 import { NavPopoverConfig, NavPopoverServices } from '../../nav_group';
 import { InternalApplicationStart } from '../../../application/types';
 import { SimplePopover } from './simple_popover';
@@ -38,6 +38,13 @@ export interface NavItemPopoverProps {
    * collapsed rail where the label is otherwise unavailable.
    */
   showTitle?: boolean;
+  /**
+   * Optional informational text. When set (and the title is shown), a
+   * right-aligned info icon is rendered in the title bar; hovering it reveals
+   * this text in a tooltip. Mirrors the info affordance on the expanded nav row
+   * so the collapsed rail's flyout carries the same context.
+   */
+  infoTooltip?: string;
 }
 
 /** Whether this item or any nested descendant matches the current app id. */
@@ -131,6 +138,7 @@ export function NavItemPopover({
   childItems,
   appId,
   showTitle = true,
+  infoTooltip,
 }: NavItemPopoverProps) {
   const actions = navPopover?.actions ?? [];
   const hasActions = actions.length > 0;
@@ -139,7 +147,27 @@ export function NavItemPopover({
 
   return (
     <div className="obsNavPopover" data-test-subj="obsNavPopover">
-      {showTitle && <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>}
+      {showTitle && (
+        <EuiPopoverTitle paddingSize="s">
+          {infoTooltip ? (
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem>{title}</EuiFlexItem>
+              <EuiFlexItem grow={false} className="obsNavPopover-titleInfo">
+                <EuiIconTip
+                  type="iInCircle"
+                  size="s"
+                  color="subdued"
+                  aria-label={infoTooltip}
+                  content={infoTooltip}
+                  position="right"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            title
+          )}
+        </EuiPopoverTitle>
+      )}
       <div className="obsNavPopover-content">
         {hasActions && (
           <div className="obsNavPopover-section">


### PR DESCRIPTION
## Description

Adds an optional `infoTooltip` field to nav-link registration so plugins can attach a short explanatory tooltip to a side-navigation item. When set, a right-aligned info (`iInCircle`) icon is rendered on the nav item; hovering it reveals the text in a tooltip.

The affordance is wired into both navigation states:

- **Expanded side nav** — The info icon is right-aligned on the nav row, after the label. It fades out when the rail collapses (there's no room for it in the icon-only rail).
- **Collapsed rail** — The info icon is corner-aligned in the top-right of the item's hover flyout title bar, so the same context is available when the nav is collapsed.

This is a generic Core capability; no built-in nav item sets `infoTooltip` in this PR. It's consumed downstream (e.g. the `dashboards-observability` "Alerts" nav item, raised separately).

## Changes

- `src/core/public/chrome/nav_group/nav_group_service.ts` — Add optional `infoTooltip?: string` to the `ChromeRegistrationNavLink` public interface.
- `src/core/public/chrome/ui/header/expanded_side_nav.tsx` — Render a right-aligned `EuiIconTip` on the nav row when `infoTooltip` is set; clicking the icon stops propagation so it doesn't trigger row navigation.
- `src/core/public/chrome/ui/header/nav_item_popover.tsx` — When the flyout title is shown, render the title as a flex row with a corner-aligned info icon.
- `src/core/public/chrome/ui/header/collapsed_side_nav.tsx` — Thread `infoTooltip` through to the flyout `NavItemPopover`.
- `src/core/public/chrome/ui/header/collapsible_nav_group_enabled.scss` — Style `.obs-nav-info`; fade it out with the label when the rail collapses.

## Testing the changes

New/updated unit tests (run with `node scripts/jest`):

- `src/core/public/chrome/ui/header/expanded_side_nav.test.tsx` — Renders a right-aligned info icon when `infoTooltip` is set; renders none when absent.
- `src/core/public/chrome/ui/header/nav_item_popover.test.tsx` — Renders the corner-aligned title info icon when `infoTooltip` is set; renders none when absent or when the title is hidden.

```bash
node scripts/jest \
  src/core/public/chrome/ui/header/expanded_side_nav.test.tsx \
  src/core/public/chrome/ui/header/nav_item_popover.test.tsx \
  src/core/public/chrome/ui/header/collapsed_side_nav.test.tsx
```

All suites green (61 tests). Also verified with `yarn typecheck` and `node scripts/eslint` on the changed files.

## Screenshot
<img width="576" height="294" alt="InfoPopup" src="https://github.com/user-attachments/assets/118a5291-6186-46d1-b7ac-d08682f635fe" />

<img width="606" height="307" alt="InfoPopupSide" src="https://github.com/user-attachments/assets/f5444191-5adf-4983-a28e-0d91a2eed834" />

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
