### PR TITLE
Enable ElasticSearch (6.8 and above) cluster to be used as a Data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ snapshots.js
 
 # osd-pm bootstrap fast-path fingerprint (local machine state)
 /.osd-bootstrap-fingerprint
+
+# git worktrees (local isolated workspaces)
+/.worktrees/

--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -446,4 +446,9 @@
 
 # @experimental Enable legacy Elasticsearch backend compatibility.
 # This feature is currently being developed and should be used with caution in production environments.
-# backendCompatibility.enabled: false
+# backend_compatibility.enabled: false
+
+# @experimental Gate SQL/PPL per selected dataset for legacy Elasticsearch data sources and route
+# those queries to the Open Distro endpoints. When disabled (default), SQL/PPL are shown for all
+# datasets and queries always use the /_plugins endpoints.
+# queryEnhancements.legacyElasticsearchCompatibility.enabled: false

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.ts
@@ -71,6 +71,7 @@ const KNOWN_MANIFEST_FIELDS = (() => {
     supportedOSDataSourceVersions: true,
     requiredOSDataSourcePlugins: true,
     unsupportedOSDataSourceEngineTypes: true,
+    minDataSourceEngineVersions: true,
   };
 
   return new Set(Object.keys(manifestFields));
@@ -255,6 +256,11 @@ export async function parseManifest(
     unsupportedOSDataSourceEngineTypes: Array.isArray(manifest.unsupportedOSDataSourceEngineTypes)
       ? manifest.unsupportedOSDataSourceEngineTypes
       : [],
+    minDataSourceEngineVersions:
+      manifest.minDataSourceEngineVersions &&
+      typeof manifest.minDataSourceEngineVersions === 'object'
+        ? manifest.minDataSourceEngineVersions
+        : undefined,
   };
 }
 

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -226,6 +226,15 @@ export interface PluginManifest {
    * engines are added.
    */
   readonly unsupportedOSDataSourceEngineTypes?: readonly string[];
+
+  /**
+   * Specifies minimum data source engine versions required by this plugin. Data sources whose
+   * engine version is below the declared minimum for their engine type will be hidden from
+   * selectors in this plugin's context.
+   *
+   * Keyed by engine type (e.g. "Elasticsearch"), value is a semver minimum (e.g. "7.9.0").
+   */
+  readonly minDataSourceEngineVersions?: Readonly<Record<string, string>>;
 }
 
 /**

--- a/src/plugins/data/common/data_source_engine_capabilities.test.ts
+++ b/src/plugins/data/common/data_source_engine_capabilities.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DEFAULT_ENGINE_CAPABILITIES,
+  getDataSourceEngineCapabilities,
+} from './data_source_engine_capabilities';
+
+describe('getDataSourceEngineCapabilities', () => {
+  it('returns Elasticsearch capabilities (Open Distro, no span, no runtime grammar, min versions)', () => {
+    const caps = getDataSourceEngineCapabilities('Elasticsearch');
+    expect(caps.usesOpenDistroSqlPpl).toBe(true);
+    expect(caps.supportsPplSpan).toBe(false);
+    expect(caps.supportsRuntimePplGrammar).toBe(false);
+    expect(caps.minLanguageVersions).toEqual({ SQL: '6.5.0', PPL: '7.9.0' });
+    expect(caps.sqlPplEndpoints).toEqual({
+      ppl: 'enhancements.pplQueryOpenDistro',
+      sql: 'enhancements.sqlQueryOpenDistro',
+    });
+  });
+
+  it('returns default capabilities for OpenSearch', () => {
+    expect(getDataSourceEngineCapabilities('OpenSearch')).toEqual(DEFAULT_ENGINE_CAPABILITIES);
+  });
+
+  it.each([
+    'OpenSearch Serverless',
+    'AnalyticEngine',
+    'OpenSearch(Cross-cluster search)',
+    'No Engine Type Available',
+    'SomethingUnknown',
+  ])('fails open to default capabilities for unmapped engine %s', (engineType) => {
+    expect(getDataSourceEngineCapabilities(engineType)).toEqual(DEFAULT_ENGINE_CAPABILITIES);
+  });
+
+  it('fails open to default capabilities when engine type is undefined', () => {
+    const caps = getDataSourceEngineCapabilities(undefined);
+    expect(caps).toEqual(DEFAULT_ENGINE_CAPABILITIES);
+    expect(caps.usesOpenDistroSqlPpl).toBe(false);
+    expect(caps.supportsPplSpan).toBe(true);
+    expect(caps.supportsRuntimePplGrammar).toBe(true);
+    expect(caps.minLanguageVersions).toBeUndefined();
+  });
+});

--- a/src/plugins/data/common/data_source_engine_capabilities.ts
+++ b/src/plugins/data/common/data_source_engine_capabilities.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// NOTE: import the engine type as a TYPE only. `DataSourceEngineType` is an enum (a runtime value),
+// and `data/common` is re-bundled into consumer plugins via `extraPublicDirs`; a runtime value-import
+// across that boundary resolves to `undefined` at load time and breaks this module. The enum's string
+// values (`'Elasticsearch'`, `'OpenSearch'`) are used directly as keys instead.
+import type { DataSourceEngineType } from '../../data_source/common/data_sources';
+
+/** String values of {@link DataSourceEngineType} used as keys here (kept in sync with the enum). */
+const ENGINE = {
+  Elasticsearch: 'Elasticsearch' as DataSourceEngineType.Elasticsearch,
+  OpenSearch: 'OpenSearch' as DataSourceEngineType.OpenSearch,
+};
+
+/**
+ * Action-name endpoints (as registered on the enhancements client in
+ * `query_enhancements/server/utils/plugins.ts`) used by the server `Facet` to run SQL/PPL for a
+ * given engine. These are client-action names, NOT URL paths — the `/_plugins/_*` vs
+ * `/_opendistro/_*` URL mapping lives in `query_enhancements/common/constants.ts`.
+ */
+export interface SqlPplEndpointActions {
+  ppl: string;
+  sql: string;
+}
+
+/**
+ * Comprehensive, declarative description of what a data-source engine supports. Centralizes the
+ * per-engine behavior that used to be scattered as inline `=== 'Elasticsearch'` checks, so adding
+ * support for another engine means filling in one entry with full context.
+ *
+ * Engines without an explicit entry fall through to {@link DEFAULT_ENGINE_CAPABILITIES}, which
+ * mirrors the historical OpenSearch behavior (fail-open): consumers therefore stay unchanged for
+ * OpenSearch, Serverless, AnalyticEngine, cross-cluster, and unknown engines.
+ */
+export interface DataSourceEngineCapabilities {
+  /**
+   * Minimum data-source version (semver) at which each language is supported on this engine.
+   * Absent => no per-version gating for that engine.
+   */
+  minLanguageVersions?: { SQL?: string; PPL?: string };
+  /** SQL/PPL live under the Open Distro endpoints (`/_opendistro/_*`) instead of `/_plugins/_*`. */
+  usesOpenDistroSqlPpl: boolean;
+  /** Whether `stats ... by span(<field>, <interval>)` time-bucketing is supported in PPL. */
+  supportsPplSpan: boolean;
+  /** Whether the backend runtime PPL grammar endpoint (`/_plugins/_ppl/_grammar`) exists. */
+  supportsRuntimePplGrammar: boolean;
+  /** Client-action endpoints the server Facet should use to run PPL/SQL for this engine. */
+  sqlPplEndpoints: SqlPplEndpointActions;
+}
+
+/** Default capabilities (historical OpenSearch behavior) for engines without an explicit entry. */
+export const DEFAULT_ENGINE_CAPABILITIES: DataSourceEngineCapabilities = {
+  usesOpenDistroSqlPpl: false,
+  supportsPplSpan: true,
+  supportsRuntimePplGrammar: true,
+  sqlPplEndpoints: { ppl: 'enhancements.pplQuery', sql: 'enhancements.sqlQuery' },
+};
+
+/**
+ * Explicit per-engine capabilities. Only engines that diverge from the default are listed; all
+ * others resolve to {@link DEFAULT_ENGINE_CAPABILITIES}.
+ */
+const ENGINE_CAPABILITIES: Partial<Record<string, DataSourceEngineCapabilities>> = {
+  // Legacy Elasticsearch: SQL/PPL live under Open Distro, no span() in the PPL grammar, no runtime
+  // grammar endpoint. Per the "features by engine version" matrix, SQL needs ES >= 6.5 and PPL
+  // needs ES >= 7.9.
+  [ENGINE.Elasticsearch]: {
+    minLanguageVersions: { SQL: '6.5.0', PPL: '7.9.0' },
+    usesOpenDistroSqlPpl: true,
+    supportsPplSpan: false,
+    supportsRuntimePplGrammar: false,
+    sqlPplEndpoints: {
+      ppl: 'enhancements.pplQueryOpenDistro',
+      sql: 'enhancements.sqlQueryOpenDistro',
+    },
+  },
+  [ENGINE.OpenSearch]: { ...DEFAULT_ENGINE_CAPABILITIES },
+};
+
+/**
+ * Returns the capabilities for the given engine type, falling back to
+ * {@link DEFAULT_ENGINE_CAPABILITIES} for unmapped/unknown/undefined engines (fail-open).
+ *
+ * @param engineType the data source engine type, typically `dataSource.engineType ?? dataSource.type`.
+ */
+export const getDataSourceEngineCapabilities = (
+  engineType?: string
+): DataSourceEngineCapabilities => {
+  return ENGINE_CAPABILITIES[engineType ?? ''] ?? DEFAULT_ENGINE_CAPABILITIES;
+};

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -16,6 +16,13 @@ export interface DataSource {
   title: string;
   /** The engine type of the data source */
   type: string;
+  /**
+   * Explicit data-source engine type (e.g. `Elasticsearch`, `OpenSearch`). Distinct from
+   * {@link type}, which is overloaded across dataset types (engine type for index patterns, the
+   * literal `DATA_SOURCE` for indexes). Consumers gating on the engine should prefer
+   * `engineType ?? type`.
+   */
+  engineType?: string;
   /** Version of the data source */
   version: string;
   /** Optional metadata for the data source */

--- a/src/plugins/data/common/index.ts
+++ b/src/plugins/data/common/index.ts
@@ -29,6 +29,7 @@
  */
 
 export * from './constants';
+export * from './data_source_engine_capabilities';
 export * from './opensearch_query';
 export * from './data_views';
 export * from './data_frames';

--- a/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_cache.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_cache.ts
@@ -158,8 +158,12 @@ class PPLGrammarCache {
 
   /**
    * Returns true if version >= 3.6.0 (grammar artifact endpoint support).
+   *
+   * Elasticsearch data sources never expose the `/_plugins/_ppl/_grammar` endpoint (their SQL/PPL
+   * live under Open Distro), so they always fall back to the bundled grammar regardless of version.
    */
-  shouldFetchFromBackend(version?: string): boolean {
+  shouldFetchFromBackend(version?: string, engineType?: string): boolean {
+    if (engineType === 'Elasticsearch') return false;
     if (!version) return false;
     const coerced = semver.coerce(version);
     return coerced ? semver.satisfies(coerced.version, '>=3.6.0') : false;
@@ -181,7 +185,8 @@ class PPLGrammarCache {
     uiSettings: IUiSettingsClient | undefined,
     savedObjectsClient?: SavedObjectsClientContract,
     datasourceId?: string,
-    datasourceVersion?: string
+    datasourceVersion?: string,
+    datasourceEngineType?: string
   ): void {
     // Check feature flag - if disabled, reset cache state but keep subscribers
     const runtimeGrammarEnabled = uiSettings?.get('query:enhancements:runtimePplGrammar') !== false;
@@ -208,7 +213,13 @@ class PPLGrammarCache {
     // Already cached, in-flight, or recently failed — nothing to do.
     if (this.cachedGrammar || this.pendingFetch || this.fetchFailed) return;
 
-    const promise = this.doWarmUp(http, savedObjectsClient, datasourceId, datasourceVersion);
+    const promise = this.doWarmUp(
+      http,
+      savedObjectsClient,
+      datasourceId,
+      datasourceVersion,
+      datasourceEngineType
+    );
     this.pendingFetch = promise;
 
     promise
@@ -252,7 +263,8 @@ class PPLGrammarCache {
     http: HttpSetup,
     savedObjectsClient: SavedObjectsClientContract | undefined,
     datasourceId?: string,
-    datasourceVersion?: string
+    datasourceVersion?: string,
+    datasourceEngineType?: string
   ): Promise<CachedGrammar | null> {
     const version = await this.resolveVersion(
       http,
@@ -260,7 +272,7 @@ class PPLGrammarCache {
       datasourceId,
       datasourceVersion
     );
-    if (!this.shouldFetchFromBackend(version)) {
+    if (!this.shouldFetchFromBackend(version, datasourceEngineType)) {
       // Version unsupported or unknown — not a failure, just nothing to fetch.
       // Don't set fetchFailed so that future warmUp calls can retry when the
       // version becomes available (e.g. /api/status wasn't ready on page load).
@@ -395,10 +407,13 @@ export const pplGrammarCache = new PPLGrammarCache();
 
 export function shouldUseRuntimeGrammar(
   _dataSourceId?: string,
-  dataSourceVersion?: string
+  dataSourceVersion?: string,
+  dataSourceEngineType?: string
 ): boolean {
+  // Elasticsearch data sources have no runtime grammar endpoint — use the bundled grammar.
+  if (dataSourceEngineType === 'Elasticsearch') return false;
   if (dataSourceVersion) {
-    return pplGrammarCache.shouldFetchFromBackend(dataSourceVersion);
+    return pplGrammarCache.shouldFetchFromBackend(dataSourceVersion, dataSourceEngineType);
   }
   return true;
 }

--- a/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_cache.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_cache.ts
@@ -12,6 +12,7 @@ import { ATN, ATNDeserializer, Vocabulary } from 'antlr4ng';
 import semver from 'semver';
 import { PPLGrammarBundle } from './ppl_bundle_loader';
 import { TokenDictionary } from '../opensearch_sql/table';
+import { getDataSourceEngineCapabilities } from '../../../common';
 
 const ARTIFACT_ENDPOINT = '/api/enhancements/ppl/grammar';
 
@@ -159,11 +160,12 @@ class PPLGrammarCache {
   /**
    * Returns true if version >= 3.6.0 (grammar artifact endpoint support).
    *
-   * Elasticsearch data sources never expose the `/_plugins/_ppl/_grammar` endpoint (their SQL/PPL
-   * live under Open Distro), so they always fall back to the bundled grammar regardless of version.
+   * Engines without a runtime PPL grammar endpoint (e.g. Elasticsearch / Open Distro, whose SQL/PPL
+   * live under Open Distro and expose no `/_plugins/_ppl/_grammar`) always fall back to the bundled
+   * grammar regardless of version.
    */
   shouldFetchFromBackend(version?: string, engineType?: string): boolean {
-    if (engineType === 'Elasticsearch') return false;
+    if (!getDataSourceEngineCapabilities(engineType).supportsRuntimePplGrammar) return false;
     if (!version) return false;
     const coerced = semver.coerce(version);
     return coerced ? semver.satisfies(coerced.version, '>=3.6.0') : false;
@@ -410,8 +412,9 @@ export function shouldUseRuntimeGrammar(
   dataSourceVersion?: string,
   dataSourceEngineType?: string
 ): boolean {
-  // Elasticsearch data sources have no runtime grammar endpoint — use the bundled grammar.
-  if (dataSourceEngineType === 'Elasticsearch') return false;
+  // Engines without a runtime grammar endpoint (e.g. Elasticsearch) use the bundled grammar.
+  if (!getDataSourceEngineCapabilities(dataSourceEngineType).supportsRuntimePplGrammar)
+    return false;
   if (dataSourceVersion) {
     return pplGrammarCache.shouldFetchFromBackend(dataSourceVersion, dataSourceEngineType);
   }

--- a/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_warmup.test.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_warmup.test.ts
@@ -52,6 +52,7 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       undefined,
+      undefined,
       undefined
     );
   });
@@ -71,7 +72,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-1',
-      '3.6.0'
+      '3.6.0',
+      undefined
     );
   });
 
@@ -110,7 +112,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-2',
-      '3.6.0'
+      '3.6.0',
+      undefined
     );
   });
 
@@ -129,7 +132,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-old',
-      '2.17.0'
+      '2.17.0',
+      undefined
     );
   });
 
@@ -148,6 +152,7 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-unknown',
+      undefined,
       undefined
     );
   });
@@ -169,7 +174,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-1',
-      '3.6.0'
+      '3.6.0',
+      undefined
     );
     expect(cache.warmUp).toHaveBeenNthCalledWith(
       2,
@@ -177,7 +183,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-2',
-      '2.17.0'
+      '2.17.0',
+      undefined
     );
     expect(cache.warmUp).toHaveBeenNthCalledWith(
       3,
@@ -185,13 +192,15 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-3',
-      '3.7.0'
+      '3.7.0',
+      undefined
     );
     expect(cache.warmUp).toHaveBeenNthCalledWith(
       4,
       http,
       uiSettings,
       savedObjectsClient,
+      undefined,
       undefined,
       undefined
     );
@@ -219,6 +228,7 @@ describe('ppl_grammar_warmup', () => {
       http,
       uiSettings,
       savedObjectsClient,
+      undefined,
       undefined,
       undefined
     );
@@ -266,7 +276,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-snap',
-      '3.6.0-SNAPSHOT'
+      '3.6.0-SNAPSHOT',
+      undefined
     );
   });
 
@@ -289,7 +300,8 @@ describe('ppl_grammar_warmup', () => {
       uiSettings,
       savedObjectsClient,
       'ds-old',
-      '2.17.0'
+      '2.17.0',
+      undefined
     );
   });
 });

--- a/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_warmup.ts
+++ b/src/plugins/data/public/antlr/opensearch_ppl/ppl_grammar_warmup.ts
@@ -16,6 +16,8 @@ interface QueryLike {
     dataSource?: {
       id?: string;
       version?: string;
+      engineType?: string;
+      type?: string;
     };
   };
 }
@@ -46,11 +48,20 @@ export function createPplGrammarWarmupHandler(
 
     const datasourceId = query.dataset.dataSource?.id;
     const datasourceVersion = query.dataset.dataSource?.version;
+    const datasourceEngineType =
+      query.dataset.dataSource?.engineType ?? query.dataset.dataSource?.type;
 
     // Always forward to warmUp so the cache can detect feature flag changes,
-    // datasource changes, and clear stale entries. The version gate (>= 3.6)
-    // lives inside the cache's doWarmUp — unsupported versions won't trigger
-    // a network fetch.
-    grammarCache.warmUp(http, uiSettings, savedObjectsClient, datasourceId, datasourceVersion);
+    // datasource changes, and clear stale entries. The version gate (>= 3.6) and the
+    // Elasticsearch short-circuit live inside the cache's doWarmUp — unsupported versions and
+    // Elasticsearch engines won't trigger a network fetch.
+    grammarCache.warmUp(
+      http,
+      uiSettings,
+      savedObjectsClient,
+      datasourceId,
+      datasourceVersion,
+      datasourceEngineType
+    );
   };
 }

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -22,11 +22,19 @@ import { IDataPluginServices } from '../../../types';
 import { indexPatternTypeConfig, indexTypeConfig } from './lib';
 import { DatasetTypeConfig, DataStructureFetchOptions } from './types';
 
+export type DatasetFilter = (dataset: Dataset) => boolean;
+
+interface AppDatasetFilter {
+  appId: string;
+  filter: DatasetFilter;
+}
+
 export class DatasetService {
   private indexPatterns?: IndexPatternsContract;
   private defaultDataset?: Dataset;
   private typesRegistry: Map<string, DatasetTypeConfig> = new Map();
   private recentDatasets: LRUCache<string, Dataset>;
+  private datasetFilters: AppDatasetFilter[] = [];
 
   constructor(
     private readonly uiSettings: CoreStart['uiSettings'],
@@ -56,6 +64,15 @@ export class DatasetService {
 
   public registerType(handlerConfig: DatasetTypeConfig): void {
     this.typesRegistry.set(handlerConfig.id, handlerConfig);
+  }
+
+  public registerDatasetFilter(appId: string, filter: DatasetFilter): void {
+    this.datasetFilters.push({ appId, filter });
+  }
+
+  public isDatasetAllowed(dataset: Dataset, appId?: string): boolean {
+    if (!appId) return true;
+    return this.datasetFilters.filter((f) => f.appId === appId).every((f) => f.filter(dataset));
   }
 
   public getType(type: string): DatasetTypeConfig | undefined {

--- a/src/plugins/data/public/query/query_string/dataset_service/index.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/index.ts
@@ -4,4 +4,4 @@
  */
 
 export * from './types';
-export { DatasetServiceContract, DatasetService } from './dataset_service';
+export { DatasetServiceContract, DatasetService, DatasetFilter } from './dataset_service';

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
@@ -74,6 +74,82 @@ describe('indexPatternTypeConfig', () => {
     });
   });
 
+  describe('toDataset engineType/version plumbing', () => {
+    test('populates engineType and version from pattern.parent and its CUSTOM meta', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'test-pattern',
+          title: 'Test Pattern',
+          type: 'INDEX_PATTERN',
+          meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+          parent: {
+            id: 'datasource-es',
+            title: 'My ES Cluster',
+            type: 'Elasticsearch',
+            meta: {
+              type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+              dataSourceVersion: '7.10.2',
+            },
+          },
+        },
+      ];
+
+      const result = indexPatternTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toEqual({
+        id: 'datasource-es',
+        title: 'My ES Cluster',
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: '7.10.2',
+      });
+    });
+
+    test('defaults version to empty string when parent meta has no dataSourceVersion', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'test-pattern',
+          title: 'Test Pattern',
+          type: 'INDEX_PATTERN',
+          meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+          parent: {
+            id: 'datasource-es',
+            title: 'My ES Cluster',
+            type: 'Elasticsearch',
+            meta: {
+              type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+            },
+          },
+        },
+      ];
+
+      const result = indexPatternTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toEqual({
+        id: 'datasource-es',
+        title: 'My ES Cluster',
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: '',
+      });
+    });
+
+    test('leaves dataSource undefined when pattern has no parent', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'test-pattern',
+          title: 'Test Pattern',
+          type: 'INDEX_PATTERN',
+          meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+        },
+      ];
+
+      const result = indexPatternTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toBeUndefined();
+    });
+  });
+
   test('fetchFields returns fields from index pattern', async () => {
     const mockIndexPattern = {
       fields: [
@@ -175,6 +251,10 @@ describe('indexPatternTypeConfig', () => {
           id: 'datasource-abc',
           title: 'My Data Source',
           type: 'OpenSearch',
+          meta: {
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+            dataSourceVersion: undefined,
+          },
         },
       });
     });
@@ -223,6 +303,10 @@ describe('indexPatternTypeConfig', () => {
           id: 'datasource-xyz',
           title: 'External Data Source',
           type: 'OpenSearch',
+          meta: {
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+            dataSourceVersion: undefined,
+          },
         },
       });
     });
@@ -319,6 +403,10 @@ describe('indexPatternTypeConfig', () => {
         id: 'datasource-1',
         title: 'Data Source 1',
         type: 'OpenSearch',
+        meta: {
+          type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          dataSourceVersion: undefined,
+        },
       });
 
       // Namespaced method
@@ -326,6 +414,10 @@ describe('indexPatternTypeConfig', () => {
         id: 'datasource-2',
         title: 'Data Source 2',
         type: 'OpenSearch',
+        meta: {
+          type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          dataSourceVersion: undefined,
+        },
       });
 
       // No data source

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.ts
@@ -32,6 +32,8 @@ export const indexPatternTypeConfig: DatasetTypeConfig = {
     const pattern = path[path.length - 1];
     const patternMeta = pattern.meta as DataStructureCustomMeta;
 
+    const parentMeta = pattern.parent?.meta as DataStructureCustomMeta | undefined;
+
     return {
       id: pattern.id,
       title: pattern.title,
@@ -44,6 +46,8 @@ export const indexPatternTypeConfig: DatasetTypeConfig = {
             id: pattern.parent.id,
             title: pattern.parent.title,
             type: pattern.parent.type,
+            engineType: pattern.parent.type,
+            version: parentMeta?.dataSourceVersion ?? '',
           }
         : undefined,
     } as Dataset;
@@ -184,6 +188,12 @@ const fetchIndexPatterns = async (client: SavedObjectsClientContract): Promise<D
           id: dataSourceId!, // Since we know it exists
           title: dataSource.title,
           type: dataSource.dataSourceEngineType ?? DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH,
+          // Carry the data-source version through CUSTOM meta so `toDataset` can populate
+          // `dataSource.version` for per-dataset language gating. Engine type stays in `type`.
+          meta: {
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+            dataSourceVersion: dataSource.dataSourceVersion,
+          } as DataStructureCustomMeta,
         };
       }
       return indexPatternDataStructure;

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
@@ -9,6 +9,7 @@ import { indexTypeConfig } from './index_type';
 import { HttpSetup, SavedObjectsClientContract } from 'opensearch-dashboards/public';
 import {
   DATA_STRUCTURE_META_TYPES,
+  DEFAULT_DATA,
   DataStructure,
   DataStructureCustomMeta,
   Dataset,
@@ -72,10 +73,13 @@ describe('indexTypeConfig', () => {
       title: 'Index 1',
       type: 'INDEXES',
       timeFieldName: '@timestamp',
+      isRemoteDataset: undefined,
       dataSource: {
         id: 'datasource1',
         title: 'DataSource 1',
         type: 'DATA_SOURCE',
+        engineType: undefined,
+        version: '',
       },
     });
   });
@@ -157,6 +161,88 @@ describe('indexTypeConfig', () => {
     // Should contain wildcard patterns first, then exact indices
     expect(result.title).toBe('logs-*,index1,index2');
     expect(result.type).toBe('INDEXES');
+  });
+
+  describe('toDataset engineType/version plumbing', () => {
+    test('populates engineType/version from the DATA_SOURCE node meta', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'datasource1',
+          title: 'DataSource 1',
+          type: 'DATA_SOURCE',
+          meta: {
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+            dataSourceEngineType: 'Elasticsearch',
+            dataSourceVersion: '7.10.2',
+          } as DataStructureCustomMeta,
+        },
+        {
+          id: 'index1',
+          title: 'Index 1',
+          type: 'INDEX',
+          meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+        },
+      ];
+
+      const result = indexTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toEqual({
+        id: 'datasource1',
+        title: 'DataSource 1',
+        type: 'DATA_SOURCE',
+        engineType: 'Elasticsearch',
+        version: '7.10.2',
+      });
+    });
+
+    test('falls back to leaf index meta when DATA_SOURCE node meta lacks engineType/version', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'datasource1',
+          title: 'DataSource 1',
+          type: 'DATA_SOURCE',
+          meta: {
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+          } as DataStructureCustomMeta,
+        },
+        {
+          id: 'index1',
+          title: 'Index 1',
+          type: 'INDEX',
+          meta: {
+            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+            timeFieldName: '@timestamp',
+            dataSourceEngineType: 'Elasticsearch',
+            dataSourceVersion: '7.10.2',
+          } as DataStructureCustomMeta,
+        },
+      ];
+
+      const result = indexTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toEqual({
+        id: 'datasource1',
+        title: 'DataSource 1',
+        type: 'DATA_SOURCE',
+        engineType: 'Elasticsearch',
+        version: '7.10.2',
+      });
+    });
+
+    test('falls back to LOCAL_DATASOURCE when there is no DATA_SOURCE node in path', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'index1',
+          title: 'Index 1',
+          type: 'INDEX',
+          meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+        },
+      ];
+
+      const result = indexTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toEqual(DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE);
+    });
   });
 
   test('fetchFields returns fields from index', async () => {
@@ -589,6 +675,8 @@ describe('indexTypeConfig', () => {
           id: 'test-datasource',
           title: 'Test DataSource',
           type: 'DATA_SOURCE',
+          engineType: undefined,
+          version: '',
         },
       });
     });

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
@@ -32,6 +32,9 @@ jest.mock('../../../../services', () => {
         getLanguageService: () => ({
           getQueryEditorExtensionMap: jest.fn().mockReturnValue({}),
         }),
+        getDatasetService: () => ({
+          isDatasetAllowed: jest.fn().mockReturnValue(true),
+        }),
       },
     }),
   };

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -120,12 +120,29 @@ export const indexTypeConfig: DatasetTypeConfig = {
 
       default: {
         const dataSources = await fetchDataSources(services.savedObjects.client, services.http);
-        // enrich dataSources with remoteConnections
+        const datasetService = services.data.query.queryString.getDatasetService();
+        const filteredDataSources = dataSources.filter((ds) => {
+          const meta = ds.meta as DataStructureCustomMeta | undefined;
+          if (!meta?.dataSourceEngineType && !meta?.dataSourceVersion) return true;
+          const fakeDataset: Dataset = {
+            id: ds.id,
+            title: ds.title,
+            type: DEFAULT_DATA.SET_TYPES.INDEX,
+            dataSource: {
+              id: ds.id,
+              title: ds.title,
+              type: meta.dataSourceEngineType ?? '',
+              engineType: meta.dataSourceEngineType,
+              version: meta.dataSourceVersion ?? '',
+            },
+          };
+          return datasetService.isDatasetAllowed(fakeDataset, services.appName);
+        });
         return {
           ...dataStructure,
           columnHeader: 'Data sources',
           hasNext: true,
-          children: dataSources,
+          children: filteredDataSources,
         };
       }
     }

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -17,7 +17,7 @@ import {
   Dataset,
 } from '../../../../../common';
 import { DatasetTypeConfig } from '../types';
-import { getIndexPatterns } from '../../../../services';
+import { getIndexPatterns, getQueryService } from '../../../../services';
 import {
   getRemoteClusterConnections,
   getRemoteClusterIndices,
@@ -120,7 +120,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
 
       default: {
         const dataSources = await fetchDataSources(services.savedObjects.client, services.http);
-        const datasetService = services.data.query.queryString.getDatasetService();
+        const datasetService = getQueryService().queryString.getDatasetService();
         const filteredDataSources = dataSources.filter((ds) => {
           const meta = ds.meta as DataStructureCustomMeta | undefined;
           if (!meta?.dataSourceEngineType && !meta?.dataSourceVersion) return true;

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -42,6 +42,12 @@ export const indexTypeConfig: DatasetTypeConfig = {
     const index = path[path.length - 1];
     const dataSource = path.find((ds) => ds.type === 'DATA_SOURCE');
     const indexMeta = index.meta as DataStructureCustomMeta;
+    const dataSourceMeta = dataSource?.meta as DataStructureCustomMeta | undefined;
+    // Prefer the engine type/version carried on the DATA_SOURCE node's meta; fall back to the leaf
+    // index's meta (stashed defensively in `fetch`) in case the node's meta did not survive.
+    const dataSourceEngineType =
+      dataSourceMeta?.dataSourceEngineType ?? indexMeta?.dataSourceEngineType;
+    const dataSourceVersion = dataSourceMeta?.dataSourceVersion ?? indexMeta?.dataSourceVersion;
 
     // Build dataset title from multi-selections (wildcards and/or exact indices)
     let datasetTitle = index.title;
@@ -75,6 +81,8 @@ export const indexTypeConfig: DatasetTypeConfig = {
             id: dataSource.id,
             title: dataSource.title,
             type: dataSource.type,
+            engineType: dataSourceEngineType,
+            version: dataSourceVersion ?? '',
           }
         : DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE,
     } as Dataset;
@@ -85,6 +93,11 @@ export const indexTypeConfig: DatasetTypeConfig = {
     switch (dataStructure.type) {
       case 'DATA_SOURCE': {
         const indices = await fetchAllIndices(dataStructure, services.http); // contains all indices
+
+        // Defensively stash the engine type + version (carried on the DATA_SOURCE node's meta) onto
+        // each child INDEX leaf, so `toDataset` can recover them even if the DATA_SOURCE node's meta
+        // does not survive to selection time.
+        const dataSourceMeta = dataStructure.meta as DataStructureCustomMeta | undefined;
 
         return {
           ...dataStructure,
@@ -98,6 +111,8 @@ export const indexTypeConfig: DatasetTypeConfig = {
             meta: {
               type: DATA_STRUCTURE_META_TYPES.CUSTOM,
               isRemoteIndex: index.isRemoteIndex,
+              dataSourceEngineType: dataSourceMeta?.dataSourceEngineType,
+              dataSourceVersion: dataSourceMeta?.dataSourceVersion,
             },
           })),
         };
@@ -196,32 +211,40 @@ const mapDataSourceSavedObjectToDataStructure = (
     .filter((connection) => connection.parentId === dataSourceId)
     .map((connection) => connection.connectionsAliases)?.[0]; // Each parentdatasourcce will have only one remote connections entry hence getting the first element
 
+  // Always carry the engine type + version through CUSTOM meta so `toDataset` can populate
+  // `dataSource.engineType`/`dataSource.version` for per-dataset language gating. Merge the
+  // cross-cluster-search icon when remote connections exist.
+  const meta: DataStructureCustomMeta = {
+    type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+    dataSourceEngineType: savedObject.attributes.dataSourceEngineType,
+    dataSourceVersion: savedObject.attributes.dataSourceVersion,
+    ...(relevantRemoteConnections && relevantRemoteConnections.length > 0
+      ? {
+          additionalAppendIcons: [
+            {
+              type: 'iInCircle',
+              tooltip: i18n.translate(
+                'data.query.queryString.datasetExplorer.index.additonalmetaIcon.tooltip',
+                {
+                  defaultMessage:
+                    'Connnected with {remoteConnections} indexes using Cross cluster search.',
+                  values: {
+                    remoteConnections: relevantRemoteConnections.join(','),
+                  },
+                }
+              ),
+            },
+          ],
+        }
+      : {}),
+  };
+
   return {
     id: dataSourceId,
     title: dataSourceTitle,
     type: 'DATA_SOURCE',
     remoteConnections: relevantRemoteConnections,
-    meta:
-      relevantRemoteConnections && relevantRemoteConnections.length > 0
-        ? {
-            type: DATA_STRUCTURE_META_TYPES.CUSTOM,
-            additionalAppendIcons: [
-              {
-                type: 'iInCircle',
-                tooltip: i18n.translate(
-                  'data.query.queryString.datasetExplorer.index.additonalmetaIcon.tooltip',
-                  {
-                    defaultMessage:
-                      'Connnected with {remoteConnections} indexes using Cross cluster search.',
-                    values: {
-                      remoteConnections: relevantRemoteConnections.join(','),
-                    },
-                  }
-                ),
-              },
-            ],
-          }
-        : undefined,
+    meta,
   };
 };
 

--- a/src/plugins/data/public/query/query_string/language_service/language_service.test.ts
+++ b/src/plugins/data/public/query/query_string/language_service/language_service.test.ts
@@ -153,4 +153,101 @@ describe('LanguageService', () => {
     service.__enhance({ queryEditorExtension: mockExtension });
     expect(service.getQueryEditorExtensionMap()).toEqual({ 'test-extension': mockExtension });
   });
+
+  describe('isLanguageSupportedForDataset', () => {
+    const makeLanguage = (
+      supportedDataSources?: LanguageConfig['supportedDataSources']
+    ): LanguageConfig =>
+      (({
+        id: 'TEST',
+        title: 'Test',
+        search: {} as any,
+        getQueryString: jest.fn(),
+        editor: {} as any,
+        supportedDataSources,
+      } as unknown) as LanguageConfig);
+
+    // Mirrors the declared minimums: SQL >= 6.5, PPL >= 7.9 on Elasticsearch.
+    const sqlLanguage = makeLanguage({ minVersionByEngine: { Elasticsearch: '6.5.0' } });
+    const pplLanguage = makeLanguage({ minVersionByEngine: { Elasticsearch: '7.9.0' } });
+
+    const datasetWith = (dataSource?: Record<string, any>) =>
+      ({ id: 'd', title: 'd', type: 'INDEX_PATTERN', dataSource } as any);
+
+    it('returns true when the language declares no supportedDataSources', () => {
+      const lang = makeLanguage(undefined);
+      expect(
+        service.isLanguageSupportedForDataset(
+          lang,
+          datasetWith({ type: 'Elasticsearch', engineType: 'Elasticsearch', version: '6.0.0' })
+        )
+      ).toBe(true);
+    });
+
+    it('hides SQL and PPL for Elasticsearch 6.4 (below both minimums)', () => {
+      const ds = datasetWith({
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: '6.4.0',
+      });
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, ds)).toBe(false);
+      expect(service.isLanguageSupportedForDataset(pplLanguage, ds)).toBe(false);
+    });
+
+    it('shows SQL but hides PPL for Elasticsearch 6.5', () => {
+      const ds = datasetWith({
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: '6.5.0',
+      });
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, ds)).toBe(true);
+      expect(service.isLanguageSupportedForDataset(pplLanguage, ds)).toBe(false);
+    });
+
+    it('shows both SQL and PPL for Elasticsearch 7.9', () => {
+      const ds = datasetWith({
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: '7.9.0',
+      });
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, ds)).toBe(true);
+      expect(service.isLanguageSupportedForDataset(pplLanguage, ds)).toBe(true);
+    });
+
+    it.each([
+      ['OpenSearch', '1.0.0'],
+      ['OpenSearchServerless', ''],
+      ['AnalyticEngine', '1.0.0'],
+      ['OpenSearchCrossCluster', '2.0.0'],
+    ])('fail-opens for non-Elasticsearch engine %s', (engineType, version) => {
+      const ds = datasetWith({ type: engineType, engineType, version });
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, ds)).toBe(true);
+      expect(service.isLanguageSupportedForDataset(pplLanguage, ds)).toBe(true);
+    });
+
+    it('fail-opens when dataset has no data source (local cluster)', () => {
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, datasetWith(undefined))).toBe(true);
+      expect(service.isLanguageSupportedForDataset(pplLanguage, undefined)).toBe(true);
+    });
+
+    it('fail-opens for Elasticsearch with empty or unparseable version', () => {
+      const empty = datasetWith({
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: '',
+      });
+      const garbage = datasetWith({
+        type: 'Elasticsearch',
+        engineType: 'Elasticsearch',
+        version: 'not-a-version',
+      });
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, empty)).toBe(true);
+      expect(service.isLanguageSupportedForDataset(pplLanguage, garbage)).toBe(true);
+    });
+
+    it('falls back to dataSource.type when engineType is absent', () => {
+      const ds = datasetWith({ type: 'Elasticsearch', version: '6.0.0' });
+      expect(service.isLanguageSupportedForDataset(sqlLanguage, ds)).toBe(false);
+    });
+  });
 });

--- a/src/plugins/data/public/query/query_string/language_service/language_service.ts
+++ b/src/plugins/data/public/query/query_string/language_service/language_service.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import semver from 'semver';
 import { EditorEnhancements, LanguageConfig } from './types';
 import { getDQLLanguageConfig, getLuceneLanguageConfig } from './lib';
 import { ISearchInterceptor } from '../../../search';
 import { createEditor, DQLBody, QueryEditorExtensionConfig, SingleLineInput } from '../../../ui';
-import { DataStorage, setOverrides as setFieldOverrides } from '../../../../common';
+import { DataStorage, Dataset, setOverrides as setFieldOverrides } from '../../../../common';
 import { dqlLanguageReference } from './lib/dql_language_reference';
 import { luceneLanguageReference } from './lib/lucene_language_reference';
 
@@ -62,6 +63,33 @@ export class LanguageService {
 
   public getDefaultLanguage(): LanguageConfig | undefined {
     return this.languages.get('kuery') || this.languages.values().next().value;
+  }
+
+  /**
+   * Determines whether a language is supported for the currently selected dataset, based on the
+   * dataset's data-source engine type and version against the language's declared
+   * {@link LanguageConfig.supportedDataSources}.
+   *
+   * Fail-open by design: returns `true` whenever applicability cannot be conclusively determined,
+   * so unknown/missing engine types, blank or unparseable versions, datasets without a data source,
+   * and languages that declare no `supportedDataSources` are all treated as supported. Only an
+   * engine with a declared minimum version AND a parseable dataset version below that minimum
+   * yields `false`.
+   */
+  public isLanguageSupportedForDataset(language: LanguageConfig, dataset?: Dataset): boolean {
+    const minVersionByEngine = language.supportedDataSources?.minVersionByEngine;
+    if (!minVersionByEngine) return true;
+
+    const engine = dataset?.dataSource?.engineType ?? dataset?.dataSource?.type;
+    if (!engine) return true;
+
+    const minVersion = minVersionByEngine[engine];
+    if (!minVersion) return true;
+
+    const coerced = semver.coerce(dataset?.dataSource?.version);
+    if (!coerced) return true;
+
+    return semver.satisfies(coerced.version, `>=${minVersion}`);
   }
 
   public getQueryEditorExtensionMap() {

--- a/src/plugins/data/public/query/query_string/language_service/language_service.ts
+++ b/src/plugins/data/public/query/query_string/language_service/language_service.ts
@@ -68,7 +68,7 @@ export class LanguageService {
   /**
    * Determines whether a language is supported for the currently selected dataset, based on the
    * dataset's data-source engine type and version against the language's declared
-   * {@link LanguageConfig.supportedDataSources}.
+   * `LanguageConfig.supportedDataSources`.
    *
    * Fail-open by design: returns `true` whenever applicability cannot be conclusively determined,
    * so unknown/missing engine types, blank or unparseable versions, datasets without a data source,

--- a/src/plugins/data/public/query/query_string/language_service/types.ts
+++ b/src/plugins/data/public/query/query_string/language_service/types.ts
@@ -66,6 +66,13 @@ export interface LanguageConfig {
   };
   editorSupportedAppNames?: string[];
   supportedAppNames?: string[];
+  /**
+   * Per-engine minimum data-source version (semver) for which this language is supported.
+   * Keyed by engine type (e.g. `Elasticsearch`). If an engine has no entry here, the language
+   * is always supported for that engine (fail-open). Used by
+   * {@link LanguageService.isLanguageSupportedForDataset} to gate languages per selected dataset.
+   */
+  supportedDataSources?: { minVersionByEngine?: Record<string, string> };
   hideDatePicker?: boolean;
   sampleQueries?: SampleQuery[];
   addFiltersToQuery?: (query: string, filters: Filter[]) => string;

--- a/src/plugins/data/public/ui/dataset_select/dataset_select.test.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.test.tsx
@@ -48,6 +48,7 @@ describe('DatasetSelect', () => {
       },
     }),
     cacheDataset: jest.fn(),
+    isDatasetAllowed: jest.fn().mockReturnValue(true),
   });
 
   // Setup dataViews service
@@ -241,6 +242,7 @@ describe('DatasetSelect', () => {
     mockQueryService.queryString.getDatasetService = jest.fn().mockReturnValue({
       getType: mockGetTypeRestricted,
       cacheDataset: jest.fn(),
+      isDatasetAllowed: jest.fn().mockReturnValue(true),
     });
 
     // Mock a dataset with the restricted type
@@ -289,6 +291,7 @@ describe('DatasetSelect', () => {
     mockQueryService.queryString.getDatasetService = jest.fn().mockReturnValue({
       getType: mockGetTypeAll,
       cacheDataset: jest.fn(),
+      isDatasetAllowed: jest.fn().mockReturnValue(true),
     });
 
     mockDataViews.getIds = jest.fn().mockResolvedValue(['all-apps-id']);
@@ -351,6 +354,7 @@ describe('DatasetSelect', () => {
     mockQueryService.queryString.getDatasetService = jest.fn().mockReturnValue({
       getType: mockGetTypeMetrics,
       cacheDataset: jest.fn(),
+      isDatasetAllowed: jest.fn().mockReturnValue(true),
     });
 
     // Create two datasets: one with metrics signal type, one with logs
@@ -904,6 +908,7 @@ describe('DatasetSelect', () => {
       mockQueryService.queryString.getDatasetService = jest.fn().mockReturnValue({
         getType: mockGetType,
         cacheDataset: jest.fn(),
+        isDatasetAllowed: jest.fn().mockReturnValue(true),
       });
 
       mockDataViews.getIds = jest.fn().mockResolvedValue(['with-time-id', 'no-time-id']);
@@ -990,6 +995,7 @@ describe('DatasetSelect', () => {
       mockQueryService.queryString.getDatasetService = jest.fn().mockReturnValue({
         getType: mockGetType,
         cacheDataset: jest.fn(),
+        isDatasetAllowed: jest.fn().mockReturnValue(true),
       });
 
       mockDataViews.getIds = jest.fn().mockResolvedValue(['with-time-id', 'no-time-id']);

--- a/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
+++ b/src/plugins/data/public/ui/dataset_select/dataset_select.tsx
@@ -504,7 +504,11 @@ const DatasetSelect: React.FC<DatasetSelectProps> = ({
           !typeConfig?.meta?.supportedAppNames ||
           typeConfig.meta.supportedAppNames.includes(services.appName);
 
-        return appNameMatch;
+        if (!appNameMatch) return false;
+
+        if (!datasetService.isDatasetAllowed(detailedDataset, services.appName)) return false;
+
+        return true;
       };
 
       const filteredDatasets = fetchedDatasets.filter(onFilter);

--- a/src/plugins/data/public/ui/dataset_selector/configurator/configurator.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator/configurator.test.tsx
@@ -31,6 +31,7 @@ const languageService = {
     return languages.find((lang) => lang.id === languageId);
   },
   setUserQueryLanguage: jest.fn(),
+  isLanguageSupportedForDataset: jest.fn().mockReturnValue(true),
 };
 
 const datasetService = {

--- a/src/plugins/data/public/ui/dataset_selector/configurator/configurator.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator/configurator.tsx
@@ -46,11 +46,13 @@ export const Configurator = ({
   const indexPatternsService = getIndexPatterns();
   const type = queryString.getDatasetService().getType(baseDataset.type);
   const supportedLanguages = type?.supportedLanguages(baseDataset) || [];
-  const languages = supportedLanguages.filter(
-    (langId) =>
-      !services.appName ||
-      languageService.getLanguage(langId)?.supportedAppNames?.includes(services.appName)
-  );
+  const languages = supportedLanguages.filter((langId) => {
+    const langConfig = languageService.getLanguage(langId);
+    return (
+      (!services.appName || langConfig?.supportedAppNames?.includes(services.appName)) &&
+      (!langConfig || languageService.isLanguageSupportedForDataset(langConfig, baseDataset))
+    );
+  });
   const [shouldSelectIndexedView, setShouldSelectIndexedView] = useState(false);
 
   const [language, setLanguage] = useState<string>(() => {

--- a/src/plugins/data/public/ui/dataset_selector/configurator/configurator_v2.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator/configurator_v2.test.tsx
@@ -31,6 +31,7 @@ const mockQueryService = {
     getLanguageService: () => ({
       getLanguage: (id: string) =>
         id === 'PPL' ? { id: 'PPL', title: 'PPL', supportedAppNames: ['explore'] } : undefined,
+      isLanguageSupportedForDataset: jest.fn().mockReturnValue(true),
     }),
     getDatasetService: () => mockDatasetService,
   },

--- a/src/plugins/data/public/ui/dataset_selector/configurator/configurator_v2.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/configurator/configurator_v2.tsx
@@ -59,11 +59,13 @@ export const ConfiguratorV2 = ({
 
   // Derived values
   const supportedLanguages = datasetType?.supportedLanguages(baseDataset) || [];
-  const languages = supportedLanguages.filter(
-    (langId) =>
-      !services.appName ||
-      languageService.getLanguage(langId)?.supportedAppNames?.includes(services.appName)
-  );
+  const languages = supportedLanguages.filter((langId) => {
+    const langConfig = languageService.getLanguage(langId);
+    return (
+      (!services.appName || langConfig?.supportedAppNames?.includes(services.appName)) &&
+      (!langConfig || languageService.isLanguageSupportedForDataset(langConfig, baseDataset))
+    );
+  });
   const isAsyncType = datasetType?.meta.isFieldLoadAsync ?? false;
   const supportsTimeFilter = datasetType?.meta?.supportsTimeFilter ?? true;
 

--- a/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_selector.tsx
@@ -95,10 +95,11 @@ export const DatasetSelector = ({
 
       const fetchedIndexPatternDataStructures = await typeConfig.fetch(services, []);
 
-      const fetchedDatasets =
+      const fetchedDatasets = (
         fetchedIndexPatternDataStructures.children?.map((pattern) =>
           typeConfig.toDataset([pattern])
-        ) ?? [];
+        ) ?? []
+      ).filter((ds) => datasetService.isDatasetAllowed(ds, services.appName));
       setIndexPatterns(fetchedDatasets);
 
       // If no dataset is selected, select the first one
@@ -117,7 +118,9 @@ export const DatasetSelector = ({
   }, [datasetService]);
 
   const recentDatasets = useMemo(() => {
-    return datasetService.getRecentDatasets();
+    return datasetService
+      .getRecentDatasets()
+      .filter((ds) => datasetService.isDatasetAllowed(ds, services.appName));
     // NOTE: Intentionally adding dependencies to ensure that we have the latest recentDatasets
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, datasetService]);

--- a/src/plugins/data/public/ui/query_editor/language_selector.test.tsx
+++ b/src/plugins/data/public/ui/query_editor/language_selector.test.tsx
@@ -25,14 +25,17 @@ jest.mock('../../services', () => {
     getLanguages: () => [
       { id: 'lucene', title: 'Lucene' },
       { id: 'kuery', title: 'DQL' },
+      { id: 'SQL', title: 'SQL' },
+      { id: 'PPL', title: 'PPL' },
     ],
     getUserQueryLanguageBlocklist: () => [],
     setUserQueryLanguage: jest.fn(),
+    isLanguageSupportedForDataset: jest.fn(() => true),
   };
 
   const datasetService = {
-    getTypes: () => [{ supportedLanguages: () => ['kuery', 'lucene'] }],
-    getType: () => ({ supportedLanguages: () => ['kuery', 'lucene'] }),
+    getTypes: () => [{ supportedLanguages: () => ['kuery', 'lucene', 'SQL', 'PPL'] }],
+    getType: () => ({ supportedLanguages: () => ['kuery', 'lucene', 'SQL', 'PPL'] }),
     addRecentDataset: jest.fn(),
   };
 
@@ -70,6 +73,16 @@ describe('LanguageSelector', () => {
     );
   }
 
+  beforeEach(() => {
+    // Reset the per-dataset support evaluator to its fail-open default before each test
+    const languageService = jest
+      .requireMock('../../services')
+      .getQueryService()
+      .queryString.getLanguageService();
+    languageService.isLanguageSupportedForDataset.mockReset();
+    languageService.isLanguageSupportedForDataset.mockImplementation(() => true);
+  });
+
   it('should select lucene if language is lucene', () => {
     // Update the mock query value before mounting
     const getQueryService = jest.requireMock('../../services').getQueryService;
@@ -101,5 +114,104 @@ describe('LanguageSelector', () => {
       })
     );
     expect(component).toMatchSnapshot();
+  });
+
+  const getRenderedLanguageLabels = (component: ReturnType<typeof mountWithIntl>) => {
+    // The menu items live inside the EuiPopover, which only renders its children
+    // once it is open, so click the trigger button first.
+    component
+      .find('[data-test-subj="queryEditorLanguageSelector"]')
+      .hostNodes()
+      .first()
+      .simulate('click');
+    component.update();
+
+    return component
+      .find('[data-test-subj="languageSelectorMenuItem"]')
+      .hostNodes()
+      .map((node) => node.text());
+  };
+
+  it('should exclude languages that are not supported for the selected dataset', () => {
+    const services = jest.requireMock('../../services');
+    const getQueryService = services.getQueryService;
+    const languageService = getQueryService().queryString.getLanguageService();
+
+    // Dataset backed by an Elasticsearch source below a language's min version.
+    const dataset = {
+      id: 'es-below-min',
+      title: 'es-below-min',
+      type: 'INDEX_PATTERN',
+      dataSource: {
+        id: 'es-source',
+        title: 'es-source',
+        type: 'OpenSearch',
+        engineType: 'Elasticsearch',
+        version: '6.8.0',
+      },
+    };
+
+    getQueryService().queryString.getQuery.mockReturnValue({
+      query: '',
+      language: 'kuery',
+      dataset,
+    });
+
+    // SQL and PPL are gated out for this Elasticsearch-below-min dataset.
+    languageService.isLanguageSupportedForDataset.mockImplementation(
+      (lang: { id: string }) => lang.id !== 'SQL' && lang.id !== 'PPL'
+    );
+
+    const component = mountWithIntl(
+      wrapInContext({
+        onSelectLanguage: jest.fn(),
+      })
+    );
+
+    const labels = getRenderedLanguageLabels(component);
+    expect(labels).toEqual(expect.arrayContaining(['DQL', 'Lucene']));
+    expect(labels).not.toContain('SQL');
+    expect(labels).not.toContain('PPL');
+    expect(languageService.isLanguageSupportedForDataset).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'SQL' }),
+      dataset
+    );
+  });
+
+  it('should keep all supported languages when the dataset supports them (evaluator returns true)', () => {
+    const services = jest.requireMock('../../services');
+    const getQueryService = services.getQueryService;
+    const languageService = getQueryService().queryString.getLanguageService();
+
+    // OpenSearch dataset at/above any min version — evaluator returns true for all.
+    const dataset = {
+      id: 'os-source-dataset',
+      title: 'os-source-dataset',
+      type: 'INDEX_PATTERN',
+      dataSource: {
+        id: 'os-source',
+        title: 'os-source',
+        type: 'OpenSearch',
+        engineType: 'OpenSearch',
+        version: '2.11.0',
+      },
+    };
+
+    getQueryService().queryString.getQuery.mockReturnValue({
+      query: '',
+      language: 'kuery',
+      dataset,
+    });
+
+    languageService.isLanguageSupportedForDataset.mockImplementation(() => true);
+
+    const component = mountWithIntl(
+      wrapInContext({
+        onSelectLanguage: jest.fn(),
+      })
+    );
+
+    const labels = getRenderedLanguageLabels(component);
+    expect(labels).toEqual(expect.arrayContaining(['DQL', 'Lucene', 'SQL', 'PPL']));
   });
 });

--- a/src/plugins/data/public/ui/query_editor/language_selector.tsx
+++ b/src/plugins/data/public/ui/query_editor/language_selector.tsx
@@ -64,13 +64,14 @@ export const QueryLanguageSelector = (props: QueryLanguageSelectorProps) => {
         return;
       }
 
-      // Build new options including app support check
+      // Build new options including app support check and per-dataset engine/version gating
       const newOptions = languageService
         .getLanguages()
         .filter(
           (lang) =>
             languages.includes(lang.id) &&
-            (!props.appName || lang.editorSupportedAppNames?.includes(props.appName))
+            (!props.appName || lang.editorSupportedAppNames?.includes(props.appName)) &&
+            languageService.isLanguageSupportedForDataset(lang, dataset)
         )
         .map(mapExternalLanguageToOptions)
         .sort((a, b) => a.label.localeCompare(b.label));

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -125,8 +125,11 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   const getValidationContext = (): PPLValidationContext => {
     const dsId = queryRef.current.dataset?.dataSource?.id;
     const dsVersion = queryRef.current.dataset?.dataSource?.version;
+    const dsEngineType =
+      queryRef.current.dataset?.dataSource?.engineType ??
+      queryRef.current.dataset?.dataSource?.type;
     return {
-      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion, dsEngineType),
       dataSourceId: dsId,
       dataSourceVersion: dsVersion,
     };
@@ -152,8 +155,9 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
   useEffect(() => {
     const dsId = query.dataset?.dataSource?.id;
     const dsVersion = query.dataset?.dataSource?.version;
+    const dsEngineType = query.dataset?.dataSource?.engineType ?? query.dataset?.dataSource?.type;
     syncPPLValidationContext(inputRef.current, {
-      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion, dsEngineType),
       dataSourceId: dsId,
       dataSourceVersion: dsVersion,
     });
@@ -162,7 +166,12 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     if (model) {
       void revalidatePPLModel(model);
     }
-  }, [query.dataset?.dataSource?.id, query.dataset?.dataSource?.version]);
+  }, [
+    query.dataset?.dataSource?.id,
+    query.dataset?.dataSource?.version,
+    query.dataset?.dataSource?.engineType,
+    query.dataset?.dataSource?.type,
+  ]);
 
   const renderQueryEditorExtensions = () => {
     if (

--- a/src/plugins/data_source_management/public/components/utils.ts
+++ b/src/plugins/data_source_management/public/components/utils.ts
@@ -165,9 +165,12 @@ export const fetchDataSourceConnections = async (
   showRemoteOpensearchConnection: boolean = false
 ) => {
   try {
-    const directQueryConnectionsPromises = dataSources.map((ds) =>
-      getDirectQueryConnections(ds.id, http!).catch(() => [])
-    );
+    const directQueryConnectionsPromises = dataSources
+      // Direct query (`_plugins/_query/_datasources`) is an OpenSearch SQL plugin
+      // feature. Elasticsearch clusters never expose it, so skip the call for them
+      // to avoid confusing errors/log noise. Mirrors `fetchRemoteClusterConnections`.
+      .filter((ds) => ds.type !== DataSourceEngineType.Elasticsearch)
+      .map((ds) => getDirectQueryConnections(ds.id, http!).catch(() => []));
     const directQueryConnectionsResult = await Promise.all(directQueryConnectionsPromises);
     const directQueryConnections = directQueryConnectionsResult.flat();
     const localClusterConnections =

--- a/src/plugins/explore/opensearch_dashboards.json
+++ b/src/plugins/explore/opensearch_dashboards.json
@@ -22,5 +22,8 @@
   ],
   "requiredBundles": ["opensearchDashboardsReact", "opensearchDashboardsUtils", "dashboard", "dataImporter"],
   "optionalPlugins": ["home", "share", "contextProvider", "datasetManagement", "dataImporter", "dataSource", "dataSourceManagement"],
-  "configPath": ["explore"]
+  "configPath": ["explore"],
+  "minDataSourceEngineVersions": {
+    "Elasticsearch": "7.9.0"
+  }
 }

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -12,6 +12,7 @@ import {
   Query,
   DataView,
   IndexPatternField,
+  getDataSourceEngineCapabilities,
 } from '../../../../../../../../src/plugins/data/common';
 import { QueryExecutionStatus } from '../types';
 import { setResults, ISearchResult, IPrometheusSearchResult } from '../slices';
@@ -539,19 +540,15 @@ const executeQueryBase = async (
       histogramConfig = createHistogramConfigWithInterval(dataView, interval, services, getState);
     }
 
-    // Legacy Elasticsearch (Open Distro) PPL has no `span()`/`timechart` time-bucketing in the
-    // `stats` by-clause, so the histogram query fails to parse. Skip building it for Elasticsearch
-    // data sources and run the plain query instead (the histogram chart just won't populate).
+    // Some engines (e.g. legacy Elasticsearch / Open Distro) have no `span()`/`timechart`
+    // time-bucketing in the PPL `stats` by-clause, so the histogram query fails to parse. Skip
+    // building it for those engines and run the plain query instead (the histogram chart just won't
+    // populate).
     const datasetEngineType = dataset?.dataSource?.engineType ?? dataset?.dataSource?.type;
-    const isElasticsearchDataset = datasetEngineType === 'Elasticsearch';
+    const supportsPplSpan = getDataSourceEngineCapabilities(datasetEngineType).supportsPplSpan;
 
     let effectiveQuery = queryString;
-    if (
-      query.language === 'PPL' &&
-      histogramConfig &&
-      isHistogramQuery &&
-      !isElasticsearchDataset
-    ) {
+    if (query.language === 'PPL' && histogramConfig && isHistogramQuery && supportsPplSpan) {
       effectiveQuery = buildPPLHistogramQuery(queryString, histogramConfig);
     }
 

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -539,8 +539,19 @@ const executeQueryBase = async (
       histogramConfig = createHistogramConfigWithInterval(dataView, interval, services, getState);
     }
 
+    // Legacy Elasticsearch (Open Distro) PPL has no `span()`/`timechart` time-bucketing in the
+    // `stats` by-clause, so the histogram query fails to parse. Skip building it for Elasticsearch
+    // data sources and run the plain query instead (the histogram chart just won't populate).
+    const datasetEngineType = dataset?.dataSource?.engineType ?? dataset?.dataSource?.type;
+    const isElasticsearchDataset = datasetEngineType === 'Elasticsearch';
+
     let effectiveQuery = queryString;
-    if (query.language === 'PPL' && histogramConfig && isHistogramQuery) {
+    if (
+      query.language === 'PPL' &&
+      histogramConfig &&
+      isHistogramQuery &&
+      !isElasticsearchDataset
+    ) {
       effectiveQuery = buildPPLHistogramQuery(queryString, histogramConfig);
     }
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -121,8 +121,10 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
     const currentQuery = queryString.getQuery();
     const dsId = currentQuery.dataset?.dataSource?.id;
     const dsVersion = currentQuery.dataset?.dataSource?.version;
+    const dsEngineType =
+      currentQuery.dataset?.dataSource?.engineType ?? currentQuery.dataset?.dataSource?.type;
     return {
-      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion, dsEngineType),
       dataSourceId: dsId,
       dataSourceVersion: dsVersion,
     };
@@ -158,8 +160,9 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
   useEffect(() => {
     const dsId = dataset?.dataSource?.id;
     const dsVersion = dataset?.dataSource?.version;
+    const dsEngineType = dataset?.dataSource?.engineType ?? dataset?.dataSource?.type;
     syncPPLValidationContext(editorRef.current, {
-      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion),
+      useRuntimeGrammar: shouldUseRuntimeGrammar(dsId, dsVersion, dsEngineType),
       dataSourceId: dsId,
       dataSourceVersion: dsVersion,
     });
@@ -167,7 +170,13 @@ export const useQueryPanelEditor = (): UseQueryPanelEditorReturnType => {
     if (model) {
       void revalidatePPLModel(model);
     }
-  }, [dataset?.dataSource?.id, dataset?.dataSource?.version, editorRef]);
+  }, [
+    dataset?.dataSource?.id,
+    dataset?.dataSource?.version,
+    dataset?.dataSource?.engineType,
+    dataset?.dataSource?.type,
+    editorRef,
+  ]);
 
   // Cleanup validation context on unmount
   useEffect(

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
@@ -10,7 +10,8 @@ jest.mock('@ag-ui/client', () => ({
 }));
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { Subject } from 'rxjs';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { LanguageToggle } from './language_toggle';
@@ -42,6 +43,12 @@ const mockGetTab = jest.fn();
 const mockGetQuery = jest.fn(() => ({ dataset: undefined }));
 const mockSetUserQueryLanguage = jest.fn();
 const mockSetQuery = jest.fn();
+const mockIsLanguageSupportedForDataset = jest.fn();
+// Default getUpdates$ subscription is a no-op so existing tests are unaffected.
+const mockUnsubscribe = jest.fn();
+let mockGetUpdates$ = jest.fn(() => ({
+  subscribe: () => ({ unsubscribe: mockUnsubscribe }),
+}));
 let mockSqlSupportEnabled = true;
 jest.mock('../../../../services/services', () => ({
   getServices: () => ({
@@ -55,9 +62,11 @@ jest.mock('../../../../services/services', () => ({
           getLanguageService: () => ({
             getLanguage: mockGetLanguage,
             setUserQueryLanguage: mockSetUserQueryLanguage,
+            isLanguageSupportedForDataset: mockIsLanguageSupportedForDataset,
           }),
           getQuery: mockGetQuery,
           setQuery: mockSetQuery,
+          getUpdates$: () => mockGetUpdates$(),
         },
       },
     },
@@ -143,6 +152,14 @@ describe('LanguageToggle', () => {
     mockGetLanguage.mockReturnValue({ title: 'PPL' });
     mockGetTab.mockReturnValue({ supportedLanguages: ['PPL'] });
     mockSqlSupportEnabled = true;
+    mockGetQuery.mockReturnValue({ dataset: undefined });
+    // By default every language is supported for the current dataset so existing
+    // tests are unaffected by the per-dataset gating.
+    mockIsLanguageSupportedForDataset.mockReturnValue(true);
+    // Default getUpdates$ subscription is a no-op (does not re-run the effect).
+    mockGetUpdates$ = jest.fn(() => ({
+      subscribe: () => ({ unsubscribe: mockUnsubscribe }),
+    }));
   });
 
   it('renders the language toggle button', () => {
@@ -436,6 +453,117 @@ describe('LanguageToggle', () => {
         expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
       });
       expect(screen.queryByTestId('queryPanelFooterLanguageToggle-SQL')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Per-Dataset Language Gating', () => {
+    it('should EXCLUDE SQL and PPL when the dataset does not support them (e.g. Elasticsearch below min version)', async () => {
+      mockSqlSupportEnabled = true;
+      mockGetTab.mockReturnValue({ supportedLanguages: ['PPL', 'SQL'] });
+      mockGetLanguage.mockImplementation((lang: string) => ({ title: lang }));
+      // Simulate a legacy Elasticsearch dataset that supports neither SQL nor PPL.
+      mockGetQuery.mockReturnValue({ dataset: { id: 'es-legacy', type: 'INDEX_PATTERN' } });
+      mockIsLanguageSupportedForDataset.mockImplementation((langConfig: { title: string }) => {
+        return langConfig.title !== 'SQL' && langConfig.title !== 'PPL';
+      });
+
+      renderWithProvider(<LanguageToggle />);
+      const button = screen.getByTestId('queryPanelFooterLanguageToggle');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queryPanelFooterLanguageToggle-AI')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('queryPanelFooterLanguageToggle-SQL')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('queryPanelFooterLanguageToggle-PPL')).not.toBeInTheDocument();
+    });
+
+    it('should keep a language whose config is not resolved (getLanguage returns undefined)', async () => {
+      mockSqlSupportEnabled = true;
+      mockGetTab.mockReturnValue({ supportedLanguages: ['PPL'] });
+      // No language config -> gating must not drop the language.
+      mockGetLanguage.mockReturnValue(undefined);
+      mockGetQuery.mockReturnValue({ dataset: { id: 'es-legacy', type: 'INDEX_PATTERN' } });
+      // Even though this would return false, it should never be consulted for an
+      // unresolved language config.
+      mockIsLanguageSupportedForDataset.mockReturnValue(false);
+
+      renderWithProvider(<LanguageToggle />);
+      const button = screen.getByTestId('queryPanelFooterLanguageToggle');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
+      });
+    });
+
+    it('should keep SQL/PPL when the dataset supports them', async () => {
+      mockSqlSupportEnabled = true;
+      mockGetTab.mockReturnValue({ supportedLanguages: ['PPL', 'SQL'] });
+      mockGetLanguage.mockImplementation((lang: string) => ({ title: lang }));
+      mockGetQuery.mockReturnValue({ dataset: { id: 'os-cluster', type: 'INDEX_PATTERN' } });
+      mockIsLanguageSupportedForDataset.mockReturnValue(true);
+
+      renderWithProvider(<LanguageToggle />);
+      const button = screen.getByTestId('queryPanelFooterLanguageToggle');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queryPanelFooterLanguageToggle-SQL')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
+    });
+
+    it('should HIDE SQL via feature flag independently of dataset gating', async () => {
+      mockSqlSupportEnabled = false;
+      mockGetTab.mockReturnValue({ supportedLanguages: ['PPL', 'SQL'] });
+      mockGetLanguage.mockImplementation((lang: string) => ({ title: lang }));
+      mockGetQuery.mockReturnValue({ dataset: { id: 'os-cluster', type: 'INDEX_PATTERN' } });
+      // Dataset would allow SQL, but the feature flag must still filter it out.
+      mockIsLanguageSupportedForDataset.mockReturnValue(true);
+
+      renderWithProvider(<LanguageToggle />);
+      const button = screen.getByTestId('queryPanelFooterLanguageToggle');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('queryPanelFooterLanguageToggle-SQL')).not.toBeInTheDocument();
+    });
+
+    it('should re-run the language gating when queryString emits an update', async () => {
+      mockSqlSupportEnabled = true;
+      mockGetTab.mockReturnValue({ supportedLanguages: ['PPL', 'SQL'] });
+      mockGetLanguage.mockImplementation((lang: string) => ({ title: lang }));
+      mockGetQuery.mockReturnValue({ dataset: { id: 'os-cluster', type: 'INDEX_PATTERN' } });
+      // Wire a real Subject so emitting re-runs updateSupportedLanguages.
+      const updates$ = new Subject<void>();
+      mockGetUpdates$ = jest.fn(() => updates$);
+
+      // Initially every language is supported.
+      mockIsLanguageSupportedForDataset.mockReturnValue(true);
+
+      renderWithProvider(<LanguageToggle />);
+      const button = screen.getByTestId('queryPanelFooterLanguageToggle');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queryPanelFooterLanguageToggle-SQL')).toBeInTheDocument();
+      });
+
+      // Switch the dataset to one that no longer supports SQL, then emit an update.
+      mockIsLanguageSupportedForDataset.mockImplementation((langConfig: { title: string }) => {
+        return langConfig.title !== 'SQL';
+      });
+      act(() => {
+        updates$.next();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('queryPanelFooterLanguageToggle-SQL')).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
     });
   });
 });

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
@@ -103,13 +103,16 @@ export const LanguageToggle = () => {
 
   // Get supported languages for the active tab
   useEffect(() => {
+    const services = getServices();
+    const queryString = services.data.query.queryString;
+    const languageSvc = queryString.getLanguageService();
+
     const updateSupportedLanguages = () => {
       if (!activeTabId) {
         // Don't update if active tab isn't set yet
         return;
       }
 
-      const services = getServices();
       const activeTab = services.tabRegistry?.getTab(activeTabId);
 
       let tabSupportedLanguages: string[];
@@ -124,10 +127,28 @@ export const LanguageToggle = () => {
         tabSupportedLanguages = tabSupportedLanguages.filter((lang) => lang !== 'SQL');
       }
 
+      // Apply per-dataset engine/version gating (e.g. hide SQL/PPL for legacy Elasticsearch
+      // data sources below the language's minimum version).
+      const dataset = queryString.getQuery().dataset;
+      tabSupportedLanguages = tabSupportedLanguages.filter((langId) => {
+        const langConfig = languageSvc.getLanguage(langId);
+        return !langConfig || languageSvc.isLanguageSupportedForDataset(langConfig, dataset);
+      });
+
       setSupportedLanguages(tabSupportedLanguages);
     };
 
     updateSupportedLanguages();
+
+    // Re-run when the dataset (or other query state) changes, since gating depends on the
+    // selected dataset's data source.
+    const subscription = queryString.getUpdates$().subscribe(() => {
+      updateSupportedLanguages();
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [activeTabId]);
 
   const badgeLabel = isPromptMode ? promptOptionText : languageTitle;

--- a/src/plugins/explore/public/plugin.test.ts
+++ b/src/plugins/explore/public/plugin.test.ts
@@ -142,6 +142,9 @@ describe('ExplorePlugin', () => {
           },
           queryString: {
             clearQuery: jest.fn(),
+            getDatasetService: jest.fn().mockReturnValue({
+              registerDatasetFilter: jest.fn(),
+            }),
           },
         },
       } as unknown) as DataPublicPluginStart,

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -4,6 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
+import semver from 'semver';
 import { stringify } from 'query-string';
 import rison from 'rison-node';
 import { BehaviorSubject } from 'rxjs';
@@ -39,6 +40,7 @@ import {
 } from '../common';
 import { ConfigSchema } from '../common/config';
 import { buildExploreNavPopover, buildMetricsNavPopover } from './nav_popover';
+import * as exploreManifest from '../opensearch_dashboards.json';
 import { generateDocViewsUrl } from './application/legacy/discover/application/components/doc_views/generate_doc_views_url';
 import { DocViewsLinksRegistry } from './application/legacy/discover/application/doc_views_links/doc_views_links_registry';
 import {
@@ -666,6 +668,25 @@ export class ExplorePlugin
     setUiActions(plugins.uiActions);
     setDashboard(plugins.dashboard);
     const opensearchDashboardsVersion = this.initializerContext.env.packageInfo.version;
+
+    // Register a dataset filter based on minDataSourceEngineVersions from the manifest.
+    // This hides data sources whose engine version is below the declared minimum (e.g.
+    // Elasticsearch < 7.9.0 which lacks PPL support required by Explore).
+    const minVersions = (exploreManifest as {
+      minDataSourceEngineVersions?: Record<string, string>;
+    }).minDataSourceEngineVersions;
+    if (minVersions) {
+      const datasetService = plugins.data.query.queryString.getDatasetService();
+      datasetService.registerDatasetFilter(PLUGIN_ID, (dataset) => {
+        const engine = dataset.dataSource?.engineType ?? dataset.dataSource?.type;
+        if (!engine) return true;
+        const minVersion = minVersions[engine];
+        if (!minVersion) return true;
+        const coerced = semver.coerce(dataset.dataSource?.version);
+        if (!coerced) return true;
+        return semver.gte(coerced.version, minVersion);
+      });
+    }
     setDashboardVersion({ version: opensearchDashboardsVersion });
 
     if (plugins.expressions) {

--- a/src/plugins/query_enhancements/common/config.ts
+++ b/src/plugins/query_enhancements/common/config.ts
@@ -7,6 +7,14 @@ import { schema, TypeOf } from '@osd/config-schema';
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
+  /**
+   * @experimental Gates per-dataset SQL/PPL gating for legacy Elasticsearch data sources and
+   * Open Distro endpoint routing. When disabled (default), behavior is unchanged: SQL/PPL are
+   * shown for all datasets and queries always hit the `/_plugins` endpoints.
+   */
+  legacyElasticsearchCompatibility: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
   queryAssist: schema.object({
     supportedLanguages: schema.arrayOf(
       schema.object({

--- a/src/plugins/query_enhancements/common/constants.ts
+++ b/src/plugins/query_enhancements/common/constants.ts
@@ -54,6 +54,10 @@ export const API = {
 export const URI = {
   PPL: '/_plugins/_ppl',
   SQL: '/_plugins/_sql',
+  // Open Distro endpoints used for legacy Elasticsearch data sources (SQL/PPL live here on ES
+  // domains that support them) when legacyElasticsearchCompatibility is enabled.
+  PPL_OPENDISTRO: '/_opendistro/_ppl',
+  SQL_OPENDISTRO: '/_opendistro/_sql',
   ASYNC_QUERY: '/_plugins/_async_query',
   DIRECT_QUERY: {
     QUERY: '/_plugins/_directquery/_query',

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -6,7 +6,12 @@ import { i18n } from '@osd/i18n';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import moment from 'moment';
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '../../../core/public';
-import { DataStorage, OSD_FIELD_TYPES } from '../../data/common';
+import { DataStorage, getDataSourceEngineCapabilities, OSD_FIELD_TYPES } from '../../data/common';
+// Type-only: DataSourceEngineType is an enum (runtime value); we use its string value directly to
+// avoid a cross-plugin runtime value-import. Keep in sync with the enum.
+import type { DataSourceEngineType } from '../../data_source/common/data_sources';
+
+const ELASTICSEARCH_ENGINE: DataSourceEngineType.Elasticsearch = 'Elasticsearch' as DataSourceEngineType.Elasticsearch;
 import {
   createEditor,
   DefaultInput,
@@ -63,15 +68,17 @@ export class QueryEnhancementsPlugin
     // When legacy Elasticsearch compatibility is enabled, declare per-engine minimum versions so
     // SQL/PPL are gated per selected dataset (and routed to Open Distro server-side). When disabled
     // (default), these stay undefined so the language service evaluator fail-opens — behavior is
-    // unchanged. Minimums follow the "features by engine version" matrix: SQL needs ES >= 6.5, PPL
-    // needs ES >= 7.9.
+    // unchanged. The minimum versions come from the centralized engine-capabilities descriptor.
     const legacyEsCompatEnabled = this.config.legacyElasticsearchCompatibility?.enabled;
-    const pplSupportedDataSources = legacyEsCompatEnabled
-      ? { minVersionByEngine: { Elasticsearch: '7.9.0' } }
-      : undefined;
-    const sqlSupportedDataSources = legacyEsCompatEnabled
-      ? { minVersionByEngine: { Elasticsearch: '6.5.0' } }
-      : undefined;
+    const esMinVersions = getDataSourceEngineCapabilities(ELASTICSEARCH_ENGINE).minLanguageVersions;
+    const pplSupportedDataSources =
+      legacyEsCompatEnabled && esMinVersions?.PPL
+        ? { minVersionByEngine: { [ELASTICSEARCH_ENGINE]: esMinVersions.PPL } }
+        : undefined;
+    const sqlSupportedDataSources =
+      legacyEsCompatEnabled && esMinVersions?.SQL
+        ? { minVersionByEngine: { [ELASTICSEARCH_ENGINE]: esMinVersions.SQL } }
+        : undefined;
 
     // Define controls once for each language and register language configurations outside of `getUpdates$`
     const pplControls = [pplLanguageReference('PPL')];

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -60,6 +60,19 @@ export class QueryEnhancementsPlugin
     const { queryString } = data.query;
     const { currentAppId$ } = this;
 
+    // When legacy Elasticsearch compatibility is enabled, declare per-engine minimum versions so
+    // SQL/PPL are gated per selected dataset (and routed to Open Distro server-side). When disabled
+    // (default), these stay undefined so the language service evaluator fail-opens — behavior is
+    // unchanged. Minimums follow the "features by engine version" matrix: SQL needs ES >= 6.5, PPL
+    // needs ES >= 7.9.
+    const legacyEsCompatEnabled = this.config.legacyElasticsearchCompatibility?.enabled;
+    const pplSupportedDataSources = legacyEsCompatEnabled
+      ? { minVersionByEngine: { Elasticsearch: '7.9.0' } }
+      : undefined;
+    const sqlSupportedDataSources = legacyEsCompatEnabled
+      ? { minVersionByEngine: { Elasticsearch: '6.5.0' } }
+      : undefined;
+
     // Define controls once for each language and register language configurations outside of `getUpdates$`
     const pplControls = [pplLanguageReference('PPL')];
     const sqlControls = [sqlLanguageReference('SQL')];
@@ -116,6 +129,7 @@ export class QueryEnhancementsPlugin
         'agentTraces',
         'dashboard',
       ],
+      supportedDataSources: pplSupportedDataSources,
       sampleQueries: [
         {
           title: i18n.translate('queryEnhancements.sampleQuery.titleContainsWind', {
@@ -158,9 +172,9 @@ export class QueryEnhancementsPlugin
     };
     queryString.getLanguageService().registerLanguage(pplLanguageConfig);
 
-    // Register SQL language configuration
-    // TODO: once analytics engine support lands, gate SQL language registration
-    // on dataset type so SQL is only exposed for Mustang-backed datasets.
+    // Register SQL language configuration. Per-dataset engine/version gating (e.g. legacy
+    // Elasticsearch below SQL's minimum) is declared via `supportedDataSources` below and applied
+    // by the language service evaluator.
     const sqlLanguageConfig: LanguageConfig = {
       id: 'SQL',
       title: 'OpenSearch SQL',
@@ -196,6 +210,7 @@ export class QueryEnhancementsPlugin
       editor: createEditor(SingleLineInput, null, sqlControls, DefaultInput),
       editorSupportedAppNames: ['discover', 'explore', 'agentTraces'],
       supportedAppNames: ['discover', 'data-explorer', 'explore', 'agentTraces'],
+      supportedDataSources: sqlSupportedDataSources,
       hideDatePicker: true,
       sampleQueries: [
         {

--- a/src/plugins/query_enhancements/public/search/filters/filter_utils.test.ts
+++ b/src/plugins/query_enhancements/public/search/filters/filter_utils.test.ts
@@ -294,7 +294,7 @@ describe('getTimeFilterCommand', () => {
 
     const result = FilterUtils.getTimeFilterWhereClause('timestamp', timeRange);
     expect(result).toBe(
-      "WHERE `timestamp` >= '2023-01-01 00:00:00.000' AND `timestamp` <= '2023-01-02 00:00:00.000'"
+      "WHERE `timestamp` >= TIMESTAMP('2023-01-01 00:00:00.000') AND `timestamp` <= TIMESTAMP('2023-01-02 00:00:00.000')"
     );
   });
 });

--- a/src/plugins/query_enhancements/public/search/filters/filter_utils.ts
+++ b/src/plugins/query_enhancements/public/search/filters/filter_utils.ts
@@ -20,12 +20,17 @@ export class FilterUtils {
    * @param timeFieldName Time field name
    * @param timeRange Time range from the time picker
    * @returns where clause of the time range filter
+   *
+   * The time literals are wrapped in `TIMESTAMP('...')` rather than bare string literals. Modern
+   * OpenSearch PPL implicitly coerces a string to a timestamp for `field >= '<string>'`, but legacy
+   * Elasticsearch (Open Distro) PPL does not and rejects it with a [TIMESTAMP,STRING] type error.
+   * `TIMESTAMP('...')` is accepted by both engines, so this form is portable across all data sources.
    */
   public static getTimeFilterWhereClause(timeFieldName: string, timeRange: TimeRange): string {
     const { fromDate, toDate } = formatTimePickerDate(timeRange, 'YYYY-MM-DD HH:mm:ss.SSS');
-    return `WHERE \`${timeFieldName}\` >= '${formatDate(
+    return `WHERE \`${timeFieldName}\` >= TIMESTAMP('${formatDate(
       fromDate
-    )}' AND \`${timeFieldName}\` <= '${formatDate(toDate)}'`;
+    )}') AND \`${timeFieldName}\` <= TIMESTAMP('${formatDate(toDate)}')`;
   }
 
   /**

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
@@ -1150,6 +1150,28 @@ describe('PPLSearchInterceptor', () => {
       });
     });
 
+    it('should return undefined for Elasticsearch data sources (no span() support)', () => {
+      const esQuery = {
+        language: 'PPL',
+        query: 'source=test_index',
+        dataset: {
+          type: 'INDEX_PATTERN',
+          timeFieldName: '@timestamp',
+          dataSource: {
+            id: 'es-1',
+            title: 'escluster-710',
+            type: 'Elasticsearch',
+            engineType: 'Elasticsearch',
+            version: '7.10.2',
+          },
+        },
+      };
+
+      const result = (pplSearchInterceptor as any).getAggConfig(mockRequest, esQuery);
+
+      expect(result).toBeUndefined();
+    });
+
     it('should build agg config for date_histogram with calendar_interval', () => {
       const requestWithCalendarInterval = {
         params: {

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -7,7 +7,12 @@ import { trimEnd } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { from, Observable } from 'rxjs';
 import { first, switchMap } from 'rxjs/operators';
-import { formatTimePickerDate, Query, UI_SETTINGS } from '../../../data/common';
+import {
+  formatTimePickerDate,
+  getDataSourceEngineCapabilities,
+  Query,
+  UI_SETTINGS,
+} from '../../../data/common';
 import {
   DataPublicPluginStart,
   IndexPatternsContract,
@@ -174,11 +179,11 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     const { aggs } = request.params.body;
     if (!aggs || !query.dataset || !query.dataset.timeFieldName) return;
 
-    // Legacy Elasticsearch (Open Distro) PPL has no `span()` grouping expression in the `stats`
-    // by-clause (it accepts field names only), so the histogram aggregation query fails to parse.
-    // Skip emitting the agg config for Elasticsearch data sources; the main query still runs.
+    // Some engines (e.g. legacy Elasticsearch / Open Distro) have no `span()` grouping expression in
+    // the PPL `stats` by-clause, so the histogram aggregation query fails to parse. Skip emitting the
+    // agg config for those engines; the main query still runs.
     const engineType = query.dataset.dataSource?.engineType ?? query.dataset.dataSource?.type;
-    if (engineType === 'Elasticsearch') return;
+    if (!getDataSourceEngineCapabilities(engineType).supportsPplSpan) return;
 
     const aggsConfig: QueryAggConfig = {};
     const { fromDate, toDate } = formatTimePickerDate(

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -173,6 +173,13 @@ export class PPLSearchInterceptor extends SearchInterceptor {
   private getAggConfig(request: IOpenSearchDashboardsSearchRequest, query: Query) {
     const { aggs } = request.params.body;
     if (!aggs || !query.dataset || !query.dataset.timeFieldName) return;
+
+    // Legacy Elasticsearch (Open Distro) PPL has no `span()` grouping expression in the `stats`
+    // by-clause (it accepts field names only), so the histogram aggregation query fails to parse.
+    // Skip emitting the agg config for Elasticsearch data sources; the main query still runs.
+    const engineType = query.dataset.dataSource?.engineType ?? query.dataset.dataSource?.type;
+    if (engineType === 'Elasticsearch') return;
+
     const aggsConfig: QueryAggConfig = {};
     const { fromDate, toDate } = formatTimePickerDate(
       this.queryService.timefilter.timefilter.getTime(),

--- a/src/plugins/query_enhancements/server/index.ts
+++ b/src/plugins/query_enhancements/server/index.ts
@@ -10,6 +10,7 @@ import { configSchema, ConfigSchema } from '../common/config';
 export const config: PluginConfigDescriptor<ConfigSchema> = {
   exposeToBrowser: {
     queryAssist: true,
+    legacyElasticsearchCompatibility: true,
   },
   schema: configSchema,
 };

--- a/src/plugins/query_enhancements/server/plugin.ts
+++ b/src/plugins/query_enhancements/server/plugin.ts
@@ -106,10 +106,33 @@ export class QueryEnhancementsPlugin
     // Initialize the default query executor for prometheus
     prometheusManager.initializeDefaultQueryExecutor(client);
 
-    const pplSearchStrategy = pplSearchStrategyProvider(this.config$, this.logger, client);
+    // Read the scoped config flag that gates legacy Elasticsearch compatibility (Open Distro
+    // endpoint routing). Config observables emit synchronously on first subscribe, so this resolves
+    // before the strategies below are constructed.
+    let legacyEsCompatEnabled = false;
+    this.initializerContext.config
+      .create<ConfigSchema>()
+      .pipe(first())
+      .subscribe((cfg) => {
+        legacyEsCompatEnabled = cfg.legacyElasticsearchCompatibility?.enabled ?? false;
+      });
+
+    const pplSearchStrategy = pplSearchStrategyProvider(
+      this.config$,
+      this.logger,
+      client,
+      undefined,
+      legacyEsCompatEnabled
+    );
     const pplRawSearchStrategy = pplRawSearchStrategyProvider(this.config$, this.logger, client);
     const promqlSearchStrategy = promqlSearchStrategyProvider(this.config$, this.logger);
-    const sqlSearchStrategy = sqlSearchStrategyProvider(this.config$, this.logger, client);
+    const sqlSearchStrategy = sqlSearchStrategyProvider(
+      this.config$,
+      this.logger,
+      client,
+      undefined,
+      legacyEsCompatEnabled
+    );
     const sqlAsyncSearchStrategy = sqlAsyncSearchStrategyProvider(
       this.config$,
       this.logger,

--- a/src/plugins/query_enhancements/server/plugin.ts
+++ b/src/plugins/query_enhancements/server/plugin.ts
@@ -48,7 +48,10 @@ export class QueryEnhancementsPlugin
     this.config$ = initializerContext.config.legacy.globalConfig$;
   }
 
-  public setup(core: CoreSetup, { data, dataSource }: QueryEnhancementsPluginSetupDependencies) {
+  public async setup(
+    core: CoreSetup,
+    { data, dataSource }: QueryEnhancementsPluginSetupDependencies
+  ) {
     this.logger.debug('queryEnhancements: Setup');
 
     // PPL lint capability — disabled by default until an operator enables it via
@@ -107,15 +110,14 @@ export class QueryEnhancementsPlugin
     prometheusManager.initializeDefaultQueryExecutor(client);
 
     // Read the scoped config flag that gates legacy Elasticsearch compatibility (Open Distro
-    // endpoint routing). Config observables emit synchronously on first subscribe, so this resolves
-    // before the strategies below are constructed.
-    let legacyEsCompatEnabled = false;
-    this.initializerContext.config
+    // endpoint routing). Await the first emission so the strategies below are always constructed
+    // with the resolved value rather than relying on synchronous observable emission.
+    const queryEnhancementsConfig = await this.initializerContext.config
       .create<ConfigSchema>()
       .pipe(first())
-      .subscribe((cfg) => {
-        legacyEsCompatEnabled = cfg.legacyElasticsearchCompatibility?.enabled ?? false;
-      });
+      .toPromise();
+    const legacyEsCompatEnabled =
+      queryEnhancementsConfig.legacyElasticsearchCompatibility?.enabled ?? false;
 
     const pplSearchStrategy = pplSearchStrategyProvider(
       this.config$,

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
@@ -24,7 +24,8 @@ export const pplSearchStrategyProvider = (
   config$: Observable<SharedGlobalConfig>,
   logger: Logger,
   client: ILegacyClusterClient,
-  usage?: SearchUsage
+  usage?: SearchUsage,
+  legacyEsCompatEnabled: boolean = false
 ): ISearchStrategy<IOpenSearchDashboardsSearchRequest, IDataFrameResponse> => {
   const pplFacet = new Facet({
     client,
@@ -33,6 +34,7 @@ export const pplSearchStrategyProvider = (
     useJobs: false,
     shimResponse: true,
     requestCompression: true,
+    legacyEsCompatEnabled,
   });
 
   return {

--- a/src/plugins/query_enhancements/server/search/sql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/sql_search_strategy.ts
@@ -20,7 +20,8 @@ export const sqlSearchStrategyProvider = (
   config$: Observable<SharedGlobalConfig>,
   logger: Logger,
   client: ILegacyClusterClient,
-  usage?: SearchUsage
+  usage?: SearchUsage,
+  legacyEsCompatEnabled: boolean = false
 ): ISearchStrategy<IOpenSearchDashboardsSearchRequest, IDataFrameResponse> => {
   const sqlFacet = new Facet({
     client,
@@ -28,6 +29,7 @@ export const sqlSearchStrategyProvider = (
     endpoint: 'enhancements.sqlQuery',
     useJobs: false,
     shimResponse: true,
+    legacyEsCompatEnabled,
   });
 
   return {

--- a/src/plugins/query_enhancements/server/utils/facet.test.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.test.ts
@@ -48,6 +48,8 @@ describe('Facet', () => {
       body: {
         query: {
           query: 'test query',
+          // `format` is nested under `query` by the client/route, matching production.
+          format: 'jdbc',
           dataset: {
             dataSource: {
               id: 'test-id',
@@ -58,7 +60,6 @@ describe('Facet', () => {
             },
           },
         },
-        format: 'jdbc',
         lang: 'sql',
       },
     };
@@ -78,6 +79,7 @@ describe('Facet', () => {
           sessionId: 'test-session',
           lang: 'sql',
         },
+        format: 'jdbc',
       });
     });
 
@@ -96,6 +98,7 @@ describe('Facet', () => {
           sessionId: 'test-session',
           lang: 'sql',
         },
+        format: 'jdbc',
       });
     });
 
@@ -121,6 +124,7 @@ describe('Facet', () => {
           query: 'test query',
           lang: 'sql',
         },
+        format: 'jdbc',
       });
     });
 
@@ -136,6 +140,7 @@ describe('Facet', () => {
           query: 'test query',
           lang: 'sql',
         },
+        format: 'jdbc',
       });
     });
 
@@ -162,6 +167,29 @@ describe('Facet', () => {
         expect.stringContaining('Facet fetch FAIL: action=test-endpoint: Error: Test error')
       );
     });
+
+    it('sends format=jdbc as a query param read from body.query.format', async () => {
+      mockClient.mockResolvedValue({ result: 'success' });
+
+      await facet.describeQuery(mockContext, mockRequest);
+
+      const callArgs = mockClient.mock.calls[0][1];
+      // `format` is a top-level sibling of `body` (becomes the `?format=` query-string param).
+      expect(callArgs.format).toBe('jdbc');
+    });
+
+    it('applies the jdbc shim (adds jsonData) when body.query.format is jdbc and shimResponse is on', async () => {
+      mockClient.mockResolvedValue({
+        schema: [{ name: 'col1' }],
+        datarows: [['a'], ['b']],
+      });
+
+      const result = await facetWithShimEnabled.describeQuery(mockContext, mockRequest);
+
+      expect(result.success).toBe(true);
+      // shimSchemaRow maps datarows -> jsonData keyed by schema name.
+      expect(result.data.jsonData).toEqual([{ col1: 'a' }, { col1: 'b' }]);
+    });
   });
 
   describe('requestCompression', () => {
@@ -178,6 +206,7 @@ describe('Facet', () => {
           sessionId: 'test-session',
           lang: 'sql',
         },
+        format: 'jdbc',
         headers: { 'accept-encoding': 'gzip, deflate' },
       });
     });
@@ -195,6 +224,7 @@ describe('Facet', () => {
           sessionId: 'test-session',
           lang: 'sql',
         },
+        format: 'jdbc',
       });
       // Verify headers are not present
       const callArgs = mockClient.mock.calls[0][1];

--- a/src/plugins/query_enhancements/server/utils/facet.test.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.test.ts
@@ -19,6 +19,9 @@ describe('Facet', () => {
     mockClient = jest.fn();
     mockLogger = ({
       error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
     } as unknown) as jest.Mocked<Logger>;
 
     const props: FacetProps = {
@@ -217,6 +220,74 @@ describe('Facet', () => {
         queryId: 'test-query-id',
         headers: { 'accept-encoding': 'gzip, deflate' },
       });
+    });
+  });
+
+  describe('legacy Elasticsearch Open Distro routing', () => {
+    const buildProps = (endpoint: string, legacyEsCompatEnabled: boolean): FacetProps => ({
+      client: { asScoped: jest.fn().mockReturnValue({ callAsCurrentUser: mockClient }) },
+      logger: mockLogger,
+      endpoint,
+      legacyEsCompatEnabled,
+    });
+
+    beforeEach(() => {
+      mockClient.mockResolvedValue({ result: 'success' });
+    });
+
+    it('routes PPL queries against Elasticsearch data sources to the Open Distro action when the flag is ON', async () => {
+      const pplFacet = new Facet(buildProps('enhancements.pplQuery', true));
+      mockRequest.body.query.dataset.dataSource.engineType = 'Elasticsearch';
+
+      await pplFacet.describeQuery(mockContext, mockRequest);
+
+      expect(mockClient.mock.calls[0][0]).toBe('enhancements.pplQueryOpenDistro');
+    });
+
+    it('routes SQL queries against Elasticsearch data sources to the Open Distro action when the flag is ON', async () => {
+      const sqlFacet = new Facet(buildProps('enhancements.sqlQuery', true));
+      mockRequest.body.query.dataset.dataSource.engineType = 'Elasticsearch';
+
+      await sqlFacet.describeQuery(mockContext, mockRequest);
+
+      expect(mockClient.mock.calls[0][0]).toBe('enhancements.sqlQueryOpenDistro');
+    });
+
+    it('does NOT remap Elasticsearch data sources when the flag is OFF', async () => {
+      const pplFacet = new Facet(buildProps('enhancements.pplQuery', false));
+      mockRequest.body.query.dataset.dataSource.engineType = 'Elasticsearch';
+
+      await pplFacet.describeQuery(mockContext, mockRequest);
+
+      expect(mockClient.mock.calls[0][0]).toBe('enhancements.pplQuery');
+    });
+
+    it('does NOT remap non-Elasticsearch (OpenSearch) data sources when the flag is ON', async () => {
+      const pplFacet = new Facet(buildProps('enhancements.pplQuery', true));
+      mockRequest.body.query.dataset.dataSource.engineType = 'OpenSearch';
+
+      await pplFacet.describeQuery(mockContext, mockRequest);
+
+      expect(mockClient.mock.calls[0][0]).toBe('enhancements.pplQuery');
+    });
+
+    it('fails open and keeps the original endpoint when dataSource is undefined and the flag is ON', async () => {
+      const pplFacet = new Facet(buildProps('enhancements.pplQuery', true));
+      mockRequest.body.query.dataset.dataSource = undefined;
+
+      await pplFacet.describeQuery(mockContext, mockRequest);
+
+      expect(mockClient.mock.calls[0][0]).toBe('enhancements.pplQuery');
+    });
+
+    it('falls back to dataSource.type when engineType is absent and remaps Elasticsearch sources when the flag is ON', async () => {
+      const pplFacet = new Facet(buildProps('enhancements.pplQuery', true));
+      delete mockRequest.body.query.dataset.dataSource.engineType;
+      mockRequest.body.query.dataset.dataSource.type = 'Elasticsearch';
+
+      await pplFacet.describeQuery(mockContext, mockRequest);
+
+      expect(mockClient.mock.calls[0][0]).toBe('enhancements.pplQueryOpenDistro');
     });
   });
 });

--- a/src/plugins/query_enhancements/server/utils/facet.test.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.test.ts
@@ -152,7 +152,7 @@ describe('Facet', () => {
 
       expect(result).toEqual({ success: false, data: error });
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Facet fetch FAIL: action=test-endpoint: Error: Test error')
+        'Facet fetch: test-endpoint: Error: Test error'
       );
     });
 
@@ -164,7 +164,7 @@ describe('Facet', () => {
 
       expect(result).toEqual({ success: false, data: error });
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Facet fetch FAIL: action=test-endpoint: Error: Test error')
+        'Facet fetch: test-endpoint: Error: Test error'
       );
     });
 

--- a/src/plugins/query_enhancements/server/utils/facet.test.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.test.ts
@@ -147,7 +147,7 @@ describe('Facet', () => {
 
       expect(result).toEqual({ success: false, data: error });
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Facet fetch: test-endpoint: Error: Test error'
+        expect.stringContaining('Facet fetch FAIL: action=test-endpoint: Error: Test error')
       );
     });
 
@@ -159,7 +159,7 @@ describe('Facet', () => {
 
       expect(result).toEqual({ success: false, data: error });
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Facet fetch: test-endpoint: Error: Test error'
+        expect.stringContaining('Facet fetch FAIL: action=test-endpoint: Error: Test error')
       );
     });
   });

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -6,7 +6,11 @@
 import { Logger } from 'opensearch-dashboards/server';
 import { FacetResponse, IPPLEventsDataSource, IPPLVisualizationDataSource } from '../types';
 import { shimSchemaRow, shimStats } from '.';
-import { Query } from '../../../data/common';
+import {
+  DEFAULT_ENGINE_CAPABILITIES,
+  getDataSourceEngineCapabilities,
+  Query,
+} from '../../../data/common';
 
 export interface FacetProps {
   client: any;
@@ -23,12 +27,11 @@ export interface FacetProps {
   legacyEsCompatEnabled?: boolean;
 }
 
-const ELASTICSEARCH_ENGINE_TYPE = 'Elasticsearch';
-
-// Maps a base client action to its Open Distro equivalent for Elasticsearch data sources.
-const OPEN_DISTRO_ACTION_BY_ENDPOINT: Record<string, string> = {
-  'enhancements.pplQuery': 'enhancements.pplQueryOpenDistro',
-  'enhancements.sqlQuery': 'enhancements.sqlQueryOpenDistro',
+// Maps a base (default) client action to its per-engine equivalent, derived from the centralized
+// engine-capabilities descriptor. Used to route Elasticsearch SQL/PPL to the Open Distro actions.
+const OPEN_DISTRO_ACTION_BY_DEFAULT_ACTION: Record<string, string> = {
+  [DEFAULT_ENGINE_CAPABILITIES.sqlPplEndpoints.ppl]: 'ppl',
+  [DEFAULT_ENGINE_CAPABILITIES.sqlPplEndpoints.sql]: 'sql',
 };
 
 export class Facet {
@@ -74,14 +77,16 @@ export class Facet {
       const dataSource = query.dataset?.dataSource;
       const meta = dataSource?.meta;
 
-      // Route Elasticsearch data sources to the Open Distro endpoints. Since below-min ES languages
-      // are already hidden client-side, any ES query that reaches here is supported, so this is a
-      // straightforward "engine is Elasticsearch => Open Distro" mapping. Fail-open: unknown/missing
-      // engine types keep the default `_plugins` action.
+      // Route the query to the engine's SQL/PPL client action, per the centralized engine
+      // capabilities. Since below-min languages are already hidden client-side, any query that
+      // reaches here is supported, so this is a straightforward per-engine endpoint lookup.
+      // Fail-open: unknown/missing engine types resolve to the default `_plugins` actions.
       if (this.legacyEsCompatEnabled) {
         const engineType = dataSource?.engineType ?? dataSource?.type;
-        if (engineType === ELASTICSEARCH_ENGINE_TYPE && OPEN_DISTRO_ACTION_BY_ENDPOINT[endpoint]) {
-          resolvedEndpoint = OPEN_DISTRO_ACTION_BY_ENDPOINT[endpoint];
+        const caps = getDataSourceEngineCapabilities(engineType);
+        const langKey = OPEN_DISTRO_ACTION_BY_DEFAULT_ACTION[endpoint];
+        if (caps.usesOpenDistroSqlPpl && langKey) {
+          resolvedEndpoint = caps.sqlPplEndpoints[langKey as 'ppl' | 'sql'];
         }
         this.logger.info(
           `Facet fetch: engineType=${engineType}, endpoint=${endpoint} -> ${resolvedEndpoint}`

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -88,9 +88,6 @@ export class Facet {
         if (caps.usesOpenDistroSqlPpl && langKey) {
           resolvedEndpoint = caps.sqlPplEndpoints[langKey as 'ppl' | 'sql'];
         }
-        this.logger.info(
-          `Facet fetch: engineType=${engineType}, endpoint=${endpoint} -> ${resolvedEndpoint}`
-        );
       }
       // `format` is nested under `query` by the client/route (`request.body.query.format`), not at
       // the top level. Read it from there (with a top-level fallback) so the `?format=jdbc` query
@@ -121,42 +118,13 @@ export class Facet {
       const client = clientId
         ? context.dataSource.opensearch.legacy.getClient(clientId).callAPI
         : this.defaultClient.asScoped(request).callAsCurrentUser;
-
-      // TEMP DEBUG: log the exact action + request params being sent to the cluster.
-      this.logger.info(
-        `Facet fetch CALL: action=${resolvedEndpoint}, clientId=${clientId ?? 'default'}, ` +
-          `engineType=${dataSource?.engineType ?? dataSource?.type}, ` +
-          `version=${dataSource?.version}, params=${JSON.stringify(params)}`
-      );
-
       const queryRes = await client(resolvedEndpoint, params);
-
-      // TEMP DEBUG: log the raw response shape from the cluster so we can see why results may be
-      // empty (e.g. schema/datarows present but in an unexpected shape for the shim).
-      this.logger.info(
-        `Facet fetch RESPONSE: action=${resolvedEndpoint}, ` +
-          `keys=${
-            queryRes && typeof queryRes === 'object'
-              ? Object.keys(queryRes).join(',')
-              : typeof queryRes
-          }, ` +
-          `schemaLen=${queryRes?.schema?.length}, datarowsLen=${queryRes?.datarows?.length}, ` +
-          `total=${queryRes?.total}, size=${queryRes?.size}, ` +
-          `body=${JSON.stringify(queryRes)?.slice(0, 2000)}`
-      );
-
       return {
         success: true,
         data: queryRes,
       };
     } catch (err: any) {
-      // TEMP DEBUG: log the full error payload (statusCode + response body), which the default
-      // `${err}` string drops. Legacy clients put the cluster's JSON error under err.body / err.response.
-      this.logger.error(
-        `Facet fetch FAIL: action=${resolvedEndpoint}: ${err}\n` +
-          `statusCode=${err?.statusCode}\n` +
-          `body=${JSON.stringify(err?.body ?? err?.response ?? err?.data)}`
-      );
+      this.logger.error(`Facet fetch: ${resolvedEndpoint}: ${err}`);
       return {
         success: false,
         data: err,

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -15,7 +15,21 @@ export interface FacetProps {
   useJobs?: boolean;
   shimResponse?: boolean;
   requestCompression?: boolean;
+  /**
+   * When true, queries against Elasticsearch data sources are routed to the Open Distro client
+   * actions (e.g. `enhancements.pplQueryOpenDistro`). Gated by
+   * queryEnhancements.legacyElasticsearchCompatibility.enabled.
+   */
+  legacyEsCompatEnabled?: boolean;
 }
+
+const ELASTICSEARCH_ENGINE_TYPE = 'Elasticsearch';
+
+// Maps a base client action to its Open Distro equivalent for Elasticsearch data sources.
+const OPEN_DISTRO_ACTION_BY_ENDPOINT: Record<string, string> = {
+  'enhancements.pplQuery': 'enhancements.pplQueryOpenDistro',
+  'enhancements.sqlQuery': 'enhancements.sqlQueryOpenDistro',
+};
 
 export class Facet {
   private defaultClient: any;
@@ -24,6 +38,7 @@ export class Facet {
   private useJobs: boolean;
   private shimResponse: boolean;
   private requestCompression: boolean;
+  private legacyEsCompatEnabled: boolean;
 
   constructor({
     client,
@@ -32,6 +47,7 @@ export class Facet {
     useJobs = false,
     shimResponse = false,
     requestCompression = false,
+    legacyEsCompatEnabled = false,
   }: FacetProps) {
     this.defaultClient = client;
     this.logger = logger;
@@ -39,6 +55,7 @@ export class Facet {
     this.useJobs = useJobs;
     this.shimResponse = shimResponse;
     this.requestCompression = requestCompression;
+    this.legacyEsCompatEnabled = legacyEsCompatEnabled;
   }
 
   private getCompressionHeaders(): Record<string, string> {
@@ -50,10 +67,26 @@ export class Facet {
     request: any,
     endpoint: string
   ): Promise<FacetResponse> => {
+    // Declared outside the try so the catch block can log the resolved endpoint too.
+    let resolvedEndpoint = endpoint;
     try {
       const query: Query = request.body.query;
       const dataSource = query.dataset?.dataSource;
       const meta = dataSource?.meta;
+
+      // Route Elasticsearch data sources to the Open Distro endpoints. Since below-min ES languages
+      // are already hidden client-side, any ES query that reaches here is supported, so this is a
+      // straightforward "engine is Elasticsearch => Open Distro" mapping. Fail-open: unknown/missing
+      // engine types keep the default `_plugins` action.
+      if (this.legacyEsCompatEnabled) {
+        const engineType = dataSource?.engineType ?? dataSource?.type;
+        if (engineType === ELASTICSEARCH_ENGINE_TYPE && OPEN_DISTRO_ACTION_BY_ENDPOINT[endpoint]) {
+          resolvedEndpoint = OPEN_DISTRO_ACTION_BY_ENDPOINT[endpoint];
+        }
+        this.logger.info(
+          `Facet fetch: engineType=${engineType}, endpoint=${endpoint} -> ${resolvedEndpoint}`
+        );
+      }
       const { format, lang, fetchSize, queryId } = request.body;
       const compressionHeaders = this.getCompressionHeaders();
       const { highlight } = request.body;
@@ -76,13 +109,27 @@ export class Facet {
       const client = clientId
         ? context.dataSource.opensearch.legacy.getClient(clientId).callAPI
         : this.defaultClient.asScoped(request).callAsCurrentUser;
-      const queryRes = await client(endpoint, params);
+
+      // TEMP DEBUG: log the exact action + request params being sent to the cluster.
+      this.logger.info(
+        `Facet fetch CALL: action=${resolvedEndpoint}, clientId=${clientId ?? 'default'}, ` +
+          `engineType=${dataSource?.engineType ?? dataSource?.type}, ` +
+          `version=${dataSource?.version}, params=${JSON.stringify(params)}`
+      );
+
+      const queryRes = await client(resolvedEndpoint, params);
       return {
         success: true,
         data: queryRes,
       };
     } catch (err: any) {
-      this.logger.error(`Facet fetch: ${endpoint}: ${err}`);
+      // TEMP DEBUG: log the full error payload (statusCode + response body), which the default
+      // `${err}` string drops. Legacy clients put the cluster's JSON error under err.body / err.response.
+      this.logger.error(
+        `Facet fetch FAIL: action=${resolvedEndpoint}: ${err}\n` +
+          `statusCode=${err?.statusCode}\n` +
+          `body=${JSON.stringify(err?.body ?? err?.response ?? err?.data)}`
+      );
       return {
         success: false,
         data: err,

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -92,7 +92,14 @@ export class Facet {
           `Facet fetch: engineType=${engineType}, endpoint=${endpoint} -> ${resolvedEndpoint}`
         );
       }
-      const { format, lang, fetchSize, queryId } = request.body;
+      // `format` is nested under `query` by the client/route (`request.body.query.format`), not at
+      // the top level. Read it from there (with a top-level fallback) so the `?format=jdbc` query
+      // param actually reaches the cluster. This matters for Open Distro (`/_opendistro/_sql`),
+      // which defaults to the native `hits` response and only returns the JDBC `{schema, datarows}`
+      // shape when `format=jdbc` is sent; `/_plugins/_sql` defaults to JDBC so this was previously
+      // a no-op there.
+      const format = request.body?.query?.format ?? request.body?.format;
+      const { lang, fetchSize, queryId } = request.body;
       const compressionHeaders = this.getCompressionHeaders();
       const { highlight } = request.body;
       const params = {
@@ -107,7 +114,7 @@ export class Facet {
           ...(highlight && { highlight }),
           ...(queryId && { queryId }),
         },
-        ...(format !== 'jdbc' && { format }),
+        ...(format && { format }),
         ...(Object.keys(compressionHeaders).length > 0 && { headers: compressionHeaders }),
       };
       const clientId = dataSource?.id;
@@ -123,6 +130,21 @@ export class Facet {
       );
 
       const queryRes = await client(resolvedEndpoint, params);
+
+      // TEMP DEBUG: log the raw response shape from the cluster so we can see why results may be
+      // empty (e.g. schema/datarows present but in an unexpected shape for the shim).
+      this.logger.info(
+        `Facet fetch RESPONSE: action=${resolvedEndpoint}, ` +
+          `keys=${
+            queryRes && typeof queryRes === 'object'
+              ? Object.keys(queryRes).join(',')
+              : typeof queryRes
+          }, ` +
+          `schemaLen=${queryRes?.schema?.length}, datarowsLen=${queryRes?.datarows?.length}, ` +
+          `total=${queryRes?.total}, size=${queryRes?.size}, ` +
+          `body=${JSON.stringify(queryRes)?.slice(0, 2000)}`
+      );
+
       return {
         success: true,
         data: queryRes,
@@ -178,7 +200,9 @@ export class Facet {
       : await this.fetch(context, request, this.endpoint);
     if (response.success === false || !this.shimResponse) return response;
 
-    const { format: dataType } = request.body;
+    // `format` lives under `query` (see `fetch` above); read it from there so the shim that adds
+    // `jsonData` (used by the raw/Vega path) is selected correctly.
+    const dataType = request.body?.query?.format ?? request.body?.format;
     const shimFunctions: { [key: string]: (data: any) => any } = {
       jdbc: (data: any) => shimSchemaRow(data as IPPLEventsDataSource),
       viz: (data: any) => shimStats(data as IPPLVisualizationDataSource),

--- a/src/plugins/query_enhancements/server/utils/plugins.ts
+++ b/src/plugins/query_enhancements/server/utils/plugins.ts
@@ -59,6 +59,18 @@ export const OpenSearchEnhancements = (client: any, config: any, components: any
     method: 'POST',
     needBody: true,
   });
+  // Open Distro endpoints for legacy Elasticsearch data sources, used when
+  // legacyElasticsearchCompatibility is enabled and the selected data source is Elasticsearch.
+  enhancements.pplQueryOpenDistro = createAction(client, components, {
+    endpoint: URI.PPL_OPENDISTRO,
+    method: 'POST',
+    needBody: true,
+  });
+  enhancements.sqlQueryOpenDistro = createAction(client, components, {
+    endpoint: URI.SQL_OPENDISTRO,
+    method: 'POST',
+    needBody: true,
+  });
   enhancements.promqlQuery = createAction(client, components, {
     endpoint: URI.DIRECT_QUERY.QUERY,
     method: 'POST',

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -646,8 +646,15 @@ export const fetchDataSourceConnections = async (
       mode === AssociationDataSourceModalMode.DirectQueryConnections
         ? await fetchDataSourceConnectionsByDataSourceIds(
             // Only data source saved object type needs to fetch data source connections, data connection type object not.
+            // Direct query (`_plugins/_query/_datasources`) is an OpenSearch SQL plugin
+            // feature; Elasticsearch clusters never expose it, so skip those to avoid
+            // confusing errors/log noise. Mirrors `fetchRemoteClusterConnections`.
             dataSources
-              .filter((ds) => ds.type === DATA_SOURCE_SAVED_OBJECT_TYPE)
+              .filter(
+                (ds) =>
+                  ds.type === DATA_SOURCE_SAVED_OBJECT_TYPE &&
+                  ds.dataSourceEngineType !== DataSourceEngineType.Elasticsearch
+              )
               .map((ds) => ds.id),
             http
           )


### PR DESCRIPTION
### Description

Enables legacy Elasticsearch clusters (connected as external data sources) to run SQL and PPL queries in Discover and Explore. Previously, SQL/PPL only worked against OpenSearch clusters because the query routing assumed `/_plugins/_*` endpoints.

Key changes:
* **Engine capabilities model** (`data_source_engine_capabilities.ts`): centralizes per-engine behavior (Open Distro endpoint routing, minimum version gating for SQL/PPL, PPL span support) so adding future engines requires a single entry.
* **Per-dataset language gating**: languages are filtered by engine type and version — SQL requires ES >= 6.5, PPL requires ES >= 7.9 — via a new `supportedDataSources` field on `LanguageConfig` and a `minVersionByEngine` evaluator in the language service.
* **Open Distro server-side routing**: the `Facet` class dynamically selects `/_opendistro/_sql` or `/_opendistro/_ppl` endpoints (JDBC format) when the target data source is Elasticsearch.
* **Dataset filter mechanism**: plugins can register per-app dataset filters (e.g. Explore hides datasets whose engine doesn't support the active language).

### Issues Resolved


## Screenshot

<!-- UI changes: language selector now hides SQL/PPL for ES data sources below the minimum version; dataset selector filters out incompatible datasets per-app -->


https://github.com/user-attachments/assets/bf89be0a-bd2d-4a2c-9a03-15e66aef72f7



## Testing the changes

Enable Following settings 
```
backend_compatibility.enabled: true
queryEnhancements.legacyElasticsearchCompatibility.enabled: true
```

Add

```bash
# Unit tests (covers new capabilities, language gating, facet routing, dataset filter, resolve_index)
yarn test:jest src/plugins/data/common/data_source_engine_capabilities.test.ts
yarn test:jest src/plugins/data/public/query/query_string/language_service/language_service.test.ts
yarn test:jest src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
yarn test:jest src/plugins/data/public/query/query_string/dataset_service/lib/index_pattern_type.test.ts
yarn test:jest src/plugins/query_enhancements/server/utils/facet.test.ts
yarn test:jest src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
yarn test:jest src/plugins/explore/public/components/query_assist/language_toggle/language_toggle.test.tsx
yarn test:jest src/plugins/index_pattern_management/server/routes/resolve_index.test.ts
yarn test:jest src/core/server/saved_objects/routes/integration_tests/import.test.ts
yarn test:jest src/core/server/saved_objects/routes/integration_tests/resolve_import_errors.test.ts

# Manual verification
# 1. Connect an ES 7.10 data source, select a dataset from it, confirm PPL and SQL are available
# 2. Connect an ES 6.8 data source, confirm only SQL is available (PPL hidden)
# 3. Switch to an OpenSearch data source, confirm no behavioral change
# 4. In Explore, switch languages — datasets incompatible with the selected language should be filtered out
```

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
