### PR TITLE
[Explore Vis]fix visualization editor panel padding & border

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/component/visualization_editor_query_panel.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/visualization_editor_query_panel.tsx
@@ -30,6 +30,8 @@ export const QueryPanel = ({
       borderRadius="none"
       className="visualizationEditorTabPanel"
       style={{ height: '100%' }}
+      hasBorder={false}
+      hasShadow={false}
     >
       <QueryPanelWidgets />
       <div className="exploreQueryPanel__editorsWrapper">

--- a/src/plugins/explore/public/application/in_context_vis_editor/visualization_editor.scss
+++ b/src/plugins/explore/public/application/in_context_vis_editor/visualization_editor.scss
@@ -53,6 +53,7 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
 
       .multiTabsPanel {
         border-top-right-radius: $euiSizeXS;
+        margin-left: $euiSizeS;
       }
     }
   }
@@ -111,7 +112,7 @@ $osdHeaderOffset: $euiHeaderHeightCompensation;
 
   // stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
   & > .euiFlexItem {
-    margin-left: $ouiSizeM;
+    margin-left: $euiSizeS;
     margin-top: $ouiSizeXS;
   }
 


### PR DESCRIPTION
### Description

This pr fix visualization editor panel padding & border

<img width="3384" height="1341" alt="截屏2026-07-03 17 21 03" src="https://github.com/user-attachments/assets/3538f0ab-b2db-4c25-b0e3-e1cda779afe4" />

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
