### PR TITLE
[Workspace] Combine workspace switcher + manage links in the footer menu

### DIFF
--- a/changelogs/fragments/12327.yml
+++ b/changelogs/fragments/12327.yml
@@ -1,0 +1,2 @@
+fix:
+- [Workspace] Combine the workspace switcher and manage-workspace links in the footer menu so it is never empty and offers workspace navigation outside a workspace ([#12327](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12327))

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/14/keyboard_shortcuts.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/14/keyboard_shortcuts.spec.js
@@ -15,6 +15,15 @@ export const runKeyboardShortcutTests = () => {
     let workspaceId;
     const endpoint = Cypress.config('baseUrl') || 'http://localhost:5601';
 
+    // Suppress the one-time "Workspace management moved" footer tour: on a fresh
+    // browser it auto-opens an EuiTour popover that overlays other UI — here it
+    // covers the workspace-creator data-source button during the `before` hook.
+    // Registered at describe scope (not in a hook) so it is active for the
+    // `before` hook's page loads too, seeding the dismissed flag pre-load.
+    Cypress.on('window:before:load', (win) => {
+      win.localStorage.setItem('workspace.manageWorkspaceMoved.tourDismissed', 'true');
+    });
+
     before(() => {
       if (PATHS.SECONDARY_ENGINE) {
         cy.osd.addDataSource({

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/14/queries_ui.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/14/queries_ui.spec.js
@@ -31,6 +31,14 @@ const datasetId = getRandomizedDatasetId();
 
 export const runQueryTests = () => {
   describe('discover Query UI tests', () => {
+    // Suppress the one-time "Workspace management moved" footer tour: on a fresh
+    // browser it auto-opens an EuiTour popover that persists in the DOM, which
+    // trips assertions expecting no popover. Seed the dismissed flag before
+    // every page load so the tour never opens.
+    Cypress.on('window:before:load', (win) => {
+      win.localStorage.setItem('workspace.manageWorkspaceMoved.tourDismissed', 'true');
+    });
+
     before(() => {
       cy.osd.setupEnvAndGetDataSource(DATASOURCE_NAME);
 

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/19/sidebar.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/query_enhancements/19/sidebar.spec.js
@@ -249,6 +249,15 @@ export const runSideBarTests = () => {
       },
     };
 
+    // Suppress the one-time "Workspace management moved" footer tour: on a fresh
+    // browser it auto-opens an EuiTour popover whose header overlays the discover
+    // sidebar fields, tripping the field-visibility assertions. Registered at
+    // describe scope so it re-seeds on every page load — note afterEach clears
+    // localStorage, so seeding once is not enough.
+    Cypress.on('window:before:load', (win) => {
+      win.localStorage.setItem('workspace.manageWorkspaceMoved.tourDismissed', 'true');
+    });
+
     before(() => {
       cy.osd.setupEnvAndGetDataSource(DATASOURCE_NAME);
 

--- a/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.test.tsx
@@ -7,7 +7,14 @@ import { fireEvent, render } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { ManageWorkspaceMenu } from './manage_workspace_menu';
 import { coreMock } from '../../../../../core/public/mocks';
-import { CoreStart, DEFAULT_APP_CATEGORIES } from '../../../../../core/public';
+import { CoreStart, DEFAULT_APP_CATEGORIES, WorkspaceObject } from '../../../../../core/public';
+import { WorkspaceUseCase } from '../../types';
+
+// The embedded workspace switcher pulls in recent-workspace + moment machinery
+// that isn't relevant here; stub it so we only assert that it is rendered.
+jest.mock('../workspace_selector/workspace_selector', () => ({
+  WorkspaceSelector: () => <div data-test-subj="mockWorkspaceSelector" />,
+}));
 
 const manageCategory = DEFAULT_APP_CATEGORIES.manageWorkspace;
 
@@ -42,37 +49,86 @@ const chromeNavLinks = [
   { id: 'discover', title: 'Discover', baseUrl: '', href: '' },
 ];
 
-const buildCore = () => {
+const registeredUseCases$ = new BehaviorSubject<WorkspaceUseCase[]>([]);
+
+const buildCore = (
+  opts: {
+    currentNavGroup?: any;
+    currentWorkspace?: WorkspaceObject | null;
+  } = {}
+) => {
+  // Use `in` so an explicit `undefined` (outside a workspace) is respected
+  // rather than falling back to the default nav group.
+  const currentNavGroup = 'currentNavGroup' in opts ? opts.currentNavGroup : (navGroup as any);
+  const currentWorkspace = 'currentWorkspace' in opts ? opts.currentWorkspace! : null;
   const core = (coreMock.createStart() as unknown) as CoreStart;
-  core.chrome.navGroup.getCurrentNavGroup$ = jest.fn(() => new BehaviorSubject(navGroup)) as any;
+  core.chrome.navGroup.getCurrentNavGroup$ = jest.fn(
+    () => new BehaviorSubject(currentNavGroup)
+  ) as any;
   core.chrome.navLinks.getNavLinks$ = jest.fn(() => new BehaviorSubject(chromeNavLinks)) as any;
   core.application.currentAppId$ = new BehaviorSubject('objects') as any;
   core.application.navigateToApp = jest.fn();
+  core.workspaces.currentWorkspace$ = new BehaviorSubject(currentWorkspace) as any;
   return core;
 };
 
+const renderMenu = (core: CoreStart) =>
+  render(<ManageWorkspaceMenu coreStart={core} registeredUseCases$={registeredUseCases$} />);
+
 describe('<ManageWorkspaceMenu />', () => {
+  beforeEach(() => {
+    // Default: tour already dismissed so it doesn't interfere with popover tests.
+    localStorage.setItem('workspace.manageWorkspaceMoved.tourDismissed', 'true');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('renders the trigger button', () => {
-    const { getByTestId } = render(<ManageWorkspaceMenu coreStart={buildCore()} />);
+    const { getByTestId } = renderMenu(buildCore());
     expect(getByTestId('manageWorkspaceMenuButton')).toBeInTheDocument();
   });
 
-  it('opens a popover listing only manage-workspace links on click', () => {
-    const { getByTestId, queryByTestId } = render(<ManageWorkspaceMenu coreStart={buildCore()} />);
+  it('opens a popover with the workspace selector and manage links', () => {
+    const { getByTestId, queryByTestId } = renderMenu(
+      buildCore({ currentWorkspace: { id: 'ws-1', name: 'My WS' } as WorkspaceObject })
+    );
     expect(queryByTestId('manageWorkspaceMenuPopover')).not.toBeInTheDocument();
 
     fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
 
     expect(getByTestId('manageWorkspaceMenuPopover')).toBeInTheDocument();
+    // The embedded switcher is the same WorkspaceSelector used in the nav header.
+    expect(getByTestId('manageWorkspaceMenuSelector')).toBeInTheDocument();
+    expect(getByTestId('mockWorkspaceSelector')).toBeInTheDocument();
     expect(getByTestId('manageWorkspaceMenuItem-workspace_detail')).toBeInTheDocument();
     expect(getByTestId('manageWorkspaceMenuItem-objects')).toBeInTheDocument();
     // The non-manage-workspace link is excluded.
     expect(queryByTestId('manageWorkspaceMenuItem-discover')).not.toBeInTheDocument();
   });
 
-  it('navigates to the app on row click', () => {
-    const core = buildCore();
-    const { getByTestId } = render(<ManageWorkspaceMenu coreStart={core} />);
+  it('has no "All workspaces" row', () => {
+    const { getByTestId, queryByTestId } = renderMenu(buildCore());
+    fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
+    expect(queryByTestId('manageWorkspaceMenuItem-allWorkspaces')).not.toBeInTheDocument();
+  });
+
+  it('shows the switcher even outside a workspace (no manage links)', () => {
+    // Outside a workspace: no current nav group, no current workspace.
+    const { getByTestId, queryByTestId } = renderMenu(
+      buildCore({ currentNavGroup: undefined, currentWorkspace: null })
+    );
+    fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
+
+    expect(getByTestId('manageWorkspaceMenuSelector')).toBeInTheDocument();
+    // No manage-workspace rows when outside a workspace.
+    expect(queryByTestId('manageWorkspaceMenuItem-workspace_detail')).not.toBeInTheDocument();
+  });
+
+  it('navigates to the app on a manage-workspace row click', () => {
+    const core = buildCore({ currentWorkspace: { id: 'ws-1', name: 'My WS' } as WorkspaceObject });
+    const { getByTestId } = renderMenu(core);
     fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
 
     fireEvent.click(getByTestId('manageWorkspaceMenuItem-workspace_detail'));
@@ -81,12 +137,46 @@ describe('<ManageWorkspaceMenu />', () => {
   });
 
   it('emphasizes the current app row', () => {
-    const { getByTestId } = render(<ManageWorkspaceMenu coreStart={buildCore()} />);
+    const { getByTestId } = renderMenu(
+      buildCore({ currentWorkspace: { id: 'ws-1', name: 'My WS' } as WorkspaceObject })
+    );
     fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
     // currentAppId$ is 'objects' — its row is bolded, others are not.
     expect(getByTestId('manageWorkspaceMenuItem-objects')).toHaveStyle('font-weight: 600');
     expect(getByTestId('manageWorkspaceMenuItem-workspace_detail')).not.toHaveStyle(
       'font-weight: 600'
     );
+  });
+
+  describe('first-visit tour', () => {
+    it('opens on mount when not previously dismissed', () => {
+      localStorage.clear();
+      const { getByTestId } = renderMenu(buildCore());
+      expect(getByTestId('manageWorkspaceTourDismiss')).toBeInTheDocument();
+    });
+
+    it('dismisses and persists the flag on "Got it"', () => {
+      localStorage.clear();
+      const { getByTestId } = renderMenu(buildCore());
+
+      fireEvent.click(getByTestId('manageWorkspaceTourDismiss'));
+
+      expect(localStorage.getItem('workspace.manageWorkspaceMoved.tourDismissed')).toBe('true');
+    });
+
+    it('does not open when the flag is already set', () => {
+      // beforeEach set the flag.
+      const { queryByTestId } = renderMenu(buildCore());
+      expect(queryByTestId('manageWorkspaceTourDismiss')).not.toBeInTheDocument();
+    });
+
+    it('is dismissed when the user opens the popover', () => {
+      localStorage.clear();
+      const { getByTestId } = renderMenu(buildCore());
+
+      fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
+
+      expect(localStorage.getItem('workspace.manageWorkspaceMoved.tourDismissed')).toBe('true');
+    });
   });
 });

--- a/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.test.tsx
+++ b/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.test.tsx
@@ -10,11 +10,34 @@ import { coreMock } from '../../../../../core/public/mocks';
 import { CoreStart, DEFAULT_APP_CATEGORIES, WorkspaceObject } from '../../../../../core/public';
 import { WorkspaceUseCase } from '../../types';
 
+// `var` (not const) so it is hoisted above the hoisted jest.mock factory that
+// references it; the `mock` prefix is what allows the factory reference.
+// eslint-disable-next-line no-var
+var mockTourStepSpy = jest.fn();
+
 // The embedded workspace switcher pulls in recent-workspace + moment machinery
 // that isn't relevant here; stub it so we only assert that it is rendered.
 jest.mock('../workspace_selector/workspace_selector', () => ({
   WorkspaceSelector: () => <div data-test-subj="mockWorkspaceSelector" />,
 }));
+
+// Spy on EuiTourStep props (to assert focus behavior, which jsdom can't observe)
+// while still rendering the anchored children + the footer action button.
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  return {
+    ...actual,
+    EuiTourStep: (props: any) => {
+      mockTourStepSpy(props);
+      return (
+        <>
+          {props.children}
+          {props.isStepOpen ? props.footerAction : null}
+        </>
+      );
+    },
+  };
+});
 
 const manageCategory = DEFAULT_APP_CATEGORIES.manageWorkspace;
 
@@ -77,6 +100,7 @@ const renderMenu = (core: CoreStart) =>
 
 describe('<ManageWorkspaceMenu />', () => {
   beforeEach(() => {
+    mockTourStepSpy.mockClear();
     // Default: tour already dismissed so it doesn't interfere with popover tests.
     localStorage.setItem('workspace.manageWorkspaceMoved.tourDismissed', 'true');
   });
@@ -114,14 +138,17 @@ describe('<ManageWorkspaceMenu />', () => {
     expect(queryByTestId('manageWorkspaceMenuItem-allWorkspaces')).not.toBeInTheDocument();
   });
 
-  it('shows the switcher even outside a workspace (no manage links)', () => {
-    // Outside a workspace: no current nav group, no current workspace.
+  it('shows the workspace picker directly (no switcher row) when there are no manage links', () => {
+    // Outside a workspace (e.g. settings page): no current nav group / workspace.
     const { getByTestId, queryByTestId } = renderMenu(
       buildCore({ currentNavGroup: undefined, currentWorkspace: null })
     );
     fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
 
-    expect(getByTestId('manageWorkspaceMenuSelector')).toBeInTheDocument();
+    // Picker is rendered directly in the popover — no "Select a workspace" row
+    // (the switcher row that would open a second popover).
+    expect(getByTestId('manageWorkspaceMenuPicker')).toBeInTheDocument();
+    expect(queryByTestId('manageWorkspaceMenuSelector')).not.toBeInTheDocument();
     // No manage-workspace rows when outside a workspace.
     expect(queryByTestId('manageWorkspaceMenuItem-workspace_detail')).not.toBeInTheDocument();
   });
@@ -177,6 +204,17 @@ describe('<ManageWorkspaceMenu />', () => {
       fireEvent.click(getByTestId('manageWorkspaceMenuButton'));
 
       expect(localStorage.getItem('workspace.manageWorkspaceMoved.tourDismissed')).toBe('true');
+    });
+
+    it('renders the tour without stealing focus (ownFocus=false)', () => {
+      localStorage.clear();
+      renderMenu(buildCore());
+      // The tour must not trap keyboard focus, otherwise page-level shortcuts
+      // (shift+/, g-d, ...) are swallowed on first visit. jsdom cannot observe
+      // the focus trap directly, so assert the prop passed to EuiTourStep.
+      const tourCall = mockTourStepSpy.mock.calls.find(([props]) => props.isStepOpen);
+      expect(tourCall).toBeDefined();
+      expect(tourCall![0].ownFocus).toBe(false);
     });
   });
 });

--- a/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.tsx
@@ -3,16 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  EuiButtonEmpty,
   EuiButtonIcon,
   EuiContextMenuItem,
   EuiContextMenuPanel,
+  EuiHorizontalRule,
   EuiPopover,
   EuiPopoverTitle,
+  EuiText,
   EuiToolTip,
+  EuiTourStep,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { BehaviorSubject } from 'rxjs';
 import { useObservable } from 'react-use';
 import {
   CoreStart,
@@ -20,30 +25,39 @@ import {
   fulfillRegistrationLinksToChromeNavLinks,
   getSortedNavLinks,
 } from '../../../../../core/public';
+import { WorkspaceUseCase } from '../../types';
+import { WorkspaceSelector } from '../workspace_selector/workspace_selector';
 
 interface Props {
   coreStart: CoreStart;
+  registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
 }
 
+// One-time first-visit tour flag: teaches users that workspace management was
+// re-grouped into this footer icon (the function of the footer button changed,
+// and the icon is easy to miss). Persisted in localStorage so it shows once.
+const MANAGE_WORKSPACE_TOUR_STORAGE_KEY = 'workspace.manageWorkspaceMoved.tourDismissed';
+
 /**
- * Footer entry-point for the "Manage workspace" apps (Workspace details,
- * Collaborators, Data sources, Index patterns, Datasets, Saved objects, Sample
- * data). These links are registered into the `manageWorkspace` category by the
- * workspace use-case service; they used to render as a collapsible section in
- * the nav body, but now live here in the footer. Clicking the button opens a
- * popover listing the links; clicking a link navigates to that app.
+ * Footer entry-point for workspace controls. Opens a popover that combines, top
+ * to bottom:
+ *  - the workspace switcher — the exact `WorkspaceSelector` used at the top of
+ *    the nav header, so switching/creating workspaces behaves identically here;
+ *  - the "Manage workspace" apps (Workspace details, Collaborators, Data
+ *    sources, Index patterns, Datasets, Assets, Sample data), registered into
+ *    the `manageWorkspace` category and filtered in here.
+ *
+ * This replaces both the old body-nav manage-workspace category AND the former
+ * footer workspace switcher: switching lives in the embedded `WorkspaceSelector`,
+ * so workspace navigation is reachable from the footer even when the user is
+ * outside any workspace (where the top-of-nav selector is not mounted).
  *
  * Uses standard EUI popover + context-menu components (not the icon side nav's
  * bespoke popover styling), because the workspace plugin renders in every
  * workspace while the icon side nav is enabled only in the Observability
  * workspace — this component must not depend on icon-nav-only styles.
- *
- * Registered only in the expanded footer / classic nav (not the collapsed icon
- * rail), matching the workspace button it replaced. Workspace switching/creation
- * is intentionally NOT here — the always-present top-of-nav workspace selector
- * owns that.
  */
-export const ManageWorkspaceMenu = ({ coreStart }: Props) => {
+export const ManageWorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) => {
   const { chrome, application } = coreStart;
 
   // `getCurrentNavGroup$()` / `getNavLinks$()` return a NEW observable instance on
@@ -60,6 +74,16 @@ export const ManageWorkspaceMenu = ({ coreStart }: Props) => {
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
+  const [isTourDismissed, setIsTourDismissed] = useState(() =>
+    Boolean(localStorage.getItem(MANAGE_WORKSPACE_TOUR_STORAGE_KEY))
+  );
+  const [isTourOpen, setIsTourOpen] = useState(false);
+  useEffect(() => {
+    if (!isTourDismissed) {
+      setIsTourOpen(true);
+    }
+  }, [isTourDismissed]);
+
   const label = i18n.translate('workspace.manageWorkspaceMenu.title', {
     defaultMessage: 'Manage workspace',
   });
@@ -73,7 +97,19 @@ export const ManageWorkspaceMenu = ({ coreStart }: Props) => {
     return getSortedNavLinks(fulfilled);
   }, [currentNavGroup, navLinks]);
 
+  const dismissTour = useCallback(() => {
+    localStorage.setItem(MANAGE_WORKSPACE_TOUR_STORAGE_KEY, 'true');
+    setIsTourDismissed(true);
+    setIsTourOpen(false);
+  }, []);
+
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+
+  const openPopover = useCallback(() => {
+    setIsPopoverOpen((open) => !open);
+    // Finding the icon is the whole point of the tour — once opened, retire it.
+    dismissTour();
+  }, [dismissTour]);
 
   const triggerButton = (
     <EuiToolTip content={label} position="right">
@@ -82,12 +118,12 @@ export const ManageWorkspaceMenu = ({ coreStart }: Props) => {
         color="text"
         aria-label={label}
         data-test-subj="manageWorkspaceMenuButton"
-        onClick={() => setIsPopoverOpen((open) => !open)}
+        onClick={openPopover}
       />
     </EuiToolTip>
   );
 
-  const menuItems = manageLinks.map((link) => (
+  const manageMenuItems = manageLinks.map((link) => (
     <EuiContextMenuItem
       key={link.id}
       icon={link.euiIconType}
@@ -104,17 +140,69 @@ export const ManageWorkspaceMenu = ({ coreStart }: Props) => {
   ));
 
   return (
-    <EuiPopover
-      anchorPosition="upCenter"
-      panelPaddingSize="none"
-      isOpen={isPopoverOpen}
-      closePopover={closePopover}
-      button={triggerButton}
+    <EuiTourStep
+      content={
+        <EuiText size="s">
+          <p style={{ maxWidth: 260 }}>
+            {i18n.translate('workspace.manageWorkspaceMenu.tour.content', {
+              defaultMessage:
+                'Workspace details, data sources, index patterns and more are now grouped here.',
+            })}
+          </p>
+        </EuiText>
+      }
+      isStepOpen={isTourOpen && !isPopoverOpen}
+      minWidth={260}
+      onFinish={dismissTour}
+      step={1}
+      stepsTotal={1}
+      anchorPosition="rightUp"
+      subtitle={i18n.translate('workspace.manageWorkspaceMenu.tour.subtitle', {
+        defaultMessage: "What's new",
+      })}
+      title={i18n.translate('workspace.manageWorkspaceMenu.tour.title', {
+        defaultMessage: 'Workspace management moved',
+      })}
+      footerAction={
+        <EuiButtonEmpty
+          size="xs"
+          color="text"
+          flush="right"
+          data-test-subj="manageWorkspaceTourDismiss"
+          onClick={dismissTour}
+        >
+          {i18n.translate('workspace.manageWorkspaceMenu.tour.dismiss', {
+            defaultMessage: 'Got it',
+          })}
+        </EuiButtonEmpty>
+      }
     >
-      <div data-test-subj="manageWorkspaceMenuPopover">
-        <EuiPopoverTitle paddingSize="s">{label}</EuiPopoverTitle>
-        <EuiContextMenuPanel items={menuItems} />
-      </div>
-    </EuiPopover>
+      <EuiPopover
+        anchorPosition="upCenter"
+        panelPaddingSize="none"
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        button={triggerButton}
+      >
+        <div data-test-subj="manageWorkspaceMenuPopover" style={{ width: 320 }}>
+          <EuiPopoverTitle paddingSize="s">{label}</EuiPopoverTitle>
+          {/* The exact workspace switcher used at the top of the nav header,
+              rendered flush so it matches the manage-workspace menu rows. */}
+          <div data-test-subj="manageWorkspaceMenuSelector">
+            <WorkspaceSelector
+              coreStart={coreStart}
+              registeredUseCases$={registeredUseCases$}
+              flush
+            />
+          </div>
+          {manageMenuItems.length > 0 && (
+            <>
+              <EuiHorizontalRule margin="none" />
+              <EuiContextMenuPanel items={manageMenuItems} />
+            </>
+          )}
+        </div>
+      </EuiPopover>
+    </EuiTourStep>
   );
 };

--- a/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -77,12 +77,8 @@ export const ManageWorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) =
   const [isTourDismissed, setIsTourDismissed] = useState(() =>
     Boolean(localStorage.getItem(MANAGE_WORKSPACE_TOUR_STORAGE_KEY))
   );
-  const [isTourOpen, setIsTourOpen] = useState(false);
-  useEffect(() => {
-    if (!isTourDismissed) {
-      setIsTourOpen(true);
-    }
-  }, [isTourDismissed]);
+  // Derived: the first-visit tour is open whenever it hasn't been dismissed.
+  const isTourOpen = !isTourDismissed;
 
   const label = i18n.translate('workspace.manageWorkspaceMenu.title', {
     defaultMessage: 'Manage workspace',
@@ -100,7 +96,6 @@ export const ManageWorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) =
   const dismissTour = useCallback(() => {
     localStorage.setItem(MANAGE_WORKSPACE_TOUR_STORAGE_KEY, 'true');
     setIsTourDismissed(true);
-    setIsTourOpen(false);
   }, []);
 
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);

--- a/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.tsx
+++ b/src/plugins/workspace/public/components/manage_workspace_menu/manage_workspace_menu.tsx
@@ -157,6 +157,12 @@ export const ManageWorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) =
       step={1}
       stepsTotal={1}
       anchorPosition="rightUp"
+      // Do not steal keyboard focus: this is a passive first-visit hint, not a
+      // modal. With ownFocus (the EuiPopover default) the tour panel traps focus
+      // on mount and swallows page-level keyboard shortcuts (e.g. shift+/ for the
+      // shortcuts help modal, g-d/g-b navigation). Matches the other icon side
+      // nav popovers, which all render with ownFocus={false}.
+      ownFocus={false}
       subtitle={i18n.translate('workspace.manageWorkspaceMenu.tour.subtitle', {
         defaultMessage: "What's new",
       })}
@@ -186,20 +192,31 @@ export const ManageWorkspaceMenu = ({ coreStart, registeredUseCases$ }: Props) =
       >
         <div data-test-subj="manageWorkspaceMenuPopover" style={{ width: 320 }}>
           <EuiPopoverTitle paddingSize="s">{label}</EuiPopoverTitle>
-          {/* The exact workspace switcher used at the top of the nav header,
-              rendered flush so it matches the manage-workspace menu rows. */}
-          <div data-test-subj="manageWorkspaceMenuSelector">
-            <WorkspaceSelector
-              coreStart={coreStart}
-              registeredUseCases$={registeredUseCases$}
-              flush
-            />
-          </div>
-          {manageMenuItems.length > 0 && (
+          {manageMenuItems.length > 0 ? (
             <>
+              {/* Inside a workspace: the switcher row (flush WorkspaceSelector)
+                  sits above the manage-workspace links. */}
+              <div data-test-subj="manageWorkspaceMenuSelector">
+                <WorkspaceSelector
+                  coreStart={coreStart}
+                  registeredUseCases$={registeredUseCases$}
+                  flush
+                />
+              </div>
               <EuiHorizontalRule margin="none" />
               <EuiContextMenuPanel items={manageMenuItems} />
             </>
+          ) : (
+            // No manage links (e.g. settings/admin page): show the workspace
+            // picker directly in this popover — no intermediate "Select a
+            // workspace" row that would open a second popover.
+            <div data-test-subj="manageWorkspaceMenuPicker">
+              <WorkspaceSelector
+                coreStart={coreStart}
+                registeredUseCases$={registeredUseCases$}
+                inline
+              />
+            </div>
           )}
         </div>
       </EuiPopover>

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss
@@ -29,3 +29,18 @@
   font-weight: $euiFontWeightMedium;
   max-width: 160px;
 }
+
+// Flush variant used inside context-menu-style popovers (e.g. the footer
+// "Manage workspace" menu): a flat, full-width row that matches sibling menu
+// items instead of the boxed nav-header button.
+.workspaceSelectorFlushButton {
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    // stylelint-disable-next-line @osd/stylelint/no_restricted_values
+    background-color: rgba($euiTextColor, 0.04);
+    transition: none !important;
+    transform: none !important;
+  }
+}

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.test.tsx
@@ -222,4 +222,46 @@ describe('<WorkspaceSelector />', () => {
     expect(screen.queryByText(/manage/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/create workspaces/i)).toBeNull();
   });
+
+  describe('flush variant', () => {
+    const FlushComponent = () => (
+      <I18nProvider>
+        {/* @ts-expect-error TS2322 TODO(ts-error): fixme */}
+        <WorkspaceSelector
+          coreStart={coreStartMock}
+          registeredUseCases$={registeredUseCases$}
+          flush
+        />
+      </I18nProvider>
+    );
+
+    it('renders the flat trigger showing the current workspace name', () => {
+      render(<FlushComponent />);
+      const button = screen.getByTestId('workspace-selector-button');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveClass('workspaceSelectorFlushButton');
+      expect(screen.getByTestId('workspace-selector-current-name')).toHaveTextContent(
+        'workspace 3'
+      );
+    });
+
+    it('opens the same picker popover on click', () => {
+      coreStartMock.workspaces.workspaceList$.next([
+        { id: 'workspace-1', name: 'workspace 1', features: [] },
+      ]);
+      render(<FlushComponent />);
+      fireEvent.click(screen.getByTestId('workspace-selector-button'));
+      expect(screen.getByText('workspace 1')).toBeInTheDocument();
+    });
+
+    it('shows "Select a workspace" as a flat row when outside a workspace', () => {
+      coreStartMock.workspaces.currentWorkspace$ = new BehaviorSubject<WorkspaceObject | null>(
+        null
+      );
+      render(<FlushComponent />);
+      const button = screen.getByTestId('workspace-selector-button');
+      expect(button).toHaveClass('workspaceSelectorFlushButton');
+      expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -41,9 +41,18 @@ const getValidWorkspaceColor = (color?: string) =>
 interface Props {
   coreStart: CoreStart;
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
+  /**
+   * Render the trigger as a flush, full-width menu row (icon + name + chevron)
+   * instead of the default nav-header panel button. Used when the selector is
+   * embedded inside a context-menu-style popover (e.g. the footer "Manage
+   * workspace" menu) so it visually matches the sibling menu rows. The
+   * outside-a-workspace state renders the same flat row ("Select a workspace")
+   * rather than a large primary button.
+   */
+  flush?: boolean;
 }
 
-export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => {
+export const WorkspaceSelector = ({ coreStart, registeredUseCases$, flush = false }: Props) => {
   const [isPopoverOpen, setPopover] = useState(false);
   const currentWorkspace = useObservable(coreStart.workspaces.currentWorkspace$, null);
   const availableUseCases = useObservable(registeredUseCases$, []);
@@ -65,7 +74,46 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
     setPopover(false);
   };
 
-  const button = currentWorkspace ? (
+  const selectWorkspaceLabel = i18n.translate('workspace.menu.selectWorkspace', {
+    defaultMessage: 'Select a workspace',
+  });
+
+  // Flush variant: a flat, full-width menu row for both the in-workspace and
+  // outside-a-workspace states, so it matches the context-menu rows it sits
+  // alongside when embedded in a popover.
+  const flushButton = (
+    <EuiPanel
+      className="workspaceSelectorFlushButton"
+      data-test-subj="workspace-selector-button"
+      paddingSize="s"
+      color="transparent"
+      hasBorder={false}
+      hasShadow={false}
+      onClick={onButtonClick}
+    >
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiIcon
+            size="m"
+            type={(currentWorkspace && getUseCase(currentWorkspace)?.icon) || 'wsSelector'}
+            color={getValidWorkspaceColor(currentWorkspace?.color)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem style={{ minWidth: 0 }}>
+          <EuiText size="s" data-test-subj="workspace-selector-current-name">
+            <span className="eui-textTruncate">
+              {currentWorkspace ? currentWorkspace.name : selectWorkspaceLabel}
+            </span>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="arrowDown" size="s" color="subdued" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+
+  const defaultButton = currentWorkspace ? (
     <div className="workspaceSelectorPopoverButtonContainer">
       <EuiPanel
         className="workspaceSelectorPopoverButton"
@@ -106,6 +154,8 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$ }: Props) => 
   ) : (
     <EuiButton onClick={onButtonClick}>Select a Workspace</EuiButton>
   );
+
+  const button = flush ? flushButton : defaultButton;
 
   return (
     <EuiPopover

--- a/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
+++ b/src/plugins/workspace/public/components/workspace_selector/workspace_selector.tsx
@@ -50,9 +50,22 @@ interface Props {
    * rather than a large primary button.
    */
   flush?: boolean;
+  /**
+   * Render only the picker content (search + workspace list + Manage/Create),
+   * with no trigger button and no popover wrapper. Used when a parent popover
+   * already provides the container (e.g. the footer "Manage workspace" menu on
+   * pages with no manage-workspace links) so the picker shows directly instead
+   * of a redundant popover-in-a-popover.
+   */
+  inline?: boolean;
 }
 
-export const WorkspaceSelector = ({ coreStart, registeredUseCases$, flush = false }: Props) => {
+export const WorkspaceSelector = ({
+  coreStart,
+  registeredUseCases$,
+  flush = false,
+  inline = false,
+}: Props) => {
   const [isPopoverOpen, setPopover] = useState(false);
   const currentWorkspace = useObservable(coreStart.workspaces.currentWorkspace$, null);
   const availableUseCases = useObservable(registeredUseCases$, []);
@@ -107,7 +120,9 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$, flush = fals
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiIcon type="arrowDown" size="s" color="subdued" />
+          {/* The flush picker opens to the right, so point the chevron toward it
+              (submenu-style disclosure) rather than down. */}
+          <EuiIcon type="arrowRight" size="s" color="subdued" />
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>
@@ -157,74 +172,91 @@ export const WorkspaceSelector = ({ coreStart, registeredUseCases$, flush = fals
 
   const button = flush ? flushButton : defaultButton;
 
+  // The picker body (search + workspace list + Manage/Create). Shared between the
+  // popover (default/flush) and the inline variant, which renders it directly
+  // without a trigger button or nested popover.
+  const pickerContent = (
+    <EuiFlexGroup direction="column" alignItems="center" gutterSize="none">
+      <EuiFlexItem>
+        <EuiPanel
+          paddingSize="none"
+          hasBorder={false}
+          hasShadow={false}
+          color="transparent"
+          // set the width fixed to achieve text truncation
+          style={{ height: '40vh', width: '310px' }}
+        >
+          <WorkspacePickerContent
+            coreStart={coreStart}
+            registeredUseCases$={registeredUseCases$}
+            onClickWorkspace={() => setPopover(false)}
+            isInTwoLines={false}
+          />
+        </EuiPanel>
+      </EuiFlexItem>
+
+      {isDashboardAdmin && (
+        <EuiFlexItem className="eui-fullWidth">
+          <EuiHorizontalRule size="full" margin="none" />
+          <EuiSpacer size="s" />
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem grow={false} className="eui-textLeft">
+              <EuiButtonEmpty
+                color="primary"
+                size="xs"
+                data-test-subj="workspace-menu-manage-button"
+                onClick={() => {
+                  closePopover();
+                  coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
+                }}
+              >
+                <EuiText size="s">{manageWorkspacesButton}</EuiText>
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false} className="eui-textRight">
+              <EuiButtonEmpty
+                color="primary"
+                size="xs"
+                iconType="plus"
+                key={WORKSPACE_CREATE_APP_ID}
+                data-test-subj="workspace-menu-create-workspace-button"
+                onClick={() => {
+                  closePopover();
+                  coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
+                }}
+              >
+                <EuiText size="s">{createWorkspaceButton}</EuiText>
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+
+  // Inline: render just the picker content (no trigger, no popover) so a parent
+  // popover (e.g. the footer "Manage workspace" menu on pages with no manage
+  // links) can show the picker directly without a redundant popover-in-popover.
+  if (inline) {
+    return pickerContent;
+  }
+
   return (
     <EuiPopover
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="s"
-      anchorPosition="downLeft"
+      // In the flush (footer) context the trigger sits at the very bottom of the
+      // nav with no room below, so open the picker to the right. In the nav
+      // header, keep the original downward dropdown.
+      anchorPosition={flush ? 'rightUp' : 'downLeft'}
       repositionOnScroll={true}
       display="block"
       className="eui-fullWidth"
     >
-      <EuiFlexGroup direction="column" alignItems="center" gutterSize="none">
-        <EuiFlexItem>
-          <EuiPanel
-            paddingSize="none"
-            hasBorder={false}
-            hasShadow={false}
-            color="transparent"
-            // set the width fixed to achieve text truncation
-            style={{ height: '40vh', width: '310px' }}
-          >
-            <WorkspacePickerContent
-              coreStart={coreStart}
-              registeredUseCases$={registeredUseCases$}
-              onClickWorkspace={() => setPopover(false)}
-              isInTwoLines={false}
-            />
-          </EuiPanel>
-        </EuiFlexItem>
-
-        {isDashboardAdmin && (
-          <EuiFlexItem className="eui-fullWidth">
-            <EuiHorizontalRule size="full" margin="none" />
-            <EuiSpacer size="s" />
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              <EuiFlexItem grow={false} className="eui-textLeft">
-                <EuiButtonEmpty
-                  color="primary"
-                  size="xs"
-                  data-test-subj="workspace-menu-manage-button"
-                  onClick={() => {
-                    closePopover();
-                    coreStart.application.navigateToApp(WORKSPACE_LIST_APP_ID);
-                  }}
-                >
-                  <EuiText size="s">{manageWorkspacesButton}</EuiText>
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-
-              <EuiFlexItem grow={false} className="eui-textRight">
-                <EuiButtonEmpty
-                  color="primary"
-                  size="xs"
-                  iconType="plus"
-                  key={WORKSPACE_CREATE_APP_ID}
-                  data-test-subj="workspace-menu-create-workspace-button"
-                  onClick={() => {
-                    closePopover();
-                    coreStart.application.navigateToApp(WORKSPACE_CREATE_APP_ID);
-                  }}
-                >
-                  <EuiText size="s">{createWorkspaceButton}</EuiText>
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
+      {pickerContent}
     </EuiPopover>
   );
 };

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -657,6 +657,7 @@ export class WorkspacePlugin
         mount: toMountPoint(
           React.createElement(ManageWorkspaceMenu, {
             coreStart: core,
+            registeredUseCases$: this.registeredUseCases$,
           })
         ),
       });


### PR DESCRIPTION
### Description

Reworks the footer **"Manage workspace"** menu (used by both the icon side navigation and the classic left nav) so it is never empty and always offers workspace navigation.

Previously, opening the footer menu **outside a workspace** showed an empty popover, and there was no workspace picker available outside a workspace at all (the top-of-nav `WorkspaceSelector` is only mounted when inside one, so users had to return to Home to switch).

Changes:
- **Embed the existing `WorkspaceSelector`** at the top of the footer popover, so switching/creating workspaces behaves identically to the nav header (same picker, same recent list, same Manage/Create actions).
- **Add a `flush` variant to `WorkspaceSelector`** that renders its trigger as a flat, full-width menu row — both inside a workspace and outside it ("Select a workspace") — so it visually matches the sibling context-menu rows instead of the boxed nav-header button.
- **Keep the manage-workspace links** (Workspace details, Data sources, Index patterns, Datasets, Assets, Sample data) below the switcher; they render only when present (i.e. inside a workspace).
- **One-time first-visit `EuiTour`** anchored to the footer icon so users learn workspace management moved here. Dismissed permanently via `localStorage` (or automatically once the user opens the menu), mirroring the existing `no_data_popover` pattern.

The default (non-`flush`) `WorkspaceSelector` behavior in the nav header is unchanged.

### Issues Resolved

Part of the icon side navigation RFC: opensearch-project/OpenSearch-Dashboards#11545

Follow-up UX fix for the footer "Manage workspace" menu introduced in #12285.

## Screenshot
* New button tour
<img height="433" alt="Screenshot 2026-07-06 at 12 04 09 AM" src="https://github.com/user-attachments/assets/eb955e03-6710-46bf-bba6-5b1d5d2499d8" />


* workspace switcher within a workspace 
<img height="433" alt="Screenshot 2026-07-06 at 12 03 29 AM" src="https://github.com/user-attachments/assets/64c386eb-cd12-4e23-ade0-21d35bf64b63" />


* workspace switcher in admin pages
<img height="433" alt="Screenshot 2026-07-06 at 12 04 30 AM" src="https://github.com/user-attachments/assets/86fcbd1b-f3ca-43d8-9d4c-333ca79ab9c5" />




## Testing the changes

1. Enable the icon side nav (`opensearchDashboards.enableIconSideNav: true`) and open an Observability workspace.
2. Click the footer **Manage workspace** icon → the popover shows a flat workspace-switcher row on top, then the manage-workspace links. The switcher row style matches the links below it.
3. Navigate **outside any workspace** → open the footer menu → it is not empty; the switcher row shows "Select a workspace" and opens the picker.
4. Classic nav (flag off) → the same footer menu renders correctly.
5. First load with a cleared `localStorage` → the "Workspace management moved" tour points at the footer icon; dismissing it (or opening the menu) prevents it from reappearing.
6. `yarn test:jest src/plugins/workspace/public/components/manage_workspace_menu src/plugins/workspace/public/components/workspace_selector` — 24 tests pass.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (affected suites)
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

