### PR TITLE
Fix Autocomplete Value Suggestions for ES clusters

### DIFF
--- a/src/plugins/data/common/data_source_engine_capabilities.ts
+++ b/src/plugins/data/common/data_source_engine_capabilities.ts
@@ -27,6 +27,14 @@ export interface SqlPplEndpointActions {
 }
 
 /**
+ * Which language to use for autocomplete column-value suggestions (the `top N column` query).
+ * - `'PPL'`: uses `source = <table> | top <n> <column>` (OpenSearch default).
+ * - `'SQL'`: uses `SELECT <column> FROM <table> GROUP BY <column> ORDER BY COUNT(*) DESC LIMIT <n>`.
+ * - `'none'`: column-value suggestions are disabled for this engine (e.g. engine too old).
+ */
+export type ColumnValueSuggestionLanguage = 'PPL' | 'SQL' | 'none';
+
+/**
  * Comprehensive, declarative description of what a data-source engine supports. Centralizes the
  * per-engine behavior that used to be scattered as inline `=== 'Elasticsearch'` checks, so adding
  * support for another engine means filling in one entry with full context.
@@ -49,6 +57,8 @@ export interface DataSourceEngineCapabilities {
   supportsRuntimePplGrammar: boolean;
   /** Client-action endpoints the server Facet should use to run PPL/SQL for this engine. */
   sqlPplEndpoints: SqlPplEndpointActions;
+  /** Which language the autocomplete column-value fetcher should use for this engine. */
+  columnValueSuggestionLanguage: ColumnValueSuggestionLanguage;
 }
 
 /** Default capabilities (historical OpenSearch behavior) for engines without an explicit entry. */
@@ -57,6 +67,7 @@ export const DEFAULT_ENGINE_CAPABILITIES: DataSourceEngineCapabilities = {
   supportsPplSpan: true,
   supportsRuntimePplGrammar: true,
   sqlPplEndpoints: { ppl: 'enhancements.pplQuery', sql: 'enhancements.sqlQuery' },
+  columnValueSuggestionLanguage: 'PPL',
 };
 
 /**
@@ -76,6 +87,7 @@ const ENGINE_CAPABILITIES: Partial<Record<string, DataSourceEngineCapabilities>>
       ppl: 'enhancements.pplQueryOpenDistro',
       sql: 'enhancements.sqlQueryOpenDistro',
     },
+    columnValueSuggestionLanguage: 'SQL',
   },
   [ENGINE.OpenSearch]: { ...DEFAULT_ENGINE_CAPABILITIES },
 };

--- a/src/plugins/data/common/data_views/data_views/data_views.test.ts
+++ b/src/plugins/data/common/data_views/data_views/data_views.test.ts
@@ -615,4 +615,51 @@ describe('DataViews', () => {
       );
     });
   });
+
+  describe('convertToDataset', () => {
+    // A plain IndexPattern (no `toDataset` method) whose `dataSourceRef` is the raw saved-object
+    // reference: `type` is the saved-object type ('data-source'), not the engine type, and there is
+    // no version. This mirrors what `IndexPatternsService.get()` returns.
+    const indexPatternWithRawRef = {
+      id: 'ip-1',
+      title: 'kibana_sample_data_ecommerce*',
+      type: undefined,
+      timeFieldName: 'order_date',
+      dataSourceRef: { id: 'ds-1', type: 'data-source', name: 'dataSource' },
+    } as any;
+
+    it('resolves the real engine type and version by fetching the data-source saved object', async () => {
+      savedObjectsClient.get = jest.fn().mockResolvedValue({
+        id: 'ds-1',
+        attributes: {
+          title: 'escluster-710',
+          dataSourceEngineType: 'Elasticsearch',
+          dataSourceVersion: '7.10.2',
+        },
+      });
+
+      const dataset = await dataViews.convertToDataset(indexPatternWithRawRef);
+
+      expect(savedObjectsClient.get).toHaveBeenCalledWith('data-source', 'ds-1');
+      expect(dataset.dataSource).toEqual({
+        id: 'ds-1',
+        title: 'escluster-710',
+        type: 'Elasticsearch',
+        version: '7.10.2',
+      });
+    });
+
+    it('falls back to the reference values when the data-source fetch fails', async () => {
+      savedObjectsClient.get = jest.fn().mockRejectedValue(new Error('not found'));
+
+      const dataset = await dataViews.convertToDataset(indexPatternWithRawRef);
+
+      expect(dataset.dataSource).toEqual({
+        id: 'ds-1',
+        title: 'dataSource',
+        type: 'data-source',
+        version: '',
+      });
+    });
+  });
 });

--- a/src/plugins/data/common/data_views/data_views/data_views.ts
+++ b/src/plugins/data/common/data_views/data_views/data_views.ts
@@ -813,14 +813,40 @@ export class DataViewsService {
       displayName: dataView.displayName,
       description: dataView.description,
       ...(dataView.dataSourceRef?.id && {
-        dataSource: {
-          id: dataView.dataSourceRef.id,
-          title: dataView.dataSourceRef.name || dataView.dataSourceRef.id,
-          type: dataView.dataSourceRef.type || DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH,
-          version: dataView.dataSourceRef.version || '',
-        },
+        dataSource: await this.resolveDataSourceForDataset(dataView.dataSourceRef),
       }),
     };
+  }
+
+  /**
+   * Resolve the {@link Dataset} `dataSource` from an IndexPattern's `dataSourceRef`.
+   *
+   * An IndexPattern's `dataSourceRef` is the raw saved-object reference, so its `type` is the
+   * saved-object type (`'data-source'`) rather than the engine type (e.g. `'Elasticsearch'`), and
+   * it carries no version. Consumers that route by engine (SQL/PPL endpoint selection in
+   * `query_enhancements`) need the real `dataSourceEngineType`/`dataSourceVersion`, so we fetch the
+   * data-source saved object to populate them — mirroring `DataView.toDataset()`. Falls back to the
+   * reference's own values (or OpenSearch defaults) if the fetch fails.
+   */
+  private async resolveDataSourceForDataset(
+    dataSourceRef: NonNullable<IndexPattern['dataSourceRef']>
+  ): Promise<Dataset['dataSource']> {
+    try {
+      const { attributes } = await this.getDataSource(dataSourceRef.id);
+      return {
+        id: dataSourceRef.id,
+        title: attributes.title || dataSourceRef.name || dataSourceRef.id,
+        type: attributes.dataSourceEngineType || DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH,
+        version: attributes.dataSourceVersion || '',
+      };
+    } catch (error) {
+      return {
+        id: dataSourceRef.id,
+        title: dataSourceRef.name || dataSourceRef.id,
+        type: dataSourceRef.type || DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH,
+        version: dataSourceRef.version || '',
+      };
+    }
   }
 }
 

--- a/src/plugins/data/public/antlr/shared/utils.ts
+++ b/src/plugins/data/public/antlr/shared/utils.ts
@@ -18,7 +18,12 @@ import { ParsingSubject } from './types';
 import { quotesRegex, SuggestionItemDetailsTags } from './constants';
 import { IndexPattern, IndexPatternField } from '../../index_patterns';
 import { IDataPluginServices } from '../../types';
-import { DEFAULT_DATA, IFieldType, UI_SETTINGS } from '../../../common';
+import {
+  DEFAULT_DATA,
+  getDataSourceEngineCapabilities,
+  IFieldType,
+  UI_SETTINGS,
+} from '../../../common';
 import { MonacoCompatibleQuerySuggestion } from '../../autocomplete/providers/query_suggestion_provider';
 import { getDataViews } from '../../services';
 
@@ -159,6 +164,20 @@ export const fetchColumnValues = async (
   return fieldInOsd?.spec.suggestions?.values ?? [];
 };
 
+const buildColumnValueQuery = (
+  table: string,
+  column: string,
+  limit: number,
+  language: 'PPL' | 'SQL'
+): string => {
+  if (language === 'SQL') {
+    return `SELECT ${escapeIdentifier(column)} FROM ${escapeIdentifier(
+      table
+    )} GROUP BY ${escapeIdentifier(column)} ORDER BY COUNT(*) DESC LIMIT ${limit}`;
+  }
+  return `source = ${escapeIdentifier(table)} | top ${limit} ${escapeIdentifier(column)}`;
+};
+
 // Non-blocking async function to update field values in background
 const updateFieldValuesAsync = async (
   table: string,
@@ -186,12 +205,22 @@ const updateFieldValuesAsync = async (
 
     const dataset = await getDataViews().convertToDataset(indexPattern);
 
+    const engineType = dataset.dataSource?.engineType ?? dataset.dataSource?.type;
+    const caps = getDataSourceEngineCapabilities(engineType);
+
+    if (caps.columnValueSuggestionLanguage === 'none') {
+      return;
+    }
+
+    const language = caps.columnValueSuggestionLanguage;
+    const queryString = buildColumnValueQuery(table, column, limit, language);
+
     const searchSource = await services.data.search.searchSource.create();
     searchSource.setFields({
       index: indexPattern,
       query: {
-        query: `source = ${escapeIdentifier(table)} | top ${limit} ${escapeIdentifier(column)}`,
-        language: 'PPL',
+        query: queryString,
+        language,
         dataset,
       },
       skipTimeFilter,

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.test.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.test.ts
@@ -244,8 +244,8 @@ describe('SQLSearchInterceptor', () => {
       const result = await (sqlSearchInterceptor as any).buildQuery(query, baseRequest);
 
       expect(result.query).toBe(
-        "SELECT * FROM test_index WHERE `@timestamp` >= '2023-01-01 00:00:00.000' " +
-          "AND `@timestamp` <= '2023-01-02 00:00:00.000'"
+        "SELECT * FROM test_index WHERE `@timestamp` >= TIMESTAMP('2023-01-01 00:00:00.000') " +
+          "AND `@timestamp` <= TIMESTAMP('2023-01-02 00:00:00.000')"
       );
     });
 
@@ -270,8 +270,8 @@ describe('SQLSearchInterceptor', () => {
       const result = await (sqlSearchInterceptor as any).buildQuery(query, baseRequest);
 
       expect(result.query).toBe(
-        "SELECT method, COUNT(*) FROM test_index WHERE `@timestamp` >= '2023-01-01 00:00:00.000' " +
-          "AND `@timestamp` <= '2023-01-02 00:00:00.000' GROUP BY method"
+        "SELECT method, COUNT(*) FROM test_index WHERE `@timestamp` >= TIMESTAMP('2023-01-01 00:00:00.000') " +
+          "AND `@timestamp` <= TIMESTAMP('2023-01-02 00:00:00.000') GROUP BY method"
       );
     });
 
@@ -288,8 +288,8 @@ describe('SQLSearchInterceptor', () => {
       const result = await (sqlSearchInterceptor as any).buildQuery(query, baseRequest);
 
       expect(result.query).toBe(
-        "SELECT * FROM test_index WHERE `@timestamp` >= '2023-01-01 00:00:00.000' " +
-          "AND `@timestamp` <= '2023-01-02 00:00:00.000'"
+        "SELECT * FROM test_index WHERE `@timestamp` >= TIMESTAMP('2023-01-01 00:00:00.000') " +
+          "AND `@timestamp` <= TIMESTAMP('2023-01-02 00:00:00.000')"
       );
     });
   });
@@ -339,7 +339,7 @@ describe('SQLSearchInterceptor', () => {
       };
       const result = await (sqlSearchInterceptor as any).buildQuery(query, baseRequest);
       expect(result.query).toBe(
-        "SELECT * FROM test_index WHERE `@timestamp` >= '2023-01-01 00:00:00.000' AND `@timestamp` <= '2023-01-02 00:00:00.000' AND ( `host` = 'a')"
+        "SELECT * FROM test_index WHERE `@timestamp` >= TIMESTAMP('2023-01-01 00:00:00.000') AND `@timestamp` <= TIMESTAMP('2023-01-02 00:00:00.000') AND ( `host` = 'a')"
       );
     });
 

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -105,9 +105,14 @@ export class SQLSearchInterceptor extends SearchInterceptor {
 
     const timeRange = this.queryService.timefilter.timefilter.getTime();
     const { fromDate, toDate } = formatTimePickerDate(timeRange, 'YYYY-MM-DD HH:mm:ss.SSS');
-    const whereClause = `\`${dataset.timeFieldName}\` >= '${formatDate(fromDate)}' AND \`${
-      dataset.timeFieldName
-    }\` <= '${formatDate(toDate)}'`;
+    // Wrap the time literals in `TIMESTAMP('...')` rather than emitting bare string literals.
+    // Modern OpenSearch SQL implicitly coerces a string to a timestamp for `field >= '<string>'`,
+    // but legacy Elasticsearch (Open Distro) SQL does not and rejects it with a [TIMESTAMP,STRING]
+    // type error. `TIMESTAMP('...')` is accepted by both engines, so this form is portable across
+    // all data sources.
+    const whereClause = `\`${dataset.timeFieldName}\` >= TIMESTAMP('${formatDate(
+      fromDate
+    )}') AND \`${dataset.timeFieldName}\` <= TIMESTAMP('${formatDate(toDate)}')`;
 
     return {
       ...nextQuery,


### PR DESCRIPTION
### Description

Fixes autocomplete column-value suggestions for legacy Elasticsearch (Open Distro) data sources. Previously the suggestion fetcher always issued a PPL `top N` query, which fails on Elasticsearch < 7.9 (PPL unavailable), so no value suggestions appeared. This routes the suggestion query by engine type and fixes two SQL portability issues that broke the query on the legacy Open Distro SQL engine.

- **Per-engine suggestion language** (`data_source_engine_capabilities.ts`, `antlr/shared/utils.ts`): added `columnValueSuggestionLanguage: 'PPL' | 'SQL' | 'none'` to the engine-capabilities descriptor. OpenSearch/default uses PPL (`source = <table> | top <n> <column>`); Elasticsearch uses SQL (`SELECT <col> FROM <table> GROUP BY <col> ... LIMIT <n>`); `'none'` disables suggestions. `updateFieldValuesAsync` resolves the engine from the dataset and builds the query accordingly.
- **Dataset engine resolution** (`data_views.ts`): `convertToDataset` now fetches the data-source saved object to populate the real `dataSourceEngineType`/`dataSourceVersion` on the dataset's `dataSource`, instead of the saved-object reference `type` (`'data-source'`) and empty version. Without this the engine-based routing above has no engine to key on. Falls back to the reference values on fetch failure.
- **Portable time filter** (`sql_search_interceptor.ts`): the time-range `WHERE` clause now wraps literals in `TIMESTAMP('...')`. Legacy Elasticsearch SQL does not implicitly coerce a string to a timestamp for `field >= '<string>'` and rejects it with a `[TIMESTAMP,STRING]` type error; `TIMESTAMP('...')` is accepted by both modern and legacy engines.

### Issues Resolved

<!-- Add the tracking issue if applicable, e.g. closes #NNNN -->

## Screenshot

https://github.com/user-attachments/assets/35db374b-c65f-4d19-8604-97772abf0170


## Testing the changes

Automated:
- `yarn test:jest src/plugins/data/common/data_views/data_views/data_views.test.ts`
- `yarn test:jest src/plugins/query_enhancements/public/search/sql_search_interceptor.test.ts`

Manual (requires a legacy Elasticsearch data source, e.g. ES 6.8):
1. Add an Elasticsearch 6.x data source and an index pattern over it.
2. In the query editor, start typing a field filter (e.g. `Carrier = `) and trigger autocomplete.
3. Verify column values populate — the request should issue a SQL query to `/_opendistro/_sql` rather than a PPL query.
4. Confirm OpenSearch data sources still return value suggestions via PPL (no regression).

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
