### PR TITLE
fix(explore): Hide disabled query panel actions and remove duplicate …

### DIFF
--- a/src/plugins/explore/public/application/pages/metrics/metrics_page_tabs.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/metrics_page_tabs.tsx
@@ -4,13 +4,12 @@
  */
 
 import './metrics_page_tabs.scss';
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import {
   EuiTabs,
   EuiTab,
   EuiHorizontalRule,
   EuiIcon,
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
@@ -23,10 +22,6 @@ import { DatasetSelectWidget } from '../../../components/query_panel/query_panel
 import { RootState } from '../../utils/state_management/store';
 import { setMetricsPageMode } from '../../utils/state_management/slices/ui/ui_slice';
 import { MetricsPageMode, MetricsPageModeContext } from './metrics_page_mode_context';
-import { CreateMetricsRuleFlyout } from './create_metrics_rule_flyout';
-import { splitMultiQueries } from '../../utils/multi_query_utils';
-import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { ExploreServices } from '../../../types';
 
 export { useMetricsPageMode } from './metrics_page_mode_context';
 
@@ -45,39 +40,7 @@ const PAGE_TABS: Array<{ id: MetricsPageMode; label: string; iconType: string }>
 
 export const MetricsPageTabs: React.FC = () => {
   const dispatch = useDispatch();
-  const { services } = useOpenSearchDashboards<ExploreServices>();
   const mode = useSelector((state: RootState) => state.ui.metricsPageMode) || 'explore';
-  const dataConnectionId = useSelector((state: RootState) => state.query.dataset?.id || '');
-  const [showAlertRuleFlyout, setShowAlertRuleFlyout] = useState(false);
-
-  const metricsExploreState = useSelector((state: RootState) => state.tab.metricsExplore);
-
-  // Read queries based on the active mode:
-  // - Explore tab: selected metric from exploration state
-  // - Query tab: QueryStringManager (synced on every keystroke)
-  const parsedQueries = useMemo(() => {
-    if (!showAlertRuleFlyout) return [];
-
-    // Explore tab: use the selected metric from the exploration state
-    if (mode === 'explore' && metricsExploreState?.metric) {
-      return [metricsExploreState.metric];
-    }
-
-    // Query tab: read from QueryStringManager
-    const raw = String(services.data.query.queryString.getQuery().query || '');
-    if (raw.trim()) {
-      if (raw.includes(';\n') || raw.endsWith(';')) {
-        return raw
-          .split(/;\s*\n/)
-          .map((q) => q.replace(/;\s*$/, '').trim())
-          .filter(Boolean);
-      }
-      return [raw.trim()];
-    }
-
-    return [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showAlertRuleFlyout, mode, metricsExploreState?.metric]);
 
   return (
     <MetricsPageModeContext.Provider value={mode}>
@@ -101,18 +64,6 @@ export const MetricsPageTabs: React.FC = () => {
               ))}
             </EuiTabs>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              size="s"
-              iconType="bell"
-              onClick={() => setShowAlertRuleFlyout(true)}
-              data-test-subj="metricsCreateAlertRuleBtn"
-            >
-              {i18n.translate('explore.metricsPage.createAlertRule', {
-                defaultMessage: 'Create alert rule',
-              })}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
         </EuiFlexGroup>
       </div>
       {mode === 'explore' ? (
@@ -125,17 +76,6 @@ export const MetricsPageTabs: React.FC = () => {
           <EuiHorizontalRule margin="none" />
           <BottomRightContainer />
         </>
-      )}
-      {showAlertRuleFlyout && (
-        <CreateMetricsRuleFlyout
-          queries={parsedQueries}
-          datasourceId={dataConnectionId}
-          onClose={() => setShowAlertRuleFlyout(false)}
-          http={services.http}
-          addToast={(title, color) =>
-            services.notifications.toasts[color === 'danger' ? 'addDanger' : 'addSuccess'](title)
-          }
-        />
       )}
     </MetricsPageModeContext.Provider>
   );

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/query_panel_actions.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/query_panel_actions.test.tsx
@@ -137,7 +137,7 @@ describe('QueryPanelActions', () => {
       });
     });
 
-    it('renders disabled inline buttons when getIsEnabled returns false', () => {
+    it('hides inline buttons when getIsEnabled returns false', () => {
       setupUseSelectorMock();
       mockRegistry.getSortedActions.mockReturnValue([
         buildAction('off', {
@@ -147,8 +147,7 @@ describe('QueryPanelActions', () => {
       ]);
 
       render(<QueryPanelActions registry={mockRegistry} />);
-      const btn = screen.getByTestId('queryPanelActionInline-off');
-      expect(btn).toBeDisabled();
+      expect(screen.queryByTestId('queryPanelActionInline-off')).not.toBeInTheDocument();
     });
 
     it('passes the live dependencies to getLabel / getIsEnabled / getIcon', () => {

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/query_panel_actions.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_actions/query_panel_actions.tsx
@@ -69,16 +69,20 @@ export const QueryPanelActions = ({ registry }: QueryPanelActionsProps) => {
     [dependencies, closePopover]
   );
 
-  // Split the sorted action list at the inline threshold. The slice is
-  // memoized so the underlying buttons keep stable identity across renders
-  // when the registry contents haven't changed.
-  const { inlineActions, overflowActions } = useMemo(() => {
-    const all = registry.getSortedActions();
-    return {
-      inlineActions: all.slice(0, INLINE_ACTION_LIMIT),
-      overflowActions: all.slice(INLINE_ACTION_LIMIT),
-    };
-  }, [registry]);
+  // Filter out disabled actions and split at the inline threshold.
+  // `getIsEnabled` acts as a visibility gate — disabled actions are hidden
+  // entirely (not greyed out) because the registry has no separate
+  // `isVisible` hook. This prevents duplicate labels (e.g. two
+  // "Create alert rule" buttons) when multiple plugins register
+  // context-specific actions for different page flavors.
+  // Not memoized: `dependencies` is a fresh object each render (the hook
+  // doesn't memoize its return value), and the computation is trivial
+  // (filter + slice over a handful of registered actions).
+  const enabledActions = registry
+    .getSortedActions()
+    .filter((action) => (action.getIsEnabled ? action.getIsEnabled(dependencies) : true));
+  const inlineActions = enabledActions.slice(0, INLINE_ACTION_LIMIT);
+  const overflowActions = enabledActions.slice(INLINE_ACTION_LIMIT);
 
   // Get open flyout configuration
   const openFlyoutConfig = useMemo(() => {
@@ -95,7 +99,6 @@ export const QueryPanelActions = ({ registry }: QueryPanelActionsProps) => {
   return (
     <div className="exploreQueryPanelActions__group" data-test-subj="queryPanelActionsGroup">
       {inlineActions.map((action) => {
-        const isEnabled = action.getIsEnabled ? action.getIsEnabled(dependencies) : true;
         const label = action.getLabel(dependencies);
         const icon = action.getIcon?.(dependencies);
 
@@ -104,7 +107,6 @@ export const QueryPanelActions = ({ registry }: QueryPanelActionsProps) => {
             key={action.id}
             size="xs"
             onClick={() => handleActionClick(action)}
-            disabled={!isEnabled}
             iconType={icon}
             data-test-subj={`queryPanelActionInline-${action.id}`}
           >
@@ -147,7 +149,6 @@ export const QueryPanelActions = ({ registry }: QueryPanelActionsProps) => {
         >
           <div className="exploreQueryPanelActions__overflowList">
             {overflowActions.map((action) => {
-              const isEnabled = action.getIsEnabled ? action.getIsEnabled(dependencies) : true;
               const label = action.getLabel(dependencies);
               const icon = action.getIcon?.(dependencies);
 
@@ -156,7 +157,6 @@ export const QueryPanelActions = ({ registry }: QueryPanelActionsProps) => {
                   key={action.id}
                   className="exploreQueryPanelActions__item"
                   onClick={() => handleActionClick(action)}
-                  disabled={!isEnabled}
                   iconType={icon}
                   data-test-subj={`queryPanelActionOverflow-${action.id}`}
                 >


### PR DESCRIPTION
…metrics button

The QueryPanelActions component previously rendered all registered actions and used the disabled prop to grey out entries whose getIsEnabled returned false. Since the registry has no isVisible hook, this caused duplicate labels when multiple plugins register context-specific actions for different page flavors (e.g. two "Create alert rule" buttons — one for Logs/PPL and one for Metrics/PromQL — where one is greyed out on each page).

Changes:
- Filter out disabled actions entirely before rendering in QueryPanelActions, treating getIsEnabled as a visibility gate.
- Remove the hardcoded "Create alert rule" button from the Metrics page tab bar (MetricsPageTabs). The observability plugin now owns this action via the queryPanelActionsRegistry, so the built-in button was causing a duplicate on the Metrics page.

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
Before the changes
<img width="3456" height="2234" alt="Image 7-6-26 at 5 51 PM" src="https://github.com/user-attachments/assets/647ff1fc-1ccd-4268-9859-47c494d95ce1" />

<img width="3456" height="2234" alt="Image 7-6-26 at 5 31 PM" src="https://github.com/user-attachments/assets/4adaf363-440e-42d0-aabe-9c3335d95d72" />

After the changes



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
