### PR TITLE
fix(workspace): normalize configUsers/configGroups to array before matching

### DIFF
--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -95,6 +95,46 @@ describe('workspace utils', () => {
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });
 
+  it('should handle configUsers as a string instead of array', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['user1'];
+    const configGroups: string[] = [];
+    const configUsers = ('user1' as unknown) as string[];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should handle configGroups as a string instead of array', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = ['admin_group'];
+    const users: string[] = [];
+    const configGroups = ('admin_group' as unknown) as string[];
+    const configUsers: string[] = [];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should handle configUsers as wildcard string instead of array', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['user1'];
+    const configGroups: string[] = [];
+    const configUsers = (OSD_ADMIN_WILDCARD_MATCH_ALL as unknown) as string[];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should not grant admin when configUsers string is a substring match', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['a'];
+    const configGroups: string[] = [];
+    const configUsers = ('admin' as unknown) as string[];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
+  });
+
   it('should transfer current user placeholder in permissions', () => {
     expect(transferCurrentUserInPermissions('foo', undefined)).toBeUndefined();
     expect(

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -135,6 +135,20 @@ describe('workspace utils', () => {
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
   });
 
+  it('should not crash when configUsers or configGroups is null or undefined', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['user1'];
+    updateDashboardAdminStateForRequest(
+      mockRequest,
+      groups,
+      users,
+      (null as unknown) as string[],
+      (undefined as unknown) as string[]
+    );
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
+  });
+
   it('should transfer current user placeholder in permissions', () => {
     expect(transferCurrentUserInPermissions('foo', undefined)).toBeUndefined();
     expect(

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -37,8 +37,16 @@ export const updateDashboardAdminStateForRequest = (
   configGroups: string | string[],
   configUsers: string | string[]
 ) => {
-  const normalizedConfigUsers = Array.isArray(configUsers) ? configUsers : [configUsers];
-  const normalizedConfigGroups = Array.isArray(configGroups) ? configGroups : [configGroups];
+  const normalizedConfigUsers = Array.isArray(configUsers)
+    ? configUsers
+    : configUsers
+    ? [configUsers]
+    : [];
+  const normalizedConfigGroups = Array.isArray(configGroups)
+    ? configGroups
+    : configGroups
+    ? [configGroups]
+    : [];
   // If the security plugin is not installed, login defaults to OSD Admin
   if (!groups.length && !users.length) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -34,19 +34,21 @@ export const updateDashboardAdminStateForRequest = (
   request: OpenSearchDashboardsRequest,
   groups: string[],
   users: string[],
-  configGroups: string[],
-  configUsers: string[]
+  configGroups: string | string[],
+  configUsers: string | string[]
 ) => {
+  const normalizedConfigUsers = Array.isArray(configUsers) ? configUsers : [configUsers];
+  const normalizedConfigGroups = Array.isArray(configGroups) ? configGroups : [configGroups];
   // If the security plugin is not installed, login defaults to OSD Admin
   if (!groups.length && !users.length) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
   // If user config contains wildcard characters '*', login defaults to OSD Admin
-  if (configUsers.includes(OSD_ADMIN_WILDCARD_MATCH_ALL)) {
+  if (normalizedConfigUsers.includes(OSD_ADMIN_WILDCARD_MATCH_ALL)) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });
   }
-  const groupMatchAny = groups.some((group) => configGroups.includes(group));
-  const userMatchAny = users.some((user) => configUsers.includes(user));
+  const groupMatchAny = groups.some((group) => normalizedConfigGroups.includes(group));
+  const userMatchAny = users.some((user) => normalizedConfigUsers.includes(user));
   return updateWorkspaceState(request, {
     isDashboardAdmin: groupMatchAny || userMatchAny,
   });


### PR DESCRIPTION
### Description

When `dashboardAdmin.users` or `dashboardAdmin.groups` config values come as a single string (e.g., `users: "*"`) instead of an array from the dynamic config service, `String.prototype.includes()` performs substring matching. This could incorrectly grant dashboard admin access — for example, a user named `"a"` would match config string `"admin"` because `"admin".includes("a")` is `true`.

This fix normalizes `configUsers` and `configGroups` to arrays before performing `.includes()` checks, ensuring correct element-level matching regardless of input type.

### Issues Resolved

<!-- fixes #XXXX -->

## Screenshot

N/A — server-side logic change only.

## Testing the changes

1. Unit tests added covering:
   - `configUsers` passed as a single string matching a user
   - `configGroups` passed as a single string matching a group
   - Wildcard `"*"` passed as a string instead of `["*"]`
   - Substring safety: user `"a"` does NOT match config string `"admin"`
2. Run `yarn test:jest src/plugins/workspace/server/utils.test.ts`

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff