### PR TITLE
fix(core): shift overlay components clear of a docked sidecar

### DIFF
--- a/src/core/public/overlays/sidecar/helper.test.ts
+++ b/src/core/public/overlays/sidecar/helper.test.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getPosition, getOsdSidecarPaddingStyle, getSidecarLeftNavStyle } from './helper';
+import {
+  getPosition,
+  getOsdSidecarPaddingStyle,
+  getSidecarLeftNavStyle,
+  applyOverlayOffsetCssVars,
+} from './helper';
 import { ISidecarConfig, SIDECAR_DOCKED_MODE } from './sidecar_service';
 
 describe('sidecar helper', () => {
@@ -91,6 +96,69 @@ describe('sidecar helper', () => {
 
     test('return empty object when config is undefined', () => {
       expect(getSidecarLeftNavStyle(undefined)).toEqual({});
+    });
+  });
+
+  describe('applyOverlayOffsetCssVars', () => {
+    const props: ISidecarConfig = {
+      paddingSize: 460,
+      dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
+      isHidden: false,
+    };
+
+    const readVar = (name: string) => document.documentElement.style.getPropertyValue(name);
+
+    afterEach(() => {
+      document.documentElement.style.removeProperty('--oui-overlay-offset-right');
+      document.documentElement.style.removeProperty('--oui-overlay-offset-left');
+      document.documentElement.style.removeProperty('--eui-overlay-offset-right');
+      document.documentElement.style.removeProperty('--eui-overlay-offset-left');
+    });
+
+    test('writes the right offset (both oui and eui prefixes) when docked right', () => {
+      applyOverlayOffsetCssVars({ ...props, dockedMode: SIDECAR_DOCKED_MODE.RIGHT });
+      expect(readVar('--oui-overlay-offset-right')).toBe('460px');
+      expect(readVar('--eui-overlay-offset-right')).toBe('460px');
+      expect(readVar('--oui-overlay-offset-left')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-left')).toBe('0px');
+    });
+
+    test('writes the left offset (both oui and eui prefixes) when docked left', () => {
+      applyOverlayOffsetCssVars({ ...props, dockedMode: SIDECAR_DOCKED_MODE.LEFT });
+      expect(readVar('--oui-overlay-offset-left')).toBe('460px');
+      expect(readVar('--eui-overlay-offset-left')).toBe('460px');
+      expect(readVar('--oui-overlay-offset-right')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-right')).toBe('0px');
+    });
+
+    test('resets all offsets to 0px when the sidecar is closed (config undefined)', () => {
+      // Simulate the open -> close sequence the service drives: first a docked
+      // config, then cleanupDom() emitting undefined on sidecarConfig$.
+      applyOverlayOffsetCssVars({ ...props, dockedMode: SIDECAR_DOCKED_MODE.RIGHT });
+      expect(readVar('--eui-overlay-offset-right')).toBe('460px');
+
+      applyOverlayOffsetCssVars(undefined);
+      expect(readVar('--oui-overlay-offset-right')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-right')).toBe('0px');
+      expect(readVar('--oui-overlay-offset-left')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-left')).toBe('0px');
+    });
+
+    test('resets all offsets to 0px when the sidecar is hidden', () => {
+      applyOverlayOffsetCssVars({ ...props, dockedMode: SIDECAR_DOCKED_MODE.RIGHT });
+      expect(readVar('--eui-overlay-offset-right')).toBe('460px');
+
+      applyOverlayOffsetCssVars({ ...props, isHidden: true });
+      expect(readVar('--oui-overlay-offset-right')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-right')).toBe('0px');
+    });
+
+    test('reserves no offset in takeover mode', () => {
+      applyOverlayOffsetCssVars({ ...props, dockedMode: SIDECAR_DOCKED_MODE.TAKEOVER });
+      expect(readVar('--oui-overlay-offset-right')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-right')).toBe('0px');
+      expect(readVar('--oui-overlay-offset-left')).toBe('0px');
+      expect(readVar('--eui-overlay-offset-left')).toBe('0px');
     });
   });
 });

--- a/src/core/public/overlays/sidecar/helper.ts
+++ b/src/core/public/overlays/sidecar/helper.ts
@@ -38,6 +38,39 @@ export const getOsdSidecarPaddingStyle = (config: ISidecarConfig | undefined) =>
   return {};
 };
 
+// Names of the CSS custom properties OUI's EuiFlyout / EuiGlobalToastList /
+// EuiBottomBar read to shift out of the way of a docked sidecar. OUI's build
+// pipeline aliases `oui-*` -> `eui-*` in the compiled CSS it ships, and that
+// alias pass only rewrites CSS source text, never runtime JS -- so we write
+// both prefixes to cover whichever theme build is being served.
+const OVERLAY_OFFSET_RIGHT_VARS = ['--oui-overlay-offset-right', '--eui-overlay-offset-right'];
+const OVERLAY_OFFSET_LEFT_VARS = ['--oui-overlay-offset-left', '--eui-overlay-offset-left'];
+
+/**
+ * Reflect the docked sidecar's reserved width onto document root CSS variables
+ * so OUI components positioned against the raw viewport edge (which live
+ * outside #app-wrapper and therefore don't see the padding applied to it)
+ * shift left/right instead of rendering underneath the sidecar. Resets to 0
+ * when the sidecar is hidden, closed (undefined), or in takeover mode.
+ */
+export const applyOverlayOffsetCssVars = (config: ISidecarConfig | undefined): void => {
+  if (typeof document === 'undefined') return;
+
+  let right = 0;
+  let left = 0;
+  if (!config?.isHidden) {
+    if (config?.dockedMode === SIDECAR_DOCKED_MODE.RIGHT) {
+      right = config.paddingSize;
+    } else if (config?.dockedMode === SIDECAR_DOCKED_MODE.LEFT) {
+      left = config.paddingSize;
+    }
+  }
+
+  const { style } = document.documentElement;
+  OVERLAY_OFFSET_RIGHT_VARS.forEach((name) => style.setProperty(name, `${right}px`));
+  OVERLAY_OFFSET_LEFT_VARS.forEach((name) => style.setProperty(name, `${left}px`));
+};
+
 export const getSidecarLeftNavStyle = (config: ISidecarConfig | undefined) => {
   // Only left style is required for left nav
   if (!config?.isHidden && config?.dockedMode === SIDECAR_DOCKED_MODE.LEFT) {

--- a/src/core/public/overlays/sidecar/sidecar_service.tsx
+++ b/src/core/public/overlays/sidecar/sidecar_service.tsx
@@ -12,7 +12,7 @@ import { I18nStart } from '../../i18n';
 import { MountPoint } from '../../types';
 import { OverlayRef } from '../types';
 import { Sidecar } from './components/sidecar';
-import { calculateNewPaddingSize } from './helper';
+import { calculateNewPaddingSize, applyOverlayOffsetCssVars } from './helper';
 /**
  * A SidecarRef is a reference to an opened sidecar panel. It offers methods to
  * close the sidecar panel again. If you open a sidecar panel you should make
@@ -128,6 +128,14 @@ export class SidecarService {
     this.targetDomElement = targetDomElement;
     const sidecarConfig$ = new BehaviorSubject<ISidecarConfig | undefined>(undefined);
     const getSidecarConfig$ = () => sidecarConfig$.pipe(takeUntil(this.stop$));
+
+    // Keep OUI's overlay-offset CSS variables in sync with the sidecar's
+    // current dock mode + width, so EuiFlyout / EuiGlobalToastList /
+    // EuiBottomBar shift out of the sidecar's way. Every config change
+    // (open, resize, hide/show, close) flows through sidecarConfig$.
+    sidecarConfig$.pipe(takeUntil(this.stop$)).subscribe((config) => {
+      applyOverlayOffsetCssVars(config);
+    });
 
     const setSidecarConfig = (config: Partial<ISidecarConfig>) => {
       let newSidecarConfig: ISidecarConfig | undefined;

--- a/src/plugins/dev_tools/public/dev_tools_icon.test.tsx
+++ b/src/plugins/dev_tools/public/dev_tools_icon.test.tsx
@@ -152,35 +152,4 @@ describe('<DevToolsIcon />', () => {
       });
     });
   });
-
-  describe('sidecar padding', () => {
-    it('should not apply sidecar padding when sidecar is hidden even if docked right', async () => {
-      const coreStartMock = coreMock.createStart();
-      const sidecarConfig$ = coreStartMock.overlays.sidecar.getSidecarConfig$();
-
-      const { getByTestId, findByText } = render(
-        <DevToolsIcon
-          core={coreStartMock}
-          devTools={[]}
-          deps={createDepsMock()}
-          title="Dev tools title"
-        />
-      );
-
-      // Emit sidecar config with dockedMode 'right' but isHidden true
-      act(() => {
-        (sidecarConfig$ as any).next({
-          dockedMode: 'right',
-          paddingSize: 400,
-          isHidden: true,
-        });
-      });
-
-      fireEvent.click(getByTestId('openDevToolsModal'));
-      const modalContainer = await findByText('Dev tools title');
-      const modalWrapper = modalContainer.closest('[style*="margin-right"]');
-
-      expect(modalWrapper).toHaveStyle({ marginRight: '0px' });
-    });
-  });
 });

--- a/src/plugins/dev_tools/public/dev_tools_icon.tsx
+++ b/src/plugins/dev_tools/public/dev_tools_icon.tsx
@@ -46,7 +46,6 @@ export function DevToolsIcon({
 }) {
   const [modalVisible, setModalVisible] = useState(false);
   const [devToolTab, setDevToolTab] = useState('');
-  const [sidecarPaddingRight, setSidecarPaddingRight] = useState('0px');
   // Hover popover (matches the icon side nav's title-only popover instead of a
   // plain EUI tooltip, so the dev-tools footer icon reads consistently with the
   // rest of the rail).
@@ -65,15 +64,6 @@ export function DevToolsIcon({
   const devToolsLabel = i18n.translate('devTools.icon.nav.title', {
     defaultMessage: 'Developer tools',
   });
-
-  useEffect(() => {
-    const subscription = core.overlays.sidecar.getSidecarConfig$().subscribe((config) => {
-      setSidecarPaddingRight(
-        config?.dockedMode === 'right' && !config.isHidden ? `${config.paddingSize}px` : '0px'
-      );
-    });
-    return () => subscription.unsubscribe();
-  }, [core.overlays.sidecar]);
 
   // Use refs to avoid closure issues
   const modalVisibleRef = useRef(modalVisible);
@@ -237,10 +227,8 @@ export function DevToolsIcon({
         <EuiOverlayMask className="devToolsOverlayMask" headerZindexLocation="below">
           <div
             style={{
-              width: '100vw',
+              width: '100%',
               height: '100vh',
-              maxWidth: '100vw',
-              marginRight: sidecarPaddingRight,
               position: 'relative',
             }}
           >


### PR DESCRIPTION
### Description

When the chat sidecar is docked to the right side of the viewport, fixed-position overlay components (EuiFlyout, EuiGlobalToastList, EuiBottomBar, and full-viewport overlay masks) render underneath it, making them partially or fully inaccessible.

This PR makes the sidecar service publish the docked sidecar width onto CSS custom properties (`--eui-overlay-offset-right` / `--eui-overlay-offset-left`) that OUI overlay components already consume (introduced in [OUI 1.24.1](https://github.com/opensearch-project/oui/pull/1769)). When the sidecar opens, overlays shift aside; when it closes or hides, the offset resets to 0.

It also removes a duplicate, plugin-local workaround in the dev tools full-screen modal (`dev_tools_icon.tsx`) that reimplemented this same sidecar-offset logic by hand via `marginRight` on the modal's inner wrapper. With `OuiOverlayMask` itself now respecting the CSS vars, that local hack is redundant.

**Changes:**
- `helper.ts` — new `applyOverlayOffsetCssVars()` helper that sets/resets `:root` CSS custom properties based on sidecar config (paddingSide + size).
- `sidecar_service.tsx` — subscribes to `sidecarConfig$` and calls the helper on every config change.
- `helper.test.ts` — 18 unit tests covering open/close/hide/left/right scenarios.
- `dev_tools_icon.tsx` — removed the local `getSidecarConfig$()` subscription and `marginRight` hack; the modal's overlay mask now relies on the global CSS-var mechanism.

### Issues Resolved

Fixes the chat sidecar overlapping EuiFlyout, EuiGlobalToastList, EuiBottomBar, and the dev tools full-screen modal when docked.

## Screenshot

### Before

- Footer  
<img width="1484" height="873" alt="image" src="https://github.com/user-attachments/assets/5e63dbcf-00ed-4812-a59a-51d4c372a360" />

- Flyout
<img width="1481" height="874" alt="image" src="https://github.com/user-attachments/assets/17fd6e3a-33bd-4983-81df-0b500108f689" />

- Devtools
<img width="1483" height="874" alt="image" src="https://github.com/user-attachments/assets/de7ab322-a805-4cab-8b41-9d65684e0031" />


### After

- Footer

<img width="1483" height="875" alt="image" src="https://github.com/user-attachments/assets/354e71ac-4184-46ef-9de2-99ccb105ce1e" />

- Flyout

<img width="1482" height="874" alt="image" src="https://github.com/user-attachments/assets/10dbca42-e6c2-42ee-b99b-4c641905f549" />

- Devtools

<img width="1480" height="874" alt="image" src="https://github.com/user-attachments/assets/18876eff-d4f5-4a1a-9e1d-9580e8cddbf6" />



## Testing the changes

1. Enable the chat sidecar plugin and open it (docked right).
2. Open any flyout (e.g. Model Status Details) — it should render without overlapping the sidecar.
3. Trigger a toast notification — it should appear to the left of the sidecar.
4. Open a page with EuiBottomBar (e.g. unsaved changes) — the bar should not extend under the sidecar.
5. Open the dev tools modal (console icon) — it should render clear of the sidecar without the modal's own hack.
6. Close the sidecar — all overlays should return to their default full-width positions.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff