### PR TITLE
fix(chat): clear stale tool call states when starting new conversation

### DIFF
--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -769,6 +769,27 @@ describe('ChatWindow', () => {
       expect(mockChatService.newThread).toHaveBeenCalled();
     });
 
+    it('should clear event handler state on new chat to prevent stale tool calls from disabling input', () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      const mockClearState = jest.fn();
+      ChatEventHandler.mockImplementation(() => ({
+        handleEvent: jest.fn(),
+        clearState: mockClearState,
+        cancelToolResultDispatch: jest.fn(),
+      }));
+
+      const ref = React.createRef<ChatWindowInstance>();
+      renderWithContext(<ChatWindow ref={ref} onClose={jest.fn()} />);
+
+      act(() => {
+        ref.current?.startNewChat();
+      });
+
+      // clearState must be called to drain stale toolCallStates
+      expect(mockClearState).toHaveBeenCalled();
+    });
+
     it('should clear pending data source selection on new chat', async () => {
       // Mock no data source to trigger the prompt
       mockChatService.getCurrentDataSourceId.mockResolvedValue(undefined);

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -532,6 +532,11 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       // Stop any ongoing streaming before starting a new chat
       stopStreaming();
 
+      // Clear all event handler state (pending tool calls, assistant messages,
+      // and toolCallStates) so stale pending/executing entries from the previous
+      // run do not keep the input disabled in the new conversation.
+      eventHandler.clearState();
+
       chatService.newThread();
       setTimeline([]);
       setCurrentRunId(null);
@@ -540,7 +545,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       setAvailableDataSources([]);
       confirmationService.cleanAll();
       setShowHistory(false);
-    }, [chatService, confirmationService, stopStreaming]);
+    }, [chatService, confirmationService, eventHandler, stopStreaming]);
 
     const handleStop = useCallback(() => {
       stopStreaming();


### PR DESCRIPTION
### Description

When starting a new conversation while tool calls are in pending/executing state (e.g., clicking "New Chat" during an `/investigate` command), the chat input remains disabled because stale `toolCallStates` from the previous run persist in the global `AssistantActionService` singleton.

This PR adds `eventHandler.clearState()` to `handleNewChat`, which drains all pending tool calls, clears active assistant messages, and resets the `toolCallStates` map in `AssistantActionService`. This is consistent with the existing behavior in `handleSelectConversation` (loading a saved conversation), which already calls `eventHandler.clearState()` before replaying events.

### Issues Resolved

Fixes chat input remaining disabled after starting a new conversation when the previous conversation had active tool calls.

## Screenshot

N/A (behavioral fix, no UI change)

## Testing the changes

1. Open the chat assistant
2. Send a message that triggers a tool call (e.g., `/investigate test`)
3. While the tool is executing (input shows "Waiting for tool execution..."), click the "New Chat" button
4. **Before fix**: Input stays disabled with "Waiting for tool execution..." placeholder
5. **After fix**: Input is enabled and ready for new messages

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (61/61 pass for chat_window)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff