### PR TITLE
fix: plugin lint adoption for ESLint 10 (concurrency warning + shared plugin registration)

### DIFF
--- a/packages/opensearch-eslint-config-opensearch-dashboards/README.md
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/README.md
@@ -2,18 +2,107 @@
 
 The ESLint flat config used by the OpenSearch Dashboards team.
 
+Requires ESLint 10+ (flat config format).
+
 ## Usage
 
-Install the peer dependencies listed in `package.json`, then spread this config
-into your `eslint.config.js`:
+Spread this config into your plugin's `eslint.config.js`, then append your own
+overrides. You do **not** need to `require` or register any ESLint plugin: this
+package registers every plugin it bundles (see `plugins.js`), so your override
+blocks can reference any plugin rule — `@typescript-eslint/*`, `jest/*`,
+`react-hooks/*`, `@osd/eslint/*`, ... — at any `files` scope.
 
 ```js
 const osdConfig = require('@elastic/eslint-config-kibana');
 
 module.exports = [
   ...osdConfig,
-  // your project-specific overrides
+  {
+    files: ['**/*.{js,mjs,ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'no-console': 0,
+    },
+  },
 ];
 ```
 
-Requires ESLint 10+ (flat config format).
+### Ignores
+
+ESLint 10 no longer reads `.eslintignore`. Put ignore patterns in a config
+object with an `ignores` key:
+
+```js
+module.exports = [
+  { ignores: ['build', 'target', '**/*.d.ts'] },
+  ...osdConfig,
+  // ...
+];
+```
+
+### EUI rules (opt-in)
+
+EUI linting is not part of the base config (OSD core does not lint against EUI
+rules). Spread the ready-made EUI block, available from the `extras` module, if
+your plugin wants it:
+
+```js
+const osdConfig = require('@elastic/eslint-config-kibana');
+const { eui } = require('@elastic/eslint-config-kibana/extras');
+
+module.exports = [...osdConfig, ...eui /*, your overrides */];
+```
+
+### License header
+
+Enforce a license header via the `@osd/eslint/require-license-header` rule in
+your own override block:
+
+```js
+const LICENSE_HEADER = `/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */`;
+
+module.exports = [
+  ...osdConfig,
+  {
+    files: ['**/*.{js,mjs,ts,tsx}'],
+    rules: { '@osd/eslint/require-license-header': ['error', { licenses: [LICENSE_HEADER] }] },
+  },
+];
+```
+
+## Overriding a rule at a different file scope
+
+The base config registers some plugins only for certain files (for example
+`@typescript-eslint` for `**/*.{ts,tsx}`), but because all plugins are also
+registered globally, you can reference their rules anywhere without doing
+anything special.
+
+If you want to register a plugin again in your own block (e.g. to apply a rule
+to a broader `files` glob), get the instance from the `extras` module's
+`plugins` rather than `require`-ing it yourself — flat config throws
+`Cannot redefine plugin` if two *different* instances share a name, and reusing
+this package's instance avoids that:
+
+```js
+const osdConfig = require('@elastic/eslint-config-kibana');
+const { plugins } = require('@elastic/eslint-config-kibana/extras');
+
+module.exports = [
+  ...osdConfig,
+  {
+    files: ['**/*.{js,ts,tsx}'],
+    plugins: { '@typescript-eslint': plugins.tsPlugin },
+    rules: { '@typescript-eslint/no-explicit-any': 'off' },
+  },
+];
+```
+
+## Exports
+
+| Subpath                                 | Contents                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `@elastic/eslint-config-kibana`         | The flat config array (spread this).                                                  |
+| `@elastic/eslint-config-kibana/extras`  | `{ eui, plugins, restrictedGlobals }` — the opt-in EUI block, bundled plugin instances (with `globalPluginRegistration`), and the restricted-globals list. |

--- a/packages/opensearch-eslint-config-opensearch-dashboards/eslint.config.js
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/eslint.config.js
@@ -17,18 +17,27 @@ const PKG = require('../../package.json');
 
 const babelParser = require('@babel/eslint-parser');
 const tsParser = require('@typescript-eslint/parser');
-const tsPlugin = require('@typescript-eslint/eslint-plugin');
-const eslintCommentsPlugin = require('@eslint-community/eslint-plugin-eslint-comments');
-const importPlugin = require('eslint-plugin-import-x');
-const jestPlugin = require('eslint-plugin-jest');
-const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
-const _mochaRaw = require('eslint-plugin-mocha');
-const mochaPlugin = _mochaRaw.default || _mochaRaw;
-const noUnsanitizedPlugin = require('eslint-plugin-no-unsanitized');
-const reactPlugin = require('eslint-plugin-react');
-const reactHooksPlugin = require('eslint-plugin-react-hooks');
-const prettierPlugin = require('eslint-plugin-prettier');
-const osdEslintPlugin = require('@osd/eslint-plugin-eslint');
+
+// Plugin instances live in a single module (plugins.js) so they are registered
+// in exactly one place. `globalPluginRegistration` is an unscoped config object
+// that registers every plugin up front: because it is the first entry in the
+// exported array below, any config object that a consumer appends can reference
+// any plugin's rules (`@typescript-eslint/*`, `jest/*`, `react-hooks/*`,
+// `@osd/eslint/*`, ...) regardless of its `files` scope, without re-registering.
+const {
+  globalPluginRegistration,
+  tsPlugin,
+  eslintCommentsPlugin,
+  importPlugin,
+  jestPlugin,
+  jsxA11yPlugin,
+  mochaPlugin,
+  noUnsanitizedPlugin,
+  reactPlugin,
+  reactHooksPlugin,
+  prettierPlugin,
+  osdEslintPlugin,
+} = require('./plugins');
 
 const RESTRICTED_GLOBALS = require('./restricted_globals');
 const RESTRICTED_MODULES = { paths: ['gulp-util'] };
@@ -43,6 +52,11 @@ const reactVersion = semver.valid(semver.coerce(PKG.dependencies.react));
 const allowedNameRegexp = '^(UNSAFE_|_{1,3})|_{1,3}$';
 
 module.exports = defineConfig([
+  // ── Global plugin registration (must stay first) ──────────────────────────
+  // Registers every plugin in one unscoped object so downstream rule references
+  // resolve at any file scope. See plugins.js.
+  globalPluginRegistration,
+
   // ── JavaScript files ────────────────────────────────────────────────────
   {
     files: ['**/*.js'],

--- a/packages/opensearch-eslint-config-opensearch-dashboards/eui.js
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/eui.js
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/* eslint-disable import/no-unresolved */
+
+// A ready-made flat-config block that registers `@elastic/eui` and applies its
+// recommended rules. Plugins that want EUI linting spread this instead of
+// requiring the plugin themselves (exposed to consumers as `eui` on the
+// `@elastic/eslint-config-kibana/extras` module):
+//
+//   const osdConfig = require('@elastic/eslint-config-kibana');
+//   const { eui } = require('@elastic/eslint-config-kibana/extras');
+//   module.exports = [...osdConfig, ...eui, { rules: { ... } }];
+//
+// EUI is intentionally not part of the base config (OSD core does not lint
+// against EUI rules), so it is exposed as a separate opt-in block.
+
+const euiPlugin = require('@elastic/eslint-plugin-eui');
+
+module.exports = [
+  {
+    plugins: { '@elastic/eui': euiPlugin },
+    rules: euiPlugin.configs.recommended.rules,
+  },
+];

--- a/packages/opensearch-eslint-config-opensearch-dashboards/extras.js
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/extras.js
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Aggregates the optional pieces that sit alongside the base flat config so
+// consumers reach them through a single import instead of several subpaths:
+//
+//   const osdConfig = require('@elastic/eslint-config-kibana');
+//   const { eui, plugins } = require('@elastic/eslint-config-kibana/extras');
+//
+//   module.exports = [...osdConfig, ...eui, { rules: { ... } }];
+//
+// - `eui`             opt-in EUI config block (an array to spread).
+// - `plugins`         bundled plugin instances + `globalPluginRegistration`.
+// - `restrictedGlobals` the restricted-globals list used by the base config.
+
+const eui = require('./eui');
+const plugins = require('./plugins');
+const restrictedGlobals = require('./restricted_globals');
+
+module.exports = {
+  eui,
+  plugins,
+  restrictedGlobals,
+};

--- a/packages/opensearch-eslint-config-opensearch-dashboards/package.json
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "The eslint config used by the opensearch dashboards team",
   "main": "eslint.config.js",
+  "exports": {
+    ".": "./eslint.config.js",
+    "./eslint.config.js": "./eslint.config.js",
+    "./extras": "./extras.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/opensearch-project/OpenSearch-Dashboards.git"
@@ -18,6 +23,10 @@
   },
   "homepage": "https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/packages/opensearch-eslint-config-opensearch-dashboards",
   "peerDependencies": {
+    "@elastic/eslint-plugin-eui": "^2.14.0",
+    "@osd/eslint-plugin-eslint": "1.0.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.6",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "@babel/eslint-parser": "^8.0.1",

--- a/packages/opensearch-eslint-config-opensearch-dashboards/plugins.js
+++ b/packages/opensearch-eslint-config-opensearch-dashboards/plugins.js
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/* eslint-disable import/no-unresolved */
+
+// Single source of truth for the ESLint plugin instances used across the
+// OpenSearch Dashboards flat config. Both the shared config (`eslint.config.js`)
+// and the plugin helper (`create_config.js`) consume these so that plugin
+// registration lives in exactly one place.
+//
+// In ESLint flat config, `plugins` registration is scoped per matched file, not
+// inherited between config objects. Downstream plugins that only want to tweak a
+// few rules should not have to know which plugin owns a rule or re-register it.
+// `globalPluginRegistration` below registers every plugin in a single unscoped
+// config object, making every rule referenceable from any later config object
+// regardless of its `files` scope.
+
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const eslintCommentsPlugin = require('@eslint-community/eslint-plugin-eslint-comments');
+const importPlugin = require('eslint-plugin-import-x');
+const jestPlugin = require('eslint-plugin-jest');
+const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
+const _mochaRaw = require('eslint-plugin-mocha');
+const mochaPlugin = _mochaRaw.default || _mochaRaw;
+const noUnsanitizedPlugin = require('eslint-plugin-no-unsanitized');
+const reactPlugin = require('eslint-plugin-react');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
+const prettierPlugin = require('eslint-plugin-prettier');
+const osdEslintPlugin = require('@osd/eslint-plugin-eslint');
+
+const plugins = {
+  '@typescript-eslint': tsPlugin,
+  '@eslint-community/eslint-comments': eslintCommentsPlugin,
+  import: importPlugin,
+  jest: jestPlugin,
+  'jsx-a11y': jsxA11yPlugin,
+  mocha: mochaPlugin,
+  'no-unsanitized': noUnsanitizedPlugin,
+  react: reactPlugin,
+  'react-hooks': reactHooksPlugin,
+  prettier: prettierPlugin,
+  '@osd/eslint': osdEslintPlugin,
+};
+
+// An unscoped flat-config object that registers every plugin globally. Spread
+// this before any config object that references a plugin's rules so the rules
+// resolve no matter which `files` glob the referencing object uses.
+const globalPluginRegistration = { plugins };
+
+module.exports = {
+  plugins,
+  globalPluginRegistration,
+  tsPlugin,
+  eslintCommentsPlugin,
+  importPlugin,
+  jestPlugin,
+  jsxA11yPlugin,
+  mochaPlugin,
+  noUnsanitizedPlugin,
+  reactPlugin,
+  reactHooksPlugin,
+  prettierPlugin,
+  osdEslintPlugin,
+};

--- a/packages/osd-plugin-generator/template/eslint.config.js.ejs
+++ b/packages/osd-plugin-generator/template/eslint.config.js.ejs
@@ -1,19 +1,15 @@
-const { defineConfig } = require("eslint/config");
+const osdConfig = require("@elastic/eslint-config-kibana");
+const { eui } = require("@elastic/eslint-config-kibana/extras");
 
-const kibanaConfig = require("@elastic/eslint-config-kibana/eslint.config.js");
-const euiPlugin = require("@elastic/eslint-plugin-eui");
-
-module.exports = defineConfig([
-    ...kibanaConfig,
-    {
-        plugins: {
-            "@elastic/eui": euiPlugin,
-        },
-        rules: euiPlugin.configs.recommended.rules,
-    },
+// Spread the shared OpenSearch Dashboards flat config, then append overrides.
+// No need to require or register ESLint plugins — the shared config does that.
+// See packages/opensearch-eslint-config-opensearch-dashboards/README.md.
+module.exports = [
+    ...osdConfig,
+    ...eui,
     {
         rules: {
             "@osd/eslint/require-license-header": "off",
         },
     },
-]);
+];

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -100,7 +100,7 @@ describe('workspace utils', () => {
     const groups: string[] = [];
     const users: string[] = ['user1'];
     const configGroups: string[] = [];
-    const configUsers = ('user1' as unknown) as string[];
+    const configUsers = 'user1' as unknown as string[];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });
@@ -109,7 +109,7 @@ describe('workspace utils', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
     const groups: string[] = ['admin_group'];
     const users: string[] = [];
-    const configGroups = ('admin_group' as unknown) as string[];
+    const configGroups = 'admin_group' as unknown as string[];
     const configUsers: string[] = [];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
@@ -120,7 +120,7 @@ describe('workspace utils', () => {
     const groups: string[] = [];
     const users: string[] = ['user1'];
     const configGroups: string[] = [];
-    const configUsers = (OSD_ADMIN_WILDCARD_MATCH_ALL as unknown) as string[];
+    const configUsers = OSD_ADMIN_WILDCARD_MATCH_ALL as unknown as string[];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });
@@ -130,7 +130,7 @@ describe('workspace utils', () => {
     const groups: string[] = [];
     const users: string[] = ['a'];
     const configGroups: string[] = [];
-    const configUsers = ('admin' as unknown) as string[];
+    const configUsers = 'admin' as unknown as string[];
     updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
   });
@@ -143,8 +143,8 @@ describe('workspace utils', () => {
       mockRequest,
       groups,
       users,
-      (null as unknown) as string[],
-      (undefined as unknown) as string[]
+      null as unknown as string[],
+      undefined as unknown as string[]
     );
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
   });

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -40,13 +40,13 @@ export const updateDashboardAdminStateForRequest = (
   const normalizedConfigUsers = Array.isArray(configUsers)
     ? configUsers
     : configUsers
-    ? [configUsers]
-    : [];
+      ? [configUsers]
+      : [];
   const normalizedConfigGroups = Array.isArray(configGroups)
     ? configGroups
     : configGroups
-    ? [configGroups]
-    : [];
+      ? [configGroups]
+      : [];
   // If the security plugin is not installed, login defaults to OSD Admin
   if (!groups.length && !users.length) {
     return updateWorkspaceState(request, { isDashboardAdmin: true });

--- a/src/setup_node_env/exit_on_warning.js
+++ b/src/setup_node_env/exit_on_warning.js
@@ -34,6 +34,10 @@ if (process.noProcessWarnings !== true) {
     'NodeDeprecationWarning',
     'MODULE_TYPELESS_PACKAGE_JSON',
     'fs.Stats constructor is deprecated.',
+    // Advisory performance hint emitted by ESLint 10 when `concurrency: 'auto'`
+    // picks multithreading for a small workload (e.g. linting a single plugin
+    // dir). Not a code problem, so it must not terminate the process.
+    'ESLintPoorConcurrencyWarning',
   ];
 
   process.on('warning', function (warn) {


### PR DESCRIPTION
### Description

Two follow-ups to the ESLint 10 / Prettier 3 upgrade (#12340), both aimed at making downstream OpenSearch Dashboards plugins able to adopt the flat-config setup cleanly.

**1. Don't terminate lint on the ESLint 10 concurrency warning**

ESLint 10 emits an advisory `ESLintPoorConcurrencyWarning` when `concurrency: 'auto'` (set in `src/dev/run_eslint.js`) selects multithreading for a small workload — e.g. linting a single plugin directory. The process-warning handler in `src/setup_node_env/exit_on_warning.js` treats any unlisted Node process-warning as fatal and calls `process.exit(1)`, so `yarn lint` exited `1` **even with zero lint errors**, spuriously failing CI. `ESLintPoorConcurrencyWarning` is added to the existing ignore list alongside the other advisory warnings.

**2. Share plugin registration via `@elastic/eslint-config-kibana`**

In flat config, `plugins` registration is scoped per matched file and is **not** inherited between config objects. A plugin that spread the shared config and then referenced, say, `@typescript-eslint/no-explicit-any` in its own override block would fail with `Could not find plugin "@typescript-eslint"` unless it re-`require`d and re-registered the plugin. That forced every plugin to know which plugin owns each rule.

This registers every bundled plugin once in an unscoped config object (`globalPluginRegistration`), placed first in the exported array, so downstream rule references resolve at any file scope with no per-plugin boilerplate:

- `plugins.js` — single source of truth for plugin instances + global registration.
- `eui.js` — opt-in EUI config block (EUI is intentionally not part of the base config; OSD core does not lint against EUI rules).
- `extras.js` — aggregates `{ eui, plugins, restrictedGlobals }` behind a single `/extras` subpath.
- `eslint.config.js` — sources instances from `plugins.js`; global registration first. The default export stays a pure spreadable array.
- `package.json` — adds an `exports` map (`.`, `./eslint.config.js`, `./extras`); aligns peer deps.
- plugin generator template + README — use the plain spread pattern, no registration.

A plugin's `eslint.config.js` now looks like:

```js
const osdConfig = require('@elastic/eslint-config-kibana');
const { eui } = require('@elastic/eslint-config-kibana/extras');

module.exports = [
  ...osdConfig,
  ...eui,
  { files: ['**/*.{js,mjs,ts,tsx}'], rules: { /* references any plugin rule, no registration */ } },
];
```

### Issues Resolved

Follow-up to #12340.

## Screenshot

N/A — no UI change.

## Testing the changes

1. Clean lint no longer terminates:
   - From a plugin directory that lints cleanly, run `node ../../scripts/eslint .`
   - Before: prints `Node.js process-warning detected ... Terminating process...` and exits `1` despite `0 errors`.
   - After: no termination message; exits `0`.
2. Real lint errors still exit `1` (verified with a file containing a missing semicolon).
3. Shared config verified against a real plugin (dashboards-investigation) using only `...osdConfig` + `...eui` + local rule overrides, with no plugin `require`/registration:
   - `@osd/eslint/require-license-header`, `@typescript-eslint/no-unused-vars` (incl. `caughtErrorsIgnorePattern`), `@typescript-eslint/no-explicit-any`, `@osd/eslint/no-restricted-paths`, `jest/expect-expect`, and `@elastic/eui/*` recommended rules all fire as expected.
   - `ignores` (migrated from `.eslintignore`) correctly skips `**/*.d.ts`.
4. OSD root config still loads and self-lints clean; `examples/expressions_example` (which imports `@elastic/eslint-config-kibana/eslint.config.js`) still resolves.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
