### PR TITLE
[Workspace] Add search and filters to the workspace home page

### DIFF
--- a/src/plugins/workspace/public/components/workspace_initial/utils.test.ts
+++ b/src/plugins/workspace/public/components/workspace_initial/utils.test.ts
@@ -5,7 +5,16 @@
 
 import moment from 'moment';
 import { recentWorkspaceManager } from '../../recent_workspace_manager';
-import { getWorkspacesWithRecentMessage, sortByRecentVisitedAndAlphabetical } from './utils';
+import {
+  WorkspaceFilterCriteria,
+  buildWorkspaceFilterCriteria,
+  filterWorkspaces,
+  getRecencyCutoff,
+  getWorkspaceRole,
+  getWorkspacesWithRecentMessage,
+  isWorkspaceFilterActive,
+  sortByRecentVisitedAndAlphabetical,
+} from './utils';
 
 describe('getWorkspacesWithRecentMessage', () => {
   const workspaces = [
@@ -89,5 +98,126 @@ describe('sortByRecentVisitedAndAlphabetical', () => {
   it('should sort alphabetically by name if neither workspace has a timestamp', () => {
     const sorted = [workspace4, workspace3].sort(sortByRecentVisitedAndAlphabetical);
     expect(sorted).toEqual([workspace3, workspace4]); // Sorted alphabetically by name
+  });
+});
+
+describe('getWorkspaceRole', () => {
+  it('returns owner when the owner flag is set', () => {
+    expect(getWorkspaceRole({ id: 'a', name: 'A', owner: true })).toBe('owner');
+  });
+
+  it('returns readonly when the readonly flag is set', () => {
+    expect(getWorkspaceRole({ id: 'a', name: 'A', readonly: true })).toBe('readonly');
+  });
+
+  it('returns readwrite when neither flag is set', () => {
+    expect(getWorkspaceRole({ id: 'a', name: 'A' })).toBe('readwrite');
+  });
+
+  it('prioritizes owner over readonly', () => {
+    expect(getWorkspaceRole({ id: 'a', name: 'A', owner: true, readonly: true })).toBe('owner');
+  });
+});
+
+describe('getRecencyCutoff', () => {
+  it('returns null for "all" (no recency filter)', () => {
+    expect(getRecencyCutoff('all')).toBeNull();
+  });
+
+  it('returns calendar start-of-period timestamps', () => {
+    expect(getRecencyCutoff('today')).toBe(moment().startOf('day').valueOf());
+    expect(getRecencyCutoff('week')).toBe(moment().startOf('week').valueOf());
+    expect(getRecencyCutoff('month')).toBe(moment().startOf('month').valueOf());
+  });
+});
+
+describe('isWorkspaceFilterActive', () => {
+  it('is false when all criteria are neutral', () => {
+    expect(isWorkspaceFilterActive({ searchQuery: '', roles: [], recency: 'all' })).toBe(false);
+  });
+
+  it('treats a whitespace-only query as inactive', () => {
+    expect(isWorkspaceFilterActive({ searchQuery: '   ', roles: [], recency: 'all' })).toBe(false);
+  });
+
+  it('is true when the search query is set', () => {
+    expect(isWorkspaceFilterActive({ searchQuery: 'abc', roles: [], recency: 'all' })).toBe(true);
+  });
+
+  it('is true when a role is selected', () => {
+    expect(isWorkspaceFilterActive({ searchQuery: '', roles: ['owner'], recency: 'all' })).toBe(
+      true
+    );
+  });
+
+  it('is true when recency is not "all"', () => {
+    expect(isWorkspaceFilterActive({ searchQuery: '', roles: [], recency: 'today' })).toBe(true);
+  });
+});
+
+describe('buildWorkspaceFilterCriteria', () => {
+  it('maps roleFilter "all" to an empty roles array', () => {
+    expect(
+      buildWorkspaceFilterCriteria({ searchQuery: 'x', roleFilter: 'all', recency: 'week' })
+    ).toEqual({ searchQuery: 'x', roles: [], recency: 'week' });
+  });
+
+  it('maps a specific roleFilter to a single-element roles array', () => {
+    expect(
+      buildWorkspaceFilterCriteria({ searchQuery: '', roleFilter: 'owner', recency: 'all' })
+    ).toEqual({ searchQuery: '', roles: ['owner'], recency: 'all' });
+  });
+});
+
+describe('filterWorkspaces', () => {
+  const now = Date.now();
+  const list = [
+    // Admin (owner), visited just now
+    { id: '1', name: 'Payments', owner: true, accessTimeStamp: now },
+    // Read only, never visited
+    { id: '2', name: 'Checkout Latency', readonly: true, accessTimeStamp: undefined },
+    // Read and write, visited two months ago
+    { id: '3', name: 'Ingestion', accessTimeStamp: moment().subtract(2, 'months').valueOf() },
+  ];
+  const neutral: WorkspaceFilterCriteria = { searchQuery: '', roles: [], recency: 'all' };
+  const ids = (result: Array<{ id: string }>) => result.map((w) => w.id);
+
+  it('returns all workspaces when no criteria are active', () => {
+    expect(ids(filterWorkspaces(list, neutral))).toEqual(['1', '2', '3']);
+  });
+
+  it('filters by case-insensitive name substring', () => {
+    expect(ids(filterWorkspaces(list, { ...neutral, searchQuery: 'lat' }))).toEqual(['2']);
+  });
+
+  it('trims the search query before matching', () => {
+    expect(ids(filterWorkspaces(list, { ...neutral, searchQuery: '  payments ' }))).toEqual(['1']);
+  });
+
+  it('filters by a single role', () => {
+    expect(ids(filterWorkspaces(list, { ...neutral, roles: ['readonly'] }))).toEqual(['2']);
+  });
+
+  it('filters by a set of roles (OR within roles)', () => {
+    expect(ids(filterWorkspaces(list, { ...neutral, roles: ['owner', 'readwrite'] }))).toEqual([
+      '1',
+      '3',
+    ]);
+  });
+
+  it('filters by recency and excludes items without an accessTimeStamp', () => {
+    // "today" keeps only id 1 (visited now); id 2 (undefined) and id 3 (old) are excluded
+    expect(ids(filterWorkspaces(list, { ...neutral, recency: 'today' }))).toEqual(['1']);
+    // "month" still excludes id 2 (undefined) and id 3 (two months old)
+    expect(ids(filterWorkspaces(list, { ...neutral, recency: 'month' }))).toEqual(['1']);
+  });
+
+  it('combines all criteria with AND', () => {
+    expect(
+      ids(filterWorkspaces(list, { searchQuery: 'payments', roles: ['owner'], recency: 'today' }))
+    ).toEqual(['1']);
+    expect(
+      filterWorkspaces(list, { searchQuery: 'payments', roles: ['readonly'], recency: 'all' })
+    ).toEqual([]);
   });
 });

--- a/src/plugins/workspace/public/components/workspace_initial/utils.ts
+++ b/src/plugins/workspace/public/components/workspace_initial/utils.ts
@@ -29,6 +29,84 @@ export const getWorkspacesWithRecentMessage = (
   });
 };
 
+export type WorkspaceRole = 'owner' | 'readwrite' | 'readonly';
+export type WorkspaceRecency = 'all' | 'today' | 'week' | 'month';
+
+export interface WorkspaceFilterCriteria {
+  searchQuery: string;
+  roles: WorkspaceRole[];
+  recency: WorkspaceRecency;
+}
+
+export type WorkspaceRoleFilter = 'all' | WorkspaceRole;
+
+export const buildWorkspaceFilterCriteria = ({
+  searchQuery,
+  roleFilter,
+  recency,
+}: {
+  searchQuery: string;
+  roleFilter: WorkspaceRoleFilter;
+  recency: WorkspaceRecency;
+}): WorkspaceFilterCriteria => ({
+  searchQuery,
+  roles: roleFilter === 'all' ? [] : [roleFilter],
+  recency,
+});
+
+export const getWorkspaceRole = (workspace: WorkspaceObject): WorkspaceRole => {
+  if (workspace.owner) {
+    return 'owner';
+  }
+  if (workspace.readonly) {
+    return 'readonly';
+  }
+  return 'readwrite';
+};
+
+export const getRecencyCutoff = (recency: WorkspaceRecency): number | null => {
+  switch (recency) {
+    case 'today':
+      return moment().startOf('day').valueOf();
+    case 'week':
+      return moment().startOf('week').valueOf();
+    case 'month':
+      return moment().startOf('month').valueOf();
+    default:
+      return null;
+  }
+};
+
+export const isWorkspaceFilterActive = ({
+  searchQuery,
+  roles,
+  recency,
+}: WorkspaceFilterCriteria): boolean =>
+  !!searchQuery.trim() || roles.length > 0 || recency !== 'all';
+
+export const filterWorkspaces = (
+  workspaces: UpdatedWorkspaceObject[],
+  { searchQuery, roles, recency }: WorkspaceFilterCriteria
+): UpdatedWorkspaceObject[] => {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const recencyCutoff = getRecencyCutoff(recency);
+  return workspaces.filter((workspace) => {
+    if (normalizedQuery && !workspace.name.toLowerCase().includes(normalizedQuery)) {
+      return false;
+    }
+    if (roles.length > 0 && !roles.includes(getWorkspaceRole(workspace))) {
+      return false;
+    }
+    if (
+      recencyCutoff !== null &&
+      (!workspace.accessTimeStamp || workspace.accessTimeStamp < recencyCutoff)
+    ) {
+      return false;
+    }
+    return true;
+  });
+};
+
 export const sortByRecentVisitedAndAlphabetical = (
   ws1: UpdatedWorkspaceObject,
   ws2: UpdatedWorkspaceObject

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
@@ -4,7 +4,7 @@
  */
 
 import './workspace_initial.scss';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
 import {
   EuiLink,
@@ -28,6 +28,13 @@ import { WORKSPACE_CREATE_APP_ID, WORKSPACE_LIST_APP_ID } from '../../../common/
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { WorkspaceUseCase } from '../../types';
 import { WorkspaceUseCaseCard } from './workspace_use_case_card';
+import { WorkspaceSearchBar } from './workspace_search_bar';
+import {
+  WorkspaceFilterCriteria,
+  WorkspaceRecency,
+  WorkspaceRoleFilter,
+  buildWorkspaceFilterCriteria,
+} from './utils';
 import { WorkspaceUseCaseFlyout } from '../workspace_form';
 import { navigateToWorkspacePageWithUseCase } from '../utils/workspace';
 
@@ -47,6 +54,14 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
   const [isUseCaseFlyoutVisible, setIsUseCaseFlyoutVisible] = useState(false);
   const [defaultExpandedUseCaseId, setDefaultExpandedUseCaseId] = useState(availableUseCases[0].id);
 
+  const [searchQuery, setSearchQuery] = useState('');
+  const [recency, setRecency] = useState<WorkspaceRecency>('all');
+  const [roleFilter, setRoleFilter] = useState<WorkspaceRoleFilter>('all');
+  const filterCriteria: WorkspaceFilterCriteria = useMemo(
+    () => buildWorkspaceFilterCriteria({ searchQuery, roleFilter, recency }),
+    [searchQuery, roleFilter, recency]
+  );
+
   const handleClickUseCaseInformation = useCallback((useCaseId: string) => {
     setIsUseCaseFlyoutVisible(true);
     setDefaultExpandedUseCaseId(useCaseId);
@@ -64,6 +79,7 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
           application={application}
           http={http}
           isDashboardAdmin={isDashboardAdmin}
+          filterCriteria={filterCriteria}
           handleClickUseCaseInformation={handleClickUseCaseInformation}
         />
       </EuiFlexItem>
@@ -186,6 +202,18 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
           <EuiFlexItem grow={false}>{isDashboardAdmin && createWorkspacePopover}</EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
+      {workspaceList.length > 0 && (
+        <EuiFlexItem grow={false}>
+          <WorkspaceSearchBar
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            recency={recency}
+            onRecencyChange={setRecency}
+            roleFilter={roleFilter}
+            onRoleFilterChange={setRoleFilter}
+          />
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow={false}>
         <EuiFlexGroup justifyContent="spaceBetween" gutterSize="m" className="eui-xScroll">
           {useCaseCards}

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_search_bar.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_search_bar.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { WorkspaceSearchBar, WorkspaceSearchBarProps } from './workspace_search_bar';
+
+describe('WorkspaceSearchBar', () => {
+  const setup = (overrides: Partial<WorkspaceSearchBarProps> = {}) => {
+    const props: WorkspaceSearchBarProps = {
+      searchQuery: '',
+      onSearchChange: jest.fn(),
+      recency: 'all',
+      onRecencyChange: jest.fn(),
+      roleFilter: 'all',
+      onRoleFilterChange: jest.fn(),
+      ...overrides,
+    };
+    return { props, ...render(<WorkspaceSearchBar {...props} />) };
+  };
+
+  it('renders the search input and both filter dropdowns with their default displays', () => {
+    const { getByTestId, getByText } = setup();
+    expect(getByTestId('workspace-initial-search-input')).toBeInTheDocument();
+    expect(getByTestId('workspace-initial-search-recency-select')).toBeInTheDocument();
+    expect(getByTestId('workspace-initial-search-role-select')).toBeInTheDocument();
+    expect(getByText('Last viewed: All')).toBeInTheDocument();
+    expect(getByText('Access level: All')).toBeInTheDocument();
+  });
+
+  it('reflects the controlled search query value', () => {
+    const { getByTestId } = setup({ searchQuery: 'payments' });
+    expect(getByTestId('workspace-initial-search-input')).toHaveValue('payments');
+  });
+
+  it('calls onSearchChange when typing in the search box', () => {
+    const { props, getByTestId } = setup();
+    fireEvent.change(getByTestId('workspace-initial-search-input'), {
+      target: { value: 'pay' },
+    });
+    expect(props.onSearchChange).toHaveBeenCalledWith('pay');
+  });
+
+  it('calls onRecencyChange when selecting a recency option', () => {
+    const { props, getByTestId, getByText } = setup();
+    fireEvent.click(getByTestId('workspace-initial-search-recency-select'));
+    fireEvent.click(getByText('This week'));
+    expect(props.onRecencyChange).toHaveBeenCalledWith('week');
+  });
+
+  it('calls onRoleFilterChange when selecting an access level', () => {
+    const { props, getByTestId, getByText } = setup();
+    fireEvent.click(getByTestId('workspace-initial-search-role-select'));
+    fireEvent.click(getByText('Read only'));
+    expect(props.onRoleFilterChange).toHaveBeenCalledWith('readonly');
+  });
+});

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_search_bar.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_search_bar.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiCompressedFieldSearch,
+  EuiCompressedSuperSelect,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSuperSelectOption,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { WorkspaceRecency, WorkspaceRoleFilter } from './utils';
+import { WORKSPACE_ACCESS_LEVEL_NAMES } from '../../constants';
+
+/** Value of the role filter dropdown: 'all' means no role filtering. */
+export interface WorkspaceSearchBarProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  recency: WorkspaceRecency;
+  onRecencyChange: (value: WorkspaceRecency) => void;
+  roleFilter: WorkspaceRoleFilter;
+  onRoleFilterChange: (value: WorkspaceRoleFilter) => void;
+}
+
+const makeOption = (
+  value: WorkspaceRecency,
+  label: string
+): EuiSuperSelectOption<WorkspaceRecency> => ({
+  value,
+  inputDisplay: i18n.translate('workspace.initial.searchBar.recency.inputDisplay', {
+    defaultMessage: 'Last viewed: {label}',
+    values: { label },
+  }),
+  dropdownDisplay: label,
+});
+
+const RECENCY_OPTIONS: Array<EuiSuperSelectOption<WorkspaceRecency>> = [
+  makeOption(
+    'all',
+    i18n.translate('workspace.initial.searchBar.recency.all', { defaultMessage: 'All' })
+  ),
+  makeOption(
+    'today',
+    i18n.translate('workspace.initial.searchBar.recency.today', { defaultMessage: 'Today' })
+  ),
+  makeOption(
+    'week',
+    i18n.translate('workspace.initial.searchBar.recency.week', { defaultMessage: 'This week' })
+  ),
+  makeOption(
+    'month',
+    i18n.translate('workspace.initial.searchBar.recency.month', { defaultMessage: 'This month' })
+  ),
+];
+
+const makeRoleOption = (
+  value: WorkspaceRoleFilter,
+  label: string
+): EuiSuperSelectOption<WorkspaceRoleFilter> => ({
+  value,
+  inputDisplay: i18n.translate('workspace.initial.searchBar.role.inputDisplay', {
+    defaultMessage: 'Access level: {label}',
+    values: { label },
+  }),
+  dropdownDisplay: label,
+});
+
+const ROLE_OPTIONS: Array<EuiSuperSelectOption<WorkspaceRoleFilter>> = [
+  makeRoleOption(
+    'all',
+    i18n.translate('workspace.initial.searchBar.role.all', { defaultMessage: 'All' })
+  ),
+  makeRoleOption('owner', WORKSPACE_ACCESS_LEVEL_NAMES.admin),
+  makeRoleOption('readwrite', WORKSPACE_ACCESS_LEVEL_NAMES.readAndWrite),
+  makeRoleOption('readonly', WORKSPACE_ACCESS_LEVEL_NAMES.readOnly),
+];
+
+export const WorkspaceSearchBar = ({
+  searchQuery,
+  onSearchChange,
+  recency,
+  onRecencyChange,
+  roleFilter,
+  onRoleFilterChange,
+}: WorkspaceSearchBarProps) => {
+  return (
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem>
+        <EuiCompressedFieldSearch
+          fullWidth
+          isClearable
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={i18n.translate('workspace.initial.searchBar.placeholder', {
+            defaultMessage: 'Search workspaces by name',
+          })}
+          aria-label={i18n.translate('workspace.initial.searchBar.ariaLabel', {
+            defaultMessage: 'Search workspaces by name',
+          })}
+          data-test-subj="workspace-initial-search-input"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} style={{ minWidth: 160 }}>
+        <EuiCompressedSuperSelect
+          options={RECENCY_OPTIONS}
+          valueOfSelected={recency}
+          onChange={(value) => onRecencyChange(value as WorkspaceRecency)}
+          hasDividers
+          aria-label={i18n.translate('workspace.initial.searchBar.recency.ariaLabel', {
+            defaultMessage: 'Filter workspaces by when they were last viewed',
+          })}
+          data-test-subj="workspace-initial-search-recency-select"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false} style={{ minWidth: 160 }}>
+        <EuiCompressedSuperSelect
+          options={ROLE_OPTIONS}
+          valueOfSelected={roleFilter}
+          onChange={(value) => onRoleFilterChange(value as WorkspaceRoleFilter)}
+          hasDividers
+          aria-label={i18n.translate('workspace.initial.searchBar.role.ariaLabel', {
+            defaultMessage: 'Filter workspaces by access level',
+          })}
+          data-test-subj="workspace-initial-search-role-select"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_use_case_card.test.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_use_case_card.test.tsx
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import { WorkspaceUseCaseCard } from './workspace_use_case_card';
 import * as utils from './utils';
+import { WorkspaceFilterCriteria } from './utils';
 import { applicationServiceMock, httpServiceMock } from '../../../../../core/public/mocks';
 
 describe('WorkspaceUseCaseCard', () => {
@@ -35,6 +36,8 @@ describe('WorkspaceUseCaseCard', () => {
     icon: 'wsObservability',
   };
 
+  const noFilter: WorkspaceFilterCriteria = { searchQuery: '', roles: [], recency: 'all' };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -48,6 +51,7 @@ describe('WorkspaceUseCaseCard', () => {
         application={applicationMock}
         http={httpMock}
         isDashboardAdmin={true}
+        filterCriteria={noFilter}
         handleClickUseCaseInformation={jest.fn}
       />
     );
@@ -74,6 +78,7 @@ describe('WorkspaceUseCaseCard', () => {
         application={applicationMock}
         http={httpMock}
         isDashboardAdmin={true}
+        filterCriteria={noFilter}
         handleClickUseCaseInformation={jest.fn}
       />
     );
@@ -95,6 +100,7 @@ describe('WorkspaceUseCaseCard', () => {
         application={applicationMock}
         http={httpMock}
         isDashboardAdmin={false}
+        filterCriteria={noFilter}
         handleClickUseCaseInformation={jest.fn}
       />
     );
@@ -104,6 +110,30 @@ describe('WorkspaceUseCaseCard', () => {
     ).toBeNull();
     expect(
       queryByText('Request a workspace owner to add you as a collaborator.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows "No matching workspaces" when the card has workspaces but none match the filter', () => {
+    jest.spyOn(utils, 'getWorkspacesWithRecentMessage').mockReturnValue(mockWorkspaces);
+    const { getByText, queryByText, getByTestId } = render(
+      <WorkspaceUseCaseCard
+        useCase={mockUseCase}
+        workspaces={mockWorkspaces}
+        application={applicationMock}
+        http={httpMock}
+        isDashboardAdmin={true}
+        filterCriteria={{ searchQuery: 'no-such-workspace', roles: [], recency: 'all' }}
+        handleClickUseCaseInformation={jest.fn}
+      />
+    );
+
+    expect(getByText('No matching workspaces')).toBeInTheDocument();
+    // the actual workspaces are filtered out
+    expect(queryByText('Workspace 1')).toBeNull();
+    expect(queryByText('Workspace 2')).toBeNull();
+    // the footer "View all" is still available
+    expect(
+      getByTestId('workspace-initial-useCaseCard-observability-button-view')
     ).toBeInTheDocument();
   });
 });

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_use_case_card.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_use_case_card.tsx
@@ -26,6 +26,8 @@ import { i18n } from '@osd/i18n';
 import { Fragment, useMemo } from 'react';
 import {
   UpdatedWorkspaceObject,
+  WorkspaceFilterCriteria,
+  filterWorkspaces,
   getWorkspacesWithRecentMessage,
   sortByRecentVisitedAndAlphabetical,
 } from './utils';
@@ -44,6 +46,7 @@ interface WorkspaceUseCaseCardProps {
   application: ApplicationStart;
   http: HttpSetup;
   isDashboardAdmin: boolean;
+  filterCriteria: WorkspaceFilterCriteria;
   handleClickUseCaseInformation: (useCaseId: string) => void;
 }
 
@@ -53,21 +56,28 @@ export const WorkspaceUseCaseCard = ({
   application,
   http,
   isDashboardAdmin,
+  filterCriteria,
   handleClickUseCaseInformation,
 }: WorkspaceUseCaseCardProps) => {
   const useCaseIcon = useCase.icon || 'logoOpenSearch';
 
   // Display the recently accessed workspaces first, and then arrange other workspaces in alphabetical order.
   const sortedWorkspaceList: UpdatedWorkspaceObject[] = useMemo(() => {
-    const filterWorkspaces = workspaces.filter(
+    const workspacesForUseCase = workspaces.filter(
       (workspace) => getFirstUseCaseOfFeatureConfigs(workspace?.features || []) === useCase.id
     );
-    return getWorkspacesWithRecentMessage(filterWorkspaces).sort(
+    return getWorkspacesWithRecentMessage(workspacesForUseCase).sort(
       sortByRecentVisitedAndAlphabetical
     );
   }, [useCase.id, workspaces]);
 
   const hasWorkspaces = sortedWorkspaceList.length > 0;
+
+  const filteredWorkspaceList: UpdatedWorkspaceObject[] = useMemo(
+    () => filterWorkspaces(sortedWorkspaceList, filterCriteria),
+    [sortedWorkspaceList, filterCriteria]
+  );
+  const hasMatches = filteredWorkspaceList.length > 0;
 
   const adminCreateWorkspaceText = i18n.translate(
     'workspace.initial.useCaseCard.adminCreateWorkspaceText',
@@ -157,15 +167,33 @@ export const WorkspaceUseCaseCard = ({
       <EuiHorizontalRule margin="none" />
       {hasWorkspaces ? (
         <>
-          <EuiSplitPanel.Inner paddingSize="none">
-            <div className="eui-yScrollWithShadows" style={{ maxHeight: '272px' }}>
-              <EuiContextMenuPanel
+          {hasMatches ? (
+            <EuiSplitPanel.Inner paddingSize="none">
+              <div className="eui-yScrollWithShadows" style={{ maxHeight: '272px' }}>
+                <EuiContextMenuPanel
+                  size="s"
+                  items={filteredWorkspaceList.map(workspaceToItem)}
+                  hasFocus={false}
+                />
+              </div>
+            </EuiSplitPanel.Inner>
+          ) : (
+            <EuiSplitPanel.Inner
+              paddingSize="m"
+              style={{ display: 'grid', placeItems: 'center', minHeight: '272px' }}
+            >
+              <EuiText
+                textAlign="center"
                 size="s"
-                items={sortedWorkspaceList.map(workspaceToItem)}
-                hasFocus={false}
-              />
-            </div>
-          </EuiSplitPanel.Inner>
+                color="subdued"
+                data-test-subj={`workspace-initial-useCaseCard-${useCase.id}-noMatchingWorkspaces`}
+              >
+                {i18n.translate('workspace.initial.useCaseCard.noMatchingWorkspaces', {
+                  defaultMessage: 'No matching workspaces',
+                })}
+              </EuiText>
+            </EuiSplitPanel.Inner>
+          )}
           <EuiHorizontalRule margin="none" />
           <EuiSplitPanel.Inner paddingSize="s" grow={false}>
             <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>


### PR DESCRIPTION
### Description
This PR adds an in-place search + filter bar above the use-case cards so users can quickly narrow down workspaces without leaving the page:

- **Search** — case-insensitive match on workspace name, applied across all use-case cards simultaneously.
- **Last viewed** — `All` / `Today` / `This week` / `This month`. Buckets are calendar-based.
- **Access level** (`EuiCompressedSuperSelect`) — `All` / `Admin` / `Read and write` / `Read only`, derived from the workspace `owner`/`readonly` flags and labeled using the existing `WORKSPACE_ACCESS_LEVEL_NAMES` constant so
  wording stays consistent with the Collaborators page.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<img width="1461" height="937" alt="image" src="https://github.com/user-attachments/assets/dd28c754-971a-40db-bca8-715520e1950b" />



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
