### PR TITLE
Fix error toast showing 'Error' without error message in production

### DIFF
--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -204,7 +204,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
             values={{ entityName: this.props.entityName }}
           />
         ),
-        text: `${error}`,
+        text: error?.body?.message || error?.message || `${error}`,
       });
     }
     this.fetchItems();

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -435,7 +435,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
             values: { useUpdatedUX },
           }
         ),
-        text: `${error}`,
+        text: error?.body?.message || error?.message || `${error}`,
       });
     }
   }, 300);
@@ -473,7 +473,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
             values: { useUpdatedUX },
           }
         ),
-        text: `${error}`,
+        text: error?.body?.message || error?.message || `${error}`,
       });
     }
   }, 300);
@@ -682,7 +682,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
             values: { useUpdatedUX },
           }
         ),
-        text: `${error}`,
+        text: error?.body?.message || error?.message || `${error}`,
       });
     }
 
@@ -755,7 +755,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
             values: { useUpdatedUX },
           }
         ),
-        text: `${error}`,
+        text: error?.body?.message || error?.message || `${error}`,
       });
     }
   };


### PR DESCRIPTION
### Description

When HTTP errors are thrown and displayed as toast notifications, the error message was being lost. The toast would show the generic title (e.g., \"Error\") with no descriptive text because `\`${error}\`` on a structured HTTP error object produces an unhelpful empty or generic string rather than the actual error message.

This fix extracts the human-readable message from `error.body.message` or `error.message` before falling back to string coercion, ensuring the actual error reason is shown to the user.

Affected locations:
- `table_list_view.tsx` — delete item error toast
- `saved_objects_table.tsx` — fetch, find, delete, and relationship-fetch error toasts

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->

## Screenshot

**Before**

<img width="608" height="109" alt="image" src="https://github.com/user-attachments/assets/59e998f9-5378-482d-95b1-504a42cdb909" />


**After**

<img width="368" height="98" alt="image" src="https://github.com/user-attachments/assets/7c0a9f30-75da-49d6-b4d8-c6853e141e71" />


## Testing the changes

1. Start OSD against an OpenSearch cluster
2. Trigger an API error in Saved Objects Management (e.g., attempt an operation that fails server-side)
3. Observe the toast now displays the actual error message instead of showing only the toast title with no body text
4. Verify that plain string errors still display correctly (fallback path)

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff