### PR TITLE
[Dashboard variable] simplify dashboard variable url

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_variables/query_panel/variable_query_panel.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/query_panel/variable_query_panel.tsx
@@ -32,6 +32,10 @@ import {
   filterVariableOptionsByRegex,
   VariableQueryResult,
 } from '../../../../variables/variable_query_utils';
+import {
+  buildVariableOptionDisplayTextMap,
+  getVariableOptionDisplayText,
+} from '../../../../variables/variable_option_display_utils';
 import { IVariableInterpolationService } from '../../../../variables/variable_interpolation_service';
 import { NormalizedVariableOption } from '../../../../variables/types';
 import { getEffectiveLanguageForAutoComplete } from '../../../../../../data/public';
@@ -203,6 +207,10 @@ export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
   const previewOptions = useMemo(
     () => filteredPreviewOptions.slice(0, MAX_PREVIEW_OPTIONS),
     [filteredPreviewOptions]
+  );
+  const previewOptionDisplayTextMap = useMemo(
+    () => buildVariableOptionDisplayTextMap(previewOptions),
+    [previewOptions]
   );
 
   const isTruncated = filteredPreviewOptions.length > MAX_PREVIEW_OPTIONS;
@@ -759,7 +767,9 @@ export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
                   <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
                     {previewOptions.map((option) => (
                       <EuiFlexItem key={option.value} grow={false}>
-                        <EuiBadge color="hollow">{option.label || option.value}</EuiBadge>
+                        <EuiBadge color="hollow">
+                          {getVariableOptionDisplayText(option, previewOptionDisplayTextMap)}
+                        </EuiBadge>
                       </EuiFlexItem>
                     ))}
                   </EuiFlexGroup>

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
@@ -23,6 +23,10 @@ import {
 import { i18n } from '@osd/i18n';
 import { VariableService } from '../../../variables/variable_service';
 import { VariableWithState } from '../../../variables/types';
+import {
+  buildVariableOptionDisplayTextMap,
+  getVariableOptionDisplayText,
+} from '../../../variables/variable_option_display_utils';
 import './variable_selector.scss';
 
 export interface VariablesBarProps {
@@ -64,6 +68,11 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
     );
   }, [variable.includeAll, variable.multi, variable.options, selectedValues]);
 
+  const optionDisplayTextMap = useMemo(
+    () => buildVariableOptionDisplayTextMap(variable.options),
+    [variable.options]
+  );
+
   // Convert to EuiSelectable options format, prepend "All" if enabled
   const selectableOptions: EuiSelectableOption[] = useMemo(() => {
     const options: EuiSelectableOption[] = [];
@@ -78,14 +87,21 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
 
     variable.options.forEach((option) => {
       options.push({
-        label: option.label || option.value,
+        label: getVariableOptionDisplayText(option, optionDisplayTextMap),
         key: `${OPTION_VALUE_KEY_PREFIX}${option.value}`,
         checked: selectedValues.includes(option.value) ? 'on' : undefined,
       });
     });
 
     return options;
-  }, [variable.options, variable.includeAll, variable.multi, selectedValues, isAllSelected]);
+  }, [
+    variable.options,
+    variable.includeAll,
+    variable.multi,
+    selectedValues,
+    isAllSelected,
+    optionDisplayTextMap,
+  ]);
 
   const handleChange = useCallback(
     (newOptions: EuiSelectableOption[]) => {
@@ -136,12 +152,12 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
   // Calculate popover width based on longest option label
   const popoverWidth = useMemo(() => {
     const longestLength = variable.options.reduce((max, option) => {
-      const displayText = option.label || option.value;
+      const displayText = getVariableOptionDisplayText(option, optionDisplayTextMap);
       return Math.max(max, displayText.length);
     }, 0);
     // ~8px per char + 60px for checkbox/padding/scrollbar
     return Math.max(300, Math.min(longestLength * 8 + 60, 700));
-  }, [variable.options]);
+  }, [variable.options, optionDisplayTextMap]);
 
   const isLoading = !!variable.loading;
   const isError = !!variable.error;
@@ -159,7 +175,9 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
     }
     if (selectedValues.length > 0) {
       const selectedOption = variable.options.find((option) => option.value === selectedValues[0]);
-      return selectedOption?.label || selectedValues[0];
+      return selectedOption
+        ? getVariableOptionDisplayText(selectedOption, optionDisplayTextMap)
+        : selectedValues[0];
     }
     if (variable.options.length === 0) {
       return i18n.translate('dashboard.variables.displayNoOptions', {

--- a/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.test.tsx
+++ b/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.test.tsx
@@ -10,14 +10,26 @@
  */
 
 import { IOsdUrlStateStorage } from 'src/plugins/opensearch_dashboards_utils/public';
-import { createDashboardGlobalAndAppState, updateStateUrl } from './create_dashboard_app_state';
+import {
+  createDashboardGlobalAndAppState,
+  hydrateDashboardAppState,
+  updateStateUrl,
+} from './create_dashboard_app_state';
 import { migrateAppState } from './migrate_app_state';
 import { dashboardAppStateStub } from './stubs';
 import { createDashboardServicesMock } from './mocks';
 import { SavedObjectDashboard } from '../..';
+import { DashboardAppState } from '../../types';
 import { syncQueryStateWithUrl } from 'src/plugins/data/public';
 import { ViewMode } from 'src/plugins/embeddable/public';
 import { scopedHistoryMock } from '../../../../../core/public/mocks';
+import {
+  CustomVariable,
+  QueryVariable,
+  Variable,
+  VariableSortOrder,
+  VariableType,
+} from '../../variables/types';
 
 const mockStartStateSync = jest.fn();
 const mockStopStateSync = jest.fn();
@@ -175,6 +187,64 @@ describe('updateStateUrl', () => {
     expect(osdUrlStateStorage.flush).toHaveBeenCalledWith({ replace: true });
   });
 
+  test('serializes only variable selection overrides in URL state', () => {
+    const stateWithVariables: DashboardAppState = {
+      ...dashboardAppState,
+      variables: [
+        {
+          id: 'custom-1',
+          name: 'OS',
+          type: VariableType.Custom,
+          current: ['ios'],
+          customOptions: [{ value: 'ios', label: 'Apple iOS' }],
+          sort: VariableSortOrder.AlphabeticalAsc,
+        },
+        {
+          id: 'query-1',
+          name: 'Airport',
+          type: VariableType.Query,
+          current: ['YOW'],
+          query: 'source = flights | dedup DestAirportID',
+          language: 'PPL',
+          dataset: {
+            id: 'dataset-1',
+            title: 'opensearch_dashboards_sample_data_flights',
+            type: 'INDEX_PATTERN',
+          },
+          valueField: 'DestAirportID',
+          labelField: 'Dest',
+        },
+      ],
+    };
+
+    const basePath = '/base';
+    const history = scopedHistoryMock.create({
+      pathname: basePath,
+    });
+
+    updateStateUrl({
+      osdUrlStateStorage,
+      state: stateWithVariables,
+      scopedHistory: history,
+      replace: true,
+    });
+
+    const { panels, variables, ...stateWithoutPanelsAndVariables } = stateWithVariables;
+    expect(osdUrlStateStorage.set).toHaveBeenCalledWith(
+      '_a',
+      {
+        ...stateWithoutPanelsAndVariables,
+        variables: [
+          { id: 'custom-1', current: ['ios'] },
+          { id: 'query-1', current: ['YOW'] },
+        ],
+      },
+      {
+        replace: true,
+      }
+    );
+  });
+
   test('preserve Dashboards scoped history state', () => {
     const basePath = '/base';
     const someState = { some: 'state' };
@@ -198,6 +268,161 @@ describe('updateStateUrl', () => {
   });
 });
 
+describe('hydrateDashboardAppState variable URL state', () => {
+  const savedVariables: [CustomVariable, QueryVariable] = [
+    {
+      id: 'custom-1',
+      name: 'OS',
+      type: VariableType.Custom,
+      current: ['win'],
+      customOptions: [
+        { value: 'win', label: 'Windows' },
+        { value: 'ios', label: 'Apple iOS' },
+      ],
+    },
+    {
+      id: 'query-1',
+      name: 'Airport',
+      type: VariableType.Query,
+      current: ['PVG'],
+      query: 'source = flights | dedup DestAirportID',
+      language: 'PPL',
+      dataset: {
+        id: 'dataset-1',
+        title: 'opensearch_dashboards_sample_data_flights',
+        type: 'INDEX_PATTERN',
+      },
+      valueField: 'DestAirportID',
+      labelField: 'Dest',
+    },
+  ];
+
+  test('applies compact URL current values to saved variable definitions', () => {
+    const result = hydrateDashboardAppState(
+      {
+        ...dashboardAppStateStub,
+        variables: savedVariables,
+      },
+      {
+        viewMode: ViewMode.VIEW,
+        variables: [
+          { id: 'custom-1', current: ['ios'] },
+          { id: 'query-1', current: ['YOW'] },
+        ],
+      }
+    );
+
+    expect(result.variables).toEqual([
+      {
+        ...savedVariables[0],
+        current: ['ios'],
+      },
+      {
+        ...savedVariables[1],
+        current: ['YOW'],
+      },
+    ]);
+  });
+
+  test('keeps saved variable definitions when URL has no variable overrides', () => {
+    const result = hydrateDashboardAppState(
+      {
+        ...dashboardAppStateStub,
+        variables: savedVariables,
+      },
+      {
+        viewMode: ViewMode.VIEW,
+      }
+    );
+
+    expect(result.variables).toEqual(savedVariables);
+  });
+
+  test('applies compact URL current values to current variable definitions when provided', () => {
+    const currentVariables: Variable[] = [
+      {
+        ...savedVariables[0],
+        customOptions: [
+          { value: 'linux', label: 'Linux' },
+          { value: 'ios', label: 'Apple iOS' },
+        ],
+      },
+      savedVariables[1],
+    ];
+
+    const result = hydrateDashboardAppState(
+      {
+        ...dashboardAppStateStub,
+        variables: savedVariables,
+      },
+      {
+        viewMode: ViewMode.VIEW,
+        variables: [{ id: 'custom-1', current: ['linux'] }],
+      },
+      undefined,
+      currentVariables
+    );
+
+    expect(result.variables).toEqual([
+      {
+        ...currentVariables[0],
+        current: ['linux'],
+      },
+      currentVariables[1],
+    ]);
+  });
+
+  test('applies current values from legacy full variables in URL state', () => {
+    const legacyUrlVariable = {
+      ...savedVariables[1],
+      current: ['YOW'],
+      query: 'source = flights | dedup Dest',
+      valueField: 'Dest',
+      labelField: undefined,
+    };
+
+    const result = hydrateDashboardAppState(
+      {
+        ...dashboardAppStateStub,
+        variables: savedVariables,
+      },
+      {
+        viewMode: ViewMode.VIEW,
+        variables: [legacyUrlVariable],
+      }
+    );
+
+    expect(result.variables).toEqual([
+      savedVariables[0],
+      {
+        ...savedVariables[1],
+        current: ['YOW'],
+      },
+    ]);
+  });
+
+  test('ignores URL entries that do not match saved variables', () => {
+    const deletedLegacyUrlVariable: QueryVariable = {
+      ...savedVariables[1],
+      id: 'deleted-query',
+      current: ['value'],
+    };
+
+    const result = hydrateDashboardAppState(
+      {
+        ...dashboardAppStateStub,
+        variables: savedVariables,
+      },
+      {
+        viewMode: ViewMode.VIEW,
+        variables: [{ id: 'missing', current: ['value'] }, deletedLegacyUrlVariable],
+      }
+    );
+
+    expect(result.variables).toEqual(savedVariables);
+  });
+});
+
 describe('panels preservation logic in URL sync', () => {
   /**
    * This test suite verifies the fix for the bug where panels were being reset
@@ -214,16 +439,7 @@ describe('panels preservation logic in URL sync', () => {
 
   // Helper to simulate the set function logic from createDashboardGlobalAndAppState
   const simulateSetFunction = (state: any, stateDefaults: any, currentPanels: any[]) => {
-    if (!state) {
-      return null; // Don't set anything for null state
-    }
-
-    // This simulates the logic in create_dashboard_app_state.tsx lines 105-109
-    return {
-      ...stateDefaults,
-      ...state,
-      panels: state.panels ?? currentPanels, // The bug fix
-    };
+    return state ? hydrateDashboardAppState(stateDefaults, state, currentPanels) : null;
   };
 
   test('should preserve current panels when URL state has no panels field (VIEW mode)', () => {
@@ -235,7 +451,7 @@ describe('panels preservation logic in URL sync', () => {
     const urlState = {
       viewMode: ViewMode.VIEW,
       title: 'Test Dashboard',
-      variables: [{ id: 'var1', name: 'test', current: ['value1'] }],
+      variables: [{ id: 'var1', current: ['value1'] }],
       // panels field is missing
     };
 
@@ -245,7 +461,7 @@ describe('panels preservation logic in URL sync', () => {
     expect(result?.panels).toEqual(currentPanels);
     expect(result?.panels).not.toEqual(initialPanels);
     expect(result?.viewMode).toBe(ViewMode.VIEW);
-    expect(result?.variables).toEqual(urlState.variables);
+    expect(result?.variables).toEqual(stateDefaults.variables);
   });
 
   test('should use panels from URL state when explicitly provided (EDIT mode)', () => {
@@ -284,7 +500,7 @@ describe('panels preservation logic in URL sync', () => {
     const urlStateAfterVariableChange = {
       viewMode: ViewMode.VIEW,
       title: 'Test Dashboard',
-      variables: [{ id: 'var1', name: 'region', current: ['us-west'] }],
+      variables: [{ id: 'var1', current: ['us-west'] }],
       // panels field is missing (VIEW mode excludes them from URL)
     };
 

--- a/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx
+++ b/src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx
@@ -15,11 +15,13 @@ import {
   DashboardAppStateTransitions,
   DashboardAppStateInUrl,
   DashboardServices,
+  DashboardVariableUrlState,
 } from '../../types';
 import { ViewMode } from '../../../../embeddable/public';
 import { getDashboardIdFromUrl } from '../utils';
 import { syncQueryStateWithUrl } from '../../../../data/public';
 import { SavedObjectDashboard } from '../../saved_dashboards';
+import { Variable } from '../../variables/types';
 
 const APP_STATE_STORAGE_KEY = '_a';
 
@@ -36,7 +38,7 @@ export const createDashboardGlobalAndAppState = ({
   services,
   savedDashboardInstance,
 }: Arguments) => {
-  const urlState = osdUrlStateStorage.get<DashboardAppState>(APP_STATE_STORAGE_KEY);
+  const urlState = osdUrlStateStorage.get<DashboardAppStateInUrl>(APP_STATE_STORAGE_KEY);
   const {
     opensearchDashboardsVersion,
     usageCollection,
@@ -53,10 +55,7 @@ export const createDashboardGlobalAndAppState = ({
   2. Update the version number on each panel to the current version.
   */
   const initialState = migrateAppState(
-    {
-      ...stateDefaults,
-      ...urlState,
-    },
+    hydrateDashboardAppState(stateDefaults, urlState),
     opensearchDashboardsVersion,
     usageCollection
   );
@@ -105,11 +104,15 @@ export const createDashboardGlobalAndAppState = ({
           // In VIEW mode, toUrlState() excludes panels from URL to keep URLs clean.
           // When syncing URL back to state, preserve current panels if URL state doesn't include them.
           // This prevents panels from being reset to stateDefaults after variable changes in VIEW mode.
-          stateContainer.set({
-            ...stateDefaults,
-            ...state,
-            panels: state.panels ?? stateContainer.getState().panels,
-          });
+          const currentState = stateContainer.getState();
+          stateContainer.set(
+            hydrateDashboardAppState(
+              stateDefaults,
+              state,
+              currentState.panels,
+              currentState.variables
+            )
+          );
         } else {
           // TODO: This logic was ported over this but can be handled more gracefully and intentionally
           // Sync from state url should be refactored within this application. The app is syncing from
@@ -141,6 +144,49 @@ export const createDashboardGlobalAndAppState = ({
   // start syncing the appState with the ('_a') url
   startStateSync();
   return { stateContainer, stopStateSync, stopSyncingQueryServiceStateWithUrl };
+};
+
+const hydrateVariablesFromUrl = (
+  defaultVariables: Variable[] | undefined,
+  urlVariables: DashboardVariableUrlState[] | undefined
+): Variable[] | undefined => {
+  if (!urlVariables || !defaultVariables) {
+    return defaultVariables;
+  }
+
+  const urlVariablesById = new Map(urlVariables.map((variable) => [variable.id, variable]));
+  return defaultVariables.map((variable) => {
+    const urlVariable = urlVariablesById.get(variable.id);
+    if (!urlVariable) {
+      return variable;
+    }
+
+    return {
+      ...variable,
+      current: urlVariable.current,
+    };
+  });
+};
+
+export const hydrateDashboardAppState = (
+  stateDefaults: DashboardAppState,
+  urlState?: Partial<DashboardAppStateInUrl> | null,
+  currentPanels?: DashboardAppState['panels'],
+  currentVariables?: Variable[]
+): DashboardAppState => {
+  if (!urlState) {
+    return stateDefaults;
+  }
+
+  const { variables, panels, ...urlStateWithoutVariablesAndPanels } = urlState;
+  const baseVariables = currentVariables ?? stateDefaults.variables;
+
+  return {
+    ...stateDefaults,
+    ...urlStateWithoutVariablesAndPanels,
+    panels: panels ?? currentPanels ?? stateDefaults.panels,
+    variables: hydrateVariablesFromUrl(baseVariables, variables),
+  };
 };
 
 /**
@@ -176,20 +222,19 @@ export const updateStateUrl = ({
 };
 
 const toUrlState = (state: DashboardAppState): DashboardAppStateInUrl => {
-  // TODO: Store only variable current-value overrides in the URL instead of
-  // serializing full variable definitions. The full definitions belong in
-  // variablesJSON; URL state should stay compact while preserving shareable
-  // variable selections.
   // Only include variables in URL when they have actual content.
   // Excluding `undefined` / empty avoids rison round-trip issues where
   // undefined values are dropped during encoding, causing applyDiff to
   // treat the missing key as a removal and trigger spurious dirty flags.
   const { variables, ...stateWithoutVariables } = state;
   const hasVariables = variables && variables.length > 0;
+  const variableUrlState = variables?.map(({ id, current }) => ({ id, current }));
 
   if (state.viewMode === ViewMode.VIEW) {
     const { panels, ...rest } = stateWithoutVariables;
-    return hasVariables ? { ...rest, variables } : rest;
+    return hasVariables ? { ...rest, variables: variableUrlState } : rest;
   }
-  return hasVariables ? { ...stateWithoutVariables, variables } : stateWithoutVariables;
+  return hasVariables
+    ? { ...stateWithoutVariables, variables: variableUrlState }
+    : stateWithoutVariables;
 };

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -132,11 +132,21 @@ export type DashboardAppStateDefaults = DashboardAppState & {
 };
 
 /**
+ * Compact variable state stored in the URL. Full variable definitions are
+ * persisted in dashboard saved objects, while URL state only shares selections.
+ */
+export interface DashboardVariableUrlState {
+  id: string;
+  current?: string[];
+}
+
+/**
  * In URL panels are optional,
  * Panels are not added to the URL when in "view" mode
  */
-export type DashboardAppStateInUrl = Omit<DashboardAppState, 'panels'> & {
+export type DashboardAppStateInUrl = Omit<DashboardAppState, 'panels' | 'variables'> & {
   panels?: SavedDashboardPanel[];
+  variables?: DashboardVariableUrlState[];
 };
 
 export interface DashboardAppStateTransitions {

--- a/src/plugins/dashboard/public/variables/variable_option_display_utils.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_option_display_utils.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildVariableOptionDisplayTextMap,
+  getVariableOptionDisplayText,
+} from './variable_option_display_utils';
+
+describe('variable option display utils', () => {
+  it('should display unique labels as labels', () => {
+    const options = [
+      { value: 'dev', label: 'Development' },
+      { value: 'prod', label: 'Production' },
+    ];
+    const displayTextMap = buildVariableOptionDisplayTextMap(options);
+
+    expect(getVariableOptionDisplayText(options[0], displayTextMap)).toBe('Development');
+    expect(getVariableOptionDisplayText(options[1], displayTextMap)).toBe('Production');
+  });
+
+  it('should append values when display labels are duplicated', () => {
+    const options = [
+      { value: 'dev-us', label: 'Development' },
+      { value: 'dev-eu', label: 'Development' },
+      { value: 'prod', label: 'Production' },
+    ];
+    const displayTextMap = buildVariableOptionDisplayTextMap(options);
+
+    expect(getVariableOptionDisplayText(options[0], displayTextMap)).toBe('Development (dev-us)');
+    expect(getVariableOptionDisplayText(options[1], displayTextMap)).toBe('Development (dev-eu)');
+    expect(getVariableOptionDisplayText(options[2], displayTextMap)).toBe('Production');
+  });
+
+  it('should fall back to values when labels are empty', () => {
+    const options = [
+      { value: 'dev', label: '' },
+      { value: 'prod', label: '   ' },
+    ];
+    const displayTextMap = buildVariableOptionDisplayTextMap(options);
+
+    expect(getVariableOptionDisplayText(options[0], displayTextMap)).toBe('dev');
+    expect(getVariableOptionDisplayText(options[1], displayTextMap)).toBe('prod');
+  });
+
+  it('should disambiguate duplicate visible text after label fallback', () => {
+    const options = [{ value: 'dev' }, { value: 'prod', label: 'dev' }];
+    const displayTextMap = buildVariableOptionDisplayTextMap(options);
+
+    expect(getVariableOptionDisplayText(options[0], displayTextMap)).toBe('dev');
+    expect(getVariableOptionDisplayText(options[1], displayTextMap)).toBe('dev (prod)');
+  });
+});

--- a/src/plugins/dashboard/public/variables/variable_option_display_utils.ts
+++ b/src/plugins/dashboard/public/variables/variable_option_display_utils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NormalizedVariableOption } from './types';
+
+const getBaseDisplayText = (option: NormalizedVariableOption): string =>
+  option.label?.trim() || option.value;
+
+const hasDisplayLabel = (option: NormalizedVariableOption): boolean => Boolean(option.label?.trim());
+
+export const buildVariableOptionDisplayTextMap = (
+  options: NormalizedVariableOption[]
+): Map<string, string> => {
+  const displayTextCounts = new Map<string, number>();
+
+  options.forEach((option) => {
+    const displayText = getBaseDisplayText(option);
+    displayTextCounts.set(displayText, (displayTextCounts.get(displayText) ?? 0) + 1);
+  });
+
+  return new Map(
+    options.map((option) => {
+      const displayText = getBaseDisplayText(option);
+      const hasDuplicateDisplayText = (displayTextCounts.get(displayText) ?? 0) > 1;
+
+      return [
+        option.value,
+        hasDuplicateDisplayText && hasDisplayLabel(option)
+          ? `${displayText} (${option.value})`
+          : displayText,
+      ];
+    })
+  );
+};
+
+export const getVariableOptionDisplayText = (
+  option: NormalizedVariableOption,
+  displayTextMap: Map<string, string>
+): string => displayTextMap.get(option.value) ?? getBaseDisplayText(option);

--- a/src/plugins/dashboard/public/variables/variable_option_display_utils.ts
+++ b/src/plugins/dashboard/public/variables/variable_option_display_utils.ts
@@ -8,7 +8,8 @@ import { NormalizedVariableOption } from './types';
 const getBaseDisplayText = (option: NormalizedVariableOption): string =>
   option.label?.trim() || option.value;
 
-const hasDisplayLabel = (option: NormalizedVariableOption): boolean => Boolean(option.label?.trim());
+const hasDisplayLabel = (option: NormalizedVariableOption): boolean =>
+  Boolean(option.label?.trim());
 
 export const buildVariableOptionDisplayTextMap = (
   options: NormalizedVariableOption[]


### PR DESCRIPTION
### Description

Compact dashboard variable URL state and improve variable option labels.

### What Changed

- Dashboard URLs now store only variable selections as `{ id, current }`.
- Full variable definitions stay in saved dashboard `variablesJSON`.
- URL selections are hydrated back onto saved/current variables by `id`.
- Deleted or unknown URL variables are ignored.

### Label Display

- Duplicate option labels now render as `Label (value)`.
- Unique labels still render as just `Label`.
- This applies to dropdowns, selected value text, and query preview badges.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
