### PR TITLE
fix(workspace): split configUsers and configGroups string by comma, space, or tab

### DIFF
--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -135,6 +135,46 @@ describe('workspace utils', () => {
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(false);
   });
 
+  it('should split configUsers string by comma', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['user2'];
+    const configGroups: string[] = [];
+    const configUsers = 'user1,user2' as unknown as string[];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should split configUsers string by space', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['user2'];
+    const configGroups: string[] = [];
+    const configUsers = 'user1 user2' as unknown as string[];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should split configGroups string by comma', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = ['group2'];
+    const users: string[] = [];
+    const configGroups = 'group1,group2' as unknown as string[];
+    const configUsers: string[] = [];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should split configGroups string by space', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = ['group2'];
+    const users: string[] = [];
+    const configGroups = 'group1 group2' as unknown as string[];
+    const configUsers: string[] = [];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
   it('should not crash when configUsers or configGroups is null or undefined', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
     const groups: string[] = [];

--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -175,6 +175,26 @@ describe('workspace utils', () => {
     expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
   });
 
+  it('should split configUsers string by tab', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = [];
+    const users: string[] = ['user2'];
+    const configGroups: string[] = [];
+    const configUsers = 'user1\tuser2' as unknown as string[];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
+  it('should split configGroups string by tab', () => {
+    const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+    const groups: string[] = ['group2'];
+    const users: string[] = [];
+    const configGroups = 'group1\tgroup2' as unknown as string[];
+    const configUsers: string[] = [];
+    updateDashboardAdminStateForRequest(mockRequest, groups, users, configGroups, configUsers);
+    expect(getWorkspaceState(mockRequest)?.isDashboardAdmin).toBe(true);
+  });
+
   it('should not crash when configUsers or configGroups is null or undefined', () => {
     const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
     const groups: string[] = [];

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -40,12 +40,18 @@ export const updateDashboardAdminStateForRequest = (
   const normalizedConfigUsers = Array.isArray(configUsers)
     ? configUsers
     : configUsers
-      ? [configUsers]
+      ? configUsers
+          .trim()
+          .split(/[\s,]+/)
+          .filter(Boolean)
       : [];
   const normalizedConfigGroups = Array.isArray(configGroups)
     ? configGroups
     : configGroups
-      ? [configGroups]
+      ? configGroups
+          .trim()
+          .split(/[\s,]+/)
+          .filter(Boolean)
       : [];
   // If the security plugin is not installed, login defaults to OSD Admin
   if (!groups.length && !users.length) {


### PR DESCRIPTION
### Description

`updateDashboardAdminStateForRequest` accepts `configUsers` and `configGroups` as `string | string[]` to accommodate YAML config values, but previously treated a plain string as a single entry. This fix splits a string value by commas, spaces, and tabs so that multi-value config entries like `"user1, user2"` or `"group1 group2"` are handled correctly.

### Issues Resolved

<!-- List any issues this PR will resolve. -->

## Screenshot

## Testing the changes

1. Run `yarn test:jest src/plugins/workspace/server/utils.test.ts` — all 29 tests should pass, including the new comma/space/tab delimiter cases.
2. Configure `opensearch_dashboards.yml` with a space- or comma-separated `opensearch_security.multitenancy.tenants.preferred` (or equivalent admin users/groups config) and verify the dashboard admin state is correctly resolved.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff