### PR TITLE
[Bug] Workspace title breadcrumb lands on feature-flag-disabled page

### DIFF
--- a/src/plugins/workspace/public/utils.test.ts
+++ b/src/plugins/workspace/public/utils.test.ts
@@ -692,6 +692,44 @@ describe('workspace utils: prependWorkspaceToBreadcrumbs', () => {
       />
     `);
   });
+
+  it('workspace breadcrumb onClick skips feature-flag-disabled nav links', () => {
+    const navGroupSearch = {
+      id: 'search',
+      title: 'Search',
+      description: 'search desc',
+      // `alerting` is registered first but flagged off; the breadcrumb must
+      // fall through to `dashboards` instead of landing on the hidden page.
+      navLinks: [{ id: 'alerting' }, { id: 'dashboards' }],
+    };
+
+    const coreStart = coreMock.createStart();
+    (coreStart.application.applications$ as BehaviorSubject<Map<string, PublicAppInfo>>).next(
+      new Map<string, PublicAppInfo>([
+        [
+          'alerting',
+          {
+            status: AppStatus.accessible,
+            navLinkStatus: AppNavLinkStatus.hidden,
+          } as Partial<PublicAppInfo> as PublicAppInfo,
+        ],
+        [
+          'dashboards',
+          {
+            status: AppStatus.accessible,
+            navLinkStatus: AppNavLinkStatus.default,
+          } as Partial<PublicAppInfo> as PublicAppInfo,
+        ],
+      ])
+    );
+
+    prependWorkspaceToBreadcrumbs(coreStart, workspace, { search: navGroupSearch }, []);
+    const enricher = coreStart.chrome.setBreadcrumbsEnricher.mock.calls[0][0];
+    const workspaceBreadcrumb = enricher?.([{ text: 'test app' }])?.[0];
+
+    workspaceBreadcrumb?.onClick?.({} as any);
+    expect(coreStart.application.navigateToApp).toHaveBeenCalledWith('dashboards');
+  });
 });
 
 describe('workspace utils: mergeDataSourcesWithConnections', () => {

--- a/src/plugins/workspace/public/utils.ts
+++ b/src/plugins/workspace/public/utils.ts
@@ -509,7 +509,16 @@ export function prependWorkspaceToBreadcrumbs(
       onClick: () => {
         if (useCase) {
           const allNavGroups = navGroupsMap[useCase];
-          core.application.navigateToApp(allNavGroups?.navLinks[0].id);
+          // Mirror the post-create redirect and `getUseCaseUrl`: skip
+          // feature-flag-disabled nav links (registered but hidden, e.g.
+          // alerting when `observability.alertManager.enabled` is false)
+          // instead of blindly landing on `navLinks[0]`. Falls back to the
+          // first nav link when no snapshot is available or none qualify.
+          const apps = getApplicationsSnapshot(core.application);
+          const landingAppId = pickUseCaseLandingAppId(allNavGroups?.navLinks, apps);
+          if (landingAppId) {
+            core.application.navigateToApp(landingAppId);
+          }
         }
       },
     };


### PR DESCRIPTION
## Description

Fixed no longer going to alert page:

https://github.com/user-attachments/assets/64e19563-21b4-4ff9-a3a5-7451d7e249ae


Follow-up fix to #12260. That PR fixed the post-create redirect and `getUseCaseUrl` so they no longer land on a hidden, feature-flag-disabled app (most visibly the Alerting page when `observability.alertManager.enabled: false`). One navigation path was missed: clicking the **workspace title breadcrumb** (the top link, e.g. **"Observability Stack"**) still navigated to the hidden Alerting page.

## Root cause

There are multiple places that resolve the landing app for a workspace use case. #12260 fixed the two in `workspace_creator.tsx` and `getUseCaseUrl`, but the workspace breadcrumb built in `prependWorkspaceToBreadcrumbs` (`src/plugins/workspace/public/utils.ts`) still indexed the first registered nav link directly:

```ts
onClick: () => {
  const allNavGroups = navGroupsMap[useCase];
  core.application.navigateToApp(allNavGroups?.navLinks[0].id);
}
```

`dashboards-observability` uses a register-then-hide pattern: the Alerting app and its nav-group entry are always registered during `setup()`, then hidden during `start()` via `AppNavLinkStatus.hidden` when `observability.alertManager.enabled` is `false`.

Because `navLinks[0]` has no awareness of which applications are actually visible, a hidden-but-registered feature could still be selected as the landing app when the breadcrumb was clicked. This is the same class of issue that #12260 fixed (`features[0]`), just on a separate navigation path that PR did not update.

The issue was most visible with `enableIconSideNav: true`, where Alerting is registered ahead of most other applications (`order: 50`), making it `navLinks[0]` whenever its nav link exists.

## Fix

The breadcrumb `onClick` now reuses the same helpers introduced in #12260 instead of directly indexing `navLinks[0]`:

- `getApplicationsSnapshot(core.application)` — obtains a synchronous snapshot of `application.applications$` (safe because the upstream observable uses `shareReplay(1)`).
- `pickUseCaseLandingAppId(navLinks, apps)` — selects the first nav link that is **not** feature-flag-disabled, falling back to the first link if no application snapshot is available or no better candidate exists.

This keeps all three navigation paths consistent:

- Post-create redirect
- `getUseCaseUrl`
- Workspace breadcrumb

It also correctly distinguishes between feature-flag-disabled applications and applications that are only temporarily hidden because the user is outside a workspace:

| `navLinkStatus` | `status` | Meaning | Skip? |
| --- | --- | --- | :---: |
| `hidden` | `accessible` | Feature-flag-disabled by the plugin | ✅ Yes |
| `hidden` | `inaccessible` | Temporarily hidden (outside a workspace) | ❌ No |
| `visible/default` | `inaccessible` | Hidden by workspace access rules | ❌ No |
| `visible/default` | `accessible` | Normal case | ❌ No |

`ChromeRegistrationNavLink` (the type used by `navGroupsMap[useCase].navLinks`) is structurally compatible with `WorkspaceUseCaseFeature`—both expose `id` and an optional `title`, and `pickUseCaseLandingAppId` only reads the `id`. No additional type plumbing was required.

## Changes

### `src/plugins/workspace/public/utils.ts`

- Updated `prependWorkspaceToBreadcrumbs` so the breadcrumb `onClick` resolves the landing app using `getApplicationsSnapshot()` and `pickUseCaseLandingAppId()` instead of `navLinks[0].id`.
- Safely no-ops if no landing application can be resolved.

### `src/plugins/workspace/public/utils.test.ts`

- Added a regression test verifying that the workspace breadcrumb skips feature-flag-disabled nav links.
- Configures Alerting as registered first but hidden (`hidden + accessible`) and verifies the breadcrumb navigates to Dashboards instead of the hidden Alerting app.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
