### PR TITLE
Hide system indices toggle for OpenSearch Serverless datasources

### DIFF
--- a/src/plugins/dataset_management/public/components/create_dataset_wizard/create_dataset_wizard.tsx
+++ b/src/plugins/dataset_management/public/components/create_dataset_wizard/create_dataset_wizard.tsx
@@ -49,6 +49,7 @@ interface CreateDatasetWizardState {
   allIndices: MatchedItem[];
   remoteClustersExist: boolean;
   isInitiallyLoadingIndices: boolean;
+  isServerlessDatasource: boolean;
   toasts: EuiGlobalToastListToast[];
   datasetCreationType: DatasetCreationConfig;
   selectedTimeField?: string;
@@ -82,6 +83,7 @@ export class CreateDatasetWizard extends Component<RouteComponentProps, CreateDa
       allIndices: [],
       remoteClustersExist: false,
       isInitiallyLoadingIndices,
+      isServerlessDatasource: false,
       toasts: [],
       datasetCreationType: context.services.datasetManagementStart.creation.getType(type),
       docLinks: context.services.docLinks,
@@ -114,6 +116,20 @@ export class CreateDatasetWizard extends Component<RouteComponentProps, CreateDa
         ]),
       }));
       return errorValue;
+    }
+  };
+
+  checkIfServerlessDatasource = async (dataSourceRef: DataSourceRef) => {
+    try {
+      const dataSource = await this.context.services.savedObjects.client.get(
+        'data-source',
+        dataSourceRef.id
+      );
+      const isServerless =
+        (dataSource.attributes as any).dataSourceEngineType === 'OpenSearch Serverless';
+      this.setState({ isServerlessDatasource: isServerless });
+    } catch {
+      this.setState({ isServerlessDatasource: false });
     }
   };
 
@@ -241,6 +257,7 @@ export class CreateDatasetWizard extends Component<RouteComponentProps, CreateDa
 
   goToNextFromDataSource = (dataSourceRef: DataSourceRef) => {
     this.setState({ isInitiallyLoadingIndices: true, dataSourceRef }, async () => {
+      this.checkIfServerlessDatasource(dataSourceRef);
       this.fetchData();
       this.goToNextStep();
     });
@@ -357,7 +374,8 @@ export class CreateDatasetWizard extends Component<RouteComponentProps, CreateDa
           goToNextStep={this.goToNextFromDataset}
           showSystemIndices={
             this.state.datasetCreationType.getShowSystemIndices() &&
-            this.state.step === INDEX_PATTERN_STEP
+            this.state.step === INDEX_PATTERN_STEP &&
+            !this.state.isServerlessDatasource
           }
           dataSourceRef={dataSourceRef}
           stepInfo={stepInfo}

--- a/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
+++ b/src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/create_index_pattern_wizard.tsx
@@ -74,6 +74,7 @@ interface CreateIndexPatternWizardState {
   allIndices: MatchedItem[];
   remoteClustersExist: boolean;
   isInitiallyLoadingIndices: boolean;
+  isServerlessDatasource: boolean;
   toasts: EuiGlobalToastListToast[];
   indexPatternCreationType: IndexPatternCreationConfig;
   selectedTimeField?: string;
@@ -111,6 +112,7 @@ export class CreateIndexPatternWizard extends Component<
       allIndices: [],
       remoteClustersExist: false,
       isInitiallyLoadingIndices,
+      isServerlessDatasource: false,
       toasts: [],
       indexPatternCreationType: context.services.indexPatternManagementStart.creation.getType(type),
       docLinks: context.services.docLinks,
@@ -143,6 +145,20 @@ export class CreateIndexPatternWizard extends Component<
         ]),
       }));
       return errorValue;
+    }
+  };
+
+  checkIfServerlessDatasource = async (dataSourceRef: DataSourceRef) => {
+    try {
+      const dataSource = await this.context.services.savedObjects.client.get(
+        'data-source',
+        dataSourceRef.id
+      );
+      const isServerless =
+        (dataSource.attributes as any).dataSourceEngineType === 'OpenSearch Serverless';
+      this.setState({ isServerlessDatasource: isServerless });
+    } catch {
+      this.setState({ isServerlessDatasource: false });
     }
   };
 
@@ -276,6 +292,7 @@ export class CreateIndexPatternWizard extends Component<
 
   goToNextFromDataSource = (dataSourceRef: DataSourceRef) => {
     this.setState({ isInitiallyLoadingIndices: true, dataSourceRef }, async () => {
+      this.checkIfServerlessDatasource(dataSourceRef);
       this.fetchData();
       this.goToNextStep();
     });
@@ -392,7 +409,8 @@ export class CreateIndexPatternWizard extends Component<
           goToNextStep={this.goToNextFromIndexPattern}
           showSystemIndices={
             this.state.indexPatternCreationType.getShowSystemIndices() &&
-            this.state.step === INDEX_PATTERN_STEP
+            this.state.step === INDEX_PATTERN_STEP &&
+            !this.state.isServerlessDatasource
           }
           dataSourceRef={dataSourceRef}
           stepInfo={stepInfo}


### PR DESCRIPTION
### Description

When a user selects an OpenSearch Serverless collection as a datasource, the "Include system and hidden indices" toggle is now hidden. Serverless collections do not support the `expand_wildcards` parameter, which causes index pattern creation to fail with a 400 error when the toggle is enabled.

The fix adds a `checkIfServerlessDatasource` method that fetches the datasource's saved object and checks the `dataSourceEngineType` attribute. When it equals `'OpenSearch Serverless'`, the `showSystemIndices` prop is set to `false`, hiding the toggle entirely.

Changes:
- `index_pattern_management`: `create_index_pattern_wizard.tsx`
- `dataset_management`: `create_dataset_wizard.tsx`

Both plugins receive the same fix. The check is wrapped in `try/catch` so it gracefully falls back to showing the toggle if the lookup fails. No new plugin dependencies are required. The code path only executes when the `data_source` plugin is installed (toggle is unreachable otherwise).

### Issues Resolved

<!-- Create a GitHub issue and link it here -->
<!-- fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/XXXX -->

## Testing the changes

1. Connect to an OpenSearch Serverless collection as a datasource
2. Navigate to Index Patterns → Create index pattern
3. Verify the "Include system and hidden indices" toggle is **not shown**
4. Enter a wildcard pattern (e.g., `otel-*`) and verify index resolution succeeds without 400 error
5. Switch to a domain datasource and verify the toggle **is shown** as before
6. Enable the toggle with a domain datasource and verify it still works normally

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

---

**Note:** You'll need to replace the screenshot URLs with GitHub-hosted images (upload them directly in the PR description editor on GitHub) since the Drive links won't be accessible publicly. Also create a GitHub issue first and link it in the "Issues Resolved" section.