### PR TITLE
fix(input_control_vis): make list control search case-insensitive

### DIFF
--- a/changelogs/fragments/11951.yml
+++ b/changelogs/fragments/11951.yml
@@ -1,0 +1,2 @@
+fix:
+- Make list control dynamic options search case-insensitive so values like "Seattle" are found when searching "seattle" ([#11951](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11951))

--- a/src/plugins/input_control_vis/public/control/list_control_factory.test.ts
+++ b/src/plugins/input_control_vis/public/control/list_control_factory.test.ts
@@ -115,6 +115,19 @@ describe('listControlFactory', () => {
         'Xi an Xianyang International Airport',
       ]);
     });
+
+    test.each(['seattle', 'Seattle', 'SEATTLE', 'SeaTtle'])(
+      'should build the same case-insensitive include pattern regardless of query casing: %s',
+      async (query) => {
+        await listControl.fetch(query);
+        const searchSourceInstance =
+          await searchSourceMock.mock.results[searchSourceMock.mock.results.length - 1].value;
+        const aggsCall = searchSourceInstance.setField.mock.calls.find(
+          ([field]: [string]) => field === 'aggs'
+        );
+        expect(aggsCall[1].termsAgg.terms.include).toEqual('.*[sS][eE][aA][tT][tT][lL][eE].*');
+      }
+    );
   });
 
   describe('fetch with ancestors', () => {

--- a/src/plugins/input_control_vis/public/control/list_control_factory.ts
+++ b/src/plugins/input_control_vis/public/control/list_control_factory.ts
@@ -47,6 +47,13 @@ function getEscapedQuery(query = '') {
   return query.replace(/[.?+*|{}[\]()"\\#@&<>~]/g, (match) => `\\${match}`);
 }
 
+function getCaseInsensitiveQuery(query = '') {
+  // Lucene regexp has no case-insensitive flag; expand letters into [aA] classes instead.
+  return getEscapedQuery(query).replace(/[a-zA-Z]/g, (match) => {
+    return `[${match.toLowerCase()}${match.toUpperCase()}]`;
+  });
+}
+
 interface TermsAggArgs {
   field?: IFieldType;
   size: number | null;
@@ -76,7 +83,7 @@ const termsAgg = ({ field, size, direction, query }: TermsAggArgs) => {
   }
 
   if (query) {
-    terms.include = `.*${getEscapedQuery(query)}.*`;
+    terms.include = `.*${getCaseInsensitiveQuery(query)}.*`;
   }
 
   return {


### PR DESCRIPTION
### Description

The list control's dynamic options search (used by the Controls visualization dropdown) builds a Lucene regexp `include` pattern from the user's search query. Lucene regexp has no inline case-insensitive flag, so the search was case-sensitive — searching `seattle` would not match a value like `Seattle`.

This change expands each letter of the query into a character class (e.g. s → [sS]) before building the `include` pattern, so the dropdown search now matches regardless of casing, while still reusing the existing special-character escaping (`getEscapedQuery`).

### Issues Resolved

Fixes #11951

## Screenshot
Before: Searching `Seattle` returns no matches, even though `seattle` exists in the index (case-sensitive include regex).
After: Searching `Seattle` matches `seattle` regardless of casing.

<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/8fe2cf8f-9e1a-41f4-8982-1fa7807df77e" />  -> <img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/5c2301f8-ba2b-4a39-8016-13a01afa5f86" />


## Testing the changes

1. Create an index pattern with a string field containing mixed-case values (e.g. `Seattle`).
2. Add a Controls visualization with a "List" control on that field, with "Update Options only on demand" / dynamic options enabled.
3. Type `seattle`, `SEATTLE`, or `SeaTtle` into the control's search box.
4. Confirm `Seattle` appears in the dropdown results regardless of the casing typed.

Also covered by unit tests in `list_control_factory.test.ts`, which assert the same include pattern is generated for `seattle`, `Seattle`, `SEATTLE`, and `SeaTtle`.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
