### PR TITLE
feat(explore): Logs Drilldown onboarding canvas (RFC #12395)

### DIFF
--- a/.github/workflows/cypress_workflow.yml
+++ b/.github/workflows/cypress_workflow.yml
@@ -270,6 +270,9 @@ jobs:
           - group: 23Explore
             config: explore
             test_location: source
+          - group: 24Explore
+            config: explore
+            test_location: source
           # Dashboard tests that require workspace and data source support
           - group: Dashboards
             config: explore
@@ -288,7 +291,7 @@ jobs:
       START_CMD: ${{ matrix.config == 'query_enhanced' &&
         'node scripts/opensearch_dashboards --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true --csp.warnLegacyBrowsers=false --uiSettings.overrides["query:enhancements:enabled"]=true --uiSettings.overrides[''home:useNewHomePage'']=true --data_source.enabled=true --workspace.enabled=true --opensearch.ignoreVersionMismatch=true --data.savedQueriesNewUI.enabled=true --home.disableExperienceModal=true' ||
         matrix.config == 'explore' &&
-        'node scripts/opensearch_dashboards --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true --csp.warnLegacyBrowsers=false --uiSettings.overrides["query:enhancements:enabled"]=true --uiSettings.overrides[''home:useNewHomePage'']=true --data_source.enabled=true --workspace.enabled=true --opensearch.ignoreVersionMismatch=true --data.savedQueriesNewUI.enabled=true --explore.enabled=true --explore.discoverTraces.enabled=true --home.disableExperienceModal=true --datasetManagement.enabled=true --dashboard.variables.enabled=true' ||
+        'node scripts/opensearch_dashboards --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true --csp.warnLegacyBrowsers=false --uiSettings.overrides["query:enhancements:enabled"]=true --uiSettings.overrides[''home:useNewHomePage'']=true --data_source.enabled=true --workspace.enabled=true --opensearch.ignoreVersionMismatch=true --data.savedQueriesNewUI.enabled=true --explore.enabled=true --explore.discoverTraces.enabled=true --explore.logsDrilldown.enabled=true --home.disableExperienceModal=true --datasetManagement.enabled=true --dashboard.variables.enabled=true' ||
         matrix.config == 'observability' &&
         'node scripts/opensearch_dashboards --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true --csp.warnLegacyBrowsers=false --uiSettings.overrides["query:enhancements:enabled"]=true --uiSettings.overrides[''home:useNewHomePage'']=true --data_source.enabled=true --workspace.enabled=true --opensearch.ignoreVersionMismatch=true --data.savedQueriesNewUI.enabled=true --explore.enabled=true --explore.discoverTraces.enabled=true --home.disableExperienceModal=true --datasetManagement.enabled=true' ||
         matrix.config == 'dashboard' &&

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/24/logs_drilldown_interaction.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/24/logs_drilldown_interaction.spec.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DATASOURCE_NAME,
+  INDEX_PATTERN_WITH_TIME,
+  START_TIME,
+  END_TIME,
+} from '../../../../../../utils/apps/explore/constants';
+import {
+  getRandomizedWorkspaceName,
+  getRandomizedDatasetId,
+} from '../../../../../../utils/apps/explore/shared';
+import {
+  prepareTestSuite,
+  createWorkspaceAndDatasetUsingEndpoint,
+} from '../../../../../../utils/helpers';
+
+const workspace = getRandomizedWorkspaceName();
+const datasetId = getRandomizedDatasetId();
+
+// The drilldown canvas uses a plain EuiSuperDatePicker (not the explore query-bar), so set the absolute
+// range via the picker and click its own Apply button. (setDatePickerDatesAndSearchIfRelevant submits via
+// the query-bar's exploreQueryExecutionButton, which does not exist on this page.)
+const setWideTimeRange = () => {
+  cy.explore.setTopNavDate(START_TIME, END_TIME, false);
+  cy.getElementByTestId('superDatePickerApplyTimeButton').click({ force: true });
+  cy.getElementByTestId('globalLoadingIndicator', { timeout: 60000 }).should('not.exist');
+};
+
+// P0 #2 — one interaction on the "Explore logs" canvas: search filters the list, selecting a raw index shows
+// the selection bar and enables "Create dataset", and clicking it opens the advanced-selector modal. Stops at
+// the modal open (no save / cross-app handoff) to stay deterministic.
+const runLogsDrilldownInteractionTests = () => {
+  describe('explore logs (logs-drilldown) interaction', () => {
+    before(() => {
+      cy.osd.setupEnvAndGetDataSource(DATASOURCE_NAME);
+      createWorkspaceAndDatasetUsingEndpoint(
+        DATASOURCE_NAME,
+        workspace,
+        datasetId,
+        INDEX_PATTERN_WITH_TIME, // 'data_logs_small_time_*'
+        'timestamp',
+        'logs',
+        ['use-case-observability']
+      );
+    });
+
+    after(() => {
+      cy.osd.cleanupWorkspaceAndDataSourceAndIndices(workspace);
+    });
+
+    beforeEach(() => {
+      const workspaceId = Cypress.env(`${workspace}:WORKSPACE_ID`);
+      cy.visit(`/w/${workspaceId}/app/explore/logs-drilldown`);
+      cy.getElementByTestId('logsDrilldownPage', { timeout: 60000 }).should('be.visible');
+      // Widen the range so the fixture (data_logs_small_time_*) is in-window and cards resolve.
+      setWideTimeRange();
+      cy.get('[data-test-subj^="logsExploreCard-"]', { timeout: 60000 }).should(
+        'have.length.at.least',
+        1
+      );
+    });
+
+    it('filters the list by search term', () => {
+      cy.get('[aria-label="Search datasets and indexes"]').clear().type('data_logs');
+      // A matching card stays visible.
+      cy.get('[data-test-subj^="logsExploreCard-"]').should('have.length.at.least', 1);
+
+      // A nonsense term yields the empty state, then clearing restores the list.
+      cy.get('[aria-label="Search datasets and indexes"]').clear().type('zzz_no_such_index_zzz');
+      cy.getElementByTestId('logsExploreRowsEmpty', { timeout: 30000 }).should('be.visible');
+      cy.get('[aria-label="Search datasets and indexes"]').clear();
+      cy.get('[data-test-subj^="logsExploreCard-"]', { timeout: 30000 }).should(
+        'have.length.at.least',
+        1
+      );
+    });
+
+    it('enables Create dataset from a selected index and opens the advanced selector', () => {
+      // Select the first raw index via its per-card checkbox.
+      cy.get('[data-test-subj^="logsExploreCardCheckbox-"]', { timeout: 60000 })
+        .first()
+        .check({ force: true });
+
+      // The multi-select selection bar appears and the toolbar button enables.
+      cy.getElementByTestId('logsExploreSelectionBar').should('be.visible');
+      cy.getElementByTestId('logsExploreToolbarBatch').should('not.be.disabled');
+
+      // Clicking it opens the shared advanced-selector modal (we stop here — no save / handoff).
+      cy.getElementByTestId('logsExploreToolbarBatch').click();
+      cy.get('.datasetSelector__advancedModal', { timeout: 30000 }).should('be.visible');
+    });
+  });
+};
+
+prepareTestSuite('Explore logs interaction', runLogsDrilldownInteractionTests);

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/24/logs_drilldown_smoke.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/24/logs_drilldown_smoke.spec.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DATASOURCE_NAME,
+  INDEX_PATTERN_WITH_TIME,
+  START_TIME,
+  END_TIME,
+} from '../../../../../../utils/apps/explore/constants';
+import {
+  getRandomizedWorkspaceName,
+  getRandomizedDatasetId,
+} from '../../../../../../utils/apps/explore/shared';
+import {
+  prepareTestSuite,
+  createWorkspaceAndDatasetUsingEndpoint,
+} from '../../../../../../utils/helpers';
+
+const workspace = getRandomizedWorkspaceName();
+const datasetId = getRandomizedDatasetId();
+
+// The drilldown canvas uses a plain EuiSuperDatePicker (portaled into the app header), NOT the explore
+// query-bar. So set the absolute range via the date picker and click its own Apply/Update button — do NOT
+// use setDatePickerDatesAndSearchIfRelevant, which submits via the query-bar's exploreQueryExecutionButton
+// (absent on this page).
+const setWideTimeRange = () => {
+  cy.explore.setTopNavDate(START_TIME, END_TIME, false);
+  cy.getElementByTestId('superDatePickerApplyTimeButton').click({ force: true });
+  cy.getElementByTestId('globalLoadingIndicator', { timeout: 60000 }).should('not.exist');
+};
+
+// P0 #1 — the "Explore logs" (logs-drilldown) canvas loads, the MDS data source picker renders, and the
+// index/dataset list resolves into cards. This is the exact happy path that regressed when buildServices()
+// dropped dataSourceManagement (picker vanished + zero cards), so this spec guards against that class of bug.
+const runLogsDrilldownSmokeTests = () => {
+  describe('explore logs (logs-drilldown) smoke', () => {
+    before(() => {
+      // Seed the MDS data source + fixture indices, then a workspace with one logs dataset.
+      cy.osd.setupEnvAndGetDataSource(DATASOURCE_NAME);
+      createWorkspaceAndDatasetUsingEndpoint(
+        DATASOURCE_NAME,
+        workspace,
+        datasetId,
+        INDEX_PATTERN_WITH_TIME, // 'data_logs_small_time_*'
+        'timestamp',
+        'logs',
+        ['use-case-observability']
+      );
+    });
+
+    after(() => {
+      cy.osd.cleanupWorkspaceAndDataSourceAndIndices(workspace);
+    });
+
+    beforeEach(() => {
+      const workspaceId = Cypress.env(`${workspace}:WORKSPACE_ID`);
+      cy.visit(`/w/${workspaceId}/app/explore/logs-drilldown`);
+      cy.getElementByTestId('logsDrilldownPage', { timeout: 60000 }).should('be.visible');
+    });
+
+    it('loads the canvas and resolves the workspace data source', () => {
+      // The page title / breadcrumb reads "Explore logs".
+      cy.contains('h1', 'Explore logs').should('be.visible');
+
+      // The MDS data source picker renders (the regression we are guarding against made this null).
+      cy.getElementByTestId('logsExploreDataSourceControl').should('exist');
+
+      // The picker auto-selects the workspace data source and persists it to the URL (`_a=(dataSource:...)`).
+      cy.url().should('include', 'dataSource:');
+    });
+
+    it('renders the index/dataset list as cards', () => {
+      // Widen the range so the fixture (data_logs_small_time_*) is in-window and cards resolve as live.
+      setWideTimeRange();
+
+      cy.getElementByTestId('logsExploreRowsView', { timeout: 60000 }).should('be.visible');
+      cy.get('[data-test-subj^="logsExploreCard-"]', { timeout: 60000 }).should(
+        'have.length.at.least',
+        1
+      );
+    });
+  });
+};
+
+prepareTestSuite('Explore logs smoke', runLogsDrilldownSmokeTests);

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "osd:ciGroup21Explore": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/21/*.spec.js\"",
     "osd:ciGroup22Explore": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/22/*.spec.js\"",
     "osd:ciGroup23Explore": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/23/*.spec.js\"",
+    "osd:ciGroup24Explore": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/24/*.spec.js\"",
     "osd:ciGroupS3Explore": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/s3_tests/*.spec.js\"",
     "osd:ciGroupDashboards": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/dashboards/*.spec.js\"",
     "osd:ciGroup1Observability": "echo \"cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/observability/1/*.spec.js\"",

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -56,6 +56,13 @@ export interface DataStructureCreatorProps<FetchOptions = unknown> {
     dataType: string,
     options?: FetchOptions
   ) => Promise<DataStructure>;
+  /**
+   * Optional index/pattern names to pre-select when the creator first mounts (backward-compatible;
+   * default undefined = today's behavior of an empty selection). Lets a caller open the selector at
+   * step 1 with the clicked index/pattern already staged. Comma-joined titles are split into items;
+   * any title containing `*` is treated as a wildcard.
+   */
+  initialSelectedItems?: string[];
 }
 
 /**

--- a/src/plugins/data/common/datasets/types.ts
+++ b/src/plugins/data/common/datasets/types.ts
@@ -63,6 +63,12 @@ export interface DataStructureCreatorProps<FetchOptions = unknown> {
    * any title containing `*` is treated as a wildcard.
    */
   initialSelectedItems?: string[];
+  /**
+   * Auto-focus the creator's search input on mount (opens the index dropdown). Default true
+   * (today's behavior); a caller that opens the creator pre-seeded can pass false so it doesn't
+   * grab focus / pop the dropdown immediately.
+   */
+  autoFocus?: boolean;
 }
 
 /**

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.test.tsx
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.test.tsx
@@ -345,4 +345,75 @@ describe('IndexDataStructureCreator', () => {
       expect(container.querySelector('.indexDataStructureCreator')).toBeInTheDocument();
     });
   });
+
+  describe('initialSelectedItems (opt-in pre-selection)', () => {
+    it('pre-selects a seeded exact index on mount and notifies via selectDataStructure', async () => {
+      const { getByTestId } = renderComponent({ initialSelectedItems: ['logs-app-1'] });
+
+      await waitFor(() => {
+        expect(getByTestId('selected-count')).toHaveTextContent('1');
+      });
+      expect(mockSelectDataStructure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'logs-app-1',
+          meta: expect.objectContaining({ isMultiIndex: true, selectedTitles: ['logs-app-1'] }),
+        }),
+        expect.any(Array)
+      );
+    });
+
+    it('splits a comma-joined seed into multiple pre-selected items', async () => {
+      const { getByTestId } = renderComponent({ initialSelectedItems: ['a-logs,b-logs'] });
+
+      await waitFor(() => {
+        expect(getByTestId('selected-count')).toHaveTextContent('2');
+      });
+      expect(mockSelectDataStructure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({ selectedTitles: ['a-logs', 'b-logs'] }),
+        }),
+        expect.any(Array)
+      );
+    });
+
+    it('treats a `*`-containing seed as a wildcard pattern', async () => {
+      const { getByTestId } = renderComponent({ initialSelectedItems: ['logs-app-*'] });
+
+      await waitFor(() => {
+        expect(getByTestId('selected-count')).toHaveTextContent('1');
+      });
+      expect(mockSelectDataStructure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            isMultiWildcard: true,
+            wildcardPatterns: ['logs-app-*'],
+          }),
+        }),
+        expect.any(Array)
+      );
+    });
+
+    it('de-duplicates repeated titles in the seed', async () => {
+      const { getByTestId } = renderComponent({ initialSelectedItems: ['dupe,dupe,other'] });
+      await waitFor(() => {
+        expect(getByTestId('selected-count')).toHaveTextContent('2');
+      });
+    });
+
+    it('does not pre-select anything when initialSelectedItems is omitted (default)', async () => {
+      const { getByTestId } = renderComponent();
+      await waitFor(() => {
+        expect(getByTestId('selected-count')).toHaveTextContent('0');
+      });
+      expect(mockSelectDataStructure).not.toHaveBeenCalled();
+    });
+
+    it('ignores an empty seed array and empty/whitespace titles', async () => {
+      const { getByTestId } = renderComponent({ initialSelectedItems: ['', '  ', ' , '] });
+      await waitFor(() => {
+        expect(getByTestId('selected-count')).toHaveTextContent('0');
+      });
+      expect(mockSelectDataStructure).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.test.tsx
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.test.tsx
@@ -17,9 +17,10 @@ jest.mock('./use_index_fetcher', () => ({
 
 // Mock the UnifiedIndexSelector component
 jest.mock('./unified_index_selector', () => ({
-  UnifiedIndexSelector: ({ selectedItems, onSelectionChange }: any) => (
+  UnifiedIndexSelector: ({ selectedItems, onSelectionChange, autoFocus }: any) => (
     <div>
       <div data-test-subj="unified-selector">Unified Index Selector</div>
+      <div data-test-subj="unified-selector-autofocus">{String(autoFocus)}</div>
       <div data-test-subj="selected-count">{selectedItems.length}</div>
       <button
         data-test-subj="add-single-index"
@@ -113,6 +114,16 @@ describe('IndexDataStructureCreator', () => {
     it('starts with no selected items', () => {
       const { getByTestId } = renderComponent();
       expect(getByTestId('selected-count')).toHaveTextContent('0');
+    });
+
+    it('leaves autoFocus undefined by default (keeps the selector default focus-on-mount)', () => {
+      const { getByTestId } = renderComponent();
+      expect(getByTestId('unified-selector-autofocus')).toHaveTextContent('undefined');
+    });
+
+    it('threads an explicit autoFocus=false down to the unified index selector', () => {
+      const { getByTestId } = renderComponent({ autoFocus: false });
+      expect(getByTestId('unified-selector-autofocus')).toHaveTextContent('false');
     });
   });
 

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.tsx
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.tsx
@@ -52,6 +52,7 @@ export const IndexDataStructureCreator: React.FC<IndexDataStructureCreatorProps>
   index,
   selectDataStructure,
   services,
+  initialSelectedItems,
 }) => {
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([]);
   const [openPopoverIndex, setOpenPopoverIndex] = useState<number | null>(null);
@@ -262,6 +263,36 @@ export const IndexDataStructureCreator: React.FC<IndexDataStructureCreatorProps>
     },
     [path, index, selectDataStructure]
   );
+
+  // Seed the selection once on mount from initialSelectedItems (opt-in; default = empty selection).
+  // Splitting comma-joined titles keeps parity with how multi-index datasets are titled elsewhere.
+  const hasSeededRef = React.useRef(false);
+  useEffect(() => {
+    if (hasSeededRef.current) return;
+    if (!initialSelectedItems || initialSelectedItems.length === 0) return;
+    hasSeededRef.current = true;
+
+    const dataSourceId = path.find((item) => item.type === 'DATA_SOURCE')?.id || 'local';
+    const seen = new Set<string>();
+    const seededItems: SelectedItem[] = [];
+    initialSelectedItems
+      .flatMap((raw) => raw.split(','))
+      .map((title) => title.trim())
+      .filter((title) => title.length > 0)
+      .forEach((title) => {
+        if (seen.has(title)) return;
+        seen.add(title);
+        seededItems.push({
+          id: `${dataSourceId}::${title}`,
+          title,
+          isWildcard: title.includes('*'),
+        });
+      });
+
+    if (seededItems.length > 0) {
+      handleSelectionChange(seededItems);
+    }
+  }, [initialSelectedItems, path, handleSelectionChange]);
 
   const handleRemoveItem = (indexToRemove: number) => {
     const newItems = selectedItems.filter((_, itemIndex) => itemIndex !== indexToRemove);

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.tsx
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/index_data_structure_creator.tsx
@@ -53,6 +53,7 @@ export const IndexDataStructureCreator: React.FC<IndexDataStructureCreatorProps>
   selectDataStructure,
   services,
   initialSelectedItems,
+  autoFocus,
 }) => {
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([]);
   const [openPopoverIndex, setOpenPopoverIndex] = useState<number | null>(null);
@@ -545,6 +546,7 @@ export const IndexDataStructureCreator: React.FC<IndexDataStructureCreatorProps>
         onSelectionChange={handleSelectionChange}
         services={services}
         path={path}
+        autoFocus={autoFocus}
       />
 
       <EuiSpacer size="s" />

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/unified_index_selector.tsx
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_data_structure_creator/unified_index_selector.tsx
@@ -30,6 +30,9 @@ interface UnifiedIndexSelectorProps {
   onSelectionChange: (items: Array<{ id: string; title: string; isWildcard: boolean }>) => void;
   services?: IDataPluginServices;
   path?: DataStructure[];
+  /** Auto-focus the search input (and open the dropdown) on mount. Default true; callers that open
+   *  the selector pre-seeded (e.g. from the logs drilldown) can pass false to avoid grabbing focus. */
+  autoFocus?: boolean;
 }
 
 // Note: * is NOT in this list because it's used for wildcards
@@ -40,6 +43,7 @@ export const UnifiedIndexSelector: React.FC<UnifiedIndexSelectorProps> = ({
   onSelectionChange,
   services,
   path,
+  autoFocus = true,
 }) => {
   const [searchValue, setSearchValue] = useState('');
   const [searchResults, setSearchResults] = useState<string[]>([]);
@@ -177,15 +181,16 @@ export const UnifiedIndexSelector: React.FC<UnifiedIndexSelectorProps> = ({
     };
   }, [searchValue, fetchIndices]);
 
-  // Auto-focus input on first mount to open dropdown
+  // Auto-focus input on first mount to open dropdown (opt-out via autoFocus=false).
   useEffect(() => {
+    if (!autoFocus) return;
     if (inputRef.current) {
       // Small delay to ensure component is fully mounted
       setTimeout(() => {
         inputRef.current?.focus();
       }, 100);
     }
-  }, []);
+  }, [autoFocus]);
 
   // Reposition cursor after wildcard is auto-appended
   useEffect(() => {

--- a/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
@@ -48,6 +48,7 @@ export const AdvancedSelector = ({
   showNonTimeFieldDatasets,
   initialSelectedItems,
   initialDataSourceId,
+  autoFocus,
 }: {
   services: IDataPluginServices;
   onSelect: (query: Partial<Query>, saveDataset?: boolean) => void;
@@ -64,6 +65,9 @@ export const AdvancedSelector = ({
   initialSelectedItems?: string[];
   /** Optional data source id (MDS) to auto-select at step 1. Opt-in. */
   initialDataSourceId?: string;
+  /** Auto-focus the creator's search input on mount. Opt-in; default (undefined) keeps today's
+   *  focus-on-mount behavior. Pass false to open the selector without grabbing focus. */
+  autoFocus?: boolean;
 }) => {
   const queryString = getQueryService().queryString;
 
@@ -123,6 +127,7 @@ export const AdvancedSelector = ({
       onCancel={onCancel}
       initialSelectedItems={initialSelectedItems}
       initialDataSourceId={initialDataSourceId}
+      autoFocus={autoFocus}
     />
   );
 };

--- a/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/advanced_selector.tsx
@@ -46,6 +46,8 @@ export const AdvancedSelector = ({
   alwaysShowDatasetFields,
   signalType,
   showNonTimeFieldDatasets,
+  initialSelectedItems,
+  initialDataSourceId,
 }: {
   services: IDataPluginServices;
   onSelect: (query: Partial<Query>, saveDataset?: boolean) => void;
@@ -55,6 +57,13 @@ export const AdvancedSelector = ({
   alwaysShowDatasetFields?: boolean;
   signalType?: string;
   showNonTimeFieldDatasets?: boolean;
+  /**
+   * Optional index/pattern names to pre-select at step 1 (browse) in a custom data-structure creator
+   * such as the INDEX creator. Opt-in; default undefined preserves today's blank-start behavior.
+   */
+  initialSelectedItems?: string[];
+  /** Optional data source id (MDS) to auto-select at step 1. Opt-in. */
+  initialDataSourceId?: string;
 }) => {
   const queryString = getQueryService().queryString;
 
@@ -112,6 +121,8 @@ export const AdvancedSelector = ({
       setPath={setPath}
       onNext={(dataset) => setSelectedDataset(dataset)}
       onCancel={onCancel}
+      initialSelectedItems={initialSelectedItems}
+      initialDataSourceId={initialDataSourceId}
     />
   );
 };

--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.test.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@osd/i18n/react';
+import { DatasetExplorer } from './dataset_explorer';
+import { DataStructure } from '../../../common';
+
+// Capture the props the custom DataStructureCreator receives so we can assert seeding.
+let lastCreatorProps: any;
+const CustomCreator = (props: any) => {
+  lastCreatorProps = props;
+  return <div data-test-subj="custom-creator" />;
+};
+
+// fetchOptions is called with the growing path when a level is auto-selected; we assert on it to
+// learn WHICH data source was auto-selected (its id is the last element of the path passed in).
+const fetchOptions = jest.fn().mockResolvedValue({
+  id: 'indexes',
+  title: 'Indexes',
+  type: 'INDEX',
+  hasNext: false,
+  columnHeader: 'Indexes',
+  DataStructureCreator: CustomCreator,
+  children: [],
+});
+
+const makeQueryString = () =>
+  (({
+    getDatasetService: () => ({
+      fetchOptions,
+      getType: () => ({ id: 'INDEX', toDataset: jest.fn() }),
+      getLastCacheTime: () => undefined,
+    }),
+  } as unknown) as any);
+
+const services = ({
+  uiSettings: { get: () => 'MMM D, YYYY @ HH:mm:ss.SSS' },
+  http: { basePath: { get: () => '' } },
+} as unknown) as any;
+
+const dataSourceNode = (id: string, title: string): DataStructure => ({
+  id,
+  title,
+  type: 'DATA_SOURCE',
+  hasNext: true,
+});
+
+const rootPath = (children: DataStructure[]): DataStructure[] => [
+  {
+    id: 'root',
+    title: 'Select data',
+    type: 'root',
+    columnHeader: 'Select data',
+    hasNext: true,
+    children,
+  },
+];
+
+const renderExplorer = (props: any = {}) => {
+  const setPath = jest.fn();
+  render(
+    <I18nProvider>
+      <DatasetExplorer
+        services={services}
+        queryString={makeQueryString()}
+        path={rootPath([dataSourceNode('ds-1', 'Cluster 1'), dataSourceNode('ds-2', 'Cluster 2')])}
+        setPath={setPath}
+        onNext={jest.fn()}
+        onCancel={jest.fn()}
+        {...props}
+      />
+    </I18nProvider>
+  );
+  return { setPath };
+};
+
+// The data source selected at the data-source level = the last element of the path fetchOptions saw.
+const autoSelectedDataSourceId = () => {
+  const pathArg = fetchOptions.mock.calls[0][1] as DataStructure[];
+  return pathArg[pathArg.length - 1].id;
+};
+
+describe('DatasetExplorer initial-selection props', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastCreatorProps = undefined;
+  });
+
+  it('auto-selects the FIRST data source by default (no initialDataSourceId)', async () => {
+    renderExplorer();
+    await waitFor(() => expect(fetchOptions).toHaveBeenCalled());
+    expect(autoSelectedDataSourceId()).toBe('ds-1');
+  });
+
+  it('auto-selects the caller-preferred data source when initialDataSourceId matches (MDS)', async () => {
+    renderExplorer({ initialDataSourceId: 'ds-2' });
+    await waitFor(() => expect(fetchOptions).toHaveBeenCalled());
+    expect(autoSelectedDataSourceId()).toBe('ds-2');
+  });
+
+  it('falls back to the first data source when initialDataSourceId does not match any child', async () => {
+    renderExplorer({ initialDataSourceId: 'does-not-exist' });
+    await waitFor(() => expect(fetchOptions).toHaveBeenCalled());
+    expect(autoSelectedDataSourceId()).toBe('ds-1');
+  });
+
+  it('forwards initialSelectedItems to a custom DataStructureCreator', async () => {
+    // A single data source that leads straight to the index creator column.
+    render(
+      <I18nProvider>
+        <DatasetExplorer
+          services={services}
+          queryString={makeQueryString()}
+          path={[
+            {
+              id: 'ds-1',
+              title: 'Cluster 1',
+              type: 'DATA_SOURCE',
+              hasNext: false,
+              columnHeader: 'Indexes',
+              DataStructureCreator: CustomCreator,
+              children: [],
+            },
+          ]}
+          setPath={jest.fn()}
+          onNext={jest.fn()}
+          onCancel={jest.fn()}
+          initialSelectedItems={['logs-app-*']}
+        />
+      </I18nProvider>
+    );
+    await waitFor(() => expect(lastCreatorProps).toBeDefined());
+    expect(lastCreatorProps.initialSelectedItems).toEqual(['logs-app-*']);
+  });
+
+  it('passes undefined initialSelectedItems to the creator by default (backward-compatible)', async () => {
+    render(
+      <I18nProvider>
+        <DatasetExplorer
+          services={services}
+          queryString={makeQueryString()}
+          path={[
+            {
+              id: 'ds-1',
+              title: 'Cluster 1',
+              type: 'DATA_SOURCE',
+              hasNext: false,
+              columnHeader: 'Indexes',
+              DataStructureCreator: CustomCreator,
+              children: [],
+            },
+          ]}
+          setPath={jest.fn()}
+          onNext={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      </I18nProvider>
+    );
+    await waitFor(() => expect(lastCreatorProps).toBeDefined());
+    expect(lastCreatorProps.initialSelectedItems).toBeUndefined();
+  });
+});

--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.test.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.test.tsx
@@ -29,18 +29,18 @@ const fetchOptions = jest.fn().mockResolvedValue({
 });
 
 const makeQueryString = () =>
-  (({
+  ({
     getDatasetService: () => ({
       fetchOptions,
       getType: () => ({ id: 'INDEX', toDataset: jest.fn() }),
       getLastCacheTime: () => undefined,
     }),
-  } as unknown) as any);
+  }) as unknown as any;
 
-const services = ({
+const services = {
   uiSettings: { get: () => 'MMM D, YYYY @ HH:mm:ss.SSS' },
   http: { basePath: { get: () => '' } },
-} as unknown) as any;
+} as unknown as any;
 
 const dataSourceNode = (id: string, title: string): DataStructure => ({
   id,

--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
@@ -40,6 +40,8 @@ export const DatasetExplorer = ({
   setPath,
   onNext,
   onCancel,
+  initialSelectedItems,
+  initialDataSourceId,
 }: {
   services: IDataPluginServices;
   queryString: QueryStringContract;
@@ -47,6 +49,11 @@ export const DatasetExplorer = ({
   setPath: (path: DataStructure[]) => void;
   onNext: (dataset: BaseDataset) => void;
   onCancel: () => void;
+  /** Index/pattern names to pre-select in a custom creator (e.g. the INDEX creator). Opt-in. */
+  initialSelectedItems?: string[];
+  /** When auto-selecting the data-source level, prefer this data source id (MDS) instead of the
+   * first child. Opt-in; default undefined = today's "select first" behavior. */
+  initialDataSourceId?: string;
 }) => {
   const uiSettings = services.uiSettings;
   const [explorerDataset, setExplorerDataset] = useState<BaseDataset | undefined>(undefined);
@@ -107,13 +114,19 @@ export const DatasetExplorer = ({
 
     // Auto-select if there's exactly one child, OR if we're at data source level (always select first)
     if (current.children.length === 1 || isDataSourceLevel) {
-      const firstChild = current.children[0];
+      // At the data-source level, prefer the caller-provided data source (MDS) when it's present in
+      // the children; otherwise keep the existing "first child" behavior.
+      const preferred =
+        isDataSourceLevel && initialDataSourceId
+          ? current.children.find((child) => child.id === initialDataSourceId)
+          : undefined;
+      const chosenChild = preferred ?? current.children[0];
       // Mark this level as auto-selected
       setAutoSelectionDone((prev) => new Set([...prev, currentIndex]));
       // Automatically select it
-      selectDataStructure(firstChild, path.slice(0, currentIndex + 1));
+      selectDataStructure(chosenChild, path.slice(0, currentIndex + 1));
     }
-  }, [path, loading, autoSelectionDone, selectDataStructure]);
+  }, [path, loading, autoSelectionDone, selectDataStructure, initialDataSourceId]);
 
   // Skip first column if it only has one child (auto-selected)
   const shouldSkipFirstColumn = path.length > 0 && path[0].children?.length === 1;
@@ -231,6 +244,7 @@ export const DatasetExplorer = ({
                     services={services}
                     // @ts-ignore custom component can have their own fetch options
                     fetchDataStructure={fetchNextDataStructure}
+                    initialSelectedItems={initialSelectedItems}
                   />
                 ) : current.multiSelect ? (
                   <DatasetTable

--- a/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
+++ b/src/plugins/data/public/ui/dataset_selector/dataset_explorer.tsx
@@ -42,6 +42,7 @@ export const DatasetExplorer = ({
   onCancel,
   initialSelectedItems,
   initialDataSourceId,
+  autoFocus,
 }: {
   services: IDataPluginServices;
   queryString: QueryStringContract;
@@ -54,6 +55,8 @@ export const DatasetExplorer = ({
   /** When auto-selecting the data-source level, prefer this data source id (MDS) instead of the
    * first child. Opt-in; default undefined = today's "select first" behavior. */
   initialDataSourceId?: string;
+  /** Auto-focus the custom creator's search input on mount. Opt-in; default keeps today's behavior. */
+  autoFocus?: boolean;
 }) => {
   const uiSettings = services.uiSettings;
   const [explorerDataset, setExplorerDataset] = useState<BaseDataset | undefined>(undefined);
@@ -245,6 +248,7 @@ export const DatasetExplorer = ({
                     // @ts-ignore custom component can have their own fetch options
                     fetchDataStructure={fetchNextDataStructure}
                     initialSelectedItems={initialSelectedItems}
+                    autoFocus={autoFocus}
                   />
                 ) : current.multiSelect ? (
                   <DatasetTable

--- a/src/plugins/data_importer/public/components/__snapshots__/data_importer_app.test.tsx.snap
+++ b/src/plugins/data_importer/public/components/__snapshots__/data_importer_app.test.tsx.snap
@@ -514,11 +514,12 @@ exports[`App should render with MDS 1`] = `
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
-                    <p
-                      class="euiComboBoxPlaceholder"
+                    <span
+                      class="euiComboBoxPill euiComboBoxPill--plainText"
+                      id=""
                     >
-                      Select a data source
-                    </p>
+                      Local cluster
+                    </span>
                     <div
                       class="euiComboBox__input"
                       style="font-size: 14px; display: inline-block;"
@@ -538,6 +539,17 @@ exports[`App should render with MDS 1`] = `
                   <div
                     class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
                   >
+                    <button
+                      aria-label="Clear input"
+                      class="euiFormControlLayoutClearButton"
+                      data-test-subj="comboBoxClearButton"
+                      type="button"
+                    >
+                      <span
+                        class="euiFormControlLayoutClearButton__icon"
+                        data-euiicon-type="cross"
+                      />
+                    </button>
                     <button
                       aria-label="Open list of options"
                       class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"

--- a/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/create_data_source_selector.test.tsx.snap
+++ b/src/plugins/data_source_management/public/components/data_source_selector/__snapshots__/create_data_source_selector.test.tsx.snap
@@ -1,6 +1,197 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`create data source selector should ignore props.hideLocalCluster, and show local cluster when data_source.hideLocalCluster is set to false 1`] = `
+exports[`create data source selector lets an explicit props.hideLocalCluster=true win over the data_source config (hides local cluster) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-label="Select a data source"
+        class="euiComboBox"
+        data-test-subj="dataSourceSelectorComboBox"
+        role="combobox"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--group"
+        >
+          <label
+            class="euiFormLabel euiFormControlLayout__prepend"
+          >
+            Data source
+          </label>
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
+              data-test-subj="comboBoxInput"
+              tabindex="-1"
+            >
+              <p
+                class="euiComboBoxPlaceholder"
+              >
+                Select a data source
+              </p>
+              <div
+                class="euiComboBox__input"
+                style="font-size: 14px; display: inline-block;"
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  role="textbox"
+                  style="box-sizing: content-box; width: 2px;"
+                  value=""
+                />
+                <div
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
+                />
+              </div>
+            </div>
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="euiFormControlLayoutCustomIcon__icon"
+                  data-euiicon-type="arrowDown"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-label="Select a data source"
+      class="euiComboBox"
+      data-test-subj="dataSourceSelectorComboBox"
+      role="combobox"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <label
+          class="euiFormLabel euiFormControlLayout__prepend"
+        >
+          Data source
+        </label>
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
+            data-test-subj="comboBoxInput"
+            tabindex="-1"
+          >
+            <p
+              class="euiComboBoxPlaceholder"
+            >
+              Select a data source
+            </p>
+            <div
+              class="euiComboBox__input"
+              style="font-size: 14px; display: inline-block;"
+            >
+              <input
+                aria-controls=""
+                data-test-subj="comboBoxSearchInput"
+                role="textbox"
+                style="box-sizing: content-box; width: 2px;"
+                value=""
+              />
+              <div
+                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <button
+              aria-label="Open list of options"
+              class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+              data-test-subj="comboBoxToggleListButton"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`create data source selector should render normally 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -144,197 +335,6 @@ Object {
                 data-euiicon-type="cross"
               />
             </button>
-            <button
-              aria-label="Open list of options"
-              class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-              data-test-subj="comboBoxToggleListButton"
-              type="button"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
-`;
-
-exports[`create data source selector should render normally 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <div
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-label="Select a data source"
-        class="euiComboBox"
-        data-test-subj="dataSourceSelectorComboBox"
-        role="combobox"
-      >
-        <div
-          class="euiFormControlLayout euiFormControlLayout--group"
-        >
-          <label
-            class="euiFormLabel euiFormControlLayout__prepend"
-          >
-            Data source
-          </label>
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
-              data-test-subj="comboBoxInput"
-              tabindex="-1"
-            >
-              <p
-                class="euiComboBoxPlaceholder"
-              >
-                Select a data source
-              </p>
-              <div
-                class="euiComboBox__input"
-                style="font-size: 14px; display: inline-block;"
-              >
-                <input
-                  aria-controls=""
-                  data-test-subj="comboBoxSearchInput"
-                  role="textbox"
-                  style="box-sizing: content-box; width: 2px;"
-                  value=""
-                />
-                <div
-                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
-                />
-              </div>
-            </div>
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-            >
-              <button
-                aria-label="Open list of options"
-                class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                data-test-subj="comboBoxToggleListButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="arrowDown"
-                />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-label="Select a data source"
-      class="euiComboBox"
-      data-test-subj="dataSourceSelectorComboBox"
-      role="combobox"
-    >
-      <div
-        class="euiFormControlLayout euiFormControlLayout--group"
-      >
-        <label
-          class="euiFormLabel euiFormControlLayout__prepend"
-        >
-          Data source
-        </label>
-        <div
-          class="euiFormControlLayout__childrenWrapper"
-        >
-          <div
-            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable euiComboBox__inputWrap--inGroup"
-            data-test-subj="comboBoxInput"
-            tabindex="-1"
-          >
-            <p
-              class="euiComboBoxPlaceholder"
-            >
-              Select a data source
-            </p>
-            <div
-              class="euiComboBox__input"
-              style="font-size: 14px; display: inline-block;"
-            >
-              <input
-                aria-controls=""
-                data-test-subj="comboBoxSearchInput"
-                role="textbox"
-                style="box-sizing: content-box; width: 2px;"
-                value=""
-              />
-              <div
-                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
-              />
-            </div>
-          </div>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-          >
             <button
               aria-label="Open list of options"
               class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.test.tsx
@@ -6,7 +6,7 @@ import { createDataSourceSelector } from './create_data_source_selector';
 import { SavedObjectsClientContract } from '../../../../../core/public';
 import { notificationServiceMock } from '../../../../../core/public/mocks';
 
-import { getByText, render } from '@testing-library/react';
+import { getByText, queryByText, render } from '@testing-library/react';
 import { coreMock } from '../../../../../core/public/mocks';
 import {
   mockDataSourcePluginSetupWithHideLocalCluster,
@@ -59,7 +59,7 @@ describe('create data source selector', () => {
     expect(toasts.addWarning).toHaveBeenCalledTimes(0);
   });
 
-  it('should ignore props.hideLocalCluster, and show local cluster when data_source.hideLocalCluster is set to false', () => {
+  it('lets an explicit props.hideLocalCluster=true win over the data_source config (hides local cluster)', () => {
     const props = {
       savedObjectsClient: client,
       notifications: toasts,
@@ -71,12 +71,34 @@ describe('create data source selector', () => {
     const dataSourceSelection = new DataSourceSelectionService();
     jest.spyOn(utils, 'getDataSourceSelection').mockReturnValue(dataSourceSelection);
 
+    // Global config says SHOW local cluster, but the caller explicitly passes hideLocalCluster=true.
     const TestComponent = createDataSourceSelector(
       uiSettings,
       mockDataSourcePluginSetupWithShowLocalCluster
     );
     const component = render(<TestComponent {...props} />);
     expect(component).toMatchSnapshot();
+    // The explicit prop wins → the synthetic "Local cluster" option is not rendered.
+    expect(queryByText(component.container, 'Local cluster')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the data_source config when the caller omits hideLocalCluster', () => {
+    const props = {
+      savedObjectsClient: client,
+      notifications: toasts,
+      onSelectedDataSource: jest.fn(),
+      disabled: false,
+      fullWidth: false,
+    };
+    const dataSourceSelection = new DataSourceSelectionService();
+    jest.spyOn(utils, 'getDataSourceSelection').mockReturnValue(dataSourceSelection);
+
+    // No hideLocalCluster prop → uses the config value (here: show local cluster).
+    const TestComponent = createDataSourceSelector(
+      uiSettings,
+      mockDataSourcePluginSetupWithShowLocalCluster
+    );
+    const component = render(<TestComponent {...(props as any)} />);
     expect(getByText(component.container, 'Local cluster')).toBeInTheDocument();
   });
 });

--- a/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
+++ b/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
@@ -13,6 +13,13 @@ export function createDataSourceSelector(
 ) {
   const { hideLocalCluster } = dataSourcePluginSetup;
   return (props: DataSourceSelectorProps) => (
-    <DataSourceSelector {...props} uiSettings={uiSettings} hideLocalCluster={hideLocalCluster} />
+    <DataSourceSelector
+      {...props}
+      uiSettings={uiSettings}
+      // An explicit `hideLocalCluster` prop from the caller wins; otherwise fall back to the
+      // cluster-wide data_source config default. (Previously the config value always overrode the
+      // prop, so callers like Logs Drilldown that pass `hideLocalCluster` were silently ignored.)
+      hideLocalCluster={props.hideLocalCluster ?? hideLocalCluster}
+    />
   );
 }

--- a/src/plugins/data_source_management/server/routes/dsl.ts
+++ b/src/plugins/data_source_management/server/routes/dsl.ts
@@ -58,6 +58,10 @@ export function registerDslRoute(
         query: schema.object({
           format: schema.string(),
           index: schema.maybe(schema.string()),
+          // Optional _cat/indices column + sort controls (e.g. h=index,creation.date.string
+          // & s=creation.date.string:desc) so callers can get creation dates / order.
+          h: schema.maybe(schema.string()),
+          s: schema.maybe(schema.string()),
         }),
       },
     },
@@ -136,6 +140,9 @@ export function registerDslRoute(
         query: schema.object({
           format: schema.string(),
           index: schema.maybe(schema.string()),
+          // Optional _cat/indices column + sort controls (see the non-MDS route above).
+          h: schema.maybe(schema.string()),
+          s: schema.maybe(schema.string()),
         }),
         params: schema.object({
           dataSourceMDSId: schema.maybe(schema.string({ defaultValue: '' })),

--- a/src/plugins/explore/common/config.ts
+++ b/src/plugins/explore/common/config.ts
@@ -26,6 +26,9 @@ export const configSchema = schema.object({
   queryProfiling: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
   }),
+  logsDrilldown: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/explore/common/index.ts
+++ b/src/plugins/explore/common/index.ts
@@ -33,7 +33,7 @@ export const VISUALIZATION_EDITOR_APP_NAME = 'VisualizationEditor';
 // Standalone Logs Drilldown app (onboarding canvas): a separate app id under the explore plugin,
 // with its own lightweight mount (no shared Redux store).
 export const LOGS_DRILLDOWN_APP_ID = `${PLUGIN_ID}/logs-drilldown`;
-export const LOGS_DRILLDOWN_APP_NAME = 'Logs drilldown';
+export const LOGS_DRILLDOWN_APP_NAME = 'Explore logs';
 
 export enum ExploreFlavor {
   Logs = 'logs',

--- a/src/plugins/explore/common/index.ts
+++ b/src/plugins/explore/common/index.ts
@@ -30,6 +30,11 @@ export const EXPLORE_METRICS_EXPLORE_TAB_ID = 'metrics-explore';
 export const VISUALIZATION_EDITOR_APP_ID = 'visualization-editor';
 export const VISUALIZATION_EDITOR_APP_NAME = 'VisualizationEditor';
 
+// Standalone Logs Drilldown app (onboarding canvas): a separate app id under the explore plugin,
+// with its own lightweight mount (no shared Redux store).
+export const LOGS_DRILLDOWN_APP_ID = `${PLUGIN_ID}/logs-drilldown`;
+export const LOGS_DRILLDOWN_APP_NAME = 'Logs drilldown';
+
 export enum ExploreFlavor {
   Logs = 'logs',
   Traces = 'traces',

--- a/src/plugins/explore/public/actions/logs_drilldown_action.tsx
+++ b/src/plugins/explore/public/actions/logs_drilldown_action.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { ButtonActionConfig } from '../services/query_panel_actions_registry';
+import { getServices } from '../application/legacy/discover/opensearch_dashboards_services';
+import { LOGS_DRILLDOWN_APP_ID } from '../../common';
+
+const label = i18n.translate('explore.queryPanel.logsDrilldownLabel', {
+  defaultMessage: 'Logs drilldown',
+});
+
+/**
+ * Query-bar action that opens the standalone Logs Drilldown app — a second entry point alongside
+ * the side-nav item (next to "Import data" / "Create monitor"). A button action; uses the explore
+ * global `getServices()` for navigation since button `onClick` receives only query dependencies.
+ */
+export const logsDrilldownActionConfig: ButtonActionConfig = {
+  id: 'logs-drilldown',
+  actionType: 'button',
+  order: 150,
+  getLabel: () => label,
+  getIcon: () => 'inspect',
+  getIsEnabled: () => true,
+  onClick: () => {
+    getServices().core.application.navigateToApp(LOGS_DRILLDOWN_APP_ID, { path: '#/' });
+  },
+};

--- a/src/plugins/explore/public/actions/logs_drilldown_action.tsx
+++ b/src/plugins/explore/public/actions/logs_drilldown_action.tsx
@@ -9,7 +9,7 @@ import { getServices } from '../application/legacy/discover/opensearch_dashboard
 import { LOGS_DRILLDOWN_APP_ID } from '../../common';
 
 const label = i18n.translate('explore.queryPanel.logsDrilldownLabel', {
-  defaultMessage: 'Logs drilldown',
+  defaultMessage: 'Explore logs',
 });
 
 /**

--- a/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.test.tsx
@@ -42,21 +42,21 @@ const makeServices = (opts: { logsDrilldownEnabled?: boolean; sqlSupportEnabled?
     data: { query: { queryString: { getDatasetService: jest.fn() } } },
     overlays: { openModal: jest.fn(() => ({ close: jest.fn() })) },
     notifications: { toasts: { addError: jest.fn() } },
-  } as any);
+  }) as any;
 
-describe('DiscoverNoIndexPatterns — Logs drilldown gating', () => {
+describe('DiscoverNoIndexPatterns — Explore logs gating', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockServices = makeServices();
   });
 
-  it('shows the Logs drilldown button on the Logs flavor when the flag is on', async () => {
+  it('shows the Explore logs button on the Logs flavor when the flag is on', async () => {
     mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Logs);
     render(<DiscoverNoIndexPatterns />);
     expect(await screen.findByTestId('discoverNoIndexPatternsLogsDrilldown')).toBeInTheDocument();
   });
 
-  it('hides the Logs drilldown button on the Traces flavor (shared empty state)', async () => {
+  it('hides the Explore logs button on the Traces flavor (shared empty state)', async () => {
     mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Traces);
     render(<DiscoverNoIndexPatterns />);
     // The create-dataset action still renders, so the component has settled.
@@ -64,7 +64,7 @@ describe('DiscoverNoIndexPatterns — Logs drilldown gating', () => {
     expect(screen.queryByTestId('discoverNoIndexPatternsLogsDrilldown')).not.toBeInTheDocument();
   });
 
-  it('hides the Logs drilldown button when the flag is off, even on Logs', async () => {
+  it('hides the Explore logs button when the flag is off, even on Logs', async () => {
     mockServices = makeServices({ logsDrilldownEnabled: false });
     mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Logs);
     render(<DiscoverNoIndexPatterns />);
@@ -72,7 +72,7 @@ describe('DiscoverNoIndexPatterns — Logs drilldown gating', () => {
     expect(screen.queryByTestId('discoverNoIndexPatternsLogsDrilldown')).not.toBeInTheDocument();
   });
 
-  it('navigates to the Logs drilldown app on click', async () => {
+  it('navigates to the Explore logs app on click', async () => {
     mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Logs);
     render(<DiscoverNoIndexPatterns />);
     const btn = await screen.findByTestId('discoverNoIndexPatternsLogsDrilldown');

--- a/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.test.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ExploreFlavor } from '../../../../../../../common';
+import { DiscoverNoIndexPatterns } from './no_index_patterns';
+
+jest.mock('@osd/i18n', () => ({
+  i18n: { translate: (_k: string, o: { defaultMessage: string }) => o.defaultMessage },
+}));
+
+// The data/public barrel pulls in UI components that break in jsdom; the empty state only needs
+// AdvancedSelector as an opaque element for the create-dataset modal.
+jest.mock('../../../../../../../../data/public', () => ({ AdvancedSelector: () => null }));
+jest.mock('../../../../../../../../data/common', () => ({
+  DEFAULT_DATA: { SET_TYPES: { INDEX: 'INDEX', INDEX_PATTERN: 'INDEX_PATTERN' } },
+}));
+jest.mock('../../../../../../../../opensearch_dashboards_react/public', () => ({
+  toMountPoint: (x: unknown) => x,
+}));
+
+// Control the resolved flavor per test.
+const mockGetCurrentFlavor = jest.fn();
+jest.mock('../../../../../../helpers/get_flavor_from_app_id', () => ({
+  getCurrentFlavor: () => mockGetCurrentFlavor(),
+}));
+
+const navigateToApp = jest.fn();
+let mockServices: any;
+jest.mock('../../../opensearch_dashboards_services', () => ({
+  getServices: () => mockServices,
+}));
+
+const makeServices = (opts: { logsDrilldownEnabled?: boolean; sqlSupportEnabled?: boolean } = {}) =>
+  ({
+    sqlSupportEnabled: opts.sqlSupportEnabled ?? false,
+    logsDrilldownEnabled: opts.logsDrilldownEnabled ?? true,
+    core: { application: { navigateToApp } },
+    data: { query: { queryString: { getDatasetService: jest.fn() } } },
+    overlays: { openModal: jest.fn(() => ({ close: jest.fn() })) },
+    notifications: { toasts: { addError: jest.fn() } },
+  } as any);
+
+describe('DiscoverNoIndexPatterns — Logs drilldown gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServices = makeServices();
+  });
+
+  it('shows the Logs drilldown button on the Logs flavor when the flag is on', async () => {
+    mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Logs);
+    render(<DiscoverNoIndexPatterns />);
+    expect(await screen.findByTestId('discoverNoIndexPatternsLogsDrilldown')).toBeInTheDocument();
+  });
+
+  it('hides the Logs drilldown button on the Traces flavor (shared empty state)', async () => {
+    mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Traces);
+    render(<DiscoverNoIndexPatterns />);
+    // The create-dataset action still renders, so the component has settled.
+    expect(await screen.findByTestId('discoverNoIndexPatternsCreateDataset')).toBeInTheDocument();
+    expect(screen.queryByTestId('discoverNoIndexPatternsLogsDrilldown')).not.toBeInTheDocument();
+  });
+
+  it('hides the Logs drilldown button when the flag is off, even on Logs', async () => {
+    mockServices = makeServices({ logsDrilldownEnabled: false });
+    mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Logs);
+    render(<DiscoverNoIndexPatterns />);
+    expect(await screen.findByTestId('discoverNoIndexPatternsCreateDataset')).toBeInTheDocument();
+    expect(screen.queryByTestId('discoverNoIndexPatternsLogsDrilldown')).not.toBeInTheDocument();
+  });
+
+  it('navigates to the Logs drilldown app on click', async () => {
+    mockGetCurrentFlavor.mockResolvedValue(ExploreFlavor.Logs);
+    render(<DiscoverNoIndexPatterns />);
+    const btn = await screen.findByTestId('discoverNoIndexPatternsLogsDrilldown');
+    btn.click();
+    await waitFor(() =>
+      expect(navigateToApp).toHaveBeenCalledWith('explore/logs-drilldown', { path: '#/' })
+    );
+  });
+});

--- a/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.tsx
@@ -13,13 +13,106 @@ import {
   EuiIcon,
   EuiText,
   EuiTitle,
+  EuiButton,
   EuiButtonEmpty,
 } from '@elastic/eui';
+import { AdvancedSelector } from '../../../../../../../../data/public';
+import { DEFAULT_DATA, Query } from '../../../../../../../../data/common';
+import { toMountPoint } from '../../../../../../../../opensearch_dashboards_react/public';
 import { getServices } from '../../../opensearch_dashboards_services';
+import {
+  LOGS_DRILLDOWN_APP_ID,
+  EXPLORE_DEFAULT_LANGUAGE,
+  ExploreFlavor,
+} from '../../../../../../../common';
+import { getCurrentFlavor } from '../../../../../../helpers/get_flavor_from_app_id';
+
+// Only these query-language docs are surfaced here: PPL always, SQL only when SQL support is enabled.
+// (DQL/Lucene/PromQL links are intentionally omitted.) Repointed at the current docs site.
+const PPL_DOC_URL = 'https://docs.opensearch.org/latest/sql-and-ppl/ppl/index/';
+const SQL_DOC_URL = 'https://docs.opensearch.org/latest/sql-and-ppl/sql/index/';
 
 export const DiscoverNoIndexPatterns: React.FC = () => {
-  const languageService = getServices().data.query.queryString.getLanguageService();
-  const registeredLanguages = languageService.getLanguages();
+  const services = getServices();
+  const { sqlSupportEnabled, logsDrilldownEnabled } = services;
+
+  // Curated doc links: PPL (always) + SQL (only when SQL support is on), replacing the full
+  // language list so onboarding users aren't shown languages that don't apply here.
+  const docLinks = [
+    {
+      id: 'PPL',
+      title: i18n.translate('explore.discover.noIndexPatterns.pplDocLink', {
+        defaultMessage: 'PPL documentation',
+      }),
+      url: PPL_DOC_URL,
+    },
+    ...(sqlSupportEnabled
+      ? [
+          {
+            id: 'SQL',
+            title: i18n.translate('explore.discover.noIndexPatterns.sqlDocLink', {
+              defaultMessage: 'SQL documentation',
+            }),
+            url: SQL_DOC_URL,
+          },
+        ]
+      : []),
+  ];
+
+  // Secondary action: open the shared dataset-creation modal in place (like the dataset dropdown's
+  // "Create dataset"). On save, set it as the active query so this empty state is replaced by results.
+  const openCreateDataset = async () => {
+    const datasetService = services.data.query.queryString.getDatasetService();
+    // This empty state is shared by the Logs AND Traces flavors — create the dataset for whichever
+    // flavor we're on (traces on the traces page, logs on the logs page), mirroring the on-page
+    // dataset dropdown which uses `signalType={flavorId}`. Falls back to logs if the flavor is
+    // unknown. `ExploreFlavor` values match CORE_SIGNAL_TYPES ('logs'/'traces'/'metrics').
+    const flavor = (await getCurrentFlavor(services)) ?? ExploreFlavor.Logs;
+    // Holder so the modal's own callbacks can close it (the ref is set right after openModal).
+    const modalHolder: { close: () => void } = { close: () => {} };
+    const element = React.createElement(AdvancedSelector, {
+      services: services as any,
+      useConfiguratorV2: true,
+      alwaysShowDatasetFields: true,
+      signalType: flavor,
+      // Match the on-page dataset dropdown's "Create dataset" modal exactly (same supportedTypes +
+      // showNonTimeFieldDatasets) so the same advanced selector opens, not a different type picker.
+      supportedTypes: services.supportedTypes || [
+        DEFAULT_DATA.SET_TYPES.INDEX,
+        DEFAULT_DATA.SET_TYPES.INDEX_PATTERN,
+      ],
+      showNonTimeFieldDatasets: false,
+      onCancel: () => modalHolder.close(),
+      onSelect: async (query: Partial<Query>, saveDataset?: boolean) => {
+        modalHolder.close();
+        if (!query?.dataset) return;
+        try {
+          if (saveDataset) {
+            await datasetService.saveDataset(query.dataset, services, flavor);
+            services.data.dataViews.clearCache();
+          } else {
+            await datasetService.cacheDataset(query.dataset, services, false, flavor);
+          }
+          const initialQuery = services.data.query.queryString.getInitialQueryByDataset({
+            ...query.dataset,
+            language: query.dataset.language || EXPLORE_DEFAULT_LANGUAGE,
+          });
+          services.data.query.queryString.setQuery(initialQuery);
+        } catch (error) {
+          services.notifications?.toasts.addError(error as Error, {
+            title: i18n.translate('explore.discover.noIndexPatterns.createDatasetError', {
+              defaultMessage: 'Error creating dataset',
+            }),
+          });
+        }
+      },
+    });
+    const modal = services.overlays.openModal(toMountPoint(element), {
+      maxWidth: false,
+      className: 'datasetSelect__advancedModal',
+    });
+    modalHolder.close = () => modal.close();
+  };
 
   return (
     <EuiFlexGroup
@@ -63,22 +156,54 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFlexGroup justifyContent="center" gutterSize="s" wrap>
-                {registeredLanguages.map(
-                  (language) =>
-                    language.docLink && (
-                      <EuiFlexItem grow={false} key={language.id}>
-                        <EuiButtonEmpty
-                          href={language.docLink.url}
-                          target="_blank"
-                          size="xs"
-                          iconType="popout"
-                          iconSide="right"
-                          iconGap="s"
-                        >
-                          <EuiText size="xs">{language.docLink.title}</EuiText>
-                        </EuiButtonEmpty>
-                      </EuiFlexItem>
-                    )
+                {docLinks.map((doc) => (
+                  <EuiFlexItem grow={false} key={doc.id}>
+                    <EuiButtonEmpty
+                      href={doc.url}
+                      target="_blank"
+                      size="xs"
+                      iconType="popout"
+                      iconSide="right"
+                      iconGap="s"
+                      data-test-subj={`discoverNoIndexPatternsDoc-${doc.id}`}
+                    >
+                      <EuiText size="xs">{doc.title}</EuiText>
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup justifyContent="center" gutterSize="s" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    size="s"
+                    onClick={openCreateDataset}
+                    data-test-subj="discoverNoIndexPatternsCreateDataset"
+                  >
+                    {i18n.translate('explore.discover.noIndexPatterns.createDataset', {
+                      defaultMessage: 'Create dataset',
+                    })}
+                  </EuiButton>
+                </EuiFlexItem>
+                {logsDrilldownEnabled && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      fill
+                      size="s"
+                      iconType="inspect"
+                      onClick={() =>
+                        services.core.application.navigateToApp(LOGS_DRILLDOWN_APP_ID, {
+                          path: '#/',
+                        })
+                      }
+                      data-test-subj="discoverNoIndexPatternsLogsDrilldown"
+                    >
+                      {i18n.translate('explore.discover.noIndexPatterns.logsDrilldown', {
+                        defaultMessage: 'Logs drilldown',
+                      })}
+                    </EuiButton>
+                  </EuiFlexItem>
                 )}
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.tsx
@@ -4,7 +4,7 @@
  */
 
 import './no_index_patterns.scss';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import {
   EuiPanel,
@@ -35,6 +35,20 @@ const SQL_DOC_URL = 'https://docs.opensearch.org/latest/sql-and-ppl/sql/index/';
 export const DiscoverNoIndexPatterns: React.FC = () => {
   const services = getServices();
   const { sqlSupportEnabled, logsDrilldownEnabled } = services;
+
+  // This empty state is shared by the Logs AND Traces flavors. Resolve the current flavor once on
+  // mount so we only surface the "Logs drilldown" action on the Logs page (drilldown is a logs-only
+  // canvas — it makes no sense from Traces). `getCurrentFlavor` is async, hence the state.
+  const [flavor, setFlavor] = useState<ExploreFlavor | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getCurrentFlavor(services).then((f) => {
+      if (!cancelled) setFlavor(f);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [services]);
 
   // Curated doc links: PPL (always) + SQL (only when SQL support is on), replacing the full
   // language list so onboarding users aren't shown languages that don't apply here.
@@ -67,14 +81,14 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
     // flavor we're on (traces on the traces page, logs on the logs page), mirroring the on-page
     // dataset dropdown which uses `signalType={flavorId}`. Falls back to logs if the flavor is
     // unknown. `ExploreFlavor` values match CORE_SIGNAL_TYPES ('logs'/'traces'/'metrics').
-    const flavor = (await getCurrentFlavor(services)) ?? ExploreFlavor.Logs;
+    const createFlavor = flavor ?? (await getCurrentFlavor(services)) ?? ExploreFlavor.Logs;
     // Holder so the modal's own callbacks can close it (the ref is set right after openModal).
     const modalHolder: { close: () => void } = { close: () => {} };
     const element = React.createElement(AdvancedSelector, {
       services: services as any,
       useConfiguratorV2: true,
       alwaysShowDatasetFields: true,
-      signalType: flavor,
+      signalType: createFlavor,
       // Match the on-page dataset dropdown's "Create dataset" modal exactly (same supportedTypes +
       // showNonTimeFieldDatasets) so the same advanced selector opens, not a different type picker.
       supportedTypes: services.supportedTypes || [
@@ -88,10 +102,10 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
         if (!query?.dataset) return;
         try {
           if (saveDataset) {
-            await datasetService.saveDataset(query.dataset, services, flavor);
+            await datasetService.saveDataset(query.dataset, services, createFlavor);
             services.data.dataViews.clearCache();
           } else {
-            await datasetService.cacheDataset(query.dataset, services, false, flavor);
+            await datasetService.cacheDataset(query.dataset, services, false, createFlavor);
           }
           const initialQuery = services.data.query.queryString.getInitialQueryByDataset({
             ...query.dataset,
@@ -113,6 +127,22 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
     });
     modalHolder.close = () => modal.close();
   };
+
+  // Logs drilldown is a logs-only onboarding canvas, so only offer it on the Logs flavor (this empty
+  // state is shared with Traces) and when the feature is enabled.
+  const showLogsDrilldown = logsDrilldownEnabled && flavor === ExploreFlavor.Logs;
+
+  // Description points at the on-screen CTAs. When Logs drilldown is available we surface both ways
+  // to create a dataset (guided canvas vs. the enhanced selector); otherwise just the selector.
+  const selectDataDescription = showLogsDrilldown
+    ? i18n.translate('explore.discover.noIndexPatterns.selectDataDescriptionWithDrilldown', {
+        defaultMessage:
+          'Get started by creating a dataset — explore your indexes with the guided Logs drilldown, or pick your data with the Create dataset button. You can also select data from the dropdown above.',
+      })
+    : i18n.translate('explore.discover.noIndexPatterns.selectDataDescription', {
+        defaultMessage:
+          'Get started by creating a dataset with the Create dataset button, then choose a query language to run your queries. You can also select data from the dropdown above.',
+      });
 
   return (
     <EuiFlexGroup
@@ -139,40 +169,10 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiText textAlign="center" color="subdued" size="xs">
-                {i18n.translate('explore.discover.noIndexPatterns.selectDataDescription', {
-                  defaultMessage:
-                    'Select an available data source and choose a query language to use for running queries. You can use the data dropdown or use the enhanced data selector to select data.',
-                })}
+                {selectDataDescription}
               </EuiText>
             </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiTitle size="xs">
-                <h4>
-                  {i18n.translate('explore.discover.noIndexPatterns.learnMoreAboutQueryLanguages', {
-                    defaultMessage: 'Learn more about query languages',
-                  })}
-                </h4>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup justifyContent="center" gutterSize="s" wrap>
-                {docLinks.map((doc) => (
-                  <EuiFlexItem grow={false} key={doc.id}>
-                    <EuiButtonEmpty
-                      href={doc.url}
-                      target="_blank"
-                      size="xs"
-                      iconType="popout"
-                      iconSide="right"
-                      iconGap="s"
-                      data-test-subj={`discoverNoIndexPatternsDoc-${doc.id}`}
-                    >
-                      <EuiText size="xs">{doc.title}</EuiText>
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                ))}
-              </EuiFlexGroup>
-            </EuiFlexItem>
+            {/* Primary CTAs row: Create dataset (+ guided Logs drilldown on the Logs flavor). */}
             <EuiFlexItem>
               <EuiFlexGroup justifyContent="center" gutterSize="s" responsive={false}>
                 <EuiFlexItem grow={false}>
@@ -186,7 +186,7 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
                     })}
                   </EuiButton>
                 </EuiFlexItem>
-                {logsDrilldownEnabled && (
+                {showLogsDrilldown && (
                   <EuiFlexItem grow={false}>
                     <EuiButton
                       fill
@@ -205,6 +205,42 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
                     </EuiButton>
                   </EuiFlexItem>
                 )}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            {/* Docs row (last): the "Learn more" label sits inline (not bold) with the doc links. */}
+            <EuiFlexItem>
+              <EuiFlexGroup
+                justifyContent="center"
+                alignItems="center"
+                gutterSize="xs"
+                wrap
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {i18n.translate(
+                      'explore.discover.noIndexPatterns.learnMoreAboutQueryLanguages',
+                      {
+                        defaultMessage: 'Learn more about query languages',
+                      }
+                    )}
+                  </EuiText>
+                </EuiFlexItem>
+                {docLinks.map((doc) => (
+                  <EuiFlexItem grow={false} key={doc.id}>
+                    <EuiButtonEmpty
+                      href={doc.url}
+                      target="_blank"
+                      size="xs"
+                      iconType="popout"
+                      iconSide="right"
+                      iconGap="s"
+                      data-test-subj={`discoverNoIndexPatternsDoc-${doc.id}`}
+                    >
+                      <EuiText size="xs">{doc.title}</EuiText>
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                ))}
               </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.tsx
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/no_index_patterns/no_index_patterns.tsx
@@ -137,7 +137,7 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
   const selectDataDescription = showLogsDrilldown
     ? i18n.translate('explore.discover.noIndexPatterns.selectDataDescriptionWithDrilldown', {
         defaultMessage:
-          'Get started by creating a dataset — explore your indexes with the guided Logs drilldown, or pick your data with the Create dataset button. You can also select data from the dropdown above.',
+          'Get started by creating a dataset — explore your indexes with the guided Explore logs experience, or pick your data with the Create dataset button. You can also select data from the dropdown above.',
       })
     : i18n.translate('explore.discover.noIndexPatterns.selectDataDescription', {
         defaultMessage:
@@ -200,7 +200,7 @@ export const DiscoverNoIndexPatterns: React.FC = () => {
                       data-test-subj="discoverNoIndexPatternsLogsDrilldown"
                     >
                       {i18n.translate('explore.discover.noIndexPatterns.logsDrilldown', {
-                        defaultMessage: 'Logs drilldown',
+                        defaultMessage: 'Explore logs',
                       })}
                     </EuiButton>
                   </EuiFlexItem>

--- a/src/plugins/explore/public/application/pages/logs_drilldown/application.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/application.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createRoot } from 'react-dom/client';
+import { AppMountParameters } from '../../../../../../core/public';
+import { OpenSearchDashboardsContextProvider } from '../../../../../opensearch_dashboards_react/public';
+import { ExploreServices } from '../../../types';
+import { LogsDrilldownPage } from './logs_drilldown_page';
+
+/**
+ * Standalone renderer for the Logs Drilldown app. Intentionally minimal — the onboarding canvas is
+ * self-contained and does NOT participate in the shared explore Redux store, tabs, or query panel.
+ * It only needs `services` (via the OSD context) + i18n. Handoff to the logs Query experience is via
+ * `navigateToApp`, so there is no store/Router coupling here.
+ */
+export const renderLogsDrilldownApp = (
+  { element, setHeaderActionMenu }: AppMountParameters,
+  services: ExploreServices
+) => {
+  const root = createRoot(element);
+  root.render(
+    <OpenSearchDashboardsContextProvider services={services}>
+      <services.core.i18n.Context>
+        <LogsDrilldownPage services={services} setHeaderActionMenu={setHeaderActionMenu} />
+      </services.core.i18n.Context>
+    </OpenSearchDashboardsContextProvider>
+  );
+
+  return () => {
+    root.unmount();
+  };
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/card_skeleton.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/card_skeleton.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CardSkeleton, LogLinesSkeleton } from './card_skeleton';
+
+describe('CardSkeleton', () => {
+  it('reserves the passed height so there is no layout shift when data arrives', () => {
+    render(<CardSkeleton height={132} />);
+    const el = screen.getByTestId('logsExploreCardSkeletonHist');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveStyle({ height: '132px' });
+  });
+
+  it('renders a deterministic set of faux bars (stable across renders, no jitter)', () => {
+    const { container, rerender } = render(<CardSkeleton height={100} />);
+    const bars = container.querySelectorAll('.logStreamCard__skeletonBar');
+    expect(bars.length).toBe(16);
+    // The rendered bar heights are deterministic — re-rendering yields the same DOM.
+    const first = container.innerHTML;
+    rerender(<CardSkeleton height={100} />);
+    expect(container.innerHTML).toBe(first);
+  });
+
+  it('is labelled for assistive tech', () => {
+    render(<CardSkeleton height={80} />);
+    expect(screen.getByLabelText('Loading histogram')).toBeInTheDocument();
+  });
+});
+
+describe('LogLinesSkeleton', () => {
+  it('renders a stack of faux log lines', () => {
+    const { container } = render(<LogLinesSkeleton />);
+    expect(screen.getByTestId('logsExploreCardSkeletonLogs')).toBeInTheDocument();
+    expect(container.querySelectorAll('.logStreamCard__skeletonLine').length).toBe(6);
+  });
+
+  it('is labelled for assistive tech', () => {
+    render(<LogLinesSkeleton />);
+    expect(screen.getByLabelText('Loading logs')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/card_skeleton.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/card_skeleton.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+/**
+ * Loading skeletons for a card — a shimmer in the exact shape of the final content (histogram bars
+ * on the left, log lines on the right), reserved to the final heights so there's no layout shift
+ * and no "one loader then two" flash. Grafana-like: the skeleton reads as intentional, not a spinner.
+ */
+
+// A row of faux bars filling the histogram area.
+export const CardSkeleton: React.FC<{ height: number }> = ({ height }) => {
+  // Deterministic bar heights (no Math.random) so re-renders don't jitter.
+  const heights = [40, 65, 50, 80, 55, 70, 45, 90, 60, 75, 50, 85, 62, 48, 78, 58];
+  return (
+    <div
+      className="logStreamCard__skeletonHist"
+      style={{ height }}
+      data-test-subj="logsExploreCardSkeletonHist"
+      aria-label="Loading histogram"
+    >
+      {heights.map((h, i) => (
+        <span key={i} className="logStreamCard__skeletonBar" style={{ height: `${h}%` }} />
+      ))}
+    </div>
+  );
+};
+
+// A stack of faux log lines filling the log area.
+export const LogLinesSkeleton: React.FC = () => (
+  <div
+    className="logStreamCard__skeletonLogs"
+    data-test-subj="logsExploreCardSkeletonLogs"
+    aria-label="Loading logs"
+  >
+    {[92, 78, 85, 70, 88, 60].map((w, i) => (
+      <span key={i} className="logStreamCard__skeletonLine" style={{ width: `${w}%` }} />
+    ))}
+  </div>
+);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/compact_row.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/compact_row.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CompactRow } from './compact_row';
+
+describe('CompactRow', () => {
+  it('renders the name as a link that fires nameOnClick when provided', () => {
+    const nameOnClick = jest.fn();
+    render(
+      <CompactRow
+        icon="index"
+        name="logs-app-2026.07.15"
+        nameOnClick={nameOnClick}
+        nameTitle="Create dataset"
+        message="No events in the last 15 minutes"
+        data-test-subj="row"
+      />
+    );
+    const link = screen.getByTestId('logsExploreCardNameLink');
+    expect(link).toHaveTextContent('logs-app-2026.07.15');
+    fireEvent.click(link);
+    expect(nameOnClick).toHaveBeenCalled();
+    expect(screen.getByText('No events in the last 15 minutes')).toBeInTheDocument();
+  });
+
+  it('renders a muted, non-actionable name when nameOnClick is absent', () => {
+    render(
+      <CompactRow
+        icon="index"
+        name="staging-ingest-test"
+        message="No documents yet"
+        meta="0 docs · created 3 days ago"
+      />
+    );
+    expect(screen.queryByTestId('logsExploreCardNameLink')).not.toBeInTheDocument();
+    expect(screen.getByText('staging-ingest-test')).toBeInTheDocument();
+    expect(screen.getByText('0 docs · created 3 days ago')).toBeInTheDocument();
+  });
+
+  it('renders an error chip and a trailing action', () => {
+    const onRetry = jest.fn();
+    render(
+      <CompactRow
+        icon="index"
+        name="restricted-pci-logs"
+        message="Couldn't load preview"
+        tone="danger"
+        errorText="security_exception · 403"
+        action={
+          <button data-test-subj="logsExploreCardRetry" onClick={onRetry}>
+            Retry
+          </button>
+        }
+        data-test-subj="logsExploreCardError"
+      />
+    );
+    expect(screen.getByTestId('logsExploreCardError')).toBeInTheDocument();
+    expect(screen.getByTestId('logsExploreCardErrorChip')).toHaveTextContent(
+      'security_exception · 403'
+    );
+    fireEvent.click(screen.getByTestId('logsExploreCardRetry'));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('renders a selection checkbox when provided and wires onChange', () => {
+    const onChange = jest.fn();
+    render(
+      <CompactRow
+        icon="index"
+        name="logs-app-1"
+        nameOnClick={jest.fn()}
+        message="No events in the last 15 minutes"
+        checkbox={{ checked: false, onChange, ariaLabel: 'Select logs-app-1', id: 'cb-logs-app-1' }}
+      />
+    );
+    const cb = screen.getByLabelText('Select logs-app-1');
+    fireEvent.click(cb);
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('omits the checkbox when not provided (e.g. empty-index rows)', () => {
+    render(<CompactRow icon="index" name="empty-idx" message="No documents yet" />);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/compact_row.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/compact_row.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiTextColor,
+  EuiLink,
+  EuiCheckbox,
+  EuiCode,
+} from '@elastic/eui';
+
+export type CompactRowTone = 'default' | 'subdued' | 'danger' | 'warning';
+
+interface Props {
+  /** EUI icon type for the leading kind glyph. */
+  icon: string;
+  /** Index / dataset name. */
+  name: string;
+  /** When provided, the name renders as a link that runs this action; otherwise it's muted text. */
+  nameOnClick?: () => void;
+  /** Title/aria for the name link (e.g. "Create dataset"). */
+  nameTitle?: string;
+  /** The one-line status message (e.g. "No events in the last 15 minutes"). */
+  message: string;
+  /** Optional trailing meta (e.g. "0 docs · created 3 days ago"). */
+  meta?: string;
+  /** Row tone — drives border/background tint. */
+  tone?: CompactRowTone;
+  /** Optional error string rendered as a monospace chip (state 04). */
+  errorText?: string;
+  /** Optional trailing action node (e.g. a Retry link). */
+  action?: React.ReactNode;
+  /** Optional selection checkbox (indexes only; omitted for empty/no-time rows). */
+  checkbox?: { checked: boolean; onChange: () => void; ariaLabel: string; id: string };
+  'data-test-subj'?: string;
+}
+
+/**
+ * The compact one-row treatment shared by the empty / no-recent-data / error states and the
+ * collapsed "no recent data" drawer rows. A single horizontal line — kind icon, name (link or
+ * muted), status message + optional meta/error chip, and an optional trailing action — inside a
+ * bordered panel, replacing the full 132px histogram+logs card for rows that carry nothing to scan.
+ */
+export const CompactRow: React.FC<Props> = ({
+  icon,
+  name,
+  nameOnClick,
+  nameTitle,
+  message,
+  meta,
+  tone = 'default',
+  errorText,
+  action,
+  checkbox,
+  'data-test-subj': dataTestSubj,
+}) => {
+  return (
+    <EuiPanel
+      hasBorder
+      paddingSize="none"
+      hasShadow={false}
+      className={classNames('logsDrilldownCompactRow', `logsDrilldownCompactRow--${tone}`)}
+      data-test-subj={dataTestSubj}
+    >
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+        {checkbox && (
+          <EuiFlexItem grow={false}>
+            <EuiCheckbox
+              id={checkbox.id}
+              checked={checkbox.checked}
+              onChange={checkbox.onChange}
+              aria-label={checkbox.ariaLabel}
+            />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={false}>
+          <EuiIcon type={icon} size="s" color={tone === 'default' ? undefined : 'subdued'} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false} className="logsDrilldownCompactRow__name">
+          <EuiText size="s">
+            {nameOnClick ? (
+              <EuiLink
+                onClick={nameOnClick}
+                title={nameTitle}
+                data-test-subj="logsExploreCardNameLink"
+              >
+                {name}
+              </EuiLink>
+            ) : (
+              <EuiTextColor color="subdued">
+                <strong>{name}</strong>
+              </EuiTextColor>
+            )}
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" color="subdued">
+            ·
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" color="subdued">
+            {message}
+          </EuiText>
+        </EuiFlexItem>
+        {errorText && (
+          <EuiFlexItem grow={false}>
+            <EuiCode data-test-subj="logsExploreCardErrorChip">{errorText}</EuiCode>
+          </EuiFlexItem>
+        )}
+        {meta && (
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="subdued" className="logsDrilldownCompactRow__meta">
+              {meta}
+            </EuiText>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={true} />
+        {action && <EuiFlexItem grow={false}>{action}</EuiFlexItem>}
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DataSourceControl } from './data_source_control';
+
+jest.mock('@osd/i18n', () => ({
+  i18n: { translate: (_k: string, o: { defaultMessage: string }) => o.defaultMessage },
+}));
+
+// A stub DataSourceSelector that captures its props and lets us fire a selection.
+let lastSelectorProps: any;
+const StubSelector = (props: any) => {
+  lastSelectorProps = props;
+  return <div data-test-subj="stub-ds-selector" />;
+};
+
+const makeServices = (withMds: boolean) =>
+  (({
+    dataSourceManagement: withMds ? { ui: { DataSourceSelector: StubSelector } } : undefined,
+    savedObjects: { client: {} },
+    notifications: { toasts: {} },
+    uiSettings: { get: jest.fn() },
+  } as unknown) as any);
+
+describe('DataSourceControl', () => {
+  beforeEach(() => {
+    lastSelectorProps = undefined;
+  });
+
+  // --- negative case ---
+  it('renders nothing when MDS is disabled / the plugin is absent (single local cluster)', () => {
+    const { container } = render(
+      <DataSourceControl services={makeServices(false)} onChange={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('logsExploreDataSourceControl')).not.toBeInTheDocument();
+  });
+
+  // --- positive cases ---
+  it('renders the data_source_management selector when MDS is available', () => {
+    render(<DataSourceControl services={makeServices(true)} onChange={jest.fn()} />);
+    expect(screen.getByTestId('logsExploreDataSourceControl')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-ds-selector')).toBeInTheDocument();
+  });
+
+  it('hides the local cluster and lets the selector auto-select a real data source', () => {
+    render(<DataSourceControl services={makeServices(true)} onChange={jest.fn()} />);
+    // The synthetic "Local cluster" option is hidden. We do NOT pass defaultOption, so the selector
+    // falls through to its default-data-source path and auto-selects a real registered cluster on
+    // load — the picker always reflects the cluster whose indexes are shown (never empty).
+    expect(lastSelectorProps.hideLocalCluster).toBe(true);
+    expect(lastSelectorProps.defaultOption).toBeUndefined();
+    expect(lastSelectorProps.uiSettings).toBeDefined();
+  });
+
+  it('maps a selected option to { id, title } via onChange', () => {
+    const onChange = jest.fn();
+    render(<DataSourceControl services={makeServices(true)} onChange={onChange} />);
+    lastSelectorProps.onSelectedDataSource([{ id: 'ds-2', label: 'Cluster 2' }]);
+    expect(onChange).toHaveBeenCalledWith({ id: 'ds-2', title: 'Cluster 2' });
+  });
+
+  it('defaults to the local cluster (empty id) when the selection is cleared/empty', () => {
+    const onChange = jest.fn();
+    render(<DataSourceControl services={makeServices(true)} onChange={onChange} />);
+    lastSelectorProps.onSelectedDataSource([]);
+    expect(onChange).toHaveBeenCalledWith({ id: '', title: undefined });
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.test.tsx
@@ -57,6 +57,19 @@ describe('DataSourceControl', () => {
     expect(lastSelectorProps.uiSettings).toBeDefined();
   });
 
+  it('pre-selects a restored data source via defaultOption when defaultDataSourceId is set', () => {
+    render(
+      <DataSourceControl
+        services={makeServices(true)}
+        onChange={jest.fn()}
+        defaultDataSourceId="ds-restored"
+      />
+    );
+    // A restored id (e.g. from the URL) is fed to the selector as its defaultOption so it re-selects
+    // that source instead of auto-picking the workspace default.
+    expect(lastSelectorProps.defaultOption).toEqual([{ id: 'ds-restored' }]);
+  });
+
   it('maps a selected option to { id, title } via onChange', () => {
     const onChange = jest.fn();
     render(<DataSourceControl services={makeServices(true)} onChange={onChange} />);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.test.tsx
@@ -19,12 +19,12 @@ const StubSelector = (props: any) => {
 };
 
 const makeServices = (withMds: boolean) =>
-  (({
+  ({
     dataSourceManagement: withMds ? { ui: { DataSourceSelector: StubSelector } } : undefined,
     savedObjects: { client: {} },
     notifications: { toasts: {} },
     uiSettings: { get: jest.fn() },
-  } as unknown) as any);
+  }) as unknown as any;
 
 describe('DataSourceControl', () => {
   beforeEach(() => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.tsx
@@ -15,6 +15,9 @@ export interface SelectedDataSource {
 interface Props {
   services: ExploreServices;
   onChange: (dataSource: SelectedDataSource) => void;
+  /** When set (e.g. restored from the URL), pre-select this data source instead of auto-selecting
+   *  the workspace default. */
+  defaultDataSourceId?: string;
 }
 
 /**
@@ -22,7 +25,7 @@ interface Props {
  * data source (MDS) the index list is scoped to. Renders nothing when MDS is disabled / the
  * plugin isn't present (single local cluster), so the local-cluster case stays chrome-free.
  */
-export const DataSourceControl: React.FC<Props> = ({ services, onChange }) => {
+export const DataSourceControl: React.FC<Props> = ({ services, onChange, defaultDataSourceId }) => {
   const DataSourceSelector = services.dataSourceManagement?.ui?.DataSourceSelector;
   if (!DataSourceSelector) {
     return null;
@@ -39,10 +42,12 @@ export const DataSourceControl: React.FC<Props> = ({ services, onChange }) => {
         // Onboarding users (Splunk/Datadog) pick a real registered cluster — the implicit local
         // cluster isn't a meaningful drilldown target, so hide it here.
         hideLocalCluster
-        // No `defaultOption` → the selector auto-selects a real registered data source on load
+        // When a data source was restored from the URL, pre-select it via `defaultOption`. Otherwise
+        // omit `defaultOption` so the selector auto-selects a real registered data source on load
         // (the workspace default, or the first available when local cluster is hidden), so the
         // picker always reflects the cluster whose indexes are actually shown — never an empty
         // selection while the list below is populated.
+        {...(defaultDataSourceId ? { defaultOption: [{ id: defaultDataSourceId }] } : {})}
         disabled={false}
         removePrepend={false}
         placeholderText={i18n.translate('explore.logsExplore.dataSource.placeholder', {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/data_source_control.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { ExploreServices } from '../../../../types';
+
+export interface SelectedDataSource {
+  id?: string;
+  title?: string;
+}
+
+interface Props {
+  services: ExploreServices;
+  onChange: (dataSource: SelectedDataSource) => void;
+}
+
+/**
+ * Reuses the data_source_management `DataSourceSelector` so the user can switch which OpenSearch
+ * data source (MDS) the index list is scoped to. Renders nothing when MDS is disabled / the
+ * plugin isn't present (single local cluster), so the local-cluster case stays chrome-free.
+ */
+export const DataSourceControl: React.FC<Props> = ({ services, onChange }) => {
+  const DataSourceSelector = services.dataSourceManagement?.ui?.DataSourceSelector;
+  if (!DataSourceSelector) {
+    return null;
+  }
+
+  return (
+    <div className="logsExploreDataSourceControl" data-test-subj="logsExploreDataSourceControl">
+      <DataSourceSelector
+        savedObjectsClient={services.savedObjects.client}
+        notifications={services.notifications.toasts}
+        uiSettings={services.uiSettings}
+        fullWidth
+        compressed
+        // Onboarding users (Splunk/Datadog) pick a real registered cluster — the implicit local
+        // cluster isn't a meaningful drilldown target, so hide it here.
+        hideLocalCluster
+        // No `defaultOption` → the selector auto-selects a real registered data source on load
+        // (the workspace default, or the first available when local cluster is hidden), so the
+        // picker always reflects the cluster whose indexes are actually shown — never an empty
+        // selection while the list below is populated.
+        disabled={false}
+        removePrepend={false}
+        placeholderText={i18n.translate('explore.logsExplore.dataSource.placeholder', {
+          defaultMessage: 'Select a data source',
+        })}
+        onSelectedDataSource={(options: Array<{ id?: string; label?: string }>) => {
+          const opt = options?.[0];
+          onChange({ id: opt?.id ?? '', title: opt?.label });
+        }}
+      />
+    </div>
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { buildChart } from './histogram_chart';
+import { HistogramResult } from '../hooks/fetch_histogram';
+import { severityColor } from '../severity';
+
+const base = (series: HistogramResult['series']): HistogramResult => ({
+  series,
+  intervalMs: 60_000,
+  from: 0,
+  to: 900_000,
+  totals: [],
+});
+
+describe('buildChart', () => {
+  // --- positive cases ---
+  it('builds a single blue series for the no-severity ("count") case', () => {
+    const { chart, palette } = buildChart(
+      base([
+        {
+          name: 'count',
+          dataPoints: [
+            [0, 5],
+            [60_000, 3],
+          ],
+        },
+      ])
+    );
+    // One series, palette is the single debug/blue color.
+    expect(palette).toEqual([severityColor('debug')]);
+    // The point-series builder spans the [from,to] bounds at the given interval, so it carries at
+    // least the two real buckets (and includes bucket 0).
+    expect(chart.xAxisOrderedValues.length).toBeGreaterThanOrEqual(2);
+    expect(chart.xAxisOrderedValues).toContain(0);
+    // No breakdown series for the single-series case.
+    expect(chart.series === undefined || chart.series.length <= 1).toBe(true);
+  });
+
+  it('orders severity series + palette error→warn→info→debug→unknown (bottom→top of stack)', () => {
+    // Deliberately shuffled input; buildChart must reorder deterministically.
+    const { chart, palette } = buildChart(
+      base([
+        { name: 'DEBUG', dataPoints: [[0, 1]] },
+        { name: 'ERROR', dataPoints: [[0, 2]] },
+        { name: 'INFO', dataPoints: [[0, 3]] },
+        { name: 'WARN', dataPoints: [[0, 4]] },
+      ])
+    );
+    // The palette reflects the canonical severity order.
+    expect(palette).toEqual([
+      severityColor('error'),
+      severityColor('warn'),
+      severityColor('info'),
+      severityColor('debug'),
+    ]);
+    // The chart carries a breakdown series per severity.
+    expect(chart.series?.map((s) => s.name)).toEqual(['ERROR', 'WARN', 'INFO', 'DEBUG']);
+  });
+
+  it('places unrecognized/unknown severities last in the stack', () => {
+    const { chart, palette } = buildChart(
+      base([
+        { name: 'banana', dataPoints: [[0, 1]] },
+        { name: 'ERROR', dataPoints: [[0, 2]] },
+      ])
+    );
+    expect(chart.series?.map((s) => s.name)).toEqual(['ERROR', 'banana']);
+    // The trailing color is the "unknown" (subdued) color.
+    expect(palette[palette.length - 1]).toBe(severityColor('unknown'));
+  });
+
+  // --- edge case ---
+  it('does not crash for an empty severity series list', () => {
+    const { chart, palette } = buildChart(base([]));
+    expect(palette).toEqual([]);
+    expect(chart.series ?? []).toEqual([]);
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.test.ts
@@ -29,8 +29,9 @@ describe('buildChart', () => {
         },
       ])
     );
-    // One series, palette is the single debug/blue color.
-    expect(palette).toEqual([severityColor('debug')]);
+    // One series, palette is the single "regular logs" blue — colored via the `unknown` bucket
+    // (SINGLE_SERIES_BUCKET), which now carries the prominent blue.
+    expect(palette).toEqual([severityColor('unknown')]);
     // The point-series builder spans the [from,to] bounds at the given interval, so it carries at
     // least the two real buckets (and includes bucket 0).
     expect(chart.xAxisOrderedValues.length).toBeGreaterThanOrEqual(2);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
@@ -32,10 +32,11 @@ interface Props {
   chartId: string;
 }
 
-// Blue for the no-severity single-series count (matches the debug/blue status color). Exported so
-// the legend colors the "logs" total the SAME blue as the bars (not the grey 'unknown' color that
-// normalizeSeverity('count') would otherwise yield).
-export const SINGLE_SERIES_BUCKET = 'debug' as const;
+// The no-severity single-series count ("regular logs") is colored via the `unknown` bucket, which
+// now carries the prominent "regular logs" blue (see severity.ts). Exported so the legend colors the
+// "logs" total the SAME blue as the bars. (Previously this pointed at `debug` to borrow its blue;
+// `debug` is now purple, so we point at `unknown` — semantically correct: no level = unknown.)
+export const SINGLE_SERIES_BUCKET = 'unknown' as const;
 const SEVERITY_STACK_ORDER: Record<string, number> = {
   error: 0,
   warn: 1,

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
@@ -100,12 +100,26 @@ export const HistogramChart: React.FC<Props> = ({
       ...spec,
       legend: { show: false },
       grid: { ...(spec as any).grid, right: 8 },
+      // Enable a hidden lineX brush so users can DRAG-select a time range on the chart (the toolbar
+      // button stays hidden — the brush is activated programmatically below). Mirrors DiscoverHistogram.
+      brush: { toolbox: ['lineX'], xAxisIndex: 0 },
+      toolbox: { show: false },
     };
     // Disable entry animation — many small charts mounting/refetching on scroll shouldn't all animate.
     inst.setOption({ ...specNoLegend, animation: false } as echarts.EChartsOption, true);
-  }, [chart, palette, isDarkMode, services.uiSettings]);
+    // Activate the brush cursor without a visible toolbar so a plain drag selects a range.
+    if (onBrush) {
+      inst.dispatchAction({
+        type: 'takeGlobalCursor',
+        key: 'brush',
+        brushOption: { brushType: 'lineX', brushMode: 'single' },
+      });
+    }
+  }, [chart, palette, isDarkMode, services.uiSettings, onBrush]);
 
-  // Brush-to-select → onBrush({from,to}); also single-click a bar selects that bucket.
+  // Time-range interactions → onBrush(from,to) → the parent updates the global time picker:
+  //  • DRAG across bars (lineX brush) selects an arbitrary [from,to] range.
+  //  • single-CLICK a bar zooms to that bucket's [start, start + interval].
   useEffect(() => {
     const inst = instanceRef.current;
     if (!inst || !onBrush) return;
@@ -113,12 +127,23 @@ export const HistogramChart: React.FC<Props> = ({
       const range = params.areas?.[0]?.coordRange;
       if (range && range[0] != null && range[1] != null) onBrush(range[0], range[1]);
     };
+    const onClick = (params: { componentType?: string; value?: [number, number] }) => {
+      if (params.componentType === 'series' && params.value) {
+        const start = params.value[0];
+        if (start != null) onBrush(start, start + histogram.intervalMs);
+      }
+    };
     // @ts-expect-error echarts event typing is loose for custom events
     inst.on('brushEnd', onBrushEnd);
+    // @ts-expect-error echarts event typing is loose for click params
+    inst.on('click', onClick);
     return () => {
-      if (!inst.isDisposed()) inst.off('brushEnd', onBrushEnd);
+      if (!inst.isDisposed()) {
+        inst.off('brushEnd', onBrushEnd);
+        inst.off('click', onClick);
+      }
     };
-  }, [onBrush]);
+  }, [onBrush, histogram.intervalMs]);
 
   // Cursor sync: publish this chart's hovered x-index; subscribe to show a crosshair when another
   // chart is hovered (like metrics explore's synced pointer). Uses echarts showTip/axisPointer.

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
@@ -1,0 +1,241 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import moment from 'moment';
+import * as echarts from 'echarts';
+import {
+  Chart,
+  Dimensions,
+  buildChartFromBreakdownSeries,
+  buildPointSeriesData,
+} from '../../../../components/chart/utils/point_series';
+import {
+  createHistogramSpec,
+  getTimezone,
+} from '../../../../components/chart/utils/echarts_histogram_utils';
+import { DEFAULT_THEME } from '../../../../components/visualizations/theme/default';
+import { ExploreServices } from '../../../../types';
+import { HistogramResult } from '../hooks/fetch_histogram';
+import { normalizeSeverity, severityColor } from '../severity';
+import { useCursorBus } from '../../metrics/explore/hooks/cursor_context';
+
+interface Props {
+  services: ExploreServices;
+  histogram: HistogramResult;
+  height: number;
+  /** Brush-select: selected [from,to] epoch-ms → caller updates the global time picker. */
+  onBrush?: (from: number, to: number) => void;
+  /** Stable key so cursor-sync can ignore self-originated pointer events. */
+  chartId: string;
+}
+
+// Blue for the no-severity single-series count (matches the debug/blue status color).
+const SINGLE_SERIES_BUCKET = 'debug' as const;
+const SEVERITY_STACK_ORDER: Record<string, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+  unknown: 4,
+};
+
+/**
+ * The per-card histogram — an ECharts bar chart built from our PPL severity series, sharing the
+ * ONE severity→color system (getColors status palette) with the legend + log-line tokens. Reuses
+ * the production `createHistogramSpec` (native tooltip, x/y axes, stacked bars, brush-to-select) so
+ * the engine matches the Query-mode chart. A shared cursor bus syncs the crosshair across all cards.
+ */
+export const HistogramChart: React.FC<Props> = ({
+  services,
+  histogram,
+  height,
+  onBrush,
+  chartId,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const instanceRef = useRef<echarts.ECharts | null>(null);
+  const bus = useCursorBus();
+
+  const isDarkMode = services.uiSettings.get('theme:darkMode');
+
+  // Build the Chart + ordered palette (severity stack order: error→warn→info→debug→unknown, bottom→top).
+  const { chart, palette } = useMemo(() => buildChart(histogram), [histogram]);
+
+  // Init the ECharts instance once.
+  useEffect(() => {
+    if (!containerRef.current || instanceRef.current) return;
+    const inst = echarts.init(containerRef.current, DEFAULT_THEME);
+    instanceRef.current = inst;
+    const resizeObserver = new ResizeObserver(() => {
+      if (inst && !inst.isDisposed()) inst.resize();
+    });
+    resizeObserver.observe(containerRef.current);
+    return () => {
+      resizeObserver.disconnect();
+      if (!inst.isDisposed()) inst.dispose();
+      instanceRef.current = null;
+    };
+  }, []);
+
+  // Apply the spec whenever the data/theme changes.
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst || inst.isDisposed()) return;
+    const spec = createHistogramSpec(chart, {
+      chartType: 'HistogramBar',
+      timeZone: getTimezone(services.uiSettings),
+      isDarkMode,
+      showYAxisLabel: false,
+      yAxisLabel: 'Count',
+      useSmartDateFormat: true,
+      colorPalette: palette,
+    });
+    // The shared spec draws its OWN ECharts legend for multi-series charts. We render a richer
+    // custom legend (with humanized totals) below the chart, so suppress the built-in one to avoid a
+    // double legend — and reclaim the right margin it reserved so the bars use the full card width.
+    const specNoLegend = {
+      ...spec,
+      legend: { show: false },
+      grid: { ...(spec as any).grid, right: 8 },
+    };
+    // Disable entry animation — many small charts mounting/refetching on scroll shouldn't all animate.
+    inst.setOption({ ...specNoLegend, animation: false } as echarts.EChartsOption, true);
+  }, [chart, palette, isDarkMode, services.uiSettings]);
+
+  // Brush-to-select → onBrush({from,to}); also single-click a bar selects that bucket.
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst || !onBrush) return;
+    const onBrushEnd = (params: { areas?: Array<{ coordRange?: [number, number] }> }) => {
+      const range = params.areas?.[0]?.coordRange;
+      if (range && range[0] != null && range[1] != null) onBrush(range[0], range[1]);
+    };
+    // @ts-expect-error echarts event typing is loose for custom events
+    inst.on('brushEnd', onBrushEnd);
+    return () => {
+      if (!inst.isDisposed()) inst.off('brushEnd', onBrushEnd);
+    };
+  }, [onBrush]);
+
+  // Cursor sync: publish this chart's hovered x-index; subscribe to show a crosshair when another
+  // chart is hovered (like metrics explore's synced pointer). Uses echarts showTip/axisPointer.
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst || !bus) return;
+
+    const zr = inst.getZr();
+    const onMove = (e: { offsetX: number; offsetY: number }) => {
+      const pointInGrid = inst.convertFromPixel({ seriesIndex: 0 }, [e.offsetX, e.offsetY]);
+      if (!pointInGrid) return;
+      const xs = chart.xAxisOrderedValues;
+      if (!xs?.length) return;
+      // Nearest bucket index to the hovered x.
+      const hoveredX = pointInGrid[0];
+      let idx = 0;
+      let best = Infinity;
+      xs.forEach((x, i) => {
+        const d = Math.abs(x - hoveredX);
+        if (d < best) {
+          best = d;
+          idx = i;
+        }
+      });
+      bus.publish({ idx, yRatio: 0 });
+    };
+    const onOut = () => bus.publish(null);
+    zr.on('mousemove', onMove);
+    zr.on('globalout', onOut);
+
+    const unsub = bus.subscribe((state) => {
+      if (inst.isDisposed()) return;
+      if (!state) {
+        inst.dispatchAction({ type: 'hideTip' });
+        inst.dispatchAction({ type: 'updateAxisPointer', currTrigger: 'leave' });
+        return;
+      }
+      const xs = chart.xAxisOrderedValues;
+      if (!xs || state.idx >= xs.length) return;
+      // Show the crosshair/tooltip at the shared bucket index on every chart.
+      inst.dispatchAction({ type: 'showTip', seriesIndex: 0, dataIndex: state.idx });
+    });
+
+    return () => {
+      zr.off('mousemove', onMove);
+      zr.off('globalout', onOut);
+      unsub();
+    };
+  }, [bus, chart]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="logStreamCard__histogram"
+      data-test-subj="logsExploreSeverityHistogram"
+      data-chart-id={chartId}
+      style={{ height, width: '100%' }}
+    />
+  );
+};
+
+/**
+ * Fold the pre-gap-filled PPL series into a Chart + a palette ordered to match the series stacking
+ * order, so `createHistogramSpec`'s index-based coloring lands the right severity color on each bar.
+ * Exported for unit testing (the ECharts render path can't run in jsdom).
+ */
+export function buildChart(histogram: HistogramResult): { chart: Chart; palette: string[] } {
+  const { series, intervalMs, from, to } = histogram;
+  const dimensions = buildDimensions(intervalMs, from, to);
+
+  const singleSeries = series.length === 1 && series[0].name === 'count';
+  if (singleSeries) {
+    const chart = buildPointSeriesData(
+      {
+        columns: [
+          { id: 'x', name: '@timestamp' },
+          { id: 'y', name: 'Count' },
+        ],
+        rows: series[0].dataPoints.map(([x, y]) => ({ x, y })),
+      } as any,
+      dimensions
+    );
+    return { chart, palette: [severityColor(SINGLE_SERIES_BUCKET)] };
+  }
+
+  // Severity breakdown: order series (and thus the palette) error→warn→info→debug→unknown.
+  const ordered = [...series].sort(
+    (a, b) =>
+      (SEVERITY_STACK_ORDER[normalizeSeverity(a.name)] ?? 9) -
+      (SEVERITY_STACK_ORDER[normalizeSeverity(b.name)] ?? 9)
+  );
+  const chart = buildChartFromBreakdownSeries(
+    {
+      breakdownField: 'severity',
+      series: ordered.map((s) => ({ breakdownValue: s.name, dataPoints: s.dataPoints })),
+    },
+    dimensions
+  );
+  const palette = ordered.map((s) => severityColor(normalizeSeverity(s.name)));
+  return { chart, palette };
+}
+
+/** Minimal Dimensions the Chart builders need: x = time bucket (moment interval + bounds), y = count. */
+function buildDimensions(intervalMs: number, from: number, to: number): Dimensions {
+  return ({
+    x: {
+      accessor: 0,
+      format: { id: 'date', params: { pattern: 'HH:mm' } },
+      params: {
+        date: true,
+        interval: moment.duration(intervalMs, 'ms'),
+        intervalOpenSearchValue: 1,
+        intervalOpenSearchUnit: 'm',
+        format: 'HH:mm',
+        bounds: { min: moment(from), max: moment(to) },
+      },
+    },
+    y: { accessor: 1, format: { id: 'number' }, params: {} },
+  } as unknown) as Dimensions;
+}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
@@ -256,7 +256,7 @@ export function buildChart(histogram: HistogramResult): { chart: Chart; palette:
 
 /** Minimal Dimensions the Chart builders need: x = time bucket (moment interval + bounds), y = count. */
 function buildDimensions(intervalMs: number, from: number, to: number): Dimensions {
-  return ({
+  return {
     x: {
       accessor: 0,
       format: { id: 'date', params: { pattern: 'HH:mm' } },
@@ -270,5 +270,5 @@ function buildDimensions(intervalMs: number, from: number, to: number): Dimensio
       },
     },
     y: { accessor: 1, format: { id: 'number' }, params: {} },
-  } as unknown) as Dimensions;
+  } as unknown as Dimensions;
 }

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/histogram_chart.tsx
@@ -32,8 +32,10 @@ interface Props {
   chartId: string;
 }
 
-// Blue for the no-severity single-series count (matches the debug/blue status color).
-const SINGLE_SERIES_BUCKET = 'debug' as const;
+// Blue for the no-severity single-series count (matches the debug/blue status color). Exported so
+// the legend colors the "logs" total the SAME blue as the bars (not the grey 'unknown' color that
+// normalizeSeverity('count') would otherwise yield).
+export const SINGLE_SERIES_BUCKET = 'debug' as const;
 const SEVERITY_STACK_ORDER: Record<string, number> = {
   error: 0,
   warn: 1,
@@ -84,6 +86,11 @@ export const HistogramChart: React.FC<Props> = ({
   useEffect(() => {
     const inst = instanceRef.current;
     if (!inst || inst.isDisposed()) return;
+    // For the no-severity single series, `createHistogramSpec` colors the bars from `customColor`
+    // (NOT `colorPalette`, which only applies to the multi-series path). Pass our single blue as
+    // customColor so the bars match the legend dot exactly (both severityColor(SINGLE_SERIES_BUCKET));
+    // otherwise the bars fall back to the generic category color and mismatch the dot.
+    const isSingleSeries = palette.length === 1;
     const spec = createHistogramSpec(chart, {
       chartType: 'HistogramBar',
       timeZone: getTimezone(services.uiSettings),
@@ -92,6 +99,7 @@ export const HistogramChart: React.FC<Props> = ({
       yAxisLabel: 'Count',
       useSmartDateFormat: true,
       colorPalette: palette,
+      ...(isSingleSeries ? { customColor: palette[0] } : {}),
     });
     // The shared spec draws its OWN ECharts legend for multi-series charts. We render a richer
     // custom legend (with humanized totals) below the chart, so suppress the built-in one to avoid a

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_line.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_line.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LogLine } from './log_line';
+
+describe('LogLine', () => {
+  it('renders timestamp + colored level chip + key=value body for a structured row', () => {
+    render(
+      <LogLine
+        row={{ '@timestamp': '2026-07-10T14:22:01Z', level: 'ERROR', message: 'boom', svc: 'api' }}
+        timeFieldName="@timestamp"
+        severityField="level"
+      />
+    );
+    // Level chip present + bucketed for coloring.
+    expect(screen.getByTestId('logsExploreLogLine-level-error')).toHaveTextContent('ERROR');
+    // Body has the non-time, non-level fields as key=value.
+    const line = screen.getByTestId('logsExploreLogLine');
+    expect(line).toHaveTextContent('message=boom');
+    expect(line).toHaveTextContent('svc=api');
+    // Timestamp shown (shortened to HH:MM:SS), and NOT duplicated into the key=value body.
+    expect(line).toHaveTextContent('14:22:01');
+    expect(line).not.toHaveTextContent('@timestamp=');
+  });
+
+  it('falls back to JSON when there are no non-time/level fields', () => {
+    render(
+      <LogLine
+        row={{ '@timestamp': 'T', level: 'INFO' }}
+        timeFieldName="@timestamp"
+        severityField="level"
+      />
+    );
+    // No extra fields → body is JSON of the whole row.
+    expect(screen.getByTestId('logsExploreLogLine')).toHaveTextContent('"level":"INFO"');
+  });
+
+  it('applies the truncated modifier by default and drops it when expanded', () => {
+    const { rerender } = render(<LogLine row={{ a: 1 }} />);
+    expect(screen.getByTestId('logsExploreLogLine').className).toContain(
+      'logsExploreLogLine--truncated'
+    );
+    rerender(<LogLine row={{ a: 1 }} truncated={false} />);
+    expect(screen.getByTestId('logsExploreLogLine').className).not.toContain(
+      'logsExploreLogLine--truncated'
+    );
+  });
+
+  it('auto-detects the level field when no explicit severityField is passed', () => {
+    // `severity` is in SEVERITY_FIELD_CANDIDATES → detected without an explicit prop.
+    render(<LogLine row={{ severity: 'warning', msg: 'disk low' }} />);
+    expect(screen.getByTestId('logsExploreLogLine-level-warn')).toHaveTextContent('WARNING');
+  });
+
+  it('renders no timestamp span when the time field is absent from the row', () => {
+    const { container } = render(
+      <LogLine row={{ level: 'INFO', msg: 'x' }} timeFieldName="@timestamp" severityField="level" />
+    );
+    expect(container.querySelector('.logsExploreLogLine__ts')).toBeNull();
+  });
+
+  it('renders no level chip when there is no severity value', () => {
+    const { container } = render(<LogLine row={{ msg: 'no level here' }} />);
+    expect(container.querySelector('.logsExploreLogLine__level')).toBeNull();
+    expect(screen.getByTestId('logsExploreLogLine')).toHaveTextContent('msg=no level here');
+  });
+
+  it('stringifies nested object values in the key=value body', () => {
+    render(<LogLine row={{ ctx: { user: 'ann', id: 7 } }} />);
+    expect(screen.getByTestId('logsExploreLogLine')).toHaveTextContent('ctx={"user":"ann","id":7}');
+  });
+
+  it('shortens an ISO timestamp to HH:MM:SS.mmm', () => {
+    render(
+      <LogLine
+        row={{ '@timestamp': '2026-07-10T14:22:01.123Z', level: 'INFO', a: 1 }}
+        timeFieldName="@timestamp"
+        severityField="level"
+      />
+    );
+    expect(screen.getByTestId('logsExploreLogLine')).toHaveTextContent('14:22:01.123');
+  });
+
+  it('shows a non-ISO timestamp string as-is (no T-match)', () => {
+    render(<LogLine row={{ '@timestamp': '1720621321000', a: 1 }} timeFieldName="@timestamp" />);
+    expect(screen.getByTestId('logsExploreLogLine')).toHaveTextContent('1720621321000');
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_line.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_line.tsx
@@ -49,7 +49,7 @@ export const LogLine: React.FC<Props> = ({
       data-test-subj="logsExploreLogLine"
     >
       {tsValue !== undefined && <span className="logsExploreLogLine__ts">{formatTs(tsValue)}</span>}
-      {levelValue !== undefined && (
+      {levelValue != null && String(levelValue).trim() !== '' && (
         <span
           className="logsExploreLogLine__level"
           style={{ color: severityColor(levelBucket) }}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_line.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_line.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+import { PreviewRow } from '../hooks/fetch_preview';
+import { SEVERITY_FIELD_CANDIDATES, normalizeSeverity, severityColor } from '../severity';
+
+interface Props {
+  row: PreviewRow;
+  timeFieldName?: string;
+  /** Field to read the level token from (detected once by the card). */
+  severityField?: string;
+  /** Truncated = one line with ellipsis; expanded = wrap + full. */
+  truncated?: boolean;
+}
+
+/**
+ * Renders one raw log line, Grafana-style: a subdued timestamp, a color-coded level chip (green
+ * info / yellow warn / red error), then the rest of the record as `key=value` pairs (or JSON when
+ * there's no obvious structure). Not a parsed column table — the whole line is the unit.
+ */
+export const LogLine: React.FC<Props> = ({
+  row,
+  timeFieldName,
+  severityField,
+  truncated = true,
+}) => {
+  const levelFieldName =
+    severityField ?? SEVERITY_FIELD_CANDIDATES.find((f) => row[f] !== undefined);
+  const levelValue = levelFieldName ? row[levelFieldName] : undefined;
+  const levelBucket = normalizeSeverity(levelValue);
+
+  const tsValue = timeFieldName ? row[timeFieldName] : undefined;
+
+  // Remaining fields = everything except the time and level fields, rendered as key=value with the
+  // key names dimmed (Grafana texture). Falls back to JSON when there's a single opaque body field.
+  const restEntries = Object.entries(row).filter(
+    ([k]) => k !== timeFieldName && k !== levelFieldName
+  );
+
+  return (
+    <div
+      className={classNames('logsExploreLogLine', {
+        'logsExploreLogLine--truncated': truncated,
+      })}
+      data-test-subj="logsExploreLogLine"
+    >
+      {tsValue !== undefined && <span className="logsExploreLogLine__ts">{formatTs(tsValue)}</span>}
+      {levelValue !== undefined && (
+        <span
+          className="logsExploreLogLine__level"
+          style={{ color: severityColor(levelBucket) }}
+          data-test-subj={`logsExploreLogLine-level-${levelBucket}`}
+        >
+          {String(levelValue).toUpperCase()}
+        </span>
+      )}
+      <span className="logsExploreLogLine__body">
+        {restEntries.length > 0
+          ? restEntries.map(([k, v], i) => (
+              <React.Fragment key={k}>
+                {i > 0 && ' '}
+                <b>{k}=</b>
+                {formatValue(v)}
+              </React.Fragment>
+            ))
+          : safeStringify(row)}
+      </span>
+    </div>
+  );
+};
+
+/** Shorten ISO timestamps to a scannable HH:MM:SS.mmm (drops the date + trailing Z). */
+function formatTs(v: unknown): string {
+  const s = String(v);
+  const m = s.match(/T(\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?)/);
+  return m ? m[1] : s;
+}
+
+function formatValue(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'object') return safeStringify(v);
+  return String(v);
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
@@ -303,7 +303,7 @@ describe('LogStreamCard', () => {
       expect(onTimeFieldChange).toHaveBeenCalledWith('event.ingested');
     });
 
-    it('shows the SAME selector — disabled — when there is only one date field (uniform UI)', () => {
+    it('shows a read-only field (NOT a disabled/greyed select) when there is only one date field', () => {
       render(
         <LogStreamCard
           {...baseProps}
@@ -315,14 +315,16 @@ describe('LogStreamCard', () => {
           })}
         />
       );
-      // Same widget as the multi-field case (no separate read-only badge), but non-interactive.
-      const select = screen.getByTestId('logsExploreCardTimeFieldSelect') as HTMLSelectElement;
-      expect(select).toBeDisabled();
-      expect(select.value).toBe('@timestamp');
-      expect(Array.from(select.options).map((o) => o.value)).toEqual(['@timestamp']);
+      // No interactive select (nothing to switch), and NOT a greyed-out disabled select — a
+      // read-only field with the same clock-prepend look and normal colors.
+      expect(screen.queryByTestId('logsExploreCardTimeFieldSelect')).not.toBeInTheDocument();
+      const readonly = screen.getByTestId('logsExploreCardTimeFieldReadonly') as HTMLInputElement;
+      expect(readonly).toHaveValue('@timestamp');
+      expect(readonly).toHaveAttribute('readonly');
+      expect(readonly).not.toBeDisabled();
     });
 
-    it('datasets show the uniform (disabled) time selector from their single timeFieldName', () => {
+    it('datasets show the read-only time field from their single timeFieldName', () => {
       render(
         <LogStreamCard
           {...baseProps}
@@ -335,14 +337,15 @@ describe('LogStreamCard', () => {
           })}
         />
       );
-      const select = screen.getByTestId('logsExploreCardTimeFieldSelect') as HTMLSelectElement;
-      expect(select).toBeDisabled();
-      expect(select.value).toBe('@timestamp');
+      expect(screen.queryByTestId('logsExploreCardTimeFieldSelect')).not.toBeInTheDocument();
+      const readonly = screen.getByTestId('logsExploreCardTimeFieldReadonly') as HTMLInputElement;
+      expect(readonly).toHaveValue('@timestamp');
+      expect(readonly).not.toBeDisabled();
     });
   });
 
   describe('dataset actions + index health', () => {
-    it('dataset card shows Show logs (→ onPrimary) and Manage (→ onManage) buttons', () => {
+    it('dataset card shows a Query action (→ onPrimary) and Manage (→ onManage) buttons', () => {
       const onPrimary = jest.fn();
       const onManage = jest.fn();
       render(
@@ -355,13 +358,15 @@ describe('LogStreamCard', () => {
           data={withData({ preview: { columns: [], rows: [] } })}
         />
       );
-      fireEvent.click(screen.getByTestId('logsExploreCardShowLogs'));
+      const queryBtn = screen.getByTestId('logsExploreCardShowLogs');
+      expect(queryBtn).toHaveTextContent('Query');
+      fireEvent.click(queryBtn);
       expect(onPrimary).toHaveBeenCalled();
       fireEvent.click(screen.getByTestId('logsExploreCardManage'));
       expect(onManage).toHaveBeenCalled();
     });
 
-    it('index cards do NOT show the dataset Show logs / Manage buttons', () => {
+    it('index cards do NOT show the dataset Query / Manage buttons', () => {
       render(
         <LogStreamCard
           {...baseProps}
@@ -374,7 +379,7 @@ describe('LogStreamCard', () => {
       expect(screen.queryByTestId('logsExploreCardManage')).not.toBeInTheDocument();
     });
 
-    it('renders a health dot for an index with cat.indices health', () => {
+    it('renders a labeled health pill for an index with cat.indices health', () => {
       render(
         <LogStreamCard
           {...baseProps}
@@ -383,10 +388,35 @@ describe('LogStreamCard', () => {
           data={withData({ preview: { columns: [], rows: [] } })}
         />
       );
-      expect(screen.getByTestId(`logsExploreCardHealth-${baseProps.name}`)).toBeInTheDocument();
+      const pill = screen.getByTestId(`logsExploreCardHealth-${baseProps.name}`);
+      expect(pill).toBeInTheDocument();
+      // Shown as a labeled status word (better than a bare dot), tinted per status.
+      expect(pill).toHaveTextContent('Degraded');
+      expect(pill.className).toContain('logStreamCard__healthPill--yellow');
     });
 
-    it('shows no health dot when health is unknown, or for a dataset card', () => {
+    it('health pill tooltip shows store size + shard layout from cat.indices on hover', async () => {
+      render(
+        <LogStreamCard
+          {...baseProps}
+          kind="index"
+          health="green"
+          storeSize="2.4gb"
+          primaryShards={5}
+          replicaCount={1}
+          data={withData({ preview: { columns: [], rows: [] } })}
+        />
+      );
+      // EuiToolTip renders its content into the DOM on hover.
+      fireEvent.mouseOver(screen.getByTestId(`logsExploreCardHealth-${baseProps.name}`));
+      const tip = await screen.findByTestId(`logsExploreCardHealthTip-${baseProps.name}`);
+      expect(tip).toHaveTextContent('Index health: Healthy');
+      expect(tip).toHaveTextContent('Store size: 2.4gb');
+      expect(tip).toHaveTextContent('Primaries: 5');
+      expect(tip).toHaveTextContent('Replicas: 1');
+    });
+
+    it('shows no health pill when health is unknown, or for a dataset card', () => {
       const { rerender } = render(
         <LogStreamCard
           {...baseProps}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
@@ -51,7 +51,6 @@ const baseProps = {
   isTimeBased: true,
   rowState: LogRowState.FULL,
   timeFieldName: '@timestamp',
-  rangeLabel: '15 minutes',
   primaryLabel: 'Create dataset',
   onPrimary: jest.fn(),
   checked: false,
@@ -165,6 +164,34 @@ describe('LogStreamCard', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows the friendly label when provided, falling back to the name (pattern) otherwise', () => {
+    const { rerender } = render(
+      <LogStreamCard
+        {...baseProps}
+        kind="dataset"
+        name="nginx-access-*"
+        label="Nginx access logs"
+        primaryLabel="Query"
+        data={withData({ preview: { columns: [], rows: [] } })}
+      />
+    );
+    // The friendly label shows, not the raw pattern.
+    expect(screen.getByTestId('logsExploreCardNameLink')).toHaveTextContent('Nginx access logs');
+    expect(screen.getByTestId('logsExploreCardNameLink')).not.toHaveTextContent('nginx-access-*');
+    // No label → falls back to the name (pattern).
+    rerender(
+      <LogStreamCard
+        {...baseProps}
+        kind="dataset"
+        name="nginx-access-*"
+        label={undefined}
+        primaryLabel="Query"
+        data={withData({ preview: { columns: [], rows: [] } })}
+      />
+    );
+    expect(screen.getByTestId('logsExploreCardNameLink')).toHaveTextContent('nginx-access-*');
+  });
+
   it('shows the cross-cluster (remote) token for a remote index', () => {
     render(
       <LogStreamCard
@@ -178,7 +205,7 @@ describe('LogStreamCard', () => {
 
   // ---- compact variants ----
 
-  it('NO_RECENT: compact row with "No events in the last {range}" + actionable name + checkbox', () => {
+  it('NO_RECENT: compact row with "no events in the selected time range" + actionable name + checkbox', () => {
     const onPrimary = jest.fn();
     render(
       <LogStreamCard
@@ -192,14 +219,32 @@ describe('LogStreamCard', () => {
       />
     );
     const row = screen.getByTestId('logsExploreCardNoRecent');
-    expect(row).toHaveTextContent('No events in the last 15 minutes');
+    expect(row).toHaveTextContent('No events in the selected time range');
     // No full body.
     expect(screen.queryByTestId('logsExploreCardLogs')).not.toBeInTheDocument();
     expect(screen.queryByTestId('mock-severity-histogram')).not.toBeInTheDocument();
-    // Name still actionable, checkbox present.
+    // Name still actionable, checkbox present (this is an index).
     fireEvent.click(screen.getByTestId('logsExploreCardNameLink'));
     expect(onPrimary).toHaveBeenCalled();
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('NO_RECENT: a DATASET in the no-recent-data group has NO checkbox', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        kind="dataset"
+        rowState={LogRowState.NO_RECENT}
+        onPrimary={jest.fn()}
+        data={withData({
+          histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+          preview: { columns: [], rows: [] },
+        })}
+      />
+    );
+    // Only raw indexes are selectable; a dataset compact row must not render a selection checkbox.
+    expect(screen.getByTestId('logsExploreCardNoRecent')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
   it('EMPTY_INDEX: "No documents yet" + count/age, muted name (no link), no checkbox', () => {
@@ -410,7 +455,9 @@ describe('LogStreamCard', () => {
       // EuiToolTip renders its content into the DOM on hover.
       fireEvent.mouseOver(screen.getByTestId(`logsExploreCardHealth-${baseProps.name}`));
       const tip = await screen.findByTestId(`logsExploreCardHealthTip-${baseProps.name}`);
-      expect(tip).toHaveTextContent('Index health: Healthy');
+      // The tooltip shows the RAW cat.indices health status as-is (not the pill's "Healthy" label).
+      expect(tip).toHaveTextContent('Status: green');
+      expect(tip).not.toHaveTextContent('Healthy');
       expect(tip).toHaveTextContent('Store size: 2.4gb');
       expect(tip).toHaveTextContent('Primaries: 5');
       expect(tip).toHaveTextContent('Replicas: 1');

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
@@ -205,45 +205,54 @@ describe('LogStreamCard', () => {
 
   // ---- compact variants ----
 
-  it('NO_RECENT: compact row with "no events in the selected time range" + actionable name + checkbox', () => {
+  it('NO_RECENT: renders the FULL card (meta controls + histogram + empty-logs body) so the time field stays switchable', () => {
     const onPrimary = jest.fn();
     render(
       <LogStreamCard
         {...baseProps}
         rowState={LogRowState.NO_RECENT}
         onPrimary={onPrimary}
+        health="green"
         data={withData({
           histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
           preview: { columns: [], rows: [] },
         })}
       />
     );
-    const row = screen.getByTestId('logsExploreCardNoRecent');
-    expect(row).toHaveTextContent('No events in the selected time range');
-    // No full body.
-    expect(screen.queryByTestId('logsExploreCardLogs')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('mock-severity-histogram')).not.toBeInTheDocument();
+    // NOT the stripped compact row — the full card renders instead.
+    expect(screen.queryByTestId('logsExploreCardNoRecent')).not.toBeInTheDocument();
+    // Header meta controls are present: the (read-only) time-field capsule and index health pill.
+    expect(screen.getByTestId('logsExploreCardTimeFieldReadonly')).toBeInTheDocument();
+    expect(screen.getByTestId(`logsExploreCardHealth-${baseProps.name}`)).toBeInTheDocument();
+    // Full body: histogram column + logs region (with the empty "no documents in range" message).
+    expect(screen.getByTestId('mock-severity-histogram')).toBeInTheDocument();
+    expect(screen.getByTestId('logsExploreCardLogs')).toHaveTextContent(
+      'No documents in the selected time range'
+    );
     // Name still actionable, checkbox present (this is an index).
     fireEvent.click(screen.getByTestId('logsExploreCardNameLink'));
     expect(onPrimary).toHaveBeenCalled();
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
   });
 
-  it('NO_RECENT: a DATASET in the no-recent-data group has NO checkbox', () => {
+  it('NO_RECENT: a DATASET renders the full card with Query/Manage actions and NO checkbox', () => {
+    const onManage = jest.fn();
     render(
       <LogStreamCard
         {...baseProps}
         kind="dataset"
         rowState={LogRowState.NO_RECENT}
         onPrimary={jest.fn()}
+        onManage={onManage}
         data={withData({
           histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
           preview: { columns: [], rows: [] },
         })}
       />
     );
-    // Only raw indexes are selectable; a dataset compact row must not render a selection checkbox.
-    expect(screen.getByTestId('logsExploreCardNoRecent')).toBeInTheDocument();
+    // Full card, not the compact row; dataset actions available but no selection checkbox.
+    expect(screen.queryByTestId('logsExploreCardNoRecent')).not.toBeInTheDocument();
+    expect(screen.getByTestId('logsExploreCardManage')).toBeInTheDocument();
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.test.tsx
@@ -1,0 +1,414 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LogStreamCard, CardData } from './log_stream_card';
+import { LogRowState } from '../row_state';
+
+jest.mock('@osd/i18n', () => ({
+  i18n: {
+    translate: (_k: string, o: { defaultMessage: string; values?: any }) => {
+      let m = o.defaultMessage;
+      if (o.values)
+        Object.entries(o.values).forEach(([k, v]) => (m = m.replace(`{${k}}`, String(v))));
+      return m;
+    },
+  },
+}));
+
+jest.mock('./severity_histogram', () => ({
+  SeverityHistogram: () => <div data-test-subj="mock-severity-histogram" />,
+}));
+jest.mock('./log_line', () => ({
+  LogLine: ({ row }: { row: any }) => (
+    <div data-test-subj="mock-log-line">{JSON.stringify(row)}</div>
+  ),
+}));
+jest.mock('./card_skeleton', () => ({
+  CardSkeleton: () => <div data-test-subj="mock-hist-skeleton" />,
+  LogLinesSkeleton: () => <div data-test-subj="mock-logs-skeleton" />,
+}));
+
+class MockIO {
+  cb: any;
+  constructor(cb: any) {
+    this.cb = cb;
+  }
+  observe() {
+    this.cb([{ isIntersecting: true }]);
+  }
+  disconnect() {}
+}
+(global as any).IntersectionObserver = MockIO;
+
+const baseProps = {
+  services: {} as any,
+  name: 'logs-app-2026.07.09',
+  kind: 'index' as const,
+  isTimeBased: true,
+  rowState: LogRowState.FULL,
+  timeFieldName: '@timestamp',
+  rangeLabel: '15 minutes',
+  primaryLabel: 'Create dataset',
+  onPrimary: jest.fn(),
+  checked: false,
+  onToggleCheck: jest.fn(),
+  onVisibilityChange: jest.fn(),
+  onBrushTime: jest.fn(),
+};
+
+const withData = (data: Partial<CardData>): CardData => ({
+  loading: false,
+  ...data,
+});
+
+describe('LogStreamCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reports visibility via IntersectionObserver on mount', () => {
+    const onVisibilityChange = jest.fn();
+    render(
+      <LogStreamCard
+        {...baseProps}
+        rowState={LogRowState.LOADING}
+        onVisibilityChange={onVisibilityChange}
+        data={withData({ loading: true })}
+      />
+    );
+    expect(onVisibilityChange).toHaveBeenCalledWith(baseProps.name, true);
+  });
+
+  it('time-based FULL card renders the severity histogram + log lines', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        data={withData({
+          histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+          preview: { columns: [], rows: [{ a: 1 }, { b: 2 }] },
+        })}
+      />
+    );
+    expect(screen.getByTestId('mock-severity-histogram')).toBeInTheDocument();
+    expect(screen.getAllByTestId('mock-log-line')).toHaveLength(2);
+  });
+
+  it('non-time-based card renders full-width logs with NO histogram', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        isTimeBased={false}
+        data={withData({ preview: { columns: [], rows: [{ a: 1 }] } })}
+      />
+    );
+    expect(screen.queryByTestId('mock-severity-histogram')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mock-log-line')).toBeInTheDocument();
+  });
+
+  it('the NAME is the primary action (no per-row button)', () => {
+    const onPrimary = jest.fn();
+    render(
+      <LogStreamCard
+        {...baseProps}
+        onPrimary={onPrimary}
+        data={withData({ preview: { columns: [], rows: [] } })}
+      />
+    );
+    // There is no dedicated primary button anymore.
+    expect(screen.queryByTestId('logsExploreCardPrimary')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('logsExploreCardNameLink'));
+    expect(onPrimary).toHaveBeenCalled();
+  });
+
+  it('toggles selection via the checkbox', () => {
+    const onToggleCheck = jest.fn();
+    render(
+      <LogStreamCard
+        {...baseProps}
+        onToggleCheck={onToggleCheck}
+        data={withData({ preview: { columns: [], rows: [] } })}
+      />
+    );
+    fireEvent.click(screen.getByTestId(`logsExploreCardCheckbox-${baseProps.name}`));
+    expect(onToggleCheck).toHaveBeenCalled();
+  });
+
+  it('shows the histogram + logs skeletons while loading', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        rowState={LogRowState.LOADING}
+        data={withData({ loading: true })}
+      />
+    );
+    expect(screen.getByTestId('mock-hist-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-logs-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the dataset kind label + name-link action for a dataset card (NO selection checkbox)', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        kind="dataset"
+        primaryLabel="Query"
+        data={withData({ preview: { columns: [], rows: [] } })}
+      />
+    );
+    expect(screen.getByTestId('logsExploreCardNameLink')).toHaveAttribute('title', 'Query');
+    expect(screen.getByText('Dataset')).toBeInTheDocument();
+    // Datasets are not selectable for batch dataset creation — no checkbox (avoids sharing checked
+    // state with a same-named index).
+    expect(
+      screen.queryByTestId(`logsExploreCardCheckbox-${baseProps.name}`)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the cross-cluster (remote) token for a remote index', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        isRemote
+        data={withData({ preview: { columns: [], rows: [] } })}
+      />
+    );
+    expect(screen.getByText('Index')).toBeInTheDocument();
+  });
+
+  // ---- compact variants ----
+
+  it('NO_RECENT: compact row with "No events in the last {range}" + actionable name + checkbox', () => {
+    const onPrimary = jest.fn();
+    render(
+      <LogStreamCard
+        {...baseProps}
+        rowState={LogRowState.NO_RECENT}
+        onPrimary={onPrimary}
+        data={withData({
+          histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+          preview: { columns: [], rows: [] },
+        })}
+      />
+    );
+    const row = screen.getByTestId('logsExploreCardNoRecent');
+    expect(row).toHaveTextContent('No events in the last 15 minutes');
+    // No full body.
+    expect(screen.queryByTestId('logsExploreCardLogs')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-severity-histogram')).not.toBeInTheDocument();
+    // Name still actionable, checkbox present.
+    fireEvent.click(screen.getByTestId('logsExploreCardNameLink'));
+    expect(onPrimary).toHaveBeenCalled();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('EMPTY_INDEX: "No documents yet" + count/age, muted name (no link), no checkbox', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        rowState={LogRowState.EMPTY_INDEX}
+        docsCount={0}
+        createdAt={Date.now() - 3 * 24 * 60 * 60 * 1000}
+        onPrimary={undefined}
+        data={withData({})}
+      />
+    );
+    const row = screen.getByTestId('logsExploreCardEmptyIndex');
+    expect(row).toHaveTextContent('No documents yet');
+    expect(row).toHaveTextContent('0 docs');
+    expect(screen.queryByTestId('logsExploreCardNameLink')).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('ERROR: danger compact row with the error chip + Retry firing onRetry', () => {
+    const onRetry = jest.fn();
+    render(
+      <LogStreamCard
+        {...baseProps}
+        rowState={LogRowState.ERROR}
+        onRetry={onRetry}
+        data={withData({ error: 'security_exception · 403' })}
+      />
+    );
+    expect(screen.getByTestId('logsExploreCardError')).toBeInTheDocument();
+    expect(screen.getByTestId('logsExploreCardErrorChip')).toHaveTextContent(
+      'security_exception · 403'
+    );
+    fireEvent.click(screen.getByTestId('logsExploreCardRetry'));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('ERROR: partial-shard failures use the warning tone', () => {
+    render(
+      <LogStreamCard
+        {...baseProps}
+        rowState={LogRowState.ERROR}
+        onRetry={jest.fn()}
+        data={withData({ error: 'Partial results — 2 of 5 shards failed' })}
+      />
+    );
+    // The row renders; tone class carries the warning variant.
+    expect(screen.getByTestId('logsExploreCardError').className).toContain(
+      'logsDrilldownCompactRow--warning'
+    );
+  });
+
+  it('NO_TIME_FIELD: collapsed row, explains why, no body/histogram/checkbox', () => {
+    render(
+      <LogStreamCard {...baseProps} rowState={LogRowState.NO_TIME_FIELD} data={withData({})} />
+    );
+    const row = screen.getByTestId('logsExploreCardNoTimeBadge');
+    expect(row).toHaveTextContent('No time field');
+    expect(screen.queryByTestId('logsExploreCardLogs')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-severity-histogram')).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  describe('time-field selector', () => {
+    const multiDate = ['@timestamp', 'observedTimestamp', 'event.ingested'];
+
+    it('shows a selector when there is more than one date field + a change handler', () => {
+      render(
+        <LogStreamCard
+          {...baseProps}
+          dateFields={multiDate}
+          onTimeFieldChange={jest.fn()}
+          data={withData({
+            histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+            preview: { columns: [], rows: [] },
+          })}
+        />
+      );
+      const select = screen.getByTestId('logsExploreCardTimeFieldSelect') as HTMLSelectElement;
+      expect(select.value).toBe('@timestamp');
+      expect(Array.from(select.options).map((o) => o.value)).toEqual(multiDate);
+    });
+
+    it('emits onTimeFieldChange with the newly-picked field', () => {
+      const onTimeFieldChange = jest.fn();
+      render(
+        <LogStreamCard
+          {...baseProps}
+          dateFields={multiDate}
+          onTimeFieldChange={onTimeFieldChange}
+          data={withData({
+            histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+            preview: { columns: [], rows: [] },
+          })}
+        />
+      );
+      fireEvent.change(screen.getByTestId('logsExploreCardTimeFieldSelect'), {
+        target: { value: 'event.ingested' },
+      });
+      expect(onTimeFieldChange).toHaveBeenCalledWith('event.ingested');
+    });
+
+    it('shows the SAME selector — disabled — when there is only one date field (uniform UI)', () => {
+      render(
+        <LogStreamCard
+          {...baseProps}
+          dateFields={['@timestamp']}
+          onTimeFieldChange={jest.fn()}
+          data={withData({
+            histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+            preview: { columns: [], rows: [] },
+          })}
+        />
+      );
+      // Same widget as the multi-field case (no separate read-only badge), but non-interactive.
+      const select = screen.getByTestId('logsExploreCardTimeFieldSelect') as HTMLSelectElement;
+      expect(select).toBeDisabled();
+      expect(select.value).toBe('@timestamp');
+      expect(Array.from(select.options).map((o) => o.value)).toEqual(['@timestamp']);
+    });
+
+    it('datasets show the uniform (disabled) time selector from their single timeFieldName', () => {
+      render(
+        <LogStreamCard
+          {...baseProps}
+          kind="dataset"
+          dateFields={undefined}
+          onTimeFieldChange={undefined}
+          data={withData({
+            histogram: { series: [], intervalMs: 60000, from: 0, to: 60000, totals: [] },
+            preview: { columns: [], rows: [] },
+          })}
+        />
+      );
+      const select = screen.getByTestId('logsExploreCardTimeFieldSelect') as HTMLSelectElement;
+      expect(select).toBeDisabled();
+      expect(select.value).toBe('@timestamp');
+    });
+  });
+
+  describe('dataset actions + index health', () => {
+    it('dataset card shows Show logs (→ onPrimary) and Manage (→ onManage) buttons', () => {
+      const onPrimary = jest.fn();
+      const onManage = jest.fn();
+      render(
+        <LogStreamCard
+          {...baseProps}
+          kind="dataset"
+          primaryLabel="Query"
+          onPrimary={onPrimary}
+          onManage={onManage}
+          data={withData({ preview: { columns: [], rows: [] } })}
+        />
+      );
+      fireEvent.click(screen.getByTestId('logsExploreCardShowLogs'));
+      expect(onPrimary).toHaveBeenCalled();
+      fireEvent.click(screen.getByTestId('logsExploreCardManage'));
+      expect(onManage).toHaveBeenCalled();
+    });
+
+    it('index cards do NOT show the dataset Show logs / Manage buttons', () => {
+      render(
+        <LogStreamCard
+          {...baseProps}
+          kind="index"
+          onManage={jest.fn()}
+          data={withData({ preview: { columns: [], rows: [] } })}
+        />
+      );
+      expect(screen.queryByTestId('logsExploreCardShowLogs')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('logsExploreCardManage')).not.toBeInTheDocument();
+    });
+
+    it('renders a health dot for an index with cat.indices health', () => {
+      render(
+        <LogStreamCard
+          {...baseProps}
+          kind="index"
+          health="yellow"
+          data={withData({ preview: { columns: [], rows: [] } })}
+        />
+      );
+      expect(screen.getByTestId(`logsExploreCardHealth-${baseProps.name}`)).toBeInTheDocument();
+    });
+
+    it('shows no health dot when health is unknown, or for a dataset card', () => {
+      const { rerender } = render(
+        <LogStreamCard
+          {...baseProps}
+          kind="index"
+          health={undefined}
+          data={withData({ preview: { columns: [], rows: [] } })}
+        />
+      );
+      expect(
+        screen.queryByTestId(`logsExploreCardHealth-${baseProps.name}`)
+      ).not.toBeInTheDocument();
+      rerender(
+        <LogStreamCard
+          {...baseProps}
+          kind="dataset"
+          health="green"
+          data={withData({ preview: { columns: [], rows: [] } })}
+        />
+      );
+      expect(
+        screen.queryByTestId(`logsExploreCardHealth-${baseProps.name}`)
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
@@ -1,0 +1,496 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useRef } from 'react';
+import moment from 'moment';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTextColor,
+  EuiLink,
+  EuiIcon,
+  EuiToken,
+  EuiCheckbox,
+  EuiToolTip,
+  EuiSelect,
+  EuiHealth,
+  EuiButtonEmpty,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { ExploreServices } from '../../../../types';
+import { PreviewResult } from '../hooks/fetch_preview';
+import { HistogramResult } from '../hooks/fetch_histogram';
+import { LogRowState } from '../row_state';
+import { SeverityHistogram } from './severity_histogram';
+import { LogLine } from './log_line';
+import { CardSkeleton, LogLinesSkeleton } from './card_skeleton';
+import { CompactRow } from './compact_row';
+
+export interface CardData {
+  preview?: PreviewResult;
+  histogram?: HistogramResult;
+  error?: string;
+  loading: boolean;
+}
+
+interface Props {
+  services: ExploreServices;
+  name: string;
+  kind: 'index' | 'dataset';
+  isRemote?: boolean;
+  isTimeBased: boolean;
+  /** The resolved visual state (full card vs. one of the compact variants). */
+  rowState: LogRowState;
+  severityField?: string;
+  timeFieldName?: string;
+  /** All date fields on the index (for the time-field selector); >1 → selector is shown. */
+  dateFields?: string[];
+  /** Doc count from cat.indices — shown in the empty-index compact row. */
+  docsCount?: number;
+  /** Cluster-health of the index (green/yellow/red) from cat.indices — shown as a header dot. */
+  health?: 'green' | 'yellow' | 'red';
+  /** Index creation time (epoch ms) — shown as "created {age}" in the empty-index compact row. */
+  createdAt?: number;
+  /** Humanized selected-range label (e.g. "15 minutes") for the no-recent-data copy. */
+  rangeLabel: string;
+  data: CardData;
+  /** The primary action label ("Query" / "Create dataset"); titles the name link. */
+  primaryLabel: string;
+  /** Runs the primary action. Undefined ⇒ the name is non-actionable (e.g. empty index). */
+  onPrimary?: () => void;
+  checked: boolean;
+  onToggleCheck: () => void;
+  onVisibilityChange: (name: string, visible: boolean) => void;
+  /** Brush-select on the histogram → update the global time range. */
+  onBrushTime: (from: number, to: number) => void;
+  /** User picked a different time field for this index → re-query preview + histogram. */
+  onTimeFieldChange?: (field: string) => void;
+  /** Retry a failed preview (state 04). */
+  onRetry?: () => void;
+  /** Dataset cards only: open this dataset in index-pattern management. */
+  onManage?: () => void;
+}
+
+// Inline log-stream height — the card shows the latest N lines; matches the histogram column height
+// so the two columns' bottoms align (#7).
+const LOGS_MAX_HEIGHT = 132;
+const HIST_HEIGHT = 132;
+
+// Distinct icons matching manage-workspace / dataset management.
+const ICON_INDEX = 'logoOpenSearch';
+const ICON_DATASET = 'indexPatternApp';
+
+/**
+ * One card in the Rows view. Resolves to a full histogram+logs card (FULL/LOADING) or to a compact
+ * one-row treatment (NO_RECENT / EMPTY_INDEX / ERROR / NO_TIME_FIELD) via {@link CompactRow}. The
+ * NAME is the primary action everywhere (no per-row button); empty-index / no-time-field names are
+ * non-actionable. Fetches are viewport-gated by the parent through IntersectionObserver.
+ */
+export const LogStreamCard: React.FC<Props> = ({
+  services,
+  name,
+  kind,
+  isRemote,
+  isTimeBased,
+  rowState,
+  severityField,
+  timeFieldName,
+  dateFields,
+  docsCount,
+  health,
+  createdAt,
+  rangeLabel,
+  data,
+  primaryLabel,
+  onPrimary,
+  checked,
+  onToggleCheck,
+  onVisibilityChange,
+  onBrushTime,
+  onTimeFieldChange,
+  onRetry,
+  onManage,
+}) => {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => onVisibilityChange(name, entry.isIntersecting),
+      { rootMargin: '100px' }
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      onVisibilityChange(name, false);
+    };
+  }, [name, onVisibilityChange]);
+
+  const icon = kind === 'dataset' ? ICON_DATASET : ICON_INDEX;
+  const checkboxProps = {
+    id: `logsDrilldownCheckCard-${name}`,
+    checked,
+    onChange: onToggleCheck,
+    ariaLabel: i18n.translate('explore.logsDrilldown.rows.selectForCreate', {
+      defaultMessage: 'Select {name} for dataset creation',
+      values: { name },
+    }),
+  };
+
+  // ---- Compact variants (a card whose body carries nothing to scan → one row) --------------------
+
+  // 05 · No time field: collapsed, non-actionable, explains WHY.
+  if (rowState === LogRowState.NO_TIME_FIELD) {
+    return (
+      <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
+        <CompactRow
+          icon="clock"
+          name={name}
+          message={i18n.translate('explore.logsDrilldown.rows.noTimeField', {
+            defaultMessage: 'No time field — can’t chart or create a dataset',
+          })}
+          tone="subdued"
+          data-test-subj="logsExploreCardNoTimeBadge"
+        />
+      </div>
+    );
+  }
+
+  // 03 · Empty index (zero docs ever): non-actionable, no checkbox, shows count + age.
+  if (rowState === LogRowState.EMPTY_INDEX) {
+    const age = createdAt ? moment(createdAt).fromNow() : undefined;
+    const meta = [
+      i18n.translate('explore.logsDrilldown.rows.docsCount', {
+        defaultMessage: '{count} docs',
+        values: { count: docsCount ?? 0 },
+      }),
+      age &&
+        i18n.translate('explore.logsDrilldown.rows.createdAge', {
+          defaultMessage: 'created {age}',
+          values: { age },
+        }),
+    ]
+      .filter(Boolean)
+      .join(' · ');
+    return (
+      <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
+        <CompactRow
+          icon={icon}
+          name={name}
+          message={i18n.translate('explore.logsDrilldown.rows.noDocsYet', {
+            defaultMessage: 'No documents yet',
+          })}
+          meta={meta}
+          tone="subdued"
+          data-test-subj="logsExploreCardEmptyIndex"
+        />
+      </div>
+    );
+  }
+
+  // 04 · Fetch error: danger (or warning for partial-shard) row with the error + Retry.
+  if (rowState === LogRowState.ERROR) {
+    const errorText = data.error ?? '';
+    const isPartial = /shard|partial|_shards/i.test(errorText);
+    return (
+      <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
+        <CompactRow
+          icon={icon}
+          name={name}
+          nameOnClick={onPrimary}
+          nameTitle={primaryLabel}
+          message={i18n.translate('explore.logsDrilldown.rows.previewError', {
+            defaultMessage: 'Couldn’t load preview',
+          })}
+          tone={isPartial ? 'warning' : 'danger'}
+          errorText={errorText}
+          action={
+            onRetry && (
+              <EuiLink onClick={onRetry} data-test-subj="logsExploreCardRetry">
+                {i18n.translate('explore.logsDrilldown.rows.retry', { defaultMessage: 'Retry' })}
+              </EuiLink>
+            )
+          }
+          checkbox={checkboxProps}
+          data-test-subj="logsExploreCardError"
+        />
+      </div>
+    );
+  }
+
+  // 02 · No events in range: healthy index, wrong window → compact, name still actionable.
+  if (rowState === LogRowState.NO_RECENT) {
+    return (
+      <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
+        <CompactRow
+          icon={icon}
+          name={name}
+          nameOnClick={onPrimary}
+          nameTitle={primaryLabel}
+          message={i18n.translate('explore.logsDrilldown.rows.noEventsInRange', {
+            defaultMessage: 'No events in the last {range}',
+            values: { range: rangeLabel },
+          })}
+          tone="subdued"
+          checkbox={checkboxProps}
+          data-test-subj="logsExploreCardNoRecent"
+        />
+      </div>
+    );
+  }
+
+  // ---- Full card (FULL / LOADING) ----------------------------------------------------------------
+
+  const rows = data.preview?.rows ?? [];
+
+  const logStream = (
+    <div
+      className="logStreamCard__logs"
+      style={{ maxHeight: LOGS_MAX_HEIGHT }}
+      data-test-subj="logsExploreCardLogs"
+    >
+      {data.loading && rows.length === 0 ? (
+        <LogLinesSkeleton />
+      ) : rows.length === 0 ? (
+        // A zero-total time-based index becomes a NO_RECENT compact row before reaching here, so this
+        // path is a safety net for the not-yet-classified / dataset case.
+        <EuiText size="xs" color="subdued" className="logStreamCard__empty">
+          {i18n.translate('explore.logsDrilldown.rows.noDocs', {
+            defaultMessage: 'No documents in the selected time range.',
+          })}
+        </EuiText>
+      ) : (
+        rows.map((row, i) => (
+          <LogLine
+            key={i}
+            row={row}
+            timeFieldName={timeFieldName}
+            severityField={severityField}
+            truncated
+          />
+        ))
+      )}
+    </div>
+  );
+
+  // Header time-field control: ALWAYS an EuiSelect for a uniform look, but disabled (non-interactive)
+  // when there's only one date field so single- and multi-timestamp indexes present identically.
+  // Datasets carry a single `timeFieldName` and no `dateFields` list → single, disabled option.
+  const hasMultipleTimeFields = !!dateFields && dateFields.length > 1;
+  const canSwitchTimeField = !!onTimeFieldChange && hasMultipleTimeFields;
+  const timeFieldOptions = hasMultipleTimeFields
+    ? dateFields!.map((f) => ({ value: f, text: f }))
+    : timeFieldName
+    ? [{ value: timeFieldName, text: timeFieldName }]
+    : [];
+  const timeControl = timeFieldName ? (
+    <EuiToolTip
+      content={
+        canSwitchTimeField
+          ? i18n.translate('explore.logsDrilldown.rows.timeFieldSwitchTip', {
+              defaultMessage: 'Time field used for the histogram and sort — switch it here',
+            })
+          : i18n.translate('explore.logsDrilldown.rows.timeFieldTip', {
+              defaultMessage: 'Time field used for the histogram and sort',
+            })
+      }
+    >
+      <EuiSelect
+        compressed
+        disabled={!canSwitchTimeField}
+        prepend={<EuiIcon type="clock" size="s" />}
+        options={timeFieldOptions}
+        value={timeFieldName}
+        onChange={(e) => onTimeFieldChange?.(e.target.value)}
+        aria-label={i18n.translate('explore.logsDrilldown.rows.timeFieldAria', {
+          defaultMessage: 'Select the time field',
+        })}
+        className="logStreamCard__timeSelect"
+        data-test-subj="logsExploreCardTimeFieldSelect"
+      />
+    </EuiToolTip>
+  ) : null;
+
+  // Dataset utility actions (next to the time control): an explicit "Show logs" (mirrors the name
+  // link) and "Manage" (opens the dataset in index-pattern management).
+  const datasetActions =
+    kind === 'dataset' ? (
+      <>
+        {onPrimary && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              iconType="play"
+              onClick={onPrimary}
+              data-test-subj="logsExploreCardShowLogs"
+            >
+              {i18n.translate('explore.logsDrilldown.rows.showLogs', {
+                defaultMessage: 'Show logs',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        )}
+        {onManage && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              iconType="gear"
+              onClick={onManage}
+              data-test-subj="logsExploreCardManage"
+            >
+              {i18n.translate('explore.logsDrilldown.rows.manageDataset', {
+                defaultMessage: 'Manage',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        )}
+      </>
+    ) : null;
+
+  // Index health dot (green/yellow/red) from cat.indices — a compact status affordance in the header.
+  const healthDot =
+    kind === 'index' && health ? (
+      <EuiFlexItem grow={false} className="logStreamCard__health">
+        <EuiToolTip
+          content={i18n.translate('explore.logsDrilldown.rows.healthTip', {
+            defaultMessage: 'Index health: {health}',
+            values: { health },
+          })}
+        >
+          <EuiHealth
+            color={health}
+            data-test-subj={`logsExploreCardHealth-${name}`}
+            aria-label={i18n.translate('explore.logsDrilldown.rows.healthAria', {
+              defaultMessage: 'Index health {health}',
+              values: { health },
+            })}
+          >
+            {''}
+          </EuiHealth>
+        </EuiToolTip>
+      </EuiFlexItem>
+    ) : null;
+
+  const histogramCol = (
+    <EuiFlexItem
+      grow={false}
+      className="logStreamCard__histCol"
+      style={{ flex: '0 0 360px', maxWidth: 360, minWidth: 0 }}
+    >
+      {data.histogram ? (
+        <SeverityHistogram
+          services={services}
+          histogram={data.histogram}
+          onBrush={onBrushTime}
+          chartId={name}
+        />
+      ) : data.loading ? (
+        <CardSkeleton height={HIST_HEIGHT} />
+      ) : (
+        // Preview succeeded but the (best-effort) histogram failed — logs still render.
+        <div className="logStreamCard__histEmpty" style={{ height: HIST_HEIGHT }}>
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('explore.logsDrilldown.rows.histError', {
+              defaultMessage: 'Histogram unavailable',
+            })}
+          </EuiText>
+        </div>
+      )}
+    </EuiFlexItem>
+  );
+
+  return (
+    <div ref={cardRef} className="logStreamCard" data-test-subj={`logsExploreCard-${name}`}>
+      <EuiPanel hasBorder paddingSize="s" hasShadow={false}>
+        {/* Header. Only raw indexes are selectable for batch dataset creation — a dataset already
+            exists, so it gets no selection checkbox. */}
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+          {kind === 'index' && (
+            <EuiFlexItem grow={false}>
+              <EuiCheckbox
+                id={checkboxProps.id}
+                checked={checked}
+                onChange={onToggleCheck}
+                aria-label={checkboxProps.ariaLabel}
+                data-test-subj={`logsExploreCardCheckbox-${name}`}
+              />
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false}>
+            <EuiIcon type={icon} size="s" />
+          </EuiFlexItem>
+          {healthDot}
+          <EuiFlexItem style={{ minWidth: 0 }}>
+            <EuiText size="s" className="logStreamCard__name">
+              {onPrimary ? (
+                <EuiLink
+                  onClick={onPrimary}
+                  title={primaryLabel}
+                  data-test-subj="logsExploreCardNameLink"
+                >
+                  <strong>{name}</strong>
+                </EuiLink>
+              ) : (
+                <strong>{name}</strong>
+              )}{' '}
+              <EuiTextColor color="subdued">
+                <small>
+                  {kind === 'dataset'
+                    ? i18n.translate('explore.logsDrilldown.rows.datasetLabel', {
+                        defaultMessage: 'Dataset',
+                      })
+                    : i18n.translate('explore.logsDrilldown.rows.indexLabel', {
+                        defaultMessage: 'Index',
+                      })}
+                </small>
+              </EuiTextColor>
+            </EuiText>
+          </EuiFlexItem>
+          {isRemote && (
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={i18n.translate('explore.logsDrilldown.rows.remote', {
+                  defaultMessage: 'Cross-cluster (remote)',
+                })}
+              >
+                <EuiToken iconType="tokenNamespace" size="s" />
+              </EuiToolTip>
+            </EuiFlexItem>
+          )}
+          {timeControl && (
+            <EuiFlexItem grow={false} className="logStreamCard__timeControl">
+              {timeControl}
+            </EuiFlexItem>
+          )}
+          {datasetActions}
+        </EuiFlexGroup>
+
+        {/* Body */}
+        <div className="logStreamCard__body">
+          {isTimeBased ? (
+            <EuiFlexGroup
+              gutterSize="m"
+              responsive={false}
+              wrap={false}
+              alignItems="stretch"
+              className="logStreamCard__split"
+            >
+              {histogramCol}
+              <EuiFlexItem grow={true} className="logStreamCard__logCol">
+                {logStream}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            // Not yet classified (time-based unknown) → full-width logs.
+            logStream
+          )}
+        </div>
+      </EuiPanel>
+    </div>
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
@@ -241,27 +241,14 @@ export const LogStreamCard: React.FC<Props> = ({
     );
   }
 
-  // 02 · No events in range: healthy index, wrong window → compact, name still actionable.
-  if (rowState === LogRowState.NO_RECENT) {
-    return (
-      <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
-        <CompactRow
-          icon={icon}
-          name={displayLabel}
-          nameOnClick={onPrimary}
-          nameTitle={primaryLabel}
-          message={i18n.translate('explore.logsDrilldown.rows.noEventsInRange', {
-            defaultMessage: 'No events in the selected time range',
-          })}
-          tone="subdued"
-          checkbox={checkboxProps}
-          data-test-subj="logsExploreCardNoRecent"
-        />
-      </div>
-    );
-  }
+  // 02 · No events in range: the index/dataset HAS data, just none in the selected window (commonly a
+  // wrong default time range vs. a different time field). Render the FULL card — not a stripped compact
+  // row — so the header meta controls (time-field selector, index health, Query/Manage) stay available;
+  // switching the time field here is exactly what lets the user find their data. The histogram column
+  // shows its own "No data in the selected time range" state and the log stream shows the empty message.
+  // (NO_RECENT rows are still demoted into the collapsed drawer by rows_view via `isDead`.)
 
-  // ---- Full card (FULL / LOADING) ----------------------------------------------------------------
+  // ---- Full card (FULL / LOADING / NO_RECENT) ----------------------------------------------------
 
   const rows = data.preview?.rows ?? [];
 

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
@@ -17,7 +17,7 @@ import {
   EuiCheckbox,
   EuiToolTip,
   EuiSelect,
-  EuiHealth,
+  EuiFieldText,
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
@@ -53,6 +53,10 @@ interface Props {
   docsCount?: number;
   /** Cluster-health of the index (green/yellow/red) from cat.indices — shown as a header dot. */
   health?: 'green' | 'yellow' | 'red';
+  /** Store size / shard counts from cat.indices — shown in the health-pill tooltip. */
+  storeSize?: string;
+  primaryShards?: number;
+  replicaCount?: number;
   /** Index creation time (epoch ms) — shown as "created {age}" in the empty-index compact row. */
   createdAt?: number;
   /** Humanized selected-range label (e.g. "15 minutes") for the no-recent-data copy. */
@@ -75,10 +79,11 @@ interface Props {
   onManage?: () => void;
 }
 
-// Inline log-stream height — the card shows the latest N lines; matches the histogram column height
-// so the two columns' bottoms align (#7).
-const LOGS_MAX_HEIGHT = 132;
-const HIST_HEIGHT = 132;
+// Inline log-stream height — sized to a whole number of ~20.7px log lines (6 × 20.7 ≈ 124px) so no
+// line is ever geometrically half-cut at the bottom on initial load. HIST_HEIGHT matches it exactly
+// so the histogram and log columns' bottoms stay aligned (#7).
+const LOGS_MAX_HEIGHT = 124;
+const HIST_HEIGHT = 124;
 
 // Distinct icons matching manage-workspace / dataset management.
 const ICON_INDEX = 'logoOpenSearch';
@@ -102,6 +107,9 @@ export const LogStreamCard: React.FC<Props> = ({
   dateFields,
   docsCount,
   health,
+  storeSize,
+  primaryShards,
+  replicaCount,
   createdAt,
   rangeLabel,
   data,
@@ -278,46 +286,58 @@ export const LogStreamCard: React.FC<Props> = ({
     </div>
   );
 
-  // Header time-field control: ALWAYS an EuiSelect for a uniform look, but disabled (non-interactive)
-  // when there's only one date field so single- and multi-timestamp indexes present identically.
-  // Datasets carry a single `timeFieldName` and no `dateFields` list → single, disabled option.
+  // Header time-field control. When there's a real choice (multi-timestamp index + a change handler)
+  // it's an interactive EuiSelect; otherwise a read-only compressed field with the same clock-prepend
+  // look — NOT a disabled select (which greys out and reads as broken). Single- and multi-timestamp
+  // cards stay visually uniform; the single case simply has no dropdown caret.
   const hasMultipleTimeFields = !!dateFields && dateFields.length > 1;
   const canSwitchTimeField = !!onTimeFieldChange && hasMultipleTimeFields;
-  const timeFieldOptions = hasMultipleTimeFields
-    ? dateFields!.map((f) => ({ value: f, text: f }))
-    : timeFieldName
-    ? [{ value: timeFieldName, text: timeFieldName }]
-    : [];
   const timeControl = timeFieldName ? (
-    <EuiToolTip
-      content={
-        canSwitchTimeField
-          ? i18n.translate('explore.logsDrilldown.rows.timeFieldSwitchTip', {
-              defaultMessage: 'Time field used for the histogram and sort — switch it here',
-            })
-          : i18n.translate('explore.logsDrilldown.rows.timeFieldTip', {
-              defaultMessage: 'Time field used for the histogram and sort',
-            })
-      }
-    >
-      <EuiSelect
-        compressed
-        disabled={!canSwitchTimeField}
-        prepend={<EuiIcon type="clock" size="s" />}
-        options={timeFieldOptions}
-        value={timeFieldName}
-        onChange={(e) => onTimeFieldChange?.(e.target.value)}
-        aria-label={i18n.translate('explore.logsDrilldown.rows.timeFieldAria', {
-          defaultMessage: 'Select the time field',
+    canSwitchTimeField ? (
+      <EuiToolTip
+        anchorClassName="logStreamCard__timeCapsule"
+        content={i18n.translate('explore.logsDrilldown.rows.timeFieldSwitchTip', {
+          defaultMessage: 'Time field used for the histogram and sort — switch it here',
         })}
-        className="logStreamCard__timeSelect"
-        data-test-subj="logsExploreCardTimeFieldSelect"
-      />
-    </EuiToolTip>
+      >
+        <EuiSelect
+          compressed
+          prepend={<EuiIcon type="clock" size="s" />}
+          options={dateFields!.map((f) => ({ value: f, text: f }))}
+          value={timeFieldName}
+          onChange={(e) => onTimeFieldChange?.(e.target.value)}
+          aria-label={i18n.translate('explore.logsDrilldown.rows.timeFieldAria', {
+            defaultMessage: 'Select the time field',
+          })}
+          className="logStreamCard__timeSelect"
+          data-test-subj="logsExploreCardTimeFieldSelect"
+        />
+      </EuiToolTip>
+    ) : (
+      <EuiToolTip
+        anchorClassName="logStreamCard__timeCapsule"
+        content={i18n.translate('explore.logsDrilldown.rows.timeFieldTip', {
+          defaultMessage: 'Time field used for the histogram and sort',
+        })}
+      >
+        <EuiFieldText
+          compressed
+          readOnly
+          prepend={<EuiIcon type="clock" size="s" />}
+          value={timeFieldName}
+          aria-label={i18n.translate('explore.logsDrilldown.rows.timeFieldAria', {
+            defaultMessage: 'Select the time field',
+          })}
+          className="logStreamCard__timeSelect"
+          data-test-subj="logsExploreCardTimeFieldReadonly"
+        />
+      </EuiToolTip>
+    )
   ) : null;
 
-  // Dataset utility actions (next to the time control): an explicit "Show logs" (mirrors the name
-  // link) and "Manage" (opens the dataset in index-pattern management).
+  // Dataset utility actions (next to the time control): an explicit "Query" action (mirrors the name
+  // link — opens the dataset in the logs Query experience) and "Manage" (opens the dataset in
+  // index-pattern management).
   const datasetActions =
     kind === 'dataset' ? (
       <>
@@ -329,8 +349,8 @@ export const LogStreamCard: React.FC<Props> = ({
               onClick={onPrimary}
               data-test-subj="logsExploreCardShowLogs"
             >
-              {i18n.translate('explore.logsDrilldown.rows.showLogs', {
-                defaultMessage: 'Show logs',
+              {i18n.translate('explore.logsDrilldown.rows.queryDataset', {
+                defaultMessage: 'Query',
               })}
             </EuiButtonEmpty>
           </EuiFlexItem>
@@ -352,26 +372,72 @@ export const LogStreamCard: React.FC<Props> = ({
       </>
     ) : null;
 
-  // Index health dot (green/yellow/red) from cat.indices — a compact status affordance in the header.
-  const healthDot =
+  // Index health (green/yellow/red) from cat.indices, shown right of the time control as a labeled
+  // capsule pill (dot + status word) rather than a bare colored dot. green→Healthy (all shards
+  // allocated), yellow→Degraded (replicas unassigned), red→Unhealthy (primaries unassigned).
+  const HEALTH_LABELS: Record<'green' | 'yellow' | 'red', string> = {
+    green: i18n.translate('explore.logsDrilldown.rows.healthHealthy', {
+      defaultMessage: 'Healthy',
+    }),
+    yellow: i18n.translate('explore.logsDrilldown.rows.healthDegraded', {
+      defaultMessage: 'Degraded',
+    }),
+    red: i18n.translate('explore.logsDrilldown.rows.healthUnhealthy', {
+      defaultMessage: 'Unhealthy',
+    }),
+  };
+  // Rich hover tooltip: the health status plus the store size / shard layout from cat.indices. Each
+  // metadata row is shown only when that value is known (remote/closed indexes omit them).
+  const healthTooltip = (
+    <div className="logStreamCard__healthTip" data-test-subj={`logsExploreCardHealthTip-${name}`}>
+      <div className="logStreamCard__healthTipTitle">
+        {health &&
+          i18n.translate('explore.logsDrilldown.rows.healthTip', {
+            defaultMessage: 'Index health: {status}',
+            values: { status: HEALTH_LABELS[health] },
+          })}
+      </div>
+      {storeSize && (
+        <div>
+          {i18n.translate('explore.logsDrilldown.rows.healthTipSize', {
+            defaultMessage: 'Store size: {size}',
+            values: { size: storeSize },
+          })}
+        </div>
+      )}
+      {primaryShards != null && (
+        <div>
+          {i18n.translate('explore.logsDrilldown.rows.healthTipPrimaries', {
+            defaultMessage: 'Primaries: {count}',
+            values: { count: primaryShards },
+          })}
+        </div>
+      )}
+      {replicaCount != null && (
+        <div>
+          {i18n.translate('explore.logsDrilldown.rows.healthTipReplicas', {
+            defaultMessage: 'Replicas: {count}',
+            values: { count: replicaCount },
+          })}
+        </div>
+      )}
+    </div>
+  );
+  const healthPill =
     kind === 'index' && health ? (
       <EuiFlexItem grow={false} className="logStreamCard__health">
-        <EuiToolTip
-          content={i18n.translate('explore.logsDrilldown.rows.healthTip', {
-            defaultMessage: 'Index health: {health}',
-            values: { health },
-          })}
-        >
-          <EuiHealth
-            color={health}
+        <EuiToolTip content={healthTooltip}>
+          <span
+            className={`logStreamCard__healthPill logStreamCard__healthPill--${health}`}
             data-test-subj={`logsExploreCardHealth-${name}`}
             aria-label={i18n.translate('explore.logsDrilldown.rows.healthAria', {
               defaultMessage: 'Index health {health}',
               values: { health },
             })}
           >
-            {''}
-          </EuiHealth>
+            <span className="logStreamCard__healthDot" />
+            {HEALTH_LABELS[health]}
+          </span>
         </EuiToolTip>
       </EuiFlexItem>
     ) : null;
@@ -406,7 +472,7 @@ export const LogStreamCard: React.FC<Props> = ({
 
   return (
     <div ref={cardRef} className="logStreamCard" data-test-subj={`logsExploreCard-${name}`}>
-      <EuiPanel hasBorder paddingSize="s" hasShadow={false}>
+      <EuiPanel hasBorder paddingSize="s" hasShadow={false} className="logStreamCard__panel">
         {/* Header. Only raw indexes are selectable for batch dataset creation — a dataset already
             exists, so it gets no selection checkbox. */}
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
@@ -424,7 +490,6 @@ export const LogStreamCard: React.FC<Props> = ({
           <EuiFlexItem grow={false}>
             <EuiIcon type={icon} size="s" />
           </EuiFlexItem>
-          {healthDot}
           <EuiFlexItem style={{ minWidth: 0 }}>
             <EuiText size="s" className="logStreamCard__name">
               {onPrimary ? (
@@ -467,6 +532,7 @@ export const LogStreamCard: React.FC<Props> = ({
               {timeControl}
             </EuiFlexItem>
           )}
+          {healthPill}
           {datasetActions}
         </EuiFlexGroup>
 

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/log_stream_card.tsx
@@ -39,7 +39,11 @@ export interface CardData {
 
 interface Props {
   services: ExploreServices;
+  /** Identity: the index/pattern name. Used for test-subj, keys, and the viewport observer. */
   name: string;
+  /** Visible label — defaults to `name`. For datasets with a friendly displayName, this is that
+   *  name while `name` stays the pattern (identity). */
+  label?: string;
   kind: 'index' | 'dataset';
   isRemote?: boolean;
   isTimeBased: boolean;
@@ -59,8 +63,6 @@ interface Props {
   replicaCount?: number;
   /** Index creation time (epoch ms) — shown as "created {age}" in the empty-index compact row. */
   createdAt?: number;
-  /** Humanized selected-range label (e.g. "15 minutes") for the no-recent-data copy. */
-  rangeLabel: string;
   data: CardData;
   /** The primary action label ("Query" / "Create dataset"); titles the name link. */
   primaryLabel: string;
@@ -98,6 +100,7 @@ const ICON_DATASET = 'indexPatternApp';
 export const LogStreamCard: React.FC<Props> = ({
   services,
   name,
+  label,
   kind,
   isRemote,
   isTimeBased,
@@ -111,7 +114,6 @@ export const LogStreamCard: React.FC<Props> = ({
   primaryShards,
   replicaCount,
   createdAt,
-  rangeLabel,
   data,
   primaryLabel,
   onPrimary,
@@ -140,15 +142,23 @@ export const LogStreamCard: React.FC<Props> = ({
   }, [name, onVisibilityChange]);
 
   const icon = kind === 'dataset' ? ICON_DATASET : ICON_INDEX;
-  const checkboxProps = {
-    id: `logsDrilldownCheckCard-${name}`,
-    checked,
-    onChange: onToggleCheck,
-    ariaLabel: i18n.translate('explore.logsDrilldown.rows.selectForCreate', {
-      defaultMessage: 'Select {name} for dataset creation',
-      values: { name },
-    }),
-  };
+  // The visible label (friendly dataset name when present) — falls back to the identity `name`.
+  const displayLabel = label || name;
+  // Only raw indexes are selectable for batch dataset creation — a dataset already exists, so it
+  // gets no selection checkbox (in the full card OR the compact variants). Undefined ⇒ CompactRow
+  // renders no checkbox.
+  const checkboxProps =
+    kind === 'index'
+      ? {
+          id: `logsDrilldownCheckCard-${name}`,
+          checked,
+          onChange: onToggleCheck,
+          ariaLabel: i18n.translate('explore.logsDrilldown.rows.selectForCreate', {
+            defaultMessage: 'Select {name} for dataset creation',
+            values: { name },
+          }),
+        }
+      : undefined;
 
   // ---- Compact variants (a card whose body carries nothing to scan → one row) --------------------
 
@@ -158,9 +168,9 @@ export const LogStreamCard: React.FC<Props> = ({
       <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
         <CompactRow
           icon="clock"
-          name={name}
+          name={displayLabel}
           message={i18n.translate('explore.logsDrilldown.rows.noTimeField', {
-            defaultMessage: 'No time field — can’t chart or create a dataset',
+            defaultMessage: 'No time field found, can’t create a logs dataset',
           })}
           tone="subdued"
           data-test-subj="logsExploreCardNoTimeBadge"
@@ -189,7 +199,7 @@ export const LogStreamCard: React.FC<Props> = ({
       <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
         <CompactRow
           icon={icon}
-          name={name}
+          name={displayLabel}
           message={i18n.translate('explore.logsDrilldown.rows.noDocsYet', {
             defaultMessage: 'No documents yet',
           })}
@@ -209,7 +219,7 @@ export const LogStreamCard: React.FC<Props> = ({
       <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
         <CompactRow
           icon={icon}
-          name={name}
+          name={displayLabel}
           nameOnClick={onPrimary}
           nameTitle={primaryLabel}
           message={i18n.translate('explore.logsDrilldown.rows.previewError', {
@@ -237,12 +247,11 @@ export const LogStreamCard: React.FC<Props> = ({
       <div ref={cardRef} data-test-subj={`logsExploreCard-${name}`}>
         <CompactRow
           icon={icon}
-          name={name}
+          name={displayLabel}
           nameOnClick={onPrimary}
           nameTitle={primaryLabel}
           message={i18n.translate('explore.logsDrilldown.rows.noEventsInRange', {
-            defaultMessage: 'No events in the last {range}',
-            values: { range: rangeLabel },
+            defaultMessage: 'No events in the selected time range',
           })}
           tone="subdued"
           checkbox={checkboxProps}
@@ -297,7 +306,8 @@ export const LogStreamCard: React.FC<Props> = ({
       <EuiToolTip
         anchorClassName="logStreamCard__timeCapsule"
         content={i18n.translate('explore.logsDrilldown.rows.timeFieldSwitchTip', {
-          defaultMessage: 'Time field used for the histogram and sort — switch it here',
+          defaultMessage: 'Time field: {field} — used for the histogram and sort. Switch it here.',
+          values: { field: timeFieldName },
         })}
       >
         <EuiSelect
@@ -317,7 +327,8 @@ export const LogStreamCard: React.FC<Props> = ({
       <EuiToolTip
         anchorClassName="logStreamCard__timeCapsule"
         content={i18n.translate('explore.logsDrilldown.rows.timeFieldTip', {
-          defaultMessage: 'Time field used for the histogram and sort',
+          defaultMessage: 'Time field: {field} — used for the histogram and sort',
+          values: { field: timeFieldName },
         })}
       >
         <EuiFieldText
@@ -386,17 +397,19 @@ export const LogStreamCard: React.FC<Props> = ({
       defaultMessage: 'Unhealthy',
     }),
   };
-  // Rich hover tooltip: the health status plus the store size / shard layout from cat.indices. Each
-  // metadata row is shown only when that value is known (remote/closed indexes omit them).
+  // Rich hover tooltip: the raw cat.indices health status as-is (green/yellow/red), plus the store
+  // size / shard layout. Each metadata row is shown only when that value is known (remote/closed
+  // indexes omit them).
   const healthTooltip = (
     <div className="logStreamCard__healthTip" data-test-subj={`logsExploreCardHealthTip-${name}`}>
-      <div className="logStreamCard__healthTipTitle">
-        {health &&
-          i18n.translate('explore.logsDrilldown.rows.healthTip', {
-            defaultMessage: 'Index health: {status}',
-            values: { status: HEALTH_LABELS[health] },
+      {health && (
+        <div className="logStreamCard__healthTipTitle">
+          {i18n.translate('explore.logsDrilldown.rows.healthTipStatus', {
+            defaultMessage: 'Status: {health}',
+            values: { health },
           })}
-      </div>
+        </div>
+      )}
       {storeSize && (
         <div>
           {i18n.translate('explore.logsDrilldown.rows.healthTipSize', {
@@ -476,7 +489,7 @@ export const LogStreamCard: React.FC<Props> = ({
         {/* Header. Only raw indexes are selectable for batch dataset creation — a dataset already
             exists, so it gets no selection checkbox. */}
         <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
-          {kind === 'index' && (
+          {checkboxProps && (
             <EuiFlexItem grow={false}>
               <EuiCheckbox
                 id={checkboxProps.id}
@@ -498,10 +511,10 @@ export const LogStreamCard: React.FC<Props> = ({
                   title={primaryLabel}
                   data-test-subj="logsExploreCardNameLink"
                 >
-                  <strong>{name}</strong>
+                  <strong>{displayLabel}</strong>
                 </EuiLink>
               ) : (
-                <strong>{name}</strong>
+                <strong>{displayLabel}</strong>
               )}{' '}
               <EuiTextColor color="subdued">
                 <small>

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/preview_empty_illustration.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/preview_empty_illustration.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
+
+/**
+ * A lightweight, on-brand SVG for the "nothing selected yet" preview state. It depicts the
+ * payoff of the flow — a card with a histogram + a few log lines — so the empty state teaches
+ * rather than showing a blank box. Colors come from the OUI theme vars so it adapts to
+ * light/dark mode. Purely decorative (aria-hidden); the surrounding copy conveys the meaning.
+ */
+export const PreviewEmptyIllustration: React.FC = () => {
+  const primary = euiThemeVars.euiColorPrimary;
+  const accent = euiThemeVars.euiColorAccent;
+  const success = euiThemeVars.euiColorSuccess;
+  const panel = euiThemeVars.euiColorEmptyShade;
+  const line = euiThemeVars.euiColorLightShade;
+  const subdued = euiThemeVars.euiColorMediumShade;
+
+  return (
+    <svg
+      className="logsExplorePreview__illustration"
+      viewBox="0 0 320 180"
+      width="320"
+      height="180"
+      role="img"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient id="lxpBars" x1="0" y1="1" x2="0" y2="0">
+          <stop offset="0%" stopColor={primary} stopOpacity="0.5" />
+          <stop offset="100%" stopColor={primary} stopOpacity="0.95" />
+        </linearGradient>
+        <linearGradient id="lxpGlow" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor={primary} stopOpacity="0.08" />
+          <stop offset="100%" stopColor={accent} stopOpacity="0.08" />
+        </linearGradient>
+      </defs>
+
+      {/* soft brand glow behind the card */}
+      <rect x="8" y="8" width="304" height="164" rx="16" fill="url(#lxpGlow)" />
+
+      {/* preview card */}
+      <rect
+        x="40"
+        y="26"
+        width="240"
+        height="128"
+        rx="10"
+        fill={panel}
+        stroke={line}
+        strokeWidth="1.5"
+      />
+
+      {/* card header: index name pill + a small "time-based" chip */}
+      <rect x="56" y="42" width="92" height="10" rx="5" fill={subdued} opacity="0.5" />
+      <rect x="212" y="40" width="52" height="14" rx="7" fill={success} opacity="0.25" />
+      <circle cx="222" cy="47" r="3" fill={success} />
+
+      {/* mini histogram */}
+      <g>
+        <rect x="56" y="92" width="12" height="18" rx="2" fill="url(#lxpBars)" />
+        <rect x="74" y="84" width="12" height="26" rx="2" fill="url(#lxpBars)" />
+        <rect x="92" y="72" width="12" height="38" rx="2" fill="url(#lxpBars)" />
+        <rect x="110" y="80" width="12" height="30" rx="2" fill="url(#lxpBars)" />
+        <rect x="128" y="66" width="12" height="44" rx="2" fill="url(#lxpBars)" />
+        <rect x="146" y="88" width="12" height="22" rx="2" fill="url(#lxpBars)" />
+        {/* baseline */}
+        <rect x="54" y="112" width="120" height="1.5" rx="1" fill={line} />
+      </g>
+
+      {/* a few log lines to the right of the chart */}
+      <g fill={subdued} opacity="0.55">
+        <rect x="188" y="72" width="76" height="6" rx="3" />
+        <rect x="188" y="86" width="60" height="6" rx="3" />
+        <rect x="188" y="100" width="70" height="6" rx="3" />
+      </g>
+
+      {/* log rows under the chart */}
+      <g fill={subdued} opacity="0.4">
+        <rect x="56" y="126" width="208" height="6" rx="3" />
+        <rect x="56" y="138" width="150" height="6" rx="3" />
+      </g>
+
+      {/* accent search/compass dot to tie it to the "explore" motif */}
+      <circle cx="278" cy="30" r="10" fill={primary} opacity="0.12" />
+      <circle cx="278" cy="30" r="3.5" fill={primary} />
+    </svg>
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
@@ -33,13 +33,33 @@ jest.mock('../hooks/use_activate_dataset', () => ({ useActivateDataset: () => mo
 // results (e.g. a zero-total histogram → NO_RECENT) to exercise liveness/banner behavior.
 const mockInvalidate = jest.fn();
 let mockResults = new Map<string, any>();
+// Capture the fetchFn RowsView passes to the scheduler so a test can invoke it directly (the stub
+// otherwise never runs it) — used to exercise the per-card fetch error → permission-toast wiring.
+let capturedFetchFn: ((key: string, signal: AbortSignal) => Promise<any>) | undefined;
 jest.mock('../../metrics/explore/hooks/use_concurrent_queries', () => ({
-  useConcurrentQueries: () => ({
-    results: mockResults,
-    errors: new Map(),
-    onVisibilityChange: jest.fn(),
-    invalidate: mockInvalidate,
-  }),
+  useConcurrentQueries: (fetchFn: (key: string, signal: AbortSignal) => Promise<any>) => {
+    capturedFetchFn = fetchFn;
+    return {
+      results: mockResults,
+      errors: new Map(),
+      onVisibilityChange: jest.fn(),
+      invalidate: mockInvalidate,
+    };
+  },
+}));
+
+// fetchPreview is what a card runs; make it rejectable so we can drive the 403 path.
+const mockFetchPreview = jest.fn();
+jest.mock('../hooks/fetch_preview', () => ({
+  ...jest.requireActual('../hooks/fetch_preview'),
+  fetchPreview: (...args: any[]) => mockFetchPreview(...args),
+}));
+jest.mock('../hooks/fetch_histogram', () => ({ fetchHistogram: jest.fn() }));
+
+// Spy on the one-time permission toast so we can assert it's raised on a 4xx card fetch.
+const mockMaybeNotify = jest.fn();
+jest.mock('../permission_toast', () => ({
+  maybeNotifyPermissionDenied: (...args: any[]) => mockMaybeNotify(...args),
 }));
 
 /** Build a resolved concurrency result whose histogram totals sum to `total`. */
@@ -609,5 +629,40 @@ describe('RowsView', () => {
   it('does not show Load more when everything fits in the first window', () => {
     renderRows();
     expect(screen.queryByTestId('logsExploreRowsLoadMore')).not.toBeInTheDocument();
+  });
+
+  // Permission handling: when multiple cards' preview fetches 4xx, each routes through the
+  // permission-toast helper (whose own once-guard collapses them to a single toast — see
+  // permission_toast.test.ts) AND the error re-throws so each card still surfaces its ERROR state.
+  it('routes per-card preview 4xx failures to the permission toast and re-throws', async () => {
+    renderRows();
+    expect(capturedFetchFn).toBeDefined();
+
+    const err403 = { statusCode: 403, message: 'security_exception' };
+    mockFetchPreview.mockRejectedValue(err403);
+
+    // Drive the captured fetchFn for two different cards (as the scheduler would for two indexes).
+    const signal = new AbortController().signal;
+    await expect(capturedFetchFn!('index:logs-app-2026.07.09', signal)).rejects.toBe(err403);
+    await expect(capturedFetchFn!('index:orders-2026', signal)).rejects.toBe(err403);
+
+    // The wiring invoked the toast helper once per failing card (the helper itself dedupes to one
+    // actual toast). Both calls carry services + the 403 error.
+    expect(mockMaybeNotify).toHaveBeenCalledTimes(2);
+    expect(mockMaybeNotify).toHaveBeenCalledWith(services, err403);
+  });
+
+  it('does not toast when a card preview fails with a non-4xx error (still re-throws)', async () => {
+    renderRows();
+    const err500 = { statusCode: 500, message: 'server error' };
+    mockFetchPreview.mockRejectedValue(err500);
+
+    const signal = new AbortController().signal;
+    await expect(capturedFetchFn!('index:logs-app-2026.07.09', signal)).rejects.toBe(err500);
+
+    // The helper is still called (it internally no-ops for non-4xx); the point is the toast itself
+    // never fires — which permission_toast.test.ts asserts for the 500 case. Here we just confirm the
+    // fetchFn routed the error through it and re-threw.
+    expect(mockMaybeNotify).toHaveBeenCalledWith(services, err500);
   });
 });

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
@@ -65,6 +65,7 @@ jest.mock('./log_stream_card', () => ({
     onTimeFieldChange,
     onManage,
     health,
+    severityField,
   }: any) => (
     <div
       data-test-subj={`card-${name}`}
@@ -74,6 +75,7 @@ jest.mock('./log_stream_card', () => ({
       data-time-field={timeFieldName ?? ''}
       data-date-fields={(dateFields ?? []).join(',')}
       data-health={health ?? ''}
+      data-severity-field={severityField ?? ''}
     >
       {onPrimary && (
         <button data-test-subj={`primary-${name}`} onClick={onPrimary}>
@@ -170,11 +172,11 @@ describe('RowsView', () => {
     );
   });
 
-  it('dataset card → Manage opens the dataset in index-pattern management', () => {
+  it('dataset card → Manage opens the dataset in the Datasets management app', () => {
     renderRows();
     fireEvent.click(screen.getByTestId('manage-logs-app-*'));
-    expect(navigateToApp).toHaveBeenCalledWith('management', {
-      path: '/opensearch-dashboards/indexPatterns/patterns/ds1',
+    expect(navigateToApp).toHaveBeenCalledWith('datasets', {
+      path: '/patterns/ds1',
     });
   });
 
@@ -383,6 +385,22 @@ describe('RowsView', () => {
     const card = screen.getByTestId('card-orders-2026');
     expect(card.getAttribute('data-time-field')).toBe('@timestamp');
     expect(card.getAttribute('data-date-fields')).toBe('@timestamp,observedTimestamp');
+  });
+
+  it('passes the detected severity field down to DATASET cards (for the severity-stacked histogram)', () => {
+    // Datasets classify too (a dataset name like `logs-app-*` is a valid field-caps wildcard) so the
+    // detected severityField reaches the card — otherwise the dataset histogram renders as plain logs
+    // even though the log lines show WARN/INFO tokens.
+    renderRows({
+      getCached: () => ({
+        classification: IndexClassification.TIME_BASED,
+        timeFieldName: '@timestamp',
+        severityField: 'severityText',
+      }),
+    });
+    const datasetCard = screen.getByTestId('card-logs-app-*');
+    expect(datasetCard.getAttribute('data-kind')).toBe('dataset');
+    expect(datasetCard.getAttribute('data-severity-field')).toBe('severityText');
   });
 
   it('applies a per-card time-field override (selector → the card shows the new field)', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
@@ -1,0 +1,450 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RowsView } from './rows_view';
+import { IndexClassification } from '../types';
+
+jest.mock('@osd/i18n', () => ({
+  i18n: {
+    translate: (_k: string, o: { defaultMessage: string; values?: any }) => {
+      let m = o.defaultMessage;
+      if (o.values)
+        Object.entries(o.values).forEach(([k, v]) => (m = m.replace(`{${k}}`, String(v))));
+      return m;
+    },
+  },
+}));
+
+const mockDatasets = jest.fn();
+const mockIndexList = jest.fn();
+jest.mock('../hooks/use_dataset_list', () => ({ useDatasetList: () => mockDatasets() }));
+jest.mock('../hooks/use_index_list', () => ({ useIndexList: () => mockIndexList() }));
+
+const mockCreate = jest.fn();
+const mockActivate = jest.fn();
+jest.mock('../hooks/use_create_dataset', () => ({ useCreateDataset: () => mockCreate }));
+jest.mock('../hooks/use_activate_dataset', () => ({ useActivateDataset: () => mockActivate }));
+
+// Deterministic no-fetch concurrency stub. `mockResults` lets a test inject per-card histogram
+// results (e.g. a zero-total histogram → NO_RECENT) to exercise liveness/banner behavior.
+const mockInvalidate = jest.fn();
+let mockResults = new Map<string, any>();
+jest.mock('../../metrics/explore/hooks/use_concurrent_queries', () => ({
+  useConcurrentQueries: () => ({
+    results: mockResults,
+    errors: new Map(),
+    onVisibilityChange: jest.fn(),
+    invalidate: mockInvalidate,
+  }),
+}));
+
+/** Build a resolved concurrency result whose histogram totals sum to `total`. */
+const resultWithTotal = (total: number) => ({
+  preview: { columns: [], rows: [] },
+  histogram: { series: [], intervalMs: 1, from: 0, to: 1, totals: [{ name: 'count', total }] },
+});
+
+// Render each card as its name + primary label + a select toggle so we can assert ordering,
+// action wiring, and multi-select. Also surface the time-field props so we can drive/observe the
+// per-card time-field override wiring.
+jest.mock('./log_stream_card', () => ({
+  LogStreamCard: ({
+    name,
+    kind,
+    primaryLabel,
+    onPrimary,
+    checked,
+    onToggleCheck,
+    rowState,
+    timeFieldName,
+    dateFields,
+    onTimeFieldChange,
+    onManage,
+    health,
+  }: any) => (
+    <div
+      data-test-subj={`card-${name}`}
+      data-kind={kind}
+      data-checked={String(Boolean(checked))}
+      data-row-state={rowState}
+      data-time-field={timeFieldName ?? ''}
+      data-date-fields={(dateFields ?? []).join(',')}
+      data-health={health ?? ''}
+    >
+      {onPrimary && (
+        <button data-test-subj={`primary-${name}`} onClick={onPrimary}>
+          {primaryLabel}
+        </button>
+      )}
+      <button data-test-subj={`check-${name}`} onClick={onToggleCheck}>
+        select
+      </button>
+      {onTimeFieldChange && (
+        <button
+          data-test-subj={`tf-${name}`}
+          onClick={() => onTimeFieldChange('observedTimestamp')}
+        >
+          change tf
+        </button>
+      )}
+      {onManage && (
+        <button data-test-subj={`manage-${name}`} onClick={onManage}>
+          manage
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+const navigateToApp = jest.fn();
+const services = {
+  data: { query: { timefilter: { timefilter: { getBounds: () => ({}) } } } },
+  core: { application: { navigateToApp } },
+} as any;
+
+// Capture the most recent batch action reported up to the toolbar.
+let lastBatchAction: any;
+
+const renderRows = (extra: Partial<React.ComponentProps<typeof RowsView>> = {}) =>
+  render(
+    <RowsView
+      services={services}
+      search=""
+      refreshKey="t0"
+      classify={jest.fn()}
+      getCached={() => ({
+        classification: IndexClassification.TIME_BASED,
+        timeFieldName: '@timestamp',
+      })}
+      onBrushTime={jest.fn()}
+      rangeFrom={Date.parse('2026-07-15T00:00:00Z')}
+      rangeTo={Date.parse('2026-07-15T00:15:00Z')}
+      onBatchActionChange={(a) => {
+        lastBatchAction = a;
+      }}
+      {...extra}
+    />
+  );
+
+describe('RowsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastBatchAction = undefined;
+    mockResults = new Map();
+    mockDatasets.mockReturnValue({
+      datasets: [
+        { name: 'logs-app-*', kind: 'dataset', datasetId: 'ds1', timeFieldName: '@timestamp' },
+      ],
+      loading: false,
+    });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'logs-app-2026.07.09', kind: 'index' },
+        { name: 'orders-2026', kind: 'index' },
+      ],
+      loading: false,
+      error: undefined,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+  });
+
+  it('renders datasets before indexes', () => {
+    renderRows();
+    const cards = screen.getAllByTestId(/^card-/);
+    expect(cards[0].getAttribute('data-test-subj')).toBe('card-logs-app-*');
+    expect(cards[0].getAttribute('data-kind')).toBe('dataset');
+    // Indexes follow.
+    expect(screen.getByTestId('card-orders-2026')).toBeInTheDocument();
+  });
+
+  it('dataset card → Query action', () => {
+    renderRows();
+    fireEvent.click(screen.getByTestId('primary-logs-app-*'));
+    expect(mockActivate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'logs-app-*', datasetId: 'ds1' })
+    );
+  });
+
+  it('dataset card → Manage opens the dataset in index-pattern management', () => {
+    renderRows();
+    fireEvent.click(screen.getByTestId('manage-logs-app-*'));
+    expect(navigateToApp).toHaveBeenCalledWith('management', {
+      path: '/opensearch-dashboards/indexPatterns/patterns/ds1',
+    });
+  });
+
+  it('index cards get no Manage action (datasets only)', () => {
+    renderRows();
+    expect(screen.queryByTestId('manage-orders-2026')).not.toBeInTheDocument();
+  });
+
+  it('passes index health down to index cards', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [{ name: 'orders-2026', kind: 'index', health: 'yellow' }],
+      loading: false,
+    });
+    renderRows();
+    expect(screen.getByTestId('card-orders-2026').getAttribute('data-health')).toBe('yellow');
+  });
+
+  it('index covered by a dataset → Query (via covering dataset)', () => {
+    renderRows();
+    // logs-app-2026.07.09 is covered by dataset logs-app-*
+    fireEvent.click(screen.getByTestId('primary-logs-app-2026.07.09'));
+    expect(mockActivate).toHaveBeenCalledWith(expect.objectContaining({ title: 'logs-app-*' }));
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('uncovered index → Create dataset (seeded with the wildcard-reduced family)', () => {
+    renderRows();
+    // orders-2026 is not covered by logs-app-*; the create flow is seeded with the reduced family
+    // (orders-2026 → orders-*) so browsing one day doesn't create a one-index dataset.
+    fireEvent.click(screen.getByTestId('primary-orders-2026'));
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ pattern: 'orders-*' }));
+  });
+
+  it('multi-select reports a Create-dataset batch action up (wildcard union), no selection bar', () => {
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'app-svc-1', kind: 'index' },
+        { name: 'app-svc-2', kind: 'index' },
+      ],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    renderRows();
+    // The old sticky selection bar is gone.
+    expect(screen.queryByTestId('logsExploreSelectionBar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('check-app-svc-1'));
+    fireEvent.click(screen.getByTestId('check-app-svc-2'));
+    // The batch action is reported up to the toolbar: uncovered → Create dataset (2), union app-svc-*.
+    expect(lastBatchAction).toEqual(
+      expect.objectContaining({ count: 2, label: 'Create dataset (2)', pattern: 'app-svc-*' })
+    );
+    lastBatchAction.onClick();
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ pattern: 'app-svc-*' }));
+  });
+
+  it('multi-select of indexes all covered by the SAME dataset reports a Query batch action', () => {
+    mockDatasets.mockReturnValue({
+      datasets: [
+        { name: 'logs-app-*', kind: 'dataset', datasetId: 'ds1', timeFieldName: '@timestamp' },
+      ],
+      loading: false,
+    });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'logs-app-2026.07.08', kind: 'index' },
+        { name: 'logs-app-2026.07.09', kind: 'index' },
+      ],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    renderRows();
+    fireEvent.click(screen.getByTestId('check-logs-app-2026.07.08'));
+    fireEvent.click(screen.getByTestId('check-logs-app-2026.07.09'));
+    expect(lastBatchAction).toEqual(
+      expect.objectContaining({ count: 2, label: 'Query (2)', pattern: 'logs-app-*' })
+    );
+    lastBatchAction.onClick();
+    expect(mockActivate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'logs-app-*', datasetId: 'ds1' })
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('a same-named dataset + index do NOT share checked state (checking the index leaves the dataset unchecked)', () => {
+    // Real-world case: the `nginx-access-logs` DATASET and the `nginx-access-logs` INDEX coexist.
+    mockDatasets.mockReturnValue({
+      datasets: [{ name: 'nginx-access-logs', kind: 'dataset', datasetId: 'ds1' }],
+      loading: false,
+    });
+    mockIndexList.mockReturnValue({
+      items: [{ name: 'nginx-access-logs', kind: 'index' }],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    renderRows();
+
+    const cardByKind = (kind: string) =>
+      Array.from(document.querySelectorAll('[data-test-subj="card-nginx-access-logs"]')).find(
+        (el) => el.getAttribute('data-kind') === kind
+      )!;
+
+    // Check the INDEX's checkbox.
+    const indexCard = cardByKind('index');
+    fireEvent.click(indexCard.querySelector('[data-test-subj="check-nginx-access-logs"]')!);
+
+    // The index is checked; the same-named dataset is NOT.
+    expect(cardByKind('index').getAttribute('data-checked')).toBe('true');
+    expect(cardByKind('dataset').getAttribute('data-checked')).toBe('false');
+    // Batch action reflects only the one index.
+    expect(lastBatchAction).toEqual(expect.objectContaining({ count: 1 }));
+  });
+
+  it('demotes both no-recent and empty-index (0 docs) rows into the dead group', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'no-recent', kind: 'index', docsCount: 10 },
+        { name: 'empty', kind: 'index', docsCount: 0 }, // dead via docsCount, no fetch needed
+        { name: 'live', kind: 'index', docsCount: 10 },
+      ],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    mockResults = new Map([
+      ['no-recent', resultWithTotal(0)],
+      ['live', resultWithTotal(500)],
+    ]);
+    renderRows();
+    // 2 dead (no-recent + empty) demote into the collapsed drawer; the live one stays primary.
+    expect(screen.getByTestId('logsExploreDeadGroupToggle')).toHaveTextContent(
+      '2 indexes with no recent data'
+    );
+    expect(screen.getByTestId('card-live')).toBeInTheDocument();
+  });
+
+  it('demotes empty-index (0 docs) rows into the collapsed dead group', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'live-idx', kind: 'index', docsCount: 100 },
+        { name: 'empty-idx', kind: 'index', docsCount: 0 },
+      ],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    renderRows();
+    // The dead group appears with a count of 1 (the empty index).
+    const toggle = screen.getByTestId('logsExploreDeadGroupToggle');
+    expect(toggle).toHaveTextContent('1 indexes with no recent data');
+    // The empty-index card is not rendered until the drawer is expanded (lazy).
+    expect(screen.queryByTestId('card-empty-idx')).not.toBeInTheDocument();
+    // The live index is in the primary list.
+    expect(screen.getByTestId('card-live-idx')).toBeInTheDocument();
+    fireEvent.click(toggle);
+    const dead = screen.getByTestId('card-empty-idx');
+    expect(dead.getAttribute('data-row-state')).toBe('empty_index');
+  });
+
+  it('shows the empty search state when nothing matches', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    renderRows({ search: 'zzz' });
+    expect(screen.getByTestId('logsExploreRowsEmpty')).toHaveTextContent('zzz');
+  });
+
+  it('shows the onboarding empty state (no data, no search)', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    renderRows({ search: '' });
+    expect(screen.getByTestId('logsExploreEmptyCreateDataset')).toBeInTheDocument();
+  });
+
+  it('renders the Datasets and Indexes section eyebrow labels (no divider)', () => {
+    renderRows();
+    expect(screen.getByText('Datasets')).toBeInTheDocument();
+    expect(screen.getByText('Indexes')).toBeInTheDocument();
+    // No divider element between groups (#6) — only the header labels.
+    expect(document.querySelector('.euiHorizontalRule')).toBeNull();
+  });
+
+  it('passes the classified time field + all date fields down to index cards', () => {
+    renderRows({
+      getCached: () => ({
+        classification: IndexClassification.TIME_BASED,
+        timeFieldName: '@timestamp',
+        dateFields: ['@timestamp', 'observedTimestamp'],
+      }),
+    });
+    const card = screen.getByTestId('card-orders-2026');
+    expect(card.getAttribute('data-time-field')).toBe('@timestamp');
+    expect(card.getAttribute('data-date-fields')).toBe('@timestamp,observedTimestamp');
+  });
+
+  it('applies a per-card time-field override (selector → the card shows the new field)', () => {
+    renderRows({
+      getCached: () => ({
+        classification: IndexClassification.TIME_BASED,
+        timeFieldName: '@timestamp',
+        dateFields: ['@timestamp', 'observedTimestamp'],
+      }),
+    });
+    const card = () => screen.getByTestId('card-orders-2026');
+    expect(card().getAttribute('data-time-field')).toBe('@timestamp');
+    // Pick a different field via the (mocked) selector.
+    fireEvent.click(screen.getByTestId('tf-orders-2026'));
+    expect(card().getAttribute('data-time-field')).toBe('observedTimestamp');
+    // Only that card is invalidated — the scheduler is NOT reset (which would refetch every card).
+    expect(mockInvalidate).toHaveBeenCalledWith('orders-2026');
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not offer the time-field selector on dataset cards (only indexes)', () => {
+    renderRows();
+    // Dataset card has no time-field change button; index cards do.
+    expect(screen.queryByTestId('tf-logs-app-*')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tf-orders-2026')).toBeInTheDocument();
+  });
+
+  it('resolves a NO_TIME_FIELD index to the no-time-field row state on the card', () => {
+    renderRows({
+      getCached: (name: string) =>
+        name === 'orders-2026'
+          ? { classification: IndexClassification.NO_TIME_FIELD, dateFields: [] }
+          : { classification: IndexClassification.TIME_BASED, timeFieldName: '@timestamp' },
+    });
+    expect(screen.getByTestId('card-orders-2026').getAttribute('data-row-state')).toBe(
+      'no_time_field'
+    );
+    expect(screen.getByTestId('card-logs-app-2026.07.09').getAttribute('data-row-state')).not.toBe(
+      'no_time_field'
+    );
+  });
+
+  it('shows the first 20 rows, then reveals 10 more per Load more click', () => {
+    // 35 indexes → first window 20; +10 → 30; +10 → capped at 35 (Load more then disappears).
+    const many = Array.from({ length: 35 }, (_, i) => ({
+      name: `idx-${String(i).padStart(2, '0')}`,
+      kind: 'index' as const,
+    }));
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({ items: many, loading: false });
+    renderRows();
+
+    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(20);
+    fireEvent.click(screen.getByTestId('logsExploreRowsLoadMore'));
+    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(30); // +10
+    fireEvent.click(screen.getByTestId('logsExploreRowsLoadMore'));
+    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(35); // +10, capped at total
+    expect(screen.queryByTestId('logsExploreRowsLoadMore')).not.toBeInTheDocument();
+  });
+
+  it('does not show Load more when everything fits in the first window', () => {
+    renderRows();
+    expect(screen.queryByTestId('logsExploreRowsLoadMore')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.test.tsx
@@ -211,7 +211,7 @@ describe('RowsView', () => {
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ pattern: 'orders-*' }));
   });
 
-  it('multi-select reports a Create-dataset batch action up (wildcard union), no selection bar', () => {
+  it('multi-select reports a Create-dataset batch action up (wildcard union)', () => {
     mockIndexList.mockReturnValue({
       items: [
         { name: 'app-svc-1', kind: 'index' },
@@ -223,7 +223,7 @@ describe('RowsView', () => {
     });
     mockDatasets.mockReturnValue({ datasets: [], loading: false });
     renderRows();
-    // The old sticky selection bar is gone.
+    // The selection bar only appears once something is checked.
     expect(screen.queryByTestId('logsExploreSelectionBar')).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId('check-app-svc-1'));
     fireEvent.click(screen.getByTestId('check-app-svc-2'));
@@ -233,6 +233,120 @@ describe('RowsView', () => {
     );
     lastBatchAction.onClick();
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ pattern: 'app-svc-*' }));
+  });
+
+  it('shows a selection bar with the checked index names + Clear all deselects them', () => {
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'app-svc-1', kind: 'index' },
+        { name: 'app-svc-2', kind: 'index' },
+      ],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    renderRows();
+
+    fireEvent.click(screen.getByTestId('check-app-svc-1'));
+    fireEvent.click(screen.getByTestId('check-app-svc-2'));
+
+    // The bar lists both checked index names as pills.
+    const bar = screen.getByTestId('logsExploreSelectionBar');
+    expect(bar).toHaveTextContent('2 indexes selected');
+    expect(screen.getByTestId('logsExploreSelectionPill-app-svc-1')).toBeInTheDocument();
+    expect(screen.getByTestId('logsExploreSelectionPill-app-svc-2')).toBeInTheDocument();
+    // Uncovered indexes → the bar previews the proposed create-dataset wildcard family.
+    expect(screen.getByTestId('logsExploreSelectionWildcard')).toHaveTextContent('app-svc-*');
+
+    // Clear all deselects everything → the bar disappears and the batch action clears.
+    fireEvent.click(screen.getByTestId('logsExploreSelectionClear'));
+    expect(screen.queryByTestId('logsExploreSelectionBar')).not.toBeInTheDocument();
+    expect(lastBatchAction).toBeNull();
+  });
+
+  it('hides the proposed wildcard when the selection is all covered by one dataset (a Query, not a create)', () => {
+    mockDatasets.mockReturnValue({
+      datasets: [
+        { name: 'logs-app-*', kind: 'dataset', datasetId: 'ds1', timeFieldName: '@timestamp' },
+      ],
+      loading: false,
+    });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'logs-app-2026.07.08', kind: 'index' },
+        { name: 'logs-app-2026.07.09', kind: 'index' },
+      ],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    renderRows();
+    fireEvent.click(screen.getByTestId('check-logs-app-2026.07.08'));
+    fireEvent.click(screen.getByTestId('check-logs-app-2026.07.09'));
+    // These resolve to Query (via the covering dataset), so there's no NEW dataset wildcard to show.
+    expect(screen.getByTestId('logsExploreSelectionBar')).toBeInTheDocument();
+    expect(screen.queryByTestId('logsExploreSelectionWildcard')).not.toBeInTheDocument();
+  });
+
+  it('warns when the selected indexes share no common time field', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'app-logs', kind: 'index' },
+        { name: 'telemetry', kind: 'index' },
+      ],
+      loading: false,
+    });
+    // Per-index classification: app-logs → @timestamp, telemetry → observedTimestamp (no overlap).
+    renderRows({
+      getCached: (name: string) =>
+        name === 'telemetry'
+          ? {
+              classification: IndexClassification.TIME_BASED,
+              timeFieldName: 'observedTimestamp',
+              dateFields: ['observedTimestamp'],
+            }
+          : {
+              classification: IndexClassification.TIME_BASED,
+              timeFieldName: '@timestamp',
+              dateFields: ['@timestamp'],
+            },
+    });
+    fireEvent.click(screen.getByTestId('check-app-logs'));
+    fireEvent.click(screen.getByTestId('check-telemetry'));
+    expect(screen.getByTestId('logsExploreSelectionNoCommonTimeField')).toHaveTextContent(
+      'No common time field across the selected indexes'
+    );
+  });
+
+  it('does NOT warn when the selected indexes share a common time field', () => {
+    mockDatasets.mockReturnValue({ datasets: [], loading: false });
+    mockIndexList.mockReturnValue({
+      items: [
+        { name: 'a-logs', kind: 'index' },
+        { name: 'b-logs', kind: 'index' },
+      ],
+      loading: false,
+    });
+    // Both have @timestamp (a-logs also has event.ingested) → common {@timestamp} → no warning.
+    renderRows({
+      getCached: (name: string) =>
+        name === 'a-logs'
+          ? {
+              classification: IndexClassification.TIME_BASED,
+              timeFieldName: '@timestamp',
+              dateFields: ['@timestamp', 'event.ingested'],
+            }
+          : {
+              classification: IndexClassification.TIME_BASED,
+              timeFieldName: '@timestamp',
+              dateFields: ['@timestamp'],
+            },
+    });
+    fireEvent.click(screen.getByTestId('check-a-logs'));
+    fireEvent.click(screen.getByTestId('check-b-logs'));
+    expect(screen.queryByTestId('logsExploreSelectionNoCommonTimeField')).not.toBeInTheDocument();
   });
 
   it('multi-select of indexes all covered by the SAME dataset reports a Query batch action', () => {
@@ -294,6 +408,35 @@ describe('RowsView', () => {
     expect(lastBatchAction).toEqual(expect.objectContaining({ count: 1 }));
   });
 
+  it('a same-named dataset + index resolve independently (no shared scheduler slot → no stuck card)', () => {
+    // Regression: keying the fetch scheduler by bare name collided a same-named dataset + index onto
+    // one results slot, leaving one card hung in LOADING. Keyed by kind:name, only the index result
+    // lands on the index card; the dataset (no result injected) stays LOADING on its own.
+    mockDatasets.mockReturnValue({
+      datasets: [{ name: 'nginx-access-logs', kind: 'dataset', datasetId: 'ds1' }],
+      loading: false,
+    });
+    mockIndexList.mockReturnValue({
+      items: [{ name: 'nginx-access-logs', kind: 'index', docsCount: 10 }],
+      loading: false,
+      hasNext: false,
+      loadMore: jest.fn(),
+    });
+    // Only the INDEX key has a resolved result.
+    mockResults = new Map([['index:nginx-access-logs', resultWithTotal(500)]]);
+    renderRows();
+
+    const cardByKind = (kind: string) =>
+      Array.from(document.querySelectorAll('[data-test-subj="card-nginx-access-logs"]')).find(
+        (el) => el.getAttribute('data-kind') === kind
+      )!;
+
+    // The index resolved (FULL) from its own slot; the dataset has no result → still LOADING, not
+    // wrongly showing the index's result.
+    expect(cardByKind('index').getAttribute('data-row-state')).toBe('full');
+    expect(cardByKind('dataset').getAttribute('data-row-state')).toBe('loading');
+  });
+
   it('demotes both no-recent and empty-index (0 docs) rows into the dead group', () => {
     mockDatasets.mockReturnValue({ datasets: [], loading: false });
     mockIndexList.mockReturnValue({
@@ -306,9 +449,10 @@ describe('RowsView', () => {
       hasNext: false,
       loadMore: jest.fn(),
     });
+    // The scheduler is keyed by kind:name.
     mockResults = new Map([
-      ['no-recent', resultWithTotal(0)],
-      ['live', resultWithTotal(500)],
+      ['index:no-recent', resultWithTotal(0)],
+      ['index:live', resultWithTotal(500)],
     ]);
     renderRows();
     // 2 dead (no-recent + empty) demote into the collapsed drawer; the live one stays primary.
@@ -417,7 +561,8 @@ describe('RowsView', () => {
     fireEvent.click(screen.getByTestId('tf-orders-2026'));
     expect(card().getAttribute('data-time-field')).toBe('observedTimestamp');
     // Only that card is invalidated — the scheduler is NOT reset (which would refetch every card).
-    expect(mockInvalidate).toHaveBeenCalledWith('orders-2026');
+    // The scheduler key is kind:name.
+    expect(mockInvalidate).toHaveBeenCalledWith('index:orders-2026');
     expect(mockInvalidate).toHaveBeenCalledTimes(1);
   });
 
@@ -443,9 +588,9 @@ describe('RowsView', () => {
     );
   });
 
-  it('shows the first 20 rows, then reveals 10 more per Load more click', () => {
-    // 35 indexes → first window 20; +10 → 30; +10 → capped at 35 (Load more then disappears).
-    const many = Array.from({ length: 35 }, (_, i) => ({
+  it('shows the first 10 rows, then reveals 10 more per Load more click', () => {
+    // 25 indexes → first window 10; +10 → 20; +10 → capped at 25 (Load more then disappears).
+    const many = Array.from({ length: 25 }, (_, i) => ({
       name: `idx-${String(i).padStart(2, '0')}`,
       kind: 'index' as const,
     }));
@@ -453,11 +598,11 @@ describe('RowsView', () => {
     mockIndexList.mockReturnValue({ items: many, loading: false });
     renderRows();
 
-    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(20);
+    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(10);
     fireEvent.click(screen.getByTestId('logsExploreRowsLoadMore'));
-    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(30); // +10
+    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(20); // +10
     fireEvent.click(screen.getByTestId('logsExploreRowsLoadMore'));
-    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(35); // +10, capped at total
+    expect(screen.getAllByTestId(/^card-idx-/)).toHaveLength(25); // +10, capped at total
     expect(screen.queryByTestId('logsExploreRowsLoadMore')).not.toBeInTheDocument();
   });
 

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
@@ -50,17 +50,13 @@ interface Props {
   /** Primitive that changes when the global time range changes; drives re-fetch of all cards. */
   refreshKey: string;
   /** Lazily classify an index (time-based? severity fields?) — from useIndexClassification. */
-  classify: (
-    name: string
-  ) => Promise<{
+  classify: (name: string) => Promise<{
     classification: IndexClassification;
     timeFieldName?: string;
     dateFields?: string[];
     severityField?: string;
   }>;
-  getCached: (
-    name: string
-  ) =>
+  getCached: (name: string) =>
     | {
         classification: IndexClassification;
         timeFieldName?: string;

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
@@ -30,6 +30,7 @@ import { fetchHistogram } from '../hooks/fetch_histogram';
 import { useCreateDataset } from '../hooks/use_create_dataset';
 import { useActivateDataset } from '../hooks/use_activate_dataset';
 import { indexCoveredByAnyDataset } from '../dataset_coverage';
+import { maybeNotifyPermissionDenied } from '../permission_toast';
 import { suggestWildcardFromName, suggestWildcardFromNames } from '../suggest_wildcard';
 import { PreviewEmptyIllustration } from './preview_empty_illustration';
 import { LogStreamCard, CardData } from './log_stream_card';
@@ -199,18 +200,26 @@ export const RowsView: React.FC<Props> = ({
       const from = bounds?.min?.valueOf() ?? Date.now() - 15 * 60 * 1000;
       const to = bounds?.max?.valueOf() ?? Date.now();
 
-      const preview = await fetchPreview(
-        services,
-        {
-          indexName: name,
-          timeFieldName,
-          dataSource,
-          size: DEFAULT_PREVIEW_SIZE,
-          // Only bound when this is a time-based index; non-time indexes have no field to filter on.
-          ...(timeFieldName ? { from, to } : {}),
-        },
-        signal
-      );
+      let preview;
+      try {
+        preview = await fetchPreview(
+          services,
+          {
+            indexName: name,
+            timeFieldName,
+            dataSource,
+            size: DEFAULT_PREVIEW_SIZE,
+            // Only bound when this is a time-based index; non-time indexes have no field to filter on.
+            ...(timeFieldName ? { from, to } : {}),
+          },
+          signal
+        );
+      } catch (e) {
+        // A 4xx (e.g. no read permission on this index) raises the one-time permission toast; the
+        // card still shows its own ERROR state from the re-thrown error.
+        maybeNotifyPermissionDenied(services, e);
+        throw e;
+      }
 
       let histogram;
       if (timeFieldName) {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
@@ -1,0 +1,536 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { EuiButton, EuiButtonEmpty, EuiEmptyPrompt, EuiText, EuiTextColor } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { Dataset } from '../../../../../../data/common';
+import { ExploreServices } from '../../../../types';
+import { BrowsableItem, IndexClassification } from '../types';
+import { deriveRowState, isDead, formatRangeLabel, LogRowState } from '../row_state';
+import { useIndexList } from '../hooks/use_index_list';
+import { useDatasetList } from '../hooks/use_dataset_list';
+import { useConcurrentQueries } from '../../metrics/explore/hooks/use_concurrent_queries';
+import { fetchPreview, DEFAULT_PREVIEW_SIZE } from '../hooks/fetch_preview';
+import { fetchHistogram } from '../hooks/fetch_histogram';
+import { useCreateDataset } from '../hooks/use_create_dataset';
+import { useActivateDataset } from '../hooks/use_activate_dataset';
+import { indexCoveredByAnyDataset } from '../dataset_coverage';
+import { suggestWildcardFromName, suggestWildcardFromNames } from '../suggest_wildcard';
+import { PreviewEmptyIllustration } from './preview_empty_illustration';
+import { LogStreamCard, CardData } from './log_stream_card';
+
+/** The batch action the toolbar button runs, reported up from RowsView (null = nothing selected). */
+export interface BatchAction {
+  count: number;
+  label: string;
+  pattern: string;
+  onClick: () => void;
+}
+
+interface Props {
+  services: ExploreServices;
+  dataSourceId?: string;
+  dataSource?: Dataset['dataSource'];
+  search: string;
+  /** Primitive that changes when the global time range changes; drives re-fetch of all cards. */
+  refreshKey: string;
+  /** Lazily classify an index (time-based? severity fields?) — from useIndexClassification. */
+  classify: (
+    name: string
+  ) => Promise<{
+    classification: IndexClassification;
+    timeFieldName?: string;
+    dateFields?: string[];
+    severityField?: string;
+  }>;
+  getCached: (
+    name: string
+  ) =>
+    | {
+        classification: IndexClassification;
+        timeFieldName?: string;
+        dateFields?: string[];
+        severityField?: string;
+      }
+    | undefined;
+  /** Brush-select on any card's histogram → update the global time range. */
+  onBrushTime: (from: number, to: number) => void;
+  /** Selected-range bounds (epoch ms) → humanized label for "No events in the last {range}". */
+  rangeFrom: number;
+  rangeTo: number;
+  /** Report the current batch (multi-select) action up to the page's toolbar button. */
+  onBatchActionChange: (action: BatchAction | null) => void;
+}
+
+// Show the first 20 rows; each "Load more" reveals 10 more.
+const INITIAL_PAGE_SIZE = 20;
+const LOAD_MORE_STEP = 10;
+
+interface CombinedResult {
+  preview: any;
+  histogram?: any;
+}
+
+/**
+ * The Rows (Grafana-drilldown) layout: a full-width vertical stack of per-item cards — existing
+ * datasets first, then raw indexes, newest-first, filtered by the shared search. Each visible card
+ * lazily fetches its raw log lines + severity histogram (viewport-gated, ≤6 concurrent).
+ */
+export const RowsView: React.FC<Props> = ({
+  services,
+  dataSourceId,
+  dataSource,
+  search,
+  refreshKey,
+  classify,
+  getCached,
+  onBrushTime,
+  rangeFrom,
+  rangeTo,
+  onBatchActionChange,
+}) => {
+  const { datasets } = useDatasetList({ services, dataSourceId, search });
+  const { items: indexItems } = useIndexList({ services, dataSourceId, search });
+
+  const [visibleCount, setVisibleCount] = useState(INITIAL_PAGE_SIZE);
+  // Multi-select: checked INDEX names (only raw indexes are selectable for dataset creation).
+  const [checkedIndexes, setCheckedIndexes] = useState<string[]>([]);
+  // Per-index user overrides of the auto-picked time field (multi-timestamp indexes).
+  const [timeFieldOverrides, setTimeFieldOverrides] = useState<Record<string, string>>({});
+  // Whether the collapsed "no recent data" drawer is expanded.
+  const [deadOpen, setDeadOpen] = useState(false);
+
+  useEffect(() => setVisibleCount(INITIAL_PAGE_SIZE), [search, dataSourceId]);
+  // Switching data source / search clears the selection (names differ per source).
+  useEffect(() => setCheckedIndexes([]), [dataSourceId]);
+
+  // Invalidate-one hook wired below (after useConcurrentQueries). Held in a ref so onTimeFieldChange
+  // can call it without depending on hook-declaration order.
+  const invalidateRef = useRef<(name: string) => void>(() => {});
+
+  // Picking a different time field for ONE index re-fetches only that card: update its override,
+  // then invalidate just that key. It must NOT reset the whole scheduler (which would refetch every
+  // other index/dataset card) — fetchFn reads overrides from a ref, so its identity stays stable.
+  const onTimeFieldChange = useCallback((name: string, field: string) => {
+    setTimeFieldOverrides((prev) => ({ ...prev, [name]: field }));
+    invalidateRef.current(name);
+  }, []);
+
+  const onToggleCheck = useCallback((name: string) => {
+    setCheckedIndexes((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
+    );
+  }, []);
+
+  // Combined: datasets first, then indexes (already newest-first). De-dupe by name.
+  const combined: BrowsableItem[] = useMemo(() => {
+    const seen = new Set<string>();
+    const out: BrowsableItem[] = [];
+    [...datasets, ...indexItems].forEach((it) => {
+      const key = `${it.kind}:${it.name}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(it);
+      }
+    });
+    return out;
+  }, [datasets, indexItems]);
+
+  const visible = combined.slice(0, visibleCount);
+  const hasNext = combined.length > visibleCount;
+
+  // Metadata per card name → drives the viewport-gated fetch.
+  const metaRef = useRef<Map<string, BrowsableItem>>(new Map());
+  useEffect(() => {
+    const m = new Map<string, BrowsableItem>();
+    combined.forEach((it) => m.set(it.name, it));
+    metaRef.current = m;
+  }, [combined]);
+
+  // Keep the latest overrides in a ref so fetchFn reads fresh values; overrideKey (below) drives
+  // the actual re-query when they change.
+  const timeFieldOverridesRef = useRef(timeFieldOverrides);
+  timeFieldOverridesRef.current = timeFieldOverrides;
+
+  // One fetch per visible card: raw lines + (for time-based) a severity-stacked histogram.
+  const fetchFn = useCallback(
+    async (name: string, signal: AbortSignal): Promise<CombinedResult> => {
+      const item = metaRef.current.get(name);
+      if (!item) return { preview: undefined };
+
+      // Determine time field + severity field. Datasets carry timeFieldName; indexes classify.
+      let timeFieldName = item.timeFieldName;
+      let severityField: string | undefined;
+      if (item.kind === 'index') {
+        const result = getCached(name) ?? (await classify(name));
+        timeFieldName = result.timeFieldName;
+        severityField = result.severityField;
+      }
+      // A user-picked time field (multi-timestamp indexes) overrides the auto-selected one.
+      timeFieldName = timeFieldOverridesRef.current[name] ?? timeFieldName;
+
+      // Read the picked time range once; both the preview (log lines) and the histogram are bounded
+      // to it so they stay consistent — no more "empty histogram but stale logs" for time-based
+      // indexes with nothing in the window.
+      const bounds = timeFieldName
+        ? services.data.query.timefilter.timefilter.getBounds()
+        : undefined;
+      const from = bounds?.min?.valueOf() ?? Date.now() - 15 * 60 * 1000;
+      const to = bounds?.max?.valueOf() ?? Date.now();
+
+      const preview = await fetchPreview(
+        services,
+        {
+          indexName: name,
+          timeFieldName,
+          dataSource,
+          size: DEFAULT_PREVIEW_SIZE,
+          // Only bound when this is a time-based index; non-time indexes have no field to filter on.
+          ...(timeFieldName ? { from, to } : {}),
+        },
+        signal
+      );
+
+      let histogram;
+      if (timeFieldName) {
+        try {
+          histogram = await fetchHistogram(
+            services,
+            {
+              indexName: name,
+              timeFieldName,
+              severityField,
+              dataSource,
+              from,
+              to,
+            },
+            signal
+          );
+        } catch {
+          // Histogram is best-effort; the logs stream still renders.
+        }
+      }
+      return { preview, histogram };
+    },
+    // refreshKey (time range) changes the fetchFn identity so the scheduler re-runs every card.
+    // Per-card time-field picks are NOT in the deps: they're read from timeFieldOverridesRef and
+    // refreshed one-at-a-time via invalidate(), so switching one card's field doesn't refetch all.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [services, dataSource, classify, getCached, refreshKey]
+  );
+
+  const { results, errors, onVisibilityChange, invalidate } = useConcurrentQueries<CombinedResult>(
+    fetchFn,
+    // refreshKey resets the scheduler on a time-range change; a time-field pick is handled per-card
+    // via invalidate() instead of a dep so it doesn't churn every other card.
+    [services, dataSource, search, refreshKey],
+    6
+  );
+  // Expose invalidate to onTimeFieldChange (declared above useConcurrentQueries).
+  invalidateRef.current = invalidate;
+
+  const createDataset = useCreateDataset(services);
+  const activateDataset = useActivateDataset(services);
+
+  // Open an existing dataset in index-pattern management (the "Manage" dataset utility action).
+  const manageDataset = useCallback(
+    (datasetId?: string) => {
+      if (!datasetId) return;
+      services.core.application.navigateToApp('management', {
+        path: `/opensearch-dashboards/indexPatterns/patterns/${datasetId}`,
+      });
+    },
+    [services]
+  );
+
+  const loadMore = useCallback(() => setVisibleCount((c) => c + LOAD_MORE_STEP), []);
+
+  // Resolve the single primary action + label + icon per item.
+  const resolvePrimary = (item: BrowsableItem) => {
+    if (item.kind === 'dataset') {
+      return {
+        label: i18n.translate('explore.logsExplore.rows.query', { defaultMessage: 'Query' }),
+        icon: 'search',
+        onClick: () =>
+          activateDataset({
+            title: item.name,
+            datasetId: item.datasetId,
+            timeFieldName: item.timeFieldName,
+            dataSource,
+          }),
+      };
+    }
+    const covering = indexCoveredByAnyDataset(item.name, datasets);
+    if (covering) {
+      return {
+        label: i18n.translate('explore.logsExplore.rows.query', { defaultMessage: 'Query' }),
+        icon: 'search',
+        onClick: () =>
+          activateDataset({
+            title: covering.name,
+            datasetId: covering.datasetId,
+            timeFieldName: covering.timeFieldName,
+            dataSource,
+          }),
+      };
+    }
+    return {
+      label: i18n.translate('explore.logsExplore.rows.createDataset', {
+        defaultMessage: 'Create dataset',
+      }),
+      icon: 'plusInCircle',
+      onClick: () =>
+        // Seed the create flow with the wildcard-reduced family (app-svc-019 → app-svc-*), not the
+        // raw index name. The advanced selector then resolves + shows the matching indexes so the
+        // user can confirm/adjust before committing.
+        createDataset({
+          pattern: suggestWildcardFromName(item.name),
+          dataSource,
+        }),
+    };
+  };
+
+  const rangeLabel = useMemo(() => formatRangeLabel(rangeFrom, rangeTo), [rangeFrom, rangeTo]);
+
+  // Resolve each card's visual state (full vs. a compact variant) from what we know so far. Liveness
+  // (histogram totals sum) is read from `results`, which arrives lazily per card — UNKNOWN cards
+  // resolve to LOADING and stay in the primary list until their fetch lands.
+  const rowStateFor = useCallback(
+    (item: BrowsableItem): LogRowState => {
+      const cached = item.kind === 'index' ? getCached(item.name) : undefined;
+      const isNoTimeField =
+        item.kind === 'index' && cached?.classification === IndexClassification.NO_TIME_FIELD;
+      const result = results.get(item.name);
+      const totalsSum = result?.histogram?.totals?.reduce(
+        (s: number, t: { total: number }) => s + t.total,
+        0
+      );
+      return deriveRowState({
+        kind: item.kind,
+        isNoTimeField,
+        docsCount: item.docsCount,
+        hasResult: !!result,
+        hasError: !!errors.get(item.name),
+        histogramTotalsSum: totalsSum,
+      });
+    },
+    [getCached, results, errors]
+  );
+
+  // Partition the windowed slice: primary rows (datasets + live/loading/error indexes) stay in place;
+  // resolved-dead rows (no recent data / empty index) demote into a collapsed drawer at the bottom.
+  // Demotion is downward-only, so a card moves at most once → no scroll thrash (v1: plain memo).
+  const { primaryRows, deadRows } = useMemo(() => {
+    const primary: Array<{ item: BrowsableItem; state: LogRowState }> = [];
+    const dead: Array<{ item: BrowsableItem; state: LogRowState }> = [];
+    visible.forEach((item) => {
+      const state = rowStateFor(item);
+      (isDead(state) ? dead : primary).push({ item, state });
+    });
+    return { primaryRows: primary, deadRows: dead };
+  }, [visible, rowStateFor]);
+
+  // Report the batch (multi-select) action up to the toolbar button. Query only when EVERY checked
+  // index resolves to the SAME covering dataset; otherwise Create dataset over the wildcard union.
+  useEffect(() => {
+    if (checkedIndexes.length === 0) {
+      onBatchActionChange(null);
+      return;
+    }
+    const covers = checkedIndexes.map((n) => indexCoveredByAnyDataset(n, datasets));
+    const allSameDataset =
+      covers.every(Boolean) &&
+      covers.every((c) => c && covers[0] && c.datasetId === covers[0]!.datasetId);
+    if (allSameDataset && covers[0]) {
+      const ds = covers[0]!;
+      onBatchActionChange({
+        count: checkedIndexes.length,
+        label: i18n.translate('explore.logsDrilldown.rows.queryCount', {
+          defaultMessage: 'Query ({count})',
+          values: { count: checkedIndexes.length },
+        }),
+        pattern: ds.name,
+        onClick: () =>
+          activateDataset({
+            title: ds.name,
+            datasetId: ds.datasetId,
+            timeFieldName: ds.timeFieldName,
+            dataSource,
+          }),
+      });
+      return;
+    }
+    const pattern = suggestWildcardFromNames(checkedIndexes);
+    onBatchActionChange({
+      count: checkedIndexes.length,
+      label: i18n.translate('explore.logsDrilldown.rows.createDatasetCount', {
+        defaultMessage: 'Create dataset ({count})',
+        values: { count: checkedIndexes.length },
+      }),
+      pattern,
+      onClick: () => createDataset({ pattern, dataSource }),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkedIndexes, datasets, dataSource]);
+
+  if (combined.length === 0) {
+    // Search-with-no-match: a compact message. Genuinely empty (no data): a cool onboarding prompt
+    // with the two primary paths.
+    if (search) {
+      return (
+        <EuiText size="s" color="subdued" data-test-subj="logsExploreRowsEmpty">
+          {i18n.translate('explore.logsDrilldown.rows.noMatch', {
+            defaultMessage: 'No datasets or indexes match “{search}”.',
+            values: { search },
+          })}
+        </EuiText>
+      );
+    }
+    return (
+      <EuiEmptyPrompt
+        data-test-subj="logsExploreRowsEmpty"
+        icon={<PreviewEmptyIllustration />}
+        title={
+          <h2>
+            {i18n.translate('explore.logsDrilldown.empty.title', {
+              defaultMessage: 'Start exploring your logs',
+            })}
+          </h2>
+        }
+        body={
+          <p>
+            {i18n.translate('explore.logsDrilldown.empty.body', {
+              defaultMessage:
+                'Create a dataset from your indexes to start querying, or drill into raw indexes to preview their logs first.',
+            })}
+          </p>
+        }
+        actions={[
+          <EuiButton
+            key="create"
+            fill
+            onClick={() => createDataset({ pattern: '', dataSource })}
+            data-test-subj="logsExploreEmptyCreateDataset"
+          >
+            {i18n.translate('explore.logsDrilldown.empty.createDataset', {
+              defaultMessage: 'Create dataset',
+            })}
+          </EuiButton>,
+        ]}
+      />
+    );
+  }
+
+  // Render one card. Shared by the primary list and the dead drawer so both stay consistent.
+  const renderCard = (item: BrowsableItem, state: LogRowState) => {
+    const cached = item.kind === 'index' ? getCached(item.name) : undefined;
+    const isTimeBased =
+      item.kind === 'dataset'
+        ? Boolean(item.timeFieldName)
+        : cached?.classification === IndexClassification.TIME_BASED;
+    const combinedResult = results.get(item.name);
+    const data: CardData = {
+      preview: combinedResult?.preview,
+      histogram: combinedResult?.histogram,
+      error: errors.get(item.name),
+      loading: !combinedResult && !errors.get(item.name),
+    };
+    const primary = resolvePrimary(item);
+    // Empty-index name is non-actionable (creating a dataset over 0 docs is a trap).
+    const onPrimary = state === LogRowState.EMPTY_INDEX ? undefined : primary.onClick;
+
+    return (
+      <LogStreamCard
+        key={`${item.kind}:${item.name}`}
+        services={services}
+        name={item.name}
+        kind={item.kind}
+        isRemote={item.isRemote}
+        isTimeBased={isTimeBased}
+        rowState={state}
+        severityField={cached?.severityField}
+        timeFieldName={timeFieldOverrides[item.name] ?? item.timeFieldName ?? cached?.timeFieldName}
+        dateFields={cached?.dateFields}
+        docsCount={item.docsCount}
+        health={item.health}
+        createdAt={item.createdAt}
+        rangeLabel={rangeLabel}
+        data={data}
+        primaryLabel={primary.label}
+        onPrimary={onPrimary}
+        // Only raw indexes participate in selection; datasets are never checked (a same-named
+        // dataset + index must not share checked state).
+        checked={item.kind === 'index' && checkedIndexes.includes(item.name)}
+        onToggleCheck={() => onToggleCheck(item.name)}
+        onVisibilityChange={onVisibilityChange}
+        onBrushTime={onBrushTime}
+        onTimeFieldChange={
+          item.kind === 'index' ? (field) => onTimeFieldChange(item.name, field) : undefined
+        }
+        onManage={item.kind === 'dataset' ? () => manageDataset(item.datasetId) : undefined}
+        onRetry={() => invalidateRef.current(item.name)}
+      />
+    );
+  };
+
+  const firstPrimaryIndexIdx = primaryRows.findIndex(({ item }) => item.kind === 'index');
+
+  return (
+    <div className="logsExploreRows" data-test-subj="logsExploreRowsView">
+      {primaryRows.map(({ item, state }, i) => (
+        <React.Fragment key={`${item.kind}:${item.name}`}>
+          {i === 0 && item.kind === 'dataset' && (
+            <SectionLabel
+              label={i18n.translate('explore.logsDrilldown.rows.datasetsSection', {
+                defaultMessage: 'Datasets',
+              })}
+            />
+          )}
+          {i === firstPrimaryIndexIdx && (
+            <SectionLabel
+              label={i18n.translate('explore.logsDrilldown.rows.indexesSection', {
+                defaultMessage: 'Indexes',
+              })}
+            />
+          )}
+          {renderCard(item, state)}
+        </React.Fragment>
+      ))}
+
+      {deadRows.length > 0 && (
+        <div className="logsExploreRows__deadGroup" data-test-subj="logsExploreDeadGroup">
+          <EuiButtonEmpty
+            size="s"
+            iconType={deadOpen ? 'arrowDown' : 'arrowRight'}
+            onClick={() => setDeadOpen((o) => !o)}
+            data-test-subj="logsExploreDeadGroupToggle"
+          >
+            {i18n.translate('explore.logsDrilldown.rows.deadGroup', {
+              defaultMessage: '{count} indexes with no recent data',
+              values: { count: deadRows.length },
+            })}
+          </EuiButtonEmpty>
+          {deadOpen && deadRows.map(({ item, state }) => renderCard(item, state))}
+        </div>
+      )}
+
+      {hasNext && (
+        <EuiButtonEmpty size="s" onClick={loadMore} data-test-subj="logsExploreRowsLoadMore">
+          {i18n.translate('explore.logsExplore.rows.loadMore', { defaultMessage: 'Load more' })}
+        </EuiButtonEmpty>
+      )}
+    </div>
+  );
+};
+
+// Section eyebrow (Datasets / Indexes). No divider line between groups (#6) — the header is enough.
+const SectionLabel: React.FC<{ label: string }> = ({ label }) => (
+  <EuiText size="xs" className="logsExploreRows__section">
+    <EuiTextColor color="subdued">
+      <strong>{label}</strong>
+    </EuiTextColor>
+  </EuiText>
+);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
@@ -161,13 +161,15 @@ export const RowsView: React.FC<Props> = ({
       const item = metaRef.current.get(name);
       if (!item) return { preview: undefined };
 
-      // Determine time field + severity field. Datasets carry timeFieldName; indexes classify.
+      // Determine time field + severity field. Both indexes AND datasets classify (a dataset name
+      // like `otel-*` is a valid field-caps wildcard) so the histogram can be severity-stacked — a
+      // dataset carries its own timeFieldName, but the severity field must still be detected from its
+      // fields. For indexes, classification supplies the time field too.
       let timeFieldName = item.timeFieldName;
-      let severityField: string | undefined;
+      const classification = getCached(name) ?? (await classify(name));
+      const severityField = classification.severityField;
       if (item.kind === 'index') {
-        const result = getCached(name) ?? (await classify(name));
-        timeFieldName = result.timeFieldName;
-        severityField = result.severityField;
+        timeFieldName = classification.timeFieldName;
       }
       // A user-picked time field (multi-timestamp indexes) overrides the auto-selected one.
       timeFieldName = timeFieldOverridesRef.current[name] ?? timeFieldName;
@@ -235,12 +237,12 @@ export const RowsView: React.FC<Props> = ({
   const createDataset = useCreateDataset(services);
   const activateDataset = useActivateDataset(services);
 
-  // Open an existing dataset in index-pattern management (the "Manage" dataset utility action).
+  // Open an existing dataset in the Datasets management app (the "Manage" dataset utility action).
   const manageDataset = useCallback(
     (datasetId?: string) => {
       if (!datasetId) return;
-      services.core.application.navigateToApp('management', {
-        path: `/opensearch-dashboards/indexPatterns/patterns/${datasetId}`,
+      services.core.application.navigateToApp('datasets', {
+        path: `/patterns/${datasetId}`,
       });
     },
     [services]
@@ -426,7 +428,10 @@ export const RowsView: React.FC<Props> = ({
 
   // Render one card. Shared by the primary list and the dead drawer so both stay consistent.
   const renderCard = (item: BrowsableItem, state: LogRowState) => {
-    const cached = item.kind === 'index' ? getCached(item.name) : undefined;
+    // Classification is cached for BOTH kinds (datasets classify too, for severity detection). A
+    // dataset's own timeFieldName still wins for time-based detection; the cached result supplies the
+    // detected severity field (and, for indexes, the time/date fields).
+    const cached = getCached(item.name);
     const isTimeBased =
       item.kind === 'dataset'
         ? Boolean(item.timeFieldName)
@@ -456,6 +461,9 @@ export const RowsView: React.FC<Props> = ({
         dateFields={cached?.dateFields}
         docsCount={item.docsCount}
         health={item.health}
+        storeSize={item.storeSize}
+        primaryShards={item.primaryShards}
+        replicaCount={item.replicaCount}
         createdAt={item.createdAt}
         rangeLabel={rangeLabel}
         data={data}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/rows_view.tsx
@@ -4,12 +4,24 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { EuiButton, EuiButtonEmpty, EuiEmptyPrompt, EuiText, EuiTextColor } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCode,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiSpacer,
+  EuiText,
+  EuiTextColor,
+} from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { Dataset } from '../../../../../../data/common';
 import { ExploreServices } from '../../../../types';
 import { BrowsableItem, IndexClassification } from '../types';
-import { deriveRowState, isDead, formatRangeLabel, LogRowState } from '../row_state';
+import { deriveRowState, isDead, LogRowState } from '../row_state';
 import { useIndexList } from '../hooks/use_index_list';
 import { useDatasetList } from '../hooks/use_dataset_list';
 import { useConcurrentQueries } from '../../metrics/explore/hooks/use_concurrent_queries';
@@ -58,16 +70,19 @@ interface Props {
     | undefined;
   /** Brush-select on any card's histogram → update the global time range. */
   onBrushTime: (from: number, to: number) => void;
-  /** Selected-range bounds (epoch ms) → humanized label for "No events in the last {range}". */
-  rangeFrom: number;
-  rangeTo: number;
   /** Report the current batch (multi-select) action up to the page's toolbar button. */
   onBatchActionChange: (action: BatchAction | null) => void;
 }
 
-// Show the first 20 rows; each "Load more" reveals 10 more.
-const INITIAL_PAGE_SIZE = 20;
+// Show the first 10 rows; each "Load more" reveals 10 more.
+const INITIAL_PAGE_SIZE = 10;
 const LOAD_MORE_STEP = 10;
+
+// The fetch scheduler + results/errors maps are keyed by this, NOT the bare name: a dataset and a
+// raw index can share a name (e.g. a `security-auditlog-2026.07.14` dataset AND index), and keying
+// by name alone collides them onto one slot — one card then ends up with neither a result nor an
+// error and hangs in LOADING. `kind:name` disambiguates them.
+const cardKey = (item: Pick<BrowsableItem, 'kind' | 'name'>) => `${item.kind}:${item.name}`;
 
 interface CombinedResult {
   preview: any;
@@ -88,8 +103,6 @@ export const RowsView: React.FC<Props> = ({
   classify,
   getCached,
   onBrushTime,
-  rangeFrom,
-  rangeTo,
   onBatchActionChange,
 }) => {
   const { datasets } = useDatasetList({ services, dataSourceId, search });
@@ -114,9 +127,9 @@ export const RowsView: React.FC<Props> = ({
   // Picking a different time field for ONE index re-fetches only that card: update its override,
   // then invalidate just that key. It must NOT reset the whole scheduler (which would refetch every
   // other index/dataset card) — fetchFn reads overrides from a ref, so its identity stays stable.
-  const onTimeFieldChange = useCallback((name: string, field: string) => {
-    setTimeFieldOverrides((prev) => ({ ...prev, [name]: field }));
-    invalidateRef.current(name);
+  const onTimeFieldChange = useCallback((key: string, field: string) => {
+    setTimeFieldOverrides((prev) => ({ ...prev, [key]: field }));
+    invalidateRef.current(key);
   }, []);
 
   const onToggleCheck = useCallback((name: string) => {
@@ -125,12 +138,14 @@ export const RowsView: React.FC<Props> = ({
     );
   }, []);
 
+  const clearSelection = useCallback(() => setCheckedIndexes([]), []);
+
   // Combined: datasets first, then indexes (already newest-first). De-dupe by name.
   const combined: BrowsableItem[] = useMemo(() => {
     const seen = new Set<string>();
     const out: BrowsableItem[] = [];
     [...datasets, ...indexItems].forEach((it) => {
-      const key = `${it.kind}:${it.name}`;
+      const key = cardKey(it);
       if (!seen.has(key)) {
         seen.add(key);
         out.push(it);
@@ -142,11 +157,13 @@ export const RowsView: React.FC<Props> = ({
   const visible = combined.slice(0, visibleCount);
   const hasNext = combined.length > visibleCount;
 
-  // Metadata per card name → drives the viewport-gated fetch.
+  // Metadata per card KEY (kind:name) → drives the viewport-gated fetch. Keyed by kind:name so a
+  // same-named dataset + index don't overwrite each other's metadata (which would fetch the wrong
+  // kind for one and hang the other).
   const metaRef = useRef<Map<string, BrowsableItem>>(new Map());
   useEffect(() => {
     const m = new Map<string, BrowsableItem>();
-    combined.forEach((it) => m.set(it.name, it));
+    combined.forEach((it) => m.set(cardKey(it), it));
     metaRef.current = m;
   }, [combined]);
 
@@ -155,11 +172,13 @@ export const RowsView: React.FC<Props> = ({
   const timeFieldOverridesRef = useRef(timeFieldOverrides);
   timeFieldOverridesRef.current = timeFieldOverrides;
 
-  // One fetch per visible card: raw lines + (for time-based) a severity-stacked histogram.
+  // One fetch per visible card: raw lines + (for time-based) a severity-stacked histogram. The
+  // scheduler key is `kind:name`; the actual index/pattern name is `item.name`.
   const fetchFn = useCallback(
-    async (name: string, signal: AbortSignal): Promise<CombinedResult> => {
-      const item = metaRef.current.get(name);
+    async (key: string, signal: AbortSignal): Promise<CombinedResult> => {
+      const item = metaRef.current.get(key);
       if (!item) return { preview: undefined };
+      const name = item.name;
 
       // Determine time field + severity field. Both indexes AND datasets classify (a dataset name
       // like `otel-*` is a valid field-caps wildcard) so the histogram can be severity-stacked — a
@@ -171,8 +190,9 @@ export const RowsView: React.FC<Props> = ({
       if (item.kind === 'index') {
         timeFieldName = classification.timeFieldName;
       }
-      // A user-picked time field (multi-timestamp indexes) overrides the auto-selected one.
-      timeFieldName = timeFieldOverridesRef.current[name] ?? timeFieldName;
+      // A user-picked time field (multi-timestamp indexes) overrides the auto-selected one. Keyed by
+      // the card key so a same-named dataset doesn't inherit an index's override.
+      timeFieldName = timeFieldOverridesRef.current[key] ?? timeFieldName;
 
       // Read the picked time range once; both the preview (log lines) and the histogram are bounded
       // to it so they stay consistent — no more "empty histogram but stale logs" for time-based
@@ -229,7 +249,10 @@ export const RowsView: React.FC<Props> = ({
     // refreshKey resets the scheduler on a time-range change; a time-field pick is handled per-card
     // via invalidate() instead of a dep so it doesn't churn every other card.
     [services, dataSource, search, refreshKey],
-    6
+    // Cap parallel per-card fetches at 4: each time-based card issues two PPL queries (preview +
+    // histogram agg), so a lower cap keeps the backend PPL endpoint predictable on larger clusters.
+    // Queued cards show a skeleton until a slot frees up (viewport-gated, abort-on-scroll-away).
+    4
   );
   // Expose invalidate to onTimeFieldChange (declared above useConcurrentQueries).
   invalidateRef.current = invalidate;
@@ -295,8 +318,6 @@ export const RowsView: React.FC<Props> = ({
     };
   };
 
-  const rangeLabel = useMemo(() => formatRangeLabel(rangeFrom, rangeTo), [rangeFrom, rangeTo]);
-
   // Resolve each card's visual state (full vs. a compact variant) from what we know so far. Liveness
   // (histogram totals sum) is read from `results`, which arrives lazily per card — UNKNOWN cards
   // resolve to LOADING and stay in the primary list until their fetch lands.
@@ -305,7 +326,8 @@ export const RowsView: React.FC<Props> = ({
       const cached = item.kind === 'index' ? getCached(item.name) : undefined;
       const isNoTimeField =
         item.kind === 'index' && cached?.classification === IndexClassification.NO_TIME_FIELD;
-      const result = results.get(item.name);
+      const key = cardKey(item);
+      const result = results.get(key);
       const totalsSum = result?.histogram?.totals?.reduce(
         (s: number, t: { total: number }) => s + t.total,
         0
@@ -315,8 +337,11 @@ export const RowsView: React.FC<Props> = ({
         isNoTimeField,
         docsCount: item.docsCount,
         hasResult: !!result,
-        hasError: !!errors.get(item.name),
+        hasError: !!errors.get(key),
         histogramTotalsSum: totalsSum,
+        // Preview is time-bounded to the same window; its row count is the deterministic fallback
+        // when the best-effort histogram didn't resolve.
+        previewRowCount: result?.preview?.rows?.length,
       });
     },
     [getCached, results, errors]
@@ -334,6 +359,41 @@ export const RowsView: React.FC<Props> = ({
     });
     return { primaryRows: primary, deadRows: dead };
   }, [visible, rowStateFor]);
+
+  // The wildcard family a "Create dataset" over the current selection would use — shown in the
+  // selection bar so the user previews the proposed dataset pattern. Only meaningful when the batch
+  // action is a CREATE (i.e. the checked indexes are NOT all covered by one existing dataset — that
+  // case is a Query, not a new dataset), so it's null otherwise.
+  const proposedWildcard = useMemo(() => {
+    if (checkedIndexes.length === 0) return null;
+    const covers = checkedIndexes.map((n) => indexCoveredByAnyDataset(n, datasets));
+    const allSameDataset =
+      covers.every(Boolean) &&
+      covers.every((c) => c && covers[0] && c.datasetId === covers[0]!.datasetId);
+    return allSameDataset ? null : suggestWildcardFromNames(checkedIndexes);
+  }, [checkedIndexes, datasets]);
+
+  // A dataset over multiple indexes queries them with ONE time field, so warn when the selected
+  // indexes share no common date field. Computed over the CLASSIFIED checked indexes only (their
+  // fields are known) — indexes not yet classified are skipped so we never false-warn while their
+  // classification is still pending. Needs ≥2 classified indexes with known date fields to conflict.
+  const noCommonTimeField = useMemo(() => {
+    // Each classified index's set of date fields (its own timeFieldName always included).
+    const fieldSets = checkedIndexes
+      .map((name) => {
+        const cached = getCached(name);
+        if (!cached) return undefined; // not classified yet → skip
+        const fields = new Set<string>(cached.dateFields ?? []);
+        if (cached.timeFieldName) fields.add(cached.timeFieldName);
+        return fields;
+      })
+      .filter((s): s is Set<string> => !!s && s.size > 0);
+    if (fieldSets.length < 2) return false; // need at least two known-field indexes to conflict
+    // Intersect all field sets; empty intersection ⇒ no shared time field.
+    const [first, ...rest] = fieldSets;
+    const common = [...first].filter((f) => rest.every((s) => s.has(f)));
+    return common.length === 0;
+  }, [checkedIndexes, getCached]);
 
   // Report the batch (multi-select) action up to the toolbar button. Query only when EVERY checked
   // index resolves to the SAME covering dataset; otherwise Create dataset over the wildcard union.
@@ -436,12 +496,15 @@ export const RowsView: React.FC<Props> = ({
       item.kind === 'dataset'
         ? Boolean(item.timeFieldName)
         : cached?.classification === IndexClassification.TIME_BASED;
-    const combinedResult = results.get(item.name);
+    // Scheduler identity is kind:name, so a same-named dataset + index never share a result/error
+    // slot (which previously left one card hung in LOADING).
+    const key = cardKey(item);
+    const combinedResult = results.get(key);
     const data: CardData = {
       preview: combinedResult?.preview,
       histogram: combinedResult?.histogram,
-      error: errors.get(item.name),
-      loading: !combinedResult && !errors.get(item.name),
+      error: errors.get(key),
+      loading: !combinedResult && !errors.get(key),
     };
     const primary = resolvePrimary(item);
     // Empty-index name is non-actionable (creating a dataset over 0 docs is a trap).
@@ -449,15 +512,16 @@ export const RowsView: React.FC<Props> = ({
 
     return (
       <LogStreamCard
-        key={`${item.kind}:${item.name}`}
+        key={key}
         services={services}
         name={item.name}
+        label={item.displayName}
         kind={item.kind}
         isRemote={item.isRemote}
         isTimeBased={isTimeBased}
         rowState={state}
         severityField={cached?.severityField}
-        timeFieldName={timeFieldOverrides[item.name] ?? item.timeFieldName ?? cached?.timeFieldName}
+        timeFieldName={timeFieldOverrides[key] ?? item.timeFieldName ?? cached?.timeFieldName}
         dateFields={cached?.dateFields}
         docsCount={item.docsCount}
         health={item.health}
@@ -465,7 +529,6 @@ export const RowsView: React.FC<Props> = ({
         primaryShards={item.primaryShards}
         replicaCount={item.replicaCount}
         createdAt={item.createdAt}
-        rangeLabel={rangeLabel}
         data={data}
         primaryLabel={primary.label}
         onPrimary={onPrimary}
@@ -473,13 +536,14 @@ export const RowsView: React.FC<Props> = ({
         // dataset + index must not share checked state).
         checked={item.kind === 'index' && checkedIndexes.includes(item.name)}
         onToggleCheck={() => onToggleCheck(item.name)}
-        onVisibilityChange={onVisibilityChange}
+        // The scheduler is keyed by kind:name, so translate the card's per-name callbacks to the key.
+        onVisibilityChange={(_name, isVisible) => onVisibilityChange(key, isVisible)}
         onBrushTime={onBrushTime}
         onTimeFieldChange={
-          item.kind === 'index' ? (field) => onTimeFieldChange(item.name, field) : undefined
+          item.kind === 'index' ? (field) => onTimeFieldChange(key, field) : undefined
         }
         onManage={item.kind === 'dataset' ? () => manageDataset(item.datasetId) : undefined}
-        onRetry={() => invalidateRef.current(item.name)}
+        onRetry={() => invalidateRef.current(key)}
       />
     );
   };
@@ -488,6 +552,89 @@ export const RowsView: React.FC<Props> = ({
 
   return (
     <div className="logsExploreRows" data-test-subj="logsExploreRowsView">
+      {checkedIndexes.length > 0 && (
+        <div className="logsExploreRows__selectionBar" data-test-subj="logsExploreSelectionBar">
+          {/* Row 1: summary + proposed dataset + clear. Row 2: the removable index pills. */}
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" className="logsExploreRows__selectionSummary">
+                <strong>
+                  {checkedIndexes.length === 1
+                    ? i18n.translate('explore.logsDrilldown.rows.selectionCountOne', {
+                        defaultMessage: '1 index selected',
+                      })
+                    : i18n.translate('explore.logsDrilldown.rows.selectionCount', {
+                        defaultMessage: '{count} indexes selected',
+                        values: { count: checkedIndexes.length },
+                      })}
+                </strong>
+              </EuiText>
+            </EuiFlexItem>
+            {proposedWildcard && (
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs">
+                  <EuiTextColor color="subdued">
+                    {i18n.translate('explore.logsDrilldown.rows.selectionWildcardLabel', {
+                      defaultMessage: 'New dataset',
+                    })}
+                  </EuiTextColor>{' '}
+                  <EuiCode
+                    className="logsExploreRows__selectionWildcard"
+                    data-test-subj="logsExploreSelectionWildcard"
+                  >
+                    {proposedWildcard}
+                  </EuiCode>
+                </EuiText>
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem grow={true} />
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="xs"
+                iconType="cross"
+                onClick={clearSelection}
+                data-test-subj="logsExploreSelectionClear"
+              >
+                {i18n.translate('explore.logsDrilldown.rows.selectionClear', {
+                  defaultMessage: 'Clear all',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          {noCommonTimeField && (
+            <EuiText
+              size="xs"
+              color="warning"
+              className="logsExploreRows__selectionWarning"
+              data-test-subj="logsExploreSelectionNoCommonTimeField"
+            >
+              <EuiIcon type="alert" size="s" />{' '}
+              {i18n.translate('explore.logsDrilldown.rows.selectionNoCommonTimeField', {
+                defaultMessage: 'No common time field across the selected indexes',
+              })}
+            </EuiText>
+          )}
+          <div className="logsExploreRows__selectionPills">
+            {checkedIndexes.map((name) => (
+              <EuiBadge
+                key={name}
+                color="hollow"
+                iconType="cross"
+                iconSide="right"
+                iconOnClick={() => onToggleCheck(name)}
+                iconOnClickAriaLabel={i18n.translate('explore.logsDrilldown.rows.selectionRemove', {
+                  defaultMessage: 'Remove {name} from selection',
+                  values: { name },
+                })}
+                data-test-subj={`logsExploreSelectionPill-${name}`}
+              >
+                {name}
+              </EuiBadge>
+            ))}
+          </div>
+        </div>
+      )}
+
       {primaryRows.map(({ item, state }, i) => (
         <React.Fragment key={`${item.kind}:${item.name}`}>
           {i === 0 && item.kind === 'dataset' && (
@@ -526,9 +673,31 @@ export const RowsView: React.FC<Props> = ({
       )}
 
       {hasNext && (
-        <EuiButtonEmpty size="s" onClick={loadMore} data-test-subj="logsExploreRowsLoadMore">
-          {i18n.translate('explore.logsExplore.rows.loadMore', { defaultMessage: 'Load more' })}
-        </EuiButtonEmpty>
+        <>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup direction="column" alignItems="center" gutterSize="xs" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                size="s"
+                iconType="arrowDown"
+                onClick={loadMore}
+                data-test-subj="logsExploreRowsLoadMore"
+              >
+                {i18n.translate('explore.logsExplore.rows.loadMore', {
+                  defaultMessage: 'Load more ({displayed} of {total})',
+                  values: { displayed: visible.length, total: combined.length },
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('explore.logsDrilldown.rows.loadMoreHint', {
+                  defaultMessage: 'or narrow your search',
+                })}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
       )}
     </div>
   );

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
@@ -13,16 +13,20 @@ jest.mock('./histogram_chart', () => ({
   HistogramChart: (props: any) => (
     <div data-test-subj="mock-histogram-chart" data-chart-id={props.chartId} />
   ),
-  SINGLE_SERIES_BUCKET: 'debug',
+  SINGLE_SERIES_BUCKET: 'unknown',
 }));
 jest.mock('../severity', () => ({
+  // Mirrors the real map after the bugbash swap: unknown → "regular logs" blue, debug → purple.
   severityColor: (b: string) =>
     (
-      ({ error: '#f13939', warn: '#F90', info: '#00BD6B', debug: '#0077CC' }) as Record<
-        string,
-        string
-      >
-    )[b] || '#8E96A3',
+      ({
+        error: '#f13939',
+        warn: '#F90',
+        info: '#00BD6B',
+        debug: '#9170B8',
+        unknown: '#0077CC',
+      }) as Record<string, string>
+    )[b] || '#0077CC',
 }));
 
 const services = {} as any;
@@ -56,25 +60,24 @@ describe('SeverityHistogram', () => {
     expect(screen.getByTestId('logsExploreLegend-ERROR')).toHaveTextContent('3');
   });
 
-  it("labels the single-series 'count' total as 'logs' and colors it the debug/blue bar color", () => {
+  it("labels the single-series 'count' total as 'logs' and colors it the 'regular logs' blue", () => {
     const { container } = render(
       <SeverityHistogram
         services={services}
         chartId="x"
         histogram={{
           ...severityHistogram,
-          // bucket is 'unknown' (as normalizeSeverity('count') yields) — the legend must STILL use
-          // the single-series debug/blue, matching the bars, not the grey 'unknown' color.
+          // bucket is 'unknown' (as normalizeSeverity('count') yields) — after the swap that IS the
+          // prominent "regular logs" blue, matching the single-series bars.
           totals: [{ name: 'count', bucket: 'unknown', total: 1500 }],
         }}
       />
     );
     expect(screen.getByTestId('logsExploreLegend-count')).toHaveTextContent('logs');
     expect(screen.getByTestId('logsExploreLegend-count')).toHaveTextContent('1.5K');
-    // The EuiHealth dot uses the debug/blue color (#0077CC), not the grey 'unknown' (#8E96A3).
+    // The EuiHealth dot uses the "regular logs" blue (#0077CC in the mock), via the unknown bucket.
     const html = container.innerHTML;
     expect(html).toContain('#0077CC');
-    expect(html).not.toContain('#8E96A3');
   });
 
   it('humanizes millions with an M suffix and thousands ≥10K without a decimal', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
@@ -13,11 +13,14 @@ jest.mock('./histogram_chart', () => ({
   HistogramChart: (props: any) => (
     <div data-test-subj="mock-histogram-chart" data-chart-id={props.chartId} />
   ),
+  SINGLE_SERIES_BUCKET: 'debug',
 }));
 jest.mock('../severity', () => ({
   severityColor: (b: string) =>
-    (({ error: '#f13939', warn: '#F90', info: '#00BD6B' } as Record<string, string>)[b] ||
-    '#8E96A3'),
+    (({ error: '#f13939', warn: '#F90', info: '#00BD6B', debug: '#0077CC' } as Record<
+      string,
+      string
+    >)[b] || '#8E96A3'),
 }));
 
 const services = {} as any;
@@ -51,19 +54,25 @@ describe('SeverityHistogram', () => {
     expect(screen.getByTestId('logsExploreLegend-ERROR')).toHaveTextContent('3');
   });
 
-  it("labels the single-series 'count' total as 'logs'", () => {
-    render(
+  it("labels the single-series 'count' total as 'logs' and colors it the debug/blue bar color", () => {
+    const { container } = render(
       <SeverityHistogram
         services={services}
         chartId="x"
         histogram={{
           ...severityHistogram,
+          // bucket is 'unknown' (as normalizeSeverity('count') yields) — the legend must STILL use
+          // the single-series debug/blue, matching the bars, not the grey 'unknown' color.
           totals: [{ name: 'count', bucket: 'unknown', total: 1500 }],
         }}
       />
     );
     expect(screen.getByTestId('logsExploreLegend-count')).toHaveTextContent('logs');
     expect(screen.getByTestId('logsExploreLegend-count')).toHaveTextContent('1.5K');
+    // The EuiHealth dot uses the debug/blue color (#0077CC), not the grey 'unknown' (#8E96A3).
+    const html = container.innerHTML;
+    expect(html).toContain('#0077CC');
+    expect(html).not.toContain('#8E96A3');
   });
 
   it('humanizes millions with an M suffix and thousands ≥10K without a decimal', () => {
@@ -82,6 +91,24 @@ describe('SeverityHistogram', () => {
     );
     expect(screen.getByTestId('logsExploreLegend-INFO')).toHaveTextContent('2.4M');
     expect(screen.getByTestId('logsExploreLegend-ERROR')).toHaveTextContent('42K');
+  });
+
+  it('humanizes billions with a B suffix', () => {
+    render(
+      <SeverityHistogram
+        services={services}
+        chartId="x"
+        histogram={{
+          ...severityHistogram,
+          totals: [
+            { name: 'INFO', bucket: 'info', total: 3_200_000_000 },
+            { name: 'WARN', bucket: 'warn', total: 45_000_000_000 },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByTestId('logsExploreLegend-INFO')).toHaveTextContent('3.2B');
+    expect(screen.getByTestId('logsExploreLegend-WARN')).toHaveTextContent('45B');
   });
 
   it('renders raw counts under 1000 without a suffix', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SeverityHistogram } from './severity_histogram';
+import { HistogramResult } from '../hooks/fetch_histogram';
+
+// ECharts can't render in jsdom; stub the chart and assert the legend/composition instead.
+jest.mock('./histogram_chart', () => ({
+  HistogramChart: (props: any) => (
+    <div data-test-subj="mock-histogram-chart" data-chart-id={props.chartId} />
+  ),
+}));
+jest.mock('../severity', () => ({
+  severityColor: (b: string) =>
+    (({ error: '#f13939', warn: '#F90', info: '#00BD6B' } as Record<string, string>)[b] ||
+    '#8E96A3'),
+}));
+
+const services = {} as any;
+
+const severityHistogram: HistogramResult = {
+  intervalMs: 60000,
+  from: 0,
+  to: 900000,
+  series: [],
+  totals: [
+    { name: 'INFO', bucket: 'info', total: 18000 },
+    { name: 'ERROR', bucket: 'error', total: 3 },
+  ],
+};
+
+describe('SeverityHistogram', () => {
+  it('renders the ECharts chart wrapper with the card chartId', () => {
+    render(
+      <SeverityHistogram services={services} histogram={severityHistogram} chartId="my-index" />
+    );
+    const chart = screen.getByTestId('mock-histogram-chart');
+    expect(chart).toBeInTheDocument();
+    expect(chart.getAttribute('data-chart-id')).toBe('my-index');
+  });
+
+  it('renders one legend entry per severity total with humanized counts', () => {
+    render(
+      <SeverityHistogram services={services} histogram={severityHistogram} chartId="my-index" />
+    );
+    expect(screen.getByTestId('logsExploreLegend-INFO')).toHaveTextContent('18K');
+    expect(screen.getByTestId('logsExploreLegend-ERROR')).toHaveTextContent('3');
+  });
+
+  it("labels the single-series 'count' total as 'logs'", () => {
+    render(
+      <SeverityHistogram
+        services={services}
+        chartId="x"
+        histogram={{
+          ...severityHistogram,
+          totals: [{ name: 'count', bucket: 'unknown', total: 1500 }],
+        }}
+      />
+    );
+    expect(screen.getByTestId('logsExploreLegend-count')).toHaveTextContent('logs');
+    expect(screen.getByTestId('logsExploreLegend-count')).toHaveTextContent('1.5K');
+  });
+
+  it('humanizes millions with an M suffix and thousands ≥10K without a decimal', () => {
+    render(
+      <SeverityHistogram
+        services={services}
+        chartId="x"
+        histogram={{
+          ...severityHistogram,
+          totals: [
+            { name: 'INFO', bucket: 'info', total: 2_400_000 },
+            { name: 'ERROR', bucket: 'error', total: 42_000 },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByTestId('logsExploreLegend-INFO')).toHaveTextContent('2.4M');
+    expect(screen.getByTestId('logsExploreLegend-ERROR')).toHaveTextContent('42K');
+  });
+
+  it('renders raw counts under 1000 without a suffix', () => {
+    render(
+      <SeverityHistogram
+        services={services}
+        chartId="x"
+        histogram={{ ...severityHistogram, totals: [{ name: 'WARN', bucket: 'warn', total: 7 }] }}
+      />
+    );
+    expect(screen.getByTestId('logsExploreLegend-WARN')).toHaveTextContent('7');
+  });
+
+  it('shows the "No data in the selected time range" state when every total is zero (#18)', () => {
+    render(
+      <SeverityHistogram
+        services={services}
+        chartId="x"
+        histogram={{ ...severityHistogram, totals: [] }}
+      />
+    );
+    // No chart, no legend — just the explicit empty-range message.
+    expect(screen.getByTestId('logsExploreHistNoData')).toHaveTextContent(
+      'No data in the selected time range'
+    );
+    expect(screen.queryByTestId('mock-histogram-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows the no-data state when totals sum to zero even if series exist', () => {
+    render(
+      <SeverityHistogram
+        services={services}
+        chartId="x"
+        histogram={{
+          ...severityHistogram,
+          series: [{ name: 'count', dataPoints: [[0, 0]] }],
+          totals: [{ name: 'count', bucket: 'unknown', total: 0 }],
+        }}
+      />
+    );
+    expect(screen.getByTestId('logsExploreHistNoData')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.test.tsx
@@ -17,10 +17,12 @@ jest.mock('./histogram_chart', () => ({
 }));
 jest.mock('../severity', () => ({
   severityColor: (b: string) =>
-    (({ error: '#f13939', warn: '#F90', info: '#00BD6B', debug: '#0077CC' } as Record<
-      string,
-      string
-    >)[b] || '#8E96A3'),
+    (
+      ({ error: '#f13939', warn: '#F90', info: '#00BD6B', debug: '#0077CC' }) as Record<
+        string,
+        string
+      >
+    )[b] || '#8E96A3',
 }));
 
 const services = {} as any;

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiHealth, EuiText, EuiTextColor } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { ExploreServices } from '../../../../types';
+import { HistogramResult, SeverityTotal } from '../hooks/fetch_histogram';
+import { severityColor } from '../severity';
+import { HistogramChart } from './histogram_chart';
+
+interface Props {
+  services: ExploreServices;
+  histogram: HistogramResult;
+  /** Brush-select → caller updates the global time picker. */
+  onBrush?: (from: number, to: number) => void;
+  /** Stable id for cursor-sync. */
+  chartId: string;
+}
+
+const CHART_HEIGHT = 96;
+
+/** Humanize a count like 14100 → "14.1K". */
+const humanize = (n: number): string => {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}K`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+};
+
+/**
+ * Card histogram = an ECharts bar chart (severity-stacked, with native tooltip + brush + synced
+ * cursor) plus a single compact legend below with humanized per-severity totals. Bars, legend, and
+ * the log-line level tokens all draw from the ONE severity→color map (`severity.ts` / getColors).
+ */
+export const SeverityHistogram: React.FC<Props> = ({ services, histogram, onBrush, chartId }) => {
+  const totalCount = histogram.totals.reduce((sum, t) => sum + t.total, 0);
+
+  // 0 docs across the whole range → an explicit "no data in range" message, not an empty axis (#18).
+  if (totalCount === 0) {
+    return (
+      <div
+        className="logStreamCard__histEmpty"
+        style={{ height: CHART_HEIGHT }}
+        data-test-subj="logsExploreHistNoData"
+      >
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('explore.logsDrilldown.rows.noDataInRange', {
+            defaultMessage: 'No data in the selected time range',
+          })}
+        </EuiText>
+      </div>
+    );
+  }
+
+  return (
+    <div className="logStreamCard__histWrap">
+      <HistogramChart
+        services={services}
+        histogram={histogram}
+        height={CHART_HEIGHT}
+        onBrush={onBrush}
+        chartId={chartId}
+      />
+      <div className="logStreamCard__legend">
+        {histogram.totals.map((t: SeverityTotal) => (
+          <EuiHealth
+            key={t.name}
+            color={severityColor(t.bucket)}
+            data-test-subj={`logsExploreLegend-${t.name}`}
+          >
+            <EuiText size="xs" className="logStreamCard__legendRow">
+              <span className="logStreamCard__legendName">
+                {t.name === 'count' ? 'logs' : t.name}
+              </span>{' '}
+              <EuiTextColor color="subdued">{humanize(t.total)}</EuiTextColor>
+            </EuiText>
+          </EuiHealth>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.tsx
@@ -9,7 +9,7 @@ import { i18n } from '@osd/i18n';
 import { ExploreServices } from '../../../../types';
 import { HistogramResult, SeverityTotal } from '../hooks/fetch_histogram';
 import { severityColor } from '../severity';
-import { HistogramChart } from './histogram_chart';
+import { HistogramChart, SINGLE_SERIES_BUCKET } from './histogram_chart';
 
 interface Props {
   services: ExploreServices;
@@ -22,11 +22,15 @@ interface Props {
 
 const CHART_HEIGHT = 96;
 
-/** Humanize a count like 14100 → "14.1K". */
+/** Humanize a count with K / M / B units, e.g. 999 → "999", 14100 → "14.1K", 2_500_000 → "2.5M",
+ *  3_200_000_000 → "3.2B". One decimal below 10×the unit, none above (14.1K but 141K). */
 const humanize = (n: number): string => {
+  const unit = (value: number, suffix: string) =>
+    `${value < 10 ? value.toFixed(1) : Math.round(value)}${suffix}`;
   if (n < 1000) return String(n);
-  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}K`;
-  return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n < 1_000_000) return unit(n / 1000, 'K');
+  if (n < 1_000_000_000) return unit(n / 1_000_000, 'M');
+  return unit(n / 1_000_000_000, 'B');
 };
 
 /**
@@ -67,7 +71,10 @@ export const SeverityHistogram: React.FC<Props> = ({ services, histogram, onBrus
         {histogram.totals.map((t: SeverityTotal) => (
           <EuiHealth
             key={t.name}
-            color={severityColor(t.bucket)}
+            // The no-severity single series ('count') colors the legend dot the SAME blue as its
+            // bars (SINGLE_SERIES_BUCKET), not the grey 'unknown' that normalizeSeverity('count')
+            // yields. Severity series use their own bucket color.
+            color={severityColor(t.name === 'count' ? SINGLE_SERIES_BUCKET : t.bucket)}
             data-test-subj={`logsExploreLegend-${t.name}`}
           >
             <EuiText size="xs" className="logStreamCard__legendRow">

--- a/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/components/severity_histogram.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiHealth, EuiText, EuiTextColor } from '@elastic/eui';
+import { EuiHealth, EuiText, EuiTextColor, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { ExploreServices } from '../../../../types';
 import { HistogramResult, SeverityTotal } from '../hooks/fetch_histogram';
@@ -31,6 +31,20 @@ const humanize = (n: number): string => {
   if (n < 1_000_000) return unit(n / 1000, 'K');
   if (n < 1_000_000_000) return unit(n / 1_000_000, 'M');
   return unit(n / 1_000_000_000, 'B');
+};
+
+/** Legend hover copy. `unknown`/`count` explain the "no recognized level" case; others name the level. */
+const legendTooltip = (t: SeverityTotal): string => {
+  if (t.name === 'count' || t.bucket === 'unknown') {
+    return i18n.translate('explore.logsDrilldown.histogram.legend.unknownTip', {
+      defaultMessage:
+        'Documents with no recognized severity/level field (e.g. severityText, level). Counted as logs.',
+    });
+  }
+  return i18n.translate('explore.logsDrilldown.histogram.legend.severityTip', {
+    defaultMessage: 'Documents at the {level} severity level',
+    values: { level: t.name },
+  });
 };
 
 /**
@@ -69,21 +83,21 @@ export const SeverityHistogram: React.FC<Props> = ({ services, histogram, onBrus
       />
       <div className="logStreamCard__legend">
         {histogram.totals.map((t: SeverityTotal) => (
-          <EuiHealth
-            key={t.name}
-            // The no-severity single series ('count') colors the legend dot the SAME blue as its
-            // bars (SINGLE_SERIES_BUCKET), not the grey 'unknown' that normalizeSeverity('count')
-            // yields. Severity series use their own bucket color.
-            color={severityColor(t.name === 'count' ? SINGLE_SERIES_BUCKET : t.bucket)}
-            data-test-subj={`logsExploreLegend-${t.name}`}
-          >
-            <EuiText size="xs" className="logStreamCard__legendRow">
-              <span className="logStreamCard__legendName">
-                {t.name === 'count' ? 'logs' : t.name}
-              </span>{' '}
-              <EuiTextColor color="subdued">{humanize(t.total)}</EuiTextColor>
-            </EuiText>
-          </EuiHealth>
+          <EuiToolTip key={t.name} content={legendTooltip(t)} position="top">
+            <EuiHealth
+              // The no-severity single series ('count') colors the legend dot the SAME blue as its
+              // bars (SINGLE_SERIES_BUCKET), matching the severity series' own bucket colors.
+              color={severityColor(t.name === 'count' ? SINGLE_SERIES_BUCKET : t.bucket)}
+              data-test-subj={`logsExploreLegend-${t.name}`}
+            >
+              <EuiText size="xs" className="logStreamCard__legendRow">
+                <span className="logStreamCard__legendName">
+                  {t.name === 'count' ? 'logs' : t.name}
+                </span>{' '}
+                <EuiTextColor color="subdued">{humanize(t.total)}</EuiTextColor>
+              </EuiText>
+            </EuiHealth>
+          </EuiToolTip>
         ))}
       </div>
     </div>

--- a/src/plugins/explore/public/application/pages/logs_drilldown/dataset_coverage.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/dataset_coverage.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { datasetCoversIndex, indexCoveredByAnyDataset } from './dataset_coverage';
+
+describe('datasetCoversIndex', () => {
+  it('matches an exact index name', () => {
+    expect(datasetCoversIndex('logs-app-2026.07.09', 'logs-app-2026.07.09')).toBe(true);
+    expect(datasetCoversIndex('logs-app-2026.07.09', 'logs-app-2026.07.08')).toBe(false);
+  });
+
+  it('matches a trailing wildcard family', () => {
+    expect(datasetCoversIndex('logs-app-*', 'logs-app-2026.07.09')).toBe(true);
+    expect(datasetCoversIndex('logs-app-*', 'logs-db-1')).toBe(false);
+  });
+
+  it('matches a mid/leading wildcard', () => {
+    expect(datasetCoversIndex('*-access-*', 'nginx-access-2026.07.09')).toBe(true);
+    expect(datasetCoversIndex('*users', 'lookup-users')).toBe(true);
+  });
+
+  it('handles comma-separated dataset titles', () => {
+    expect(datasetCoversIndex('logs-app-*,nginx-*', 'nginx-access-1')).toBe(true);
+    expect(datasetCoversIndex('logs-app-*,nginx-*', 'orders-1')).toBe(false);
+  });
+
+  it('strips dataSourceId:: and cross-cluster prefixes before comparing', () => {
+    expect(datasetCoversIndex('abc123::logs-app-*', 'logs-app-2026.07.09')).toBe(true);
+    expect(datasetCoversIndex('logs-app-*', 'prod:logs-app-2026.07.09')).toBe(true);
+  });
+
+  it('does not treat regex specials as wildcards', () => {
+    // A literal dot is escaped; only * is a wildcard.
+    expect(datasetCoversIndex('logs.app', 'logsXapp')).toBe(false);
+    expect(datasetCoversIndex('logs.app', 'logs.app')).toBe(true);
+  });
+
+  it('returns false for empty inputs', () => {
+    expect(datasetCoversIndex('', 'x')).toBe(false);
+    expect(datasetCoversIndex('x', '')).toBe(false);
+  });
+});
+
+describe('indexCoveredByAnyDataset', () => {
+  const datasets = [
+    { name: 'nginx-*', datasetId: 'ds-nginx' },
+    { name: 'logs-app-*', datasetId: 'ds-logs' },
+  ];
+
+  it('returns the first covering dataset', () => {
+    expect(indexCoveredByAnyDataset('logs-app-2026.07.09', datasets)?.datasetId).toBe('ds-logs');
+    expect(indexCoveredByAnyDataset('nginx-access-1', datasets)?.datasetId).toBe('ds-nginx');
+  });
+
+  it('returns undefined when nothing covers the index', () => {
+    expect(indexCoveredByAnyDataset('orders-2026', datasets)).toBeUndefined();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/dataset_coverage.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/dataset_coverage.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Determines whether an existing dataset "covers" a raw index — i.e. querying the dataset would
+ * include that index — so the Rows view can show a direct "Query" action instead of "Create
+ * dataset". Matching is deliberately conservative: only `*` is treated as a wildcard, everything
+ * else is an exact match, and data-source / cross-cluster prefixes are stripped before comparing.
+ */
+
+/** Strip a `dataSourceId::` prefix and a cross-cluster `cluster:` prefix from a name/token. */
+const stripPrefixes = (raw: string): string => {
+  let s = raw.trim();
+  const dsIdx = s.indexOf('::');
+  if (dsIdx !== -1) s = s.slice(dsIdx + 2);
+  const ccsIdx = s.indexOf(':');
+  if (ccsIdx !== -1) s = s.slice(ccsIdx + 1);
+  return s;
+};
+
+/** Convert one pattern token (possibly containing `*`) into an anchored RegExp. */
+const tokenToRegExp = (token: string): RegExp => {
+  const escaped = token.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+};
+
+/**
+ * Does a dataset title (which may be a wildcard like `logs-app-*` or a comma-separated set like
+ * `a,b,c`) cover the given concrete index name?
+ */
+export const datasetCoversIndex = (datasetTitle: string, indexName: string): boolean => {
+  if (!datasetTitle || !indexName) return false;
+  const idx = stripPrefixes(indexName);
+  return datasetTitle
+    .split(',')
+    .map((t) => stripPrefixes(t))
+    .filter(Boolean)
+    .some((token) => (token.includes('*') ? tokenToRegExp(token).test(idx) : token === idx));
+};
+
+/**
+ * A minimal dataset shape for coverage checks. `name` is the dataset title/pattern (matches the
+ * `BrowsableItem` shape the Rows view passes in).
+ */
+export interface CoverageDataset {
+  name: string;
+  datasetId?: string;
+  timeFieldName?: string;
+}
+
+/**
+ * Return the first listed dataset that covers the index, or undefined. Callers should pass only
+ * datasets scoped to the active data source (coverage does not itself check the data source).
+ */
+export const indexCoveredByAnyDataset = <T extends CoverageDataset>(
+  indexName: string,
+  datasets: T[]
+): T | undefined => datasets.find((d) => datasetCoversIndex(d.name, indexName));

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.test.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fetchHistogram } from './fetch_histogram';
+
+// A fixed 15-minute window (epoch ms): 2026-07-11T03:05:00Z … 03:20:00Z. Fixed (no Date.now()) so
+// the sample bucket timestamps below land inside the window after gap-fill.
+const TO = 1_783_740_000_000; // 2026-07-11T03:20:00Z
+const FROM = TO - 15 * 60 * 1000; // 2026-07-11T03:05:00Z
+
+const post = jest.fn();
+const makeServices = () => (({ http: { post } } as unknown) as any);
+
+// Build a columnar PPL data_frame response the way the enhancements endpoint returns it.
+const dataFrame = (fields: Array<{ name: string; values: unknown[] }>) => ({
+  body: { fields, size: fields[0]?.values.length ?? 0 },
+});
+
+const sentQueryOf = () => JSON.parse(post.mock.calls[0][1].body).query.query as string;
+
+describe('fetchHistogram', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // --- positive cases ---
+
+  it('builds a severity-stacked query bounded to the time range and folds it into series', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [5, 2, 3] },
+        {
+          name: 'span(@timestamp,30s)',
+          values: ['2026-07-11 03:10:00', '2026-07-11 03:10:00', '2026-07-11 03:10:30'],
+        },
+        { name: 'severityText', values: ['INFO', 'ERROR', 'INFO'] },
+      ])
+    );
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'otel-frontend',
+      timeFieldName: '@timestamp',
+      severityField: 'severityText',
+      from: FROM,
+      to: TO,
+    });
+
+    // The PPL query is time-bounded (WHERE ... TIMESTAMP(...)) and groups by span + severity, with
+    // both the time field and severity field backtick-quoted.
+    const sentQuery = sentQueryOf();
+    expect(sentQuery).toMatch(
+      /where `@timestamp` >= TIMESTAMP\('.*'\) and `@timestamp` <= TIMESTAMP\('.*'\)/
+    );
+    expect(sentQuery).toMatch(
+      /stats count\(\) as count by span\(`@timestamp`, .*\), `severityText`/
+    );
+
+    // Two severity series (INFO, ERROR); totals summed per severity.
+    const names = res.series.map((s) => s.name).sort();
+    expect(names).toEqual(['ERROR', 'INFO']);
+    const totalsByName = Object.fromEntries(res.totals.map((t) => [t.name, t.total]));
+    expect(totalsByName.INFO).toBe(8); // 5 + 3
+    expect(totalsByName.ERROR).toBe(2);
+  });
+
+  it('handles the no-severity single-series case', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [10, 4] },
+        { name: 'span(@timestamp,30s)', values: ['2026-07-11 03:10:00', '2026-07-11 03:10:30'] },
+      ])
+    );
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'nginx-access-logs',
+      timeFieldName: '@timestamp',
+      from: FROM,
+      to: TO,
+    });
+
+    const sentQuery = sentQueryOf();
+    expect(sentQuery).toMatch(/stats count\(\) as count by span\(`@timestamp`, .*\)$/);
+    expect(res.series).toHaveLength(1);
+    expect(res.series[0].name).toBe('count');
+    expect(res.totals[0].total).toBe(14);
+  });
+
+  it('backtick-quotes a dotted nested time field so the path resolves (span, where, and severity)', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [1] },
+        { name: 'span(attributes.time,30s)', values: ['2026-07-11 03:10:00'] },
+        { name: 'log.level', values: ['WARN'] },
+      ])
+    );
+
+    await fetchHistogram(makeServices(), {
+      indexName: 'otel-nested',
+      timeFieldName: 'attributes.time',
+      severityField: 'log.level',
+      from: FROM,
+      to: TO,
+    });
+
+    const sentQuery = sentQueryOf();
+    // Dotted nested paths must be a single backtick-quoted identifier everywhere they appear.
+    expect(sentQuery).toContain('span(`attributes.time`, ');
+    expect(sentQuery).toContain('`log.level`');
+    expect(sentQuery).toMatch(/where `attributes\.time` >= TIMESTAMP/);
+    // A dotted path must never appear un-quoted (would be parsed as `attributes`.`time`).
+    expect(sentQuery).not.toMatch(/span\(attributes\.time,/);
+  });
+
+  it('buckets OTel numeric severityNumber values into colored severity totals', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [7, 1] },
+        { name: 'span(@timestamp,30s)', values: ['2026-07-11 03:10:00', '2026-07-11 03:10:00'] },
+        { name: 'severityNumber', values: ['9', '17'] }, // 9=info, 17=error
+      ])
+    );
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'otel-frontend',
+      timeFieldName: '@timestamp',
+      severityField: 'severityNumber',
+      from: FROM,
+      to: TO,
+    });
+
+    const buckets = Object.fromEntries(res.totals.map((t) => [t.bucket, t.total]));
+    expect(buckets.info).toBe(7);
+    expect(buckets.error).toBe(1);
+  });
+
+  it('gap-fills empty buckets across the range (0-count buckets are present)', async () => {
+    // A single data point; the rest of the 15m/30s buckets should be zero-filled.
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [3] },
+        { name: 'span(@timestamp,30s)', values: ['2026-07-11 03:10:00'] },
+      ])
+    );
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'sparse-index',
+      timeFieldName: '@timestamp',
+      from: FROM,
+      to: TO,
+    });
+
+    // More than one bucket returned (zero-filled), and the sum equals the single real count.
+    expect(res.series[0].dataPoints.length).toBeGreaterThan(1);
+    const sum = res.series[0].dataPoints.reduce((acc, [, y]) => acc + y, 0);
+    expect(sum).toBe(3);
+    // At least one zero bucket exists.
+    expect(res.series[0].dataPoints.some(([, y]) => y === 0)).toBe(true);
+  });
+
+  it('sends the data source id + index into the isolated PPL dataset (multi-data-source)', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [1] },
+        { name: 'span(@timestamp,30s)', values: ['2026-07-11 03:10:00'] },
+      ])
+    );
+
+    await fetchHistogram(makeServices(), {
+      indexName: 'remote-logs',
+      timeFieldName: '@timestamp',
+      dataSource: { id: 'ds-2', title: 'Cluster 2', type: 'OpenSearch' } as any,
+      from: FROM,
+      to: TO,
+    });
+
+    const body = JSON.parse(post.mock.calls[0][1].body);
+    expect(body.query.dataset.dataSource.id).toBe('ds-2');
+    expect(body.query.dataset.title).toBe('remote-logs');
+    expect(body.query.language).toBe('PPL');
+  });
+
+  // --- negative / edge cases ---
+
+  it('returns empty series + totals for an empty response body (no data in range)', async () => {
+    post.mockResolvedValue({ body: { fields: [], size: 0 } });
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'empty-index',
+      timeFieldName: '@timestamp',
+      from: FROM,
+      to: TO,
+    });
+
+    // Single-series shape, all-zero after gap-fill, and zero total.
+    expect(res.series).toHaveLength(1);
+    expect(res.totals).toEqual([]);
+    const sum = res.series[0].dataPoints.reduce((acc, [, y]) => acc + y, 0);
+    expect(sum).toBe(0);
+  });
+
+  it('tolerates a malformed response (missing body) without throwing', async () => {
+    post.mockResolvedValue(undefined);
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'weird-index',
+      timeFieldName: '@timestamp',
+      from: FROM,
+      to: TO,
+    });
+
+    expect(res.series).toHaveLength(1);
+    expect(res.totals).toEqual([]);
+  });
+
+  it('coerces non-numeric / missing counts to 0 rather than NaN', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: ['not-a-number', null] },
+        { name: 'span(@timestamp,30s)', values: ['2026-07-11 03:10:00', '2026-07-11 03:10:30'] },
+      ])
+    );
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'bad-counts',
+      timeFieldName: '@timestamp',
+      from: FROM,
+      to: TO,
+    });
+
+    const sum = res.series[0].dataPoints.reduce((acc, [, y]) => acc + y, 0);
+    expect(Number.isNaN(sum)).toBe(false);
+    expect(sum).toBe(0);
+  });
+
+  it('propagates an aborted/failed request to the caller (best-effort handled upstream)', async () => {
+    post.mockRejectedValue(new Error('aborted'));
+
+    await expect(
+      fetchHistogram(makeServices(), {
+        indexName: 'x',
+        timeFieldName: '@timestamp',
+        from: FROM,
+        to: TO,
+      })
+    ).rejects.toThrow('aborted');
+  });
+
+  it('labels missing severity values as "unknown"', async () => {
+    post.mockResolvedValue(
+      dataFrame([
+        { name: 'count', values: [2] },
+        { name: 'span(@timestamp,30s)', values: ['2026-07-11 03:10:00'] },
+        { name: 'severityText', values: [null] },
+      ])
+    );
+
+    const res = await fetchHistogram(makeServices(), {
+      indexName: 'missing-sev',
+      timeFieldName: '@timestamp',
+      severityField: 'severityText',
+      from: FROM,
+      to: TO,
+    });
+
+    expect(res.series.map((s) => s.name)).toEqual(['unknown']);
+    expect(res.totals[0]).toMatchObject({ name: 'unknown', bucket: 'unknown', total: 2 });
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.test.ts
@@ -11,7 +11,7 @@ const TO = 1_783_740_000_000; // 2026-07-11T03:20:00Z
 const FROM = TO - 15 * 60 * 1000; // 2026-07-11T03:05:00Z
 
 const post = jest.fn();
-const makeServices = () => (({ http: { post } } as unknown) as any);
+const makeServices = () => ({ http: { post } }) as unknown as any;
 
 // Build a columnar PPL data_frame response the way the enhancements endpoint returns it.
 const dataFrame = (fields: Array<{ name: string; values: unknown[] }>) => ({

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.ts
@@ -169,7 +169,7 @@ function parseColumnar(
   const size: number = response?.body?.size ?? fields[0]?.values?.length ?? 0;
 
   const countCol = fields.find((f) => /count/i.test(f.name))?.values ?? [];
-  const sevCol = severityField ? fields.find((f) => f.name === severityField)?.values ?? [] : [];
+  const sevCol = severityField ? (fields.find((f) => f.name === severityField)?.values ?? []) : [];
   // The time-bucket column is whatever remains (the `span(...)` expression echoes as the column
   // name, which varies by engine) — pick the first field that is neither count nor severity.
   const timeCol =

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_histogram.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import moment from 'moment';
+import { Dataset, DEFAULT_DATA, formatTimePickerDate } from '../../../../../../data/common';
+import { ExploreServices } from '../../../../types';
+import { fillTimeBucketGaps } from '../../../../components/chart/utils/point_series';
+import { normalizeSeverity } from '../severity';
+
+/**
+ * Build the time-range WHERE clause exactly as the production query-enhancements PPL path does
+ * (`FilterUtils.getTimeFilterWhereClause`): `TIMESTAMP('...')` literals are portable across modern
+ * and legacy PPL engines. Our isolated `http.post` bypasses the search interceptor that would
+ * normally inject this, so we add it here to bound the histogram to the picked time range.
+ */
+const timeWhereClause = (timeFieldName: string, from: number, to: number): string => {
+  const { fromDate, toDate } = formatTimePickerDate(
+    { from: new Date(from).toISOString(), to: new Date(to).toISOString() },
+    'YYYY-MM-DD HH:mm:ss.SSS'
+  );
+  return `where \`${timeFieldName}\` >= TIMESTAMP('${fromDate}') and \`${timeFieldName}\` <= TIMESTAMP('${toDate}')`;
+};
+
+const SEARCH_STRATEGY_PPL = 'ppl';
+// Target number of histogram bars — kept low (20) so bars are fat/scannable in the 360px card
+// histogram column. The Query-mode full-width chart uses 50; for the small Rows card fewer is better.
+const TARGET_BUCKETS = 20;
+
+export interface SeverityTotal {
+  /** Raw breakdown value (e.g. "INFO"), or 'count' for the no-severity case. */
+  name: string;
+  /** Coarse bucket for coloring. */
+  bucket: ReturnType<typeof normalizeSeverity>;
+  total: number;
+}
+
+/** One severity series' points as `[timestampMs, count]` tuples (raw, pre-render). */
+export interface HistogramSeries {
+  /** Raw breakdown value (e.g. "INFO"), or 'count' for the no-severity single series. */
+  name: string;
+  dataPoints: Array<[number, number]>;
+}
+
+export interface HistogramResult {
+  /** Per-severity series (self-contained; the drilldown renders its own SVG bars from these). */
+  series: HistogramSeries[];
+  /** Bucket interval in ms (for the x-axis span). */
+  intervalMs: number;
+  /** Global time bounds (epoch ms). */
+  from: number;
+  to: number;
+  /** Per-severity running totals for the card legend (group-by-sum over the response). */
+  totals: SeverityTotal[];
+}
+
+interface FetchHistogramArgs {
+  indexName: string;
+  timeFieldName: string;
+  severityField?: string;
+  dataSource?: Dataset['dataSource'];
+  /** Global time range bounds (epoch ms). */
+  from: number;
+  to: number;
+}
+
+/**
+ * Runs a real PPL `date_histogram` (`stats count() by span(timeField, <auto>)`, optionally also
+ * `, <severityField>`) for one index, out of Redux, and folds the columnar response into a `Chart`
+ * (with `.series[]` stacked by severity when a severity field is present, else a single series) plus
+ * per-severity totals for the legend. Abortable via `signal`.
+ */
+export const fetchHistogram = async (
+  services: ExploreServices,
+  { indexName, timeFieldName, severityField, dataSource, from, to }: FetchHistogramArgs,
+  signal?: AbortSignal
+): Promise<HistogramResult> => {
+  const { interval, spanExpr } = autoSpan(from, to);
+
+  const dataset: Dataset = {
+    id: `logs-explore-hist::${dataSource?.id ?? ''}::${indexName}`,
+    title: indexName,
+    type: DEFAULT_DATA.SET_TYPES.INDEX,
+    timeFieldName,
+    dataSource: (dataSource ?? DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE) as Dataset['dataSource'],
+  };
+
+  // Backtick-quote field identifiers so dotted nested paths (e.g. `attributes.time`) and reserved
+  // words resolve, matching the WHERE clause above.
+  const statsBy = severityField
+    ? `span(\`${timeFieldName}\`, ${spanExpr}), \`${severityField}\``
+    : `span(\`${timeFieldName}\`, ${spanExpr})`;
+  // Bound to the picked time range (else the un-filtered stats returns every bucket across all
+  // history, and gap-fill to now-15m leaves the recent buckets buried / mis-aligned).
+  const query = `source = ${indexName} | ${timeWhereClause(
+    timeFieldName,
+    from,
+    to
+  )} | stats count() as count by ${statsBy}`;
+
+  const response = await services.http.post(`/api/enhancements/search/${SEARCH_STRATEGY_PPL}`, {
+    signal,
+    body: JSON.stringify({
+      query: { query, language: 'PPL', dataset, format: 'jdbc' },
+    }),
+  });
+
+  const parsed = parseColumnar(response, timeFieldName, severityField);
+  const intervalMs = interval.asMilliseconds();
+
+  // Zero-fill empty buckets across the full [from,to] range using the SAME tried-and-tested helper
+  // the production logs-explore histogram uses (`fillTimeBucketGaps`), so the x-axis reads
+  // continuously and 0-count buckets are accounted for. The drilldown then renders its own SVG bars.
+  const rawSeries: HistogramSeries[] = severityField
+    ? parsed.series.map((s) => ({ name: s.breakdownValue, dataPoints: s.dataPoints }))
+    : [{ name: 'count', dataPoints: parsed.single }];
+
+  const series: HistogramSeries[] = rawSeries.map((s) => ({
+    name: s.name,
+    dataPoints: fillTimeBucketGaps(
+      s.dataPoints.map(([x, y]) => ({ x, y })),
+      intervalMs,
+      from,
+      to
+    ).map((p) => [p.x, p.y] as [number, number]),
+  }));
+
+  return { series, intervalMs, from, to, totals: parsed.totals };
+};
+
+// Choose a span (interval) that yields ~TARGET_BUCKETS bars across [from,to], expressed in a PPL
+// span unit. Returns the moment Duration (for the Chart) + the PPL span expression string.
+function autoSpan(from: number, to: number): { interval: moment.Duration; spanExpr: string } {
+  const rangeMs = Math.max(1, to - from);
+  const rawMs = rangeMs / TARGET_BUCKETS;
+  const candidates: Array<[number, string]> = [
+    [1000, '1s'],
+    [5000, '5s'],
+    [10000, '10s'],
+    [30000, '30s'],
+    [60000, '1m'],
+    [5 * 60000, '5m'],
+    [10 * 60000, '10m'],
+    [30 * 60000, '30m'],
+    [60 * 60000, '1h'],
+    [3 * 3600000, '3h'],
+    [12 * 3600000, '12h'],
+    [24 * 3600000, '1d'],
+    [7 * 86400000, '7d'],
+  ];
+  const chosen = candidates.find(([ms]) => ms >= rawMs) ?? candidates[candidates.length - 1];
+  return { interval: moment.duration(chosen[0], 'ms'), spanExpr: chosen[1] };
+}
+
+// Parse the PPL columnar `data_frame` response into per-severity series + totals (and the
+// single-series [time,count][] when no severity field). Column names: the time bucket column echoes
+// the `span(...)` expression, `count`, and the severity field.
+function parseColumnar(
+  response: any,
+  timeFieldName: string,
+  severityField?: string
+): {
+  series: Array<{ breakdownValue: string; dataPoints: Array<[number, number]> }>;
+  single: Array<[number, number]>;
+  totals: SeverityTotal[];
+} {
+  const fields: Array<{ name: string; values: unknown[] }> = response?.body?.fields ?? [];
+  const size: number = response?.body?.size ?? fields[0]?.values?.length ?? 0;
+
+  const countCol = fields.find((f) => /count/i.test(f.name))?.values ?? [];
+  const sevCol = severityField ? fields.find((f) => f.name === severityField)?.values ?? [] : [];
+  // The time-bucket column is whatever remains (the `span(...)` expression echoes as the column
+  // name, which varies by engine) — pick the first field that is neither count nor severity.
+  const timeCol =
+    fields.find((f) => !/count/i.test(f.name) && (!severityField || f.name !== severityField))
+      ?.values ?? [];
+
+  // PPL returns bucket timestamps as naive strings (e.g. "2026-07-10 19:43:00") which are UTC but
+  // have no zone marker — bare Date.parse() would read them as LOCAL time and shift every bucket by
+  // the host's UTC offset, pushing the bars outside the query window (chart looks empty). Append
+  // 'Z' when there's no zone info, matching the Query-mode histogram (actions/utils.ts).
+  const toTs = (v: unknown): number => {
+    if (typeof v === 'number') return v;
+    const s = String(v);
+    const hasZone =
+      s.includes('Z') || s.includes('+') || (s.includes('-') && s.lastIndexOf('-') > 10);
+    const t = new Date(hasZone ? s : `${s}Z`).getTime();
+    return Number.isFinite(t) ? t : 0;
+  };
+
+  const totalsMap = new Map<string, number>();
+  const single: Array<[number, number]> = [];
+  const seriesMap = new Map<string, Array<[number, number]>>();
+
+  for (let i = 0; i < size; i++) {
+    const ts = toTs(timeCol[i]);
+    const count = Number(countCol[i]) || 0;
+    if (severityField) {
+      const sev = String(sevCol[i] ?? 'unknown');
+      if (!seriesMap.has(sev)) seriesMap.set(sev, []);
+      seriesMap.get(sev)!.push([ts, count]);
+      totalsMap.set(sev, (totalsMap.get(sev) ?? 0) + count);
+    } else {
+      single.push([ts, count]);
+      totalsMap.set('count', (totalsMap.get('count') ?? 0) + count);
+    }
+  }
+
+  const totals: SeverityTotal[] = Array.from(totalsMap.entries())
+    .map(([name, total]) => ({ name, total, bucket: normalizeSeverity(name) }))
+    .sort((a, b) => b.total - a.total);
+
+  return {
+    series: Array.from(seriesMap.entries()).map(([breakdownValue, dataPoints]) => ({
+      breakdownValue,
+      dataPoints,
+    })),
+    single,
+    totals,
+  };
+}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.test.ts
@@ -108,7 +108,7 @@ describe('fetchPreview', () => {
 
   it('sorts by the (backtick-quoted) time field for a time-based index and issues head N', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, {
+    await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'logs-app-1',
       timeFieldName: '@timestamp',
       size: 10,
@@ -119,7 +119,7 @@ describe('fetchPreview', () => {
 
   it('bounds the preview to the time range (WHERE before sort) when from/to are given', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, {
+    await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'logs-app-1',
       timeFieldName: '@timestamp',
       size: 10,
@@ -135,7 +135,7 @@ describe('fetchPreview', () => {
 
   it('does NOT add a time filter when from/to are omitted (latest N docs)', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, {
+    await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'logs-app-1',
       timeFieldName: '@timestamp',
       size: 10,
@@ -147,7 +147,7 @@ describe('fetchPreview', () => {
 
   it('does NOT add a time filter for a no-time-field index even if from/to are passed', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, {
+    await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'lookup-users',
       size: 10,
       from: 1,
@@ -159,7 +159,7 @@ describe('fetchPreview', () => {
 
   it('backtick-quotes a dotted nested time field so the sort path resolves', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, {
+    await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'otel-nested',
       timeFieldName: 'attributes.time',
       size: 5,
@@ -171,7 +171,7 @@ describe('fetchPreview', () => {
 
   it('omits the sort for a no-time-field index', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, {
+    await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'lookup-users',
       size: 10,
     });
@@ -181,7 +181,7 @@ describe('fetchPreview', () => {
 
   it('defaults to DEFAULT_PREVIEW_SIZE when size is omitted', async () => {
     const post = mkPost();
-    await fetchPreview(({ http: { post } } as unknown) as any, { indexName: 'logs' });
+    await fetchPreview({ http: { post } } as unknown as any, { indexName: 'logs' });
     const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
     expect(q).toBe(`source = logs | head ${DEFAULT_PREVIEW_SIZE}`);
   });
@@ -190,7 +190,7 @@ describe('fetchPreview', () => {
     const post = mkPost();
     const signal = new AbortController().signal;
     await fetchPreview(
-      ({ http: { post } } as unknown) as any,
+      { http: { post } } as unknown as any,
       {
         indexName: 'remote-logs',
         timeFieldName: '@timestamp',
@@ -214,7 +214,7 @@ describe('fetchPreview', () => {
         ],
       },
     });
-    const res = await fetchPreview(({ http: { post } } as unknown) as any, {
+    const res = await fetchPreview({ http: { post } } as unknown as any, {
       indexName: 'logs',
       timeFieldName: '@timestamp',
     });

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.test.ts
@@ -93,6 +93,13 @@ describe('toFriendlyError', () => {
     expect(toFriendlyError('GET /_plugins/_ppl failed')).toMatch(/PPL query engine/);
   });
 
+  it('maps a 403 / permission error to actionable guidance', () => {
+    expect(toFriendlyError({ statusCode: 403, message: 'forbidden' })).toMatch(/permission/i);
+    expect(toFriendlyError(new Error('security_exception: no permissions for'))).toMatch(
+      /permission/i
+    );
+  });
+
   it('passes through other messages', () => {
     expect(toFriendlyError(new Error('boom'))).toBe('boom');
   });

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  extractRows,
+  deriveColumns,
+  toFriendlyError,
+  fetchPreview,
+  DEFAULT_PREVIEW_SIZE,
+} from './fetch_preview';
+
+describe('extractRows', () => {
+  it('un-pivots a columnar PPL data_frame into row objects', () => {
+    const rows = extractRows({
+      body: {
+        size: 2,
+        fields: [
+          { name: '@timestamp', values: ['t1', 't2'] },
+          { name: 'level', values: ['INFO', 'ERROR'] },
+        ],
+      },
+    });
+    expect(rows).toEqual([
+      { '@timestamp': 't1', level: 'INFO' },
+      { '@timestamp': 't2', level: 'ERROR' },
+    ]);
+  });
+
+  it('derives the row count from the first field when body.size is absent', () => {
+    const rows = extractRows({
+      body: { fields: [{ name: 'a', values: [1, 2, 3] }] },
+    });
+    expect(rows).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  });
+
+  it('falls back to classic hits[]._source', () => {
+    const rows = extractRows({ hits: { hits: [{ _source: { a: 1 } }, { _source: { b: 2 } }] } });
+    expect(rows).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('tolerates a hit missing _source', () => {
+    expect(extractRows({ hits: { hits: [{}, { _source: { a: 1 } }] } })).toEqual([{}, { a: 1 }]);
+  });
+
+  it('returns an empty list for an empty response', () => {
+    expect(extractRows({})).toEqual([]);
+  });
+
+  it('returns an empty list for an undefined/null response', () => {
+    expect(extractRows(undefined)).toEqual([]);
+    expect(extractRows(null)).toEqual([]);
+  });
+});
+
+describe('deriveColumns', () => {
+  it('leads with the time field and caps at 6 columns', () => {
+    const rows = [{ a: 1, b: 2, '@timestamp': 't', c: 3, d: 4, e: 5, f: 6 }];
+    const cols = deriveColumns(rows, '@timestamp');
+    expect(cols[0]).toBe('@timestamp');
+    expect(cols).toHaveLength(6);
+  });
+
+  it('unions column names across rows with differing keys', () => {
+    const cols = deriveColumns([{ a: 1 }, { b: 2 }, { a: 3, c: 4 }]);
+    expect(cols).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not lead with a time field that is not present in the rows', () => {
+    // timeFieldName given but no row has it → plain order, no crash.
+    expect(deriveColumns([{ user_id: 1 }], '@timestamp')).toEqual(['user_id']);
+  });
+
+  it('handles a no-time-field index (no leading time column)', () => {
+    expect(deriveColumns([{ user_id: 1, email: 'x' }])).toEqual(['user_id', 'email']);
+  });
+
+  it('returns an empty list when there are no rows', () => {
+    expect(deriveColumns([])).toEqual([]);
+    expect(deriveColumns([], '@timestamp')).toEqual([]);
+  });
+});
+
+describe('toFriendlyError', () => {
+  it('maps a missing-PPL-engine error to actionable guidance', () => {
+    expect(toFriendlyError(new Error('no handler found for _plugins/_ppl'))).toMatch(
+      /PPL query engine/
+    );
+  });
+
+  it('maps a raw _ppl string (non-Error) to guidance', () => {
+    expect(toFriendlyError('GET /_plugins/_ppl failed')).toMatch(/PPL query engine/);
+  });
+
+  it('passes through other messages', () => {
+    expect(toFriendlyError(new Error('boom'))).toBe('boom');
+  });
+
+  it('gives a generic fallback for an empty/nullish error', () => {
+    expect(toFriendlyError(undefined)).toBe('Unable to preview this index');
+    expect(toFriendlyError('')).toBe('Unable to preview this index');
+  });
+});
+
+describe('fetchPreview', () => {
+  const mkPost = () => jest.fn().mockResolvedValue({ body: { size: 0, fields: [] } });
+
+  it('sorts by the (backtick-quoted) time field for a time-based index and issues head N', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'logs-app-1',
+      timeFieldName: '@timestamp',
+      size: 10,
+    });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    expect(q).toBe('source = logs-app-1 | sort - `@timestamp` | head 10');
+  });
+
+  it('bounds the preview to the time range (WHERE before sort) when from/to are given', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'logs-app-1',
+      timeFieldName: '@timestamp',
+      size: 10,
+      from: Date.parse('2026-07-13T22:30:00.000Z'),
+      to: Date.parse('2026-07-13T22:45:00.000Z'),
+    });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    // WHERE clause sits between source and sort, so it matches the histogram's window.
+    expect(q).toMatch(
+      /^source = logs-app-1 \| where `@timestamp` >= TIMESTAMP\('.*'\) and `@timestamp` <= TIMESTAMP\('.*'\) \| sort - `@timestamp` \| head 10$/
+    );
+  });
+
+  it('does NOT add a time filter when from/to are omitted (latest N docs)', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'logs-app-1',
+      timeFieldName: '@timestamp',
+      size: 10,
+    });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    expect(q).toBe('source = logs-app-1 | sort - `@timestamp` | head 10');
+    expect(q).not.toMatch(/where/);
+  });
+
+  it('does NOT add a time filter for a no-time-field index even if from/to are passed', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'lookup-users',
+      size: 10,
+      from: 1,
+      to: 2,
+    });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    expect(q).toBe('source = lookup-users | head 10');
+  });
+
+  it('backtick-quotes a dotted nested time field so the sort path resolves', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'otel-nested',
+      timeFieldName: 'attributes.time',
+      size: 5,
+    });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    expect(q).toBe('source = otel-nested | sort - `attributes.time` | head 5');
+    expect(q).not.toMatch(/sort - attributes\.time/);
+  });
+
+  it('omits the sort for a no-time-field index', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'lookup-users',
+      size: 10,
+    });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    expect(q).toBe('source = lookup-users | head 10');
+  });
+
+  it('defaults to DEFAULT_PREVIEW_SIZE when size is omitted', async () => {
+    const post = mkPost();
+    await fetchPreview(({ http: { post } } as unknown) as any, { indexName: 'logs' });
+    const q = JSON.parse(post.mock.calls[0][1].body).query.query as string;
+    expect(q).toBe(`source = logs | head ${DEFAULT_PREVIEW_SIZE}`);
+  });
+
+  it('forwards the abort signal and the data source id into the dataset', async () => {
+    const post = mkPost();
+    const signal = new AbortController().signal;
+    await fetchPreview(
+      ({ http: { post } } as unknown) as any,
+      {
+        indexName: 'remote-logs',
+        timeFieldName: '@timestamp',
+        dataSource: { id: 'ds-2', title: 'C2', type: 'OpenSearch' } as any,
+      },
+      signal
+    );
+    expect(post.mock.calls[0][1].signal).toBe(signal);
+    const body = JSON.parse(post.mock.calls[0][1].body);
+    expect(body.query.dataset.dataSource.id).toBe('ds-2');
+    expect(body.query.dataset.title).toBe('remote-logs');
+  });
+
+  it('returns parsed rows + columns from a columnar response', async () => {
+    const post = jest.fn().mockResolvedValue({
+      body: {
+        size: 1,
+        fields: [
+          { name: 'level', values: ['INFO'] },
+          { name: '@timestamp', values: ['t1'] },
+        ],
+      },
+    });
+    const res = await fetchPreview(({ http: { post } } as unknown) as any, {
+      indexName: 'logs',
+      timeFieldName: '@timestamp',
+    });
+    expect(res.rows).toEqual([{ level: 'INFO', '@timestamp': 't1' }]);
+    // Time field leads the column list.
+    expect(res.columns[0]).toBe('@timestamp');
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Dataset, DEFAULT_DATA, formatTimePickerDate } from '../../../../../../data/common';
+import { ExploreServices } from '../../../../types';
+
+export interface PreviewRow {
+  [field: string]: unknown;
+}
+
+export interface PreviewResult {
+  columns: string[];
+  rows: PreviewRow[];
+}
+
+export const DEFAULT_PREVIEW_SIZE = 10;
+export const EXPANDED_PREVIEW_SIZE = 100;
+
+// The query-enhancements PPL search route (BASE_API `/api/enhancements/search` + strategy `ppl`).
+const SEARCH_STRATEGY_PPL = 'ppl';
+
+/**
+ * The same time-range WHERE clause the histogram uses (and the production query-enhancements PPL
+ * path). `TIMESTAMP('...')` literals are portable across modern and legacy PPL engines. Our isolated
+ * `http.post` bypasses the search interceptor that would normally inject this, so we add it here to
+ * bound the preview to the picked time range — keeping the log lines consistent with the histogram.
+ */
+const timeWhereClause = (timeFieldName: string, from: number, to: number): string => {
+  const { fromDate, toDate } = formatTimePickerDate(
+    { from: new Date(from).toISOString(), to: new Date(to).toISOString() },
+    'YYYY-MM-DD HH:mm:ss.SSS'
+  );
+  return `where \`${timeFieldName}\` >= TIMESTAMP('${fromDate}') and \`${timeFieldName}\` <= TIMESTAMP('${toDate}')`;
+};
+
+interface FetchPreviewArgs {
+  indexName: string;
+  timeFieldName?: string;
+  dataSource?: Dataset['dataSource'];
+  size?: number;
+  /** Global time range bounds (epoch ms). When present with a time field, the preview is bounded to
+   *  this range — so the log lines match the histogram instead of showing the latest docs ever. */
+  from?: number;
+  to?: number;
+}
+
+/**
+ * Runs a one-off, isolated PPL preview for an index — the latest `size` docs, as raw rows. Abortable
+ * via `signal`, so a viewport-gated stack of cards can cancel scrolled-away fetches. Isolated from the
+ * Redux results slice: it POSTs directly to the PPL enhancements route and returns local data.
+ */
+export const fetchPreview = async (
+  services: ExploreServices,
+  { indexName, timeFieldName, dataSource, size = DEFAULT_PREVIEW_SIZE, from, to }: FetchPreviewArgs,
+  signal?: AbortSignal
+): Promise<PreviewResult> => {
+  const previewDataset: Dataset = {
+    id: `logs-explore-preview::${dataSource?.id ?? ''}::${indexName}`,
+    title: indexName,
+    type: DEFAULT_DATA.SET_TYPES.INDEX,
+    timeFieldName,
+    dataSource: (dataSource ?? DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE) as Dataset['dataSource'],
+  };
+
+  // Bound the preview to the picked time range (same clause the histogram uses) so the log lines
+  // agree with the histogram. Only when we have both a time field and explicit bounds; otherwise
+  // (non-time index, or no bounds passed) fall back to the latest `size` docs.
+  const whereClause =
+    timeFieldName && from != null && to != null
+      ? ` | ${timeWhereClause(timeFieldName, from, to)}`
+      : '';
+  const sortClause = timeFieldName ? ` | sort - \`${timeFieldName}\`` : '';
+
+  const path = `/api/enhancements/search/${SEARCH_STRATEGY_PPL}`;
+  const response = await services.http.post(path, {
+    signal,
+    body: JSON.stringify({
+      query: {
+        // Backtick-quote the time field so dotted nested paths (e.g. `attributes.time`) and
+        // reserved words sort correctly.
+        query: `source = ${indexName}${whereClause}${sortClause} | head ${size}`,
+        language: 'PPL',
+        dataset: previewDataset,
+        format: 'jdbc',
+      },
+    }),
+  });
+
+  const rows = extractRows(response);
+  const columns = deriveColumns(rows, timeFieldName);
+  return { columns, rows };
+};
+
+// Normalize a search response into row objects. PPL (query enhancements) returns a columnar
+// `data_frame` (`body.fields[] = { name, values[] }`); the classic search path returns
+// `hits.hits[]._source`. Handle both.
+export function extractRows(response: any): PreviewRow[] {
+  const fields = response?.body?.fields;
+  if (Array.isArray(fields) && fields.length > 0) {
+    const rowCount = response?.body?.size ?? fields[0]?.values?.length ?? 0;
+    const rows: PreviewRow[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row: PreviewRow = {};
+      fields.forEach((f: { name: string; values: unknown[] }) => {
+        row[f.name] = f.values?.[i];
+      });
+      rows.push(row);
+    }
+    return rows;
+  }
+  const hits = response?.hits?.hits ?? [];
+  return hits.map((h: { _source: PreviewRow }) => h._source ?? {});
+}
+
+// Translate low-level search errors into actionable guidance. The most common one on a bare
+// cluster is a missing PPL engine (the SQL plugin isn't installed), which otherwise surfaces as
+// a cryptic "Bad Request".
+export function toFriendlyError(e: unknown): string {
+  const raw = e instanceof Error ? e.message : String(e ?? '');
+  if (/_plugins\/_ppl|no handler found|_ppl/i.test(raw)) {
+    return 'Preview needs the PPL query engine, which is not available on this cluster. You can still create a dataset and query it.';
+  }
+  return raw || 'Unable to preview this index';
+}
+
+// Pick up to 6 columns, leading with the time field when present.
+export function deriveColumns(rows: PreviewRow[], timeFieldName?: string): string[] {
+  const seen = new Set<string>();
+  rows.forEach((row) => Object.keys(row).forEach((k) => seen.add(k)));
+  const all = Array.from(seen);
+  if (timeFieldName && all.includes(timeFieldName)) {
+    return [timeFieldName, ...all.filter((c) => c !== timeFieldName)].slice(0, 6);
+  }
+  return all.slice(0, 6);
+}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/fetch_preview.ts
@@ -119,6 +119,17 @@ export function extractRows(response: any): PreviewRow[] {
 // a cryptic "Bad Request".
 export function toFriendlyError(e: unknown): string {
   const raw = e instanceof Error ? e.message : String(e ?? '');
+  const statusCode =
+    (e as { statusCode?: number; body?: { statusCode?: number } })?.statusCode ??
+    (e as { body?: { statusCode?: number } })?.body?.statusCode;
+  // Permission denied (403 / security-plugin authorization failure) → actionable copy instead of a
+  // cryptic security message.
+  if (
+    statusCode === 403 ||
+    /\b403\b|forbidden|unauthorized|not authorized|no permissions for|security_exception/i.test(raw)
+  ) {
+    return "You don't have permission to read this index. Ask an administrator for access.";
+  }
   if (/_plugins\/_ppl|no handler found|_ppl/i.test(raw)) {
     return 'Preview needs the PPL query engine, which is not available on this cluster. You can still create a dataset and query it.';
   }

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_activate_dataset.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_activate_dataset.test.tsx
@@ -15,7 +15,7 @@ const setQuery = jest.fn();
 const navigateToApp = jest.fn();
 
 const makeServices = () =>
-  (({
+  ({
     core: { application: { navigateToApp } },
     uiSettings: {},
     savedObjects: {},
@@ -30,7 +30,7 @@ const makeServices = () =>
         },
       },
     },
-  } as unknown) as any);
+  }) as unknown as any;
 
 const Harness: React.FC<{ services: any; args: any }> = ({ services, args }) => {
   const activate = useActivateDataset(services);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_activate_dataset.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_activate_dataset.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { useActivateDataset } from './use_activate_dataset';
+
+const cacheDataset = jest.fn();
+const getInitialQueryByDataset = jest
+  .fn()
+  .mockReturnValue({ query: 'source = x', language: 'PPL' });
+const setQuery = jest.fn();
+const navigateToApp = jest.fn();
+
+const makeServices = () =>
+  (({
+    core: { application: { navigateToApp } },
+    uiSettings: {},
+    savedObjects: {},
+    notifications: {},
+    http: {},
+    data: {
+      query: {
+        queryString: {
+          getDatasetService: () => ({ cacheDataset }),
+          getInitialQueryByDataset,
+          setQuery,
+        },
+      },
+    },
+  } as unknown) as any);
+
+const Harness: React.FC<{ services: any; args: any }> = ({ services, args }) => {
+  const activate = useActivateDataset(services);
+  return (
+    <button data-test-subj="go" onClick={() => activate(args)}>
+      go
+    </button>
+  );
+};
+
+const run = (args: any) => {
+  const services = makeServices();
+  const { getByTestId } = render(<Harness services={services} args={args} />);
+  fireEvent.click(getByTestId('go'));
+};
+
+describe('useActivateDataset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cacheDataset.mockResolvedValue(undefined);
+  });
+
+  // --- positive cases ---
+  it('caches the dataset (PPL pinned), writes the query, and navigates to the logs app', async () => {
+    run({ title: 'logs-app-*', datasetId: 'ds-1', timeFieldName: '@timestamp' });
+
+    await waitFor(() => expect(cacheDataset).toHaveBeenCalled());
+    const cachedDataset = cacheDataset.mock.calls[0][0];
+    expect(cachedDataset.title).toBe('logs-app-*');
+    expect(cachedDataset.id).toBe('ds-1');
+    // Language is pinned to the explore default (PPL) so hand-off doesn't inherit stale SQL/DQL.
+    expect(cachedDataset.language).toBeDefined();
+
+    await waitFor(() => expect(setQuery).toHaveBeenCalled());
+    expect(navigateToApp).toHaveBeenCalledWith('explore/logs', { path: '#/' });
+  });
+
+  it('derives a data-source-scoped id when no datasetId is given', async () => {
+    run({
+      title: 'orders-*',
+      dataSource: { id: 'ds-2', title: 'C2', type: 'DATA_SOURCE' },
+    });
+    await waitFor(() => expect(cacheDataset).toHaveBeenCalled());
+    expect(cacheDataset.mock.calls[0][0].id).toBe('ds-2::orders-*');
+  });
+
+  it('falls back to the title as the id for the local cluster (no dataSource, no datasetId)', async () => {
+    run({ title: 'local-logs' });
+    await waitFor(() => expect(cacheDataset).toHaveBeenCalled());
+    expect(cacheDataset.mock.calls[0][0].id).toBe('local-logs');
+  });
+
+  // --- negative case ---
+  it('still navigates when caching fields throws (caching is non-fatal)', async () => {
+    cacheDataset.mockRejectedValue(new Error('field caps down'));
+    run({ title: 'logs-app-*', datasetId: 'ds-1' });
+
+    // Even though caching rejected, the query is written and we navigate.
+    await waitFor(() => expect(navigateToApp).toHaveBeenCalledWith('explore/logs', { path: '#/' }));
+    expect(setQuery).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_activate_dataset.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_activate_dataset.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback } from 'react';
+import { Dataset, DEFAULT_DATA } from '../../../../../../data/common';
+import { ExploreServices } from '../../../../types';
+import { PLUGIN_ID, ExploreFlavor, EXPLORE_DEFAULT_LANGUAGE } from '../../../../../common';
+
+interface ActivateDatasetArgs {
+  /** Dataset title / index pattern (e.g. `logs-app-*`). */
+  title: string;
+  /** Existing dataset saved-object id, if this is an already-created dataset. */
+  datasetId?: string;
+  timeFieldName?: string;
+  dataSource?: Dataset['dataSource'];
+}
+
+/**
+ * Activates an EXISTING dataset (or a covered index) and hands off to the logs Query experience —
+ * the "Query" primary action in the Rows view. Standalone (no Redux): it caches the dataset
+ * in-session, writes it to the shared query-string manager (which the logs flavor hydrates from on
+ * mount via `resolveDataset`), then navigates to `explore/logs`.
+ */
+export const useActivateDataset = (services: ExploreServices) => {
+  return useCallback(
+    async ({ title, datasetId, timeFieldName, dataSource }: ActivateDatasetArgs) => {
+      const datasetService = services.data.query.queryString.getDatasetService();
+
+      const dataset: Dataset = {
+        id: datasetId ?? (dataSource?.id ? `${dataSource.id}::${title}` : title),
+        title,
+        type: DEFAULT_DATA.SET_TYPES.INDEX,
+        timeFieldName,
+        // Logs drilldown is a PPL experience; pin the language so activating a dataset doesn't
+        // inherit a stale SQL/DQL language from the shared query state (avoids the "Language
+        // changed to OpenSearch SQL" surprise on hand-off).
+        language: EXPLORE_DEFAULT_LANGUAGE,
+        dataSource: (dataSource ??
+          DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE) as Dataset['dataSource'],
+      };
+
+      try {
+        // Cache the dataset in-session so the query pipeline can resolve it without a save.
+        await datasetService.cacheDataset(
+          dataset,
+          {
+            uiSettings: services.uiSettings,
+            savedObjects: services.savedObjects,
+            notifications: services.notifications,
+            http: services.http,
+            data: services.data,
+          },
+          false
+        );
+      } catch {
+        // Non-fatal — proceed even if caching fields fails.
+      }
+
+      // Write to the SHARED query-string manager; the logs flavor reads dataset from here on mount.
+      const initialQuery = services.data.query.queryString.getInitialQueryByDataset(dataset);
+      services.data.query.queryString.setQuery(initialQuery);
+
+      // Hand off to the logs Query experience.
+      services.core.application.navigateToApp(`${PLUGIN_ID}/${ExploreFlavor.Logs}`, {
+        path: '#/',
+      });
+    },
+    [services]
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { useCreateDataset } from './use_create_dataset';
+
+// Capture the props passed to the create-flow UI so the test can drive its callbacks. Both seeded
+// and unseeded flows now open AdvancedSelector at step 1 (browse) — seeded ones pre-select the index.
+let lastAdvancedProps: any;
+jest.mock('../../../../../../data/public', () => ({
+  AdvancedSelector: (props: any) => {
+    lastAdvancedProps = props;
+    return null;
+  },
+}));
+jest.mock('../../../../../../opensearch_dashboards_react/public', () => ({
+  toMountPoint: (node: any) => node,
+}));
+jest.mock('@osd/i18n', () => ({
+  i18n: {
+    translate: (_k: string, o: { defaultMessage: string; values?: any }) => {
+      let m = o.defaultMessage;
+      if (o.values)
+        Object.entries(o.values).forEach(([k, v]) => (m = m.replace(`{${k}}`, String(v))));
+      return m;
+    },
+  },
+}));
+
+const saveDataset = jest.fn();
+const getInitialQueryByDataset = jest.fn().mockReturnValue({
+  query: 'source = logs-app-*',
+  language: 'PPL',
+  dataset: { title: 'logs-app-*' },
+});
+const setQuery = jest.fn();
+const navigateToApp = jest.fn();
+const addSuccess = jest.fn();
+const addDanger = jest.fn();
+const clearCache = jest.fn();
+const modalClose = jest.fn();
+const openModal = jest.fn().mockImplementation((node: any) => {
+  render(node); // render the modal content so the mocked selector captures its props
+  return { close: modalClose };
+});
+
+const makeServices = () =>
+  (({
+    core: { application: { navigateToApp } },
+    overlays: { openModal },
+    notifications: { toasts: { addSuccess, addDanger } },
+    data: {
+      dataViews: { clearCache },
+      query: {
+        queryString: {
+          getDatasetService: () => ({ saveDataset }),
+          getInitialQueryByDataset,
+          setQuery,
+        },
+      },
+    },
+  } as unknown) as any);
+
+const Harness: React.FC<{ services: any; args: any }> = ({ services, args }) => {
+  const createDataset = useCreateDataset(services);
+  return (
+    <button data-test-subj="go" onClick={() => createDataset(args)}>
+      go
+    </button>
+  );
+};
+
+const renderHook = (services: any, args: any) =>
+  render(<Harness services={services} args={args} />);
+
+// Drive the confirm callback the way the modal would once the user finishes the flow.
+const confirm = (dataset: any) => lastAdvancedProps.onSelect({ dataset });
+
+describe('useCreateDataset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastAdvancedProps = undefined;
+  });
+
+  // --- step-1 pre-selection (#19) ---
+
+  it('opens AdvancedSelector at step 1 pre-selecting the seeded pattern (signalType logs)', () => {
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'logs-app-*' });
+    fireEvent.click(getByTestId('go'));
+    expect(openModal).toHaveBeenCalled();
+    expect(lastAdvancedProps).toBeDefined();
+    expect(lastAdvancedProps.signalType).toBe('logs');
+    expect(lastAdvancedProps.useConfiguratorV2).toBe(true);
+    expect(lastAdvancedProps.supportedTypes).toEqual(['INDEXES']);
+    // The clicked index/pattern is pre-selected at step 1 (browse), not skipped to step 2.
+    expect(lastAdvancedProps.initialSelectedItems).toEqual(['logs-app-*']);
+  });
+
+  it('passes a comma-joined multi-index pattern as a single seed (creator splits it)', () => {
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'a-logs,b-logs' });
+    fireEvent.click(getByTestId('go'));
+    expect(lastAdvancedProps.initialSelectedItems).toEqual(['a-logs,b-logs']);
+  });
+
+  it('pre-selects the active data source (MDS) at step 1', () => {
+    const { getByTestId } = renderHook(makeServices(), {
+      pattern: 'logs-app-*',
+      dataSource: { id: 'ds-2', title: 'C2', type: 'DATA_SOURCE' },
+    });
+    fireEvent.click(getByTestId('go'));
+    expect(lastAdvancedProps.initialDataSourceId).toBe('ds-2');
+  });
+
+  it('opens step 1 blank when there is no seed (empty-state "Create dataset")', () => {
+    const { getByTestId } = renderHook(makeServices(), { pattern: '' });
+    fireEvent.click(getByTestId('go'));
+    expect(lastAdvancedProps).toBeDefined();
+    expect(lastAdvancedProps.signalType).toBe('logs');
+    // No pre-selection when unseeded.
+    expect(lastAdvancedProps.initialSelectedItems).toBeUndefined();
+    expect(lastAdvancedProps.initialDataSourceId).toBeUndefined();
+  });
+
+  // --- confirm / save behavior ---
+
+  it('on confirm: saves with signalType logs, then navigates to the logs app', async () => {
+    saveDataset.mockResolvedValue(undefined);
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'logs-app-*' });
+    fireEvent.click(getByTestId('go'));
+
+    await confirm({ title: 'logs-app-*', id: 'logs-app-*' });
+
+    expect(saveDataset).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'logs-app-*' }),
+      expect.anything(),
+      'logs'
+    );
+    await waitFor(() => expect(setQuery).toHaveBeenCalled());
+    expect(navigateToApp).toHaveBeenCalledWith('explore/logs', { path: '#/' });
+    expect(modalClose).toHaveBeenCalled();
+  });
+
+  it('swallows a DuplicateDataViewError and still navigates (no error toast)', async () => {
+    saveDataset.mockRejectedValue({ name: 'DuplicateDataViewError' });
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'logs-app-*' });
+    fireEvent.click(getByTestId('go'));
+
+    await confirm({ title: 'logs-app-*', id: 'logs-app-*' });
+
+    expect(addDanger).not.toHaveBeenCalled();
+    await waitFor(() => expect(navigateToApp).toHaveBeenCalled());
+  });
+
+  it('treats a "Duplicate data view" message (no name) as a duplicate and still navigates', async () => {
+    saveDataset.mockRejectedValue(new Error('Duplicate data view: logs-app-*'));
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'logs-app-*' });
+    fireEvent.click(getByTestId('go'));
+
+    await confirm({ title: 'logs-app-*', id: 'logs-app-*' });
+
+    expect(addDanger).not.toHaveBeenCalled();
+    await waitFor(() => expect(navigateToApp).toHaveBeenCalled());
+  });
+
+  it('surfaces a toast and does not navigate on an unexpected save error', async () => {
+    saveDataset.mockRejectedValue(new Error('network down'));
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'logs-app-*' });
+    fireEvent.click(getByTestId('go'));
+
+    await confirm({ title: 'logs-app-*', id: 'logs-app-*' });
+
+    expect(addDanger).toHaveBeenCalled();
+    expect(navigateToApp).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the create flow returns no dataset (guard)', async () => {
+    const { getByTestId } = renderHook(makeServices(), { pattern: 'logs-app-*' });
+    fireEvent.click(getByTestId('go'));
+
+    await lastAdvancedProps.onSelect({}); // no .dataset
+
+    expect(saveDataset).not.toHaveBeenCalled();
+    expect(navigateToApp).not.toHaveBeenCalled();
+    // The modal is still closed regardless.
+    expect(modalClose).toHaveBeenCalled();
+  });
+
+  it('drives the unseeded onSelect path through to navigation', async () => {
+    saveDataset.mockResolvedValue(undefined);
+    const { getByTestId } = renderHook(makeServices(), { pattern: '' });
+    fireEvent.click(getByTestId('go'));
+
+    await confirm({ title: 'picked-*', id: 'picked-*' });
+
+    expect(saveDataset).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'picked-*' }),
+      expect.anything(),
+      'logs'
+    );
+    await waitFor(() => expect(navigateToApp).toHaveBeenCalled());
+    expect(modalClose).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.test.tsx
@@ -48,7 +48,7 @@ const openModal = jest.fn().mockImplementation((node: any) => {
 });
 
 const makeServices = () =>
-  (({
+  ({
     core: { application: { navigateToApp } },
     overlays: { openModal },
     notifications: { toasts: { addSuccess, addDanger } },
@@ -62,7 +62,7 @@ const makeServices = () =>
         },
       },
     },
-  } as unknown) as any);
+  }) as unknown as any;
 
 const Harness: React.FC<{ services: any; args: any }> = ({ services, args }) => {
   const createDataset = useCreateDataset(services);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.ts
@@ -93,6 +93,9 @@ export const useCreateDataset = (services: ExploreServices) => {
         useConfiguratorV2: true,
         alwaysShowDatasetFields: true,
         signalType: SIGNAL_TYPE_LOGS,
+        // Don't grab focus / auto-open the index dropdown: this flow opens pre-seeded from a card,
+        // so the user's context is the staged selection, not the search box.
+        autoFocus: false,
         // Comma-joined multi-index patterns split into individual pre-selected items in the creator.
         ...(pattern ? { initialSelectedItems: [pattern] } : {}),
         ...(dataSource?.id ? { initialDataSourceId: dataSource.id } : {}),

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_create_dataset.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback } from 'react';
+import { i18n } from '@osd/i18n';
+import { BaseDataset, DEFAULT_DATA, Query } from '../../../../../../data/common';
+import { AdvancedSelector } from '../../../../../../data/public';
+import { toMountPoint } from '../../../../../../opensearch_dashboards_react/public';
+import { ExploreServices } from '../../../../types';
+import { PLUGIN_ID, ExploreFlavor, EXPLORE_DEFAULT_LANGUAGE } from '../../../../../common';
+
+interface CreateDatasetArgs {
+  /** The seeded pattern: a wildcard (`logs-app-*`) or comma-separated set (`a,b,c`). */
+  pattern: string;
+  /** Active data source (MDS), or undefined for the local cluster. */
+  dataSource?: BaseDataset['dataSource'];
+}
+
+const SIGNAL_TYPE_LOGS = 'logs';
+
+/**
+ * Opens the shared dataset-creation modal (`AdvancedSelector`) at step 1 (browse) — the same staging
+ * UI + `saveDataset` APIs the dataset plugin's "Create dataset" flow uses (name + time field + schema
+ * mappings). When seeded from a card/selection, the clicked index/pattern + active data source are
+ * PRE-SELECTED at step 1 so the user sees what they're building before configuring it. On confirm it
+ * persists the dataset with `signalType: 'logs'` and hands off to the logs Query experience.
+ * Standalone: no Redux, navigate via `navigateToApp`.
+ */
+export const useCreateDataset = (services: ExploreServices) => {
+  return useCallback(
+    ({ pattern, dataSource }: CreateDatasetArgs) => {
+      const datasetService = services.data.query.queryString.getDatasetService();
+
+      // Persist the configured dataset (signalType: logs) then hand off to the logs Query app.
+      const onSelect = async (query: Partial<Query>) => {
+        if (!query?.dataset) return;
+        try {
+          await datasetService.saveDataset(
+            query.dataset,
+            { data: services.data } as any,
+            SIGNAL_TYPE_LOGS
+          );
+          services.notifications.toasts.addSuccess({
+            title: i18n.translate('explore.logsDrilldown.createDatasetSuccess', {
+              defaultMessage: 'Dataset "{title}" created',
+              values: { title: query.dataset.title },
+            }),
+          });
+          services.data.dataViews.clearCache();
+        } catch (error) {
+          const isDuplicate =
+            (error as { name?: string })?.name === 'DuplicateDataViewError' ||
+            (error as { message?: string })?.message?.includes('Duplicate data view');
+          if (!isDuplicate) {
+            services.notifications.toasts.addDanger(
+              i18n.translate('explore.logsDrilldown.createDatasetError', {
+                defaultMessage: 'Unable to create dataset "{title}"',
+                values: { title: query.dataset.title },
+              })
+            );
+            return;
+          }
+          // Duplicate → reuse the existing dataset (fall through to activate it).
+        }
+
+        // Write to the shared query-string manager; the logs flavor hydrates from it on mount.
+        // Pin PPL so the hand-off doesn't inherit a stale SQL/DQL language ("Language changed" toast).
+        const initialQuery = services.data.query.queryString.getInitialQueryByDataset({
+          ...query.dataset,
+          language: query.dataset.language || EXPLORE_DEFAULT_LANGUAGE,
+        });
+        services.data.query.queryString.setQuery(initialQuery);
+        services.core.application.navigateToApp(`${PLUGIN_ID}/${ExploreFlavor.Logs}`, {
+          path: '#/',
+        });
+      };
+
+      // Holder so the modal's own callbacks can close it (the ref is set right after openModal).
+      const modalHolder: { close: () => void } = { close: () => {} };
+      const closeModal = () => modalHolder.close();
+
+      // Always open the full AdvancedSelector at step 1 (browse) so the user sees which
+      // index/pattern the dataset is built from before configuring it. When seeded from a card or a
+      // multi-select (`pattern`), the clicked index/pattern is PRE-SELECTED at step 1 (via the
+      // additive `initialSelectedItems`), and the active data source is pre-selected too — so the
+      // user lands on step 1 with everything staged and only has to click Next. Unseeded
+      // (empty-state "Create dataset") opens step 1 blank.
+      const element = React.createElement(AdvancedSelector, {
+        services: services as any, // ExploreServices ⊇ IDataPluginServices for this UI
+        supportedTypes: [DEFAULT_DATA.SET_TYPES.INDEX],
+        useConfiguratorV2: true,
+        alwaysShowDatasetFields: true,
+        signalType: SIGNAL_TYPE_LOGS,
+        // Comma-joined multi-index patterns split into individual pre-selected items in the creator.
+        ...(pattern ? { initialSelectedItems: [pattern] } : {}),
+        ...(dataSource?.id ? { initialDataSourceId: dataSource.id } : {}),
+        onCancel: closeModal,
+        onSelect: async (q: Partial<Query>) => {
+          closeModal();
+          await onSelect(q);
+        },
+      });
+
+      const modal = services.overlays.openModal(toMountPoint(element), {
+        maxWidth: false,
+        className: 'datasetSelector__advancedModal',
+      });
+      modalHolder.close = () => modal.close();
+    },
+    [services]
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { useDatasetList } from './use_dataset_list';
+
+const patternFetch = jest.fn();
+
+const makeServices = (typeRegistered = true) =>
+  (({
+    data: {
+      query: {
+        queryString: {
+          getDatasetService: () => ({
+            getType: (t: string) =>
+              t === 'INDEX_PATTERN' && typeRegistered
+                ? { id: 'INDEX_PATTERN', title: 'Index patterns', fetch: patternFetch }
+                : undefined,
+          }),
+        },
+      },
+    },
+  } as unknown) as any);
+
+// Build a children result where each child carries a parent data-source id + a time field.
+const children = (
+  rows: Array<{ title: string; id: string; parentId?: string; timeFieldName?: string }>
+) => ({
+  children: rows.map((r) => ({
+    title: r.title,
+    id: r.id,
+    parent: r.parentId != null ? { id: r.parentId } : undefined,
+    meta: { timeFieldName: r.timeFieldName },
+  })),
+});
+
+let result: ReturnType<typeof useDatasetList>;
+const Harness: React.FC<{ services: any; search: string; dataSourceId?: string }> = ({
+  services,
+  search,
+  dataSourceId,
+}) => {
+  result = useDatasetList({ services, search, dataSourceId });
+  return null;
+};
+
+describe('useDatasetList', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // --- positive cases ---
+  it('lists local-cluster datasets (no parent) and maps id + timeFieldName', async () => {
+    patternFetch.mockResolvedValue(
+      children([
+        { title: 'logs-app-*', id: 'ds-logs', timeFieldName: '@timestamp' },
+        { title: 'orders-*', id: 'ds-orders' },
+      ])
+    );
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets).toEqual([
+      { name: 'logs-app-*', kind: 'dataset', datasetId: 'ds-logs', timeFieldName: '@timestamp' },
+      { name: 'orders-*', kind: 'dataset', datasetId: 'ds-orders', timeFieldName: undefined },
+    ]);
+  });
+
+  it('scopes to the active data source id (MDS), excluding datasets from other sources', async () => {
+    patternFetch.mockResolvedValue(
+      children([
+        { title: 'ds2-logs', id: '1', parentId: 'ds-2' },
+        { title: 'local-logs', id: '2', parentId: '' },
+        { title: 'ds3-logs', id: '3', parentId: 'ds-3' },
+      ])
+    );
+    render(<Harness services={makeServices()} search="" dataSourceId="ds-2" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets.map((d) => d.name)).toEqual(['ds2-logs']);
+  });
+
+  it('filters client-side by search term (case-insensitive)', async () => {
+    patternFetch.mockResolvedValue(
+      children([
+        { title: 'logs-app-*', id: '1' },
+        { title: 'Orders', id: '2' },
+        { title: 'LOGS-db', id: '3' },
+      ])
+    );
+    render(<Harness services={makeServices()} search="logs" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets.map((d) => d.name).sort()).toEqual(['LOGS-db', 'logs-app-*']);
+  });
+
+  // --- negative cases ---
+  it('returns an empty list (no error) when the INDEX_PATTERN type is not registered', async () => {
+    patternFetch.mockResolvedValue(children([{ title: 'x', id: '1' }]));
+    render(<Harness services={makeServices(false)} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('surfaces an error and empties the list when the fetch rejects', async () => {
+    patternFetch.mockRejectedValue(new Error('saved objects unavailable'));
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.error).toBe('saved objects unavailable');
+    expect(result.datasets).toEqual([]);
+  });
+
+  it('handles a fetch result with no children', async () => {
+    patternFetch.mockResolvedValue({});
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets).toEqual([]);
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
@@ -9,7 +9,12 @@ import { useDatasetList } from './use_dataset_list';
 
 const patternFetch = jest.fn();
 
-const makeServices = (typeRegistered = true) =>
+// `signalTypes`: id → signalType saved-object attribute, returned by savedObjects.client.find so the
+// hook can filter to log datasets. Default {} → find resolves an empty set → hook shows all (fallback).
+const makeServices = (
+  typeRegistered = true,
+  signalTypes: Record<string, string | undefined> = {}
+) =>
   ({
     data: {
       query: {
@@ -21,6 +26,16 @@ const makeServices = (typeRegistered = true) =>
                 : undefined,
           }),
         },
+      },
+    },
+    savedObjects: {
+      client: {
+        find: jest.fn().mockResolvedValue({
+          savedObjects: Object.entries(signalTypes).map(([id, signalType]) => ({
+            id,
+            attributes: { signalType },
+          })),
+        }),
       },
     },
   }) as unknown as any;
@@ -147,5 +162,39 @@ describe('useDatasetList', () => {
     render(<Harness services={makeServices()} search="" />);
     await waitFor(() => expect(result.loading).toBe(false));
     expect(result.datasets).toEqual([]);
+  });
+
+  // --- logs-only signalType filter ---
+  it('shows only log + untyped datasets, hiding traces/metrics (by signalType)', async () => {
+    patternFetch.mockResolvedValue(
+      children([
+        { title: 'app-logs-*', id: 'log-1' },
+        { title: 'otel-traces-*', id: 'trace-1' },
+        { title: 'prom-metrics-*', id: 'metric-1' },
+        { title: 'legacy-*', id: 'legacy-1' }, // no signalType (legacy) → kept
+      ])
+    );
+    const services = makeServices(true, {
+      'log-1': 'logs',
+      'trace-1': 'traces',
+      'metric-1': 'metrics',
+      // legacy-1 intentionally absent → undefined signalType
+    });
+    render(<Harness services={services} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets.map((d) => d.name)).toEqual(['app-logs-*', 'legacy-*']);
+  });
+
+  it('falls back to showing all datasets when the signalType lookup returns nothing', async () => {
+    patternFetch.mockResolvedValue(
+      children([
+        { title: 'app-logs-*', id: 'log-1' },
+        { title: 'otel-traces-*', id: 'trace-1' },
+      ])
+    );
+    // No signalTypes provided → find resolves empty → hook does not filter (over-show, not blank).
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets.map((d) => d.name).sort()).toEqual(['app-logs-*', 'otel-traces-*']);
   });
 });

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
@@ -10,7 +10,7 @@ import { useDatasetList } from './use_dataset_list';
 const patternFetch = jest.fn();
 
 const makeServices = (typeRegistered = true) =>
-  (({
+  ({
     data: {
       query: {
         queryString: {
@@ -23,7 +23,7 @@ const makeServices = (typeRegistered = true) =>
         },
       },
     },
-  } as unknown) as any);
+  }) as unknown as any;
 
 // Build a children result where each child carries a parent data-source id + a time field.
 const children = (

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.test.tsx
@@ -27,13 +27,19 @@ const makeServices = (typeRegistered = true) =>
 
 // Build a children result where each child carries a parent data-source id + a time field.
 const children = (
-  rows: Array<{ title: string; id: string; parentId?: string; timeFieldName?: string }>
+  rows: Array<{
+    title: string;
+    id: string;
+    parentId?: string;
+    timeFieldName?: string;
+    displayName?: string;
+  }>
 ) => ({
   children: rows.map((r) => ({
     title: r.title,
     id: r.id,
     parent: r.parentId != null ? { id: r.parentId } : undefined,
-    meta: { timeFieldName: r.timeFieldName },
+    meta: { timeFieldName: r.timeFieldName, displayName: r.displayName },
   })),
 });
 
@@ -61,9 +67,36 @@ describe('useDatasetList', () => {
     render(<Harness services={makeServices()} search="" />);
     await waitFor(() => expect(result.loading).toBe(false));
     expect(result.datasets).toEqual([
-      { name: 'logs-app-*', kind: 'dataset', datasetId: 'ds-logs', timeFieldName: '@timestamp' },
-      { name: 'orders-*', kind: 'dataset', datasetId: 'ds-orders', timeFieldName: undefined },
+      {
+        name: 'logs-app-*',
+        displayName: undefined,
+        kind: 'dataset',
+        datasetId: 'ds-logs',
+        timeFieldName: '@timestamp',
+      },
+      {
+        name: 'orders-*',
+        displayName: undefined,
+        kind: 'dataset',
+        datasetId: 'ds-orders',
+        timeFieldName: undefined,
+      },
     ]);
+  });
+
+  it('maps the friendly displayName when the index-pattern has one (pattern stays as name)', async () => {
+    patternFetch.mockResolvedValue(
+      children([
+        { title: 'nginx-access-*', id: 'ds1', displayName: 'Nginx access logs' },
+        { title: 'orders-*', id: 'ds2' }, // no displayName → undefined
+      ])
+    );
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.datasets[0]).toEqual(
+      expect.objectContaining({ name: 'nginx-access-*', displayName: 'Nginx access logs' })
+    );
+    expect(result.datasets[1].displayName).toBeUndefined();
   });
 
   it('scopes to the active data source id (MDS), excluding datasets from other sources', async () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.ts
@@ -60,12 +60,18 @@ export const useDatasetList = ({
             const parentId = child.parent?.id ?? '';
             return parentId === activeId;
           })
-          .map((child) => ({
-            name: child.title,
-            kind: 'dataset' as const,
-            datasetId: child.id,
-            timeFieldName: (child.meta as { timeFieldName?: string } | undefined)?.timeFieldName,
-          }));
+          .map((child) => {
+            const meta = child.meta as { timeFieldName?: string; displayName?: string } | undefined;
+            return {
+              name: child.title,
+              // Friendly name (index-pattern displayName) → shown as the card label; the pattern
+              // (`name`) stays the identity for coverage/activation/create-seeding.
+              displayName: meta?.displayName || undefined,
+              kind: 'dataset' as const,
+              datasetId: child.id,
+              timeFieldName: meta?.timeFieldName,
+            };
+          });
 
         if (requestId === requestIdRef.current) setAll(datasets);
       } catch (e) {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { DataStructure, DEFAULT_DATA } from '../../../../../../data/common';
+import { ExploreServices } from '../../../../types';
+import { BrowsableItem } from '../types';
+
+interface UseDatasetListArgs {
+  services: ExploreServices;
+  /** Data source id to scope to (MDS). Empty string / undefined = local cluster. */
+  dataSourceId?: string;
+  /** Debounced search string; filters dataset titles client-side. */
+  search: string;
+}
+
+interface UseDatasetListResult {
+  datasets: BrowsableItem[];
+  loading: boolean;
+  error?: string;
+}
+
+/**
+ * Lists existing datasets (index-patterns) for the active data source, mapped to `BrowsableItem`s
+ * (`kind:'dataset'`). These render first in the Rows view — they're already activated, so their
+ * primary action is a direct "Query". Uses the same `datasetService` the dataset-create UI uses.
+ */
+export const useDatasetList = ({
+  services,
+  dataSourceId,
+  search,
+}: UseDatasetListArgs): UseDatasetListResult => {
+  const [all, setAll] = useState<BrowsableItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    const run = async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        const datasetService = services.data.query.queryString.getDatasetService();
+        const type = datasetService.getType(DEFAULT_DATA.SET_TYPES.INDEX_PATTERN);
+        if (!type) {
+          if (requestId === requestIdRef.current) setAll([]);
+          return;
+        }
+        const root: DataStructure = { id: type.id, title: type.title, type: type.id };
+        const result = await type.fetch(services as any, [root]);
+        const activeId = dataSourceId ?? '';
+
+        const datasets: BrowsableItem[] = (result.children ?? [])
+          .filter((child) => {
+            // Scope to the active data source: local cluster (no parent) when activeId is empty,
+            // else match the parent data-source id.
+            const parentId = child.parent?.id ?? '';
+            return parentId === activeId;
+          })
+          .map((child) => ({
+            name: child.title,
+            kind: 'dataset' as const,
+            datasetId: child.id,
+            timeFieldName: (child.meta as { timeFieldName?: string } | undefined)?.timeFieldName,
+          }));
+
+        if (requestId === requestIdRef.current) setAll(datasets);
+      } catch (e) {
+        if (requestId === requestIdRef.current) {
+          setError(e instanceof Error ? e.message : 'Unable to load datasets');
+          setAll([]);
+        }
+      } finally {
+        if (requestId === requestIdRef.current) setLoading(false);
+      }
+    };
+    run();
+  }, [services, dataSourceId]);
+
+  const normalized = search.trim().toLowerCase();
+  const datasets = normalized ? all.filter((d) => d.name.toLowerCase().includes(normalized)) : all;
+
+  return { datasets, loading, error };
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_dataset_list.ts
@@ -22,8 +22,14 @@ interface UseDatasetListResult {
   error?: string;
 }
 
+// Logs Drilldown only surfaces LOG datasets. A dataset qualifies when its saved-object `signalType`
+// is 'logs' OR is absent (legacy index-patterns predate signal typing — treat them as logs). Traces
+// and metrics datasets are hidden. `signalType` isn't carried on the shared index-pattern fetch, so
+// we resolve it client-side via one saved-objects lookup and filter here (drilldown-local).
+const SIGNAL_TYPE_LOGS = 'logs';
+
 /**
- * Lists existing datasets (index-patterns) for the active data source, mapped to `BrowsableItem`s
+ * Lists existing LOG datasets (index-patterns) for the active data source, mapped to `BrowsableItem`s
  * (`kind:'dataset'`). These render first in the Rows view — they're already activated, so their
  * primary action is a direct "Query". Uses the same `datasetService` the dataset-create UI uses.
  */
@@ -53,6 +59,27 @@ export const useDatasetList = ({
         const result = await type.fetch(services as any, [root]);
         const activeId = dataSourceId ?? '';
 
+        // Resolve each index-pattern's signalType (not carried on the shared fetch above) so we can
+        // keep only LOG datasets. One saved-objects lookup; map id → signalType.
+        const signalTypeById = new Map<string, string | undefined>();
+        try {
+          const so = await services.savedObjects.client.find<{ signalType?: string }>({
+            type: 'index-pattern',
+            fields: ['signalType'],
+            perPage: 10000,
+          });
+          so.savedObjects.forEach((s) => signalTypeById.set(s.id, s.attributes?.signalType));
+        } catch {
+          // If the lookup fails, fall back to showing all (data-source-scoped) datasets rather than
+          // hiding everything — better to over-show than to blank the list.
+        }
+        const isLogDataset = (id: string): boolean => {
+          if (signalTypeById.size === 0) return true; // lookup unavailable → don't filter
+          const st = signalTypeById.get(id);
+          // Logs, or untyped/legacy index-patterns (no signalType). Traces/metrics are excluded.
+          return st === SIGNAL_TYPE_LOGS || st == null;
+        };
+
         const datasets: BrowsableItem[] = (result.children ?? [])
           .filter((child) => {
             // Scope to the active data source: local cluster (no parent) when activeId is empty,
@@ -60,6 +87,8 @@ export const useDatasetList = ({
             const parentId = child.parent?.id ?? '';
             return parentId === activeId;
           })
+          // Logs-only: hide traces/metrics datasets; keep logs + untyped legacy index-patterns.
+          .filter((child) => isLogDataset(child.id))
           .map((child) => {
             const meta = child.meta as { timeFieldName?: string; displayName?: string } | undefined;
             return {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, cleanup } from '@testing-library/react';
 import { useIndexClassification } from './use_index_classification';
 import { ClassificationResult, IndexClassification } from '../types';
 
@@ -18,15 +18,17 @@ interface Api {
   getStatus: (name: string) => IndexClassification;
 }
 let api: Api;
-const Harness: React.FC = () => {
-  api = useIndexClassification(makeServices());
+// MDS-only: the hook requires a data source id. `dataSourceId` is passed through verbatim — the outer
+// suite renders with a concrete id; the no-data-source suite passes none.
+const Harness: React.FC<{ dataSourceId?: string }> = ({ dataSourceId }) => {
+  api = useIndexClassification(makeServices(), dataSourceId);
   return null;
 };
 
 describe('useIndexClassification', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    render(<Harness />);
+    render(<Harness dataSourceId="ds-1" />);
   });
 
   it('classifies a time-based index and picks the first date field as the time field', async () => {
@@ -150,5 +152,24 @@ describe('useIndexClassification', () => {
       await api.classify('x');
     });
     expect(api.getStatus('x')).toBe(IndexClassification.TIME_BASED);
+  });
+});
+
+// MDS-only: no local cluster, so field resolution must target an explicit data source.
+// Separate describe so it does NOT inherit the outer beforeEach that renders with a default id.
+describe('useIndexClassification — no data source (MDS-only)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanup(); // unmount any harness from the prior describe so `api` reflects only this render
+    render(<Harness dataSourceId={undefined} />);
+  });
+
+  it('does NOT call getFieldsForWildcard when there is no data source id', async () => {
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('logs-app-1');
+    });
+    expect(getFieldsForWildcard).not.toHaveBeenCalled();
+    expect(res!.classification).toBe(IndexClassification.NO_TIME_FIELD);
   });
 });

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useIndexClassification } from './use_index_classification';
+import { ClassificationResult, IndexClassification } from '../types';
+
+const getFieldsForWildcard = jest.fn();
+const makeServices = () => (({ indexPatterns: { getFieldsForWildcard } } as unknown) as any);
+
+// Expose the hook's API to the test via a ref-carrying harness (no react-hooks testing lib here).
+interface Api {
+  classify: (name: string) => Promise<ClassificationResult>;
+  getCached: (name: string) => ClassificationResult | undefined;
+  getStatus: (name: string) => IndexClassification;
+}
+let api: Api;
+const Harness: React.FC = () => {
+  api = useIndexClassification(makeServices());
+  return null;
+};
+
+describe('useIndexClassification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    render(<Harness />);
+  });
+
+  it('classifies a time-based index and picks the first date field as the time field', async () => {
+    getFieldsForWildcard.mockResolvedValue([
+      { name: '@timestamp', type: 'date' },
+      { name: 'message', type: 'text' },
+      { name: 'level', type: 'keyword' },
+    ]);
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('logs-app-1');
+    });
+    expect(res!.classification).toBe(IndexClassification.TIME_BASED);
+    expect(res!.timeFieldName).toBe('@timestamp');
+    expect(res!.dateFields).toEqual(['@timestamp']);
+    // Severity detected from a keyword field (not a date field).
+    expect(res!.severityField).toBe('level');
+  });
+
+  it('surfaces ALL date fields for a multi-timestamp index (user can switch the time field)', async () => {
+    getFieldsForWildcard.mockResolvedValue([
+      { name: '@timestamp', type: 'date' },
+      { name: 'observedTimestamp', type: 'date' },
+      { name: 'event.ingested', type: 'date' },
+      { name: 'severityText', type: 'keyword' },
+    ]);
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('otel-multi');
+    });
+    expect(res!.classification).toBe(IndexClassification.TIME_BASED);
+    // All date fields are returned so the create-flow time-field picker can offer them.
+    expect(res!.dateFields).toEqual(['@timestamp', 'observedTimestamp', 'event.ingested']);
+    expect(res!.timeFieldName).toBe('@timestamp');
+    expect(res!.severityField).toBe('severityText');
+  });
+
+  it('flattens dotted nested date fields into dateFields (they appear in the picker)', async () => {
+    // _field_caps returns leaf fields with dotted paths; nested date subfields must be offered.
+    getFieldsForWildcard.mockResolvedValue([
+      { name: 'attributes.time', type: 'date' },
+      { name: 'resource.attributes.observedTimestamp', type: 'date' },
+      { name: 'body', type: 'text' },
+    ]);
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('otel-deeply-nested');
+    });
+    expect(res!.classification).toBe(IndexClassification.TIME_BASED);
+    expect(res!.dateFields).toEqual(['attributes.time', 'resource.attributes.observedTimestamp']);
+    // No canonical top-level match → falls back to the first (nested) date field.
+    expect(res!.timeFieldName).toBe('attributes.time');
+  });
+
+  it('picks the canonical OTel/PPL time field, not just the first date field', async () => {
+    // `event.ingested` sorts first but the heuristic should prefer `timestamp` over it.
+    getFieldsForWildcard.mockResolvedValue([
+      { name: 'event.ingested', type: 'date' },
+      { name: 'timestamp', type: 'date' },
+    ]);
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('otel-ordered');
+    });
+    expect(res!.timeFieldName).toBe('timestamp');
+  });
+
+  it('classifies an index with NO timestamp as NO_TIME_FIELD (no histogram)', async () => {
+    getFieldsForWildcard.mockResolvedValue([
+      { name: 'user_id', type: 'keyword' },
+      { name: 'email', type: 'text' },
+    ]);
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('lookup-users');
+    });
+    expect(res!.classification).toBe(IndexClassification.NO_TIME_FIELD);
+    expect(res!.dateFields).toEqual([]);
+    expect(res!.timeFieldName).toBeUndefined();
+    expect(res!.severityField).toBeUndefined();
+  });
+
+  it('detects severity even on a no-time-field index (level without a date)', async () => {
+    getFieldsForWildcard.mockResolvedValue([
+      { name: 'level', type: 'keyword' },
+      { name: 'msg', type: 'text' },
+    ]);
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('no-time-but-leveled');
+    });
+    expect(res!.classification).toBe(IndexClassification.NO_TIME_FIELD);
+    expect(res!.severityField).toBe('level');
+  });
+
+  it('degrades to NO_TIME_FIELD when the field fetch fails', async () => {
+    getFieldsForWildcard.mockRejectedValue(new Error('field_caps unavailable'));
+    let res: ClassificationResult;
+    await act(async () => {
+      res = await api.classify('broken-index');
+    });
+    expect(res!.classification).toBe(IndexClassification.NO_TIME_FIELD);
+  });
+
+  it('caches the result: a second classify does not re-fetch', async () => {
+    getFieldsForWildcard.mockResolvedValue([{ name: '@timestamp', type: 'date' }]);
+    await act(async () => {
+      await api.classify('cached-index');
+    });
+    await act(async () => {
+      await api.classify('cached-index');
+    });
+    expect(getFieldsForWildcard).toHaveBeenCalledTimes(1);
+    expect(api.getCached('cached-index')?.classification).toBe(IndexClassification.TIME_BASED);
+  });
+
+  it('getStatus reports UNKNOWN before any classify, then the resolved classification', async () => {
+    getFieldsForWildcard.mockResolvedValue([{ name: '@timestamp', type: 'date' }]);
+    expect(api.getStatus('x')).toBe(IndexClassification.UNKNOWN);
+    await act(async () => {
+      await api.classify('x');
+    });
+    expect(api.getStatus('x')).toBe(IndexClassification.TIME_BASED);
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.test.tsx
@@ -9,7 +9,7 @@ import { useIndexClassification } from './use_index_classification';
 import { ClassificationResult, IndexClassification } from '../types';
 
 const getFieldsForWildcard = jest.fn();
-const makeServices = () => (({ indexPatterns: { getFieldsForWildcard } } as unknown) as any);
+const makeServices = () => ({ indexPatterns: { getFieldsForWildcard } }) as unknown as any;
 
 // Expose the hook's API to the test via a ref-carrying harness (no react-hooks testing lib here).
 interface Api {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.ts
@@ -34,6 +34,18 @@ export const useIndexClassification = (services: ExploreServices, dataSourceId?:
       if (inFlightRef.current.has(cacheKey))
         return { classification: IndexClassification.CLASSIFYING };
 
+      // MDS-only: field resolution must target an explicit data source. A bare `getFieldsForWildcard`
+      // (no data source id) targets the local cluster, which does not exist under MDS (e.g. Neo) and
+      // 500s on an unconfigured client. With no data source we can't classify — cache/return
+      // NO_TIME_FIELD (same shape as the failure path) without issuing the request.
+      if (!dataSourceId) {
+        const result: ClassificationResult = {
+          classification: IndexClassification.NO_TIME_FIELD,
+        };
+        cacheRef.current.set(cacheKey, result);
+        return result;
+      }
+
       inFlightRef.current.add(cacheKey);
       force((n) => n + 1);
       try {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.ts
@@ -21,9 +21,10 @@ export const useIndexClassification = (services: ExploreServices, dataSourceId?:
   const inFlightRef = useRef<Set<string>>(new Set());
   const [, force] = useState(0);
 
-  const keyFor = useCallback((indexName: string) => `${dataSourceId ?? ''}::${indexName}`, [
-    dataSourceId,
-  ]);
+  const keyFor = useCallback(
+    (indexName: string) => `${dataSourceId ?? ''}::${indexName}`,
+    [dataSourceId]
+  );
 
   const classify = useCallback(
     async (indexName: string): Promise<ClassificationResult> => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_classification.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { ExploreServices } from '../../../../types';
+import { ClassificationResult, IndexClassification } from '../types';
+import { detectSeverityField, pickTimeField } from '../severity';
+
+/**
+ * Lazily classifies an index as time-based (logs) vs no-time-field by fetching its fields
+ * (`getFieldsForWildcard` → server `_field_caps`) and looking for a `date` field. Classifying
+ * every index up front would be one field-caps request per index — a request storm on large
+ * clusters — so we classify on demand (hover/selection) and cache the result. While a fetch is
+ * in flight the row reports CLASSIFYING (a real spinner); before any fetch it reports UNKNOWN
+ * (no badge), never a false "Classifying…" label.
+ */
+export const useIndexClassification = (services: ExploreServices, dataSourceId?: string) => {
+  const cacheRef = useRef<Map<string, ClassificationResult>>(new Map());
+  const inFlightRef = useRef<Set<string>>(new Set());
+  const [, force] = useState(0);
+
+  const keyFor = useCallback((indexName: string) => `${dataSourceId ?? ''}::${indexName}`, [
+    dataSourceId,
+  ]);
+
+  const classify = useCallback(
+    async (indexName: string): Promise<ClassificationResult> => {
+      const cacheKey = keyFor(indexName);
+      const cached = cacheRef.current.get(cacheKey);
+      if (cached) return cached;
+      if (inFlightRef.current.has(cacheKey))
+        return { classification: IndexClassification.CLASSIFYING };
+
+      inFlightRef.current.add(cacheKey);
+      force((n) => n + 1);
+      try {
+        const fields = await services.indexPatterns.getFieldsForWildcard({
+          pattern: indexName,
+          dataSourceId,
+        });
+        const dateFields = fields
+          .filter((field: { type: string }) => field.type === 'date')
+          .map((field: { name: string }) => field.name);
+        // Severity/level fields are keyword-typed, so detect over ALL field names (not dateFields).
+        const severityField = detectSeverityField(
+          fields.map((field: { name: string }) => field.name)
+        );
+        const result: ClassificationResult = dateFields.length
+          ? {
+              classification: IndexClassification.TIME_BASED,
+              // Prefer the canonical OTel/PPL timestamp order, not an arbitrary first date field.
+              timeFieldName: pickTimeField(dateFields),
+              dateFields,
+              severityField,
+            }
+          : { classification: IndexClassification.NO_TIME_FIELD, dateFields: [], severityField };
+        cacheRef.current.set(cacheKey, result);
+        return result;
+      } catch {
+        // On failure, treat as no-time-field so the preview still degrades gracefully.
+        const result: ClassificationResult = {
+          classification: IndexClassification.NO_TIME_FIELD,
+        };
+        cacheRef.current.set(cacheKey, result);
+        return result;
+      } finally {
+        inFlightRef.current.delete(cacheKey);
+        force((n) => n + 1);
+      }
+    },
+    [services, dataSourceId, keyFor]
+  );
+
+  const getCached = useCallback(
+    (indexName: string): ClassificationResult | undefined =>
+      cacheRef.current.get(keyFor(indexName)),
+    [keyFor]
+  );
+
+  /** Classification for display: resolved result, an in-flight spinner, or UNKNOWN (no badge). */
+  const getStatus = useCallback(
+    (indexName: string): IndexClassification => {
+      const cacheKey = keyFor(indexName);
+      const cached = cacheRef.current.get(cacheKey);
+      if (cached) return cached.classification;
+      if (inFlightRef.current.has(cacheKey)) return IndexClassification.CLASSIFYING;
+      return IndexClassification.UNKNOWN;
+    },
+    [keyFor]
+  );
+
+  return { classify, getCached, getStatus };
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
@@ -82,8 +82,28 @@ describe('useIndexList', () => {
     render(<Harness services={makeServices()} search="" />);
     await waitFor(() => expect(result.loading).toBe(false));
     expect(result.items.map((i) => i.name)).toEqual(['b', 'c', 'a']);
-    // One cat.indices call carries creation.date + docs.count + health (no extra round-trips).
-    expect(httpGet.mock.calls[0][1].query.h).toBe('index,creation.date,docs.count,health');
+    // One cat.indices call carries creation.date + docs.count + health + store.size/pri/rep
+    // (no extra round-trips).
+    expect(httpGet.mock.calls[0][1].query.h).toBe(
+      'index,creation.date,docs.count,health,store.size,pri,rep'
+    );
+  });
+
+  it('maps store size + shard layout (store.size/pri/rep) onto items; missing → undefined', async () => {
+    indexFetch.mockResolvedValue(children(['full', 'partial']));
+    httpGet.mockResolvedValue([
+      { index: 'full', 'creation.date': '300', 'store.size': '2.4gb', pri: '5', rep: '1' },
+      { index: 'partial', 'creation.date': '200' }, // no size/shards (e.g. remote/closed)
+    ]);
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    const byName = Object.fromEntries(result.items.map((i: any) => [i.name, i]));
+    expect(byName.full.storeSize).toBe('2.4gb');
+    expect(byName.full.primaryShards).toBe(5);
+    expect(byName.full.replicaCount).toBe(1);
+    expect(byName.partial.storeSize).toBeUndefined();
+    expect(byName.partial.primaryShards).toBeUndefined();
+    expect(byName.partial.replicaCount).toBeUndefined();
   });
 
   it('maps index health (green/yellow/red) onto items; unknown/invalid → undefined', async () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
@@ -12,7 +12,7 @@ const indexFetch = jest.fn();
 const httpGet = jest.fn();
 
 const makeServices = () =>
-  (({
+  ({
     data: {
       query: {
         queryString: {
@@ -24,7 +24,7 @@ const makeServices = () =>
       },
     },
     http: { get: httpGet },
-  } as unknown) as any);
+  }) as unknown as any;
 
 const children = (names: string[], remote: string[] = []) => ({
   children: names.map((title) => ({
@@ -164,12 +164,12 @@ describe('useIndexList', () => {
 
   // --- negative cases ---
   it('surfaces an error and empties the list when the INDEX type is not registered', async () => {
-    const services = ({
+    const services = {
       data: {
         query: { queryString: { getDatasetService: () => ({ getType: () => undefined }) } },
       },
       http: { get: httpGet },
-    } as unknown) as any;
+    } as unknown as any;
     render(<Harness services={services} search="" />);
     await waitFor(() => expect(result.loading).toBe(false));
     expect(result.error).toMatch(/not registered/);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { useIndexList } from './use_index_list';
+
+// The INDEX dataset type's fetch() result (children = indexes) + the _cat/indices creation dates.
+const indexFetch = jest.fn();
+const httpGet = jest.fn();
+
+const makeServices = () =>
+  (({
+    data: {
+      query: {
+        queryString: {
+          getDatasetService: () => ({
+            getType: (t: string) =>
+              t === 'INDEXES' ? { id: 'INDEXES', title: 'Indexes', fetch: indexFetch } : undefined,
+          }),
+        },
+      },
+    },
+    http: { get: httpGet },
+  } as unknown) as any);
+
+const children = (names: string[], remote: string[] = []) => ({
+  children: names.map((title) => ({
+    title,
+    meta: { isRemoteIndex: remote.includes(title) },
+  })),
+});
+
+let result: ReturnType<typeof useIndexList>;
+const Harness: React.FC<{ services: any; search: string; dataSourceId?: string }> = ({
+  services,
+  search,
+  dataSourceId,
+}) => {
+  result = useIndexList({ services, search, dataSourceId });
+  return <div data-test-subj="names">{result.items.map((i) => i.name).join(',')}</div>;
+};
+
+describe('useIndexList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: _cat/indices returns nothing usable → name-descending fallback.
+    httpGet.mockResolvedValue([]);
+  });
+
+  // --- positive cases ---
+  it('lists indexes for the local cluster and filters out `.`-prefixed system indexes', async () => {
+    indexFetch.mockResolvedValue(children(['logs-app-1', '.kibana_1', 'orders']));
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    // `.kibana_1` is excluded; the rest are name-descending (no creation dates).
+    expect(result.items.map((i) => i.name)).toEqual(['orders', 'logs-app-1']);
+  });
+
+  it('also filters `.`-prefixed remote system indexes after stripping the cluster: prefix', async () => {
+    indexFetch.mockResolvedValue(
+      children(['remote:.internal', 'remote:app-logs'], ['remote:app-logs'])
+    );
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    const names = result.items.map((i) => i.name);
+    expect(names).toContain('remote:app-logs');
+    expect(names).not.toContain('remote:.internal');
+    // Remote flag is carried through from meta.isRemoteIndex.
+    expect(result.items.find((i) => i.name === 'remote:app-logs')?.isRemote).toBe(true);
+  });
+
+  it('orders newest-first using _cat/indices creation dates when available', async () => {
+    indexFetch.mockResolvedValue(children(['a', 'b', 'c']));
+    httpGet.mockResolvedValue([
+      { index: 'a', 'creation.date': '100' },
+      { index: 'b', 'creation.date': '300' }, // newest
+      { index: 'c', 'creation.date': '200' },
+    ]);
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.items.map((i) => i.name)).toEqual(['b', 'c', 'a']);
+    // One cat.indices call carries creation.date + docs.count + health (no extra round-trips).
+    expect(httpGet.mock.calls[0][1].query.h).toBe('index,creation.date,docs.count,health');
+  });
+
+  it('maps index health (green/yellow/red) onto items; unknown/invalid → undefined', async () => {
+    indexFetch.mockResolvedValue(children(['green-idx', 'red-idx', 'unknown-idx']));
+    httpGet.mockResolvedValue([
+      { index: 'green-idx', 'creation.date': '300', health: 'green' },
+      { index: 'red-idx', 'creation.date': '200', health: 'RED' }, // case-insensitive
+      { index: 'unknown-idx', 'creation.date': '100' }, // no health (e.g. remote/closed)
+    ]);
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    const byName = Object.fromEntries(result.items.map((i: any) => [i.name, i.health]));
+    expect(byName['green-idx']).toBe('green');
+    expect(byName['red-idx']).toBe('red'); // normalized to lowercase
+    expect(byName['unknown-idx']).toBeUndefined(); // absent → unknown
+  });
+
+  it('maps docs.count onto items (0 preserved for empty-index, missing → undefined)', async () => {
+    indexFetch.mockResolvedValue(children(['live', 'empty', 'unknown']));
+    httpGet.mockResolvedValue([
+      { index: 'live', 'creation.date': '300', 'docs.count': '4200' },
+      { index: 'empty', 'creation.date': '200', 'docs.count': '0' },
+      { index: 'unknown', 'creation.date': '100' }, // no docs.count (e.g. remote/closed)
+    ]);
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    const byName = Object.fromEntries(result.items.map((i: any) => [i.name, i.docsCount]));
+    expect(byName.live).toBe(4200);
+    expect(byName.empty).toBe(0); // explicit 0 preserved → empty-index detection
+    expect(byName.unknown).toBeUndefined(); // absent → unknown, never coerced to 0
+  });
+
+  it('filters client-side by the search term (case-insensitive)', async () => {
+    indexFetch.mockResolvedValue(children(['logs-app-1', 'orders', 'LOGS-db']));
+    render(<Harness services={makeServices()} search="logs" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.items.map((i) => i.name).sort()).toEqual(['LOGS-db', 'logs-app-1']);
+  });
+
+  it('scopes the fetch + cat.indices call to a data source id (MDS)', async () => {
+    indexFetch.mockResolvedValue(children(['ds2-logs']));
+    render(<Harness services={makeServices()} search="" dataSourceId="ds-2" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    // The DATA_SOURCE node passed to fetch carries the id.
+    const dataSourceNode = indexFetch.mock.calls[0][1][1];
+    expect(dataSourceNode.id).toBe('ds-2');
+    expect(httpGet.mock.calls[0][0]).toContain('dataSourceMDSId=ds-2');
+  });
+
+  it('returns the FULL list (no internal cap) — RowsView owns the visible-window pagination', async () => {
+    const many = Array.from({ length: 60 }, (_, i) => `idx-${String(i).padStart(2, '0')}`);
+    indexFetch.mockResolvedValue(children(many));
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    // All 60 are returned — no silent 50-cap that would hide indexes from search / Load more.
+    expect(result.items.length).toBe(60);
+  });
+
+  // --- negative cases ---
+  it('surfaces an error and empties the list when the INDEX type is not registered', async () => {
+    const services = ({
+      data: {
+        query: { queryString: { getDatasetService: () => ({ getType: () => undefined }) } },
+      },
+      http: { get: httpGet },
+    } as unknown) as any;
+    render(<Harness services={services} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.error).toMatch(/not registered/);
+    expect(result.items).toEqual([]);
+  });
+
+  it('surfaces an error when the index fetch rejects', async () => {
+    indexFetch.mockRejectedValue(new Error('resolve_index failed'));
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.error).toBe('resolve_index failed');
+    expect(result.items).toEqual([]);
+  });
+
+  it('falls back to name-descending when the cat.indices call rejects', async () => {
+    indexFetch.mockResolvedValue(children(['a', 'z', 'm']));
+    httpGet.mockRejectedValue(new Error('directquery route unavailable'));
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.items.map((i) => i.name)).toEqual(['z', 'm', 'a']);
+    // The fetch itself succeeded, so there is no error surfaced.
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns an empty list (no crash) when the fetch has no children', async () => {
+    indexFetch.mockResolvedValue({});
+    render(<Harness services={makeServices()} search="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(result.items).toEqual([]);
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.test.tsx
@@ -34,10 +34,12 @@ const children = (names: string[], remote: string[] = []) => ({
 });
 
 let result: ReturnType<typeof useIndexList>;
+// MDS-only: the hook requires a data source id, so the harness defaults to one. Cases that exercise
+// the no-data-source path pass `dataSourceId={undefined}` explicitly.
 const Harness: React.FC<{ services: any; search: string; dataSourceId?: string }> = ({
   services,
   search,
-  dataSourceId,
+  dataSourceId = 'ds-default',
 }) => {
   result = useIndexList({ services, search, dataSourceId });
   return <div data-test-subj="names">{result.items.map((i) => i.name).join(',')}</div>;
@@ -51,7 +53,7 @@ describe('useIndexList', () => {
   });
 
   // --- positive cases ---
-  it('lists indexes for the local cluster and filters out `.`-prefixed system indexes', async () => {
+  it('lists indexes for the data source and filters out `.`-prefixed system indexes', async () => {
     indexFetch.mockResolvedValue(children(['logs-app-1', '.kibana_1', 'orders']));
     render(<Harness services={makeServices()} search="" />);
     await waitFor(() => expect(result.loading).toBe(false));
@@ -151,6 +153,17 @@ describe('useIndexList', () => {
     const dataSourceNode = indexFetch.mock.calls[0][1][1];
     expect(dataSourceNode.id).toBe('ds-2');
     expect(httpGet.mock.calls[0][0]).toContain('dataSourceMDSId=ds-2');
+  });
+
+  // MDS-only: no local cluster to enumerate → no request, empty result.
+  // Empty-string id is the "local cluster" sentinel; it must be treated as "no data source".
+  it('does NOT resolve indexes when there is no data source id (never hits the local cluster)', async () => {
+    render(<Harness services={makeServices()} search="" dataSourceId="" />);
+    await waitFor(() => expect(result.loading).toBe(false));
+    expect(indexFetch).not.toHaveBeenCalled();
+    expect(httpGet).not.toHaveBeenCalled();
+    expect(result.items).toEqual([]);
+    expect(result.error).toBeUndefined();
   });
 
   it('returns the FULL list (no internal cap) — RowsView owns the visible-window pagination', async () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
 import { DataStructure, DEFAULT_DATA } from '../../../../../../data/common';
 import { ExploreServices } from '../../../../types';
 import { BrowsableItem } from '../types';
+import { maybeNotifyPermissionDenied } from '../permission_toast';
 
 interface UseIndexListArgs {
   services: ExploreServices;
@@ -213,7 +214,11 @@ async function sortByCreationDate(
         if (b.createdAt != null) return 1;
         return b.name.localeCompare(a.name);
       });
-  } catch {
+  } catch (e) {
+    // cat.indices enrichment is best-effort: on ANY failure we still show the list (name-ordered),
+    // just without creation date / docs.count / health / size. A 4xx (e.g. no cat permission) also
+    // raises the one-time "index details unavailable — check permissions" toast.
+    maybeNotifyPermissionDenied(services, e);
     return nameDescending();
   }
 }

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
@@ -129,16 +129,24 @@ async function sortByCreationDate(
   if (items.length === 0) return items;
 
   try {
-    // Also request `docs.count` + `health` — they ride along on this ONE already-made cat.indices
-    // call (the route is a pass-through), so empty-index detection AND the health dot cost zero
-    // extra round-trips. Both are absent for remote/closed indices → we leave those `docsCount` /
-    // `health` undefined (unknown), never 0/green.
+    // Also request `docs.count`, `health`, `store.size`, `pri`, `rep` — they ride along on this ONE
+    // already-made cat.indices call (the route is a pass-through), so empty-index detection, the
+    // health dot AND the health tooltip metadata cost zero extra round-trips. All are absent for
+    // remote/closed indices → we leave those fields undefined (unknown), never 0/green.
     const response = await services.http.get<
-      Array<{ index: string; 'creation.date'?: string; 'docs.count'?: string; health?: string }>
+      Array<{
+        index: string;
+        'creation.date'?: string;
+        'docs.count'?: string;
+        health?: string;
+        'store.size'?: string;
+        pri?: string;
+        rep?: string;
+      }>
     >(`/api/directquery/dsl/cat.indices/dataSourceMDSId=${dataSourceId ?? ''}`, {
       query: {
         format: 'json',
-        h: 'index,creation.date,docs.count,health',
+        h: 'index,creation.date,docs.count,health,store.size,pri,rep',
         s: 'creation.date:desc',
       },
     });
@@ -147,6 +155,10 @@ async function sortByCreationDate(
     const createdByName = new Map<string, number>();
     const docsByName = new Map<string, number>();
     const healthByName = new Map<string, BrowsableItem['health']>();
+    const metaByName = new Map<
+      string,
+      { storeSize?: string; primaryShards?: number; replicaCount?: number }
+    >();
     response.forEach((row) => {
       const ts = Number(row['creation.date']);
       if (row.index && Number.isFinite(ts)) createdByName.set(row.index, ts);
@@ -156,6 +168,15 @@ async function sortByCreationDate(
       if (row.index && (health === 'green' || health === 'yellow' || health === 'red')) {
         healthByName.set(row.index, health);
       }
+      if (row.index) {
+        const pri = Number(row.pri);
+        const rep = Number(row.rep);
+        metaByName.set(row.index, {
+          storeSize: row['store.size'] || undefined,
+          primaryShards: Number.isFinite(pri) ? pri : undefined,
+          replicaCount: Number.isFinite(rep) ? rep : undefined,
+        });
+      }
     });
 
     return [...items]
@@ -164,6 +185,9 @@ async function sortByCreationDate(
         createdAt: createdByName.get(item.name),
         docsCount: docsByName.get(item.name),
         health: healthByName.get(item.name),
+        storeSize: metaByName.get(item.name)?.storeSize,
+        primaryShards: metaByName.get(item.name)?.primaryShards,
+        replicaCount: metaByName.get(item.name)?.replicaCount,
       }))
       .sort((a, b) => {
         // Rows with a known creation date come first, newest → oldest; then name-descending.

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { DataStructure, DEFAULT_DATA } from '../../../../../../data/common';
+import { ExploreServices } from '../../../../types';
+import { BrowsableItem } from '../types';
+
+interface UseIndexListArgs {
+  services: ExploreServices;
+  /** Data source id to scope to (MDS). Empty string / undefined = local cluster. */
+  dataSourceId?: string;
+  /** Debounced search string; filters the index names. */
+  search: string;
+}
+
+interface UseIndexListResult {
+  items: BrowsableItem[];
+  loading: boolean;
+  error?: string;
+}
+
+/**
+ * Lists concrete indexes/aliases/data_streams for the active data source using the SAME API
+ * the dataset-create UI uses (`datasetService.fetchOptions`), so the Explore browser stays in
+ * sync with dataset creation. Search filters client-side over the returned names. Returns the FULL
+ * filtered list — RowsView owns the visible-window pagination ("Load more"), so windowing here too
+ * would double-paginate and silently cap the list.
+ */
+export const useIndexList = ({
+  services,
+  dataSourceId,
+  search,
+}: UseIndexListArgs): UseIndexListResult => {
+  const [allItems, setAllItems] = useState<BrowsableItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    const fetchIndices = async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        const datasetService = services.data.query.queryString.getDatasetService();
+        const indexType = datasetService.getType(DEFAULT_DATA.SET_TYPES.INDEX);
+        if (!indexType) {
+          throw new Error('Index dataset type is not registered');
+        }
+
+        // Fetch indexes for the target data source directly. We build the DATA_SOURCE node
+        // ourselves rather than walking the data-source LIST first: inside a workspace / non-MDS
+        // setup the list may not contain a local-cluster node (id ''), which would leave us with
+        // nothing to fetch. index_type's fetch only reads `dataStructure.id` to scope the
+        // resolve_index call (empty id => local cluster), so a hand-built node is sufficient.
+        const indexRoot: DataStructure = {
+          id: indexType.id,
+          title: indexType.title,
+          type: indexType.id,
+        };
+        const dataSourceNode: DataStructure = dataSourceId
+          ? { id: dataSourceId, title: dataSourceId, type: 'DATA_SOURCE' }
+          : { ...DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE };
+
+        const indexesResult = await indexType.fetch(services as any, [indexRoot, dataSourceNode]);
+        const items: BrowsableItem[] = (indexesResult.children ?? [])
+          .map((child) => ({
+            name: child.title,
+            kind: 'index' as const,
+            isRemote: Boolean(
+              (child.meta as { isRemoteIndex?: boolean } | undefined)?.isRemoteIndex
+            ),
+          }))
+          // Hide `.`-prefixed system indexes (plugin-internal, not for customers to explore).
+          // Strip a cross-cluster `cluster:` prefix before the check so remote system indexes are
+          // filtered too. Mirrors `get_matched_indices.ts` isSystemIndex.
+          .filter((item) => {
+            const bare = item.name.includes(':')
+              ? item.name.slice(item.name.indexOf(':') + 1)
+              : item.name;
+            return !bare.startsWith('.');
+          });
+
+        // Enrich with creation dates and sort newest-first. `_cat/indices` (via the directquery
+        // route) exposes `creation.date.string`; we ask it to sort descending and use that order,
+        // falling back to name-descending if the call fails or a row lacks a date.
+        const sorted = await sortByCreationDate(items, services, dataSourceId);
+
+        if (requestId === requestIdRef.current) {
+          setAllItems(sorted);
+        }
+      } catch (e) {
+        if (requestId === requestIdRef.current) {
+          setError(e instanceof Error ? e.message : 'Unable to load indexes for this data source');
+          setAllItems([]);
+        }
+      } finally {
+        if (requestId === requestIdRef.current) setLoading(false);
+      }
+    };
+
+    fetchIndices();
+  }, [services, dataSourceId]);
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const filtered = normalizedSearch
+    ? allItems.filter((item) => item.name.toLowerCase().includes(normalizedSearch))
+    : allItems;
+
+  return { items: filtered, loading, error };
+};
+
+/**
+ * Orders indexes newest-first using `_cat/indices?h=index,creation.date&s=creation.date:desc`
+ * via the directquery route. On any failure (route unavailable, remote-only cluster, etc.) it
+ * falls back to name-descending, which approximates newest-first for date-suffixed/rolling
+ * index names.
+ */
+async function sortByCreationDate(
+  items: BrowsableItem[],
+  services: ExploreServices,
+  dataSourceId?: string
+): Promise<BrowsableItem[]> {
+  const nameDescending = () => [...items].sort((a, b) => b.name.localeCompare(a.name));
+
+  if (items.length === 0) return items;
+
+  try {
+    // Also request `docs.count` + `health` — they ride along on this ONE already-made cat.indices
+    // call (the route is a pass-through), so empty-index detection AND the health dot cost zero
+    // extra round-trips. Both are absent for remote/closed indices → we leave those `docsCount` /
+    // `health` undefined (unknown), never 0/green.
+    const response = await services.http.get<
+      Array<{ index: string; 'creation.date'?: string; 'docs.count'?: string; health?: string }>
+    >(`/api/directquery/dsl/cat.indices/dataSourceMDSId=${dataSourceId ?? ''}`, {
+      query: {
+        format: 'json',
+        h: 'index,creation.date,docs.count,health',
+        s: 'creation.date:desc',
+      },
+    });
+    if (!Array.isArray(response)) return nameDescending();
+
+    const createdByName = new Map<string, number>();
+    const docsByName = new Map<string, number>();
+    const healthByName = new Map<string, BrowsableItem['health']>();
+    response.forEach((row) => {
+      const ts = Number(row['creation.date']);
+      if (row.index && Number.isFinite(ts)) createdByName.set(row.index, ts);
+      const docs = Number(row['docs.count']);
+      if (row.index && Number.isFinite(docs)) docsByName.set(row.index, docs);
+      const health = row.health?.toLowerCase();
+      if (row.index && (health === 'green' || health === 'yellow' || health === 'red')) {
+        healthByName.set(row.index, health);
+      }
+    });
+
+    return [...items]
+      .map((item) => ({
+        ...item,
+        createdAt: createdByName.get(item.name),
+        docsCount: docsByName.get(item.name),
+        health: healthByName.get(item.name),
+      }))
+      .sort((a, b) => {
+        // Rows with a known creation date come first, newest → oldest; then name-descending.
+        if (a.createdAt != null && b.createdAt != null) return b.createdAt - a.createdAt;
+        if (a.createdAt != null) return -1;
+        if (b.createdAt != null) return 1;
+        return b.name.localeCompare(a.name);
+      });
+  } catch {
+    return nameDescending();
+  }
+}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/hooks/use_index_list.ts
@@ -10,7 +10,7 @@ import { BrowsableItem } from '../types';
 
 interface UseIndexListArgs {
   services: ExploreServices;
-  /** Data source id to scope to (MDS). Empty string / undefined = local cluster. */
+  /** Data source id to scope to (MDS, required). Empty/undefined ⇒ no resolution (MDS-only). */
   dataSourceId?: string;
   /** Debounced search string; filters the index names. */
   search: string;
@@ -42,6 +42,18 @@ export const useIndexList = ({
   useEffect(() => {
     const requestId = ++requestIdRef.current;
     const fetchIndices = async () => {
+      // MDS-only: index resolution must target an explicit data source. A bare resolve_index (empty
+      // data source id) targets the local cluster, which does not exist under MDS (e.g. Neo) and 500s
+      // on an unconfigured client. With no data source there is nothing to enumerate — return empty
+      // and let the page's empty state guide the user to pick one. Never build the empty-id
+      // LOCAL_DATASOURCE node.
+      if (!dataSourceId) {
+        setAllItems([]);
+        setError(undefined);
+        setLoading(false);
+        return;
+      }
+
       setLoading(true);
       setError(undefined);
       try {
@@ -51,19 +63,19 @@ export const useIndexList = ({
           throw new Error('Index dataset type is not registered');
         }
 
-        // Fetch indexes for the target data source directly. We build the DATA_SOURCE node
-        // ourselves rather than walking the data-source LIST first: inside a workspace / non-MDS
-        // setup the list may not contain a local-cluster node (id ''), which would leave us with
-        // nothing to fetch. index_type's fetch only reads `dataStructure.id` to scope the
-        // resolve_index call (empty id => local cluster), so a hand-built node is sufficient.
+        // Fetch indexes for the target data source directly. We build the DATA_SOURCE node ourselves
+        // rather than walking the data-source LIST first. index_type's fetch reads `dataStructure.id`
+        // to scope the resolve_index call to this data source (MDS), so a hand-built node suffices.
         const indexRoot: DataStructure = {
           id: indexType.id,
           title: indexType.title,
           type: indexType.id,
         };
-        const dataSourceNode: DataStructure = dataSourceId
-          ? { id: dataSourceId, title: dataSourceId, type: 'DATA_SOURCE' }
-          : { ...DEFAULT_DATA.STRUCTURES.LOCAL_DATASOURCE };
+        const dataSourceNode: DataStructure = {
+          id: dataSourceId,
+          title: dataSourceId,
+          type: 'DATA_SOURCE',
+        };
 
         const indexesResult = await indexType.fetch(services as any, [indexRoot, dataSourceNode]);
         const items: BrowsableItem[] = (indexesResult.children ?? [])
@@ -127,6 +139,11 @@ async function sortByCreationDate(
   const nameDescending = () => [...items].sort((a, b) => b.name.localeCompare(a.name));
 
   if (items.length === 0) return items;
+
+  // MDS-only: without a data source there is no cluster to hit (no local cluster under MDS). Skip the
+  // cat.indices call entirely rather than issue a bare `dataSourceMDSId=` request, and fall back to
+  // name-descending ordering.
+  if (!dataSourceId) return nameDescending();
 
   try {
     // Also request `docs.count`, `health`, `store.size`, `pri`, `rep` — they ride along on this ONE

--- a/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
@@ -54,6 +54,9 @@
   margin-bottom: $euiSizeXS;
   padding: $euiSizeXS $euiSizeS;
 
+  // Match the full card's softer corner rounding (HTML design mock).
+  border-radius: 8px;
+
   &__name {
     min-width: 0;
     overflow: hidden;
@@ -80,6 +83,11 @@
   min-width: 0;
   margin-bottom: $euiSizeS;
 
+  // Softer, larger corner rounding than the default panel — matches the HTML design mock.
+  &__panel {
+    border-radius: 8px;
+  }
+
   &__name {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -93,7 +101,7 @@
   }
 
   &__body {
-    margin-top: $euiSizeS;
+    margin-top: $euiSizeXS;
   }
 
   // Histogram + logs sit side by side; both must be allowed to shrink below content width.
@@ -127,16 +135,101 @@
     min-width: 0;
   }
 
-  // Index health dot in the header — EuiHealth with an empty label renders as a bare status dot.
+  // Index health, shown right of the time control as a labeled capsule pill (dot + status word).
   &__health {
     display: flex;
     align-items: center;
   }
 
+  &__healthPill {
+    display: inline-flex;
+    align-items: center;
+    gap: $euiSizeXS;
+    height: 20px;
+    padding: 0 $euiSizeS;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: $euiFontWeightMedium;
+    line-height: 1;
+    white-space: nowrap;
+
+    // Label uses the theme text color so it stays legible in BOTH light and dark themes; the color
+    // signal comes from the saturated dot + a semi-transparent hue wash (both theme-adaptive).
+    color: $euiTextColor;
+    border: 1px solid transparent;
+
+    // Refined status shades from the OUI VIS palette (theme tokens) — softer/distinct from the stark
+    // stock status red/yellow/green, per design. Background/border are transparentized so the wash
+    // sits correctly over any card background in both light and dark themes.
+    &--green {
+      background-color: transparentize($euiColorVis0, 0.88);
+      border-color: transparentize($euiColorVis0, 0.72);
+
+      .logStreamCard__healthDot {
+        background-color: $euiColorVis0;
+      }
+    }
+
+    &--yellow {
+      background-color: transparentize($euiColorVis5, 0.86);
+      border-color: transparentize($euiColorVis5, 0.7);
+
+      .logStreamCard__healthDot {
+        background-color: $euiColorVis5;
+      }
+    }
+
+    &--red {
+      background-color: transparentize($euiColorVis9, 0.88);
+      border-color: transparentize($euiColorVis9, 0.72);
+
+      .logStreamCard__healthDot {
+        background-color: $euiColorVis9;
+      }
+    }
+  }
+
+  &__healthDot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  // Health-pill hover tooltip: a small stacked list (status + store size + shard layout).
+  &__healthTip {
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  &__healthTipTitle {
+    font-weight: $euiFontWeightBold;
+  }
+
   // Compressed time-field control in the header — uniform across single/multi-timestamp cards
-  // (disabled, non-interactive when there's only one date field).
+  // (read-only field when there's only one date field, interactive select otherwise). Kept compact:
+  // a smaller max-width so the capsule reads as a chip. Font bumped to 12px for legibility with the
+  // vertical padding trimmed to 2px so the taller text still fits the same pill height.
   &__timeSelect {
-    max-width: 180px;
+    max-width: 150px;
+    font-size: 12px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+
+  // Capsule (pill) wrapper around the time control. We can't round the EUI form-control layout
+  // directly (its bordered wrapper is a global .eui* selector the stylelint denylist forbids
+  // touching), so this tooltip-anchor span clips the control — border, clock prepend, and all —
+  // into rounded ends. The inner control's content sits flush to the right edge (≈1px gap), so a
+  // full 999px pill radius would force a half-circle cap with no content clearance and slice the
+  // right edge into a flat vertical cut ("chopped"). A moderate radius (half the control height)
+  // rounds the corners smoothly without needing clearance the flush content doesn't have.
+  &__timeCapsule {
+    display: inline-flex;
+    align-items: center;
+    max-width: 150px;
+    border-radius: $euiSizeM; // 12px — rounded corners that don't chop the flush right edge
+    overflow: hidden;
   }
 
   // Muted placeholder when the histogram query errors (keeps the column height stable).
@@ -184,6 +277,49 @@
     min-width: 0;
     background: transparent;
     padding: 0;
+
+    // Scrollbars hidden at rest, revealed on hover (and while scrolling). The edge fade below is the
+    // resting "more content" cue; the container stays scrollable/focusable so keyboard + trackpad
+    // scrolling are unaffected — only the visual track is hidden.
+    scrollbar-width: none; // Firefox
+
+    &::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+
+    &:hover {
+      scrollbar-width: thin; // Firefox
+
+      @include euiScrollBar; // WebKit/Chromium: restore the themed thin scrollbar on hover
+    }
+
+    // Faded scroll ends (same technique as EUI's euiYScrollWithShadows / the workspace-selector
+    // popover): a linear-gradient mask softens the FAR scroll ends only — bottom (vertical overflow)
+    // and right (long horizontal lines). The top and left stay crisp, so the first line and the
+    // start of each line are never dimmed. We compose the two gradients and intersect them. `red` is
+    // a mask placeholder — only the gradient's alpha matters (mirrors the OUI ouiOverflowShadow
+    // mixin). Autoprefixer emits the -webkit-mask-composite fallback for Safari.
+    // Fade band trimmed to $euiSizeS (8px): the container is sized to a whole 6 lines (~124px), so
+    // the smaller band sits over the scroll gap / next-line boundary and never dims a full line —
+    // the previous 12px band ate into the last visible line, making it read as clipped.
+    $logsFade: $euiSizeS;
+
+    mask-image:
+      linear-gradient(
+        to bottom,
+        transparentize(red, 0) 0%,
+        transparentize(red, 0) calc(100% - #{$logsFade}),
+        transparentize(red, 0.9) 100%
+      ),
+      linear-gradient(
+        to right,
+        transparentize(red, 0) 0%,
+        transparentize(red, 0) calc(100% - #{$logsFade}),
+        transparentize(red, 0.9) 100%
+      );
+    mask-composite: intersect;
+    contain: paint;
   }
 
   &__empty {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
@@ -170,7 +170,9 @@
     display: inline-flex;
     align-items: center;
     gap: $euiSizeXS;
-    height: 20px;
+
+    // Match the time-field capsule height (24px) so the two header chips align (bugbash #1).
+    height: 24px;
     padding: 0 $euiSizeS;
     border-radius: 999px;
     font-size: 11px;
@@ -304,6 +306,10 @@
     min-width: 0;
     background: transparent;
     padding: 0;
+
+    // Reserve the scrollbar gutter permanently so revealing the scrollbar on :hover (below) doesn't
+    // reflow the log lines — fixes the "logs shift slightly on hover" report (bugbash #6).
+    scrollbar-gutter: stable;
 
     // Scrollbars hidden at rest, revealed on hover (and while scrolling). The edge fade below is the
     // resting "more content" cue; the container stays scrollable/focusable so keyboard + trackpad

--- a/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
@@ -39,6 +39,31 @@
     letter-spacing: 0.06em;
   }
 
+  // Selection summary bar: row 1 = "N indexes selected · New dataset {pattern}" + Clear all;
+  // row 2 = the removable index pills. Sticks to the top so the selection stays visible on scroll.
+  &__selectionBar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    margin-bottom: $euiSizeS;
+    padding: $euiSizeS;
+    border-radius: 8px;
+    background-color: $euiColorLightestShade;
+  }
+
+  // Amber warning line (e.g. no common time field) between the summary row and the pills.
+  &__selectionWarning {
+    margin-top: $euiSizeXS;
+  }
+
+  // Row 2: pills wrap onto their own line, comfortably spaced below the summary row.
+  &__selectionPills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $euiSizeXS;
+    margin-top: $euiSizeXS;
+  }
+
   // The collapsed "N indexes with no recent data" drawer at the bottom of the list.
   &__deadGroup {
     margin-top: $euiSizeM;
@@ -213,8 +238,8 @@
   &__timeSelect {
     max-width: 150px;
     font-size: 12px;
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   // Capsule (pill) wrapper around the time control. We can't round the EUI form-control layout
@@ -228,6 +253,8 @@
     display: inline-flex;
     align-items: center;
     max-width: 150px;
+    height: 24px; // compact fixed height for the header chip
+    border: $euiBorderThin; // pill outline (the inner control's border is clipped by overflow:hidden)
     border-radius: $euiSizeM; // 12px — rounded corners that don't chop the flush right edge
     overflow: hidden;
   }

--- a/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/index.scss
@@ -1,0 +1,319 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.logsDrilldown {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: $euiSize;
+
+  &__toolbar {
+    flex-shrink: 0;
+  }
+
+  &__toolbarDs {
+    min-width: 220px;
+    max-width: 320px;
+  }
+
+  &__toolbarTime {
+    min-width: 260px;
+  }
+}
+
+// --- Rows (Grafana-drilldown) view ---
+// A recessed "terminal" surface for the log streams — the distinctive Grafana texture, but
+// theme-aware: the code-block background is a light grey in the light theme and ink-dark in the
+// dark theme, so severity tokens stay legible in both. All widths are constrained (min-width:0 +
+// fixed histogram px) so the chart and nowrap log lines can never blow the card out horizontally.
+.logsExploreRows {
+  display: block;
+  width: 100%;
+  min-width: 0;
+
+  &__section {
+    margin: $euiSizeM 0 $euiSizeXS;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  // The collapsed "N indexes with no recent data" drawer at the bottom of the list.
+  &__deadGroup {
+    margin-top: $euiSizeM;
+    border-top: $euiBorderThin;
+    padding-top: $euiSizeXS;
+  }
+}
+
+// Compact one-row treatment for the empty / no-recent / error states and the dead-group rows.
+// Panel renders with paddingSize="none"; we set our own tight padding so these read as dense
+// one-line list rows rather than cards.
+.logsDrilldownCompactRow {
+  margin-bottom: $euiSizeXS;
+  padding: $euiSizeXS $euiSizeS;
+
+  &__name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__meta {
+    white-space: nowrap;
+  }
+
+  // Tint the row border to match its tone (default keeps the plain panel border).
+  &--danger {
+    border-color: $euiColorDanger;
+  }
+
+  &--warning {
+    border-color: $euiColorWarning;
+  }
+}
+
+.logStreamCard {
+  width: 100%;
+  min-width: 0;
+  margin-bottom: $euiSizeS;
+
+  &__name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    // Reset the EuiText default margins so the name aligns with the header buttons.
+    p,
+    span {
+      margin-bottom: 0;
+    }
+  }
+
+  &__body {
+    margin-top: $euiSizeS;
+  }
+
+  // Histogram + logs sit side by side; both must be allowed to shrink below content width.
+  &__split {
+    min-width: 0;
+  }
+
+  &__histCol {
+    // Fixed-width histogram column so the chart's intrinsic size can't stretch the row.
+    flex: 0 0 360px;
+    max-width: 360px;
+    min-width: 0;
+  }
+
+  &__logCol {
+    min-width: 0; // critical: lets the nowrap log lines ellipsize instead of overflowing.
+  }
+
+  &__histWrap {
+    min-width: 0;
+  }
+
+  // ECharts renders the bars + its own axes/tooltip/brush inside here.
+  &__histogram {
+    width: 100%;
+    min-width: 0;
+  }
+
+  // Header time control (#4): sits at the right of the header.
+  &__timeControl {
+    min-width: 0;
+  }
+
+  // Index health dot in the header — EuiHealth with an empty label renders as a bare status dot.
+  &__health {
+    display: flex;
+    align-items: center;
+  }
+
+  // Compressed time-field control in the header — uniform across single/multi-timestamp cards
+  // (disabled, non-interactive when there's only one date field).
+  &__timeSelect {
+    max-width: 180px;
+  }
+
+  // Muted placeholder when the histogram query errors (keeps the column height stable).
+  &__histEmpty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    border: $euiBorderThin;
+    border-radius: $euiBorderRadius;
+  }
+
+  // Compact legend row of severity chips + humanized totals, sitting under the chart.
+  &__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $euiSizeXS $euiSizeS;
+    margin-top: $euiSizeXS;
+  }
+
+  &__legendRow {
+    white-space: nowrap;
+  }
+
+  &__legendName {
+    text-transform: capitalize;
+  }
+
+  // Crossed-clock affordance for no-time-field indexes.
+  &__noTimeIcon {
+    // A slash overlay via a pseudo-element would need a wrapper; the tooltip carries the meaning,
+    // so a muted clock icon + "No time field" text is enough. Kept subdued.
+    vertical-align: text-bottom;
+  }
+
+  // The raw log stream: transparent (uses the card/container bg, not a recessed surface — #5).
+  // Grafana-style (#6): horizontal scroll for long lines (they don't wrap/truncate), vertical scroll
+  // for overflow. Height matches the histogram column so the two columns' bottoms align (#7).
+  &__logs {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch; // each line stretches to the widest line's width (full scroll content)
+    overflow-y: auto;
+    overflow-x: auto;
+    min-width: 0;
+    background: transparent;
+    padding: 0;
+  }
+
+  &__empty {
+    padding: $euiSizeS;
+    color: $euiTextSubduedColor;
+  }
+
+  // Loading skeletons (shimmer) — reserved to the final content heights so there's no layout shift.
+  &__skeletonHist,
+  &__skeletonLogs {
+    min-width: 0;
+  }
+
+  &__skeletonHist {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    padding: 0 2px;
+  }
+
+  &__skeletonBar {
+    flex: 1 1 auto;
+    border-radius: 2px 2px 0 0;
+    animation: logsDrilldownShimmer 1.4s ease-in-out infinite;
+    background: transparentize($euiColorMediumShade, 0.6);
+  }
+
+  &__skeletonLogs {
+    display: flex;
+    flex-direction: column;
+    gap: $euiSizeS;
+    padding: $euiSizeXS 0;
+  }
+
+  &__skeletonLine {
+    height: 8px;
+    border-radius: 2px;
+    animation: logsDrilldownShimmer 1.4s ease-in-out infinite;
+    background: transparentize($euiColorMediumShade, 0.6);
+  }
+}
+
+@keyframes logsDrilldownShimmer {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+
+  50% {
+    opacity: 0.75;
+  }
+}
+
+.logsExploreLogLine {
+  @include euiCodeFont;
+
+  // inline-flex + min-width:100% so the row (and its hover background) stretches to the FULL
+  // scrollable content width, not just the visible viewport — otherwise the highlight cuts off
+  // when the log stream is scrolled horizontally (#6).
+  display: inline-flex;
+  min-width: 100%;
+  width: max-content;
+  align-items: baseline;
+  gap: $euiSizeS;
+  font-size: 11px;
+  line-height: 1.7;
+  padding: 1px $euiSizeS;
+  color: $euiTextColor;
+
+  // Per-line hover highlight (#6). transition kept short so scanning feels responsive.
+  transition: background-color 80ms ease-in;
+
+  &:hover {
+    background-color: $euiColorLightestShade;
+  }
+
+  // Card view (#6): one line, no wrap — long lines extend and the stream scrolls horizontally
+  // (instead of ellipsizing), so the whole record is readable by scrolling right.
+  &--truncated {
+    white-space: nowrap;
+
+    .logsExploreLogLine__body {
+      white-space: nowrap;
+    }
+  }
+
+  &:not(&--truncated) {
+    align-items: flex-start;
+
+    .logsExploreLogLine__body {
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+  }
+
+  &__ts {
+    color: $euiTextSubduedColor;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  // Level token color is set inline from the single severity color map (severity.ts).
+  &__level {
+    font-weight: $euiFontWeightBold;
+    flex-shrink: 0;
+    width: 42px;
+    text-align: left;
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: $euiTextColor;
+  }
+
+  // Dim the key names inside the body so the values stand out (Grafana texture).
+  &__body b {
+    color: $euiTextSubduedColor;
+    font-weight: $euiFontWeightRegular;
+  }
+}
+
+.logsExplorePreview {
+  // On-brand SVG illustration for the empty state — depicts the payoff (a card with a histogram +
+  // log lines) instead of a blank box.
+  &__illustration {
+    display: block;
+    width: 320px;
+    max-width: 90%;
+    height: auto;
+    margin: 0 auto;
+  }
+}

--- a/src/plugins/explore/public/application/pages/logs_drilldown/index.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { renderLogsDrilldownApp } from './application';
+export { LogsDrilldownPage } from './logs_drilldown_page';

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
@@ -43,6 +43,12 @@ jest.mock('./components/data_source_control', () => ({
 jest.mock('./hooks/use_index_classification', () => ({
   useIndexClassification: () => ({ classify: jest.fn(), getCached: jest.fn() }),
 }));
+// Stub the data plugin barrel (importing it whole breaks in jsdom via its UI components). The page
+// only needs syncQueryStateWithUrl from it.
+const mockSyncQueryStateWithUrl = jest.fn(() => ({ stop: jest.fn() }));
+jest.mock('../../../../../data/public', () => ({
+  syncQueryStateWithUrl: (...args: any[]) => mockSyncQueryStateWithUrl(...args),
+}));
 
 const setTime = jest.fn();
 const timeUpdate$ = new Subject<void>();
@@ -50,11 +56,20 @@ let currentTime = { from: 'now-15m', to: 'now' };
 
 const setBreadcrumbs = jest.fn();
 
-const makeServices = (opts: { mds?: boolean } = {}) =>
+const makeServices = (
+  opts: { mds?: boolean; dataSourceTotal?: number; urlStateStorage?: any } = {}
+) =>
   (({
     chrome: { setBreadcrumbs },
     // MDS on ⇒ dataSourceManagement.ui.DataSourceSelector is present (the page's mdsEnabled gate).
     dataSourceManagement: opts.mds ? { ui: { DataSourceSelector: () => null } } : undefined,
+    // The page queries data-source existence to pick the right empty-state copy (none vs. unselected).
+    savedObjects: {
+      client: { find: jest.fn().mockResolvedValue({ total: opts.dataSourceTotal ?? 1 }) },
+    },
+    uiSettings: { get: jest.fn() },
+    // URL state storage (present in the real drilldown mount) → _g time sync + _a data-source persist.
+    osdUrlStateStorage: opts.urlStateStorage,
     data: {
       query: {
         timefilter: {
@@ -68,6 +83,18 @@ const makeServices = (opts: { mds?: boolean } = {}) =>
       },
     },
   } as unknown) as any);
+
+// A minimal in-memory osdUrlStateStorage stub for the URL-state tests.
+const makeUrlStateStorage = (initial: Record<string, any> = {}) => {
+  const store: Record<string, any> = { ...initial };
+  return {
+    get: jest.fn((key: string) => store[key] ?? null),
+    set: jest.fn((key: string, value: any) => {
+      store[key] = value;
+    }),
+    _store: store,
+  };
+};
 
 describe('LogsDrilldownPage', () => {
   beforeEach(() => {
@@ -148,30 +175,74 @@ describe('LogsDrilldownPage', () => {
     await waitFor(() => expect(lastRowsProps.dataSourceId).toBe('ds-2'));
   });
 
+  it('syncs the global time range with the URL (_g) when url state storage is present', () => {
+    const urlStateStorage = makeUrlStateStorage();
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    expect(mockSyncQueryStateWithUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      urlStateStorage,
+      expect.anything()
+    );
+  });
+
+  it('persists the selected data source to the _a URL key on change', async () => {
+    const urlStateStorage = makeUrlStateStorage();
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    fireEvent.click(screen.getByTestId('ds-change'));
+    await waitFor(() => expect(lastRowsProps.dataSourceId).toBe('ds-2'));
+    expect(urlStateStorage.set).toHaveBeenCalledWith(
+      '_a',
+      { dataSource: expect.objectContaining({ id: 'ds-2' }) },
+      { replace: true }
+    );
+  });
+
+  it('restores the selected data source from the _a URL key on mount', () => {
+    const urlStateStorage = makeUrlStateStorage({
+      _a: { dataSource: { id: 'ds-restored', title: 'Restored', type: 'DATA_SOURCE' } },
+    });
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    // The restored data source flows straight into RowsView (no user interaction needed).
+    expect(lastRowsProps.dataSourceId).toBe('ds-restored');
+  });
+
   it('non-MDS: shows the index list (implicit local cluster is the queryable target)', () => {
     render(<LogsDrilldownPage services={makeServices()} />);
     expect(screen.getByTestId('mock-rows-view')).toBeInTheDocument();
     expect(screen.queryByTestId('logsDrilldownNoDataSource')).not.toBeInTheDocument();
   });
 
-  it('MDS with no resolved data source (empty workspace): NO index list, shows empty state', () => {
-    render(<LogsDrilldownPage services={makeServices({ mds: true })} />);
-    // Local cluster is hidden under MDS, so nothing is queryable until a source resolves — we must
-    // NOT fall back to local-cluster indexes.
+  it('MDS, sources exist but none selected: NO index list, shows the SELECT prompt', async () => {
+    render(<LogsDrilldownPage services={makeServices({ mds: true, dataSourceTotal: 3 })} />);
+    // Local cluster is hidden under MDS, so nothing is queryable until a source is selected — we
+    // must NOT fall back to local-cluster indexes.
     expect(screen.queryByTestId('mock-rows-view')).not.toBeInTheDocument();
-    expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument();
-    // An empty selection (empty workspace) keeps it gated.
+    // Sources exist → prompt to select, not the "none available" copy.
+    await waitFor(() =>
+      expect(screen.getByTestId('logsDrilldownSelectDataSource')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('logsDrilldownNoDataSource')).not.toBeInTheDocument();
+    // An empty selection keeps it gated on the select prompt.
     fireEvent.click(screen.getByTestId('ds-empty'));
     expect(screen.queryByTestId('mock-rows-view')).not.toBeInTheDocument();
-    expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument();
+    expect(screen.getByTestId('logsDrilldownSelectDataSource')).toBeInTheDocument();
+  });
+
+  it('MDS, NO sources in the workspace: shows the "none available" prompt (not select)', async () => {
+    render(<LogsDrilldownPage services={makeServices({ mds: true, dataSourceTotal: 0 })} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('logsDrilldownSelectDataSource')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-rows-view')).not.toBeInTheDocument();
   });
 
   it('MDS: resolving a real data source reveals the index list', async () => {
     render(<LogsDrilldownPage services={makeServices({ mds: true })} />);
-    expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument();
+    expect(screen.getByTestId('logsDrilldownSelectDataSource')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('ds-change'));
     await waitFor(() => expect(screen.getByTestId('mock-rows-view')).toBeInTheDocument());
-    expect(screen.queryByTestId('logsDrilldownNoDataSource')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('logsDrilldownSelectDataSource')).not.toBeInTheDocument();
     expect(lastRowsProps.dataSourceId).toBe('ds-2');
   });
 

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
@@ -116,6 +116,18 @@ describe('LogsDrilldownPage', () => {
     expect(setBreadcrumbs).toHaveBeenCalledWith([{ text: 'Logs drilldown' }]);
   });
 
+  it('defaults the time range to last 15m on mount when the URL has no _g time', () => {
+    const urlStateStorage = makeUrlStateStorage(); // no _g
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    expect(setTime).toHaveBeenCalledWith({ from: 'now-15m', to: 'now' });
+  });
+
+  it('respects the URL _g time on mount (does NOT override with 15m)', () => {
+    const urlStateStorage = makeUrlStateStorage({ _g: { time: { from: 'now-7d', to: 'now' } } });
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    expect(setTime).not.toHaveBeenCalledWith({ from: 'now-15m', to: 'now' });
+  });
+
   it('updates refreshKey when the global time range changes (timeUpdate$)', async () => {
     render(<LogsDrilldownPage services={makeServices()} />);
     expect(lastRowsProps.refreshKey).toBe('now-15m|now|0');
@@ -142,6 +154,28 @@ describe('LogsDrilldownPage', () => {
     );
     expect(screen.getByTestId('logsExploreToolbarBatch')).not.toBeDisabled();
     expect(screen.getByTestId('logsExploreToolbarBatch')).toHaveTextContent('Query (2)');
+  });
+
+  it('shows a select-index tooltip on the disabled batch button, and none once enabled', async () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    // Disabled → hovering the button's tooltip anchor reveals the guidance.
+    fireEvent.mouseOver(screen.getByTestId('logsExploreToolbarBatch'));
+    expect(
+      await screen.findByText('Select one or more indexes to create a dataset')
+    ).toBeInTheDocument();
+
+    // Enabled → the tooltip content is cleared (no guidance needed).
+    act(() =>
+      lastRowsProps.onBatchActionChange({
+        count: 1,
+        label: 'Create dataset (1)',
+        pattern: 'x',
+        onClick: jest.fn(),
+      })
+    );
+    expect(
+      screen.queryByText('Select one or more indexes to create a dataset')
+    ).not.toBeInTheDocument();
   });
 
   it('the batch button runs the reported onClick', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { Subject } from 'rxjs';
+import { LogsDrilldownPage } from './logs_drilldown_page';
+
+jest.mock('@osd/i18n', () => ({
+  i18n: { translate: (_k: string, o: { defaultMessage: string }) => o.defaultMessage },
+}));
+
+// Capture the props RowsView receives so we can assert the page's orchestration + drive onBrushTime.
+let lastRowsProps: any;
+jest.mock('./components/rows_view', () => ({
+  RowsView: (props: any) => {
+    lastRowsProps = props;
+    return <div data-test-subj="mock-rows-view" data-refresh-key={props.refreshKey} />;
+  },
+}));
+// Portal renders its children inline in jsdom, so header-portaled controls are still queryable.
+jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
+  MountPointPortal: ({ children }: any) => (
+    <div data-test-subj="mock-header-portal">{children}</div>
+  ),
+}));
+// DataSourceControl → expose buttons that trigger a data-source change (resolve to a concrete
+// source, or report an empty selection like an empty workspace does).
+jest.mock('./components/data_source_control', () => ({
+  DataSourceControl: ({ onChange }: any) => (
+    <>
+      <button data-test-subj="ds-change" onClick={() => onChange({ id: 'ds-2', title: 'C2' })}>
+        ds
+      </button>
+      <button data-test-subj="ds-empty" onClick={() => onChange({ id: '', title: undefined })}>
+        ds-empty
+      </button>
+    </>
+  ),
+}));
+jest.mock('./hooks/use_index_classification', () => ({
+  useIndexClassification: () => ({ classify: jest.fn(), getCached: jest.fn() }),
+}));
+
+const setTime = jest.fn();
+const timeUpdate$ = new Subject<void>();
+let currentTime = { from: 'now-15m', to: 'now' };
+
+const setBreadcrumbs = jest.fn();
+
+const makeServices = (opts: { mds?: boolean } = {}) =>
+  (({
+    chrome: { setBreadcrumbs },
+    // MDS on ⇒ dataSourceManagement.ui.DataSourceSelector is present (the page's mdsEnabled gate).
+    dataSourceManagement: opts.mds ? { ui: { DataSourceSelector: () => null } } : undefined,
+    data: {
+      query: {
+        timefilter: {
+          timefilter: {
+            getTime: () => currentTime,
+            setTime,
+            getTimeUpdate$: () => timeUpdate$,
+            getBounds: () => ({}),
+          },
+        },
+      },
+    },
+  } as unknown) as any);
+
+describe('LogsDrilldownPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastRowsProps = undefined;
+    currentTime = { from: 'now-15m', to: 'now' };
+  });
+
+  it('renders the toolbar + RowsView and threads the initial time range into refreshKey', () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    expect(screen.getByTestId('logsDrilldownPage')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-rows-view')).toBeInTheDocument();
+    // refreshKey now carries a manual-refresh nonce (starts at 0).
+    expect(lastRowsProps.refreshKey).toBe('now-15m|now|0');
+  });
+
+  it('sets the "Logs drilldown" breadcrumb on mount', () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    expect(setBreadcrumbs).toHaveBeenCalledWith([{ text: 'Logs drilldown' }]);
+  });
+
+  it('updates refreshKey when the global time range changes (timeUpdate$)', async () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    expect(lastRowsProps.refreshKey).toBe('now-15m|now|0');
+
+    // Simulate the timepicker publishing a new range.
+    currentTime = { from: 'now-1h', to: 'now' };
+    act(() => timeUpdate$.next());
+
+    await waitFor(() => expect(lastRowsProps.refreshKey).toBe('now-1h|now|0'));
+  });
+
+  it('the toolbar batch button is disabled until RowsView reports a batch action', () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    const btn = screen.getByTestId('logsExploreToolbarBatch');
+    expect(btn).toBeDisabled();
+    // RowsView reports a selection → button enables + adopts the label.
+    act(() =>
+      lastRowsProps.onBatchActionChange({
+        count: 2,
+        label: 'Query (2)',
+        pattern: 'x',
+        onClick: jest.fn(),
+      })
+    );
+    expect(screen.getByTestId('logsExploreToolbarBatch')).not.toBeDisabled();
+    expect(screen.getByTestId('logsExploreToolbarBatch')).toHaveTextContent('Query (2)');
+  });
+
+  it('the batch button runs the reported onClick', () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    const onClick = jest.fn();
+    act(() =>
+      lastRowsProps.onBatchActionChange({
+        count: 1,
+        label: 'Create dataset (1)',
+        pattern: 'x',
+        onClick,
+      })
+    );
+    fireEvent.click(screen.getByTestId('logsExploreToolbarBatch'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('brush-select on a card sets the global time range (ISO)', () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    act(() => lastRowsProps.onBrushTime(0, 60_000));
+    expect(setTime).toHaveBeenCalledWith({
+      from: new Date(0).toISOString(),
+      to: new Date(60_000).toISOString(),
+    });
+  });
+
+  it('changing the data source flows a dataSourceId into RowsView', async () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    expect(lastRowsProps.dataSourceId).toBeUndefined();
+    fireEvent.click(screen.getByTestId('ds-change'));
+    await waitFor(() => expect(lastRowsProps.dataSourceId).toBe('ds-2'));
+  });
+
+  it('non-MDS: shows the index list (implicit local cluster is the queryable target)', () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    expect(screen.getByTestId('mock-rows-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('logsDrilldownNoDataSource')).not.toBeInTheDocument();
+  });
+
+  it('MDS with no resolved data source (empty workspace): NO index list, shows empty state', () => {
+    render(<LogsDrilldownPage services={makeServices({ mds: true })} />);
+    // Local cluster is hidden under MDS, so nothing is queryable until a source resolves — we must
+    // NOT fall back to local-cluster indexes.
+    expect(screen.queryByTestId('mock-rows-view')).not.toBeInTheDocument();
+    expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument();
+    // An empty selection (empty workspace) keeps it gated.
+    fireEvent.click(screen.getByTestId('ds-empty'));
+    expect(screen.queryByTestId('mock-rows-view')).not.toBeInTheDocument();
+    expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument();
+  });
+
+  it('MDS: resolving a real data source reveals the index list', async () => {
+    render(<LogsDrilldownPage services={makeServices({ mds: true })} />);
+    expect(screen.getByTestId('logsDrilldownNoDataSource')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('ds-change'));
+    await waitFor(() => expect(screen.getByTestId('mock-rows-view')).toBeInTheDocument());
+    expect(screen.queryByTestId('logsDrilldownNoDataSource')).not.toBeInTheDocument();
+    expect(lastRowsProps.dataSourceId).toBe('ds-2');
+  });
+
+  it('debounces the search input before passing it to RowsView', async () => {
+    render(<LogsDrilldownPage services={makeServices()} />);
+    const searchBox = screen.getByLabelText('Search datasets and indexes');
+    fireEvent.change(searchBox, { target: { value: 'logs' } });
+    // Debounced: the search prop only updates after the debounce window elapses.
+    await waitFor(() => expect(lastRowsProps.search).toBe('logs'));
+  });
+
+  it('unsubscribes from timeUpdate$ on unmount (no leak / late update)', () => {
+    const { unmount } = render(<LogsDrilldownPage services={makeServices()} />);
+    expect(timeUpdate$.observers.length).toBe(1);
+    unmount();
+    expect(timeUpdate$.observers.length).toBe(0);
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
@@ -101,6 +101,8 @@ describe('LogsDrilldownPage', () => {
     jest.clearAllMocks();
     lastRowsProps = undefined;
     currentTime = { from: 'now-15m', to: 'now' };
+    // The page remembers the data source in sessionStorage; jsdom persists it across tests.
+    window.sessionStorage.clear();
   });
 
   it('renders the toolbar + RowsView and threads the initial time range into refreshKey', () => {
@@ -219,7 +221,7 @@ describe('LogsDrilldownPage', () => {
     );
   });
 
-  it('persists the selected data source to the _a URL key on change', async () => {
+  it('persists the selected data source to the _a URL key AND sessionStorage on change', async () => {
     const urlStateStorage = makeUrlStateStorage();
     render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
     fireEvent.click(screen.getByTestId('ds-change'));
@@ -228,6 +230,10 @@ describe('LogsDrilldownPage', () => {
       '_a',
       { dataSource: expect.objectContaining({ id: 'ds-2' }) },
       { replace: true }
+    );
+    // Also remembered per-tab so re-entry from a bare `#/` restores it.
+    expect(JSON.parse(window.sessionStorage.getItem('logsDrilldown.dataSource')!)).toEqual(
+      expect.objectContaining({ id: 'ds-2' })
     );
   });
 
@@ -238,6 +244,34 @@ describe('LogsDrilldownPage', () => {
     render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
     // The restored data source flows straight into RowsView (no user interaction needed).
     expect(lastRowsProps.dataSourceId).toBe('ds-restored');
+  });
+
+  it('falls back to the sessionStorage data source when the URL has no _a (re-entry from #/)', () => {
+    window.sessionStorage.setItem(
+      'logsDrilldown.dataSource',
+      JSON.stringify({ id: 'ds-session', title: 'Session', type: 'DATA_SOURCE' })
+    );
+    const urlStateStorage = makeUrlStateStorage(); // no _a
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    expect(lastRowsProps.dataSourceId).toBe('ds-session');
+    // The session-restored source is seeded back into the URL so `_a` is authoritative immediately.
+    expect(urlStateStorage.set).toHaveBeenCalledWith(
+      '_a',
+      { dataSource: expect.objectContaining({ id: 'ds-session' }) },
+      { replace: true }
+    );
+  });
+
+  it('URL _a wins over sessionStorage when both are present', () => {
+    window.sessionStorage.setItem(
+      'logsDrilldown.dataSource',
+      JSON.stringify({ id: 'ds-session', title: 'Session', type: 'DATA_SOURCE' })
+    );
+    const urlStateStorage = makeUrlStateStorage({
+      _a: { dataSource: { id: 'ds-url', title: 'FromUrl', type: 'DATA_SOURCE' } },
+    });
+    render(<LogsDrilldownPage services={makeServices({ urlStateStorage })} />);
+    expect(lastRowsProps.dataSourceId).toBe('ds-url');
   });
 
   it('non-MDS: shows the index list (implicit local cluster is the queryable target)', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.test.tsx
@@ -59,7 +59,7 @@ const setBreadcrumbs = jest.fn();
 const makeServices = (
   opts: { mds?: boolean; dataSourceTotal?: number; urlStateStorage?: any } = {}
 ) =>
-  (({
+  ({
     chrome: { setBreadcrumbs },
     // MDS on ⇒ dataSourceManagement.ui.DataSourceSelector is present (the page's mdsEnabled gate).
     dataSourceManagement: opts.mds ? { ui: { DataSourceSelector: () => null } } : undefined,
@@ -82,7 +82,7 @@ const makeServices = (
         },
       },
     },
-  } as unknown) as any);
+  }) as unknown as any;
 
 // A minimal in-memory osdUrlStateStorage stub for the URL-state tests.
 const makeUrlStateStorage = (initial: Record<string, any> = {}) => {
@@ -113,9 +113,9 @@ describe('LogsDrilldownPage', () => {
     expect(lastRowsProps.refreshKey).toBe('now-15m|now|0');
   });
 
-  it('sets the "Logs drilldown" breadcrumb on mount', () => {
+  it('sets the "Explore logs" breadcrumb on mount', () => {
     render(<LogsDrilldownPage services={makeServices()} />);
-    expect(setBreadcrumbs).toHaveBeenCalledWith([{ text: 'Logs drilldown' }]);
+    expect(setBreadcrumbs).toHaveBeenCalledWith([{ text: 'Explore logs' }]);
   });
 
   it('defaults the time range to last 15m on mount when the URL has no _g time', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
@@ -23,12 +23,18 @@ import { AppMountParameters } from 'opensearch-dashboards/public';
 import { MountPointPortal } from '../../../../../opensearch_dashboards_react/public';
 import { Dataset } from '../../../../../data/common';
 import { syncQueryStateWithUrl } from '../../../../../data/public';
+import { Storage } from '../../../../../opensearch_dashboards_utils/public';
 import { ExploreServices } from '../../../types';
 import { DataSourceControl } from './components/data_source_control';
 import { RowsView, BatchAction } from './components/rows_view';
 import { useIndexClassification } from './hooks/use_index_classification';
 
 const SEARCH_DEBOUNCE_MS = 300;
+
+// Per-tab remembered data source. The nav-popover / query-bar entry points open the drilldown at a
+// bare `#/` (no `_a`), so the URL alone can't survive re-entry — this sessionStorage fallback keeps
+// the last selection for the tab session. URL `_a` still wins when present (shareable/bookmarkable).
+const DATA_SOURCE_STORAGE_KEY = 'logsDrilldown.dataSource';
 
 type Props = {
   services: ExploreServices;
@@ -46,10 +52,15 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
   const timefilter = services.data.query.timefilter.timefilter;
   const urlStateStorage = services.osdUrlStateStorage;
 
-  // Restore the selected data source from the `_a` URL state on first mount (bookmarkable/shareable).
+  // Per-tab session store for the last selected data source (survives re-entry from a bare `#/`).
+  const sessionStore = useMemo(() => new Storage(window.sessionStorage), []);
+
+  // Restore the selected data source on first mount. The URL `_a` wins (bookmarkable/shareable);
+  // when it's absent — as when the nav-popover / query-bar action opens the drilldown at a bare
+  // `#/` — fall back to the per-tab session store so the last selection isn't lost on re-entry.
   const initialDataSource = useMemo<Dataset['dataSource'] | undefined>(() => {
-    const appState = urlStateStorage?.get<{ dataSource?: Dataset['dataSource'] }>('_a');
-    return appState?.dataSource;
+    const fromUrl = urlStateStorage?.get<{ dataSource?: Dataset['dataSource'] }>('_a')?.dataSource;
+    return fromUrl ?? sessionStore.get(DATA_SOURCE_STORAGE_KEY) ?? undefined;
     // Read once on mount; later changes are written out, not read back in.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -60,6 +71,16 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
   );
   const dataSource = selectedDataSource;
   const dataSourceId = dataSource?.id;
+
+  // If the source was restored from the session store (the URL had no `_a`, e.g. re-entry from a
+  // bare `#/`), seed it into the URL now so `_a` is authoritative immediately — shareable and
+  // reload-safe without waiting for the picker to fire a change.
+  useEffect(() => {
+    if (initialDataSource && !urlStateStorage?.get('_a')) {
+      urlStateStorage?.set('_a', { dataSource: initialDataSource }, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Default the time range to the last 15 minutes on mount UNLESS this drilldown's own URL already
   // pins a range (`_g.time`). The timefilter is a shared singleton, so without this the drilldown
@@ -186,8 +207,11 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
       setSelectedDataSource(nextDataSource);
       // Persist to the `_a` URL key so the selection is restored on reload / shared via the URL.
       urlStateStorage?.set('_a', { dataSource: nextDataSource }, { replace: true });
+      // Also remember it per-tab so re-entry from a bare `#/` (nav-popover / query-bar) restores it.
+      if (nextDataSource) sessionStore.set(DATA_SOURCE_STORAGE_KEY, nextDataSource);
+      else sessionStore.remove(DATA_SOURCE_STORAGE_KEY);
     },
-    [urlStateStorage]
+    [urlStateStorage, sessionStore]
   );
 
   const { classify, getCached } = useIndexClassification(services, dataSourceId);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
@@ -28,6 +28,7 @@ import { ExploreServices } from '../../../types';
 import { DataSourceControl } from './components/data_source_control';
 import { RowsView, BatchAction } from './components/rows_view';
 import { useIndexClassification } from './hooks/use_index_classification';
+import { resetPermissionToast } from './permission_toast';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
@@ -152,6 +153,12 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
 
   // The batch (multi-select) action RowsView reports up — drives the toolbar button.
   const [batchAction, setBatchAction] = useState<BatchAction | null>(null);
+
+  // Reset the one-time "permission denied" toast whenever the data source changes: a different source
+  // is a fresh permission context, so its own failures should be allowed to toast once.
+  useEffect(() => {
+    resetPermissionToast();
+  }, [dataSourceId]);
 
   // Page breadcrumb. This standalone app has no explore tab chrome, so it sets its own.
   useEffect(() => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
@@ -21,6 +21,7 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { MountPointPortal } from '../../../../../opensearch_dashboards_react/public';
 import { Dataset } from '../../../../../data/common';
+import { syncQueryStateWithUrl } from '../../../../../data/public';
 import { ExploreServices } from '../../../types';
 import { DataSourceControl } from './components/data_source_control';
 import { RowsView, BatchAction } from './components/rows_view';
@@ -42,11 +43,35 @@ type Props = {
  */
 export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMenu }) => {
   const timefilter = services.data.query.timefilter.timefilter;
+  const urlStateStorage = services.osdUrlStateStorage;
 
-  // Data source scoping the list (MDS). Local state — no Redux.
-  const [selectedDataSource, setSelectedDataSource] = useState<Dataset['dataSource']>(undefined);
+  // Restore the selected data source from the `_a` URL state on first mount (bookmarkable/shareable).
+  const initialDataSource = useMemo<Dataset['dataSource'] | undefined>(() => {
+    const appState = urlStateStorage?.get<{ dataSource?: Dataset['dataSource'] }>('_a');
+    return appState?.dataSource;
+    // Read once on mount; later changes are written out, not read back in.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Data source scoping the list (MDS). Local state, mirrored to the `_a` URL key.
+  const [selectedDataSource, setSelectedDataSource] = useState<Dataset['dataSource']>(
+    initialDataSource
+  );
   const dataSource = selectedDataSource;
   const dataSourceId = dataSource?.id;
+
+  // Sync the global time range (`_g`) with the URL so it survives a hard reload and stays shareable
+  // — the time range is already shared across apps via the singleton timefilter; this adds URL
+  // persistence, matching the logs/traces/metrics flavors' `syncQueryStateWithUrl`.
+  useEffect(() => {
+    if (!urlStateStorage) return;
+    const { stop } = syncQueryStateWithUrl(
+      services.data.query,
+      urlStateStorage,
+      services.uiSettings
+    );
+    return stop;
+  }, [services.data.query, services.uiSettings, urlStateStorage]);
 
   // Is MDS active on this instance? When it is, the local cluster is hidden from the picker (see
   // DataSourceControl), so the ONLY queryable target is an explicitly-resolved data source. When
@@ -54,10 +79,36 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
   // own render gate so the two stay in sync.
   const mdsEnabled = !!services.dataSourceManagement?.ui?.DataSourceSelector;
   // Whether the selector has resolved to a concrete data source yet (only meaningful when MDS is on).
-  const [dataSourceResolved, setDataSourceResolved] = useState(false);
-  // With MDS on we must NOT fall back to local-cluster indexes when the workspace has no attached
-  // data sources — the picker reports an empty selection and we show an empty state instead.
+  // Seeded true when a data source was restored from the URL so the list shows immediately on reload.
+  const [dataSourceResolved, setDataSourceResolved] = useState(!!initialDataSource?.id);
+  // With MDS on we must NOT fall back to local-cluster indexes when no data source is selected — the
+  // picker reports an empty selection and we show one of the two empty states below instead.
   const canQueryIndexes = !mdsEnabled || (dataSourceResolved && !!dataSourceId);
+
+  // Does the (workspace-scoped) instance have ANY data source at all? Distinguishes the two empty
+  // states: none exist (associate one) vs. some exist but none picked yet (select one). undefined =
+  // not yet checked. Probed lazily ONLY while gated (no source resolved) — so when the picker
+  // auto-selects a source we show the list and never make this call. It's a `perPage:1` existence
+  // check, not a full list fetch. (The selector fetches the full list itself for its dropdown; we
+  // can't observe that, so this is the minimal extra probe needed to pick the right copy.)
+  const [hasAnyDataSource, setHasAnyDataSource] = useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    if (!mdsEnabled || canQueryIndexes || hasAnyDataSource !== undefined) return;
+    let cancelled = false;
+    services.savedObjects.client
+      .find({ type: 'data-source', fields: ['id'], perPage: 1 })
+      .then((res) => {
+        if (!cancelled) setHasAnyDataSource((res?.total ?? 0) > 0);
+      })
+      .catch(() => {
+        // On error, assume some may exist so we prompt to SELECT (never falsely claim none) — the
+        // picker itself surfaces any fetch failure.
+        if (!cancelled) setHasAnyDataSource(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mdsEnabled, canQueryIndexes, hasAnyDataSource, services.savedObjects.client]);
 
   // Shared, debounced search across datasets + indexes.
   const [searchInput, setSearchInput] = useState('');
@@ -119,17 +170,21 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
     [timefilter]
   );
 
-  const onDataSourceChange = useCallback((ds: { id?: string; title?: string }) => {
-    // An `id` means a concrete data source is selected. An empty id means the picker reported no
-    // selection — with MDS on that's an empty workspace (no attached data sources), which must NOT
-    // silently fall back to the local cluster (`dataSourceResolved` stays false → empty state).
-    setDataSourceResolved(!!ds.id);
-    setSelectedDataSource(
-      ds.id
+  const onDataSourceChange = useCallback(
+    (ds: { id?: string; title?: string }) => {
+      // An `id` means a concrete data source is selected. An empty id means the picker reported no
+      // selection — with MDS on that's an empty workspace (no attached data sources), which must NOT
+      // silently fall back to the local cluster (`dataSourceResolved` stays false → empty state).
+      setDataSourceResolved(!!ds.id);
+      const nextDataSource = ds.id
         ? ({ id: ds.id, title: ds.title ?? '', type: 'DATA_SOURCE' } as Dataset['dataSource'])
-        : undefined
-    );
-  }, []);
+        : undefined;
+      setSelectedDataSource(nextDataSource);
+      // Persist to the `_a` URL key so the selection is restored on reload / shared via the URL.
+      urlStateStorage?.set('_a', { dataSource: nextDataSource }, { replace: true });
+    },
+    [urlStateStorage]
+  );
 
   const { classify, getCached } = useIndexClassification(services, dataSourceId);
 
@@ -156,7 +211,11 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
         className="logsDrilldown__toolbar"
       >
         <EuiFlexItem grow={false} className="logsDrilldown__toolbarDs">
-          <DataSourceControl services={services} onChange={onDataSourceChange} />
+          <DataSourceControl
+            services={services}
+            onChange={onDataSourceChange}
+            defaultDataSourceId={initialDataSource?.id}
+          />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFieldSearch
@@ -195,7 +254,15 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
         )}
       </EuiFlexGroup>
     ),
-    [services, onDataSourceChange, searchInput, batchAction, setHeaderActionMenu, datePicker]
+    [
+      services,
+      onDataSourceChange,
+      searchInput,
+      batchAction,
+      setHeaderActionMenu,
+      datePicker,
+      initialDataSource,
+    ]
   );
 
   return (
@@ -220,16 +287,16 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
           rangeTo={rangeTo}
           onBatchActionChange={setBatchAction}
         />
-      ) : (
-        // MDS is on but no data source is attached to this workspace → we deliberately don't fall
-        // back to the local cluster; guide the user to connect one instead.
+      ) : hasAnyDataSource === false ? (
+        // No data sources exist in this workspace at all → nothing to select; guide the user to
+        // associate one. (We deliberately don't fall back to the local cluster.)
         <EuiEmptyPrompt
           iconType="database"
           data-test-subj="logsDrilldownNoDataSource"
           title={
             <h2>
               {i18n.translate('explore.logsDrilldown.noDataSource.title', {
-                defaultMessage: 'No data source connected',
+                defaultMessage: 'No data sources available',
               })}
             </h2>
           }
@@ -238,6 +305,28 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
               {i18n.translate('explore.logsDrilldown.noDataSource.body', {
                 defaultMessage:
                   'This workspace has no data sources associated with it. Associate a data source to explore its indexes and logs.',
+              })}
+            </p>
+          }
+        />
+      ) : (
+        // Data sources exist but none is selected yet → prompt the user to pick one from the toolbar
+        // picker. (hasAnyDataSource === true, or still undefined/loading — select is the safe copy.)
+        <EuiEmptyPrompt
+          iconType="database"
+          data-test-subj="logsDrilldownSelectDataSource"
+          title={
+            <h2>
+              {i18n.translate('explore.logsDrilldown.selectDataSource.title', {
+                defaultMessage: 'Select a data source',
+              })}
+            </h2>
+          }
+          body={
+            <p>
+              {i18n.translate('explore.logsDrilldown.selectDataSource.body', {
+                defaultMessage:
+                  'Choose a data source from the picker above to explore its indexes and logs.',
               })}
             </p>
           }

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
@@ -1,0 +1,248 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './index.scss';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFieldSearch,
+  EuiSuperDatePicker,
+  EuiSpacer,
+  OnTimeChangeProps,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import useDebounce from 'react-use/lib/useDebounce';
+import { AppMountParameters } from 'opensearch-dashboards/public';
+import { MountPointPortal } from '../../../../../opensearch_dashboards_react/public';
+import { Dataset } from '../../../../../data/common';
+import { ExploreServices } from '../../../types';
+import { DataSourceControl } from './components/data_source_control';
+import { RowsView, BatchAction } from './components/rows_view';
+import { useIndexClassification } from './hooks/use_index_classification';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+type Props = {
+  services: ExploreServices;
+} & Partial<Pick<AppMountParameters, 'setHeaderActionMenu'>>;
+
+/**
+ * LogsDrilldownPage — the standalone onboarding canvas (Grafana-style logs drilldown).
+ *
+ * Rows-only: a full-width vertical stack of per-item cards (histogram + raw log lines), teaching the
+ * `data source → index → dataset` hierarchy and turning raw indexes into a durable dataset. Fully
+ * self-contained: no explore Redux store; the data source is local React state, the global time
+ * range drives the previews, and activating/creating a dataset hands off to the logs Query app.
+ */
+export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMenu }) => {
+  const timefilter = services.data.query.timefilter.timefilter;
+
+  // Data source scoping the list (MDS). Local state — no Redux.
+  const [selectedDataSource, setSelectedDataSource] = useState<Dataset['dataSource']>(undefined);
+  const dataSource = selectedDataSource;
+  const dataSourceId = dataSource?.id;
+
+  // Is MDS active on this instance? When it is, the local cluster is hidden from the picker (see
+  // DataSourceControl), so the ONLY queryable target is an explicitly-resolved data source. When
+  // MDS is off, the implicit local cluster is the queryable target. We mirror DataSourceControl's
+  // own render gate so the two stay in sync.
+  const mdsEnabled = !!services.dataSourceManagement?.ui?.DataSourceSelector;
+  // Whether the selector has resolved to a concrete data source yet (only meaningful when MDS is on).
+  const [dataSourceResolved, setDataSourceResolved] = useState(false);
+  // With MDS on we must NOT fall back to local-cluster indexes when the workspace has no attached
+  // data sources — the picker reports an empty selection and we show an empty state instead.
+  const canQueryIndexes = !mdsEnabled || (dataSourceResolved && !!dataSourceId);
+
+  // Shared, debounced search across datasets + indexes.
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  useDebounce(() => setSearch(searchInput), SEARCH_DEBOUNCE_MS, [searchInput]);
+
+  // The batch (multi-select) action RowsView reports up — drives the toolbar button.
+  const [batchAction, setBatchAction] = useState<BatchAction | null>(null);
+
+  // Page breadcrumb. This standalone app has no explore tab chrome, so it sets its own.
+  useEffect(() => {
+    services.chrome.setBreadcrumbs([
+      {
+        text: i18n.translate('explore.logsDrilldown.breadcrumb', {
+          defaultMessage: 'Logs drilldown',
+        }),
+      },
+    ]);
+  }, [services.chrome]);
+
+  // Global time range mirror, so the date picker reflects + drives the shared timefilter.
+  const [time, setTime] = useState(() => timefilter.getTime());
+  useEffect(() => {
+    const sub = timefilter.getTimeUpdate$().subscribe(() => setTime(timefilter.getTime()));
+    return () => sub.unsubscribe();
+  }, [timefilter]);
+
+  // Manual refresh: a monotonically-increasing nonce folded into refreshKey, so pressing the update
+  // button re-runs the scheduler even when the time range string hasn't changed.
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const onRefresh = useCallback(() => setRefreshNonce((n) => n + 1), []);
+
+  // refreshKey changes when the range OR the manual-refresh nonce changes → RowsView re-fetches.
+  const refreshKey = `${time.from}|${time.to}|${refreshNonce}`;
+
+  // Resolve the picked range to epoch-ms bounds for the "No events in the last {range}" copy.
+  // Depends on time.from/time.to intentionally — getBounds() reflects the range but isn't itself a dep.
+  const { rangeFrom, rangeTo } = useMemo(() => {
+    const bounds = timefilter.getBounds();
+    return {
+      rangeFrom: bounds?.min?.valueOf() ?? Date.now() - 15 * 60 * 1000,
+      rangeTo: bounds?.max?.valueOf() ?? Date.now(),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timefilter, time.from, time.to]);
+
+  const onTimeChange = useCallback(
+    ({ start, end }: OnTimeChangeProps) => {
+      timefilter.setTime({ from: start, to: end });
+    },
+    [timefilter]
+  );
+
+  // Brush-select on a card histogram → set the global time range to the selected [from,to] (ISO).
+  const onBrushTime = useCallback(
+    (from: number, to: number) => {
+      timefilter.setTime({ from: new Date(from).toISOString(), to: new Date(to).toISOString() });
+    },
+    [timefilter]
+  );
+
+  const onDataSourceChange = useCallback((ds: { id?: string; title?: string }) => {
+    // An `id` means a concrete data source is selected. An empty id means the picker reported no
+    // selection — with MDS on that's an empty workspace (no attached data sources), which must NOT
+    // silently fall back to the local cluster (`dataSourceResolved` stays false → empty state).
+    setDataSourceResolved(!!ds.id);
+    setSelectedDataSource(
+      ds.id
+        ? ({ id: ds.id, title: ds.title ?? '', type: 'DATA_SOURCE' } as Dataset['dataSource'])
+        : undefined
+    );
+  }, []);
+
+  const { classify, getCached } = useIndexClassification(services, dataSourceId);
+
+  const datePicker = useMemo(
+    () => (
+      <EuiSuperDatePicker
+        compressed
+        start={time.from}
+        end={time.to}
+        onTimeChange={onTimeChange}
+        onRefresh={onRefresh}
+        showUpdateButton
+      />
+    ),
+    [time.from, time.to, onTimeChange, onRefresh]
+  );
+
+  const toolbar = useMemo(
+    () => (
+      <EuiFlexGroup
+        gutterSize="s"
+        alignItems="center"
+        responsive={false}
+        className="logsDrilldown__toolbar"
+      >
+        <EuiFlexItem grow={false} className="logsDrilldown__toolbarDs">
+          <DataSourceControl services={services} onChange={onDataSourceChange} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFieldSearch
+            compressed
+            fullWidth
+            isClearable
+            placeholder={i18n.translate('explore.logsDrilldown.searchPlaceholder', {
+              defaultMessage: 'Search datasets and indexes…',
+            })}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            aria-label={i18n.translate('explore.logsDrilldown.searchAriaLabel', {
+              defaultMessage: 'Search datasets and indexes',
+            })}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            size="s"
+            fill
+            isDisabled={!batchAction}
+            onClick={() => batchAction?.onClick()}
+            data-test-subj="logsExploreToolbarBatch"
+          >
+            {batchAction?.label ??
+              i18n.translate('explore.logsDrilldown.rows.createDataset', {
+                defaultMessage: 'Create dataset',
+              })}
+          </EuiButton>
+        </EuiFlexItem>
+        {/* When there's no app header to portal into (embedded / tests), keep the picker inline. */}
+        {!setHeaderActionMenu && (
+          <EuiFlexItem grow={false} className="logsDrilldown__toolbarTime">
+            {datePicker}
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    ),
+    [services, onDataSourceChange, searchInput, batchAction, setHeaderActionMenu, datePicker]
+  );
+
+  return (
+    <div className="logsDrilldown" data-test-subj="logsDrilldownPage">
+      {/* Portal the date picker + refresh into the app header, like the Logs Query experience. */}
+      {setHeaderActionMenu && (
+        <MountPointPortal setMountPoint={setHeaderActionMenu}>{datePicker}</MountPointPortal>
+      )}
+      {toolbar}
+      <EuiSpacer size="s" />
+      {canQueryIndexes ? (
+        <RowsView
+          services={services}
+          dataSourceId={dataSourceId}
+          dataSource={dataSource}
+          search={search}
+          refreshKey={refreshKey}
+          classify={classify}
+          getCached={getCached}
+          onBrushTime={onBrushTime}
+          rangeFrom={rangeFrom}
+          rangeTo={rangeTo}
+          onBatchActionChange={setBatchAction}
+        />
+      ) : (
+        // MDS is on but no data source is attached to this workspace → we deliberately don't fall
+        // back to the local cluster; guide the user to connect one instead.
+        <EuiEmptyPrompt
+          iconType="database"
+          data-test-subj="logsDrilldownNoDataSource"
+          title={
+            <h2>
+              {i18n.translate('explore.logsDrilldown.noDataSource.title', {
+                defaultMessage: 'No data source connected',
+              })}
+            </h2>
+          }
+          body={
+            <p>
+              {i18n.translate('explore.logsDrilldown.noDataSource.body', {
+                defaultMessage:
+                  'This workspace has no data sources associated with it. Associate a data source to explore its indexes and logs.',
+              })}
+            </p>
+          }
+        />
+      )}
+    </div>
+  );
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
@@ -14,6 +14,7 @@ import {
   EuiFieldSearch,
   EuiSuperDatePicker,
   EuiSpacer,
+  EuiToolTip,
   OnTimeChangeProps,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
@@ -59,6 +60,20 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
   );
   const dataSource = selectedDataSource;
   const dataSourceId = dataSource?.id;
+
+  // Default the time range to the last 15 minutes on mount UNLESS this drilldown's own URL already
+  // pins a range (`_g.time`). The timefilter is a shared singleton, so without this the drilldown
+  // would inherit whatever (possibly very wide) range the Logs Query page had — flooding the cluster
+  // with heavy per-card queries on first load. A user-picked range persists to `_g` (via the sync
+  // below), so it survives reloads and is respected here. Runs once, before the URL sync starts.
+  useEffect(() => {
+    const urlTime = urlStateStorage?.get<{ time?: unknown }>('_g')?.time;
+    if (!urlTime) {
+      timefilter.setTime({ from: 'now-15m', to: 'now' });
+    }
+    // Mount-only: we intentionally read the URL once and don't re-run on range changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Sync the global time range (`_g`) with the URL so it survives a hard reload and stays shareable
   // — the time range is already shared across apps via the singleton timefilter; this adds URL
@@ -144,17 +159,6 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
   // refreshKey changes when the range OR the manual-refresh nonce changes → RowsView re-fetches.
   const refreshKey = `${time.from}|${time.to}|${refreshNonce}`;
 
-  // Resolve the picked range to epoch-ms bounds for the "No events in the last {range}" copy.
-  // Depends on time.from/time.to intentionally — getBounds() reflects the range but isn't itself a dep.
-  const { rangeFrom, rangeTo } = useMemo(() => {
-    const bounds = timefilter.getBounds();
-    return {
-      rangeFrom: bounds?.min?.valueOf() ?? Date.now() - 15 * 60 * 1000,
-      rangeTo: bounds?.max?.valueOf() ?? Date.now(),
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timefilter, time.from, time.to]);
-
   const onTimeChange = useCallback(
     ({ start, end }: OnTimeChangeProps) => {
       timefilter.setTime({ from: start, to: end });
@@ -233,18 +237,30 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
-            size="s"
-            fill
-            isDisabled={!batchAction}
-            onClick={() => batchAction?.onClick()}
-            data-test-subj="logsExploreToolbarBatch"
+          <EuiToolTip
+            // Only explain the disabled state; when enabled the button label is self-explanatory.
+            // EuiToolTip anchors on its wrapper span, so it still shows over the disabled button.
+            content={
+              batchAction
+                ? undefined
+                : i18n.translate('explore.logsDrilldown.rows.createDatasetDisabledTip', {
+                    defaultMessage: 'Select one or more indexes to create a dataset',
+                  })
+            }
           >
-            {batchAction?.label ??
-              i18n.translate('explore.logsDrilldown.rows.createDataset', {
-                defaultMessage: 'Create dataset',
-              })}
-          </EuiButton>
+            <EuiButton
+              size="s"
+              fill
+              isDisabled={!batchAction}
+              onClick={() => batchAction?.onClick()}
+              data-test-subj="logsExploreToolbarBatch"
+            >
+              {batchAction?.label ??
+                i18n.translate('explore.logsDrilldown.rows.createDataset', {
+                  defaultMessage: 'Create dataset',
+                })}
+            </EuiButton>
+          </EuiToolTip>
         </EuiFlexItem>
         {/* When there's no app header to portal into (embedded / tests), keep the picker inline. */}
         {!setHeaderActionMenu && (
@@ -283,8 +299,6 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
           classify={classify}
           getCached={getCached}
           onBrushTime={onBrushTime}
-          rangeFrom={rangeFrom}
-          rangeTo={rangeTo}
           onBatchActionChange={setBatchAction}
         />
       ) : hasAnyDataSource === false ? (
@@ -308,6 +322,18 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
               })}
             </p>
           }
+          actions={[
+            <EuiButton
+              key="associate"
+              fill
+              onClick={() => services.core.application.navigateToApp('dataSources')}
+              data-test-subj="logsDrilldownAssociateDataSource"
+            >
+              {i18n.translate('explore.logsDrilldown.noDataSource.associate', {
+                defaultMessage: 'Associate a data source',
+              })}
+            </EuiButton>,
+          ]}
         />
       ) : (
         // Data sources exist but none is selected yet → prompt the user to pick one from the toolbar

--- a/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/logs_drilldown_page.tsx
@@ -66,9 +66,8 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
   }, []);
 
   // Data source scoping the list (MDS). Local state, mirrored to the `_a` URL key.
-  const [selectedDataSource, setSelectedDataSource] = useState<Dataset['dataSource']>(
-    initialDataSource
-  );
+  const [selectedDataSource, setSelectedDataSource] =
+    useState<Dataset['dataSource']>(initialDataSource);
   const dataSource = selectedDataSource;
   const dataSourceId = dataSource?.id;
 
@@ -159,7 +158,7 @@ export const LogsDrilldownPage: React.FC<Props> = ({ services, setHeaderActionMe
     services.chrome.setBreadcrumbs([
       {
         text: i18n.translate('explore.logsDrilldown.breadcrumb', {
-          defaultMessage: 'Logs drilldown',
+          defaultMessage: 'Explore logs',
         }),
       },
     ]);

--- a/src/plugins/explore/public/application/pages/logs_drilldown/permission_toast.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/permission_toast.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  isClientAuthError,
+  maybeNotifyPermissionDenied,
+  notifyPermissionDenied,
+  resetPermissionToast,
+} from './permission_toast';
+
+jest.mock('@osd/i18n', () => ({
+  i18n: { translate: (_k: string, o: { defaultMessage: string }) => o.defaultMessage },
+}));
+
+const addWarning = jest.fn();
+const makeServices = () => ({ notifications: { toasts: { addWarning } } }) as unknown as any;
+
+describe('permission_toast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetPermissionToast();
+  });
+
+  describe('isClientAuthError', () => {
+    it.each([
+      [{ statusCode: 403 }, true],
+      [{ statusCode: 401 }, true],
+      [{ body: { statusCode: 403 } }, true],
+      [{ status: 403 }, true],
+      [new Error('security_exception: no permissions for [indices:data/read/search]'), true],
+      [new Error('403 Forbidden'), true],
+      [{ statusCode: 500 }, false],
+      [{ statusCode: 404 }, true], // 4xx family — still a client error
+      [new Error('some unrelated failure'), false],
+      [undefined, false],
+    ])('classifies %j → %s', (err, expected) => {
+      expect(isClientAuthError(err)).toBe(expected);
+    });
+  });
+
+  it('shows exactly ONE warning toast across many auth failures', () => {
+    const services = makeServices();
+    maybeNotifyPermissionDenied(services, { statusCode: 403 }); // cat.indices
+    maybeNotifyPermissionDenied(services, { statusCode: 403 }); // card preview #1
+    maybeNotifyPermissionDenied(services, new Error('security_exception')); // card preview #2
+    expect(addWarning).toHaveBeenCalledTimes(1);
+    expect(addWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Index health & size unavailable — check permissions.',
+      })
+    );
+  });
+
+  it('does NOT toast for non-4xx failures', () => {
+    const services = makeServices();
+    expect(maybeNotifyPermissionDenied(services, { statusCode: 500 })).toBe(false);
+    expect(maybeNotifyPermissionDenied(services, new Error('timeout'))).toBe(false);
+    expect(addWarning).not.toHaveBeenCalled();
+  });
+
+  it('toasts again after reset (a new view / data source)', () => {
+    const services = makeServices();
+    notifyPermissionDenied(services);
+    notifyPermissionDenied(services);
+    expect(addWarning).toHaveBeenCalledTimes(1);
+
+    resetPermissionToast();
+    notifyPermissionDenied(services);
+    expect(addWarning).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/permission_toast.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/permission_toast.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { ExploreServices } from '../../../types';
+
+/**
+ * Was this failure a 4xx client error (typically 403 permission denied / 401 auth)? The drilldown
+ * hits several APIs (resolve_index/cat.indices for the list + metadata, PPL search for previews and
+ * histograms); a locked-down role can 4xx on any of them. We detect the status from the several
+ * shapes OSD/opensearch-js surface it in, plus a text fallback for security-plugin messages.
+ */
+export const isClientAuthError = (e: unknown): boolean => {
+  const err = e as
+    | { statusCode?: number; status?: number; body?: { statusCode?: number; status?: number } }
+    | undefined;
+  const status =
+    err?.statusCode ?? err?.status ?? err?.body?.statusCode ?? err?.body?.status ?? undefined;
+  if (typeof status === 'number' && status >= 400 && status < 500) return true;
+  const raw = e instanceof Error ? e.message : String(e ?? '');
+  return /\b40[13]\b|forbidden|unauthorized|not authorized|no permissions for|security_exception/i.test(
+    raw
+  );
+};
+
+/**
+ * Show a SINGLE permission-denied toast for the whole Logs Drilldown view, no matter how many of its
+ * API calls 4xx. The drilldown fires up to three kinds of request (index list/metadata via
+ * resolve_index + cat.indices, and per-card PPL preview/histogram); without this guard a locked-down
+ * role would get a burst of identical toasts. The flag resets when a new view mounts (see reset()).
+ */
+let shown = false;
+
+export const resetPermissionToast = (): void => {
+  shown = false;
+};
+
+export const notifyPermissionDenied = (services: ExploreServices): void => {
+  if (shown) return;
+  shown = true;
+  services.notifications.toasts.addWarning({
+    title: i18n.translate('explore.logsDrilldown.permissionToast.title', {
+      defaultMessage: 'Some index details are unavailable',
+    }),
+    text: i18n.translate('explore.logsDrilldown.permissionToast.text', {
+      defaultMessage: 'Index health & size unavailable — check permissions.',
+    }),
+  });
+};
+
+/** If the error is a 4xx auth/permission error, surface the one-time toast. Returns whether it was. */
+export const maybeNotifyPermissionDenied = (services: ExploreServices, e: unknown): boolean => {
+  if (!isClientAuthError(e)) return false;
+  notifyPermissionDenied(services);
+  return true;
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/row_state.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/row_state.test.ts
@@ -27,12 +27,65 @@ describe('deriveRowState', () => {
     expect(deriveRowState({ ...base, docsCount: undefined })).toBe(LogRowState.LOADING);
   });
 
-  it('NO_RECENT requires a resolved histogram summing to zero', () => {
+  it('NO_RECENT when a resolved histogram sums to zero', () => {
     expect(deriveRowState({ ...base, docsCount: 42, hasResult: true, histogramTotalsSum: 0 })).toBe(
       LogRowState.NO_RECENT
     );
     // No result yet → still loading, not no-recent.
     expect(deriveRowState({ ...base, docsCount: 42, hasResult: false })).toBe(LogRowState.LOADING);
+  });
+
+  it('falls back to the preview row count when the (best-effort) histogram did not resolve', () => {
+    // Histogram absent (undefined total) but the time-bounded preview came back with 0 rows → the
+    // index genuinely has no recent data. This is the deterministic fallback that stops the row from
+    // flip-flopping between NO_RECENT and FULL depending on whether the histogram query succeeded.
+    expect(
+      deriveRowState({
+        ...base,
+        docsCount: 42,
+        hasResult: true,
+        histogramTotalsSum: undefined,
+        previewRowCount: 0,
+      })
+    ).toBe(LogRowState.NO_RECENT);
+    // Histogram absent but the preview has rows → FULL.
+    expect(
+      deriveRowState({
+        ...base,
+        docsCount: 42,
+        hasResult: true,
+        histogramTotalsSum: undefined,
+        previewRowCount: 5,
+      })
+    ).toBe(LogRowState.FULL);
+  });
+
+  it('the histogram total wins over the preview count when both are present', () => {
+    // Histogram says there is data → FULL even if the preview page happened to be empty.
+    expect(
+      deriveRowState({
+        ...base,
+        docsCount: 42,
+        hasResult: true,
+        histogramTotalsSum: 100,
+        previewRowCount: 0,
+      })
+    ).toBe(LogRowState.FULL);
+    // Histogram says zero → NO_RECENT even if a stray preview row exists.
+    expect(
+      deriveRowState({
+        ...base,
+        docsCount: 42,
+        hasResult: true,
+        histogramTotalsSum: 0,
+        previewRowCount: 3,
+      })
+    ).toBe(LogRowState.NO_RECENT);
+  });
+
+  it('resolved with neither histogram nor preview counts → FULL (safe default, not dead)', () => {
+    // Both undefined (e.g. non-time index result): don't demote to the dead group on a missing signal.
+    expect(deriveRowState({ ...base, docsCount: 42, hasResult: true })).toBe(LogRowState.FULL);
   });
 
   it('LOADING when unresolved and not otherwise classified', () => {

--- a/src/plugins/explore/public/application/pages/logs_drilldown/row_state.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/row_state.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LogRowState, deriveRowState, isDead, formatRangeLabel } from './row_state';
+
+describe('deriveRowState', () => {
+  const base = { kind: 'index' as const, hasResult: false, hasError: false };
+
+  it('NO_TIME_FIELD wins over everything (even an error/empty)', () => {
+    expect(deriveRowState({ ...base, isNoTimeField: true, hasError: true, docsCount: 0 })).toBe(
+      LogRowState.NO_TIME_FIELD
+    );
+  });
+
+  it('ERROR wins over empty/no-recent', () => {
+    expect(deriveRowState({ ...base, hasError: true, docsCount: 0 })).toBe(LogRowState.ERROR);
+    expect(
+      deriveRowState({ ...base, hasError: true, hasResult: true, histogramTotalsSum: 0 })
+    ).toBe(LogRowState.ERROR);
+  });
+
+  it('EMPTY_INDEX fires only on an explicit docsCount === 0', () => {
+    expect(deriveRowState({ ...base, docsCount: 0 })).toBe(LogRowState.EMPTY_INDEX);
+    // undefined (remote/closed/unknown) must NOT be treated as empty.
+    expect(deriveRowState({ ...base, docsCount: undefined })).toBe(LogRowState.LOADING);
+  });
+
+  it('NO_RECENT requires a resolved histogram summing to zero', () => {
+    expect(deriveRowState({ ...base, docsCount: 42, hasResult: true, histogramTotalsSum: 0 })).toBe(
+      LogRowState.NO_RECENT
+    );
+    // No result yet → still loading, not no-recent.
+    expect(deriveRowState({ ...base, docsCount: 42, hasResult: false })).toBe(LogRowState.LOADING);
+  });
+
+  it('LOADING when unresolved and not otherwise classified', () => {
+    expect(deriveRowState({ ...base, docsCount: 10 })).toBe(LogRowState.LOADING);
+  });
+
+  it('FULL when resolved with events in range', () => {
+    expect(
+      deriveRowState({ ...base, docsCount: 10, hasResult: true, histogramTotalsSum: 128 })
+    ).toBe(LogRowState.FULL);
+  });
+
+  it('datasets are never treated as no-time-field even if the flag leaks', () => {
+    expect(
+      deriveRowState({
+        kind: 'dataset',
+        isNoTimeField: true,
+        hasResult: true,
+        hasError: false,
+        histogramTotalsSum: 5,
+      })
+    ).toBe(LogRowState.FULL);
+  });
+});
+
+describe('isDead', () => {
+  it('NO_RECENT and EMPTY_INDEX are dead; others are not', () => {
+    expect(isDead(LogRowState.NO_RECENT)).toBe(true);
+    expect(isDead(LogRowState.EMPTY_INDEX)).toBe(true);
+    expect(isDead(LogRowState.LOADING)).toBe(false);
+    expect(isDead(LogRowState.FULL)).toBe(false);
+    expect(isDead(LogRowState.ERROR)).toBe(false);
+    expect(isDead(LogRowState.NO_TIME_FIELD)).toBe(false);
+  });
+});
+
+describe('formatRangeLabel', () => {
+  it('humanizes common spans', () => {
+    const from = Date.parse('2026-07-15T00:00:00Z');
+    expect(formatRangeLabel(from, from + 15 * 60 * 1000)).toBe('15 minutes');
+    expect(formatRangeLabel(from, from + 24 * 60 * 60 * 1000)).toBe('a day');
+  });
+
+  it('returns empty for a non-positive or invalid span', () => {
+    expect(formatRangeLabel(100, 100)).toBe('');
+    expect(formatRangeLabel(200, 100)).toBe('');
+    expect(formatRangeLabel(NaN, 100)).toBe('');
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/row_state.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/row_state.ts
@@ -37,6 +37,10 @@ interface DeriveArgs {
   hasError: boolean;
   /** Sum of the histogram severity totals for the selected window (undefined = no histogram yet). */
   histogramTotalsSum?: number;
+  /** Count of preview log lines returned for the selected window (undefined = no preview yet).
+   *  The histogram is best-effort and can fail independently; the time-bounded preview is the
+   *  authoritative "has recent data?" signal so the row-state stays deterministic when it doesn't. */
+  previewRowCount?: number;
 }
 
 /**
@@ -45,8 +49,11 @@ interface DeriveArgs {
  *
  * Rationale for the order: a structural fact (no time field) trumps everything; a hard failure
  * (error) trumps emptiness; a definitively-empty index (docs.count === 0, known up-front from
- * cat.indices) trumps a window-empty one; "no events in range" only applies once a histogram has
- * come back with a zero total; otherwise we're still loading, and finally the happy full card.
+ * cat.indices) trumps a window-empty one; "no events in range" applies once EITHER the histogram
+ * has come back with a zero total OR the (time-bounded) preview came back with zero rows — the
+ * histogram is best-effort and can fail independently, so relying on it alone made a window-empty
+ * index flip between "no recent data" and the full list across loads; otherwise we're still loading,
+ * and finally the happy full card.
  */
 export const deriveRowState = ({
   kind,
@@ -55,16 +62,21 @@ export const deriveRowState = ({
   hasResult,
   hasError,
   histogramTotalsSum,
+  previewRowCount,
 }: DeriveArgs): LogRowState => {
   if (kind === 'index' && isNoTimeField) return LogRowState.NO_TIME_FIELD;
   if (hasError) return LogRowState.ERROR;
   // Empty-index is known synchronously from cat.indices — only ever on an explicit 0, never on
   // `undefined` (remote/closed indices report no count and must not be mistaken for empty).
   if (docsCount === 0) return LogRowState.EMPTY_INDEX;
-  // "No events in range" requires a resolved histogram whose totals sum to exactly zero.
-  if (hasResult && histogramTotalsSum === 0) return LogRowState.NO_RECENT;
   if (!hasResult) return LogRowState.LOADING;
-  return LogRowState.FULL;
+  // Resolved: decide "no events in range" from whichever in-window signal is available. Prefer the
+  // histogram total; if the (best-effort) histogram didn't resolve, fall back to the preview row
+  // count. Relying on the histogram alone made a window-empty index flip between NO_RECENT and the
+  // full list depending on whether that query happened to succeed.
+  const emptyInRange =
+    histogramTotalsSum !== undefined ? histogramTotalsSum === 0 : previewRowCount === 0;
+  return emptyInRange ? LogRowState.NO_RECENT : LogRowState.FULL;
 };
 
 /**

--- a/src/plugins/explore/public/application/pages/logs_drilldown/row_state.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/row_state.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import moment from 'moment';
+
+/**
+ * The visual state a drilldown row resolves to. This is the single source of truth for which card
+ * variant renders — a full histogram+logs card, one of the compact one-row treatments, or the
+ * collapsed/no-time-field row — so `rows_view` and `log_stream_card` never re-derive it ad hoc.
+ */
+export enum LogRowState {
+  /** Fetch not yet resolved (no result, no error). Stays in the primary list (in place). */
+  LOADING = 'loading',
+  /** Has events in the selected window → the full histogram + log-lines card. */
+  FULL = 'full',
+  /** Has documents but none in the selected time range → compact "No events in the last {range}". */
+  NO_RECENT = 'no_recent',
+  /** Zero documents ever (docs.count === 0) → compact "No documents yet"; no create action. */
+  EMPTY_INDEX = 'empty_index',
+  /** The preview fetch failed → compact danger/warning row with the error + Retry. */
+  ERROR = 'error',
+  /** Index has no date field → collapsed row; can't chart or become a dataset. */
+  NO_TIME_FIELD = 'no_time_field',
+}
+
+interface DeriveArgs {
+  kind: 'index' | 'dataset';
+  /** True when a raw index has been classified as having no date field. */
+  isNoTimeField?: boolean;
+  /** Cumulative doc count from cat.indices; `0` ⇒ empty index, `undefined` ⇒ unknown. */
+  docsCount?: number;
+  /** Whether this row's preview/histogram fetch has produced a result. */
+  hasResult: boolean;
+  /** Whether this row's (preview) fetch errored. */
+  hasError: boolean;
+  /** Sum of the histogram severity totals for the selected window (undefined = no histogram yet). */
+  histogramTotalsSum?: number;
+}
+
+/**
+ * Resolve a row's {@link LogRowState}. Precedence (highest first):
+ *   NO_TIME_FIELD → ERROR → EMPTY_INDEX → NO_RECENT → LOADING → FULL
+ *
+ * Rationale for the order: a structural fact (no time field) trumps everything; a hard failure
+ * (error) trumps emptiness; a definitively-empty index (docs.count === 0, known up-front from
+ * cat.indices) trumps a window-empty one; "no events in range" only applies once a histogram has
+ * come back with a zero total; otherwise we're still loading, and finally the happy full card.
+ */
+export const deriveRowState = ({
+  kind,
+  isNoTimeField,
+  docsCount,
+  hasResult,
+  hasError,
+  histogramTotalsSum,
+}: DeriveArgs): LogRowState => {
+  if (kind === 'index' && isNoTimeField) return LogRowState.NO_TIME_FIELD;
+  if (hasError) return LogRowState.ERROR;
+  // Empty-index is known synchronously from cat.indices — only ever on an explicit 0, never on
+  // `undefined` (remote/closed indices report no count and must not be mistaken for empty).
+  if (docsCount === 0) return LogRowState.EMPTY_INDEX;
+  // "No events in range" requires a resolved histogram whose totals sum to exactly zero.
+  if (hasResult && histogramTotalsSum === 0) return LogRowState.NO_RECENT;
+  if (!hasResult) return LogRowState.LOADING;
+  return LogRowState.FULL;
+};
+
+/**
+ * A "dead" row is one that carries no events to look at in the current window and can be demoted
+ * into the collapsed "no recent data" drawer at the bottom of the list. LOADING/UNKNOWN rows are
+ * NOT dead (we can't know until their fetch lands), which is what keeps the sort from thrashing.
+ */
+export const isDead = (state: LogRowState): boolean =>
+  state === LogRowState.NO_RECENT || state === LogRowState.EMPTY_INDEX;
+
+/**
+ * A humanized label for a time range, e.g. `15 minutes`, `24 hours`. Used in copy such as
+ * "No events in the last {range}". Falls back to an empty string for a non-positive span.
+ */
+export const formatRangeLabel = (fromMs: number, toMs: number): string => {
+  const ms = toMs - fromMs;
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  return moment.duration(ms, 'milliseconds').humanize();
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/severity.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/severity.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { detectSeverityField, normalizeSeverity, pickTimeField } from './severity';
+
+describe('detectSeverityField', () => {
+  it('prefers severityText, then severity, then level', () => {
+    expect(detectSeverityField(['message', 'severityText', 'level'])).toBe('severityText');
+    expect(detectSeverityField(['message', 'severity', 'level'])).toBe('severity');
+    expect(detectSeverityField(['message', 'level'])).toBe('level');
+  });
+
+  it('falls back to severityNumber for numeric-only OTel indexes (text fields win when present)', () => {
+    // No text field → use severityNumber (the OTel numeric field).
+    expect(detectSeverityField(['message', 'severityNumber', '@timestamp'])).toBe('severityNumber');
+    // A text field is preferred over severityNumber when both exist.
+    expect(detectSeverityField(['severityNumber', 'severityText'])).toBe('severityText');
+    expect(detectSeverityField(['severityNumber', 'level'])).toBe('level');
+  });
+
+  it('returns undefined when no severity field exists', () => {
+    expect(detectSeverityField(['message', 'user_id', '@timestamp'])).toBeUndefined();
+  });
+});
+
+describe('pickTimeField', () => {
+  it('prefers the canonical OTel/PPL order (@timestamp → time → … → observedTimestamp)', () => {
+    expect(pickTimeField(['observedTimestamp', 'time', '@timestamp'])).toBe('@timestamp');
+    expect(pickTimeField(['observedTimestamp', 'time'])).toBe('time');
+    expect(pickTimeField(['observedTimestamp', 'endTime'])).toBe('endTime');
+  });
+
+  it('falls back to the first date field when none match the canonical list', () => {
+    expect(pickTimeField(['event.ingested', 'created_on'])).toBe('event.ingested');
+  });
+
+  it('returns undefined for no date fields', () => {
+    expect(pickTimeField([])).toBeUndefined();
+  });
+});
+
+describe('normalizeSeverity', () => {
+  it('buckets textual levels', () => {
+    expect(normalizeSeverity('INFO')).toBe('info');
+    expect(normalizeSeverity('Information')).toBe('info');
+    expect(normalizeSeverity('WARN')).toBe('warn');
+    expect(normalizeSeverity('warning')).toBe('warn');
+    expect(normalizeSeverity('ERROR')).toBe('error');
+    expect(normalizeSeverity('fatal')).toBe('error');
+    expect(normalizeSeverity('debug')).toBe('debug');
+    expect(normalizeSeverity('trace')).toBe('debug');
+  });
+
+  it('buckets OTel severityNumber ranges', () => {
+    expect(normalizeSeverity('9')).toBe('info');
+    expect(normalizeSeverity('13')).toBe('warn');
+    expect(normalizeSeverity('17')).toBe('error');
+    expect(normalizeSeverity('5')).toBe('debug');
+  });
+
+  it('returns unknown for empty/unrecognized values', () => {
+    expect(normalizeSeverity(undefined)).toBe('unknown');
+    expect(normalizeSeverity('')).toBe('unknown');
+    expect(normalizeSeverity('banana')).toBe('unknown');
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/severity.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/severity.ts
@@ -87,11 +87,17 @@ export const normalizeSeverity = (raw: unknown): SeverityBucket => {
   return 'unknown';
 };
 
+// Distinct colorblind-safe purple (euiPaletteColorBlind index 3) for the rare `debug` bucket, so it
+// stays separable from `unknown`, which now takes the prominent "regular logs" blue below.
+const DEBUG_PURPLE = '#9170B8';
+
 /**
  * THE single severity → color map for the whole drilldown. Used identically by the histogram bars,
  * the legend, and the log-line level tokens so a severity reads the same everywhere. Sourced from
- * the SAME palette Metrics Explore uses — `getColors()` status colors (theme-aware, WCAG-tuned) —
- * so the two experiences look like one system: error→red, warn→yellow, info→green, debug→blue.
+ * the SAME palette Metrics Explore uses — `getColors()` status colors (theme-aware, WCAG-tuned).
+ * error→red, warn→yellow, info→green. `unknown` (no recognized level — the common "just logs" case,
+ * and the color of a no-severity index's single series) takes the prominent blue; the rare `debug`
+ * takes a distinct purple so the two never collide (bugbash #2).
  */
 export const severityColor = (bucket: SeverityBucket): string => {
   const c = getColors();
@@ -103,9 +109,10 @@ export const severityColor = (bucket: SeverityBucket): string => {
     case 'info':
       return c.statusGreen;
     case 'debug':
-      return c.statusBlue;
+      return DEBUG_PURPLE;
     default:
-      return c.subText ?? '#8E96A3';
+      // `unknown` (and no-severity single-series logs) → the "regular logs" blue.
+      return c.statusBlue;
   }
 };
 

--- a/src/plugins/explore/public/application/pages/logs_drilldown/severity.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/severity.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getColors } from '../../../components/visualizations/theme/default_colors';
+
+/**
+ * Canonical OTel-ish severity field precedence. Matches the repo convention in
+ * `traces/.../ppl_request_logs.tsx` (`severityText || severity || level`). Field names are the
+ * flattened OTel LogRecord fields as stored in OpenSearch (Data Prepper / OTel exporter),
+ * i.e. `severityText` / `severityNumber` — NOT dotted `severity.text`.
+ *
+ * `severityNumber` is listed LAST so a human-readable text field (severityText/severity/level) is
+ * always preferred when present; a numeric-only OTel index still gets detected + bucketed via the
+ * OTel severityNumber ranges in `normalizeSeverity`.
+ */
+export const SEVERITY_FIELD_CANDIDATES = [
+  'severityText',
+  'severity',
+  'level',
+  'log.level',
+  'severityNumber',
+];
+
+/**
+ * Preferred time-field precedence — Data Prepper OTel mappings + PPL's expected default timestamp
+ * fields. When an index has several date fields we pick the first match here (rather than an
+ * arbitrary `dateFields[0]`), falling back to the first date field if none match.
+ */
+export const TIME_FIELD_CANDIDATES = [
+  '@timestamp',
+  'time',
+  'startTime',
+  'endTime',
+  'timestamp',
+  'observedTimestamp',
+];
+
+/**
+ * Choose the default time field from an index's date-typed field names, preferring the canonical
+ * OTel/PPL order above; falls back to the first date field. Returns undefined if there are none.
+ */
+export const pickTimeField = (dateFields: string[]): string | undefined => {
+  if (dateFields.length === 0) return undefined;
+  const set = new Set(dateFields);
+  return TIME_FIELD_CANDIDATES.find((f) => set.has(f)) ?? dateFields[0];
+};
+
+/**
+ * Pick the severity field for an index from its available field names, or undefined if none is
+ * present (→ plain single-series count histogram, uncolored level tokens).
+ */
+export const detectSeverityField = (fieldNames: string[]): string | undefined => {
+  const set = new Set(fieldNames);
+  return SEVERITY_FIELD_CANDIDATES.find((f) => set.has(f));
+};
+
+/** Coarse severity buckets we color by. */
+export type SeverityBucket = 'error' | 'warn' | 'info' | 'debug' | 'unknown';
+
+/**
+ * Normalize an arbitrary severity value (e.g. "INFO", "WARNING", "err", "ERROR", severityNumber
+ * as string) into a coarse bucket for coloring. OTel severityNumber ranges: 1-4 trace/debug,
+ * 5-8 debug, 9-12 info, 13-16 warn, 17-24 error/fatal.
+ */
+export const normalizeSeverity = (raw: unknown): SeverityBucket => {
+  if (raw == null) return 'unknown';
+  const s = String(raw).trim().toLowerCase();
+  if (s === '') return 'unknown';
+
+  // Numeric severityNumber form.
+  const n = Number(s);
+  if (Number.isFinite(n) && /^\d+$/.test(s)) {
+    if (n >= 17) return 'error';
+    if (n >= 13) return 'warn';
+    if (n >= 9) return 'info';
+    if (n >= 5) return 'debug';
+    return 'unknown';
+  }
+
+  if (/(^|[^a-z])(err|error|fatal|crit|critical|alert|emerg|severe)($|[^a-z])/.test(s))
+    return 'error';
+  if (/(^|[^a-z])(warn|warning)($|[^a-z])/.test(s)) return 'warn';
+  if (/(^|[^a-z])(info|information|notice)($|[^a-z])/.test(s)) return 'info';
+  if (/(^|[^a-z])(debug|trace|verbose|fine|finest)($|[^a-z])/.test(s)) return 'debug';
+  return 'unknown';
+};
+
+/**
+ * THE single severity → color map for the whole drilldown. Used identically by the histogram bars,
+ * the legend, and the log-line level tokens so a severity reads the same everywhere. Sourced from
+ * the SAME palette Metrics Explore uses — `getColors()` status colors (theme-aware, WCAG-tuned) —
+ * so the two experiences look like one system: error→red, warn→yellow, info→green, debug→blue.
+ */
+export const severityColor = (bucket: SeverityBucket): string => {
+  const c = getColors();
+  switch (bucket) {
+    case 'error':
+      return c.statusRed;
+    case 'warn':
+      return c.statusYellow;
+    case 'info':
+      return c.statusGreen;
+    case 'debug':
+      return c.statusBlue;
+    default:
+      return c.subText ?? '#8E96A3';
+  }
+};
+
+/** Color for a raw severity value in one step (normalize + map). */
+export const severityColorForValue = (raw: unknown): string =>
+  severityColor(normalizeSeverity(raw));

--- a/src/plugins/explore/public/application/pages/logs_drilldown/suggest_wildcard.test.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/suggest_wildcard.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  suggestWildcardFromName,
+  suggestWildcardFromNames,
+  longestCommonPrefix,
+  commaSeparated,
+  seedCreatePattern,
+} from './suggest_wildcard';
+
+describe('suggestWildcardFromName', () => {
+  it('strips a single trailing numeric counter', () => {
+    expect(suggestWildcardFromName('logs-0001')).toBe('logs-*');
+    expect(suggestWildcardFromName('my-name-logs-019')).toBe('my-name-logs-*');
+    expect(suggestWildcardFromName('nginx_access_000123')).toBe('nginx_access_*');
+  });
+
+  it('strips the ENTIRE trailing run of numeric date tokens', () => {
+    expect(suggestWildcardFromName('logs-2026.07.09')).toBe('logs-*');
+    expect(suggestWildcardFromName('logs-02.01.2026')).toBe('logs-*');
+    expect(suggestWildcardFromName('logs-02-01-2026')).toBe('logs-*');
+    expect(suggestWildcardFromName('logs-app-2026.07.09')).toBe('logs-app-*');
+  });
+
+  it('anchors the wildcard at the correct mixed separator', () => {
+    // The separator before the numeric run is `.`, not `-`, so it must round-trip.
+    expect(suggestWildcardFromName('logs.2026-07-09')).toBe('logs.*');
+  });
+
+  it('reduces a data-stream backing index', () => {
+    expect(suggestWildcardFromName('.ds-logs-otel-2026.07.09-000001')).toBe('.ds-logs-otel-*');
+  });
+
+  it('leaves an all-numeric name unchanged (no text stem to anchor on)', () => {
+    expect(suggestWildcardFromName('2026.07.09')).toBe('2026.07.09');
+  });
+
+  it('leaves a name whose trailing token is not purely numeric unchanged', () => {
+    expect(suggestWildcardFromName('logs-v2')).toBe('logs-v2');
+    expect(suggestWildcardFromName('logs-2026w01')).toBe('logs-2026w01');
+    expect(suggestWildcardFromName('logs-app-reindex')).toBe('logs-app-reindex');
+  });
+
+  it('leaves a too-thin stem unchanged (guard rail: stem >= 3 chars)', () => {
+    expect(suggestWildcardFromName('a-1')).toBe('a-1');
+    expect(suggestWildcardFromName('x-0001')).toBe('x-0001');
+  });
+
+  it('returns the exact name when there is no usable separator', () => {
+    expect(suggestWildcardFromName('orders')).toBe('orders');
+    expect(suggestWildcardFromName('logs001')).toBe('logs001');
+  });
+
+  it('leaves an existing wildcard untouched', () => {
+    expect(suggestWildcardFromName('logs-app-*')).toBe('logs-app-*');
+  });
+
+  it('handles empty input', () => {
+    expect(suggestWildcardFromName('')).toBe('');
+  });
+});
+
+describe('longestCommonPrefix', () => {
+  it('returns the shared prefix', () => {
+    expect(longestCommonPrefix(['logs-app-a', 'logs-app-b'])).toBe('logs-app-');
+  });
+
+  it('returns empty when there is no shared prefix', () => {
+    expect(longestCommonPrefix(['logs-app', 'nginx'])).toBe('');
+  });
+
+  it('returns the single element unchanged', () => {
+    expect(longestCommonPrefix(['only'])).toBe('only');
+  });
+
+  it('returns empty for an empty list', () => {
+    expect(longestCommonPrefix([])).toBe('');
+  });
+});
+
+describe('suggestWildcardFromNames', () => {
+  it('reduces each name then agrees on a single family (fixes the LCP date truncation)', () => {
+    // Both reduce to `logs-app-*`; raw LCP would give the broken `logs-app-2026.07.0*`.
+    expect(suggestWildcardFromNames(['logs-app-2026.07.09', 'logs-app-2026.07.08'])).toBe(
+      'logs-app-*'
+    );
+  });
+
+  it('comma-joins when reduced families differ (avoids over-broad LCP like ap*)', () => {
+    expect(suggestWildcardFromNames(['api-1', 'app-1'])).toBe('api-1,app-1');
+  });
+
+  it('comma-joins names that do not reduce (no numeric suffix)', () => {
+    expect(suggestWildcardFromNames(['orders', 'users'])).toBe('orders,users');
+  });
+
+  it('delegates to the single-name heuristic for one item', () => {
+    expect(suggestWildcardFromNames(['logs-app-2026.07.09'])).toBe('logs-app-*');
+  });
+});
+
+describe('commaSeparated', () => {
+  it('joins names with commas', () => {
+    expect(commaSeparated(['a', 'b', 'c'])).toBe('a,b,c');
+  });
+});
+
+describe('seedCreatePattern', () => {
+  it('seeds a wildcard for a single index', () => {
+    expect(seedCreatePattern(['logs-app-2026.07.09'])).toEqual({
+      mode: 'wildcard',
+      pattern: 'logs-app-*',
+    });
+  });
+
+  it('seeds a wildcard for a multi-set that reduces to one family', () => {
+    expect(seedCreatePattern(['logs-app-001', 'logs-app-002'])).toEqual({
+      mode: 'wildcard',
+      pattern: 'logs-app-*',
+    });
+  });
+
+  it('seeds comma-separated for a heterogeneous multi-set', () => {
+    expect(seedCreatePattern(['orders', 'users'])).toEqual({
+      mode: 'comma',
+      pattern: 'orders,users',
+    });
+  });
+
+  it('handles an empty selection', () => {
+    expect(seedCreatePattern([])).toEqual({ mode: 'wildcard', pattern: '' });
+  });
+});

--- a/src/plugins/explore/public/application/pages/logs_drilldown/suggest_wildcard.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/suggest_wildcard.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Heuristics that turn concrete index names into a dataset pattern, so browsing an index
+ * doesn't spawn one dataset per rolling/daily index. The result is always shown to the user
+ * as an editable pattern with a live "matches N indexes" preview — we suggest, never commit.
+ */
+
+const SEPARATOR_RE = /[-._]/;
+const SEPARATORS = ['-', '.', '_'];
+
+/** A token made entirely of digits (a rolling counter or a date component like 2026, 07, 09). */
+const isPurelyNumeric = (token: string): boolean => token.length > 0 && /^\d+$/.test(token);
+
+/**
+ * Derive a suggested wildcard from a single concrete index name by stripping the ENTIRE trailing
+ * run of purely-numeric tokens (a rolling counter or a multi-part date) and anchoring `*` at the
+ * separator before that run.
+ *
+ *   logs-0001            -> logs-*
+ *   logs-02.01.2026      -> logs-*          (strips the whole -02.01.2026 date run)
+ *   logs-02-01-2026      -> logs-*
+ *   my-name-logs-019     -> my-name-logs-*
+ *   nginx_access_000123  -> nginx_access_*
+ *   2026.07.09           -> 2026.07.09      (all-numeric, no text prefix to anchor on → unchanged)
+ *   orders               -> orders          (no trailing numeric run → unchanged)
+ *   logs-v2              -> logs-v2          (`v2` is not purely numeric → unchanged)
+ *   logs001              -> logs001          (no separator → unchanged; we don't split alpha↔digit)
+ *
+ * Guard rail: we only reduce when the retained stem is >= 3 chars AND contains at least one
+ * non-numeric token — so short/ambiguous names like `a-1` and bare dates like `2026.07.09` are
+ * left exact rather than producing an over-broad `a-*` / `2026.07.*`.
+ */
+export const suggestWildcardFromName = (name: string): string => {
+  if (!name) return name;
+  if (name.includes('*')) return name; // already a pattern
+
+  // Split into tokens while remembering the separator characters, so we can re-anchor `*` at the
+  // exact separator index (mixing `-` and `.` must round-trip: `logs.2026-07` stays `logs.*`).
+  const tokens = name.split(SEPARATOR_RE);
+  if (tokens.length < 2) return name; // no usable separator
+
+  // Find the start of the trailing run of purely-numeric tokens.
+  let runStart = tokens.length;
+  while (runStart > 0 && isPurelyNumeric(tokens[runStart - 1])) {
+    runStart -= 1;
+  }
+  // No trailing numeric token (runStart === tokens.length) → nothing to reduce.
+  if (runStart === tokens.length) return name;
+
+  const stemTokens = tokens.slice(0, runStart);
+  // Guard rail: need a real stem to anchor on. All-numeric name (no stem) or a too-thin/all-numeric
+  // stem is left exact rather than over-grouping.
+  if (stemTokens.length === 0) return name;
+  const stem = stemTokens.join('');
+  if (stem.length < 3 || !stemTokens.some((t) => !isPurelyNumeric(t))) {
+    return name;
+  }
+
+  // Re-anchor `*` at the separator index that precedes the numeric run. The separator before token
+  // `runStart` is the (runStart)-th separator in the original name; find it by walking separators.
+  const stemLength = anchorIndex(name, runStart);
+  return `${name.slice(0, stemLength)}*`;
+};
+
+/**
+ * Return the character index in `name` just past the `n`-th separator (1-based count of separators
+ * consumed), i.e. the length of the prefix that includes the first `n` tokens and their trailing
+ * separators. Used to slice the stem + its anchoring separator before appending `*`.
+ */
+const anchorIndex = (name: string, tokenCount: number): number => {
+  let seen = 0;
+  for (let i = 0; i < name.length; i++) {
+    if (SEPARATOR_RE.test(name[i])) {
+      seen += 1;
+      if (seen === tokenCount) return i + 1; // include the separator, drop everything after
+    }
+  }
+  return name.length;
+};
+
+/**
+ * The longest common prefix of a set of strings.
+ */
+export const longestCommonPrefix = (names: string[]): string => {
+  if (names.length === 0) return '';
+  if (names.length === 1) return names[0];
+  let prefix = names[0];
+  for (const name of names.slice(1)) {
+    while (name.indexOf(prefix) !== 0) {
+      prefix = prefix.slice(0, -1);
+      if (prefix === '') return '';
+    }
+  }
+  return prefix;
+};
+
+/**
+ * Comma-join a set of index names into a single multi-index dataset title. OpenSearch treats
+ * `a,b,c` as a multi-index target natively (this mirrors indexTypeConfig.toDataset).
+ */
+export const commaSeparated = (names: string[]): string => names.join(',');
+
+/**
+ * Derive a suggested wildcard from a multi-selected set by reducing EACH name first, then:
+ *  - if every name reduces to the same wildcard family, use that single wildcard;
+ *  - otherwise, fall back to the comma-separated set.
+ *
+ * Reducing each name first avoids the longest-common-prefix traps:
+ *   ['logs-2026.07.08','logs-2026.07.09'] → both reduce to `logs-*` → `logs-*`
+ *     (raw LCP would give the broken `logs-2026.07.0*`, matching only days 00–09)
+ *   ['api-1','app-1'] → reduce to `api-*` / `app-*` → differ → comma-join
+ *     (raw LCP `ap` would give the over-broad `ap*`)
+ */
+export const suggestWildcardFromNames = (names: string[]): string => {
+  if (names.length === 0) return '';
+  if (names.length === 1) return suggestWildcardFromName(names[0]);
+
+  const reduced = names.map(suggestWildcardFromName);
+  const allAgree = reduced.every((r) => r === reduced[0]);
+  // Only accept the shared reduction when it's an actual wildcard family (contains `*`) — if the
+  // names didn't reduce (no numeric suffix), they're distinct names → comma-join them.
+  if (allAgree && reduced[0].includes('*')) {
+    return reduced[0];
+  }
+  return commaSeparated(names);
+};
+
+export type CreateMode = 'wildcard' | 'comma';
+
+/**
+ * Decide the default create mode + seed pattern for a selection. Single selections and multi-sets
+ * that all reduce to the same wildcard family default to a wildcard; heterogeneous sets default to
+ * comma-joined. Delegates to the same reduce-each-then-agree logic as {@link suggestWildcardFromNames}.
+ */
+export const seedCreatePattern = (names: string[]): { mode: CreateMode; pattern: string } => {
+  if (names.length <= 1) {
+    return { mode: 'wildcard', pattern: suggestWildcardFromName(names[0] ?? '') };
+  }
+  const pattern = suggestWildcardFromNames(names);
+  return { mode: pattern.includes(',') ? 'comma' : 'wildcard', pattern };
+};

--- a/src/plugins/explore/public/application/pages/logs_drilldown/types.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/types.ts
@@ -22,8 +22,13 @@ export enum IndexClassification {
 
 /** A browsable row in the left list. */
 export interface BrowsableItem {
-  /** Concrete index / alias / data_stream name, or dataset title. */
+  /** Concrete index / alias / data_stream name, or dataset title (the PATTERN, e.g. `nginx-*`).
+   *  This is the identity used for coverage matching, activation, and create-seeding — NOT for the
+   *  visible label when a dataset has a friendly `displayName`. */
   name: string;
+  /** Datasets only: the user-chosen friendly name (index-pattern `displayName`), if any. Shown as
+   *  the card label in preference to the pattern; falls back to `name` when empty. */
+  displayName?: string;
   /** Whether this row is an existing dataset (jump straight into Query) vs a raw index. */
   kind: 'index' | 'dataset';
   /** True for cross-cluster (remote) indices. */

--- a/src/plugins/explore/public/application/pages/logs_drilldown/types.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/types.ts
@@ -36,6 +36,13 @@ export interface BrowsableItem {
   /** Cluster-health of the index from `_cat/indices` (`green`/`yellow`/`red`). `undefined` ⇒
    *  unknown (remote/closed index, or the cat.indices call was unavailable). */
   health?: 'green' | 'yellow' | 'red';
+  /** Primary+replica store size string from `_cat/indices` (e.g. "2.4gb"). Shown in the health
+   *  tooltip. `undefined` ⇒ unknown (remote/closed, or the call was unavailable). */
+  storeSize?: string;
+  /** Primary shard count from `_cat/indices`. `undefined` ⇒ unknown. */
+  primaryShards?: number;
+  /** Replica count from `_cat/indices`. `undefined` ⇒ unknown. */
+  replicaCount?: number;
   /** For dataset rows: the dataset id to select. */
   datasetId?: string;
   /** For dataset rows: whether the dataset is time-based (carries a timeFieldName). */

--- a/src/plugins/explore/public/application/pages/logs_drilldown/types.ts
+++ b/src/plugins/explore/public/application/pages/logs_drilldown/types.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * How an index is classified for the logs Explore canvas. Only the time-based vs
+ * no-time-field distinction changes behavior (it gates the histogram preview), so it is
+ * the only classification that gets a colored badge; "remote"/"dataset" are shown as
+ * subdued tokens instead.
+ */
+export enum IndexClassification {
+  /** Not yet classified — no field fetch has run; the badge slot stays empty (no false spinner). */
+  UNKNOWN = 'unknown',
+  /** A field fetch for this index is currently in flight. */
+  CLASSIFYING = 'classifying',
+  /** Has a date field — logs; histogram preview is available. */
+  TIME_BASED = 'time_based',
+  /** No date field — non-log index; table-only preview. */
+  NO_TIME_FIELD = 'no_time_field',
+}
+
+/** A browsable row in the left list. */
+export interface BrowsableItem {
+  /** Concrete index / alias / data_stream name, or dataset title. */
+  name: string;
+  /** Whether this row is an existing dataset (jump straight into Query) vs a raw index. */
+  kind: 'index' | 'dataset';
+  /** True for cross-cluster (remote) indices. */
+  isRemote?: boolean;
+  /** Index creation time (epoch ms), when available — used to sort newest-first. */
+  createdAt?: number;
+  /** Cumulative primary-shard doc count from `_cat/indices`. `0` ⇒ empty index (state 03);
+   *  `undefined` ⇒ unknown (remote/closed index, or the cat.indices call was unavailable). */
+  docsCount?: number;
+  /** Cluster-health of the index from `_cat/indices` (`green`/`yellow`/`red`). `undefined` ⇒
+   *  unknown (remote/closed index, or the cat.indices call was unavailable). */
+  health?: 'green' | 'yellow' | 'red';
+  /** For dataset rows: the dataset id to select. */
+  datasetId?: string;
+  /** For dataset rows: whether the dataset is time-based (carries a timeFieldName). */
+  timeFieldName?: string;
+}
+
+/** Result of classifying a single index by fetching its fields. */
+export interface ClassificationResult {
+  classification: IndexClassification;
+  /** The chosen time field (first date field), if any. */
+  timeFieldName?: string;
+  /** All date fields on the index, so the user can switch the auto-selected one. */
+  dateFields?: string[];
+  /** The detected severity/level field (e.g. severityText, level), if any — used to stack the
+   *  histogram and color the log-line level tokens. */
+  severityField?: string;
+}

--- a/src/plugins/explore/public/application/pages/metrics/explore/hooks/use_concurrent_queries.test.ts
+++ b/src/plugins/explore/public/application/pages/metrics/explore/hooks/use_concurrent_queries.test.ts
@@ -48,6 +48,38 @@ describe('useConcurrentQueries', () => {
     expect(result.current.results.get('a')).toBe('data-a');
   });
 
+  it('invalidate() re-fetches only the given key (leaves the rest cached)', async () => {
+    const fetchFn = jest.fn().mockImplementation((key: string) => Promise.resolve(`v1-${key}`));
+    const { result } = renderHook(() => useConcurrentQueries(fetchFn, [1]));
+
+    act(() => {
+      result.current.onVisibilityChange('a', true);
+      result.current.onVisibilityChange('b', true);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(result.current.results.get('a')).toBe('v1-a');
+    expect(result.current.results.get('b')).toBe('v1-b');
+    const callsAfterInitial = fetchFn.mock.calls.length;
+
+    // Second-round fetches return a new value so we can see WHICH keys re-ran.
+    fetchFn.mockImplementation((key: string) => Promise.resolve(`v2-${key}`));
+
+    act(() => {
+      result.current.invalidate('a');
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+
+    // 'a' re-fetched (new value); 'b' untouched (still cached, no extra fetch for it).
+    expect(result.current.results.get('a')).toBe('v2-a');
+    expect(result.current.results.get('b')).toBe('v1-b');
+    expect(fetchFn).toHaveBeenCalledTimes(callsAfterInitial + 1);
+    expect(fetchFn.mock.calls[callsAfterInitial][0]).toBe('a');
+  });
+
   it('cancels pending fetch when key leaves viewport', async () => {
     const fetchFn = jest.fn().mockResolvedValue('data');
     const { result } = renderHook(() => useConcurrentQueries(fetchFn, [1]));

--- a/src/plugins/explore/public/application/pages/metrics/explore/hooks/use_concurrent_queries.ts
+++ b/src/plugins/explore/public/application/pages/metrics/explore/hooks/use_concurrent_queries.ts
@@ -181,5 +181,27 @@ export function useConcurrentQueries<T>(
     drainRef.current();
   }, []);
 
-  return { results, errors, onVisibilityChange, enqueueAll };
+  // Re-fetch a SINGLE key without resetting the whole scheduler: forget its cached result, abort any
+  // in-flight/pending work for it, and (if it's still in the viewport) re-queue just that one. Lets a
+  // caller refresh one card in place — e.g. a per-item option change — without churning every other.
+  const invalidate = useCallback((key: string) => {
+    const s = stateRef.current;
+    s.fetched.delete(key);
+    const ctrl = s.inflight.get(key);
+    if (ctrl) {
+      ctrl.abort();
+      s.inflight.delete(key);
+    }
+    const timer = s.pending.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      s.pending.delete(key);
+    }
+    if (s.viewport.has(key) && !s.queue.includes(key)) {
+      s.queue.push(key);
+    }
+    drainRef.current();
+  }, []);
+
+  return { results, errors, onVisibilityChange, enqueueAll, invalidate };
 }

--- a/src/plugins/explore/public/build_services.ts
+++ b/src/plugins/explore/public/build_services.ts
@@ -107,6 +107,7 @@ export function buildServices(
     supportedTypes,
     sqlSupportEnabled: config.sqlSupport?.enabled ?? false,
     queryProfilingEnabled: config.queryProfiling?.enabled ?? false,
+    logsDrilldownEnabled: config.logsDrilldown?.enabled ?? false,
     isDatasetManagementEnabled,
     dataImporterConfig,
     dataSourceEnabled,

--- a/src/plugins/explore/public/nav_popover.test.tsx
+++ b/src/plugins/explore/public/nav_popover.test.tsx
@@ -6,7 +6,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import { of } from 'rxjs';
 import { buildExploreNavPopover } from './nav_popover';
-import { ExploreFlavor } from '../common';
+import { ExploreFlavor, LOGS_DRILLDOWN_APP_ID } from '../common';
 import { httpServiceMock } from '../../../core/public/mocks';
 import { NavPopoverServices, ChromeRecentlyAccessedHistoryItem } from '../../../core/public';
 
@@ -27,8 +27,30 @@ describe('buildExploreNavPopover (Logs)', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  it('declares new + browse actions', () => {
+  it('declares new + browse actions (no drilldown item when the flag is off / omitted)', () => {
     expect((popover.actions ?? []).map((a) => a.id)).toEqual(['newSearch', 'browseSaved']);
+  });
+
+  it('includes the Logs drilldown action SECOND when the feature flag is on', () => {
+    const flagged = buildExploreNavPopover(ExploreFlavor.Logs, true);
+    // Ordered: New search → Logs drilldown → Browse saved searches.
+    expect((flagged.actions ?? []).map((a) => a.id)).toEqual([
+      'newSearch',
+      'logsDrilldown',
+      'browseSaved',
+    ]);
+  });
+
+  it('the drilldown action navigates to the Logs Drilldown app', () => {
+    const flagged = buildExploreNavPopover(ExploreFlavor.Logs, true);
+    const services = makeServices();
+    flagged.actions!.find((a) => a.id === 'logsDrilldown')!.onClick(services);
+    expect(services.navigateToApp).toHaveBeenCalledWith(LOGS_DRILLDOWN_APP_ID, { path: '#/' });
+  });
+
+  it('never shows the drilldown action for a non-Logs flavor even when the flag is on', () => {
+    const traces = buildExploreNavPopover(ExploreFlavor.Traces, true);
+    expect((traces.actions ?? []).map((a) => a.id)).not.toContain('logsDrilldown');
   });
 
   it('opens a blank logs search on "New search"', () => {

--- a/src/plugins/explore/public/nav_popover.test.tsx
+++ b/src/plugins/explore/public/nav_popover.test.tsx
@@ -31,9 +31,9 @@ describe('buildExploreNavPopover (Logs)', () => {
     expect((popover.actions ?? []).map((a) => a.id)).toEqual(['newSearch', 'browseSaved']);
   });
 
-  it('includes the Logs drilldown action SECOND when the feature flag is on', () => {
+  it('includes the Explore logs action SECOND when the feature flag is on', () => {
     const flagged = buildExploreNavPopover(ExploreFlavor.Logs, true);
-    // Ordered: New search → Logs drilldown → Browse saved searches.
+    // Ordered: New search → Explore logs → Browse saved searches.
     expect((flagged.actions ?? []).map((a) => a.id)).toEqual([
       'newSearch',
       'logsDrilldown',

--- a/src/plugins/explore/public/nav_popover.tsx
+++ b/src/plugins/explore/public/nav_popover.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { NavPopoverConfig, NavPopoverServices } from '../../../core/public';
-import { PLUGIN_ID, ExploreFlavor } from '../common';
+import { PLUGIN_ID, ExploreFlavor, LOGS_DRILLDOWN_APP_ID } from '../common';
 
 interface RecentItem {
   id: string;
@@ -180,6 +180,21 @@ export function buildExploreNavPopover(flavor: ExploreFlavor): NavPopoverConfig 
         iconType: 'folderOpen',
         onClick: ({ navigateToApp }) => navigateToApp(appId, { path: OPEN_SAVED_PATH }),
       },
+      // Logs-only: the onboarding drilldown canvas lives here (a Logs action), NOT as its own
+      // top-level side-nav item.
+      ...(flavor === ExploreFlavor.Logs
+        ? [
+            {
+              id: 'logsDrilldown',
+              label: i18n.translate('explore.navPopover.logsDrilldown', {
+                defaultMessage: 'Logs drilldown',
+              }),
+              iconType: 'inspect',
+              onClick: ({ navigateToApp }: NavPopoverServices) =>
+                navigateToApp(LOGS_DRILLDOWN_APP_ID, { path: '#/' }),
+            },
+          ]
+        : []),
     ],
     render: (services) => <RecentExploreSearches flavor={flavor} {...services} />,
   };

--- a/src/plugins/explore/public/nav_popover.tsx
+++ b/src/plugins/explore/public/nav_popover.tsx
@@ -159,7 +159,10 @@ export function buildMetricsNavPopover(): NavPopoverConfig {
  * Nav-popover config for an explore flavor (Logs/Traces/Metrics): quick actions
  * (new search / browse saved searches) plus a recent-searches list.
  */
-export function buildExploreNavPopover(flavor: ExploreFlavor): NavPopoverConfig {
+export function buildExploreNavPopover(
+  flavor: ExploreFlavor,
+  logsDrilldownEnabled: boolean = false
+): NavPopoverConfig {
   const appId = flavorAppId(flavor);
   return {
     actions: [
@@ -172,17 +175,9 @@ export function buildExploreNavPopover(flavor: ExploreFlavor): NavPopoverConfig 
         iconType: 'plusInCircle',
         onClick: ({ navigateToApp }) => navigateToApp(appId, { path: '#/' }),
       },
-      {
-        id: 'browseSaved',
-        label: i18n.translate('explore.navPopover.browseSaved', {
-          defaultMessage: 'Browse saved searches',
-        }),
-        iconType: 'folderOpen',
-        onClick: ({ navigateToApp }) => navigateToApp(appId, { path: OPEN_SAVED_PATH }),
-      },
-      // Logs-only: the onboarding drilldown canvas lives here (a Logs action), NOT as its own
-      // top-level side-nav item.
-      ...(flavor === ExploreFlavor.Logs
+      // Logs-only: the onboarding drilldown canvas lives here (a Logs action, feature-flagged), NOT
+      // as its own top-level side-nav item. Sits second — between New search and Browse saved.
+      ...(flavor === ExploreFlavor.Logs && logsDrilldownEnabled
         ? [
             {
               id: 'logsDrilldown',
@@ -195,6 +190,14 @@ export function buildExploreNavPopover(flavor: ExploreFlavor): NavPopoverConfig 
             },
           ]
         : []),
+      {
+        id: 'browseSaved',
+        label: i18n.translate('explore.navPopover.browseSaved', {
+          defaultMessage: 'Browse saved searches',
+        }),
+        iconType: 'folderOpen',
+        onClick: ({ navigateToApp }) => navigateToApp(appId, { path: OPEN_SAVED_PATH }),
+      },
     ],
     render: (services) => <RecentExploreSearches flavor={flavor} {...services} />,
   };

--- a/src/plugins/explore/public/nav_popover.tsx
+++ b/src/plugins/explore/public/nav_popover.tsx
@@ -182,7 +182,7 @@ export function buildExploreNavPopover(
             {
               id: 'logsDrilldown',
               label: i18n.translate('explore.navPopover.logsDrilldown', {
-                defaultMessage: 'Logs drilldown',
+                defaultMessage: 'Explore logs',
               }),
               iconType: 'inspect',
               onClick: ({ navigateToApp }: NavPopoverServices) =>

--- a/src/plugins/explore/public/plugin.test.ts
+++ b/src/plugins/explore/public/plugin.test.ts
@@ -283,9 +283,11 @@ describe('ExplorePlugin', () => {
   });
 
   describe('setup', () => {
-    it('should register explore applications', () => {
+    it('should register explore applications (logs drilldown OFF by default)', () => {
       plugin.setup(coreSetup as any, setupDeps as any);
 
+      // logsDrilldown flag is off in the default mock config → the drilldown app is NOT registered,
+      // so only the 5 always-on apps register (visualization editor + logs/traces/metrics + explore).
       expect(coreSetup.application.register).toHaveBeenCalledTimes(5);
       expect(coreSetup.application.register).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -310,6 +312,25 @@ describe('ExplorePlugin', () => {
           id: 'explore',
           title: 'Discover',
         })
+      );
+      // The feature-flagged Logs Drilldown app is absent.
+      expect(coreSetup.application.register).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'explore/logs-drilldown' })
+      );
+    });
+
+    it('registers the Logs Drilldown app + query-bar action when the feature flag is ON', () => {
+      initializerContext.config.get.mockReturnValue({
+        discoverTraces: { enabled: false },
+        logsDrilldown: { enabled: true },
+      });
+      plugin = new ExplorePlugin(initializerContext as any);
+      plugin.setup(coreSetup as any, setupDeps as any);
+
+      // The 5 always-on apps + the drilldown app = 6 registrations.
+      expect(coreSetup.application.register).toHaveBeenCalledTimes(6);
+      expect(coreSetup.application.register).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'explore/logs-drilldown' })
       );
     });
 

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -153,6 +153,12 @@ export class ExplorePlugin implements Plugin<
     this.hideLocalCluster = setupDeps.dataSource?.hideLocalCluster || false;
     this.dataSourceManagement = setupDeps.dataSourceManagement;
 
+    // Feature flag: the standalone Logs Drilldown canvas ships behind `explore.logsDrilldown.enabled`
+    // (default off). Read synchronously from the browser-exposed config (mirrors `sqlSupport`); gates
+    // the app registration, the query-bar action, and the nav-popover entry point below.
+    const logsDrilldownEnabled =
+      this.initializerContext.config.get<ConfigSchema>().logsDrilldown?.enabled ?? false;
+
     // Set usage collector
     setUsageCollector(setupDeps.usageCollection);
     this.registerExploreVisualizationAlias(setupDeps);
@@ -166,8 +172,10 @@ export class ExplorePlugin implements Plugin<
       queryPanelActionsRegistry.register(importDataActionConfig);
     }
 
-    // Query-bar entry point to the standalone Logs Drilldown app.
-    queryPanelActionsRegistry.register(logsDrilldownActionConfig);
+    // Query-bar entry point to the standalone Logs Drilldown app (feature-flagged).
+    if (logsDrilldownEnabled) {
+      queryPanelActionsRegistry.register(logsDrilldownActionConfig);
+    }
 
     this.docViewsRegistry = new DocViewsRegistry();
     setDocViewsRegistry(this.docViewsRegistry);
@@ -485,6 +493,15 @@ export class ExplorePlugin implements Plugin<
           this.dataSourceManagement
         );
 
+        // URL state storage (like the flavor apps) so the drilldown persists its time range (`_g`)
+        // and selected data source (`_a`) — bookmarkable/shareable and reload-proof. Uses this app's
+        // own scoped history.
+        services.osdUrlStateStorage = createOsdUrlStateStorage({
+          history: params.history,
+          useHash: coreStart.uiSettings.get('state:storeInSessionStorage'),
+          ...withNotifyOnErrors(coreStart.notifications.toasts),
+        });
+
         const { renderLogsDrilldownApp } = await import('./application/pages/logs_drilldown');
         return renderLogsDrilldownApp(params, services);
       },
@@ -618,10 +635,12 @@ export class ExplorePlugin implements Plugin<
         updater$: this.stateUpdaterByApp[ExploreFlavor.Metrics]!.asObservable(),
       })
     );
-    // Standalone Logs Drilldown app (own mount, no shared store). MUST be registered before the
-    // base `explore` app: the base app's route (`/app/explore`) is a non-exact prefix that would
-    // otherwise match `/app/explore/logs-drilldown` first and redirect to the logs flavor.
-    core.application.register(createLogsDrilldownApp());
+    // Standalone Logs Drilldown app (own mount, no shared store), feature-flagged. MUST be registered
+    // before the base `explore` app: the base app's route (`/app/explore`) is a non-exact prefix that
+    // would otherwise match `/app/explore/logs-drilldown` first and redirect to the logs flavor.
+    if (logsDrilldownEnabled) {
+      core.application.register(createLogsDrilldownApp());
+    }
     core.application.register(createExploreApp());
 
     // Register nav links for different workspaces
@@ -663,14 +682,14 @@ export class ExplorePlugin implements Plugin<
           category: undefined,
           order: 200,
           euiIconType: 'discoverApp' as const,
-          navPopover: buildExploreNavPopover(ExploreFlavor.Logs),
+          navPopover: buildExploreNavPopover(ExploreFlavor.Logs, logsDrilldownEnabled),
         },
         {
           id: `${PLUGIN_ID}/${ExploreFlavor.Traces}`,
           category: DEFAULT_APP_CATEGORIES.applicationPerformance,
           order: 100,
           euiIconType: 'apmTrace' as const,
-          navPopover: buildExploreNavPopover(ExploreFlavor.Traces),
+          navPopover: buildExploreNavPopover(ExploreFlavor.Traces, logsDrilldownEnabled),
         },
         {
           id: `${PLUGIN_ID}/${ExploreFlavor.Metrics}`,

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -37,6 +37,8 @@ import {
   PLUGIN_NAME,
   VISUALIZATION_EDITOR_APP_ID,
   VISUALIZATION_EDITOR_APP_NAME,
+  LOGS_DRILLDOWN_APP_ID,
+  LOGS_DRILLDOWN_APP_NAME,
 } from '../common';
 import { ConfigSchema } from '../common/config';
 import { buildExploreNavPopover, buildMetricsNavPopover } from './nav_popover';
@@ -87,6 +89,7 @@ import { SlotRegistryService } from './services/slot_registry';
 import { logActionRegistry } from './services/log_action_registry';
 import { createAskAiAction } from './actions/ask_ai_action';
 import { importDataActionConfig } from './actions/import_data_action';
+import { logsDrilldownActionConfig } from './actions/logs_drilldown_action';
 import { AskAIEmbeddableAction } from './actions/ask_ai_embeddable_action';
 import { CONTEXT_MENU_TRIGGER } from '../../embeddable/public';
 import {
@@ -162,6 +165,9 @@ export class ExplorePlugin implements Plugin<
     if (this.dataImporterConfig) {
       queryPanelActionsRegistry.register(importDataActionConfig);
     }
+
+    // Query-bar entry point to the standalone Logs Drilldown app.
+    queryPanelActionsRegistry.register(logsDrilldownActionConfig);
 
     this.docViewsRegistry = new DocViewsRegistry();
     setDocViewsRegistry(this.docViewsRegistry);
@@ -434,6 +440,56 @@ export class ExplorePlugin implements Plugin<
       };
     };
 
+    // Standalone Logs Drilldown app: its OWN lightweight mount — builds `services` via the shared
+    // buildServices, but renders the self-contained onboarding canvas WITHOUT the explore Redux
+    // store, tabs, or query panel. Handoff to the logs Query experience is via navigateToApp, so the
+    // widely-used logs flavor state is never touched.
+    const createLogsDrilldownApp = (): App => ({
+      id: LOGS_DRILLDOWN_APP_ID,
+      title: LOGS_DRILLDOWN_APP_NAME,
+      order: 1000,
+      workspaceAvailability: WorkspaceAvailability.insideWorkspace,
+      euiIconType: 'discoverApp',
+      defaultPath: '#/',
+      category: DEFAULT_APP_CATEGORIES.observability,
+      // Reached via the Logs nav-popover action + the query-bar action, NOT its own side-nav item.
+      navLinkStatus: AppNavLinkStatus.hidden,
+      mount: async (params: AppMountParameters) => {
+        if (!this.initializeServices) {
+          throw Error('Explore plugin method initializeServices is undefined');
+        }
+        const { core: coreStart, plugins: pluginsStart } = await this.initializeServices();
+        const isExploreEnabledWorkspace = await this.getIsExploreEnabledWorkspace(coreStart);
+        if (
+          !isExploreEnabledWorkspace ||
+          !!localStorage.getItem(SHOW_CLASSIC_DISCOVER_LOCAL_STORAGE_KEY)
+        ) {
+          coreStart.application.navigateToApp('discover', { replace: true });
+          return () => {};
+        }
+
+        pluginsStart.data.indexPatterns.clearCache();
+
+        const services = buildServices(
+          coreStart,
+          pluginsStart,
+          this.initializerContext,
+          this.tabRegistry,
+          this.visualizationRegistryService,
+          this.queryPanelActionsRegistryService,
+          this.isDatasetManagementEnabled,
+          this.slotRegistryService,
+          this.dataImporterConfig,
+          this.dataSourceEnabled,
+          this.hideLocalCluster,
+          this.dataSourceManagement
+        );
+
+        const { renderLogsDrilldownApp } = await import('./application/pages/logs_drilldown');
+        return renderLogsDrilldownApp(params, services);
+      },
+    });
+
     const createExploreVisualizationEditorApp = () => {
       const {
         appMounted,
@@ -562,6 +618,10 @@ export class ExplorePlugin implements Plugin<
         updater$: this.stateUpdaterByApp[ExploreFlavor.Metrics]!.asObservable(),
       })
     );
+    // Standalone Logs Drilldown app (own mount, no shared store). MUST be registered before the
+    // base `explore` app: the base app's route (`/app/explore`) is a non-exact prefix that would
+    // otherwise match `/app/explore/logs-drilldown` first and redirect to the logs flavor.
+    core.application.register(createLogsDrilldownApp());
     core.application.register(createExploreApp());
 
     // Register nav links for different workspaces

--- a/src/plugins/explore/public/types.ts
+++ b/src/plugins/explore/public/types.ts
@@ -199,6 +199,7 @@ export interface ExploreServices {
   supportedTypes?: string[];
   sqlSupportEnabled: boolean;
   queryProfilingEnabled: boolean;
+  logsDrilldownEnabled: boolean;
   isDatasetManagementEnabled: boolean;
   dataImporterConfig?: DataImporterPluginSetup['config'];
   dataSourceEnabled: boolean;

--- a/src/plugins/explore/server/index.ts
+++ b/src/plugins/explore/server/index.ts
@@ -18,6 +18,7 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     enabled: true,
     sqlSupport: true,
     queryProfiling: true,
+    logsDrilldown: true,
   },
   schema: configSchema,
   deprecations: ({ rename, unused }) => [


### PR DESCRIPTION
### Description

Adds the **Logs Drilldown** onboarding canvas to the `explore` plugin — a standalone, full-width vertical stack of per-index/dataset cards (severity histogram + raw log-line preview) that teaches the `data source → index → dataset` hierarchy and turns raw indexes into durable datasets. The whole feature is gated behind a new `explore.logsDrilldown.enabled` config (default **off**) so it can ship dark and be enabled per-environment.

This PR implements the design proposed in the RFC (#12395).

**Highlights**

- **Rows canvas** — viewport-gated concurrent previews, lazy severity histograms, and raw log-line previews per card. Liveness-aware layout: live cards stay primary; no-recent-data / empty (0-doc) indexes demote into a collapsed drawer.
- **Card header** — a time-field selector (non-interactive pill when the index has a single time field, naming the field in its tooltip), an index health dot (green/yellow/red), and dataset "Show logs" + "Manage" actions — all riding the existing `cat.indices` call with no extra round-trips.
- **Data-source scoping (MDS)** — hides the synthetic local cluster in the picker; an empty workspace shows an "Associate a data source" empty state, sources-but-none-selected shows a "Select a data source" prompt (no silent fall-back to the local cluster).
- **Create-dataset flow** — the shared advanced selector / index selector gain an opt-in `autoFocus` prop (default `true`) so the drilldown's pre-seeded flow doesn't steal focus; the disabled toolbar "Create dataset" button carries a tooltip guiding the user to select indexes; the logs/traces Query empty state is reworked into a flavor-aware "Select data" experience (Create dataset + PPL/SQL docs filter + a "Logs drilldown" action gated on the flag).
- **Selection** — a two-row selection banner proposes a dataset wildcard and warns when the checked indexes share no common time field.
- **Paging** — 10 rows on first load with a centered secondary "Load more (N of M)" button.
- **Time range** — defaults to the last 15 minutes on mount unless the URL (`_g`) already pins a range, so arriving from Logs Query doesn't flood the cluster with a wide range on first load. The global time range and the selected data source persist to the URL (`_g` / `_a`) for shareable/bookmarkable state.

### Issues Resolved

Implements the design in #12395 (RFC). Does not close the RFC — it remains open for tracking.

## Screenshot

<!-- To be attached: Logs Drilldown canvas (light + dark), the selection banner, and the reworked "Select data" empty state. -->

## Testing the changes

1. Set `explore.logsDrilldown.enabled: true` in `config/opensearch_dashboards.yml` and start against a cluster with a few log indexes.
2. Open **Explore → Logs**, then the **Logs drilldown** entry (query-bar action / nav popover). Confirm the entry points are absent when the flag is off.
3. Verify the rows canvas: histograms + log previews render, no-recent-data indexes demote, health dots show, the time-field pill names the field.
4. Select multiple indexes → the selection banner proposes a wildcard and warns on no common time field; "Create dataset" opens the advanced selector pre-seeded (no autofocus).
5. Confirm the time range defaults to last 15m on mount and persists to the URL after a change; "Load more" pages 10 at a time.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (explore Logs Drilldown suite + touched `data` plugin tests)
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
