### PR TITLE
Fix PPL time filter to avoid script compilation rate limit on OpenSearch

### DIFF
--- a/src/plugins/query_enhancements/public/search/filters/filter_utils.test.ts
+++ b/src/plugins/query_enhancements/public/search/filters/filter_utils.test.ts
@@ -286,13 +286,27 @@ describe('convertFiltersToClause', () => {
 });
 
 describe('getTimeFilterCommand', () => {
-  it('should create a time filter command with the correct format', () => {
-    const timeRange: TimeRange = {
-      from: '2023-01-01T00:00:00Z',
-      to: '2023-01-02T00:00:00Z',
-    };
+  const timeRange: TimeRange = {
+    from: '2023-01-01T00:00:00Z',
+    to: '2023-01-02T00:00:00Z',
+  };
 
+  it('emits bare string literals for OpenSearch (folds to a native range query, no scripts)', () => {
+    const result = FilterUtils.getTimeFilterWhereClause('timestamp', timeRange, 'OpenSearch');
+    expect(result).toBe(
+      "WHERE `timestamp` >= '2023-01-01 00:00:00.000' AND `timestamp` <= '2023-01-02 00:00:00.000'"
+    );
+  });
+
+  it('defaults to bare string literals when the engine type is unknown/undefined (fail-open)', () => {
     const result = FilterUtils.getTimeFilterWhereClause('timestamp', timeRange);
+    expect(result).toBe(
+      "WHERE `timestamp` >= '2023-01-01 00:00:00.000' AND `timestamp` <= '2023-01-02 00:00:00.000'"
+    );
+  });
+
+  it('wraps literals in TIMESTAMP() for legacy Elasticsearch (Open Distro rejects bare strings)', () => {
+    const result = FilterUtils.getTimeFilterWhereClause('timestamp', timeRange, 'Elasticsearch');
     expect(result).toBe(
       "WHERE `timestamp` >= TIMESTAMP('2023-01-01 00:00:00.000') AND `timestamp` <= TIMESTAMP('2023-01-02 00:00:00.000')"
     );

--- a/src/plugins/query_enhancements/public/search/filters/filter_utils.ts
+++ b/src/plugins/query_enhancements/public/search/filters/filter_utils.ts
@@ -7,6 +7,7 @@ import {
   Filter,
   filterMatchesIndex,
   formatTimePickerDate,
+  getDataSourceEngineCapabilities,
   getFilterField,
   IIndexPattern,
   isFilterDisabled,
@@ -19,18 +20,31 @@ export class FilterUtils {
    * Get time filter where clause
    * @param timeFieldName Time field name
    * @param timeRange Time range from the time picker
+   * @param engineType Engine type of the target data source (`engineType ?? type`), used to decide
+   *   whether the time literals need to be wrapped in `TIMESTAMP('...')`.
    * @returns where clause of the time range filter
    *
-   * The time literals are wrapped in `TIMESTAMP('...')` rather than bare string literals. Modern
-   * OpenSearch PPL implicitly coerces a string to a timestamp for `field >= '<string>'`, but legacy
-   * Elasticsearch (Open Distro) PPL does not and rejects it with a [TIMESTAMP,STRING] type error.
-   * `TIMESTAMP('...')` is accepted by both engines, so this form is portable across all data sources.
+   * Legacy Elasticsearch (Open Distro) PPL does NOT coerce a string to a timestamp for
+   * `field >= '<string>'` and rejects it with a [TIMESTAMP,STRING] type error, so those engines need
+   * the explicit `TIMESTAMP('...')` wrapper. OpenSearch PPL, however, folds a bare-string comparison
+   * into a native Lucene `range` query, whereas `TIMESTAMP('...')` (a function call on the RHS) forces
+   * a per-value `opensearch_query_expression` script filter — each unique timestamp compiles a new
+   * script and quickly trips the cluster's script-compilation rate limit
+   * (`script.context.filter.max_compilations_rate`, default 75/5m). So we only wrap for engines that
+   * require it (`usesOpenDistroSqlPpl`), keeping OpenSearch on the native, script-free range query.
    */
-  public static getTimeFilterWhereClause(timeFieldName: string, timeRange: TimeRange): string {
+  public static getTimeFilterWhereClause(
+    timeFieldName: string,
+    timeRange: TimeRange,
+    engineType?: string
+  ): string {
     const { fromDate, toDate } = formatTimePickerDate(timeRange, 'YYYY-MM-DD HH:mm:ss.SSS');
-    return `WHERE \`${timeFieldName}\` >= TIMESTAMP('${formatDate(
-      fromDate
-    )}') AND \`${timeFieldName}\` <= TIMESTAMP('${formatDate(toDate)}')`;
+    const wrap = getDataSourceEngineCapabilities(engineType).usesOpenDistroSqlPpl
+      ? (literal: string) => `TIMESTAMP('${literal}')`
+      : (literal: string) => `'${literal}'`;
+    return `WHERE \`${timeFieldName}\` >= ${wrap(formatDate(fromDate))} AND \`${timeFieldName}\` <= ${wrap(
+      formatDate(toDate)
+    )}`;
   }
 
   /**

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
@@ -659,7 +659,8 @@ describe('PPLSearchInterceptor', () => {
 
       expect(mockPPLFilterUtils.getTimeFilterWhereClause).toHaveBeenCalledWith(
         '@timestamp',
-        mockTimeRange
+        mockTimeRange,
+        undefined
       );
       expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields *');
     });

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -159,7 +159,8 @@ export class PPLSearchInterceptor extends SearchInterceptor {
     ) {
       const timeFilter = PPLFilterUtils.getTimeFilterWhereClause(
         dataset.timeFieldName,
-        this.queryService.timefilter.timefilter.getTime()
+        this.queryService.timefilter.timefilter.getTime(),
+        dataset.dataSource?.engineType ?? dataset.dataSource?.type
       );
       whereCommands.push(timeFilter);
     }


### PR DESCRIPTION
Make getTimeFilterWhereClause engine-aware: emit bare string literals for OpenSearch (which fold to native Lucene range queries) and only wrap in TIMESTAMP('...') for legacy Elasticsearch/Open Distro engines that reject bare strings.

On OpenSearch, `field >= TIMESTAMP('...')` cannot be folded to a native range query because the RHS is a function expression, so it is pushed down as a per-value `opensearch_query_expression` script filter. Each unique timestamp compiles a new script and quickly exhausts the cluster-wide `script.context.filter.max_compilations_rate` limit (default 75/5m), producing `CircuitBreakingException` errors in classic Discover. Emitting a bare string lets the optimizer produce a native range query with zero script compilations, while Elasticsearch keeps the TIMESTAMP() wrapper it requires.

### Description

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
