### PR TITLE
Fix TSVB Non math metric Id

### DIFF
--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric_raw.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric_raw.js
@@ -37,16 +37,19 @@ import { METRIC_TYPES } from '../../../../../common/metric_types';
 /**
  * stdMetricRaw - Modified version of stdMetric for the raw endpoint
  *
- * This processor is identical to stdMetric except it appends the metric ID
- * to the series ID. This allows the client-side code to differentiate between
- * different metrics in the same series when evaluating math expressions.
+ * This processor is identical to stdMetric except that, when the series ends
+ * in a math metric, it emits one component series per non-math metric and
+ * appends the metric ID to the series ID. This allows the client-side code
+ * (process_math_series.js) to find the component metrics for a math series by
+ * matching series IDs against the pattern "series-id:*".
  *
- * Example:
- *   Regular stdMetric: id = "series-1"
+ * Example (math series):
  *   stdMetricRaw: id = "series-1:count" or "series-1:avg-cpu"
  *
- * This format allows client-side process_math_series.js to find component
- * metrics by searching for series IDs matching the pattern "series-id:*"
+ * For a regular (non-math) series the id is left untouched (id = split.id, e.g.
+ * "series-1" for an unsplit series or "series-1:<bucketKey>" for a term/filter
+ * split). Suffixing every series with the metric ID would break downstream
+ * colon-based split detection and produce phantom split labels.
  */
 export function stdMetricRaw(resp, panel, series, meta) {
   return (next) => (results) => {
@@ -98,8 +101,7 @@ export function stdMetricRaw(resp, panel, series, meta) {
     getSplits(resp, panel, series, meta).forEach((split) => {
       const data = split.timeseries.buckets.map(mapBucket(metric));
       results.push({
-        // MODIFIED: Append metric ID to series ID for client-side differentiation
-        id: `${split.id}:${metric.id}`,
+        id: split.id,
         label: split.label,
         labelFormatted: split.labelFormatted,
         color: split.color,

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric_raw.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric_raw.test.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { stdMetricRaw } from './std_metric_raw';
+
+describe('stdMetricRaw(resp, panel, series, meta)', () => {
+  let panel;
+  let series;
+  let resp;
+
+  beforeEach(() => {
+    panel = { time_field: 'timestamp' };
+    series = {
+      chart_type: 'line',
+      stacked: false,
+      line_width: 1,
+      point_size: 1,
+      fill: 0,
+      color: 'rgb(255, 0, 0)',
+      id: 'test',
+      split_mode: 'everything',
+      metrics: [{ id: 'avgmetric', type: 'avg', field: 'cpu' }],
+    };
+    resp = {
+      aggregations: {
+        test: {
+          timeseries: {
+            buckets: [
+              { key: 1, avgmetric: { value: 1 } },
+              { key: 2, avgmetric: { value: 2 } },
+            ],
+          },
+        },
+      },
+    };
+  });
+
+  test('calls next when finished', () => {
+    const next = jest.fn();
+    stdMetricRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+  });
+
+  test('is a no-op for percentile metrics', () => {
+    series.metrics[0].type = 'percentile';
+    const next = jest.fn((d) => d);
+    const results = stdMetricRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+    expect(results).toHaveLength(0);
+  });
+
+  test('is a no-op for std_deviation band metrics', () => {
+    series.metrics[0].type = 'std_deviation';
+    series.metrics[0].mode = 'band';
+    const next = jest.fn((d) => d);
+    const results = stdMetricRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+    expect(results).toHaveLength(0);
+  });
+
+  test('emits a plain (colon-free) id for a regular non-split series', () => {
+    // Regression: the non-math branch must NOT append the metric id. A
+    // "test:avgmetric" id would be misread downstream as a split bucket.
+    const results = stdMetricRaw(resp, panel, series)((r) => r)([]);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('test');
+    expect(results[0].id).not.toContain(':');
+    expect(results[0]).toHaveProperty('label', 'Average of cpu');
+    expect(results[0].data).toEqual([
+      [1, 1],
+      [2, 2],
+    ]);
+  });
+
+  test('preserves the split id (series:bucketKey) for a terms split series', () => {
+    series.split_mode = 'terms';
+    series.terms_field = 'host';
+    resp.aggregations.test = {
+      buckets: [
+        {
+          key: 'host-a',
+          timeseries: { buckets: [{ key: 1, avgmetric: { value: 5 } }] },
+        },
+        {
+          key: 'host-b',
+          timeseries: { buckets: [{ key: 1, avgmetric: { value: 7 } }] },
+        },
+      ],
+    };
+
+    const results = stdMetricRaw(resp, panel, series)((r) => r)([]);
+    expect(results.map((r) => r.id)).toEqual(['test:host-a', 'test:host-b']);
+    expect(results[0].data).toEqual([[1, 5]]);
+    expect(results[1].data).toEqual([[1, 7]]);
+  });
+
+  test('emits one component series per non-math metric with a metric-id suffix', () => {
+    series.metrics = [
+      { id: 'avg-cpu', type: 'avg', field: 'cpu' },
+      { id: 'max-cpu', type: 'max', field: 'cpu' },
+      {
+        id: 'math-1',
+        type: 'math',
+        script: 'params.a / params.b',
+        variables: [
+          { name: 'a', field: 'avg-cpu' },
+          { name: 'b', field: 'max-cpu' },
+        ],
+      },
+    ];
+    resp.aggregations.test.timeseries.buckets = [
+      { key: 1, 'avg-cpu': { value: 1 }, 'max-cpu': { value: 10 } },
+      { key: 2, 'avg-cpu': { value: 2 }, 'max-cpu': { value: 20 } },
+    ];
+
+    const results = stdMetricRaw(resp, panel, series)((r) => r)([]);
+    const byId = Object.fromEntries(results.map((r) => [r.id, r.data]));
+    expect(Object.keys(byId).sort()).toEqual(['test:avg-cpu', 'test:max-cpu']);
+    expect(byId['test:avg-cpu']).toEqual([
+      [1, 1],
+      [2, 2],
+    ]);
+    expect(byId['test:max-cpu']).toEqual([
+      [1, 10],
+      [2, 20],
+    ]);
+  });
+});

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling_raw.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling_raw.js
@@ -36,8 +36,16 @@ import { getSiblingAggValue } from '../../helpers/get_sibling_agg_value';
 /**
  * stdSiblingRaw - Modified version of stdSibling for the raw endpoint
  *
- * This processor is identical to stdSibling except it appends the metric ID
- * to the series ID for client-side differentiation, similar to stdMetricRaw.
+ * This processor is identical to stdSibling except that, when the series ends
+ * in a math metric, it emits one component series per sibling (bucket)
+ * aggregation and appends the metric ID to the series ID, so the client-side
+ * code (process_math_series.js) can find the component metrics for a math
+ * series by matching series IDs against the pattern "series-id:*".
+ *
+ * For a regular (non-math) sibling series the id is left untouched
+ * (id = split.id), mirroring stdMetricRaw. Suffixing every series with the
+ * metric ID would break downstream colon-based split detection and produce
+ * phantom split labels.
  */
 export function stdSiblingRaw(resp, panel, series, meta) {
   return (next) => (results) => {
@@ -84,8 +92,7 @@ export function stdSiblingRaw(resp, panel, series, meta) {
         return [bucket.key, getSiblingAggValue(split, metric)];
       });
       results.push({
-        // MODIFIED: Append metric ID to series ID for client-side differentiation
-        id: `${split.id}:${metric.id}`,
+        id: split.id,
         label: split.label,
         color: split.color,
         data,

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling_raw.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling_raw.test.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { stdSiblingRaw } from './std_sibling_raw';
+
+describe('stdSiblingRaw(resp, panel, series, meta)', () => {
+  let panel;
+  let series;
+  let resp;
+
+  beforeEach(() => {
+    panel = { time_field: 'timestamp' };
+    series = {
+      chart_type: 'line',
+      stacked: false,
+      line_width: 1,
+      point_size: 1,
+      fill: 0,
+      color: 'rgb(255, 0, 0)',
+      id: 'test',
+      split_mode: 'everything',
+      metrics: [
+        { id: 'avgcpu', type: 'avg', field: 'cpu' },
+        { id: 'sib', type: 'std_deviation_bucket', field: 'avgcpu' },
+      ],
+    };
+    resp = {
+      aggregations: {
+        test: {
+          sib: { std_deviation: 0.23 },
+          timeseries: {
+            buckets: [
+              { key: 1, avgcpu: { value: 0.23 } },
+              { key: 2, avgcpu: { value: 0.22 } },
+            ],
+          },
+        },
+      },
+    };
+  });
+
+  test('calls next when finished', () => {
+    const next = jest.fn();
+    stdSiblingRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+  });
+
+  test('is a no-op when the last metric is not a sibling (bucket) aggregation', () => {
+    series.metrics = [series.metrics[0]]; // only the avg metric
+    const next = jest.fn((d) => d);
+    const results = stdSiblingRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+    expect(results).toHaveLength(0);
+  });
+
+  test('is a no-op for std_deviation_bucket band metrics', () => {
+    series.metrics[1].mode = 'band';
+    const next = jest.fn((d) => d);
+    const results = stdSiblingRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+    expect(results).toHaveLength(0);
+  });
+
+  test('emits a plain (colon-free) id for a regular non-split sibling series', () => {
+    // Regression: the non-math branch must NOT append the metric id. A
+    // "test:sib" id would be misread downstream as a split bucket.
+    const results = stdSiblingRaw(resp, panel, series)((r) => r)([]);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('test');
+    expect(results[0].id).not.toContain(':');
+    expect(results[0].data).toEqual([
+      [1, 0.23],
+      [2, 0.23],
+    ]);
+  });
+
+  test('preserves the split id (series:bucketKey) for a terms split sibling series', () => {
+    series.split_mode = 'terms';
+    series.terms_field = 'host';
+    resp.aggregations.test = {
+      buckets: [
+        {
+          key: 'host-a',
+          sib: { std_deviation: 0.1 },
+          timeseries: { buckets: [{ key: 1, avgcpu: { value: 0.1 } }] },
+        },
+        {
+          key: 'host-b',
+          sib: { std_deviation: 0.2 },
+          timeseries: { buckets: [{ key: 1, avgcpu: { value: 0.2 } }] },
+        },
+      ],
+    };
+
+    const results = stdSiblingRaw(resp, panel, series)((r) => r)([]);
+    expect(results.map((r) => r.id)).toEqual(['test:host-a', 'test:host-b']);
+    expect(results[0].data).toEqual([[1, 0.1]]);
+    expect(results[1].data).toEqual([[1, 0.2]]);
+  });
+
+  test('is a no-op when the series ends in a math metric (pre-existing gap)', () => {
+    // NOTE: The `_bucket$` guard at the top of stdSiblingRaw returns early when
+    // the last metric is `math` (type 'math' does not match /_bucket$/), so the
+    // sibling-component branch is currently unreachable. A math expression that
+    // references a sibling aggregation therefore yields no component series in
+    // the raw flow. This is a pre-existing gap from PR #11129, not introduced by
+    // the id fix; this test documents the current behavior. See follow-up.
+    series.metrics.push({
+      id: 'math-1',
+      type: 'math',
+      script: 'params.a',
+      variables: [{ name: 'a', field: 'sib' }],
+    });
+
+    const next = jest.fn((d) => d);
+    const results = stdSiblingRaw(resp, panel, series)(next)([]);
+    expect(next.mock.calls.length).toEqual(1);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Description

Fixes the series ID emitted by the TSVB raw-data response processors for non-math metrics. The client-side math evaluation added in #11129 made `stdMetricRaw` and `stdSiblingRaw` append the metric ID to every series ID (`${split.id}:${metric.id}`). That suffix is only needed for the component series of a math expression so `process_math_series.js` can match them by the `series-id:*` pattern. Applying it to regular series produced IDs with a stray colon (e.g. `test:avgmetric`), which downstream colon-based split detection misreads as a term/filter split bucket, yielding phantom split labels.

The non-math branch of both processors now emits the plain `split.id`; the metric-ID suffix is retained only on the math component branch. Existing unsplit IDs (`series-1`) and real split IDs (`series-1:<bucketKey>`) are preserved.

### Issues Resolved

<!-- Add the tracking issue here, e.g. closes #XXXX -->

## Screenshot

<!-- No UI code changed; attach a before/after TSVB panel screenshot showing the corrected series labels if desired. -->
Before 
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/3913da4c-affe-43cf-ad70-d672ae0fc8bd" />


After
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/f240891f-552b-432c-ad92-2bdf2cad69ac" />


## Testing the changes

- `node scripts/jest.js src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_metric_raw.test.js`
- `node scripts/jest.js src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/std_sibling_raw.test.js`

New unit tests cover:
- non-math, non-split series emit a colon-free ID (regression for the bug)
- terms-split series preserve the `series:bucketKey` ID
- math series still emit one `series:metricId` component per non-math metric
- percentile / std_deviation band metrics remain no-ops
- `stdSiblingRaw` returns no series when the series ends in a math metric (documents a pre-existing gap from #11129: the top-level `_bucket$` guard makes the sibling-component branch unreachable, so math over a sibling aggregation emits no component data — separate follow-up)

Manual: open a TSVB panel with a standard metric (e.g. Average) and confirm the legend shows the metric label instead of a phantom split entry.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
