### PR TITLE
Align S3 Cypress and Lighthouse CI with OpenSearch 3.4.0

### DIFF
--- a/.github/workflows/cypress_workflow_with_s3.yml
+++ b/.github/workflows/cypress_workflow_with_s3.yml
@@ -33,7 +33,7 @@ env:
   CYPRESS_DATASOURCE_MANAGEMENT_ENABLED: false
   OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
   NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
-  LATEST_VERSION: '2.17.0'
+  LATEST_VERSION: '3.4.0'
 
 jobs:
   cypress-tests:
@@ -43,7 +43,7 @@ jobs:
       options: --user 1001
     env:
       START_CMD: 'node scripts/opensearch_dashboards --dev --no-base-path --no-watch --savedObjects.maxImportPayloadBytes=10485760 --server.maxPayloadBytes=1759977 --logging.json=false --data.search.aggs.shardDelay.enabled=true --csp.warnLegacyBrowsers=false --uiSettings.overrides["query:enhancements:enabled"]=true --uiSettings.overrides[''home:useNewHomePage'']=true --data_source.enabled=true --workspace.enabled=true --opensearch.ignoreVersionMismatch=true'
-      OPENSEARCH_SNAPSHOT_CMD: '/bin/bash -c "./opensearch-2.17.0/opensearch-tar-install.sh &"'
+      OPENSEARCH_SNAPSHOT_CMD: '/bin/bash -c "./opensearch-${{ env.LATEST_VERSION }}/opensearch-tar-install.sh &"'
     name: Run cypress tests with S3
     steps:
       - name: Checkout code

--- a/.github/workflows/lighthouse_testing.yml
+++ b/.github/workflows/lighthouse_testing.yml
@@ -54,8 +54,11 @@ jobs:
           rm -f opensearch-*.tar.gz
         shell: bash
 
-      - name: Remove security plugin
+      - name: Remove security plugin and dependent plugins
         run: |
+          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-flow-framework"
+          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-anomaly-detection"
+          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-ml"
           /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-security"
         shell: bash
 

--- a/.github/workflows/lighthouse_testing.yml
+++ b/.github/workflows/lighthouse_testing.yml
@@ -56,9 +56,10 @@ jobs:
 
       - name: Remove security plugin and dependent plugins
         run: |
-          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-flow-framework"
-          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-anomaly-detection"
+          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-skills"
           /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-ml"
+          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-anomaly-detection"
+          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-flow-framework"
           /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-security"
         shell: bash
 

--- a/.github/workflows/lighthouse_testing.yml
+++ b/.github/workflows/lighthouse_testing.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   OSD_OPTIMIZER_THEMES: v8light
   NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
-  LATEST_VERSION: '2.17.0'
+  LATEST_VERSION: '3.4.0'
 
 jobs:
   lighthouse:

--- a/.github/workflows/lighthouse_testing.yml
+++ b/.github/workflows/lighthouse_testing.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run bootstrap
         run: yarn osd bootstrap
 
+      - name: Setup Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Download OpenSearch
         uses: suisei-cn/actions-download-file@15306412d2c75df56b46844362b86b65235b7db1 # v1.4.0
         with:


### PR DESCRIPTION
## Summary

- update the Cypress-with-S3 workflow from OpenSearch 2.17.0 to 3.4.0
- derive the S3 workflow startup path from LATEST_VERSION to prevent future drift
- update the Lighthouse workflow from OpenSearch 2.17.0 to 3.4.0
- configure Java 21 and remove the OpenSearch plugins that depend on security before removing security in the Lighthouse test cluster

## Why

These workflows still referenced OpenSearch 2.17.0 while the primary Cypress workflow used 3.4.0, leaving the CI configurations inconsistent. OpenSearch 3.4.0 requires Java 21 and does not allow removing the security plugin while its dependent plugins remain installed.

Fixes #11672.

## Impact

This aligns CI test infrastructure with the current OpenSearch version. The plugin removals apply only to the disposable, unauthenticated Lighthouse test cluster; product runtime behavior is unchanged.

## Validation

- focused workflow regression assertions, verified red before each fix and green after it
- parsed the related workflow YAML files with js-yaml
- completed yarn osd bootstrap with Node.js 22.22.2
- passed git diff --check
- completed code review
- attempted yarn typecheck; it remains blocked by a pre-existing unrelated TS2769 error in src/core/server/rendering/rendering_service.test.ts:53
- GitHub CI reruns validate the full configured matrix