### PR TITLE
Change the allowed title length to 64 to comply with the collection t…

### DIFF
--- a/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/data_source/server/saved_objects/data_source_saved_objects_client_wrapper.test.ts
@@ -215,7 +215,7 @@ describe('DataSourceSavedObjectsClientWrapper', () => {
 
       it(`should throw error when title is longer than ${DATA_SOURCE_TITLE_LENGTH_LIMIT} characters`, async () => {
         const mockDataSourceAttributes = attributes({
-          title: 'a'.repeat(33),
+          title: 'a'.repeat(65),
         });
         await expect(
           wrapperClient.create(DATA_SOURCE_SAVED_OBJECT_TYPE, mockDataSourceAttributes, {})

--- a/src/plugins/data_source/server/util/constants.ts
+++ b/src/plugins/data_source/server/util/constants.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const DATA_SOURCE_TITLE_LENGTH_LIMIT = 32;
+export const DATA_SOURCE_TITLE_LENGTH_LIMIT = 64;


### PR DESCRIPTION
…itle length

### Description

Loosen the data source `title` length limit from 32 to 64 characters
(`DATA_SOURCE_TITLE_LENGTH_LIMIT` in the data_source plugin).

Serverless (AOSS) collection names can exceed 32 characters.
The previous 32-char cap in `DataSourceSavedObjectsClientWrapper.validateTitle()`
caused data-source creation to fail with:
`400 – "title" attribute is limited to 32 characters`
for titles such as `nonprod-business-audit-v2-sandbox` (33 chars).



### Changelog
- fix: loosen data source title length limit from 32 to 64 characters


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
