### PR TITLE
[Chat]Add dashboard context-aware and enable auto-vis

### DIFF
--- a/src/core/public/chat/chat_service.ts
+++ b/src/core/public/chat/chat_service.ts
@@ -11,6 +11,7 @@ import {
   ChatServiceStart,
   ChatImplementationFunctions,
   Message,
+  InputContent,
   ChatWindowState,
   ConversationMemoryProvider,
 } from './types';
@@ -171,7 +172,7 @@ export class ChatService implements CoreService<ChatServiceSetup, ChatServiceSta
       },
 
       sendMessageWithWindow: async (
-        content: string,
+        content: string | InputContent[],
         messages: Message[],
         options?: { clearConversation?: boolean }
       ) => {

--- a/src/core/public/chat/index.ts
+++ b/src/core/public/chat/index.ts
@@ -20,6 +20,7 @@ export {
   ChatWindowState,
   SavedConversation,
   TextInputContent,
+  InputContent,
   ConversationMemoryProvider,
   ConversationPaginationParams,
   PaginatedConversations,

--- a/src/core/public/chat/types.ts
+++ b/src/core/public/chat/types.ts
@@ -10,6 +10,7 @@ import type { Event } from './events';
 export interface TextInputContent {
   type: 'text';
   text: string;
+  name?: string;
 }
 
 interface BinaryInputContent {
@@ -19,9 +20,29 @@ interface BinaryInputContent {
   url?: string;
   data?: string;
   filename?: string;
+  name?: string;
 }
 
-type InputContent = TextInputContent | BinaryInputContent;
+interface InputContentDataSource {
+  type: 'data';
+  value: string;
+  mimeType: string;
+}
+
+interface InputContentUrlSource {
+  type: 'url';
+  value: string;
+  mimeType?: string;
+}
+
+type InputContentSource = InputContentDataSource | InputContentUrlSource;
+
+interface ImageInputContent {
+  type: 'image';
+  source: InputContentSource;
+  metadata?: Record<string, unknown>;
+}
+export type InputContent = TextInputContent | BinaryInputContent | ImageInputContent;
 
 /**
  * Function call interface
@@ -167,7 +188,7 @@ export interface ChatServiceInterface {
     messages: Message[]
   ): Promise<{ observable: any; userMessage: UserMessage }>;
   sendMessageWithWindow(
-    content: string,
+    content: string | InputContent[],
     messages: Message[],
     options?: { clearConversation?: boolean }
   ): Promise<{ observable: any; userMessage: UserMessage }>;
@@ -185,7 +206,7 @@ export interface ChatImplementationFunctions {
   ) => Promise<{ observable: any; userMessage: UserMessage }>;
 
   sendMessageWithWindow: (
-    content: string,
+    content: string | InputContent[],
     messages: Message[],
     options?: { clearConversation?: boolean }
   ) => Promise<{ observable: any; userMessage: UserMessage }>;

--- a/src/plugins/chat/common/types.ts
+++ b/src/plugins/chat/common/types.ts
@@ -17,6 +17,7 @@ export type {
   ToolMessage,
   Role,
   TextInputContent,
+  InputContent,
 } from '../../../core/public/chat';
 
 // Zod schemas for runtime validation - these ensure the core types are followed
@@ -32,9 +33,11 @@ export const ToolCallSchema = z.object({
 });
 
 // AG-UI Protocol: Input content schemas for multimodal content (text + images)
+// name marks a msg as a machine-only payload — hidden from the conversation view
 export const TextInputContentSchema = z.object({
   type: z.literal('text'),
   text: z.string(),
+  name: z.string().optional(),
 });
 
 export const BinaryInputContentSchema = z.object({
@@ -44,9 +47,26 @@ export const BinaryInputContentSchema = z.object({
   url: z.string().optional(),
   data: z.string().optional(),
   filename: z.string().optional(),
+  name: z.string().optional(),
 });
 
-export const InputContentSchema = z.union([TextInputContentSchema, BinaryInputContentSchema]);
+export const InputContentSourceSchema = z.union([
+  z.object({ type: z.literal('data'), value: z.string(), mimeType: z.string() }),
+  z.object({ type: z.literal('url'), value: z.string(), mimeType: z.string().optional() }),
+]);
+
+export const ImageInputContentSchema = z.object({
+  type: z.literal('image'),
+  source: InputContentSourceSchema,
+  metadata: z.record(z.unknown()).optional(),
+  name: z.string().optional(),
+});
+
+export const InputContentSchema = z.union([
+  TextInputContentSchema,
+  BinaryInputContentSchema,
+  ImageInputContentSchema,
+]);
 
 export const BaseMessageSchema = z.object({
   id: z.string(),

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -16,13 +16,13 @@ import React, {
 import { useUnmount, useMount } from 'react-use';
 import moment from 'moment';
 import { i18n } from '@osd/i18n';
-import { EuiButton, EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
+import { EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
 import { useChatContext } from '../contexts/chat_context';
 import { ChatEventHandler } from '../services/chat_event_handler';
 import { AssistantActionService } from '../../../context_provider/public';
 import { ConfirmationRequest } from '../services/confirmation_service';
 import { type Event as ChatEvent } from '../../common/events';
-import type { Message, SystemMessage, UserMessage } from '../../common/types';
+import type { InputContent, Message, SystemMessage, UserMessage } from '../../common/types';
 import { ChatLayoutMode } from '../types';
 import { ChatContainer } from './chat_container';
 import { ChatHeader } from './chat_header';
@@ -38,11 +38,16 @@ import type { SavedConversation } from '../services/conversation_history_service
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../core/public';
 import { ChatSessionErrorBoundary } from './chat_session_error_boundary';
+
+import { flattenContentText } from '../utils/user_message_input';
 import './chat_window.scss';
 
 export interface ChatWindowInstance {
   startNewChat: () => void;
-  sendMessage: (options: { content: string; messages?: Message[] }) => Promise<unknown>;
+  sendMessage: (options: {
+    content: string | InputContent[];
+    messages?: Message[];
+  }) => Promise<unknown>;
 }
 
 interface ChatWindowProps {
@@ -113,9 +118,17 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     const timelineRef = React.useRef<Message[]>(timeline);
 
-    React.useEffect(() => {
-      timelineRef.current = timeline;
-    }, [timeline]);
+    // Wrap setTimeline so timelineRef updates synchronously within the updater, before React renders.
+    const setTimelineSynced = useCallback(
+      (updater: Message[] | ((prev: Message[]) => Message[])) => {
+        setTimeline((prev) => {
+          const next = typeof updater === 'function' ? updater(prev) : updater;
+          timelineRef.current = next;
+          return next;
+        });
+      },
+      []
+    );
 
     // Subscribe to pending confirmations
     useEffect(() => {
@@ -146,13 +159,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           confirmationService,
           telemetryRecorder,
           callbacks: {
-            onTimelineUpdate: setTimeline,
+            onTimelineUpdate: setTimelineSynced,
             onStreamingStateChange: setIsStreaming,
             onStartResponse: setStartResponse,
             getTimeline: () => timelineRef.current,
           },
         }),
-      [service, chatService, confirmationService, telemetryRecorder]
+      [service, chatService, confirmationService, telemetryRecorder, setTimelineSynced]
     );
 
     // Subscribe to tool updates from the service
@@ -243,7 +256,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         setIsStreaming(true);
         setStartResponse(false);
 
-        const content = userMessage.content as string;
+        const content = flattenContentText(userMessage.content);
 
         try {
           const { observable } = await chatService.sendMessage(content, messages, userMessage);
@@ -318,10 +331,10 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           };
           if (pendingUserMessage) {
             // User message already in timeline (data source selection flow) — append response
-            setTimeline((prev) => [...prev, responseMsg]);
+            setTimelineSynced((prev) => [...prev, responseMsg]);
           } else {
             const userMsg = chatService.getUserMessage(messageContent);
-            setTimeline((prev) => [...prev, userMsg, responseMsg]);
+            setTimelineSynced((prev) => [...prev, userMsg, responseMsg]);
           }
           setScreenshotData(undefined);
           return true;
@@ -330,18 +343,18 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           const userMsg = chatService.getUserMessage(commandResult.message, messageContent);
           if (pendingUserMessage) {
             // Replace the pending user message (by id) with the resolved command message
-            setTimeline((prev) =>
+            setTimelineSynced((prev) =>
               prev.map((msg) => (msg.id === pendingUserMessage.id ? userMsg : msg))
             );
           } else {
-            setTimeline((prev) => [...prev, userMsg]);
+            setTimelineSynced((prev) => [...prev, userMsg]);
           }
           subscribeToMessageStream(messagesToSend, userMsg);
           return true;
         }
         return true;
       },
-      [chatService, subscribeToMessageStream]
+      [chatService, subscribeToMessageStream, setTimelineSynced]
     );
 
     // Handler for when user selects a data source from the prompt
@@ -388,7 +401,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
               defaultMessage: 'The current data source does not support AI features.',
             }),
           };
-          setTimeline((prev) => [...prev, systemMsg]);
+          setTimelineSynced((prev) => [...prev, systemMsg]);
           return { valid: false, reason: 'unsupported' };
         }
 
@@ -415,38 +428,40 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
                 'There are no data sources associated with this workspace. Please ask your workspace admin to associate data sources to this workspace.',
             }),
           };
-          setTimeline((prev) => [...prev, infoMsg]);
+          setTimelineSynced((prev) => [...prev, infoMsg]);
           return { valid: false, reason: 'no_data_sources' };
         }
 
         return { valid: true };
       },
-      [chatService, isUnsupportedDataSource]
+      [chatService, setTimelineSynced, isUnsupportedDataSource]
     );
 
-    const handleSend = async (options?: { input?: string; messages?: Message[] }) => {
-      const messageContent = options?.input ?? input.trim();
+    const handleSend = async (options?: {
+      input?: string | InputContent[];
+      messages?: Message[];
+    }) => {
+      let messageContent: string | InputContent[] = options?.input ?? input.trim();
+
+      const isEmpty = Array.isArray(messageContent) ? messageContent.length === 0 : !messageContent;
       // Use ref for immediate check since React 18 batches state updates
-      if (!messageContent || isStreamingRef.current || isValidatingRef.current || hasPendingResend)
-        return;
+      if (isEmpty || isStreamingRef.current || hasPendingResend) return;
 
       // Prepare additional messages for sending (but don't add to timeline yet)
-      let additionalMessages = options?.messages ?? [];
-
+      const additionalMessages = options?.messages ?? [];
       // Only add screenshot data if messages not provided
-      if (!options?.messages && screenshotData) {
-        additionalMessages = [
+      if (!options?.input && typeof messageContent === 'string' && screenshotData) {
+        messageContent = [
+          // binary is deprecated
           {
-            role: 'user' as const,
-            id: chatService.generateMessageId(),
-            content: [
-              {
-                type: 'binary' as const,
-                mimeType: screenshotData.mimeType,
-                data: screenshotData.base64,
-              },
-            ],
+            type: 'image',
+            source: {
+              type: 'data',
+              value: screenshotData.base64,
+              mimeType: screenshotData.mimeType,
+            },
           },
+          { type: 'text' as const, text: messageContent },
         ];
       }
 
@@ -454,7 +469,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
       // Show user message immediately (optimistic rendering)
       const userMsg = chatService.getUserMessage(messageContent);
-      setTimeline((prev) => [...prev, userMsg]);
+      setTimelineSynced((prev) => [...prev, userMsg]);
 
       // Merge additional messages with current timeline for sending
       const messagesToSend = [...timeline, ...additionalMessages];
@@ -469,10 +484,12 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
         // Check if this is a slash command — pass userMsg so executeSlashCommand
         // can replace it (by id) with the resolved command message.
-        const handled = await executeSlashCommand(messageContent, messagesToSend, userMsg);
-        if (handled) return;
+        if (typeof messageContent === 'string') {
+          const handled = await executeSlashCommand(messageContent, messagesToSend);
+          if (handled) return;
+        }
 
-        // Normal message flow — user message already in timeline, just stream
+        // Normal message flow — the content can be multimodal
         return subscribeToMessageStream(messagesToSend, userMsg);
       } finally {
         isValidatingRef.current = false;
@@ -502,21 +519,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
         if (messageIndex === -1) return;
 
-        let textContent = typeof message.content === 'string' ? message.content : '';
-        const additionalMessages: Message[] = [];
-
-        if (Array.isArray(message.content)) {
-          const lastMessageContent = message.content[message.content.length - 1];
-          if (lastMessageContent.type === 'text') {
-            textContent = lastMessageContent.text;
-            additionalMessages.push({
-              ...message,
-              content: message.content.slice(0, message.content.length - 1),
-            });
-          }
-        }
-
-        if (textContent === '') {
+        const content = message.content;
+        const isEmpty = Array.isArray(content) ? content.length === 0 : !content;
+        if (isEmpty) {
           return;
         }
 
@@ -527,11 +532,11 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         setInput('');
 
         // Add user message back and stream
-        const userMsg = chatService.getUserMessage(textContent);
-        setTimeline([...truncatedTimeline, userMsg]);
-        subscribeToMessageStream([...truncatedTimeline, ...additionalMessages], userMsg);
+        const userMsg = chatService.getUserMessage(content);
+        setTimelineSynced([...truncatedTimeline, userMsg]);
+        subscribeToMessageStream(truncatedTimeline, userMsg);
       },
-      [timeline, subscribeToMessageStream, setInput, chatService]
+      [timeline, subscribeToMessageStream, setInput, setTimelineSynced, chatService]
     );
 
     const handleResendToolResult = useCallback(
@@ -547,10 +552,10 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         // Avoid concurrent resends while streaming or already sending a tool result
         if (isStreamingRef.current || hasActiveToolCallsRef.current) return;
         // Remove the error message from timeline
-        setTimeline((prev) => prev.filter((msg) => msg.id !== messageId));
+        setTimelineSynced((prev) => prev.filter((msg) => msg.id !== messageId));
         await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
       },
-      [eventHandler, setTimeline]
+      [eventHandler, setTimelineSynced]
     );
 
     // Helper function to stop streaming and clean up subscriptions
@@ -582,7 +587,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       eventHandler.clearState();
 
       chatService.newThread();
-      setTimeline([]);
+      setTimelineSynced([]);
       setCurrentRunId(null);
       setPendingConfirmation(null);
       setPendingMessage(null);
@@ -591,7 +596,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       setIsValidating(false);
       confirmationService.cleanAll();
       setShowHistory(false);
-    }, [chatService, confirmationService, eventHandler, stopStreaming]);
+    }, [chatService, confirmationService, eventHandler, stopStreaming, setTimelineSynced]);
 
     const handleStop = useCallback(() => {
       stopStreaming();

--- a/src/plugins/chat/public/components/message_row.test.tsx
+++ b/src/plugins/chat/public/components/message_row.test.tsx
@@ -176,6 +176,63 @@ describe('MessageRow', () => {
       expect(screen.getByRole('img')).toBeInTheDocument();
       expect(screen.getByText('Plain text block')).toBeInTheDocument();
     });
+
+    it('should hide named blocks from the conversation view', () => {
+      const message: Message = {
+        id: 'msg-9',
+        role: 'user',
+        content: [
+          {
+            type: 'binary',
+            mimeType: 'image/jpeg',
+            data: 'imagedata',
+          },
+          {
+            type: 'text',
+            text: '[Visualization Context] Chart Type: line',
+            name: 'visualization_context',
+          },
+          {
+            type: 'text',
+            text: 'Summarize this chart',
+          },
+        ],
+      };
+
+      render(<MessageRow message={message} />);
+
+      // Unnamed blocks stay visible
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByText('Summarize this chart')).toBeInTheDocument();
+      // Named block is machine-only
+      expect(
+        screen.queryByText('[Visualization Context] Chart Type: line')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should hide named binary blocks', () => {
+      const message: Message = {
+        id: 'msg-10',
+        role: 'user',
+        content: [
+          {
+            type: 'binary',
+            mimeType: 'image/png',
+            data: 'hiddenimage',
+            name: 'internal_screenshot',
+          },
+          {
+            type: 'text',
+            text: 'Visible text',
+          },
+        ],
+      };
+
+      render(<MessageRow message={message} />);
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(screen.getByText('Visible text')).toBeInTheDocument();
+    });
   });
 
   describe('role-based styling', () => {

--- a/src/plugins/chat/public/components/message_row.tsx
+++ b/src/plugins/chat/public/components/message_row.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@osd/i18n';
 import { Markdown } from '../../../opensearch_dashboards_react/public';
 import type { Message, AssistantMessage } from '../../common/types';
 import { stripInlineSuggestions } from '../../common/parse_inline_suggestions';
+import { getImageSrc } from '../utils/user_message_input';
 import { ShareModal } from './share_modal';
 import './message_row.scss';
 
@@ -71,28 +72,30 @@ export const MessageRow: React.FC<MessageRowProps> = ({
     if (Array.isArray(content)) {
       return (
         <>
-          {content.map((block: any, index: number) => {
-            // Render binary content (images)
-            if (block.type === 'binary' && block.data) {
-              return (
-                <img
-                  key={index}
-                  src={`data:${block.mimeType || 'image/jpeg'};base64,${block.data}`}
-                  alt={block.filename || 'Visualization'}
-                  style={{ maxWidth: '100%', marginBottom: '8px', borderRadius: '4px' }}
-                />
-              );
-            }
-            // Render text content as markdown
-            if (block.type === 'text' && block.text) {
-              return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
-            }
-            // Handle plain text blocks (for backward compatibility)
-            if (block.text) {
-              return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
-            }
-            return null;
-          })}
+          {content
+            .filter((block: any) => !block.name)
+            .map((block: any, index: number) => {
+              const imageSrc = getImageSrc(block);
+              if (imageSrc) {
+                return (
+                  <img
+                    key={index}
+                    src={imageSrc}
+                    alt={block.filename || 'Visualization'}
+                    style={{ maxWidth: '100%', marginBottom: '8px', borderRadius: '4px' }}
+                  />
+                );
+              }
+              // Render text content as markdown
+              if (block.type === 'text' && block.text) {
+                return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
+              }
+              // Handle plain text blocks (for backward compatibility)
+              if (block.text) {
+                return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
+              }
+              return null;
+            })}
         </>
       );
     }

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -36,6 +36,8 @@ const mockAssistantActionService = {
 const mockChatService = {
   sendToolResult: jest.fn(),
   getCurrentDataSourceId: jest.fn().mockReturnValue(undefined),
+  getCurrentDataSourceInfo: jest.fn().mockResolvedValue(undefined),
+  getCurrentTimeRange: jest.fn().mockReturnValue(undefined),
   resetConnection: jest.fn(),
 } as unknown as jest.Mocked<ChatService>;
 

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -313,15 +313,16 @@ export class ChatEventHandler {
 
     // Strategy 1: Use explicitly provided parent message ID
     // This is the most reliable approach when the backend provides it
-    if (parentMessageId) {
-      this.addToolCallToMessage(parentMessageId, toolCall);
+    if (parentMessageId && this.addToolCallToMessage(parentMessageId, toolCall)) {
       return;
     }
 
     // Strategy 2: Determine placement based on message timeline positions
-    // Check if the last assistant message is still the most recent response
+    // Check if the last assistant message is still the most recent response.
+    // Skipped when the backend named a parent: it wants this tool call on a message of
+    // its own, not folded into the text message it has already ended.
     const timelineMessages = this.getTimeline();
-    if (this.lastTextMessageStartId) {
+    if (!parentMessageId && this.lastTextMessageStartId) {
       const lastAssistantTextMessageIndex = timelineMessages.findLastIndex(
         (message) => message.id === this.lastTextMessageStartId
       );
@@ -341,16 +342,18 @@ export class ChatEventHandler {
     // This handles the case where the LLM responds with tool calls but without any text message.
     // Since there's no TEXT_MESSAGE_START event, we need to create a fake assistant message
     // to hold the tool calls so they appear in the correct position in the timeline.
-    const fakeAssistantMessageId = `fake-assistant-message-` + new Date().getTime();
-    this.onTimelineUpdate((prev) => {
-      const newMessage: AssistantMessage = {
-        id: fakeAssistantMessageId,
-        role: 'assistant',
-        toolCalls: [toolCall],
-      };
-      return [...prev, newMessage];
-    });
-    this.lastTextMessageStartId = fakeAssistantMessageId;
+    const newMessageId = parentMessageId ?? `fake-assistant-message-` + new Date().getTime();
+    const newMessage: AssistantMessage = {
+      id: newMessageId,
+      role: 'assistant',
+      toolCalls: [toolCall],
+    };
+    // Register in the active map too, not just the timeline: TEXT_MESSAGE_CONTENT resolves
+    // its target through this map, so a timeline-only insert would silently drop any text
+    // the agent streams onto the same message id afterwards.
+    this.activeAssistantMessages.set(newMessageId, newMessage);
+    this.onTimelineUpdate((prev) => [...prev, newMessage]);
+    this.lastTextMessageStartId = newMessageId;
   }
 
   /**
@@ -403,7 +406,8 @@ export class ChatEventHandler {
             toolCall.function.name,
             args,
             toolCallId,
-            await this.chatService.getCurrentDataSourceId()
+            await this.chatService.getCurrentDataSourceInfo(),
+            this.chatService.getCurrentTimeRange()
           );
 
       // Check if tool execution was cancelled (e.g., due to cleanup)
@@ -626,7 +630,7 @@ export class ChatEventHandler {
   /**
    * Add tool call to a specific message in timeline
    */
-  private addToolCallToMessage(messageId: string, toolCall: ToolCall): void {
+  private addToolCallToMessage(messageId: string, toolCall: ToolCall): boolean {
     // Check if message is in active messages
     const activeMessage = this.activeAssistantMessages.get(messageId);
     if (activeMessage) {
@@ -643,8 +647,11 @@ export class ChatEventHandler {
         }
         return prev;
       });
-      return;
+      return true;
     }
+
+    const known = this.getTimeline().find((m) => m.id === messageId);
+    if (!known || known.role !== 'assistant') return false;
 
     // Otherwise find in timeline and update
     this.onTimelineUpdate((prev) => {
@@ -663,6 +670,8 @@ export class ChatEventHandler {
 
       return updated;
     });
+
+    return true;
   }
 
   /**
@@ -873,8 +882,25 @@ export class ChatEventHandler {
    * Simply sets the timeline to the saved messages
    */
   private async handleMessagesSnapshot(event: MessagesSnapshotEvent): Promise<void> {
-    // Set timeline to snapshot messages
-    this.onTimelineUpdate(() => event.messages || []);
+    // agent backends may serialize a user message's `InputContent[]` to str
+    // restore multimodal user messages
+    this.onTimelineUpdate((prev) => {
+      const snapshot = event.messages || [];
+
+      const localArrayContent = new Map<string, unknown>();
+      for (const message of prev) {
+        if (message.role === 'user' && Array.isArray(message.content)) {
+          localArrayContent.set(message.id, message.content);
+        }
+      }
+      if (localArrayContent.size === 0) return snapshot;
+
+      return snapshot.map((message) => {
+        if (message.role !== 'user' || typeof message.content !== 'string') return message;
+        const content = localArrayContent.get(message.id);
+        return content ? ({ ...message, content } as Message) : message;
+      });
+    });
 
     // Reset streaming state
     this.onStreamingStateChange(false);

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -1494,7 +1494,19 @@ describe('ChatService', () => {
     });
   });
 
-  describe('extractDataSourceIdFromPageContext', () => {
+  describe('getDataSourceFromPageContext', () => {
+    // Helper to stub the global context store and invoke the current method.
+    const extractDataSourceId = (contexts: any[]) => {
+      (global as any).window.assistantContextStore = {
+        getAllContexts: jest.fn().mockReturnValue(contexts),
+      };
+      return (chatService as any).getDataSourceFromPageContext();
+    };
+
+    afterEach(() => {
+      delete (global as any).window.assistantContextStore;
+    });
+
     it('should extract data source ID from valid page context', () => {
       const contexts = [
         {
@@ -1515,7 +1527,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBe('correct-data-source-id');
     });
 
@@ -1531,7 +1543,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBe('investigation-data-source');
     });
 
@@ -1551,7 +1563,8 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      // const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1564,7 +1577,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1577,7 +1590,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1590,7 +1603,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1614,12 +1627,12 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBe('first-id'); // Should return first valid page context
     });
 
     it('should handle empty contexts array', () => {
-      const result = (chatService as any).extractDataSourceIdFromPageContext([]);
+      const result = extractDataSourceId([]);
       expect(result).toBeUndefined();
     });
   });
@@ -2333,6 +2346,31 @@ describe('ChatService', () => {
 
       expect(result.content).toBe('spaced');
       expect(result.rawMessage).toBe('spaced');
+    });
+
+    it('should pass multimodal content arrays through untouched', () => {
+      const content = [
+        { type: 'binary' as const, mimeType: 'image/png', data: 'abc123' },
+        { type: 'text' as const, text: 'describe this chart' },
+      ];
+
+      const result = chatService.getUserMessage(content);
+
+      expect(result).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'user',
+        content,
+      });
+      expect(result.rawMessage).toBeUndefined();
+    });
+
+    it('should keep an explicit rawMessage alongside array content', () => {
+      const content = [{ type: 'text' as const, text: '/vis output' }];
+
+      const result = chatService.getUserMessage(content, '/vis');
+
+      expect(result.content).toEqual(content);
+      expect(result.rawMessage).toBe('/vis');
     });
   });
 });

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -5,7 +5,7 @@
 
 import { Observable, Subscription } from 'rxjs';
 import { AgUiAgent } from './ag_ui_agent';
-import { RunAgentInput, Message, UserMessage, ToolMessage } from '../../common/types';
+import { RunAgentInput, Message, UserMessage, ToolMessage, InputContent } from '../../common/types';
 import type { ToolDefinition } from '../../../context_provider/public';
 import { AssistantActionService } from '../../../context_provider/public';
 import type { ChatWindowInstance } from '../components/chat_window';
@@ -230,7 +230,7 @@ export class ChatService {
   }
 
   public async sendMessageWithWindow(
-    content: string,
+    content: string | InputContent[],
     messages: Message[],
     options?: { clearConversation?: boolean }
   ): Promise<{
@@ -255,7 +255,7 @@ export class ChatService {
     const userMessage: UserMessage = {
       id: this.generateMessageId(),
       role: 'user',
-      content: content.trim(),
+      content: typeof content === 'string' ? content.trim() : content,
     };
 
     // Return a dummy observable since ChatWindow handles everything internally
@@ -266,39 +266,42 @@ export class ChatService {
     return { observable: dummyObservable, userMessage };
   }
 
-  /**
-   * Extract data source ID from page context
-   * Looks for page contexts with appId and dataset.dataSource.id structure
-   */
-  private extractDataSourceIdFromPageContext(allContexts: any[]): string | undefined {
-    // Find page context by checking for 'page' category and appId in value
-    const pageContext = allContexts.find((ctx) => {
-      // Look for contexts in 'page' category instead of filtering by ID existence
-      if (!ctx.categories?.includes('page')) return false;
+  private getDataSourceFromPageContext() {
+    const dsId = this.getPageContextValue()?.dataset?.dataSource?.id;
+    return dsId;
+  }
 
+  private getAllAssistantContexts(): any[] {
+    const contextStore = (window as any).assistantContextStore;
+    return contextStore ? contextStore.getAllContexts() : [];
+  }
+
+  /**
+   * Resolve the parsed value of the current page context (the one carrying appId).
+   */
+  private getPageContextValue(): any | undefined {
+    const pageContext = this.getAllAssistantContexts().find((ctx) => {
+      if (!ctx.categories?.includes('page')) return false;
       try {
         const value = typeof ctx.value === 'string' ? JSON.parse(ctx.value) : ctx.value;
-        return value?.appId; // Page contexts have appId
+        return value?.appId;
       } catch {
         return false;
       }
     });
-
     if (!pageContext) return undefined;
 
-    const contextValue =
-      typeof pageContext.value === 'string' ? JSON.parse(pageContext.value) : pageContext.value;
-
-    // TODO: Consider adding more robust nested field search for dataSource.id
-    // if the standard dataset.dataSource.id pattern is not found
-    return contextValue?.dataset?.dataSource?.id;
+    return typeof pageContext.value === 'string'
+      ? JSON.parse(pageContext.value)
+      : pageContext.value;
   }
 
-  private getDataSourceFromPageContext() {
-    const contextStore = (window as any).assistantContextStore;
-    const allContexts = contextStore ? contextStore.getAllContexts() : [];
-
-    return this.extractDataSourceIdFromPageContext(allContexts);
+  public getCurrentTimeRange(): { from: string; to: string } | undefined {
+    const timeRange = this.getPageContextValue()?.timeRange;
+    if (timeRange?.from && timeRange?.to) {
+      return { from: timeRange.from, to: timeRange.to };
+    }
+    return undefined;
   }
 
   /**
@@ -357,6 +360,14 @@ export class ChatService {
       this.cachedDataSourceId ||
       (await this.getWorkspaceAwareDataSourceId())
     );
+  }
+
+  public async getCurrentDataSourceInfo(): Promise<{ id: string; title?: string } | undefined> {
+    const id = await this.getCurrentDataSourceId();
+    if (!id) return undefined;
+    const availableDs = await this.getAvailableDataSources();
+    const title = availableDs.find((ds) => ds.id === id)?.title;
+    return { id, title };
   }
 
   public async sendMessage(
@@ -969,7 +980,16 @@ export class ChatService {
   /**
    * Create a user message for timeline display
    */
-  public getUserMessage(content: string, rawMessage?: string): UserMessage {
+  public getUserMessage(content: string | InputContent[], rawMessage?: string): UserMessage {
+    if (Array.isArray(content)) {
+      return {
+        id: this.generateMessageId(),
+        role: 'user',
+        content,
+        ...(rawMessage ? { rawMessage } : {}),
+      };
+    }
+
     return {
       id: this.generateMessageId(),
       role: 'user',

--- a/src/plugins/chat/public/services/export/investigation_export_service.ts
+++ b/src/plugins/chat/public/services/export/investigation_export_service.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../common/types';
 import { TOOL_EXECUTION_ERROR_PREFIX } from '../../../common';
 import { stripInlineSuggestions } from '../../../common/parse_inline_suggestions';
+import { resolveImageContent } from '../../utils/user_message_input';
 import { ChatExportData, ChatExportOptions, ChatTraceStep, QuestionImage } from './types';
 import { generatePDFReport } from './pdf_template';
 import { generateMarkdownReport } from './markdown_template';
@@ -107,11 +108,11 @@ export function findPrecedingQuestion(
           .filter((c): c is TextInputContent => c.type === 'text')
           .map((c) => c.text)
           .join(' ');
-        const binaryContent = msg.content.find((c) => c.type === 'binary' && 'data' in c);
-        const image =
-          binaryContent && binaryContent.type === 'binary' && binaryContent.data
-            ? { base64: binaryContent.data, mimeType: binaryContent.mimeType || 'image/png' }
-            : undefined;
+
+        const imageContent = msg.content.map(resolveImageContent).find((c) => c?.base64);
+        const image = imageContent?.base64
+          ? { base64: imageContent.base64, mimeType: imageContent.mimeType }
+          : undefined;
         return { text, image };
       }
       return { text: '' };

--- a/src/plugins/chat/public/services/tool_executor.test.ts
+++ b/src/plugins/chat/public/services/tool_executor.test.ts
@@ -53,11 +53,15 @@ describe('ToolExecutor', () => {
       mockAssistantActionService.isUserConfirmRequired.mockReturnValue(false);
       mockAssistantActionService.executeAction.mockResolvedValue({ result: 'success' });
 
-      await toolExecutor.executeTool('testTool', { param: 'value' }, 'call-123', 'datasource-1');
+      await toolExecutor.executeTool('testTool', { param: 'value' }, 'call-123', {
+        id: 'datasource-1',
+        title: 'Datasource 1',
+      });
 
       expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('testTool', {
         param: 'value',
         datasourceId: 'datasource-1',
+        datasourceTitle: 'Datasource 1',
       });
     });
   });
@@ -119,7 +123,8 @@ describe('ToolExecutor', () => {
         'confirmTool',
         { param: 'value' },
         'call-123',
-        'datasource-1'
+        // 'datasource-1'
+        { id: 'datasource-1', title: 'Datasource 1' }
       );
 
       const pending = confirmationService.getPendingConfirmations();
@@ -131,6 +136,7 @@ describe('ToolExecutor', () => {
         param: 'value',
         confirmed: true,
         datasourceId: 'datasource-1',
+        datasourceTitle: 'Datasource 1',
       });
     });
   });

--- a/src/plugins/chat/public/services/tool_executor.ts
+++ b/src/plugins/chat/public/services/tool_executor.ts
@@ -45,7 +45,8 @@ export class ToolExecutor {
     toolName: string,
     toolArgs: any,
     toolCallId: string,
-    datasourceId?: string
+    datasourceInfo?: { id: string; title?: string },
+    timeRange?: { from: string; to: string }
   ): Promise<ToolResult> {
     try {
       // Check if this tool requires confirmation
@@ -84,7 +85,14 @@ export class ToolExecutor {
       }
 
       // Include datasourceId in toolArgs if provided
-      const enrichedToolArgs = datasourceId ? { ...toolArgs, datasourceId } : toolArgs;
+
+      let enrichedToolArgs = datasourceInfo
+        ? { ...toolArgs, datasourceId: datasourceInfo.id, datasourceTitle: datasourceInfo.title }
+        : toolArgs;
+      // Include the current page time range
+      if (timeRange) {
+        enrichedToolArgs = { ...enrichedToolArgs, timeRange };
+      }
 
       // First, check if this is a registered assistant action
       const registeredAction = await this.tryExecuteRegisteredAction(toolName, enrichedToolArgs);

--- a/src/plugins/chat/public/utils/user_message_input.ts
+++ b/src/plugins/chat/public/utils/user_message_input.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InputContent } from '../../common/types';
+
+export interface ResolvedImage {
+  base64?: string;
+  url?: string;
+  mimeType: string;
+}
+
+/**
+ * Normalize an image content block, whatever shape it arrived in.
+ *
+ * Two shapes are in play, so every consumer that renders or exports an image has to accept both
+ * or the image silently disappears:
+ * - `{type: 'image', source: {type: 'data' | 'url', value, mimeType}}` — the current shape.
+ * - `{type: 'binary', mimeType, data | url}` — the legacy flat shape, still produced by the local
+ *   screenshot path and still present in saved conversations.
+ *
+ * Returns undefined when the block is not an image or carries no payload.
+ */
+export const resolveImageContent = (block: unknown): ResolvedImage | undefined => {
+  if (typeof block !== 'object' || block === null) return undefined;
+  const candidate = block as {
+    type?: string;
+    mimeType?: string;
+    data?: string;
+    url?: string;
+    source?: { type?: string; value?: string; mimeType?: string };
+  };
+
+  if (candidate.type === 'image' && candidate.source?.value) {
+    const { type, value, mimeType } = candidate.source;
+    const resolvedMimeType = mimeType || 'image/jpeg';
+    return type === 'url'
+      ? { url: value, mimeType: resolvedMimeType }
+      : { base64: value, mimeType: resolvedMimeType };
+  }
+
+  if (candidate.type === 'binary') {
+    const resolvedMimeType = candidate.mimeType || 'image/jpeg';
+    if (candidate.data) return { base64: candidate.data, mimeType: resolvedMimeType };
+    if (candidate.url) return { url: candidate.url, mimeType: resolvedMimeType };
+  }
+
+  return undefined;
+};
+
+//  Resolve an image content block to a value usable as an `<img src>`
+export const getImageSrc = (block: unknown): string | undefined => {
+  const image = resolveImageContent(block);
+  if (!image) return undefined;
+  return image.url ?? `data:${image.mimeType};base64,${image.base64}`;
+};
+
+export const flattenContentText = (content: string | InputContent[]): string =>
+  Array.isArray(content)
+    ? content
+        .filter((block) => 'text' in block)
+        .map((block) => block.text)
+        .join('\n')
+    : content;

--- a/src/plugins/dashboard/opensearch_dashboards.json
+++ b/src/plugins/dashboard/opensearch_dashboards.json
@@ -14,5 +14,5 @@
   "optionalPlugins": ["home", "share", "usageCollection"],
   "server": true,
   "ui": true,
-  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home"]
+  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home", "contextProvider"]
 }

--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -26,7 +26,7 @@ import { DashboardVariables } from './dashboard_variables';
 export const DashboardEditor = () => {
   const { id: dashboardIdFromUrl } = useParams<{ id: string }>();
   const { services } = useOpenSearchDashboards<DashboardServices>();
-  const { chrome, uiSettings, keyboardShortcut, workspaces } = services;
+  const { chrome, uiSettings, keyboardShortcut, workspaces, chat } = services;
   // Master switch for the Dashboard Variables feature (dashboard.variables.enabled, default false).
   const variablesEnabled =
     services.pluginInitializerContext.config.get<{ variables?: { enabled?: boolean } }>()?.variables
@@ -58,6 +58,18 @@ export const DashboardEditor = () => {
     dashboardContainer: currentContainer,
     appState,
   });
+
+  useEffect(() => {
+    chat?.screenshot?.configure({
+      enabled: true,
+      title: i18n.translate('dashboard.editor.chat.addScreenshot', {
+        defaultMessage: 'Add dashboard screenshot',
+      }),
+    });
+    return () => {
+      chat?.screenshot.configure({ enabled: false });
+    };
+  }, [chat]);
 
   useEffect(() => {
     if (showActionsInGroup) setHeaderVariant?.(HeaderVariant.APPLICATION);

--- a/src/plugins/dashboard/public/application/index.tsx
+++ b/src/plugins/dashboard/public/application/index.tsx
@@ -3,15 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Router } from 'react-router-dom';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
+import { usePageContext } from '../../../context_provider/public';
 import { addHelpMenuToAppChrome } from './utils';
 import { DashboardApp } from './app';
 import { DashboardServices } from '../types';
 export * from './embeddable';
 export * from './actions';
+
+// Parse the dashboard saved-object id
+const getDashboardIdFromHash = (hash: string): string | undefined => {
+  const match = hash.match(/#\/view\/([^/?]+)/);
+  return match ? match[1] : undefined;
+};
+
+// register the dashboard page context
+const DashboardPageContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  usePageContext({
+    description: 'Dashboard application page context',
+    convert: (urlState: any) => ({
+      appId: 'dashboards',
+      dashboardId: getDashboardIdFromHash(urlState.hash || ''),
+      timeRange: urlState._g?.time,
+    }),
+    categories: ['page', 'static'],
+  });
+
+  return <>{children}</>;
+};
 
 export const renderApp = ({ element }: AppMountParameters, services: DashboardServices) => {
   addHelpMenuToAppChrome(services.chrome, services.docLinks);
@@ -20,7 +43,9 @@ export const renderApp = ({ element }: AppMountParameters, services: DashboardSe
     <Router history={services.history}>
       <OpenSearchDashboardsContextProvider services={services}>
         <services.i18n.Context>
-          <DashboardApp />
+          <DashboardPageContextProvider>
+            <DashboardApp />
+          </DashboardPageContextProvider>
         </services.i18n.Context>
       </OpenSearchDashboardsContextProvider>
     </Router>

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -29,7 +29,7 @@
  */
 
 import { NameList } from 'elasticsearch';
-import { Filter, IDataFrame, DataView, IndexPattern, Query } from '../..';
+import { Filter, IDataFrame, DataView, IndexPattern, Query, TimeRange } from '../..';
 import { SearchSource } from './search_source';
 
 /**
@@ -106,6 +106,12 @@ export interface SearchSourceFields {
   df?: IDataFrame;
   skipTimeFilter?: boolean;
   skipFilters?: boolean;
+  /**
+   * An explicit time range for languages that inject a time filter
+   * into the query. When set, it overrides the global timefilter, letting a
+   * caller pin the query to a fixed (absolute) window.
+   */
+  timeRange?: TimeRange;
 }
 
 export interface SearchSourceOptions {

--- a/src/plugins/explore/public/actions/ask_ai_embeddable_action.test.tsx
+++ b/src/plugins/explore/public/actions/ask_ai_embeddable_action.test.tsx
@@ -162,17 +162,27 @@ describe('AskAIEmbeddableAction', () => {
       document.body.innerHTML = '';
     });
 
-    it('should add context to context provider', async () => {
+    it('should send visualization context to chat', async () => {
       await action.execute({ embeddable: mockEmbeddable });
 
       await waitFor(() => {
-        expect(mockContextProvider.getAssistantContextStore).toHaveBeenCalled();
-        expect(mockContextProvider.getAssistantContextStore().addContext).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringContaining('visualization-'),
-            description: expect.stringContaining('Test Visualization'),
-            categories: ['visualization', 'dashboard', 'chat'],
-          })
+        expect(mockCore.chat.sendMessageWithWindow).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: 'image',
+              source: expect.objectContaining({
+                type: 'data',
+                value: 'mockImageData',
+                mimeType: 'image/jpeg',
+              }),
+            }),
+            expect.objectContaining({
+              type: 'text',
+              name: 'visualization_context',
+              text: expect.stringContaining('Test Visualization'),
+            }),
+          ]),
+          []
         );
       });
     });

--- a/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
@@ -105,48 +105,59 @@ export class AskAIEmbeddableAction implements Action<EmbeddableContext> {
       // Use JPEG format with low quality to save tokens
       visualizationBase64 = canvas.toDataURL('image/jpeg', 0.5).split(',')[1];
 
-      // Create context for the assistant with summary
-      const visualizationContext = {
-        title,
-        visType,
-        savedObjectId,
-        timeRange,
-        query: query?.query,
-        filters,
-        index: query?.dataset?.title,
-      };
+      // Parse visualization config for axes mapping and transformations
+      const visualizationConfig = JSON.parse(visEmbeddable.savedExplore.visualization || '{}');
+      const axesMapping = visualizationConfig.axesMapping;
+      const chartType = visualizationConfig.chartType;
+      const dataTransformations = visualizationConfig.dataTransformations;
 
-      // Add context to the context provider
-      if (this.contextProvider) {
-        const contextStore = this.contextProvider.getAssistantContextStore();
-        await contextStore.addContext({
-          id: `visualization-${savedObjectId || embeddable.id}`,
-          description: `Visualization: ${title}`,
-          value: visualizationContext,
-          label: `Visualization: ${title}`,
-          categories: ['visualization', 'dashboard', 'chat'],
-        });
-      }
+      const visualizationContextText = [
+        `[Visualization Context]`,
+        `Title: ${title}`,
+        `Chart Type: ${chartType || visType}`,
+        `Saved Object ID: ${savedObjectId}`,
+        `Index: ${query?.dataset?.title || 'N/A'}`,
+        `Query: ${query?.query || 'N/A'}`,
+        `Time Range: ${timeRange ? `${timeRange.from} → ${timeRange.to}` : 'N/A'}`,
+        filters && filters.length > 0 ? `Filters: ${JSON.stringify(filters)}` : null,
+        axesMapping && Object.keys(axesMapping).length > 0
+          ? `Axes Mapping: ${JSON.stringify(axesMapping)}`
+          : null,
+        dataTransformations && dataTransformations.length > 0
+          ? `Data Transformations: ${dataTransformations
+              .map(
+                (t: any) =>
+                  `${t.definitionId}${t.hide ? ' (disabled)' : ''}: ${JSON.stringify(t.config)}`
+              )
+              .join('; ')}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join('\n');
 
       // Send visualization screenshot to chat
       if (this.core.chat) {
-        // Create a message with the visualization image following AG-UI protocol
-        const imageMessage = {
-          role: 'user' as const,
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          content: [
+        await this.core.chat.sendMessageWithWindow(
+          [
             {
-              type: 'binary' as const,
-              mimeType: 'image/jpeg',
-              data: visualizationBase64,
+              type: 'image',
+              source: {
+                type: 'data',
+                value: visualizationBase64,
+                mimeType: 'image/jpeg',
+              },
+            },
+            {
+              type: 'text',
+              text: visualizationContextText,
+              name: 'visualization_context',
+            },
+            {
+              type: 'text',
+              text: 'Give me a summary for the selected visualization',
             },
           ],
-        };
-
-        // sendMessageWithWindow will open the chat window and send the message
-        await this.core.chat.sendMessageWithWindow(
-          'Give me a summary for the selected visualization',
-          [imageMessage]
+          []
         );
       }
     } catch (error) {

--- a/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
@@ -210,7 +210,7 @@ export const queryExecution = async ({
       throw new Error('Dataset not found for query execution');
     }
 
-    const dataset = services.data.dataViews.convertToDataset(dataView);
+    const dataset = await services.data.dataViews.convertToDataset(dataView);
 
     const preparedQueryObject = {
       ...query,

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -532,7 +532,7 @@ const executeQueryBase = async (
       throw new Error('Dataset not found for query execution');
     }
 
-    const dataset = services.data.dataViews.convertToDataset(dataView);
+    const dataset = await services.data.dataViews.convertToDataset(dataView);
 
     // Create histogram config once for use in both query building and result processing
     let histogramConfig: HistogramConfig | null = null;

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.test.tsx
@@ -1,0 +1,434 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import rison from 'rison-node';
+import {
+  registerAutoVisualizationAction,
+  AUTO_VISUALIZATION_TOOL_NAME,
+} from './auto_visualization_action';
+
+// --- Mocks for heavy / environment-coupled dependencies -------------------
+
+const mockFindRulesByColumns = jest.fn();
+const mockGetAxesMappingByRule = jest.fn();
+const mockGetVisualization = jest.fn();
+
+jest.mock('../../../components/visualizations/visualization_registry', () => ({
+  visualizationRegistry: {
+    findRulesByColumns: (...args: any[]) => mockFindRulesByColumns(...args),
+    getAxesMappingByRule: (...args: any[]) => mockGetAxesMappingByRule(...args),
+    getVisualization: (...args: any[]) => mockGetVisualization(...args),
+  },
+}));
+
+const mockNormalizeResultRows = jest.fn();
+jest.mock('../../../components/visualizations/utils/normalize_result_rows', () => ({
+  normalizeResultRows: (...args: any[]) => mockNormalizeResultRows(...args),
+}));
+
+jest.mock('../../../components/visualizations/visualization_render', () => ({
+  CommonVisualizationRender: () => <div data-test-subj="commonVisRender" />,
+}));
+
+jest.mock('../../../application/in_context_vis_editor/component/vis_editor_no_results', () => ({
+  VisEditorNoResults: () => <div data-test-subj="visEditorNoResults" />,
+}));
+
+jest.mock('./utils', () => ({
+  AUTO_VISUALIZATION_TOOL_NAME: 'auto_create_visualization',
+  AutoVisMeta: {
+    name: 'auto_create_visualization',
+    description: 'desc',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+}));
+
+const baseArgs = {
+  query: 'source=flights | stats avg(price) by carrier',
+  indexName: 'flights',
+  columns: [
+    { name: 'carrier', type: 'keyword' },
+    { name: 'avg(price)', type: 'double' },
+  ],
+};
+
+const createCore = () =>
+  ({
+    uiSettings: { get: jest.fn(() => 500) },
+    http: { basePath: { prepend: (p: string) => `/base${p}` } },
+    savedObjects: {
+      client: { get: jest.fn().mockResolvedValue({ attributes: { title: 'My Dashboard' } }) },
+    },
+    notifications: { toasts: {} },
+    application: { navigateToApp: jest.fn() },
+  }) as unknown as any;
+
+const createData = (bounds?: { min: any; max: any }, globalTime?: any) =>
+  ({
+    query: {
+      timefilter: {
+        timefilter: {
+          getTime: jest.fn(() => globalTime),
+          calculateBounds: jest.fn(() => bounds ?? { min: undefined, max: undefined }),
+        },
+      },
+    },
+    search: { searchSource: { create: jest.fn() } },
+  }) as unknown as any;
+
+const createContextProvider = (dashboardId?: string) =>
+  ({
+    getAssistantContextStore: () => ({
+      getContextsByCategory: (category: string) =>
+        category === 'page' && dashboardId ? [{ value: { appId: 'dashboards', dashboardId } }] : [],
+    }),
+  }) as unknown as any;
+
+const registerAndGetAction = (core: any, data: any, contextProvider?: any): any => {
+  let captured: any;
+  const registerAction = jest.fn((action: any) => {
+    captured = action;
+  });
+  registerAutoVisualizationAction(registerAction, core, data, contextProvider);
+  return captured;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNormalizeResultRows.mockReturnValue({
+    transformedData: [{ carrier: 'A', 'avg(price)': 1 }],
+    numericalColumns: [{ name: 'avg(price)' }],
+    categoricalColumns: [{ name: 'carrier' }],
+    dateColumns: [],
+    unknownColumns: [],
+  });
+  mockFindRulesByColumns.mockReturnValue({
+    exact: [{ visType: 'bar', rules: [{ priority: 10 }] }],
+    all: [{ visType: 'bar', rules: [{ priority: 10 }] }],
+  });
+  mockGetAxesMappingByRule.mockReturnValue({ x: 'carrier', y: 'avg(price)' });
+  mockGetVisualization.mockReturnValue({ ui: { style: { defaults: { color: 'red' } } } });
+});
+
+describe('registerAutoVisualizationAction', () => {
+  it('does nothing when registerAction is undefined', () => {
+    expect(() =>
+      registerAutoVisualizationAction(undefined as any, createCore(), createData())
+    ).not.toThrow();
+  });
+
+  it('registers an action with the auto visualization tool name and custom renderer', () => {
+    const action = registerAndGetAction(createCore(), createData());
+    expect(action.name).toBe(AUTO_VISUALIZATION_TOOL_NAME);
+    expect(action.useCustomRenderer).toBe(true);
+    expect(typeof action.handler).toBe('function');
+    expect(typeof action.render).toBe('function');
+  });
+});
+
+describe('handler', () => {
+  it('resolves the highest-priority compatible chart and returns a success result', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+
+    expect(result.success).toBe(true);
+    expect(result.chartType).toBe('bar');
+    expect(result.resolvedAxesMapping).toEqual({ x: 'carrier', y: 'avg(price)' });
+    expect(result.visConfig).toEqual({
+      type: 'bar',
+      axesMapping: { x: 'carrier', y: 'avg(price)' },
+      splitField: undefined,
+      styles: { color: 'red' },
+    });
+    expect(result.preparedQuery).toEqual({
+      dataset: expect.objectContaining({ id: 'flights', title: 'flights' }),
+      language: 'PPL',
+      query: baseArgs.query,
+    });
+  });
+
+  it('honors a compatible potentialChartType hint', async () => {
+    mockFindRulesByColumns.mockReturnValue({
+      exact: [
+        { visType: 'bar', rules: [{ priority: 5 }] },
+        { visType: 'pie', rules: [{ priority: 3 }] },
+      ],
+      all: [],
+    });
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler({ ...baseArgs, potentialChartType: 'pie' });
+    expect(result.chartType).toBe('pie');
+  });
+
+  it('falls back to table when no compatible charts are found', async () => {
+    mockFindRulesByColumns.mockReturnValue({ exact: [], all: [] });
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+    expect(result.success).toBe(true);
+    expect(result.chartType).toBe('table');
+    expect(result.resolvedAxesMapping).toEqual({});
+  });
+
+  it('returns a failure result when the chart-type hint is incompatible', async () => {
+    // Only 'bar' is compatible, but the user asked for 'pie'.
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler({ ...baseArgs, potentialChartType: 'pie' });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not compatible');
+    expect(result.message).toContain('bar');
+  });
+
+  it('builds an editor path with encoded _v and _eq params', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+
+    expect(result.editorPath).toEqual(expect.stringContaining('#/?_v='));
+    expect(result.editorPath).toEqual(expect.stringContaining('&_eq='));
+    // No time range / dashboard by default.
+    expect(result.editorPath).not.toContain('_g=');
+    expect(result.editorPath).not.toContain('_c=');
+  });
+
+  it('resolves a relative time range to an absolute window', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    expect(result.resolvedTimeRange).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-08T00:00:00.000Z',
+    });
+    // _g is encoded into the editor path.
+    const gParam = `_g=${encodeURIComponent(
+      rison.encode({
+        time: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-08T00:00:00.000Z' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(gParam);
+  });
+
+  it('prefers the from/to the agent asked for over the injected page time range', async () => {
+    const min = { toISOString: () => '2026-02-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-02-02T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      from: 'now-1d',
+      to: 'now',
+      // chat injects this from the page context on every tool call
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    expect(data.query.timefilter.timefilter.calculateBounds).toHaveBeenCalledWith({
+      from: 'now-1d',
+      to: 'now',
+    });
+    expect(data.query.timefilter.timefilter.getTime).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the global time filter when neither from/to nor a page range is given', async () => {
+    const min = { toISOString: () => '2026-03-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-03-02T00:00:00.000Z' };
+    const data = createData({ min, max }, { from: 'now-15m', to: 'now' });
+    const action = registerAndGetAction(createCore(), data);
+
+    await action.handler({ ...baseArgs, timeFieldName: 'timestamp' });
+
+    expect(data.query.timefilter.timefilter.getTime).toHaveBeenCalled();
+    expect(data.query.timefilter.timefilter.calculateBounds).toHaveBeenCalledWith({
+      from: 'now-15m',
+      to: 'now',
+    });
+  });
+
+  it('ignores a half-specified time range and uses the page range instead', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      from: 'now-1d',
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    // No throw: the resolved range the payload reports is the page one, so the llm can
+    // see its half-range was not used.
+    expect(result.success).toBe(true);
+    expect(data.query.timefilter.timefilter.calculateBounds).toHaveBeenCalledWith({
+      from: 'now-7d',
+      to: 'now',
+    });
+  });
+
+  it('rejects a time range without timeFieldName, since it would be dropped', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const action = registerAndGetAction(createCore(), createData({ min, max }));
+
+    const result = await action.handler({ ...baseArgs, from: 'now-1d', to: 'now' });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('timeFieldName');
+    // Both ways out are offered so an index with no time field cannot trap the llm.
+    expect(result.message).toContain('omit from/to');
+  });
+
+  it('reports no resolved range when the agent time range is unparseable', async () => {
+    // dateMath yields null min/max for anything it cannot parse, e.g. "last tuesday".
+    const action = registerAndGetAction(createCore(), createData());
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      from: 'last tuesday',
+      to: 'now',
+    });
+
+    // The chart still renders, but resolvedTimeRange stays undefined, so nothing claims
+    // the requested range was applied.
+    expect(result.success).toBe(true);
+    expect(result.resolvedTimeRange).toBeUndefined();
+    expect(result.editorPath).not.toContain('_g=');
+  });
+
+  it('keeps rendering without a time range when the page range is unparseable', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      timeRange: { from: 'bogus', to: 'now' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.resolvedTimeRange).toBeUndefined();
+    expect(result.editorPath).not.toContain('_g=');
+  });
+
+  it('adds dashboard container info (_c) when on a dashboard page', async () => {
+    const core = createCore();
+    const action = registerAndGetAction(core, createData(), createContextProvider('dash-1'));
+    const result = await action.handler(baseArgs);
+
+    expect(core.savedObjects.client.get).toHaveBeenCalledWith('dashboard', 'dash-1');
+    const cParam = `_c=${encodeURIComponent(
+      rison.encode({
+        originatingApp: 'dashboards',
+        containerInfo: { containerId: 'dash-1', containerName: 'My Dashboard' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(cParam);
+  });
+
+  it('omits _c when not on a dashboard page', async () => {
+    const action = registerAndGetAction(createCore(), createData(), createContextProvider());
+    const result = await action.handler(baseArgs);
+    expect(result.editorPath).not.toContain('_c=');
+  });
+
+  it('still succeeds when the dashboard name lookup fails', async () => {
+    const core = createCore();
+    core.savedObjects.client.get = jest.fn().mockRejectedValue(new Error('not found'));
+    const action = registerAndGetAction(core, createData(), createContextProvider('dash-1'));
+    const result = await action.handler(baseArgs);
+
+    // containerId present, containerName omitted.
+    const cParam = `_c=${encodeURIComponent(
+      rison.encode({
+        originatingApp: 'dashboards',
+        containerInfo: { containerId: 'dash-1' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(cParam);
+  });
+});
+
+describe('render', () => {
+  const renderResult = (core: any, data: any, props: any) => {
+    const action = registerAndGetAction(core, data, undefined);
+    return render(action.render(props));
+  };
+
+  it('renders nothing while pending', () => {
+    const { container } = renderResult(createCore(), createData(), {
+      status: 'executing',
+      args: baseArgs,
+      result: undefined,
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the parameters accordion and open-in-editor button on success', () => {
+    // Chart preview kicks off a fetch; make searchSource resolve to empty rows.
+    const data = createData();
+    data.search.searchSource.create = jest.fn().mockResolvedValue({
+      setFields: jest.fn(),
+      fetch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+      getDataFrame: jest.fn(() => ({ schema: [] })),
+    });
+    data.query.queryString = {
+      getLanguageService: () => ({ getLanguage: () => ({}) }),
+    };
+
+    renderResult(createCore(), data, {
+      status: 'complete',
+      args: baseArgs,
+      result: {
+        success: true,
+        preparedQuery: { dataset: { title: 'flights' }, language: 'PPL', query: baseArgs.query },
+        visConfig: { type: 'bar', axesMapping: {}, styles: {} },
+        editorPath: '#/?_v=x',
+      },
+    });
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    expect(screen.getByText('Open in Editor')).toBeInTheDocument();
+  });
+
+  it('shows the resolved window in the parameters, not the raw from/to', () => {
+    const data = createData();
+    data.search.searchSource.create = jest.fn().mockResolvedValue({
+      setFields: jest.fn(),
+      fetch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+      getDataFrame: jest.fn(() => ({ schema: [] })),
+    });
+    data.query.queryString = {
+      getLanguageService: () => ({ getLanguage: () => ({}) }),
+    };
+
+    renderResult(createCore(), data, {
+      status: 'complete',
+      args: { ...baseArgs, timeFieldName: 'timestamp', from: 'now-7d', to: 'now' },
+      result: {
+        success: true,
+        preparedQuery: { dataset: { title: 'flights' }, language: 'PPL', query: baseArgs.query },
+        visConfig: { type: 'bar', axesMapping: {}, styles: {} },
+        editorPath: '#/?_v=x',
+        resolvedTimeRange: {
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-01-08T00:00:00.000Z',
+        },
+      },
+    });
+
+    const paramsJson = screen.getByText(/"timeRange"/).textContent ?? '';
+    expect(paramsJson).toContain('2026-01-01T00:00:00.000Z');
+    expect(paramsJson).not.toContain('now-7d');
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
@@ -1,0 +1,583 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import rison from 'rison-node';
+import {
+  EuiPanel,
+  EuiText,
+  EuiSpacer,
+  EuiButton,
+  EuiAccordion,
+  EuiCodeBlock,
+  EuiLoadingChart,
+  EuiCallOut,
+} from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { RenderProps, ContextProviderStart } from '../../../../../context_provider/public';
+import { DataPublicPluginStart, TimeRange } from '../../../../../data/public';
+import { Dataset, DEFAULT_DATA } from '../../../../../data/common';
+import { ChartType } from '../../../components/visualizations/utils/use_visualization_types';
+import {
+  AxisFieldNameMappings,
+  RenderChartConfig,
+  VisColumn,
+} from '../../../components/visualizations/types';
+import { VisData } from '../../../components/visualizations/visualization_builder.types';
+import { CommonVisualizationRender } from '../../../components/visualizations/visualization_render';
+import { normalizeResultRows } from '../../../components/visualizations/utils/normalize_result_rows';
+import { visualizationRegistry } from '../../../components/visualizations/visualization_registry';
+import { SAMPLE_SIZE_SETTING, VISUALIZATION_EDITOR_APP_ID } from '../../../../common';
+import { VisEditorNoResults } from '../../../application/in_context_vis_editor/component/vis_editor_no_results';
+import { AutoVisMeta } from './utils';
+
+export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+
+interface AutoVisualizationArgs {
+  query: string;
+  indexName: string;
+  // user intended chart type
+  potentialChartType?: string;
+  columns: Array<{ name: string; type: string }>;
+  splitField?: string;
+  // used to build dataset, without it time range search bar will not show
+  timeFieldName?: string;
+  // injected by chat from the current page context
+  timeRange?: TimeRange;
+  // used to build dataset
+  datasourceId?: string;
+  datasourceTitle?: string;
+  dashboardId?: string;
+  // the time range the llm passed
+  from?: string;
+  to?: string;
+}
+
+interface PreparedQuery {
+  dataset: Dataset;
+  language: string;
+  query: string;
+}
+
+interface VisualizationConfigResult {
+  success: true;
+  visConfig: RenderChartConfig;
+  query: PreparedQuery;
+  resolvedChartType: ChartType;
+  resolvedAxesMapping: AxisFieldNameMappings;
+}
+
+const DASHBOARDS_APP_ID = 'dashboards';
+
+function buildEditorPath(
+  visConfig: RenderChartConfig,
+  query: PreparedQuery,
+  timeRange?: TimeRange,
+  dashboardId?: string,
+  dashboardName?: string,
+  originatingApp?: string
+): string {
+  const visState: Record<string, any> = {
+    chartType: visConfig.type,
+    axesMapping: visConfig.axesMapping,
+    styleOptions: visConfig.styles,
+  };
+  if (visConfig.splitField) {
+    visState.splitField = visConfig.splitField;
+  }
+
+  const vParam = rison.encode(visState);
+  const eqParam = rison.encode(query as Record<string, any>);
+
+  const gParam = timeRange
+    ? `&_g=${encodeURIComponent(rison.encode({ time: { from: timeRange.from, to: timeRange.to } }))}`
+    : '';
+
+  // Bind the visualization to the originating dashboard via `_c` (containerInfo),
+  const cParam = originatingApp
+    ? `&_c=${encodeURIComponent(
+        rison.encode({
+          originatingApp,
+          ...(dashboardId && {
+            containerInfo: {
+              containerId: dashboardId,
+              ...(dashboardName && { containerName: dashboardName }),
+            },
+          }),
+        })
+      )}`
+    : '';
+
+  return `#/?_v=${encodeURIComponent(vParam)}&_eq=${encodeURIComponent(eqParam)}${gParam}${cParam}`;
+}
+
+/**
+ * Resolve axes mapping and chart type given the classified columns.
+ */
+function resolveChartFromSchema(
+  numericalColumns: VisColumn[],
+  categoricalColumns: VisColumn[],
+  dateColumns: VisColumn[],
+  potentialChartType?: string
+): {
+  chartType: ChartType;
+  axesMapping: AxisFieldNameMappings;
+} {
+  // 1. find all compatible rules with visualization registry
+  const { all: allMatches, exact: exactMatches } = visualizationRegistry.findRulesByColumns(
+    numericalColumns,
+    categoricalColumns,
+    dateColumns
+  );
+
+  const candidates: Array<{
+    chartType: ChartType;
+    priority: number;
+    axesMapping: AxisFieldNameMappings;
+  }> = [];
+  const seenChartTypes = new Set<string>();
+
+  for (const matches of [exactMatches, allMatches]) {
+    for (const { visType, rules } of matches) {
+      if (seenChartTypes.has(visType)) continue;
+      seenChartTypes.add(visType);
+      // 2. only provide the highest-priority rule for each chart type
+      const bestRule = rules.reduce((best, r) => (r.priority > best.priority ? r : best));
+      const axesMapping = visualizationRegistry.getAxesMappingByRule(
+        bestRule,
+        numericalColumns,
+        categoricalColumns,
+        dateColumns
+      );
+      if (Object.keys(axesMapping).length === 0) continue;
+
+      candidates.push({
+        chartType: visType as ChartType,
+        priority: bestRule.priority,
+        axesMapping,
+      });
+    }
+  }
+
+  // 3. If the user provided a potential chart-type, use it
+  if (potentialChartType) {
+    const matched = candidates.find(
+      (c) => c.chartType.toLowerCase() === potentialChartType.toLowerCase()
+    );
+    if (matched) {
+      return { chartType: matched.chartType, axesMapping: matched.axesMapping };
+    }
+    // chart is incompatible with the columns.
+    // the throw reaches the llm.
+    throw new Error(
+      `Chart type "${potentialChartType}" is not compatible with the query result columns. ` +
+        `Compatible chart types: [${candidates.map((c) => c.chartType).join(', ')}]. ` +
+        `Please adjust ppl query.`
+    );
+  }
+
+  // 4. No potential chart and candidates, use table
+  if (candidates.length === 0) {
+    // fallback to table vis
+    return { chartType: 'table', axesMapping: {} };
+  }
+
+  // 5. No potential chart, use the chart with highest-priority
+  const best = candidates.reduce((a, b) => (b.priority > a.priority ? b : a));
+  return { chartType: best.chartType, axesMapping: best.axesMapping };
+}
+
+/**
+ * Build the dataset manually + prepared query object from the tool args. The dataset is
+ * built manually and will not be created.
+ */
+function buildPreparedQuery(args: AutoVisualizationArgs): PreparedQuery {
+  const datasetId = args.datasourceId ? `${args?.datasourceId}_${args.indexName}` : args.indexName;
+  const dataset: Dataset = {
+    id: datasetId,
+    title: args.indexName,
+    type: DEFAULT_DATA.SET_TYPES.INDEX,
+    timeFieldName: args.timeFieldName,
+    ...(args.datasourceId && {
+      dataSource: {
+        id: args.datasourceId,
+        title: args?.datasourceTitle || '',
+        type: 'DATA_SOURCE',
+        version: '',
+      },
+    }),
+  };
+
+  return {
+    dataset,
+    language: 'PPL',
+    query: args.query,
+  };
+}
+
+/**
+ * Read the current dashboard id from the page context,
+ * Read lazily (only when building the editor URL) rather than injected
+ * into every tool call, since most tools don't need it.
+ */
+function getCurrentDashboardContext(contextProvider?: ContextProviderStart): {
+  originatingApp?: string;
+  dashboardId?: string;
+} {
+  const pageContexts = contextProvider?.getAssistantContextStore().getContextsByCategory('page');
+  const dashboardContext = pageContexts?.find((ctx) => {
+    const value = typeof ctx.value === 'string' ? JSON.parse(ctx.value) : ctx.value;
+    return value?.appId === DASHBOARDS_APP_ID;
+  });
+  if (!dashboardContext) return {};
+  const value =
+    typeof dashboardContext.value === 'string'
+      ? JSON.parse(dashboardContext.value)
+      : dashboardContext.value;
+  return { originatingApp: DASHBOARDS_APP_ID, dashboardId: value?.dashboardId };
+}
+
+async function getDashboardName(core: CoreStart, dashboardId: string): Promise<string | undefined> {
+  try {
+    const savedObject = await core.savedObjects.client.get<{ title?: string }>(
+      'dashboard',
+      dashboardId
+    );
+    return savedObject.attributes?.title;
+  } catch {
+    return undefined;
+  }
+}
+
+function getAbsoluteTimeRange(
+  data: DataPublicPluginStart,
+  args: Pick<AutoVisualizationArgs, 'from' | 'to' | 'timeRange'>
+): TimeRange | undefined {
+  const time = args.from && args.to ? { from: args.from, to: args.to } : undefined;
+
+  // if there is not timeRange in page context use global time filter
+  const range = time ?? args?.timeRange ?? data.query.timefilter.timefilter.getTime();
+  const bounds = data.query.timefilter.timefilter.calculateBounds(range);
+  if (!bounds.min || !bounds.max) return undefined;
+  return { from: bounds.min.toISOString(), to: bounds.max.toISOString() };
+}
+
+/**
+ * Execute the PPL query and normalize the results into VisData.
+ */
+async function executePPLQuery(
+  preparedQueryObject: PreparedQuery,
+  core: CoreStart,
+  data: DataPublicPluginStart,
+  timeRange?: TimeRange,
+  abortSignal?: AbortSignal
+): Promise<VisData> {
+  const uiSettings = core.uiSettings;
+  const dataset = preparedQueryObject.dataset;
+
+  await data.query.queryString.getDatasetService().cacheDataset(
+    dataset,
+    {
+      uiSettings: core.uiSettings,
+      savedObjects: core.savedObjects,
+      notifications: core.notifications,
+      http: core.http,
+      data,
+    },
+    false
+  );
+  const dataView = await data.dataViews.get(dataset.id);
+
+  const size = uiSettings.get(SAMPLE_SIZE_SETTING);
+  const searchSource = await data.search.searchSource.create();
+
+  searchSource.setFields({
+    index: dataView,
+    size,
+    query: preparedQueryObject,
+    highlightAll: false,
+    version: false,
+
+    // Pass absolute time range so the PPL search interceptor injects
+    // it into the query instead of using the global timefilter.
+    ...(timeRange && dataset.timeFieldName ? { timeRange } : {}),
+  });
+
+  const languageConfig = data.query.queryString
+    .getLanguageService()
+    .getLanguage(preparedQueryObject.language);
+
+  // Execute query
+  const rawResults = await searchSource.fetch({
+    abortSignal,
+    withLongNumeralsSupport: await uiSettings.get('data:withLongNumerals'),
+    ...(languageConfig?.fields?.formatter ? { formatter: languageConfig.fields.formatter } : {}),
+  });
+
+  const rawResultsHit = rawResults.hits?.hits ?? [];
+  const fieldSchema = searchSource.getDataFrame()?.schema ?? [];
+  return normalizeResultRows(rawResultsHit, fieldSchema);
+}
+
+/**
+ * resolve the chart config from ppl execution columns results
+ */
+function buildVisConfig(args: AutoVisualizationArgs): VisualizationConfigResult {
+  const preparedQueryObject = buildPreparedQuery(args);
+
+  // 1. get normalized schema
+  const schema = (args.columns || []).map((col) => ({ name: col.name, type: col.type }));
+  const { numericalColumns, categoricalColumns, dateColumns } = normalizeResultRows([], schema);
+
+  // 2. resolve axes mapping and chart type
+  const matchChart = resolveChartFromSchema(
+    numericalColumns,
+    categoricalColumns,
+    dateColumns,
+    args.potentialChartType
+  );
+
+  // 3. build vis config
+  const defaultStyles = visualizationRegistry.getVisualization(matchChart.chartType)?.ui.style
+    .defaults;
+
+  const visConfig: RenderChartConfig = {
+    type: matchChart.chartType,
+    axesMapping: matchChart.axesMapping,
+    splitField: args.splitField,
+    styles: defaultStyles || {},
+  };
+
+  return {
+    visConfig,
+    query: preparedQueryObject,
+    success: true,
+    resolvedChartType: matchChart.chartType,
+    resolvedAxesMapping: matchChart.axesMapping,
+  };
+}
+
+/**
+ * Chart preview that executes the PPL query at render time to fetch the row data,
+ */
+function ChartPreview({
+  query,
+  visConfig,
+  core,
+  data,
+  timeRange,
+}: {
+  query: PreparedQuery;
+  visConfig: RenderChartConfig;
+  core: CoreStart;
+  data: DataPublicPluginStart;
+  timeRange?: TimeRange;
+}) {
+  const [visData, setVisData] = useState<VisData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+    executePPLQuery(query, core, data, timeRange, abortController.signal)
+      .then((result) => {
+        if (!cancelled) setVisData(result);
+      })
+      .catch((e) => {
+        if (!cancelled && !abortController.signal.aborted) {
+          setError(e instanceof Error ? e.message : 'Failed to load chart data');
+        }
+      });
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (error) {
+    return (
+      <EuiCallOut size="s" color="danger" title="Could not render chart">
+        <EuiText size="xs">{error}</EuiText>
+      </EuiCallOut>
+    );
+  }
+
+  if (!visData) {
+    return (
+      <div
+        style={{
+          height: 250,
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <EuiLoadingChart size="l" />
+      </div>
+    );
+  }
+
+  if (visData.transformedData.length === 0) {
+    return (
+      <div style={{ height: 250, width: '100%' }}>
+        <VisEditorNoResults />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <CommonVisualizationRender
+        visualizationData={visData}
+        visConfig={visConfig}
+        showRawTable={false}
+      />
+    </div>
+  );
+}
+
+function ArgsParameters({
+  args,
+  absoluteTimeRange,
+}: {
+  args: AutoVisualizationArgs;
+  absoluteTimeRange?: TimeRange;
+}) {
+  const { from, to, ...restArgs } = args;
+  const displayArgs = absoluteTimeRange ? { ...restArgs, timeRange: absoluteTimeRange } : restArgs;
+  return (
+    <EuiAccordion id="auto-vis-args" buttonContent="Parameters" paddingSize="xs">
+      <EuiPanel hasBorder paddingSize="s" style={{ wordBreak: 'break-all' }} hasShadow={false}>
+        <EuiCodeBlock
+          language="json"
+          paddingSize="none"
+          fontSize="s"
+          transparentBackground
+          overflowHeight={150}
+          isCopyable
+        >
+          {JSON.stringify(displayArgs, null, 2)}
+        </EuiCodeBlock>
+      </EuiPanel>
+    </EuiAccordion>
+  );
+}
+
+function getCurrentAppId(core: CoreStart): string | undefined {
+  let appId: string | undefined;
+  const subscription = core.application.currentAppId$.subscribe((id) => {
+    appId = id;
+  });
+  subscription.unsubscribe();
+  return appId;
+}
+
+function openVisualizationEditor(core: CoreStart, editorPath: string) {
+  const visEditorAppBase = core.http.basePath.prepend(`/app/${VISUALIZATION_EDITOR_APP_ID}`);
+  if (getCurrentAppId(core) === VISUALIZATION_EDITOR_APP_ID) {
+    // When already on the vis editor app, navigateToApp only calls history.push without
+    // remounting the page, so the new URL params are ignored by the already-initialized
+    // component. Use window.location.href instead to force a full navigation that
+    // unmounts and remounts the app.
+    window.location.href = `${visEditorAppBase}${editorPath}`;
+  } else {
+    core.application.navigateToApp(VISUALIZATION_EDITOR_APP_ID, { path: editorPath });
+  }
+}
+
+function checkTimeRangeArgsUsable(args: AutoVisualizationArgs): void {
+  if (!args.from || !args.to) return;
+
+  if (!args.timeFieldName) {
+    throw new Error(
+      'A time range (from/to) cannot be applied without timeFieldName, so it would be ' +
+        'ignored. Either call the index mapping tool to look up the time field of ' +
+        `"${args.indexName}" and pass it as timeFieldName, or omit from/to if this index ` +
+        'has no time field.'
+    );
+  }
+}
+
+export function registerAutoVisualizationAction(
+  registerAction: ((action: any) => void) | undefined,
+  core: CoreStart,
+  data: DataPublicPluginStart,
+  contextProvider?: ContextProviderStart
+) {
+  if (!registerAction) return;
+
+  const renderAutoVisualization = ({
+    status,
+    args,
+    result,
+  }: RenderProps<AutoVisualizationArgs>) => {
+    if (status === 'complete' && result?.success) {
+      return (
+        <EuiPanel paddingSize="s" grow={false} hasShadow={false}>
+          {args && <ArgsParameters args={args} absoluteTimeRange={result.resolvedTimeRange} />}
+          <ChartPreview
+            query={result.preparedQuery}
+            visConfig={result.visConfig}
+            core={core}
+            data={data}
+            timeRange={result.resolvedTimeRange}
+          />
+          <EuiSpacer size="s" />
+          <EuiButton size="s" onClick={() => openVisualizationEditor(core, result.editorPath)}>
+            Open in Editor
+          </EuiButton>
+        </EuiPanel>
+      );
+    }
+
+    return null;
+  };
+
+  registerAction({
+    ...AutoVisMeta,
+    useCustomRenderer: true,
+    handler: async (args: AutoVisualizationArgs) => {
+      try {
+        checkTimeRangeArgsUsable(args);
+        const { visConfig, query, resolvedChartType, resolvedAxesMapping } = buildVisConfig(args);
+        const resolvedTimeRange = getAbsoluteTimeRange(data, args);
+        const { originatingApp, dashboardId } = getCurrentDashboardContext(contextProvider);
+
+        const dashboardName = dashboardId ? await getDashboardName(core, dashboardId) : undefined;
+        const editorPath = buildEditorPath(
+          visConfig,
+          query,
+          resolvedTimeRange,
+          dashboardId,
+          dashboardName,
+          originatingApp
+        );
+
+        return {
+          success: true,
+          chartType: resolvedChartType,
+          resolvedAxesMapping,
+          query: args.query,
+          indexName: args.indexName,
+          editorPath,
+          visConfig,
+          preparedQuery: query,
+          resolvedTimeRange,
+          message: `Created ${resolvedChartType} visualization for ${args.indexName}`,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          query: args.query,
+          indexName: args.indexName,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        };
+      }
+    },
+    render: renderAutoVisualization,
+  });
+}

--- a/src/plugins/explore/public/components/visualizations/actions/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/actions/utils.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+
+const CHART_TYPE_INFO: Record<string, string> = {
+  line: 'trends over time. Use when user asks about trends, changes over time, or time-series',
+  bar: 'compare values across categories or time buckets. Use for comparisons, rankings, distributions across groups',
+  area: 'stacked/cumulative trends over time. Use for cumulative totals, composition over time',
+  pie: 'proportional breakdown of a whole. Use when user asks about proportions, shares, percentages, breakdown',
+  scatter: 'correlation between two numerical variables. Use color/size to add dimensions',
+  heatmap: 'density or intensity across two categorical dimensions',
+  metric: 'single aggregated number, optionally with sparkline. Use for KPIs, totals, counts',
+  gauge: 'single value against a threshold range',
+  bar_gauge: 'progress bars against threshold range',
+  histogram: 'frequency distribution of a numerical field (auto-binned)',
+  state_timeline: 'discrete status/value changes over time',
+  table: 'raw tabular display',
+};
+
+function buildChartTypeGuide(): string {
+  return Object.entries(CHART_TYPE_INFO)
+    .map(([type, desc]) => `\n"${type}" — ${desc}`)
+    .join('');
+}
+
+export const AutoVisMeta = {
+  name: AUTO_VISUALIZATION_TOOL_NAME,
+  description:
+    'Creates a visualization from a PPL query and its result column schema. This tool does NOT ' +
+    'execute the query itself — it resolves the axes mapping from the provided columns, renders a ' +
+    'chart preview, and provides an editor link.' +
+    '\n\nWORKFLOW (follow in order):' +
+    '\n1. IMPOARTANT: always Call the index mapping tool to look up the timeFieldName; if it exists, pass it in.' +
+    '\n2. Call the pplQueryTool tool with the PPL query to run it and obtain the result column schema.' +
+    '\n3. the query must NOT contain time filters — use the from/to parameters to specify the time range, and pass the same from/to you passed to pplQueryTool.' +
+    '\n4. from, to and timeFieldName go together: passing a time range without ' +
+    'timeFieldName is rejected.' +
+    '\n\nCHART TYPE GUIDE (choose based on user intent and data shape):' +
+    buildChartTypeGuide(),
+
+  parameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description:
+          'The PPL query to visualize (e.g. "source=flights | stats avg(delay) by carrier"). ' +
+          'This must be the same query previously run via pplQueryTool.',
+      },
+      indexName: {
+        type: 'string',
+        description: 'The index/dataset name to query',
+      },
+      potentialChartType: {
+        type: 'string',
+        description:
+          'Optional. The chart type you infer the user most likely wants, based on their input ' +
+          'The chart type must be on one of: "line", "bar", "area", "pie", "scatter", ' +
+          '"heatmap", "metric", "gauge", "histogram", "state_timeline", "table". ' +
+          'This is only a hint. Omit it when the user does not imply a specific chart type.',
+      },
+      columns: {
+        type: 'array',
+        description:
+          'The result column schema returned by ppl execution. Each column has a name and type ' +
+          '(e.g. "integer", "keyword", "date", "double", "long", "float", "text", "timestamp"). ' +
+          'Used to resolve which chart types and axes mappings are compatible.',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Field name' },
+            type: {
+              type: 'string',
+              description: 'Field type from the query result schema',
+            },
+          },
+          required: ['name', 'type'],
+        },
+      },
+      splitField: {
+        type: 'string',
+        description:
+          'Optional categorical or numerical field to split/facet the chart by (small multiples)' +
+          'Infer the user most likely wants.',
+      },
+      timeFieldName: {
+        type: 'string',
+        description:
+          'The time field name of the index (e.g. "@timestamp", "timestamp"). ' +
+          'Get this from the index mapping. ' +
+          'Required whenever you pass from/to - a time range without it is rejected.',
+      },
+      from: {
+        type: 'string',
+        description:
+          'Start time for the time range (e.g., "now-1h", "now-7d", "2024-01-01"). Must be date math or an ISO 8601 timestamp. If provided along with to, the time range will be updated.',
+      },
+      to: {
+        type: 'string',
+        description:
+          'End time for the time range (e.g., "now", "2024-01-31"). If provided along with from, the time range will be updated.',
+      },
+    },
+    required: ['query', 'indexName', 'columns'],
+  },
+};

--- a/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { skip } from 'rxjs/operators';
 import { ExploreEmbeddable } from './explore_embeddable';
 import { ExploreInput } from './types';
@@ -27,10 +27,25 @@ jest.mock('react-dom/client', () => ({
 
 // Mock the ExploreEmbeddableComponent
 jest.mock('./explore_embeddable_component', () => ({
-  ExploreEmbeddableComponent: jest.fn(() => (
-    <div data-test-subj="mockExploreEmbeddableComponent" />
-  )),
+  ExploreEmbeddableComponent: jest.fn(() => null),
 }));
+
+// Mock the PanelDataService singleton. The real getInstance() throws unless
+// PanelDataService.init() was called during plugin setup, which never happens
+// in this unit test — so fetch()/destroy() would blow up. Return a stub whose
+// setPanelData/removePanelData are no-ops.
+jest.mock('./panel_data_service', () => {
+  const mockPanelDataInstance = {
+    setPanelData: jest.fn(),
+    removePanelData: jest.fn(),
+  };
+  return {
+    PanelDataService: {
+      getInstance: jest.fn(() => mockPanelDataInstance),
+      init: jest.fn(),
+    },
+  };
+});
 
 // Mock the services
 jest.mock('../application/legacy/discover/opensearch_dashboards_services', () => {

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -66,6 +66,7 @@ import {
   TransformationService,
   registerAllTransformations,
 } from '../components/data_transformations';
+import { PanelDataService } from './panel_data_service';
 
 // TODO cleanup unused props
 export interface SearchProps {
@@ -657,6 +658,15 @@ export class ExploreEmbeddable
     this.searchProps.hits = transformedRows.length;
     this.searchProps.isLoading = false;
 
+    // Update shared panel data store so the global fetch_panel_data tool returns fresh data
+    const savedExploreId = this.savedExplore.id;
+    if (savedExploreId) {
+      PanelDataService.getInstance().setPanelData(savedExploreId, {
+        rows: transformedRows,
+        panelTitle: this.panelTitle || this.savedExplore.title,
+      });
+    }
+
     // set tabular for DataViewComponent to display via adapters.data.getTabular()
     if (this.inspectorAdaptors.data && visualizationData?.transformedData) {
       const allColumns = [
@@ -722,6 +732,10 @@ export class ExploreEmbeddable
     // Cleanup transformation service
     if (this.transformationService) {
       this.transformationService.destroy();
+    }
+
+    if (this.savedExplore.id) {
+      PanelDataService.getInstance().removePanelData(this.savedExplore.id);
     }
 
     if (this.abortController) {

--- a/src/plugins/explore/public/embeddable/index.ts
+++ b/src/plugins/explore/public/embeddable/index.ts
@@ -6,3 +6,4 @@
 export { EXPLORE_EMBEDDABLE_TYPE } from './constants';
 export * from './types';
 export * from './explore_embeddable_factory';
+export { PanelDataService } from './panel_data_service';

--- a/src/plugins/explore/public/embeddable/panel_data_service.test.ts
+++ b/src/plugins/explore/public/embeddable/panel_data_service.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PanelDataService, FETCH_PANEL_DATA_TOOL_NAME } from './panel_data_service';
+
+describe('PanelDataService', () => {
+  let registerAction: jest.Mock;
+  let unregisterAction: jest.Mock;
+
+  const getRegisteredAction = () => {
+    // The action object passed to the most recent registerAction call.
+    return registerAction.mock.calls[registerAction.mock.calls.length - 1][0];
+  };
+
+  beforeEach(() => {
+    // Reset the singleton so each test starts from a clean store + unregistered tool.
+    (PanelDataService as any).instance = null;
+
+    registerAction = jest.fn();
+    unregisterAction = jest.fn();
+
+    PanelDataService.init(registerAction, unregisterAction);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getInstance', () => {
+    it('returns the same instance across calls', () => {
+      expect(PanelDataService.getInstance()).toBe(PanelDataService.getInstance());
+    });
+  });
+
+  describe('setPanelData', () => {
+    it('registers the shared tool lazily on the first publish', () => {
+      const service = PanelDataService.getInstance();
+      expect(registerAction).not.toHaveBeenCalled();
+
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+
+      expect(registerAction).toHaveBeenCalledTimes(1);
+      expect(getRegisteredAction().name).toBe(FETCH_PANEL_DATA_TOOL_NAME);
+    });
+
+    it('registers the tool only once across multiple publishes', () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+      service.setPanelData('panel-2', { rows: [], panelTitle: 'Panel 2' });
+      service.setPanelData('panel-1', { rows: [{ a: 1 }], panelTitle: 'Panel 1' });
+
+      expect(registerAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fetch_panel_data handler', () => {
+    it('returns the formatted rows for a known panel', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', {
+        rows: [{ _source: { host: 'a' } }, { fields: { host: 'b' } }, { host: 'c' }],
+        panelTitle: 'Hosts',
+      });
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+
+      expect(result).toEqual({
+        success: true,
+        panelTitle: 'Hosts',
+        savedObjectId: 'panel-1',
+        rowCount: 3,
+        // _source, then fields, then the raw hit fallback.
+        rows: [{ host: 'a' }, { host: 'b' }, { host: 'c' }],
+      });
+    });
+
+    it('returns a not-loaded failure for an unknown panel', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'missing' });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('missing');
+    });
+
+    it('reflects the latest rows after an overwrite', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
+      service.setPanelData('panel-1', { rows: [{ v: 2 }, { v: 3 }], panelTitle: 'Panel 1' });
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+
+      expect(result.rowCount).toBe(2);
+      expect(result.rows).toEqual([{ v: 2 }, { v: 3 }]);
+    });
+  });
+
+  describe('removePanelData', () => {
+    it('drops the panel data so the handler reports it as unavailable', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
+
+      service.removePanelData('panel-1');
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('leaves the shared tool registered even after the last panel is removed', () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+
+      service.removePanelData('panel-1');
+
+      // No churn: the tool stays registered for the plugin's lifetime.
+      expect(unregisterAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all data and unregisters the tool', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
+      service.setPanelData('panel-2', { rows: [{ v: 2 }], panelTitle: 'Panel 2' });
+
+      service.reset();
+
+      expect(unregisterAction).toHaveBeenCalledTimes(1);
+      expect(unregisterAction).toHaveBeenCalledWith(FETCH_PANEL_DATA_TOOL_NAME);
+      // Store is cleared: the previously captured handler now finds nothing.
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('is a no-op unregister when nothing was ever registered', () => {
+      const service = PanelDataService.getInstance();
+
+      service.reset();
+
+      expect(unregisterAction).not.toHaveBeenCalled();
+    });
+
+    it('re-registers on the next publish after reset', () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+      service.reset();
+      registerAction.mockClear();
+
+      service.setPanelData('panel-2', { rows: [], panelTitle: 'Panel 2' });
+
+      expect(registerAction).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/plugins/explore/public/embeddable/panel_data_service.ts
+++ b/src/plugins/explore/public/embeddable/panel_data_service.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AssistantAction } from 'src/plugins/context_provider/public';
+
+export const FETCH_PANEL_DATA_TOOL_NAME = 'fetch_panel_data';
+
+interface PanelDataEntry {
+  rows: any[];
+  panelTitle: string;
+}
+
+type RegisterAction = (action: AssistantAction<any>) => void;
+type UnregisterAction = (id: string) => void;
+
+/**
+ * Global singleton that owns the shared panel-data store.
+ * fetch_panel_data tool is shared among all panels and it takes a
+ * savedObjectId argument and looks the panel up in the store
+ */
+export class PanelDataService {
+  private static instance: PanelDataService | null = null;
+
+  private readonly store = new Map<string, PanelDataEntry>();
+  private toolRegistered = false;
+
+  private registerAction: RegisterAction | undefined;
+  private unregisterAction: UnregisterAction | undefined;
+
+  private constructor() {}
+
+  static init(registerAction: RegisterAction, unregisterAction: UnregisterAction) {
+    PanelDataService.instance = new PanelDataService();
+    PanelDataService.instance.registerAction = registerAction;
+    PanelDataService.instance.unregisterAction = unregisterAction;
+  }
+
+  static getInstance(): PanelDataService {
+    if (!PanelDataService.instance) {
+      throw new Error(
+        'PanelDataService has not been initialized. Call PanelDataService.init() first.'
+      );
+    }
+    return PanelDataService.instance;
+  }
+
+  setPanelData(savedObjectId: string, entry: PanelDataEntry) {
+    this.store.set(savedObjectId, entry);
+    this.registerTool();
+  }
+
+  removePanelData(savedObjectId: string) {
+    this.store.delete(savedObjectId);
+  }
+
+  reset() {
+    this.store.clear();
+    this.unregisterTool();
+  }
+
+  private registerTool() {
+    if (this.toolRegistered || !this.registerAction) return;
+    this.toolRegistered = true;
+
+    this.registerAction({
+      name: FETCH_PANEL_DATA_TOOL_NAME,
+      description:
+        'Retrieves the underlying data rows from a dashboard panel by its saved object ID. ' +
+        'IMPORTANT: Do NOT call this tool for general questions like "summarize this", "what does this show", or "explain the chart" — ' +
+        'use the screenshot and visualization context already provided in the conversation for those. ' +
+        'ONLY call this tool when the user explicitly asks for specific data that requires exact values. ',
+      parameters: {
+        type: 'object',
+        properties: {
+          savedObjectId: {
+            type: 'string',
+            description: 'The saved explore object ID of the panel to fetch data from',
+          },
+        },
+        required: ['savedObjectId'],
+      },
+      handler: async (args: { savedObjectId: string }) => {
+        const entry = this.store.get(args.savedObjectId);
+        if (!entry) {
+          return {
+            success: false,
+            message: `No data available for panel ${args.savedObjectId}. The panel may not be loaded yet.`,
+          };
+        }
+
+        const formattedRows = entry.rows.map((hit: any) => hit._source || hit.fields || hit);
+        return {
+          success: true,
+          panelTitle: entry.panelTitle,
+          savedObjectId: args.savedObjectId,
+          rowCount: formattedRows.length,
+          rows: formattedRows,
+        };
+      },
+    });
+  }
+
+  private unregisterTool() {
+    if (!this.toolRegistered || !this.unregisterAction) return;
+    this.toolRegistered = false;
+    this.unregisterAction(FETCH_PANEL_DATA_TOOL_NAME);
+  }
+}

--- a/src/plugins/explore/public/plugin.test.ts
+++ b/src/plugins/explore/public/plugin.test.ts
@@ -3,11 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { ExplorePlugin } from './plugin';
 import { coreMock } from '../../../core/public/mocks';
 import { AskAIEmbeddableAction } from './actions/ask_ai_embeddable_action';
 import { CONTEXT_MENU_TRIGGER } from '../../embeddable/public';
-import { CoreSetup, CoreStart } from 'opensearch-dashboards/public';
+import {
+  CoreSetup,
+  CoreStart,
+  DEFAULT_NAV_GROUPS,
+  getUseCaseFeatureConfig,
+} from 'opensearch-dashboards/public';
 import { ExplorePluginStart, ExploreSetupDependencies, ExploreStartDependencies } from './types';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
@@ -28,6 +34,7 @@ import { ContextProviderStart } from '../../context_provider/public';
 import { registerDisabledPPLExecuteQueryAction } from './components/query_panel/actions/ppl_execute_query_action';
 import { registerDisabledPPLLintFixAction } from './components/query_panel/actions/ppl_lint_fix_action';
 import { clearActivePPLLintFixSession } from './components/query_panel/actions/ppl_lint_fix_session';
+import { registerAutoVisualizationAction } from './components/visualizations/actions/auto_visualization_action';
 
 // Mock the action
 jest.mock('./actions/ask_ai_embeddable_action');
@@ -62,6 +69,11 @@ jest.mock('./components/query_panel/actions/ppl_lint_fix_session', () => ({
   clearActivePPLLintFixSession: jest.fn(),
 }));
 
+jest.mock('./components/visualizations/actions/auto_visualization_action', () => ({
+  registerAutoVisualizationAction: jest.fn(),
+  AUTO_VISUALIZATION_TOOL_NAME: 'auto_create_visualization',
+}));
+
 // Mock createOsdUrlTracker
 jest.mock('../../opensearch_dashboards_utils/public', () => ({
   ...jest.requireActual('../../opensearch_dashboards_utils/public'),
@@ -80,6 +92,7 @@ describe('ExplorePlugin', () => {
   let setupDeps: ExploreSetupDependencies;
   let startDeps: ExploreStartDependencies;
   let mockCapabilities: any;
+  let currentWorkspace$: BehaviorSubject<{ features?: string[] } | null>;
 
   function createMockInitializerContext() {
     return {
@@ -231,20 +244,14 @@ describe('ExplorePlugin', () => {
 
     // Mock core start
     coreStart = coreMock.createStart();
-    // Add workspaces mock with proper BehaviorSubject-like structure
+    // A real BehaviorSubject rather than a hand-rolled stub: the plugin both reads it once
+    // (`getIsExploreEnabledWorkspace`) and subscribes to it for the lifetime of start()
+    // (`getIsExploreEnabledWorkspace$`), and tests need to push workspace switches through it.
+    currentWorkspace$ = new BehaviorSubject<{ features?: string[] } | null>({
+      features: ['observability'],
+    });
     Object.defineProperty(coreStart, 'workspaces', {
-      value: {
-        currentWorkspace$: {
-          pipe: jest.fn().mockReturnValue({
-            toPromise: jest.fn().mockResolvedValue({
-              features: ['observability'],
-            }),
-          }),
-          subscribe: jest.fn(),
-          getValue: jest.fn(),
-          next: jest.fn(),
-        },
-      },
+      value: { currentWorkspace$ },
       writable: true,
       configurable: true,
     });
@@ -682,6 +689,92 @@ describe('ExplorePlugin', () => {
       // Verify disabled action is registered before other actions
       const disabledActionIndex = callOrder.indexOf('registerDisabledAction');
       expect(disabledActionIndex).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('visualization assistant tool workspace gating', () => {
+    const mockRegisterAutoVisualizationAction = registerAutoVisualizationAction as jest.Mock;
+    // isNavGroupInFeatureConfigs matches on the prefixed form, not the bare nav group id.
+    const OBSERVABILITY_FEATURE = getUseCaseFeatureConfig(DEFAULT_NAV_GROUPS.observability.id);
+
+    const unregisterCalls = () =>
+      (startDeps.contextProvider!.actions.unregisterAssistantAction as jest.Mock).mock.calls.filter(
+        ([name]) => name === 'auto_create_visualization'
+      );
+
+    beforeEach(() => {
+      mockRegisterAutoVisualizationAction.mockClear();
+    });
+
+    it('registers the tool when start happens inside an explore-enabled workspace', () => {
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledTimes(1);
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledWith(
+        startDeps.contextProvider!.actions.registerAssistantAction,
+        coreStart,
+        startDeps.data,
+        startDeps.contextProvider
+      );
+    });
+
+    it('does not register the tool outside an explore-enabled workspace', () => {
+      currentWorkspace$.next({ features: ['use-case-search'] });
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      expect(mockRegisterAutoVisualizationAction).not.toHaveBeenCalled();
+    });
+
+    it('registers once the workspace loads, not just at start', () => {
+      // currentWorkspace$ is null until the workspace list resolves, which is the state
+      // start() usually observes. A one-shot read here would skip registration for good.
+      currentWorkspace$.next(null);
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+      expect(mockRegisterAutoVisualizationAction).not.toHaveBeenCalled();
+
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('unregisters the tool when leaving the workspace', () => {
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      const before = unregisterCalls().length;
+      currentWorkspace$.next(null);
+
+      expect(unregisterCalls().length).toBe(before + 1);
+    });
+
+    it('ignores workspace switches that do not change explore enablement', () => {
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      // A different workspace, same enablement — re-registering would rebuild the tool
+      // definition and churn every chat subscriber for nothing.
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE, 'use-case-search'] });
+
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops reacting to workspace changes after stop', () => {
+      currentWorkspace$.next(null);
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+      plugin.stop();
+
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+
+      expect(mockRegisterAutoVisualizationAction).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -7,8 +7,8 @@ import { i18n } from '@osd/i18n';
 import semver from 'semver';
 import qs from 'query-string';
 import rison from 'rison-node';
-import { BehaviorSubject } from 'rxjs';
-import { filter, map, take } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, map, take } from 'rxjs/operators';
 import {
   App,
   AppMountParameters,
@@ -76,7 +76,7 @@ import {
   ExploreStartDependencies,
 } from './types';
 import { DocViewsRegistry } from './types/doc_views_types';
-import { ExploreEmbeddableFactory } from './embeddable';
+import { ExploreEmbeddableFactory, PanelDataService } from './embeddable';
 import { SAVED_OBJECT_TYPE } from './saved_explore/_saved_explore';
 import { DASHBOARD_ADD_PANEL_TRIGGER } from '../../dashboard/public';
 import { createAbortDataQueryAction } from './application/utils/state_management/actions/abort_controller';
@@ -101,6 +101,11 @@ import {
   registerDisabledPPLLintFixAction,
 } from './components/query_panel/actions/ppl_lint_fix_action';
 import { clearActivePPLLintFixSession } from './components/query_panel/actions/ppl_lint_fix_session';
+
+import {
+  registerAutoVisualizationAction,
+  AUTO_VISUALIZATION_TOOL_NAME,
+} from './components/visualizations/actions/auto_visualization_action';
 
 export class ExplorePlugin implements Plugin<
   ExplorePluginSetup,
@@ -141,6 +146,8 @@ export class ExplorePlugin implements Plugin<
   private editorStopUrlTracking?: () => void;
   private unregisterPPLExecuteQueryAction?: () => void;
   private unregisterPPLLintFixAction?: () => void;
+  private unregisterVisualizationTools?: () => void;
+  private visualizationToolsWorkspaceSubscription?: Subscription;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {}
 
@@ -902,6 +909,33 @@ export class ExplorePlugin implements Plugin<
         plugins.contextProvider!.actions.unregisterAssistantAction(
           APPLY_PPL_LINT_FIX_EXPLORE_TOOL_DEFINITION.name
         );
+      const { registerAssistantAction, unregisterAssistantAction } =
+        plugins.contextProvider.actions;
+
+      // The tool will only be registered in an explore-enabled workspace as it depends on vis editor
+      this.visualizationToolsWorkspaceSubscription = this.getIsExploreEnabledWorkspace$(
+        core
+      ).subscribe((isExploreEnabledWorkspace) => {
+        if (isExploreEnabledWorkspace) {
+          registerAutoVisualizationAction(
+            registerAssistantAction,
+            core,
+            plugins.data,
+            plugins.contextProvider
+          );
+        } else {
+          // Leaving the workspace must take the tool back out of availableTools
+          unregisterAssistantAction(AUTO_VISUALIZATION_TOOL_NAME);
+        }
+      });
+
+      this.unregisterVisualizationTools = () => {
+        this.visualizationToolsWorkspaceSubscription?.unsubscribe();
+        unregisterAssistantAction(AUTO_VISUALIZATION_TOOL_NAME);
+      };
+
+      // Inject contextProvider action helpers into PanelDataService
+      PanelDataService.init(registerAssistantAction, unregisterAssistantAction);
     }
 
     const savedExploreLoader = createSavedExploreLoader({
@@ -929,6 +963,9 @@ export class ExplorePlugin implements Plugin<
     this.unregisterPPLExecuteQueryAction?.();
     this.unregisterPPLLintFixAction?.();
     clearActivePPLLintFixSession();
+    this.unregisterVisualizationTools?.();
+    // cleanup shared panel-data store + fetch_panel_data tool.
+    PanelDataService.getInstance().reset();
   }
 
   private registerEmbeddable(
@@ -1098,16 +1135,33 @@ export class ExplorePlugin implements Plugin<
     }
   }
 
-  private async getIsExploreEnabledWorkspace(core: CoreStart) {
-    const features = await core.workspaces.currentWorkspace$
-      .pipe(take(1))
-      .toPromise()
-      .then((workspace) => workspace?.features);
+  private isExploreEnabledWorkspaceFeatures(features?: string[]) {
     return (
       (features &&
         (isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.observability.id, features) ||
           isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.all.id, features))) ??
       false
+    );
+  }
+
+  private async getIsExploreEnabledWorkspace(core: CoreStart) {
+    const features = await core.workspaces.currentWorkspace$
+      .pipe(take(1))
+      .toPromise()
+      .then((workspace) => workspace?.features);
+    return this.isExploreEnabledWorkspaceFeatures(features);
+  }
+
+  /**
+   * Emits on every workspace switch, unlike `getIsExploreEnabledWorkspace`, which reads
+   * `currentWorkspace$` once. Use this for anything that has to be torn down again when
+   * the user leaves the workspace; the one-shot read is fine for app mounts, which are
+   * re-run per navigation anyway.
+   */
+  private getIsExploreEnabledWorkspace$(core: CoreStart): Observable<boolean> {
+    return core.workspaces.currentWorkspace$.pipe(
+      map((workspace) => this.isExploreEnabledWorkspaceFeatures(workspace?.features)),
+      distinctUntilChanged()
     );
   }
 }

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -157,9 +157,10 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       // Skip adding time filters if hideDatePicker is false. Let search strategy insert time filters.
       datasetService.getType(dataset.type)?.languageOverrides?.PPL?.hideDatePicker !== false
     ) {
+      // Prefer an explicit time range passed and fall back to the global timefilter.
       const timeFilter = PPLFilterUtils.getTimeFilterWhereClause(
         dataset.timeFieldName,
-        this.queryService.timefilter.timefilter.getTime(),
+        request.params?.body?.timeRange ?? this.queryService.timefilter.timefilter.getTime(),
         dataset.dataSource?.engineType ?? dataset.dataSource?.type
       );
       whereCommands.push(timeFilter);

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
@@ -170,23 +170,23 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
 
       // Send visualization screenshot to chat
       if (this.core.chat) {
-        // Create a message with the visualization image following AG-UI protocol
-        const imageMessage = {
-          role: 'user' as const,
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          content: [
+        await this.core.chat.sendMessageWithWindow(
+          [
             {
-              type: 'binary' as const,
-              mimeType: 'image/jpeg',
-              data: visualizationBase64,
+              type: 'image',
+              source: {
+                type: 'data',
+                value: visualizationBase64,
+                mimeType: 'image/jpeg',
+              },
+            },
+
+            {
+              type: 'text',
+              text: 'Give me a summary for the selected visualization',
             },
           ],
-        };
-
-        // sendMessageWithWindow will open the chat window and send the message
-        await this.core.chat.sendMessageWithWindow(
-          'Give me a summary for the selected visualization',
-          [imageMessage]
+          []
         );
       }
     } catch (error) {


### PR DESCRIPTION
### Description

This PR adds an AI-driven visualization capability to the chat assistant. Users can describe what they want in natural language (e.g. "show the average ticket price per airport"), and the assistant generates a PPL query, picks a suitable chart type, renders a live chart preview inside the chat window, and offers an "Open in Editor" link that deep-links into the full visualization editor.

The core new tool is auto_create_visualization. And it relies on https://github.com/opensearch-project/opensearch-mcp-server-py/pull/257.

The intended tool-call workflow (encoded in the tool description) is:
Index mapping tool → look up timeFieldName
ppl_execute → run the query, return the result column schema
auto_create_visualization → resolve chart config from columns, render preview, provide editor link

Besides, this pr adds:
1. `fetch_panel_data tool` , access panel explore embeddable data
2. Add dashboard page context and screenshot configuration, revert changes in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11287



## Screenshot
1. ask for dashboard panel data

https://github.com/user-attachments/assets/42177924-44bd-4ea5-93a9-eefdcaf99d14


2. text2v and add to dashboard

https://github.com/user-attachments/assets/e5493100-ebbd-4ced-acd7-7e9a7bae4f0f



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
