### PR TITLE
fix(dashboard): disabled dashboard filter overriding visualization filter

### DIFF
--- a/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards_context.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards_context.ts
@@ -129,7 +129,7 @@ export const opensearchDashboardsContextFunction: ExpressionFunctionOpenSearchDa
     return {
       type: 'opensearch_dashboards_context',
       query: queries,
-      filters: uniqFilters(filters).filter((f: any) => !f.meta?.disabled),
+      filters: uniqFilters(filters.filter((f: any) => !f.meta?.disabled)),
       timeRange,
     };
   },

--- a/src/plugins/expressions/common/expression_functions/specs/tests/opensearch_dashboards_context.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/opensearch_dashboards_context.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Filter } from '../../../../../data/common';
+import { OpenSearchDashboardsContext } from '../../../expression_types';
+import { opensearchDashboardsContextFunction } from '../opensearch_dashboards_context';
+import { functionWrapper } from './utils';
+
+const createFilter = (alias: string, disabled: boolean): Filter =>
+  ({
+    meta: {
+      alias,
+      disabled,
+      negate: false,
+    },
+    query: {
+      match_phrase: {
+        cancelled: true,
+      },
+    },
+  }) as Filter;
+
+describe('interpreter/functions#opensearch-dashboards-context', () => {
+  const fn = functionWrapper(opensearchDashboardsContextFunction);
+
+  it('removes disabled filters before deduplicating duplicates', async () => {
+    const dashboardFilter = createFilter('dashboard filter', true);
+    const visualizationFilter = createFilter('visualization filter', false);
+    const input: OpenSearchDashboardsContext = {
+      type: 'opensearch_dashboards_context',
+      filters: [dashboardFilter],
+    };
+
+    const actual = await fn(input, { filters: JSON.stringify([visualizationFilter]) });
+
+    expect(actual.filters).toEqual([visualizationFilter]);
+  });
+
+  it('keeps one filter when matching dashboard and visualization filters are enabled', async () => {
+    const dashboardFilter = createFilter('dashboard filter', false);
+    const visualizationFilter = createFilter('visualization filter', false);
+    const input: OpenSearchDashboardsContext = {
+      type: 'opensearch_dashboards_context',
+      filters: [dashboardFilter],
+    };
+
+    const actual = await fn(input, { filters: JSON.stringify([visualizationFilter]) });
+
+    expect(actual.filters).toEqual([dashboardFilter]);
+  });
+});


### PR DESCRIPTION
### Description
Remove disabled filters before deduplicating expression context filters so a disabled dashboard-level filter cannot shadow an equivalent enabled filter saved on a visualization. Keep existing behavior for matching enabled filters by deduplicating them to a single active filter.
<!-- Describe what this change achieves-->

### Issues Resolved
resolved #12404
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/f8f7fa7c-136b-4fbd-89a1-af1627eec4da


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
