### PR TITLE
feat: add support for range field types in Discover

### DIFF
--- a/src/plugins/data/common/osd_field_types/osd_field_types.test.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types.test.ts
@@ -98,6 +98,27 @@ describe('utils/osd_field_types', () => {
 
       expect(castTo).toBe('unknown');
     });
+
+    test('casts range field types to distinct range OSD types', () => {
+      expect(castOpenSearchToOsdFieldTypeName(OPENSEARCH_FIELD_TYPES.INTEGER_RANGE)).toBe(
+        OSD_FIELD_TYPES.NUMBER_RANGE
+      );
+      expect(castOpenSearchToOsdFieldTypeName(OPENSEARCH_FIELD_TYPES.FLOAT_RANGE)).toBe(
+        OSD_FIELD_TYPES.NUMBER_RANGE
+      );
+      expect(castOpenSearchToOsdFieldTypeName(OPENSEARCH_FIELD_TYPES.LONG_RANGE)).toBe(
+        OSD_FIELD_TYPES.NUMBER_RANGE
+      );
+      expect(castOpenSearchToOsdFieldTypeName(OPENSEARCH_FIELD_TYPES.DOUBLE_RANGE)).toBe(
+        OSD_FIELD_TYPES.NUMBER_RANGE
+      );
+      expect(castOpenSearchToOsdFieldTypeName(OPENSEARCH_FIELD_TYPES.DATE_RANGE)).toBe(
+        OSD_FIELD_TYPES.DATE_RANGE
+      );
+      expect(castOpenSearchToOsdFieldTypeName(OPENSEARCH_FIELD_TYPES.IP_RANGE)).toBe(
+        OSD_FIELD_TYPES.IP_RANGE
+      );
+    });
   });
 
   describe('getOsdTypeNames()', () => {
@@ -110,13 +131,16 @@ describe('utils/osd_field_types', () => {
         OSD_FIELD_TYPES.BOOLEAN,
         OSD_FIELD_TYPES.CONFLICT,
         OSD_FIELD_TYPES.DATE,
+        OSD_FIELD_TYPES.DATE_RANGE,
         OSD_FIELD_TYPES.GEO_POINT,
         OSD_FIELD_TYPES.GEO_SHAPE,
         OSD_FIELD_TYPES.HISTOGRAM,
         OSD_FIELD_TYPES.IP,
+        OSD_FIELD_TYPES.IP_RANGE,
         OSD_FIELD_TYPES.MURMUR3,
         OSD_FIELD_TYPES.NESTED,
         OSD_FIELD_TYPES.NUMBER,
+        OSD_FIELD_TYPES.NUMBER_RANGE,
         OSD_FIELD_TYPES.OBJECT,
         OSD_FIELD_TYPES.STRING,
         OSD_FIELD_TYPES.UNKNOWN,

--- a/src/plugins/data/common/osd_field_types/osd_field_types_factory.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types_factory.ts
@@ -121,6 +121,7 @@ export const createOsdFieldTypes = (): OsdFieldType[] => [
   }),
   new OsdFieldType({
     name: OSD_FIELD_TYPES.NUMBER_RANGE,
+    filterable: true,
     esTypes: [
       OPENSEARCH_FIELD_TYPES.INTEGER_RANGE,
       OPENSEARCH_FIELD_TYPES.FLOAT_RANGE,
@@ -130,10 +131,12 @@ export const createOsdFieldTypes = (): OsdFieldType[] => [
   }),
   new OsdFieldType({
     name: OSD_FIELD_TYPES.DATE_RANGE,
+    filterable: true,
     esTypes: [OPENSEARCH_FIELD_TYPES.DATE_RANGE],
   }),
   new OsdFieldType({
     name: OSD_FIELD_TYPES.IP_RANGE,
+    filterable: true,
     esTypes: [OPENSEARCH_FIELD_TYPES.IP_RANGE],
   }),
   new OsdFieldType({

--- a/src/plugins/data/common/osd_field_types/osd_field_types_factory.ts
+++ b/src/plugins/data/common/osd_field_types/osd_field_types_factory.ts
@@ -120,6 +120,23 @@ export const createOsdFieldTypes = (): OsdFieldType[] => [
     esTypes: [OPENSEARCH_FIELD_TYPES.HISTOGRAM],
   }),
   new OsdFieldType({
+    name: OSD_FIELD_TYPES.NUMBER_RANGE,
+    esTypes: [
+      OPENSEARCH_FIELD_TYPES.INTEGER_RANGE,
+      OPENSEARCH_FIELD_TYPES.FLOAT_RANGE,
+      OPENSEARCH_FIELD_TYPES.LONG_RANGE,
+      OPENSEARCH_FIELD_TYPES.DOUBLE_RANGE,
+    ],
+  }),
+  new OsdFieldType({
+    name: OSD_FIELD_TYPES.DATE_RANGE,
+    esTypes: [OPENSEARCH_FIELD_TYPES.DATE_RANGE],
+  }),
+  new OsdFieldType({
+    name: OSD_FIELD_TYPES.IP_RANGE,
+    esTypes: [OPENSEARCH_FIELD_TYPES.IP_RANGE],
+  }),
+  new OsdFieldType({
     name: OSD_FIELD_TYPES.CONFLICT,
   }),
   OsdFieldTypeUnknown,

--- a/src/plugins/data/common/osd_field_types/types.ts
+++ b/src/plugins/data/common/osd_field_types/types.ts
@@ -77,6 +77,13 @@ export enum OPENSEARCH_FIELD_TYPES {
   MURMUR3 = 'murmur3',
 
   HISTOGRAM = 'histogram',
+
+  INTEGER_RANGE = 'integer_range',
+  FLOAT_RANGE = 'float_range',
+  LONG_RANGE = 'long_range',
+  DOUBLE_RANGE = 'double_range',
+  DATE_RANGE = 'date_range',
+  IP_RANGE = 'ip_range',
 }
 
 /** @public **/
@@ -96,6 +103,9 @@ export enum OSD_FIELD_TYPES {
   OBJECT = 'object',
   NESTED = 'nested',
   HISTOGRAM = 'histogram',
+  NUMBER_RANGE = 'number_range',
+  DATE_RANGE = 'date_range',
+  IP_RANGE = 'ip_range',
 }
 
 // Types from opensearch-project/sql/docs/user/ppl/general/datatypes.md

--- a/src/plugins/dataset_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
+++ b/src/plugins/dataset_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
@@ -909,6 +909,18 @@ exports[`FieldEditor should show deprecated lang warning 1`] = `
               "value": "histogram",
             },
             Object {
+              "text": "number_range",
+              "value": "number_range",
+            },
+            Object {
+              "text": "date_range",
+              "value": "date_range",
+            },
+            Object {
+              "text": "ip_range",
+              "value": "ip_range",
+            },
+            Object {
               "text": "conflict",
               "value": "conflict",
             },

--- a/src/plugins/index_pattern_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
+++ b/src/plugins/index_pattern_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
@@ -909,6 +909,18 @@ exports[`FieldEditor should show deprecated lang warning 1`] = `
               "value": "histogram",
             },
             Object {
+              "text": "number_range",
+              "value": "number_range",
+            },
+            Object {
+              "text": "date_range",
+              "value": "date_range",
+            },
+            Object {
+              "text": "ip_range",
+              "value": "ip_range",
+            },
+            Object {
               "text": "conflict",
               "value": "conflict",
             },


### PR DESCRIPTION
## Description

Add support for OpenSearch range field types (`integer_range`, `float_range`, `long_range`, `double_range`, `date_range`, `ip_range`) in Discover. These types were missing since OpenSearch was forked from Elasticsearch 7.12, causing range fields to display as `unknown`.

## Approach

Range fields are interval/object values (`{gte, lte}`), not scalar values. Instead of mapping them to scalar OSD types, range fields are modeled with **distinct OSD field types**:

| OpenSearch field type | OSD field type |
|---|---|
| `integer_range`, `float_range`, `long_range`, `double_range` | `NUMBER_RANGE` |
| `date_range` | `DATE_RANGE` |
| `ip_range` | `IP_RANGE` |

These types default to `sortable: false, filterable: false`, preventing invalid sort/filter/aggregation operations.

## Changes

- **types.ts**: Added `NUMBER_RANGE`, `DATE_RANGE`, `IP_RANGE` to `OSD_FIELD_TYPES` enum + range OpenSearch types
- **osd_field_types_factory.ts**: Added 3 new `OsdFieldType` entries with range-specific esTypes mappings
- **osd_field_types.test.ts**: Updated cast and type name tests for new range types
- **field_editor.test.tsx.snap**: Updated snapshot to include new range field types

## Related issue

Closes #11053

## Note

Previous PR #12393 was closed due to test snapshot failures and missing DCO sign-off. This is a single squashed commit with all fixes applied and DCO signed.