### PR TITLE
Enable dashboard variables feature by default

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -282,11 +282,12 @@
 # functionality in Visualization.
 # vis_builder.enabled: false
 
-# Enable the Dashboard Variables feature (disabled by default). When off, the `variablesJSON`
-# field is never added to the dashboard mapping or written on save.
-# Turning it on triggers a one-time saved object index migration.
-# Warning: before turning it back off, remove `variablesJSON` from all dashboard documents,
-# otherwise the index migration fails with strict_dynamic_mapping_exception on every startup.
+# Enable the Dashboard Variables feature (enabled by default). The `variablesJSON`
+# field is included in the dashboard mapping and written on save.
+# On first startup after upgrade, this triggers a one-time saved object index migration.
+# Warning: before disabling this feature, remove `variablesJSON` from all dashboard
+# documents, otherwise the index migration fails with strict_dynamic_mapping_exception
+# on every startup.
 # dashboard.variables.enabled: false
 
 # Set the value of this setting to true to hide local cluster in data source feature.

--- a/src/plugins/dashboard/config.ts
+++ b/src/plugins/dashboard/config.ts
@@ -33,7 +33,7 @@ import { schema, TypeOf } from '@osd/config-schema';
 export const configSchema = schema.object({
   allowByValueEmbeddables: schema.boolean({ defaultValue: false }),
   variables: schema.object({
-    enabled: schema.boolean({ defaultValue: false }),
+    enabled: schema.boolean({ defaultValue: true }),
   }),
 });
 


### PR DESCRIPTION
### Description

Change the default value of `dashboard.variables.enabled` from `false` to `true`, making the Dashboard Variables feature available out-of-the-box without requiring explicit configuration.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
