### PR TITLE
Fix csp-modifications dropping nonce, lowercasing values, and mishandling semicolons

### DIFF
--- a/src/core/server/csp_modifications/utils.test.ts
+++ b/src/core/server/csp_modifications/utils.test.ts
@@ -268,4 +268,77 @@ describe('applyCspModifications', () => {
       expect(result).toContain('https://*.examples.com');
     });
   });
+
+  describe('case handling', () => {
+    it('should preserve the case of nonce values in base rules', () => {
+      const nonceRules = ["style-src-elem 'self' 'nonce-AbC123+dEf/GhI=='", "script-src 'self'"];
+      const modifications: CspModificationRule[] = [
+        { directive: 'frame-ancestors', action: 'add', values: ['https://app.example.com'] },
+      ];
+      const result = applyCspModifications(nonceRules, modifications);
+      expect(result).toContain("'nonce-AbC123+dEf/GhI=='");
+    });
+
+    it('should preserve the case of hash values in base rules', () => {
+      const hashRules = ["script-src 'self' 'sha256-AbCdEfGh123=='"];
+      const result = applyCspModifications(hashRules, []);
+      expect(result).toContain("'sha256-AbCdEfGh123=='");
+    });
+
+    it('should preserve the case of modification values', () => {
+      const modifications: CspModificationRule[] = [
+        { directive: 'script-src', action: 'add', values: ["'nonce-XyZ987=='"] },
+      ];
+      const result = applyCspModifications(defaultRules, modifications);
+      expect(result).toContain("'nonce-XyZ987=='");
+    });
+
+    it('should match directive names case-insensitively', () => {
+      const modifications: CspModificationRule[] = [
+        { directive: 'Frame-Ancestors', action: 'add', values: ['https://app.example.com'] },
+      ];
+      const result = applyCspModifications(
+        ["frame-ancestors 'self'", "script-src 'self'"],
+        modifications
+      );
+      expect(result).toContain("frame-ancestors 'self' https://app.example.com");
+      // Must not create a duplicate directive
+      expect(result.match(/frame-ancestors/g)).toHaveLength(1);
+    });
+
+    it('should normalize mixed-case directive names in base rules', () => {
+      const result = applyCspModifications(
+        ["Frame-Ancestors 'self'"],
+        [{ directive: 'frame-ancestors', action: 'add', values: ['https://app.example.com'] }]
+      );
+      expect(result).toContain("frame-ancestors 'self' https://app.example.com");
+    });
+  });
+
+  describe('semicolon handling', () => {
+    it('should strip trailing semicolons from base rules', () => {
+      const result = applyCspModifications(
+        ["frame-ancestors 'self' https://console.example.com;"],
+        [{ directive: 'frame-ancestors', action: 'add', values: ['http://localhost:9000'] }]
+      );
+      expect(result).toBe(
+        "frame-ancestors 'self' https://console.example.com http://localhost:9000"
+      );
+    });
+
+    it('should split base rules containing embedded semicolons', () => {
+      const result = applyCspModifications(
+        ["script-src 'self'; style-src 'self'"],
+        [{ directive: 'style-src', action: 'add', values: ["'unsafe-inline'"] }]
+      );
+      expect(result).toContain("script-src 'self'");
+      expect(result).toContain("style-src 'self' 'unsafe-inline'");
+    });
+
+    it('should not emit double semicolons', () => {
+      const result = applyCspModifications(["default-src 'self' data:;", "font-src 'self';"], []);
+      expect(result).not.toContain(';;');
+      expect(result).toBe("default-src 'self' data:; font-src 'self'");
+    });
+  });
 });

--- a/src/core/server/csp_modifications/utils.ts
+++ b/src/core/server/csp_modifications/utils.ts
@@ -26,23 +26,23 @@ export function applyCspModifications(
   const directiveMap = new Map<string, Set<string>>();
 
   for (const rule of baseRules) {
-    const trimmed = rule.trim().toLowerCase();
-    if (!trimmed) continue;
-
-    const firstSpace = trimmed.indexOf(' ');
-    if (firstSpace === -1) {
-      // Directive with no values (e.g., "upgrade-insecure-requests")
-      directiveMap.set(trimmed, new Set());
-    } else {
-      const [directive, ...values] = trimmed.split(' ').filter((v) => !!v.length);
-      directiveMap.set(directive, new Set(values));
+    // Rules may carry embedded or trailing ';' separators.
+    for (const segment of rule.split(';')) {
+      const tokens = segment
+        .trim()
+        .split(' ')
+        .filter((v) => !!v.length);
+      if (tokens.length === 0) continue;
+      // Directive names are case-insensitive; values (e.g. nonces, hashes) are not.
+      const [directive, ...values] = tokens;
+      directiveMap.set(directive.toLowerCase(), new Set(values));
     }
   }
 
   for (const mod of modifications) {
     const directive = mod.directive.toLowerCase();
     const action = mod.action;
-    const values = mod.values.map((v) => v.toLowerCase());
+    const values = mod.values;
 
     switch (action) {
       case 'add':

--- a/src/legacy/ui/ui_render/ui_render_mixin.js
+++ b/src/legacy/ui/ui_render/ui_render_mixin.js
@@ -337,7 +337,8 @@ export function uiRenderMixin(osdServer, server, config) {
 
       const modifications = cspModificationsDynamicConfig?.modifications;
       if (modifications && modifications.length > 0) {
-        cspHeader = applyCspModifications(http.csp.rules, modifications);
+        // Apply to the built header so the per-request nonce is preserved.
+        cspHeader = applyCspModifications(cspHeader.split('; '), modifications);
       }
     } catch {
       // Fall back to default CSP header on error

--- a/src/legacy/ui/ui_render/utils.js
+++ b/src/legacy/ui/ui_render/utils.js
@@ -14,23 +14,23 @@ export function applyCspModifications(baseRules, modifications) {
   const directiveMap = new Map();
 
   for (const rule of baseRules) {
-    const trimmed = rule.trim().toLowerCase();
-    if (!trimmed) continue;
-
-    const firstSpace = trimmed.indexOf(' ');
-    if (firstSpace === -1) {
-      // Directive with no values (e.g., "upgrade-insecure-requests")
-      directiveMap.set(trimmed, new Set());
-    } else {
-      const [directive, ...values] = trimmed.split(' ').filter((v) => !!v.length);
-      directiveMap.set(directive, new Set(values));
+    // Rules may carry embedded or trailing ';' separators.
+    for (const segment of rule.split(';')) {
+      const tokens = segment
+        .trim()
+        .split(' ')
+        .filter((v) => !!v.length);
+      if (tokens.length === 0) continue;
+      // Directive names are case-insensitive; values (e.g. nonces, hashes) are not.
+      const [directive, ...values] = tokens;
+      directiveMap.set(directive.toLowerCase(), new Set(values));
     }
   }
 
   for (const mod of modifications) {
     const directive = mod.directive.toLowerCase();
     const action = mod.action;
-    const values = mod.values.map((v) => v.toLowerCase());
+    const values = mod.values;
 
     switch (action) {
       case 'add':

--- a/src/legacy/ui/ui_render/utils.test.js
+++ b/src/legacy/ui/ui_render/utils.test.js
@@ -254,4 +254,77 @@ describe('applyCspModifications', () => {
       expect(result).toContain('https://*.examples.com');
     });
   });
+
+  describe('case handling', () => {
+    it('should preserve the case of nonce values in base rules', () => {
+      const nonceRules = ["style-src-elem 'self' 'nonce-AbC123+dEf/GhI=='", "script-src 'self'"];
+      const modifications = [
+        { directive: 'frame-ancestors', action: 'add', values: ['https://app.example.com'] },
+      ];
+      const result = applyCspModifications(nonceRules, modifications);
+      expect(result).toContain("'nonce-AbC123+dEf/GhI=='");
+    });
+
+    it('should preserve the case of hash values in base rules', () => {
+      const hashRules = ["script-src 'self' 'sha256-AbCdEfGh123=='"];
+      const result = applyCspModifications(hashRules, []);
+      expect(result).toContain("'sha256-AbCdEfGh123=='");
+    });
+
+    it('should preserve the case of modification values', () => {
+      const modifications = [
+        { directive: 'script-src', action: 'add', values: ["'nonce-XyZ987=='"] },
+      ];
+      const result = applyCspModifications(defaultRules, modifications);
+      expect(result).toContain("'nonce-XyZ987=='");
+    });
+
+    it('should match directive names case-insensitively', () => {
+      const modifications = [
+        { directive: 'Frame-Ancestors', action: 'add', values: ['https://app.example.com'] },
+      ];
+      const result = applyCspModifications(
+        ["frame-ancestors 'self'", "script-src 'self'"],
+        modifications
+      );
+      expect(result).toContain("frame-ancestors 'self' https://app.example.com");
+      // Must not create a duplicate directive
+      expect(result.match(/frame-ancestors/g)).toHaveLength(1);
+    });
+
+    it('should normalize mixed-case directive names in base rules', () => {
+      const result = applyCspModifications(
+        ["Frame-Ancestors 'self'"],
+        [{ directive: 'frame-ancestors', action: 'add', values: ['https://app.example.com'] }]
+      );
+      expect(result).toContain("frame-ancestors 'self' https://app.example.com");
+    });
+  });
+
+  describe('semicolon handling', () => {
+    it('should strip trailing semicolons from base rules', () => {
+      const result = applyCspModifications(
+        ["frame-ancestors 'self' https://console.example.com;"],
+        [{ directive: 'frame-ancestors', action: 'add', values: ['http://localhost:9000'] }]
+      );
+      expect(result).toBe(
+        "frame-ancestors 'self' https://console.example.com http://localhost:9000"
+      );
+    });
+
+    it('should split base rules containing embedded semicolons', () => {
+      const result = applyCspModifications(
+        ["script-src 'self'; style-src 'self'"],
+        [{ directive: 'style-src', action: 'add', values: ["'unsafe-inline'"] }]
+      );
+      expect(result).toContain("script-src 'self'");
+      expect(result).toContain("style-src 'self' 'unsafe-inline'");
+    });
+
+    it('should not emit double semicolons', () => {
+      const result = applyCspModifications(["default-src 'self' data:;", "font-src 'self';"], []);
+      expect(result).not.toContain(';;');
+      expect(result).toBe("default-src 'self' data:; font-src 'self'");
+    });
+  });
 });


### PR DESCRIPTION
### Description

Applying any `csp-modifications` dynamic-config entry corrupts the emitted `Content-Security-Policy` header in three independent ways:

1. **Per-request nonce dropped.** `ui_render_mixin.js` rebuilt the header from raw `http.csp.rules` when modifications were present, discarding the nonce injected by `buildHeaderWithNonce`. The page still renders nonce-attributed tags, so browsers block every dynamically injected stylesheet (`element.sheet === null` → `insertRule` TypeError during plugin setup → unhandled rejection kills client bootstrap). A single `frame-ancestors add` modification takes down the whole UI.

2. **Values lowercased wholesale.** Both `applyCspModifications` implementations (core `csp_modifications/utils.ts` and legacy `ui_render/utils.js`) lowercased base rules and modification values. Nonces (`'nonce-...'`) and hashes (`'sha256-...'`) are case-sensitive base64, so even a surviving nonce is corrupted.

3. **Semicolons mishandled.** Base rule strings that carry trailing or embedded `;` separators (common when rules are assembled from config) glued the `;` onto the last value token. An added value then landed *outside* its directive in the emitted header — e.g. `frame-ancestors 'self' https://example.com; https://added-origin.com; img-src ...` — which browsers parse as an unknown directive and silently ignore. Directives were also emitted with `;;` doublets.

### Changes

- `src/legacy/ui/ui_render/ui_render_mixin.js`: apply modifications to the already-built (nonce-bearing) header, matching the behavior of `http_resources_service.ts`.
- `src/core/server/csp_modifications/utils.ts`, `src/legacy/ui/ui_render/utils.js`: lowercase only directive names (case-insensitive matching per spec); preserve value case verbatim; split base-rule segments on `;` while parsing.

### Issues Resolved

Found while validating a runtime frame-ancestors allowlist delivered through the dynamic config service: the modified header both broke the application UI (nonce loss) and failed to actually allow the added origin (semicolon misplacement).

### Testing

- New unit tests in `utils.test.ts` and `utils.test.js`: nonce/hash case preservation in base rules and modification values, case-insensitive directive matching without duplicate directives, trailing/embedded semicolon handling, no `;;` in output.
- Verified end to end on a live deployment built with this change: with a `frame-ancestors add` modification active, the emitted header keeps the nonce, the added origin appears inside the `frame-ancestors` directive, the application UI is healthy, and an external page can iframe the app.

### Check List

- [x] All tests pass
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`
