### PR TITLE
fix: avoid repeated DOMPurify hook registration in table cells

### DIFF
--- a/src/plugins/vis_type_table/public/components/table_vis_cell.tsx
+++ b/src/plugins/vis_type_table/public/components/table_vis_cell.tsx
@@ -9,6 +9,23 @@ import dompurify from 'dompurify';
 import { OpenSearchDashboardsDatatableRow } from 'src/plugins/expressions';
 import { FormattedColumn } from '../types';
 
+const tableCellDompurify = dompurify(window);
+
+tableCellDompurify.addHook('uponSanitizeAttribute', (node, event) => {
+  if (event.attrName === 'target') {
+    event.forceKeepAttr = true;
+  }
+});
+
+tableCellDompurify.addHook('afterSanitizeElements', (node) => {
+  if (node instanceof Element && node.tagName?.toUpperCase() === 'A') {
+    const target = node.getAttribute('target');
+    if (target && target !== '_self') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  }
+});
+
 export const getTableVisCellValue = (
   sortedRows: OpenSearchDashboardsDatatableRow[],
   columns: FormattedColumn[]
@@ -23,20 +40,6 @@ export const getTableVisCellValue = (
   const rawContent = row[columnId];
   const colIndex = columns.findIndex((col) => col.id === columnId);
   const htmlContent = columns[colIndex].formatter.convert(rawContent, 'html');
-  dompurify.addHook('uponSanitizeAttribute', (node, event) => {
-    if (event.attrName === 'target') {
-      event.forceKeepAttr = true;
-    }
-  });
-
-  dompurify.addHook('afterSanitizeElements', (node) => {
-    if (node instanceof Element && node.tagName?.toUpperCase() === 'A') {
-      const target = node.getAttribute('target');
-      if (target && target !== '_self') {
-        node.setAttribute('rel', 'noopener noreferrer');
-      }
-    }
-  });
   const formattedContent = (
     /*
      * Justification for dangerouslySetInnerHTML:
@@ -46,7 +49,7 @@ export const getTableVisCellValue = (
      * `htmlContent` is created by converting raw data via HTML field formatter, so we need to make sure this value never contains
      * any unsafe HTML (e.g. by bypassing the field formatter).
      */
-    <div dangerouslySetInnerHTML={{ __html: dompurify.sanitize(htmlContent) }} /> // eslint-disable-line react/no-danger
+    <div dangerouslySetInnerHTML={{ __html: tableCellDompurify.sanitize(htmlContent) }} /> // eslint-disable-line react/no-danger
   );
   return formattedContent || null;
 };


### PR DESCRIPTION
### Description
Fixes repeated DOMPurify hook registration in the 2.19 table visualization cell renderer.

`getTableVisCellValue()` previously registered DOMPurify hooks every time a table cell value was rendered. Since DOMPurify appends hooks, large tables or repeated renders could cause hook accumulation and repeated hook execution.

This change creates a table-cell-specific DOMPurify instance, registers the link-handling hooks once on that instance, and uses it for table cell sanitization. This preserves the existing `target` / `rel="noopener noreferrer"` behavior without mutating the shared DOMPurify instance used by other code paths.

<!-- Describe what this change achieves-->

### Issues Resolved
resolved #12386
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
