### PR TITLE
feat(vega): restore Vega input signal values on refresh

### DIFF
--- a/src/plugins/vis_type_vega/public/data_model/types.ts
+++ b/src/plugins/vis_type_vega/public/data_model/types.ts
@@ -113,6 +113,7 @@ export interface OpenSearchDashboards {
   controlsLocation: ControlsLocation;
   controlsDirection: ControlsDirection;
   hideWarnings: boolean;
+  restoreSignalValuesOnRefresh?: boolean;
   type: string;
   renderer: Renderer;
   visibleVisLayers?: Map<VisLayerTypes, boolean>;

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -82,6 +82,7 @@ const DEFAULT_PARSER: string = 'opensearch';
 export class VegaParser {
   spec: VegaSpec;
   hideWarnings: boolean;
+  restoreSignalValuesOnRefresh: boolean;
   error?: string;
   warnings: string[];
   _urlParsers: UrlParserConfig | undefined;
@@ -112,6 +113,7 @@ export class VegaParser {
   ) {
     this.spec = spec as VegaSpec;
     this.hideWarnings = false;
+    this.restoreSignalValuesOnRefresh = false;
     this.visibleVisLayers = new Map<VisLayerTypes, boolean>();
     this.visAugmenterConfig = {} as VisAugmenterEmbeddableConfig;
 
@@ -192,6 +194,8 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
 
     this._config = this._parseConfig();
     this.hideWarnings = !!this._config.hideWarnings;
+    this._parseBool('restoreSignalValuesOnRefresh', this._config, false);
+    this.restoreSignalValuesOnRefresh = !!this._config.restoreSignalValuesOnRefresh;
     this.visibleVisLayers = this._config.visibleVisLayers;
     this.visAugmenterConfig = this._config.visAugmenterConfig;
     this.useMap = this._config.type === 'map';

--- a/src/plugins/vis_type_vega/public/lib/vega_signal_state_manager.js
+++ b/src/plugins/vis_type_vega/public/lib/vega_signal_state_manager.js
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function getSignalState(view, signalNames) {
+  const signalNameSet = new Set(signalNames || []);
+  if (!signalNameSet.size) return null;
+
+  // Restore only the selected signal values. Data and subcontext state belong
+  // to the new refresh cycle and should not be carried over from the old view.
+  const state = view.getState({
+    signals: (name) => signalNameSet.has(name),
+    data: false,
+    recurse: false,
+  });
+  if (!state?.signals || !Object.keys(state.signals).length) {
+    return null;
+  }
+
+  return state.signals;
+}
+
+function getFocusedControl(controlsEl) {
+  // The controls container is destroyed on refresh. Capture enough identity to
+  // find the equivalent generated control after Vega recreates it.
+  if (
+    typeof document === 'undefined' ||
+    !controlsEl ||
+    !document.activeElement ||
+    !controlsEl.contains(document.activeElement)
+  ) {
+    return null;
+  }
+
+  const { activeElement } = document;
+  const name = activeElement.getAttribute('name');
+  if (!name) return null;
+
+  const focusedControl = {
+    name,
+    tagName: activeElement.tagName,
+    type: activeElement.getAttribute('type'),
+    value: activeElement.getAttribute('value'),
+  };
+
+  if (typeof activeElement.selectionStart === 'number') {
+    focusedControl.selectionStart = activeElement.selectionStart;
+    focusedControl.selectionEnd = activeElement.selectionEnd;
+  }
+
+  return focusedControl;
+}
+
+function getMatchingControl(controlsEl, focusedControl) {
+  if (!controlsEl || !focusedControl) return null;
+
+  // Vega-generated controls use the signal name as the element name. Radio
+  // controls share a name, so include the value to restore the exact option.
+  return Array.from(controlsEl.querySelectorAll('[name]')).find((element) => {
+    if (element.getAttribute('name') !== focusedControl.name) return false;
+    if (element.tagName !== focusedControl.tagName) return false;
+    if (focusedControl.type && element.getAttribute('type') !== focusedControl.type) return false;
+    if (focusedControl.type === 'radio' && element.getAttribute('value') !== focusedControl.value) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function restoreFocusedControl(controlsEl, focusedControl) {
+  const element = getMatchingControl(controlsEl, focusedControl);
+  if (!element) return;
+
+  try {
+    element.focus({ preventScroll: true });
+  } catch {
+    element.focus();
+  }
+
+  if (
+    typeof element.setSelectionRange === 'function' &&
+    typeof focusedControl.selectionStart === 'number'
+  ) {
+    try {
+      element.setSelectionRange(focusedControl.selectionStart, focusedControl.selectionEnd);
+    } catch {
+      // Some input types do not support selection ranges.
+    }
+  }
+}
+
+export class VegaSignalStateManager {
+  constructor() {
+    this._state = null;
+    this._focusedControl = null;
+  }
+
+  clear() {
+    this._state = null;
+    this._focusedControl = null;
+  }
+
+  getState() {
+    return this._state;
+  }
+
+  save(view, controlsEl, signalNames) {
+    if (!view || typeof view.getState !== 'function') return;
+
+    try {
+      this._state = getSignalState(view, signalNames);
+      this._focusedControl = getFocusedControl(controlsEl);
+    } catch {
+      this.clear();
+    }
+  }
+
+  restore(view, controlsEl) {
+    const savedState = this.getState();
+
+    if (savedState) {
+      try {
+        // Set signal values before the first run so generated inputs are
+        // initialized with the restored values, not their spec defaults.
+        Object.entries(savedState).forEach(([name, value]) => {
+          view.signal(name, value);
+        });
+      } catch {
+        this.clear();
+      }
+    }
+
+    return view.runAsync().then(() => {
+      restoreFocusedControl(controlsEl, this._focusedControl);
+      return view;
+    });
+  }
+}

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -80,6 +80,7 @@ export class VegaBaseView {
     this._applyFilter = opts.applyFilter;
     this._triggerExternalAction = opts.externalAction;
     this._timefilter = opts.timefilter;
+    this._vegaSignalStateManager = opts.vegaSignalStateManager;
     this._view = null;
     this._vegaViewConfig = null;
     this._vegaViewOptions = null;
@@ -116,6 +117,10 @@ export class VegaBaseView {
       ).appendTo(this._$parentEl);
 
       this._addDestroyHandler(() => {
+        if (this._view && this._vegaSignalStateManager) {
+          const signalNames = this.getSignalNames();
+          this._vegaSignalStateManager.save(this._view, this._$controls?.[0], signalNames);
+        }
         if (this._$container) {
           this._$container.remove();
           this._$container = null;
@@ -281,6 +286,14 @@ export class VegaBaseView {
     }
   }
 
+  getSignalNames() {
+    // Bound signals back Vega-generated controls. Future config-provided signal
+    // names can be merged here without changing the state manager API.
+    return (this._parser.spec?.signals || [])
+      .filter((signal) => signal?.name && signal.bind)
+      .map((signal) => signal.name);
+  }
+
   setView(view) {
     if (this._view === view) return;
 
@@ -300,7 +313,9 @@ export class VegaBaseView {
         new TooltipHandler(this._$container[0], view, this._parser.tooltips);
       }
 
-      return view.runAsync(); // Allows callers to await rendering
+      return this._vegaSignalStateManager
+        ? this._vegaSignalStateManager.restore(view, this._$controls?.[0])
+        : view.runAsync(); // Allows callers to await rendering
     }
   }
 

--- a/src/plugins/vis_type_vega/public/vega_visualization.js
+++ b/src/plugins/vis_type_vega/public/vega_visualization.js
@@ -30,6 +30,7 @@
 
 import { i18n } from '@osd/i18n';
 import { getNotifications, getData } from './services';
+import { VegaSignalStateManager } from './lib/vega_signal_state_manager';
 
 export const createVegaVisualization = ({ getServiceSettings }) =>
   class VegaVisualization {
@@ -37,6 +38,8 @@ export const createVegaVisualization = ({ getServiceSettings }) =>
       this._el = el;
       this._vis = vis;
       this.dataPlugin = getData();
+      this._lastSpec = undefined;
+      this._vegaSignalStateManager = null;
     }
 
     /**
@@ -45,7 +48,7 @@ export const createVegaVisualization = ({ getServiceSettings }) =>
      * @param {*} status
      * @returns {Promise<void>}
      */
-    async render(visData) {
+    async render(visData, visParams) {
       const { toasts } = getNotifications();
 
       if (!visData && !this._vegaView) {
@@ -58,7 +61,7 @@ export const createVegaVisualization = ({ getServiceSettings }) =>
       }
 
       try {
-        await this._render(visData);
+        await this._render(visData, visParams);
       } catch (error) {
         if (this._vegaView) {
           this._vegaView.onError(error);
@@ -72,13 +75,26 @@ export const createVegaVisualization = ({ getServiceSettings }) =>
       }
     }
 
-    async _render(vegaParser) {
+    async _render(vegaParser, visParams) {
       if (vegaParser) {
-        // New data received, rebuild the graph
+        const spec = typeof visParams?.spec === 'string' ? visParams.spec : undefined;
+        const specChanged = spec !== undefined && spec !== this._lastSpec;
+
+        // New data received, rebuild the graph. Destroy first so same-spec
+        // refreshes can save state; clear that state afterwards for spec edits.
         if (this._vegaView) {
           await this._vegaView.destroy();
           this._vegaView = null;
         }
+
+        if (specChanged) {
+          this._vegaSignalStateManager?.clear();
+          this._lastSpec = spec;
+        }
+
+        this._vegaSignalStateManager = vegaParser.restoreSignalValuesOnRefresh
+          ? this._vegaSignalStateManager || new VegaSignalStateManager()
+          : null;
 
         const serviceSettings = await getServiceSettings();
         const { filterManager } = this.dataPlugin.query;
@@ -91,6 +107,7 @@ export const createVegaVisualization = ({ getServiceSettings }) =>
           filterManager,
           timefilter,
           externalAction: this._vis.API.events.externalAction,
+          vegaSignalStateManager: this._vegaSignalStateManager,
         };
 
         if (vegaParser.useMap) {
@@ -106,6 +123,8 @@ export const createVegaVisualization = ({ getServiceSettings }) =>
     }
 
     destroy() {
-      return this._vegaView && this._vegaView.destroy();
+      const destroyPromise = this._vegaView && this._vegaView.destroy();
+      this._vegaSignalStateManager?.clear();
+      return destroyPromise;
     }
   };


### PR DESCRIPTION
### Description
This adds support for `config.kibana.restoreSignalValuesOnRefresh` in Vega visualizations.

When enabled, Vega visualizations preserve values from Vega-generated input controls, such as text inputs, selects, checkboxes, radio buttons, and ranges, across dashboard refreshes. This prevents dashboard auto-refresh from resetting bound control values back to their spec defaults.

The implementation intentionally restores only bound signal values from Vega controls. It does not restore query data or general Vega runtime state, so refreshed OpenSearch results and Vega/Vega-Lite internal state are still recomputed on refresh.

<!-- Describe what this change achieves-->

### Issues Resolved
resolved #9840
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/4ce4601b-1d5d-4bc9-9d2d-71bbbb107492


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
