### PR TITLE
Fix BWC legend title selector for charts 71

### DIFF
--- a/cypress/integration/with_security/check_filter_and_query.js
+++ b/cypress/integration/with_security/check_filter_and_query.js
@@ -77,7 +77,7 @@ describe('check dashboards filter and query', () => {
 
       //[Logs] Response chart should show 200 label
       cy.get('[data-title="[Logs] Response Codes Over Time + Annotations"]')
-        .find('[title="200"]')
+        .find('[title^="200"]')
         .should('have.text', '200');
     });
   });

--- a/cypress/integration/without_security/check_filter_and_query.js
+++ b/cypress/integration/without_security/check_filter_and_query.js
@@ -67,7 +67,7 @@ describe('check dashboards filter and query', () => {
 
       //[Logs] Response chart should show 200 label
       cy.get('[data-title="[Logs] Response Codes Over Time + Annotations"]')
-        .find('[title="200"]')
+        .find('[title^="200"]')
         .should('have.text', '200');
     });
   });


### PR DESCRIPTION
## Summary
Post-merge BWC test runs (osd_2.0.0–osd_2.9.0) fail in `check_filter_and_query` (both security variants):

```
Expected to find element: [title="200"], but never found it. Queried from:
cy.get([data-title="[Logs] Response Codes Over Time + Annotations"])
```

### Root cause
`@elastic/charts` 71 (#12434) appends interactivity hints to the legend label `title` attribute for toggleable series — e.g. `"200\nClick: hide, …"` — so the exact-match selector `[title="200"]` no longer matches the legend item of the TSVB "Response Codes Over Time" panel.

### Fix
Use a starts-with attribute selector `[title^="200"]`, which matches both the old exact title and the new title-with-hints. The `.should('have.text', '200')` assertion is unchanged and still validates the visible legend label.

### Testing
Selector verified against the charts 71 legend label markup (`title` = label + `\n` + interactivity text for toggleable items).

### Related issues
Closes #12439
Closes #12453
Closes #12454
Closes #12456
Closes #12457
Closes #12459
