### PR TITLE
[Chat]Add AI-driven visualization with transformation pipeline support

### DIFF
--- a/src/core/public/chat/chat_service.ts
+++ b/src/core/public/chat/chat_service.ts
@@ -11,6 +11,7 @@ import {
   ChatServiceStart,
   ChatImplementationFunctions,
   Message,
+  InputContent,
   ChatWindowState,
   ConversationMemoryProvider,
 } from './types';
@@ -171,7 +172,7 @@ export class ChatService implements CoreService<ChatServiceSetup, ChatServiceSta
       },
 
       sendMessageWithWindow: async (
-        content: string,
+        content: string | InputContent[],
         messages: Message[],
         options?: { clearConversation?: boolean }
       ) => {

--- a/src/core/public/chat/index.ts
+++ b/src/core/public/chat/index.ts
@@ -20,6 +20,7 @@ export {
   ChatWindowState,
   SavedConversation,
   TextInputContent,
+  InputContent,
   ConversationMemoryProvider,
   ConversationPaginationParams,
   PaginatedConversations,

--- a/src/core/public/chat/types.ts
+++ b/src/core/public/chat/types.ts
@@ -10,6 +10,7 @@ import type { Event } from './events';
 export interface TextInputContent {
   type: 'text';
   text: string;
+  name?: string;
 }
 
 interface BinaryInputContent {
@@ -19,9 +20,29 @@ interface BinaryInputContent {
   url?: string;
   data?: string;
   filename?: string;
+  name?: string;
 }
 
-type InputContent = TextInputContent | BinaryInputContent;
+interface InputContentDataSource {
+  type: 'data';
+  value: string;
+  mimeType: string;
+}
+
+interface InputContentUrlSource {
+  type: 'url';
+  value: string;
+  mimeType?: string;
+}
+
+type InputContentSource = InputContentDataSource | InputContentUrlSource;
+
+interface ImageInputContent {
+  type: 'image';
+  source: InputContentSource;
+  metadata?: Record<string, unknown>;
+}
+export type InputContent = TextInputContent | BinaryInputContent | ImageInputContent;
 
 /**
  * Function call interface
@@ -167,7 +188,7 @@ export interface ChatServiceInterface {
     messages: Message[]
   ): Promise<{ observable: any; userMessage: UserMessage }>;
   sendMessageWithWindow(
-    content: string,
+    content: string | InputContent[],
     messages: Message[],
     options?: { clearConversation?: boolean }
   ): Promise<{ observable: any; userMessage: UserMessage }>;
@@ -185,7 +206,7 @@ export interface ChatImplementationFunctions {
   ) => Promise<{ observable: any; userMessage: UserMessage }>;
 
   sendMessageWithWindow: (
-    content: string,
+    content: string | InputContent[],
     messages: Message[],
     options?: { clearConversation?: boolean }
   ) => Promise<{ observable: any; userMessage: UserMessage }>;

--- a/src/plugins/chat/common/types.ts
+++ b/src/plugins/chat/common/types.ts
@@ -17,6 +17,7 @@ export type {
   ToolMessage,
   Role,
   TextInputContent,
+  InputContent,
 } from '../../../core/public/chat';
 
 // Zod schemas for runtime validation - these ensure the core types are followed
@@ -32,9 +33,11 @@ export const ToolCallSchema = z.object({
 });
 
 // AG-UI Protocol: Input content schemas for multimodal content (text + images)
+// name marks a msg as a machine-only payload — hidden from the conversation view
 export const TextInputContentSchema = z.object({
   type: z.literal('text'),
   text: z.string(),
+  name: z.string().optional(),
 });
 
 export const BinaryInputContentSchema = z.object({
@@ -44,9 +47,26 @@ export const BinaryInputContentSchema = z.object({
   url: z.string().optional(),
   data: z.string().optional(),
   filename: z.string().optional(),
+  name: z.string().optional(),
 });
 
-export const InputContentSchema = z.union([TextInputContentSchema, BinaryInputContentSchema]);
+export const InputContentSourceSchema = z.union([
+  z.object({ type: z.literal('data'), value: z.string(), mimeType: z.string() }),
+  z.object({ type: z.literal('url'), value: z.string(), mimeType: z.string().optional() }),
+]);
+
+export const ImageInputContentSchema = z.object({
+  type: z.literal('image'),
+  source: InputContentSourceSchema,
+  metadata: z.record(z.unknown()).optional(),
+  name: z.string().optional(),
+});
+
+export const InputContentSchema = z.union([
+  TextInputContentSchema,
+  BinaryInputContentSchema,
+  ImageInputContentSchema,
+]);
 
 export const BaseMessageSchema = z.object({
   id: z.string(),

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -16,13 +16,13 @@ import React, {
 import { useUnmount, useMount } from 'react-use';
 import moment from 'moment';
 import { i18n } from '@osd/i18n';
-import { EuiButton, EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
+import { EuiButtonIcon, EuiLoadingSpinner, EuiText } from '@elastic/eui';
 import { useChatContext } from '../contexts/chat_context';
 import { ChatEventHandler } from '../services/chat_event_handler';
 import { AssistantActionService } from '../../../context_provider/public';
 import { ConfirmationRequest } from '../services/confirmation_service';
 import { type Event as ChatEvent } from '../../common/events';
-import type { Message, SystemMessage, UserMessage } from '../../common/types';
+import type { InputContent, Message, SystemMessage, UserMessage } from '../../common/types';
 import { ChatLayoutMode } from '../types';
 import { ChatContainer } from './chat_container';
 import { ChatHeader } from './chat_header';
@@ -38,11 +38,16 @@ import type { SavedConversation } from '../services/conversation_history_service
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../core/public';
 import { ChatSessionErrorBoundary } from './chat_session_error_boundary';
+
+import { flattenContentText } from '../utils/user_message_input';
 import './chat_window.scss';
 
 export interface ChatWindowInstance {
   startNewChat: () => void;
-  sendMessage: (options: { content: string; messages?: Message[] }) => Promise<unknown>;
+  sendMessage: (options: {
+    content: string | InputContent[];
+    messages?: Message[];
+  }) => Promise<unknown>;
 }
 
 interface ChatWindowProps {
@@ -113,9 +118,17 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     const timelineRef = React.useRef<Message[]>(timeline);
 
-    React.useEffect(() => {
-      timelineRef.current = timeline;
-    }, [timeline]);
+    // Wrap setTimeline so timelineRef updates synchronously within the updater, before React renders.
+    const setTimelineSynced = useCallback(
+      (updater: Message[] | ((prev: Message[]) => Message[])) => {
+        setTimeline((prev) => {
+          const next = typeof updater === 'function' ? updater(prev) : updater;
+          timelineRef.current = next;
+          return next;
+        });
+      },
+      []
+    );
 
     // Subscribe to pending confirmations
     useEffect(() => {
@@ -146,13 +159,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           confirmationService,
           telemetryRecorder,
           callbacks: {
-            onTimelineUpdate: setTimeline,
+            onTimelineUpdate: setTimelineSynced,
             onStreamingStateChange: setIsStreaming,
             onStartResponse: setStartResponse,
             getTimeline: () => timelineRef.current,
           },
         }),
-      [service, chatService, confirmationService, telemetryRecorder]
+      [service, chatService, confirmationService, telemetryRecorder, setTimelineSynced]
     );
 
     // Subscribe to tool updates from the service
@@ -227,7 +240,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         setIsStreaming(true);
         setStartResponse(false);
 
-        const content = userMessage.content as string;
+        const content = flattenContentText(userMessage.content);
 
         try {
           const { observable } = await chatService.sendMessage(content, messages, userMessage);
@@ -302,10 +315,10 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           };
           if (pendingUserMessage) {
             // User message already in timeline (data source selection flow) — append response
-            setTimeline((prev) => [...prev, responseMsg]);
+            setTimelineSynced((prev) => [...prev, responseMsg]);
           } else {
             const userMsg = chatService.getUserMessage(messageContent);
-            setTimeline((prev) => [...prev, userMsg, responseMsg]);
+            setTimelineSynced((prev) => [...prev, userMsg, responseMsg]);
           }
           setScreenshotData(undefined);
           return true;
@@ -314,18 +327,18 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           const userMsg = chatService.getUserMessage(commandResult.message, messageContent);
           if (pendingUserMessage) {
             // Replace the pending user message (by id) with the resolved command message
-            setTimeline((prev) =>
+            setTimelineSynced((prev) =>
               prev.map((msg) => (msg.id === pendingUserMessage.id ? userMsg : msg))
             );
           } else {
-            setTimeline((prev) => [...prev, userMsg]);
+            setTimelineSynced((prev) => [...prev, userMsg]);
           }
           subscribeToMessageStream(messagesToSend, userMsg);
           return true;
         }
         return true;
       },
-      [chatService, subscribeToMessageStream]
+      [chatService, subscribeToMessageStream, setTimelineSynced]
     );
 
     // Handler for when user selects a data source from the prompt
@@ -372,7 +385,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
               defaultMessage: 'The current data source does not support AI features.',
             }),
           };
-          setTimeline((prev) => [...prev, systemMsg]);
+          setTimelineSynced((prev) => [...prev, systemMsg]);
           return { valid: false, reason: 'unsupported' };
         }
 
@@ -399,38 +412,40 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
                 'There are no data sources associated with this workspace. Please ask your workspace admin to associate data sources to this workspace.',
             }),
           };
-          setTimeline((prev) => [...prev, infoMsg]);
+          setTimelineSynced((prev) => [...prev, infoMsg]);
           return { valid: false, reason: 'no_data_sources' };
         }
 
         return { valid: true };
       },
-      [chatService, isUnsupportedDataSource]
+      [chatService, setTimelineSynced, isUnsupportedDataSource]
     );
 
-    const handleSend = async (options?: { input?: string; messages?: Message[] }) => {
-      const messageContent = options?.input ?? input.trim();
+    const handleSend = async (options?: {
+      input?: string | InputContent[];
+      messages?: Message[];
+    }) => {
+      let messageContent: string | InputContent[] = options?.input ?? input.trim();
+
+      const isEmpty = Array.isArray(messageContent) ? messageContent.length === 0 : !messageContent;
       // Use ref for immediate check since React 18 batches state updates
-      if (!messageContent || isStreamingRef.current || isValidatingRef.current || hasPendingResend)
-        return;
+      if (isEmpty || isStreamingRef.current || hasPendingResend) return;
 
       // Prepare additional messages for sending (but don't add to timeline yet)
-      let additionalMessages = options?.messages ?? [];
-
+      const additionalMessages = options?.messages ?? [];
       // Only add screenshot data if messages not provided
-      if (!options?.messages && screenshotData) {
-        additionalMessages = [
+      if (!options?.input && typeof messageContent === 'string' && screenshotData) {
+        messageContent = [
+          // binary is deprecated
           {
-            role: 'user' as const,
-            id: chatService.generateMessageId(),
-            content: [
-              {
-                type: 'binary' as const,
-                mimeType: screenshotData.mimeType,
-                data: screenshotData.base64,
-              },
-            ],
+            type: 'image',
+            source: {
+              type: 'data',
+              value: screenshotData.base64,
+              mimeType: screenshotData.mimeType,
+            },
           },
+          { type: 'text' as const, text: messageContent },
         ];
       }
 
@@ -438,7 +453,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
       // Show user message immediately (optimistic rendering)
       const userMsg = chatService.getUserMessage(messageContent);
-      setTimeline((prev) => [...prev, userMsg]);
+      setTimelineSynced((prev) => [...prev, userMsg]);
 
       // Merge additional messages with current timeline for sending
       const messagesToSend = [...timeline, ...additionalMessages];
@@ -453,10 +468,12 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
         // Check if this is a slash command — pass userMsg so executeSlashCommand
         // can replace it (by id) with the resolved command message.
-        const handled = await executeSlashCommand(messageContent, messagesToSend, userMsg);
-        if (handled) return;
+        if (typeof messageContent === 'string') {
+          const handled = await executeSlashCommand(messageContent, messagesToSend);
+          if (handled) return;
+        }
 
-        // Normal message flow — user message already in timeline, just stream
+        // Normal message flow — the content can be multimodal
         return subscribeToMessageStream(messagesToSend, userMsg);
       } finally {
         isValidatingRef.current = false;
@@ -486,21 +503,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
         if (messageIndex === -1) return;
 
-        let textContent = typeof message.content === 'string' ? message.content : '';
-        const additionalMessages: Message[] = [];
-
-        if (Array.isArray(message.content)) {
-          const lastMessageContent = message.content[message.content.length - 1];
-          if (lastMessageContent.type === 'text') {
-            textContent = lastMessageContent.text;
-            additionalMessages.push({
-              ...message,
-              content: message.content.slice(0, message.content.length - 1),
-            });
-          }
-        }
-
-        if (textContent === '') {
+        const content = message.content;
+        const isEmpty = Array.isArray(content) ? content.length === 0 : !content;
+        if (isEmpty) {
           return;
         }
 
@@ -511,11 +516,11 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         setInput('');
 
         // Add user message back and stream
-        const userMsg = chatService.getUserMessage(textContent);
-        setTimeline([...truncatedTimeline, userMsg]);
-        subscribeToMessageStream([...truncatedTimeline, ...additionalMessages], userMsg);
+        const userMsg = chatService.getUserMessage(content);
+        setTimelineSynced([...truncatedTimeline, userMsg]);
+        subscribeToMessageStream(truncatedTimeline, userMsg);
       },
-      [timeline, subscribeToMessageStream, setInput, chatService]
+      [timeline, subscribeToMessageStream, setInput, setTimelineSynced, chatService]
     );
 
     const handleResendToolResult = useCallback(
@@ -531,10 +536,10 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         // Avoid concurrent resends while streaming or already sending a tool result
         if (isStreamingRef.current || hasActiveToolCallsRef.current) return;
         // Remove the error message from timeline
-        setTimeline((prev) => prev.filter((msg) => msg.id !== messageId));
+        setTimelineSynced((prev) => prev.filter((msg) => msg.id !== messageId));
         await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
       },
-      [eventHandler, setTimeline]
+      [eventHandler, setTimelineSynced]
     );
 
     // Helper function to stop streaming and clean up subscriptions
@@ -566,7 +571,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       eventHandler.clearState();
 
       chatService.newThread();
-      setTimeline([]);
+      setTimelineSynced([]);
       setCurrentRunId(null);
       setPendingConfirmation(null);
       setPendingMessage(null);
@@ -575,7 +580,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       setIsValidating(false);
       confirmationService.cleanAll();
       setShowHistory(false);
-    }, [chatService, confirmationService, eventHandler, stopStreaming]);
+    }, [chatService, confirmationService, eventHandler, stopStreaming, setTimelineSynced]);
 
     const handleStop = useCallback(() => {
       stopStreaming();

--- a/src/plugins/chat/public/components/message_row.test.tsx
+++ b/src/plugins/chat/public/components/message_row.test.tsx
@@ -176,6 +176,63 @@ describe('MessageRow', () => {
       expect(screen.getByRole('img')).toBeInTheDocument();
       expect(screen.getByText('Plain text block')).toBeInTheDocument();
     });
+
+    it('should hide named blocks from the conversation view', () => {
+      const message: Message = {
+        id: 'msg-9',
+        role: 'user',
+        content: [
+          {
+            type: 'binary',
+            mimeType: 'image/jpeg',
+            data: 'imagedata',
+          },
+          {
+            type: 'text',
+            text: '[Visualization Context] Chart Type: line',
+            name: 'visualization_context',
+          },
+          {
+            type: 'text',
+            text: 'Summarize this chart',
+          },
+        ],
+      };
+
+      render(<MessageRow message={message} />);
+
+      // Unnamed blocks stay visible
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByText('Summarize this chart')).toBeInTheDocument();
+      // Named block is machine-only
+      expect(
+        screen.queryByText('[Visualization Context] Chart Type: line')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should hide named binary blocks', () => {
+      const message: Message = {
+        id: 'msg-10',
+        role: 'user',
+        content: [
+          {
+            type: 'binary',
+            mimeType: 'image/png',
+            data: 'hiddenimage',
+            name: 'internal_screenshot',
+          },
+          {
+            type: 'text',
+            text: 'Visible text',
+          },
+        ],
+      };
+
+      render(<MessageRow message={message} />);
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(screen.getByText('Visible text')).toBeInTheDocument();
+    });
   });
 
   describe('role-based styling', () => {

--- a/src/plugins/chat/public/components/message_row.tsx
+++ b/src/plugins/chat/public/components/message_row.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@osd/i18n';
 import { Markdown } from '../../../opensearch_dashboards_react/public';
 import type { Message, AssistantMessage } from '../../common/types';
 import { stripInlineSuggestions } from '../../common/parse_inline_suggestions';
+import { getImageSrc } from '../utils/user_message_input';
 import { ShareModal } from './share_modal';
 import './message_row.scss';
 
@@ -71,28 +72,30 @@ export const MessageRow: React.FC<MessageRowProps> = ({
     if (Array.isArray(content)) {
       return (
         <>
-          {content.map((block: any, index: number) => {
-            // Render binary content (images)
-            if (block.type === 'binary' && block.data) {
-              return (
-                <img
-                  key={index}
-                  src={`data:${block.mimeType || 'image/jpeg'};base64,${block.data}`}
-                  alt={block.filename || 'Visualization'}
-                  style={{ maxWidth: '100%', marginBottom: '8px', borderRadius: '4px' }}
-                />
-              );
-            }
-            // Render text content as markdown
-            if (block.type === 'text' && block.text) {
-              return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
-            }
-            // Handle plain text blocks (for backward compatibility)
-            if (block.text) {
-              return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
-            }
-            return null;
-          })}
+          {content
+            .filter((block: any) => !block.name)
+            .map((block: any, index: number) => {
+              const imageSrc = getImageSrc(block);
+              if (imageSrc) {
+                return (
+                  <img
+                    key={index}
+                    src={imageSrc}
+                    alt={block.filename || 'Visualization'}
+                    style={{ maxWidth: '100%', marginBottom: '8px', borderRadius: '4px' }}
+                  />
+                );
+              }
+              // Render text content as markdown
+              if (block.type === 'text' && block.text) {
+                return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
+              }
+              // Handle plain text blocks (for backward compatibility)
+              if (block.text) {
+                return <Markdown key={index} markdown={block.text} openLinksInNewTab={true} />;
+              }
+              return null;
+            })}
         </>
       );
     }

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -36,6 +36,8 @@ const mockAssistantActionService = {
 const mockChatService = {
   sendToolResult: jest.fn(),
   getCurrentDataSourceId: jest.fn().mockReturnValue(undefined),
+  getCurrentDataSourceInfo: jest.fn().mockResolvedValue(undefined),
+  getCurrentTimeRange: jest.fn().mockReturnValue(undefined),
   resetConnection: jest.fn(),
 } as unknown as jest.Mocked<ChatService>;
 

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -394,11 +394,14 @@ export class ChatEventHandler {
       });
 
       // Execute the tool and update tool execution status
+      const dataSourceInfo = await this.chatService.getCurrentDataSourceInfo();
+      const timeRange = this.chatService.getCurrentTimeRange();
       const result = await this.toolExecutor.executeTool(
         toolCall.function.name,
         args,
         toolCallId,
-        await this.chatService.getCurrentDataSourceId()
+        dataSourceInfo,
+        timeRange
       );
 
       // Check if tool execution was cancelled (e.g., due to cleanup)
@@ -828,8 +831,25 @@ export class ChatEventHandler {
    * Simply sets the timeline to the saved messages
    */
   private async handleMessagesSnapshot(event: MessagesSnapshotEvent): Promise<void> {
-    // Set timeline to snapshot messages
-    this.onTimelineUpdate(() => event.messages || []);
+    // agent backends may serialize a user message's `InputContent[]` to str
+    // restore multimodal user messages
+    this.onTimelineUpdate((prev) => {
+      const snapshot = event.messages || [];
+
+      const localArrayContent = new Map<string, unknown>();
+      for (const message of prev) {
+        if (message.role === 'user' && Array.isArray(message.content)) {
+          localArrayContent.set(message.id, message.content);
+        }
+      }
+      if (localArrayContent.size === 0) return snapshot;
+
+      return snapshot.map((message) => {
+        if (message.role !== 'user' || typeof message.content !== 'string') return message;
+        const content = localArrayContent.get(message.id);
+        return content ? ({ ...message, content } as Message) : message;
+      });
+    });
 
     // Reset streaming state
     this.onStreamingStateChange(false);

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -1494,7 +1494,19 @@ describe('ChatService', () => {
     });
   });
 
-  describe('extractDataSourceIdFromPageContext', () => {
+  describe('getDataSourceFromPageContext', () => {
+    // Helper to stub the global context store and invoke the current method.
+    const extractDataSourceId = (contexts: any[]) => {
+      (global as any).window.assistantContextStore = {
+        getAllContexts: jest.fn().mockReturnValue(contexts),
+      };
+      return (chatService as any).getDataSourceFromPageContext();
+    };
+
+    afterEach(() => {
+      delete (global as any).window.assistantContextStore;
+    });
+
     it('should extract data source ID from valid page context', () => {
       const contexts = [
         {
@@ -1515,7 +1527,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBe('correct-data-source-id');
     });
 
@@ -1531,7 +1543,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBe('investigation-data-source');
     });
 
@@ -1551,7 +1563,8 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      // const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1564,7 +1577,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1577,7 +1590,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1590,7 +1603,7 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBeUndefined();
     });
 
@@ -1614,12 +1627,12 @@ describe('ChatService', () => {
         },
       ];
 
-      const result = (chatService as any).extractDataSourceIdFromPageContext(contexts);
+      const result = extractDataSourceId(contexts);
       expect(result).toBe('first-id'); // Should return first valid page context
     });
 
     it('should handle empty contexts array', () => {
-      const result = (chatService as any).extractDataSourceIdFromPageContext([]);
+      const result = extractDataSourceId([]);
       expect(result).toBeUndefined();
     });
   });
@@ -2333,6 +2346,31 @@ describe('ChatService', () => {
 
       expect(result.content).toBe('spaced');
       expect(result.rawMessage).toBe('spaced');
+    });
+
+    it('should pass multimodal content arrays through untouched', () => {
+      const content = [
+        { type: 'binary' as const, mimeType: 'image/png', data: 'abc123' },
+        { type: 'text' as const, text: 'describe this chart' },
+      ];
+
+      const result = chatService.getUserMessage(content);
+
+      expect(result).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'user',
+        content,
+      });
+      expect(result.rawMessage).toBeUndefined();
+    });
+
+    it('should keep an explicit rawMessage alongside array content', () => {
+      const content = [{ type: 'text' as const, text: '/vis output' }];
+
+      const result = chatService.getUserMessage(content, '/vis');
+
+      expect(result.content).toEqual(content);
+      expect(result.rawMessage).toBe('/vis');
     });
   });
 });

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -5,7 +5,7 @@
 
 import { Observable, Subscription } from 'rxjs';
 import { AgUiAgent } from './ag_ui_agent';
-import { RunAgentInput, Message, UserMessage, ToolMessage } from '../../common/types';
+import { RunAgentInput, Message, UserMessage, ToolMessage, InputContent } from '../../common/types';
 import type { ToolDefinition } from '../../../context_provider/public';
 import { AssistantActionService } from '../../../context_provider/public';
 import type { ChatWindowInstance } from '../components/chat_window';
@@ -230,7 +230,7 @@ export class ChatService {
   }
 
   public async sendMessageWithWindow(
-    content: string,
+    content: string | InputContent[],
     messages: Message[],
     options?: { clearConversation?: boolean }
   ): Promise<{
@@ -255,7 +255,7 @@ export class ChatService {
     const userMessage: UserMessage = {
       id: this.generateMessageId(),
       role: 'user',
-      content: content.trim(),
+      content: typeof content === 'string' ? content.trim() : content,
     };
 
     // Return a dummy observable since ChatWindow handles everything internally
@@ -266,39 +266,42 @@ export class ChatService {
     return { observable: dummyObservable, userMessage };
   }
 
-  /**
-   * Extract data source ID from page context
-   * Looks for page contexts with appId and dataset.dataSource.id structure
-   */
-  private extractDataSourceIdFromPageContext(allContexts: any[]): string | undefined {
-    // Find page context by checking for 'page' category and appId in value
-    const pageContext = allContexts.find((ctx) => {
-      // Look for contexts in 'page' category instead of filtering by ID existence
-      if (!ctx.categories?.includes('page')) return false;
+  private getDataSourceFromPageContext() {
+    const dsId = this.getPageContextValue()?.dataset?.dataSource?.id;
+    return dsId;
+  }
 
+  private getAllAssistantContexts(): any[] {
+    const contextStore = (window as any).assistantContextStore;
+    return contextStore ? contextStore.getAllContexts() : [];
+  }
+
+  /**
+   * Resolve the parsed value of the current page context (the one carrying appId).
+   */
+  private getPageContextValue(): any | undefined {
+    const pageContext = this.getAllAssistantContexts().find((ctx) => {
+      if (!ctx.categories?.includes('page')) return false;
       try {
         const value = typeof ctx.value === 'string' ? JSON.parse(ctx.value) : ctx.value;
-        return value?.appId; // Page contexts have appId
+        return value?.appId;
       } catch {
         return false;
       }
     });
-
     if (!pageContext) return undefined;
 
-    const contextValue =
-      typeof pageContext.value === 'string' ? JSON.parse(pageContext.value) : pageContext.value;
-
-    // TODO: Consider adding more robust nested field search for dataSource.id
-    // if the standard dataset.dataSource.id pattern is not found
-    return contextValue?.dataset?.dataSource?.id;
+    return typeof pageContext.value === 'string'
+      ? JSON.parse(pageContext.value)
+      : pageContext.value;
   }
 
-  private getDataSourceFromPageContext() {
-    const contextStore = (window as any).assistantContextStore;
-    const allContexts = contextStore ? contextStore.getAllContexts() : [];
-
-    return this.extractDataSourceIdFromPageContext(allContexts);
+  public getCurrentTimeRange(): { from: string; to: string } | undefined {
+    const timeRange = this.getPageContextValue()?.timeRange;
+    if (timeRange?.from && timeRange?.to) {
+      return { from: timeRange.from, to: timeRange.to };
+    }
+    return undefined;
   }
 
   /**
@@ -357,6 +360,14 @@ export class ChatService {
       this.cachedDataSourceId ||
       (await this.getWorkspaceAwareDataSourceId())
     );
+  }
+
+  public async getCurrentDataSourceInfo(): Promise<{ id: string; title?: string } | undefined> {
+    const id = await this.getCurrentDataSourceId();
+    if (!id) return undefined;
+    const availableDs = await this.getAvailableDataSources();
+    const title = availableDs.find((ds) => ds.id === id)?.title;
+    return { id, title };
   }
 
   public async sendMessage(
@@ -969,7 +980,16 @@ export class ChatService {
   /**
    * Create a user message for timeline display
    */
-  public getUserMessage(content: string, rawMessage?: string): UserMessage {
+  public getUserMessage(content: string | InputContent[], rawMessage?: string): UserMessage {
+    if (Array.isArray(content)) {
+      return {
+        id: this.generateMessageId(),
+        role: 'user',
+        content,
+        ...(rawMessage ? { rawMessage } : {}),
+      };
+    }
+
     return {
       id: this.generateMessageId(),
       role: 'user',

--- a/src/plugins/chat/public/services/export/investigation_export_service.ts
+++ b/src/plugins/chat/public/services/export/investigation_export_service.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../common/types';
 import { TOOL_EXECUTION_ERROR_PREFIX } from '../../../common';
 import { stripInlineSuggestions } from '../../../common/parse_inline_suggestions';
+import { resolveImageContent } from '../../utils/user_message_input';
 import { ChatExportData, ChatExportOptions, ChatTraceStep, QuestionImage } from './types';
 import { generatePDFReport } from './pdf_template';
 import { generateMarkdownReport } from './markdown_template';
@@ -107,11 +108,11 @@ export function findPrecedingQuestion(
           .filter((c): c is TextInputContent => c.type === 'text')
           .map((c) => c.text)
           .join(' ');
-        const binaryContent = msg.content.find((c) => c.type === 'binary' && 'data' in c);
-        const image =
-          binaryContent && binaryContent.type === 'binary' && binaryContent.data
-            ? { base64: binaryContent.data, mimeType: binaryContent.mimeType || 'image/png' }
-            : undefined;
+
+        const imageContent = msg.content.map(resolveImageContent).find((c) => c?.base64);
+        const image = imageContent?.base64
+          ? { base64: imageContent.base64, mimeType: imageContent.mimeType }
+          : undefined;
         return { text, image };
       }
       return { text: '' };

--- a/src/plugins/chat/public/services/tool_executor.test.ts
+++ b/src/plugins/chat/public/services/tool_executor.test.ts
@@ -53,11 +53,15 @@ describe('ToolExecutor', () => {
       mockAssistantActionService.isUserConfirmRequired.mockReturnValue(false);
       mockAssistantActionService.executeAction.mockResolvedValue({ result: 'success' });
 
-      await toolExecutor.executeTool('testTool', { param: 'value' }, 'call-123', 'datasource-1');
+      await toolExecutor.executeTool('testTool', { param: 'value' }, 'call-123', {
+        id: 'datasource-1',
+        title: 'Datasource 1',
+      });
 
       expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('testTool', {
         param: 'value',
         datasourceId: 'datasource-1',
+        datasourceTitle: 'Datasource 1',
       });
     });
   });
@@ -119,7 +123,8 @@ describe('ToolExecutor', () => {
         'confirmTool',
         { param: 'value' },
         'call-123',
-        'datasource-1'
+        // 'datasource-1'
+        { id: 'datasource-1', title: 'Datasource 1' }
       );
 
       const pending = confirmationService.getPendingConfirmations();
@@ -131,6 +136,7 @@ describe('ToolExecutor', () => {
         param: 'value',
         confirmed: true,
         datasourceId: 'datasource-1',
+        datasourceTitle: 'Datasource 1',
       });
     });
   });

--- a/src/plugins/chat/public/services/tool_executor.ts
+++ b/src/plugins/chat/public/services/tool_executor.ts
@@ -45,7 +45,8 @@ export class ToolExecutor {
     toolName: string,
     toolArgs: any,
     toolCallId: string,
-    datasourceId?: string
+    datasourceInfo?: { id: string; title?: string },
+    timeRange?: { from: string; to: string }
   ): Promise<ToolResult> {
     try {
       // Check if this tool requires confirmation
@@ -84,7 +85,14 @@ export class ToolExecutor {
       }
 
       // Include datasourceId in toolArgs if provided
-      const enrichedToolArgs = datasourceId ? { ...toolArgs, datasourceId } : toolArgs;
+
+      let enrichedToolArgs = datasourceInfo
+        ? { ...toolArgs, datasourceId: datasourceInfo.id, datasourceTitle: datasourceInfo.title }
+        : toolArgs;
+      // Include the current page time range
+      if (timeRange) {
+        enrichedToolArgs = { ...enrichedToolArgs, timeRange };
+      }
 
       // First, check if this is a registered assistant action
       const registeredAction = await this.tryExecuteRegisteredAction(toolName, enrichedToolArgs);

--- a/src/plugins/chat/public/utils/user_message_input.ts
+++ b/src/plugins/chat/public/utils/user_message_input.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InputContent } from '../../common/types';
+
+export interface ResolvedImage {
+  base64?: string;
+  url?: string;
+  mimeType: string;
+}
+
+/**
+ * Normalize an image content block, whatever shape it arrived in.
+ *
+ * Two shapes are in play, so every consumer that renders or exports an image has to accept both
+ * or the image silently disappears:
+ * - `{type: 'image', source: {type: 'data' | 'url', value, mimeType}}` — the current shape.
+ * - `{type: 'binary', mimeType, data | url}` — the legacy flat shape, still produced by the local
+ *   screenshot path and still present in saved conversations.
+ *
+ * Returns undefined when the block is not an image or carries no payload.
+ */
+export const resolveImageContent = (block: unknown): ResolvedImage | undefined => {
+  if (typeof block !== 'object' || block === null) return undefined;
+  const candidate = block as {
+    type?: string;
+    mimeType?: string;
+    data?: string;
+    url?: string;
+    source?: { type?: string; value?: string; mimeType?: string };
+  };
+
+  if (candidate.type === 'image' && candidate.source?.value) {
+    const { type, value, mimeType } = candidate.source;
+    const resolvedMimeType = mimeType || 'image/jpeg';
+    return type === 'url'
+      ? { url: value, mimeType: resolvedMimeType }
+      : { base64: value, mimeType: resolvedMimeType };
+  }
+
+  if (candidate.type === 'binary') {
+    const resolvedMimeType = candidate.mimeType || 'image/jpeg';
+    if (candidate.data) return { base64: candidate.data, mimeType: resolvedMimeType };
+    if (candidate.url) return { url: candidate.url, mimeType: resolvedMimeType };
+  }
+
+  return undefined;
+};
+
+//  Resolve an image content block to a value usable as an `<img src>`
+export const getImageSrc = (block: unknown): string | undefined => {
+  const image = resolveImageContent(block);
+  if (!image) return undefined;
+  return image.url ?? `data:${image.mimeType};base64,${image.base64}`;
+};
+
+export const flattenContentText = (content: string | InputContent[]): string =>
+  Array.isArray(content)
+    ? content
+        .filter((block) => 'text' in block)
+        .map((block) => block.text)
+        .join('\n')
+    : content;

--- a/src/plugins/dashboard/opensearch_dashboards.json
+++ b/src/plugins/dashboard/opensearch_dashboards.json
@@ -14,5 +14,5 @@
   "optionalPlugins": ["home", "share", "usageCollection"],
   "server": true,
   "ui": true,
-  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home"]
+  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home", "contextProvider"]
 }

--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -26,7 +26,7 @@ import { DashboardVariables } from './dashboard_variables';
 export const DashboardEditor = () => {
   const { id: dashboardIdFromUrl } = useParams<{ id: string }>();
   const { services } = useOpenSearchDashboards<DashboardServices>();
-  const { chrome, uiSettings, keyboardShortcut, workspaces } = services;
+  const { chrome, uiSettings, keyboardShortcut, workspaces, chat } = services;
   // Master switch for the Dashboard Variables feature (dashboard.variables.enabled, default false).
   const variablesEnabled =
     services.pluginInitializerContext.config.get<{ variables?: { enabled?: boolean } }>()?.variables
@@ -58,6 +58,18 @@ export const DashboardEditor = () => {
     dashboardContainer: currentContainer,
     appState,
   });
+
+  useEffect(() => {
+    chat?.screenshot?.configure({
+      enabled: true,
+      title: i18n.translate('dashboard.editor.chat.addScreenshot', {
+        defaultMessage: 'Add dashboard screenshot',
+      }),
+    });
+    return () => {
+      chat?.screenshot.configure({ enabled: false });
+    };
+  }, [chat]);
 
   useEffect(() => {
     if (showActionsInGroup) setHeaderVariant?.(HeaderVariant.APPLICATION);

--- a/src/plugins/dashboard/public/application/index.tsx
+++ b/src/plugins/dashboard/public/application/index.tsx
@@ -3,15 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Router } from 'react-router-dom';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
+import { usePageContext } from '../../../context_provider/public';
 import { addHelpMenuToAppChrome } from './utils';
 import { DashboardApp } from './app';
 import { DashboardServices } from '../types';
 export * from './embeddable';
 export * from './actions';
+
+// Parse the dashboard saved-object id
+const getDashboardIdFromHash = (hash: string): string | undefined => {
+  const match = hash.match(/#\/view\/([^/?]+)/);
+  return match ? match[1] : undefined;
+};
+
+// register the dashboard page context
+const DashboardPageContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  usePageContext({
+    description: 'Dashboard application page context',
+    convert: (urlState: any) => ({
+      appId: 'dashboards',
+      dashboardId: getDashboardIdFromHash(urlState.hash || ''),
+      timeRange: urlState._g?.time,
+    }),
+    categories: ['page', 'static'],
+  });
+
+  return <>{children}</>;
+};
 
 export const renderApp = ({ element }: AppMountParameters, services: DashboardServices) => {
   addHelpMenuToAppChrome(services.chrome, services.docLinks);
@@ -20,7 +43,9 @@ export const renderApp = ({ element }: AppMountParameters, services: DashboardSe
     <Router history={services.history}>
       <OpenSearchDashboardsContextProvider services={services}>
         <services.i18n.Context>
-          <DashboardApp />
+          <DashboardPageContextProvider>
+            <DashboardApp />
+          </DashboardPageContextProvider>
         </services.i18n.Context>
       </OpenSearchDashboardsContextProvider>
     </Router>

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -29,7 +29,7 @@
  */
 
 import { NameList } from 'elasticsearch';
-import { Filter, IDataFrame, DataView, IndexPattern, Query } from '../..';
+import { Filter, IDataFrame, DataView, IndexPattern, Query, TimeRange } from '../..';
 import { SearchSource } from './search_source';
 
 /**
@@ -106,6 +106,12 @@ export interface SearchSourceFields {
   df?: IDataFrame;
   skipTimeFilter?: boolean;
   skipFilters?: boolean;
+  /**
+   * An explicit time range for languages that inject a time filter
+   * into the query. When set, it overrides the global timefilter, letting a
+   * caller pin the query to a fixed (absolute) window.
+   */
+  timeRange?: TimeRange;
 }
 
 export interface SearchSourceOptions {

--- a/src/plugins/explore/public/actions/ask_ai_embeddable_action.test.tsx
+++ b/src/plugins/explore/public/actions/ask_ai_embeddable_action.test.tsx
@@ -162,17 +162,27 @@ describe('AskAIEmbeddableAction', () => {
       document.body.innerHTML = '';
     });
 
-    it('should add context to context provider', async () => {
+    it('should send visualization context to chat', async () => {
       await action.execute({ embeddable: mockEmbeddable });
 
       await waitFor(() => {
-        expect(mockContextProvider.getAssistantContextStore).toHaveBeenCalled();
-        expect(mockContextProvider.getAssistantContextStore().addContext).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringContaining('visualization-'),
-            description: expect.stringContaining('Test Visualization'),
-            categories: ['visualization', 'dashboard', 'chat'],
-          })
+        expect(mockCore.chat.sendMessageWithWindow).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: 'image',
+              source: expect.objectContaining({
+                type: 'data',
+                value: 'mockImageData',
+                mimeType: 'image/jpeg',
+              }),
+            }),
+            expect.objectContaining({
+              type: 'text',
+              name: 'visualization_context',
+              text: expect.stringContaining('Test Visualization'),
+            }),
+          ]),
+          []
         );
       });
     });

--- a/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
@@ -105,48 +105,59 @@ export class AskAIEmbeddableAction implements Action<EmbeddableContext> {
       // Use JPEG format with low quality to save tokens
       visualizationBase64 = canvas.toDataURL('image/jpeg', 0.5).split(',')[1];
 
-      // Create context for the assistant with summary
-      const visualizationContext = {
-        title,
-        visType,
-        savedObjectId,
-        timeRange,
-        query: query?.query,
-        filters,
-        index: query?.dataset?.title,
-      };
+      // Parse visualization config for axes mapping and transformations
+      const visualizationConfig = JSON.parse(visEmbeddable.savedExplore.visualization || '{}');
+      const axesMapping = visualizationConfig.axesMapping;
+      const chartType = visualizationConfig.chartType;
+      const dataTransformations = visualizationConfig.dataTransformations;
 
-      // Add context to the context provider
-      if (this.contextProvider) {
-        const contextStore = this.contextProvider.getAssistantContextStore();
-        await contextStore.addContext({
-          id: `visualization-${savedObjectId || embeddable.id}`,
-          description: `Visualization: ${title}`,
-          value: visualizationContext,
-          label: `Visualization: ${title}`,
-          categories: ['visualization', 'dashboard', 'chat'],
-        });
-      }
+      const visualizationContextText = [
+        `[Visualization Context]`,
+        `Title: ${title}`,
+        `Chart Type: ${chartType || visType}`,
+        `Saved Object ID: ${savedObjectId}`,
+        `Index: ${query?.dataset?.title || 'N/A'}`,
+        `Query: ${query?.query || 'N/A'}`,
+        `Time Range: ${timeRange ? `${timeRange.from} → ${timeRange.to}` : 'N/A'}`,
+        filters && filters.length > 0 ? `Filters: ${JSON.stringify(filters)}` : null,
+        axesMapping && Object.keys(axesMapping).length > 0
+          ? `Axes Mapping: ${JSON.stringify(axesMapping)}`
+          : null,
+        dataTransformations && dataTransformations.length > 0
+          ? `Data Transformations: ${dataTransformations
+              .map(
+                (t: any) =>
+                  `${t.definitionId}${t.hide ? ' (disabled)' : ''}: ${JSON.stringify(t.config)}`
+              )
+              .join('; ')}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join('\n');
 
       // Send visualization screenshot to chat
       if (this.core.chat) {
-        // Create a message with the visualization image following AG-UI protocol
-        const imageMessage = {
-          role: 'user' as const,
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          content: [
+        await this.core.chat.sendMessageWithWindow(
+          [
             {
-              type: 'binary' as const,
-              mimeType: 'image/jpeg',
-              data: visualizationBase64,
+              type: 'image',
+              source: {
+                type: 'data',
+                value: visualizationBase64,
+                mimeType: 'image/jpeg',
+              },
+            },
+            {
+              type: 'text',
+              text: visualizationContextText,
+              name: 'visualization_context',
+            },
+            {
+              type: 'text',
+              text: 'Give me a summary for the selected visualization',
             },
           ],
-        };
-
-        // sendMessageWithWindow will open the chat window and send the message
-        await this.core.chat.sendMessageWithWindow(
-          'Give me a summary for the selected visualization',
-          [imageMessage]
+          []
         );
       }
     } catch (error) {

--- a/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
@@ -210,7 +210,7 @@ export const queryExecution = async ({
       throw new Error('Dataset not found for query execution');
     }
 
-    const dataset = services.data.dataViews.convertToDataset(dataView);
+    const dataset = await services.data.dataViews.convertToDataset(dataView);
 
     const preparedQueryObject = {
       ...query,

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -532,7 +532,7 @@ const executeQueryBase = async (
       throw new Error('Dataset not found for query execution');
     }
 
-    const dataset = services.data.dataViews.convertToDataset(dataView);
+    const dataset = await services.data.dataViews.convertToDataset(dataView);
 
     // Create histogram config once for use in both query building and result processing
     let histogramConfig: HistogramConfig | null = null;

--- a/src/plugins/explore/public/components/data_transformations/index.ts
+++ b/src/plugins/explore/public/components/data_transformations/index.ts
@@ -10,6 +10,10 @@ export type {
   ITransformationService,
   FieldSchema,
   UrlTransformationState,
+  TransformationConfigSchema,
+  ConfigFieldSpec,
+  ConfigFieldKind,
+  ConfigEnumOption,
 } from './types';
 
 export {
@@ -25,34 +29,42 @@ export {
 export {
   createLimitTransformation,
   limitTransformationDefinition,
+  limitConfigSchema,
 } from './transformations/limit_transformation';
 export {
   createSortByTransformation,
   sortByTransformationDefinition,
+  sortByConfigSchema,
 } from './transformations/sortby_transformation';
 export {
   createFilterTransformation,
   filterTransformationDefinition,
+  filterConfigSchema,
 } from './transformations/filter_transformation';
 export {
   createFilterFieldsTransformation,
   filterFieldsTransformationDefinition,
+  filterFieldsConfigSchema,
 } from './transformations/filter_fields_transformation';
 export {
   createConvertFieldTypeTransformation,
   convertFieldTypeTransformationDefinition,
+  convertFieldTypeConfigSchema,
 } from './transformations/convert_field_type_transformation';
 export {
   createGroupByTransformation,
   groupByTransformationDefinition,
+  groupByConfigSchema,
 } from './transformations/group_by_transformation';
 export {
   createExtractFieldsTransformation,
   extractFieldsTransformationDefinition,
+  extractFieldsConfigSchema,
 } from './transformations/extract_fields_transformation';
 export {
   createAddFieldTransformation,
   addFieldTransformationDefinition,
+  addFieldConfigSchema,
 } from './transformations/add_field_transformation';
 
 export { TransformPanel } from './transform_panel';

--- a/src/plugins/explore/public/components/data_transformations/transformations/add_field_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/add_field_transformation.tsx
@@ -20,7 +20,12 @@ import { FieldSelector } from '../field_selector';
 import { VisFieldType } from '../../visualizations/types';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 import { DebouncedFieldText } from '../../visualizations/style_panel/utils';
-import { binaryOperatorOptions, unaryOperatorOptions, modeToggleOptions } from '../types';
+import {
+  binaryOperatorOptions,
+  unaryOperatorOptions,
+  modeToggleOptions,
+  TransformationConfigSchema,
+} from '../types';
 
 type Mode = 'binary' | 'unary' | 'crossFields';
 type BinaryOperator = '+' | '-' | '*' | '/';
@@ -585,4 +590,146 @@ export const addFieldTransformationDefinition: TransformationDefinition<AddField
   }),
   iconType: 'plusInCircle',
   createInstance: createAddFieldTransformation,
+};
+
+/**
+ * Config schema for add_field.
+ *
+ * The `mode` field is a discriminator: the set of relevant config fields changes
+ * depending on its value.
+ *
+ * mode = "binary": field1, field1CustomValue, binaryOperator, field2, field2CustomValue, alias
+ * mode = "unary":  unaryOperator, unaryField, alias
+ * mode = "crossFields" + crossFieldsOperator != "expression": crossFields, alias
+ * mode = "crossFields" + crossFieldsOperator == "expression": expression, alias
+ *
+ * To use a constant number instead of a field in binary mode, set field1 or field2 to the
+ * special sentinel value "__CUSTOM__" and put the number string in field1CustomValue /
+ * field2CustomValue.
+ */
+export const addFieldConfigSchema: TransformationConfigSchema = {
+  mode: {
+    description:
+      'Calculation mode. Determines which other fields are used. ' +
+      '"binary" — arithmetic between two operands (fields or constants); ' +
+      '"unary" — single math function applied to one numerical field; ' +
+      '"crossFields" — aggregate or expression across multiple numerical fields.',
+    kind: 'enum',
+    defaultValue: 'binary',
+    required: true,
+    discriminates: [
+      'field1',
+      'field1CustomValue',
+      'binaryOperator',
+      'field2',
+      'field2CustomValue',
+      'unaryOperator',
+      'unaryField',
+      'crossFieldsOperator',
+      'crossFields',
+      'expression',
+    ],
+    enumOptions: modeToggleOptions.map((o) => ({ value: o.id, label: o.label })),
+  },
+  // ---- binary mode fields ----
+  field1: {
+    description:
+      '(binary mode) First operand. Set to a column name from the result schema, ' +
+      'or to the sentinel "__CUSTOM__" to use a constant number from field1CustomValue.',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: false,
+  },
+  field1CustomValue: {
+    description:
+      '(binary mode) Constant value for field1 when field1 === "__CUSTOM__". ' +
+      'Pass a numeric string, e.g. "60".',
+    kind: 'string',
+    defaultValue: '',
+    required: false,
+  },
+  binaryOperator: {
+    description: '(binary mode) Arithmetic operator to apply between field1 and field2.',
+    kind: 'enum',
+    defaultValue: '+',
+    required: false,
+    enumOptions: binaryOperatorOptions.map((o) => ({ value: o.value, label: o.text })),
+  },
+  field2: {
+    description:
+      '(binary mode) Second operand. Same rules as field1 — use a column name or "__CUSTOM__".',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: false,
+  },
+  field2CustomValue: {
+    description:
+      '(binary mode) Constant value for field2 when field2 === "__CUSTOM__". ' +
+      'Pass a numeric string.',
+    kind: 'string',
+    defaultValue: '',
+    required: false,
+  },
+  // ---- unary mode fields ----
+  unaryOperator: {
+    description: '(unary mode) Math function to apply to unaryField.',
+    kind: 'enum',
+    defaultValue: 'abs',
+    required: false,
+    enumOptions: unaryOperatorOptions.map((o) => ({ value: o.value, label: o.text })),
+  },
+  unaryField: {
+    description: '(unary mode) Numerical column to apply the unary function to.',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: false,
+  },
+  // ---- crossFields mode fields ----
+  crossFieldsOperator: {
+    description:
+      '(crossFields mode) How to combine the selected fields. ' +
+      '"total" sums them, "mean" averages them, ' +
+      '"expression" evaluates a custom formula (see expression field).',
+    kind: 'enum',
+    defaultValue: 'total',
+    required: false,
+    enumOptions: [
+      { value: 'total', label: 'Sum (total)' },
+      { value: 'mean', label: 'Mean (average)' },
+      { value: 'expression', label: 'Custom expression' },
+    ],
+  },
+  crossFields: {
+    description:
+      '(crossFields mode, operator != "expression") List of numerical columns to aggregate. ' +
+      'Only the "name" property is used.',
+    kind: 'object[]',
+    defaultValue: [],
+    required: false,
+    nestedSchema: {
+      name: {
+        description: 'Numerical column name.',
+        kind: 'field_name',
+        required: true,
+      },
+    },
+  },
+  expression: {
+    description:
+      '(crossFields mode, operator == "expression") Arithmetic expression over column values. ' +
+      'Reference columns with ${fieldName} syntax, e.g. "${price} * 1.1 - ${discount}". ' +
+      'Supports +, -, *, /, parentheses, and numeric literals.',
+    kind: 'string',
+    defaultValue: '',
+    required: false,
+  },
+  // ---- shared ----
+  alias: {
+    description:
+      'Name of the new column added to each row. ' +
+      'If omitted, a name is auto-generated from the operator and field names.',
+    kind: 'string',
+    defaultValue: '',
+    required: false,
+  },
 };

--- a/src/plugins/explore/public/components/data_transformations/transformations/convert_field_type_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/convert_field_type_transformation.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiSelect } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { TransformationInstance, TransformationDefinition, FieldSchema } from '../index';
+import { TransformationConfigSchema } from '../types';
 import { FieldSelector } from '../field_selector';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 
@@ -230,3 +231,33 @@ export const convertFieldTypeTransformationDefinition: TransformationDefinition<
     iconType: 'inputOutput',
     createInstance: createConvertFieldTypeTransformation,
   };
+
+export const convertFieldTypeConfigSchema: TransformationConfigSchema = {
+  rules: {
+    description:
+      'One or more conversion rules. Each rule casts a single column to a target type. ' +
+      'Multiple rules are applied in order.',
+    kind: 'object[]',
+    defaultValue: [],
+    required: true,
+    nestedSchema: {
+      field: {
+        description: 'Column name to convert.',
+        kind: 'field_name',
+        required: true,
+      },
+      targetType: {
+        description: 'Target type to cast the field value to.',
+        kind: 'enum',
+        defaultValue: 'string',
+        required: true,
+        enumOptions: [
+          { value: 'string', label: 'String' },
+          { value: 'number', label: 'Number' },
+          { value: 'boolean', label: 'Boolean' },
+          { value: 'date', label: 'Date (ISO 8601)' },
+        ],
+      },
+    },
+  },
+};

--- a/src/plugins/explore/public/components/data_transformations/transformations/extract_fields_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/extract_fields_transformation.tsx
@@ -9,6 +9,7 @@ import { EuiButtonGroup, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/
 import { i18n } from '@osd/i18n';
 import { get } from 'lodash';
 import { TransformationInstance, TransformationDefinition, FieldSchema } from '../index';
+import { TransformationConfigSchema } from '../types';
 import { FieldSelector } from '../field_selector';
 import { VisFieldType } from '../../visualizations/types';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
@@ -186,3 +187,35 @@ export const extractFieldsTransformationDefinition: TransformationDefinition<Ext
     iconType: 'unlink',
     createInstance: createExtractFieldsTransformation,
   };
+
+export const extractFieldsConfigSchema: TransformationConfigSchema = {
+  field: {
+    description:
+      'The column to extract from. Must be a categorical (non-numerical, non-date) column ' +
+      'whose value is either a nested object or a JSON-encoded string.',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: true,
+  },
+  format: {
+    description:
+      'How the field value is structured. ' +
+      'Use "object" when the value is already a JS object; ' +
+      'use "json" when it is a JSON-encoded string that needs parsing.',
+    kind: 'enum',
+    defaultValue: 'object',
+    required: true,
+    enumOptions: [
+      { value: 'object', label: 'Nested object' },
+      { value: 'json', label: 'JSON string' },
+    ],
+  },
+  prefix: {
+    description:
+      'Optional string prepended to each extracted column name to avoid name collisions ' +
+      '(e.g. "loc_" turns "lat" into "loc_lat"). Leave empty for no prefix.',
+    kind: 'string',
+    defaultValue: '',
+    required: false,
+  },
+};

--- a/src/plugins/explore/public/components/data_transformations/transformations/filter_fields_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/filter_fields_transformation.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { EuiButtonGroup, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { TransformationInstance, TransformationDefinition, FieldSchema } from '../index';
+import { TransformationConfigSchema } from '../types';
 import { FieldSelector } from '../field_selector';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 
@@ -128,4 +129,32 @@ export const filterFieldsTransformationDefinition: TransformationDefinition<Filt
   }),
   iconType: 'tableOfContents',
   createInstance: createFilterFieldsTransformation,
+};
+
+export const filterFieldsConfigSchema: TransformationConfigSchema = {
+  mode: {
+    description: 'Whether to keep only the listed fields (include) or drop them (exclude).',
+    kind: 'enum',
+    defaultValue: 'exclude',
+    required: true,
+    enumOptions: [
+      { value: 'include', label: 'Include only these fields' },
+      { value: 'exclude', label: 'Exclude these fields' },
+    ],
+  },
+  fieldOptions: {
+    description:
+      'List of column names to include or exclude. Only the "name" property is used at runtime; ' +
+      'provide objects with just { name: string }.',
+    kind: 'object[]',
+    defaultValue: [],
+    required: true,
+    nestedSchema: {
+      name: {
+        description: 'Column name from the result schema.',
+        kind: 'field_name',
+        required: true,
+      },
+    },
+  },
 };

--- a/src/plugins/explore/public/components/data_transformations/transformations/filter_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/filter_transformation.tsx
@@ -16,6 +16,7 @@ import {
   FilterConfig,
   numericalOperatorOptions,
   allOperatorOptions,
+  TransformationConfigSchema,
 } from '../types';
 import { VisFieldType } from '../../visualizations/types';
 import { FieldSelector } from '../field_selector';
@@ -217,4 +218,37 @@ export const filterTransformationDefinition: TransformationDefinition<FilterConf
   // TODO icon filter is not applicable
   iconType: 'filter',
   createInstance: createFilterTransformation,
+};
+
+export const filterConfigSchema: TransformationConfigSchema = {
+  field: {
+    description: 'The column to filter on. Must be a column name from the result schema.',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: true,
+  },
+  operator: {
+    description:
+      'Comparison operator. Available operators depend on the field type — ' +
+      'use base operators for all types, add numerical extras for number fields, ' +
+      'add date extras for date/timestamp fields. ' +
+      'value must always be passed as a string.',
+    kind: 'enum',
+    defaultValue: 'equals',
+    required: true,
+    byFieldType: {
+      base: allOperatorOptions.map((o) => ({ value: o.value, label: o.text })),
+      numerical: numericalOperatorOptions.map((o) => ({ value: o.value, label: o.text })),
+      date: dateOperatorOptions.map((o) => ({ value: o.value, label: o.text })),
+    },
+  },
+  value: {
+    description:
+      'The value to compare against. Always a string — ' +
+      'pass numbers as numeric strings (e.g. "500"), ' +
+      'dates as ISO 8601 strings (e.g. "2025-01-01T00:00:00.000Z").',
+    kind: 'string',
+    defaultValue: '',
+    required: true,
+  },
 };

--- a/src/plugins/explore/public/components/data_transformations/transformations/group_by_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/group_by_transformation.tsx
@@ -9,6 +9,7 @@ import { EuiAccordion, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiText } from 
 import { i18n } from '@osd/i18n';
 import { get } from 'lodash';
 import { TransformationInstance, TransformationDefinition, FieldSchema } from '../types';
+import { TransformationConfigSchema } from '../types';
 import { FieldSelector } from '../field_selector';
 import { VisFieldType } from '../../visualizations/types';
 import { FIELD_TYPE_MAP } from '../../visualizations/constants';
@@ -269,4 +270,56 @@ export const groupByTransformationDefinition: TransformationDefinition<GroupByCo
   }),
   iconType: 'aggregate',
   createInstance: createGroupByTransformation,
+};
+
+export const groupByConfigSchema: TransformationConfigSchema = {
+  groupByField: {
+    description:
+      'The column to group rows by. Each unique value in this column becomes one output row.',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: true,
+  },
+  aggregations: {
+    description:
+      'Aggregation methods to apply to all other columns per group. ' +
+      'The output column name is "<method>_<field>" (e.g. "mean_AvgTicketPrice"). ' +
+      'Set hidden: true to exclude a field from the output.',
+    kind: 'object[]',
+    defaultValue: [],
+    required: true,
+    nestedSchema: {
+      field: {
+        description: 'Column name to aggregate.',
+        kind: 'field_name',
+        required: true,
+      },
+      method: {
+        description:
+          'Aggregation method. Not all methods apply to all field types: ' +
+          'string fields support count/first/last only; ' +
+          'date fields support count/min/max/first/last; ' +
+          'numerical fields support all methods.',
+        kind: 'enum',
+        defaultValue: 'count',
+        required: true,
+        enumOptions: [
+          { value: 'count', label: 'Count' },
+          { value: 'total', label: 'Sum (total)' },
+          { value: 'mean', label: 'Mean (average)' },
+          { value: 'median', label: 'Median' },
+          { value: 'min', label: 'Min' },
+          { value: 'max', label: 'Max' },
+          { value: 'first', label: 'First value' },
+          { value: 'last', label: 'Last value' },
+        ],
+      },
+      hidden: {
+        description: 'Set to true to exclude this aggregation from the output.',
+        kind: 'boolean',
+        defaultValue: false,
+        required: false,
+      },
+    },
+  },
 };

--- a/src/plugins/explore/public/components/data_transformations/transformations/limit_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/limit_transformation.tsx
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { EuiFormRow } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { TransformationInstance, TransformationDefinition } from '../index';
+import { TransformationConfigSchema } from '../types';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 import { DebouncedFieldNumber } from '../../visualizations/style_panel/utils';
 
@@ -60,4 +61,13 @@ export const limitTransformationDefinition: TransformationDefinition<LimitConfig
   }),
   iconType: 'filter',
   createInstance: createLimitTransformation,
+};
+
+export const limitConfigSchema: TransformationConfigSchema = {
+  limit: {
+    description: 'Maximum number of rows to keep. Omit or set to undefined to keep all rows.',
+    kind: 'number',
+    defaultValue: 10,
+    required: false,
+  },
 };

--- a/src/plugins/explore/public/components/data_transformations/transformations/sortby_transformation.tsx
+++ b/src/plugins/explore/public/components/data_transformations/transformations/sortby_transformation.tsx
@@ -8,6 +8,7 @@ import { EuiFormRow, EuiButtonGroup, EuiFlexGroup, EuiFlexItem } from '@elastic/
 import { i18n } from '@osd/i18n';
 import { get } from 'lodash';
 import { TransformationInstance, TransformationDefinition, FieldSchema } from '../index';
+import { TransformationConfigSchema } from '../types';
 import { FieldSelector } from '../field_selector';
 import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 
@@ -141,4 +142,23 @@ export const sortByTransformationDefinition: TransformationDefinition<SortByConf
   }),
   iconType: 'sortable',
   createInstance: createSortByTransformation,
+};
+
+export const sortByConfigSchema: TransformationConfigSchema = {
+  field: {
+    description: 'The column to sort by. Must be a column name from the result schema.',
+    kind: 'field_name',
+    defaultValue: undefined,
+    required: true,
+  },
+  order: {
+    description: 'Sort direction.',
+    kind: 'enum',
+    defaultValue: 'asc',
+    required: true,
+    enumOptions: [
+      { value: 'asc', label: 'Ascending' },
+      { value: 'desc', label: 'Descending' },
+    ],
+  },
 };

--- a/src/plugins/explore/public/components/data_transformations/types.ts
+++ b/src/plugins/explore/public/components/data_transformations/types.ts
@@ -247,3 +247,55 @@ export const modeToggleOptions = [
     }),
   },
 ];
+
+export interface ConfigEnumOption {
+  value: string;
+  label?: string;
+}
+
+/** Config field types */
+export type ConfigFieldKind =
+  | 'number' // numeric input
+  | 'string' // free-text input
+  | 'enum' // fixed set of string values
+  | 'boolean' // true / false
+  | 'field_name' // references a column name from the result schema
+  | 'field_name[]' // array of column names
+  | 'object[]'; // array of sub-objects (described by nestedSchema)
+
+export interface ConfigFieldSpec {
+  /** Human-readable description of this field */
+  description: string;
+  /** Data kind — determines what values are valid */
+  kind: ConfigFieldKind;
+  /** Default value used when the transformation is first created */
+  defaultValue?: unknown;
+  /** Whether this field is required for the transformation to execute */
+  required?: boolean;
+  /**
+   * Allowed enum values when kind === 'enum'.
+   * If the available values depend on the field type (e.g. filter operators),
+   * use `byFieldType` instead and leave this undefined.
+   */
+  enumOptions?: ConfigEnumOption[];
+  /**
+   * Field-type-specific enum values (kind === 'enum' only).
+   */
+  byFieldType?: {
+    base: ConfigEnumOption[]; // available for every field type
+    numerical?: ConfigEnumOption[]; // additional for numerical fields
+    date?: ConfigEnumOption[]; // additional for date fields
+  };
+  /**
+   * Schema for items when kind === 'object[]'.
+   * Keys are sub-field names; values are nested ConfigFieldSpec.
+   */
+  nestedSchema?: Record<string, ConfigFieldSpec>;
+  /**
+   * For kind === 'enum' fields that act as a discriminator: lists the other
+   * config field names whose presence/shape changes depending on this field's value.
+   */
+  discriminates?: string[];
+}
+
+export type TransformationConfigSchema = Record<string, ConfigFieldSpec>;

--- a/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.tsx
+++ b/src/plugins/explore/public/components/query_panel/actions/ppl_execute_query_action.tsx
@@ -17,8 +17,12 @@ import { prepareQueryForLanguage } from '../../../application/utils/languages';
 // Shared tool definition for execute_ppl_query action
 export const EXECUTE_PPL_QUERY_TOOL_DEFINITION = {
   name: 'execute_ppl_query',
+
   description:
-    'Updates the query bar with a PPL query and executes it in the UI. IMPORTANT: This tool only updates the visual query interface and returns execution status (success/failure) - it does NOT return the actual query results or data. Use this tool when you want to help the user visualize data in the Explore interface. If you need to retrieve actual data for analysis or generating reports, use backend data retrieval tools instead, and make sure to pass the same time range (from/to) to those backend tools for consistent results. The query should NOT contain time filters - use the from/to parameters to specify the time range.',
+    'UI ONLY - DOES NOT RETURN DATA. Writes a PPL query into the Explore query bar and runs it so the user sees the results on their screen. The return value is nothing but an execution status (success/failure); it NEVER contains rows, fields, counts, aggregations, or any query output. ' +
+    'CHOOSING BETWEEN THIS TOOL AND THE BACKEND PPL TOOL: if you need the actual data - to answer a question, compute a number, inspect fields, validate a query, summarize, or generate a report - call the backend PPL query tool (pplQueryTool) instead; it is the only tool that returns query results. Call this tool only to change what the user is looking at, i.e. when the user asked to see, run, plot, or explore something in the Explore UI, or when you want to leave them with the final query for further exploration. ' +
+    'Never call this tool as a way to fetch data, and never claim or infer what the data contains from its status response. When you need both - the data and the on-screen view - call pplQueryTool first to get the data, then call this tool once with the same query and the same time range so the UI stays consistent with your answer. ' +
+    'The query must NOT contain time filters - use the from/to parameters to specify the time range, and pass the same from/to you passed to pplQueryTool.',
   parameters: {
     type: 'object' as const,
     properties: {

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.test.tsx
@@ -1,0 +1,299 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import rison from 'rison-node';
+import {
+  registerAutoVisualizationAction,
+  AUTO_VISUALIZATION_TOOL_NAME,
+} from './auto_visualization_action';
+
+// --- Mocks for heavy / environment-coupled dependencies -------------------
+
+const mockFindRulesByColumns = jest.fn();
+const mockGetAxesMappingByRule = jest.fn();
+const mockGetVisualization = jest.fn();
+
+jest.mock('../../../components/visualizations/visualization_registry', () => ({
+  visualizationRegistry: {
+    findRulesByColumns: (...args: any[]) => mockFindRulesByColumns(...args),
+    getAxesMappingByRule: (...args: any[]) => mockGetAxesMappingByRule(...args),
+    getVisualization: (...args: any[]) => mockGetVisualization(...args),
+  },
+}));
+
+const mockNormalizeResultRows = jest.fn();
+jest.mock('../../../components/visualizations/utils/normalize_result_rows', () => ({
+  normalizeResultRows: (...args: any[]) => mockNormalizeResultRows(...args),
+}));
+
+jest.mock('../../../components/visualizations/visualization_render', () => ({
+  CommonVisualizationRender: () => <div data-test-subj="commonVisRender" />,
+}));
+
+jest.mock('../../../application/in_context_vis_editor/component/vis_editor_no_results', () => ({
+  VisEditorNoResults: () => <div data-test-subj="visEditorNoResults" />,
+}));
+
+jest.mock('./utils', () => ({
+  AUTO_VISUALIZATION_TOOL_NAME: 'auto_create_visualization',
+  AutoVisMeta: {
+    name: 'auto_create_visualization',
+    description: 'desc',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+}));
+
+const baseArgs = {
+  query: 'source=flights | stats avg(price) by carrier',
+  indexName: 'flights',
+  columns: [
+    { name: 'carrier', type: 'keyword' },
+    { name: 'avg(price)', type: 'double' },
+  ],
+};
+
+const createCore = () =>
+  ({
+    uiSettings: { get: jest.fn(() => 500) },
+    http: { basePath: { prepend: (p: string) => `/base${p}` } },
+    savedObjects: {
+      client: { get: jest.fn().mockResolvedValue({ attributes: { title: 'My Dashboard' } }) },
+    },
+    notifications: { toasts: {} },
+    application: { navigateToApp: jest.fn() },
+  }) as unknown as any;
+
+const createData = (bounds?: { min: any; max: any }, globalTime?: any) =>
+  ({
+    query: {
+      timefilter: {
+        timefilter: {
+          getTime: jest.fn(() => globalTime),
+          calculateBounds: jest.fn(() => bounds ?? { min: undefined, max: undefined }),
+        },
+      },
+    },
+    search: { searchSource: { create: jest.fn() } },
+  }) as unknown as any;
+
+const createContextProvider = (dashboardId?: string) =>
+  ({
+    getAssistantContextStore: () => ({
+      getContextsByCategory: (category: string) =>
+        category === 'page' && dashboardId ? [{ value: { appId: 'dashboards', dashboardId } }] : [],
+    }),
+  }) as unknown as any;
+
+const registerAndGetAction = (core: any, data: any, contextProvider?: any): any => {
+  let captured: any;
+  const registerAction = jest.fn((action: any) => {
+    captured = action;
+  });
+  registerAutoVisualizationAction(registerAction, core, data, contextProvider);
+  return captured;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNormalizeResultRows.mockReturnValue({
+    transformedData: [{ carrier: 'A', 'avg(price)': 1 }],
+    numericalColumns: [{ name: 'avg(price)' }],
+    categoricalColumns: [{ name: 'carrier' }],
+    dateColumns: [],
+    unknownColumns: [],
+  });
+  mockFindRulesByColumns.mockReturnValue({
+    exact: [{ visType: 'bar', rules: [{ priority: 10 }] }],
+    all: [{ visType: 'bar', rules: [{ priority: 10 }] }],
+  });
+  mockGetAxesMappingByRule.mockReturnValue({ x: 'carrier', y: 'avg(price)' });
+  mockGetVisualization.mockReturnValue({ ui: { style: { defaults: { color: 'red' } } } });
+});
+
+describe('registerAutoVisualizationAction', () => {
+  it('does nothing when registerAction is undefined', () => {
+    expect(() =>
+      registerAutoVisualizationAction(undefined as any, createCore(), createData())
+    ).not.toThrow();
+  });
+
+  it('registers an action with the auto visualization tool name and custom renderer', () => {
+    const action = registerAndGetAction(createCore(), createData());
+    expect(action.name).toBe(AUTO_VISUALIZATION_TOOL_NAME);
+    expect(action.useCustomRenderer).toBe(true);
+    expect(typeof action.handler).toBe('function');
+    expect(typeof action.render).toBe('function');
+  });
+});
+
+describe('handler', () => {
+  it('resolves the highest-priority compatible chart and returns a success result', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+
+    expect(result.success).toBe(true);
+    expect(result.chartType).toBe('bar');
+    expect(result.resolvedAxesMapping).toEqual({ x: 'carrier', y: 'avg(price)' });
+    expect(result.visConfig).toEqual({
+      type: 'bar',
+      axesMapping: { x: 'carrier', y: 'avg(price)' },
+      splitField: undefined,
+      styles: { color: 'red' },
+    });
+    expect(result.preparedQuery).toEqual({
+      dataset: expect.objectContaining({ id: 'flights', title: 'flights' }),
+      language: 'PPL',
+      query: baseArgs.query,
+    });
+  });
+
+  it('honors a compatible potentialChartType hint', async () => {
+    mockFindRulesByColumns.mockReturnValue({
+      exact: [
+        { visType: 'bar', rules: [{ priority: 5 }] },
+        { visType: 'pie', rules: [{ priority: 3 }] },
+      ],
+      all: [],
+    });
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler({ ...baseArgs, potentialChartType: 'pie' });
+    expect(result.chartType).toBe('pie');
+  });
+
+  it('falls back to table when no compatible charts are found', async () => {
+    mockFindRulesByColumns.mockReturnValue({ exact: [], all: [] });
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+    expect(result.success).toBe(true);
+    expect(result.chartType).toBe('table');
+    expect(result.resolvedAxesMapping).toEqual({});
+  });
+
+  it('returns a failure result when the chart-type hint is incompatible', async () => {
+    // Only 'bar' is compatible, but the user asked for 'pie'.
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler({ ...baseArgs, potentialChartType: 'pie' });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not compatible');
+    expect(result.message).toContain('bar');
+  });
+
+  it('builds an editor path with encoded _v and _eq params', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+
+    expect(result.editorPath).toEqual(expect.stringContaining('#/?_v='));
+    expect(result.editorPath).toEqual(expect.stringContaining('&_eq='));
+    // No time range / dashboard by default.
+    expect(result.editorPath).not.toContain('_g=');
+    expect(result.editorPath).not.toContain('_c=');
+  });
+
+  it('resolves a relative time range to an absolute window', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    expect(result.resolvedTimeRange).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-08T00:00:00.000Z',
+    });
+    // _g is encoded into the editor path.
+    const gParam = `_g=${encodeURIComponent(
+      rison.encode({
+        time: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-08T00:00:00.000Z' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(gParam);
+  });
+
+  it('adds dashboard container info (_c) when on a dashboard page', async () => {
+    const core = createCore();
+    const action = registerAndGetAction(core, createData(), createContextProvider('dash-1'));
+    const result = await action.handler(baseArgs);
+
+    expect(core.savedObjects.client.get).toHaveBeenCalledWith('dashboard', 'dash-1');
+    const cParam = `_c=${encodeURIComponent(
+      rison.encode({
+        originatingApp: 'dashboards',
+        containerInfo: { containerId: 'dash-1', containerName: 'My Dashboard' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(cParam);
+  });
+
+  it('omits _c when not on a dashboard page', async () => {
+    const action = registerAndGetAction(createCore(), createData(), createContextProvider());
+    const result = await action.handler(baseArgs);
+    expect(result.editorPath).not.toContain('_c=');
+  });
+
+  it('still succeeds when the dashboard name lookup fails', async () => {
+    const core = createCore();
+    core.savedObjects.client.get = jest.fn().mockRejectedValue(new Error('not found'));
+    const action = registerAndGetAction(core, createData(), createContextProvider('dash-1'));
+    const result = await action.handler(baseArgs);
+
+    // containerId present, containerName omitted.
+    const cParam = `_c=${encodeURIComponent(
+      rison.encode({
+        originatingApp: 'dashboards',
+        containerInfo: { containerId: 'dash-1' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(cParam);
+  });
+});
+
+describe('render', () => {
+  const renderResult = (core: any, data: any, props: any) => {
+    const action = registerAndGetAction(core, data, undefined);
+    return render(action.render(props));
+  };
+
+  it('renders nothing while pending', () => {
+    const { container } = renderResult(createCore(), createData(), {
+      status: 'executing',
+      args: baseArgs,
+      result: undefined,
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the parameters accordion and open-in-editor button on success', () => {
+    // Chart preview kicks off a fetch; make searchSource resolve to empty rows.
+    const data = createData();
+    data.search.searchSource.create = jest.fn().mockResolvedValue({
+      setFields: jest.fn(),
+      fetch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+      getDataFrame: jest.fn(() => ({ schema: [] })),
+    });
+    data.query.queryString = {
+      getLanguageService: () => ({ getLanguage: () => ({}) }),
+    };
+
+    renderResult(createCore(), data, {
+      status: 'complete',
+      args: baseArgs,
+      result: {
+        success: true,
+        preparedQuery: { dataset: { title: 'flights' }, language: 'PPL', query: baseArgs.query },
+        visConfig: { type: 'bar', axesMapping: {}, styles: {} },
+        editorPath: '#/?_v=x',
+      },
+    });
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    expect(screen.getByText('Open in Editor')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
@@ -1,0 +1,547 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import rison from 'rison-node';
+import {
+  EuiPanel,
+  EuiText,
+  EuiSpacer,
+  EuiButton,
+  EuiAccordion,
+  EuiCodeBlock,
+  EuiLoadingChart,
+  EuiCallOut,
+} from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { RenderProps, ContextProviderStart } from '../../../../../context_provider/public';
+import { DataPublicPluginStart, TimeRange } from '../../../../../data/public';
+import { Dataset, DEFAULT_DATA } from '../../../../../data/common';
+import { ChartType } from '../../../components/visualizations/utils/use_visualization_types';
+import {
+  AxisFieldNameMappings,
+  RenderChartConfig,
+  VisColumn,
+} from '../../../components/visualizations/types';
+import { VisData } from '../../../components/visualizations/visualization_builder.types';
+import { CommonVisualizationRender } from '../../../components/visualizations/visualization_render';
+import { normalizeResultRows } from '../../../components/visualizations/utils/normalize_result_rows';
+import { visualizationRegistry } from '../../../components/visualizations/visualization_registry';
+import { SAMPLE_SIZE_SETTING, VISUALIZATION_EDITOR_APP_ID } from '../../../../common';
+import { VisEditorNoResults } from '../../../application/in_context_vis_editor/component/vis_editor_no_results';
+import { AutoVisMeta } from './utils';
+
+export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+
+interface AutoVisualizationArgs {
+  query: string;
+  indexName: string;
+  // user intended chart type
+  potentialChartType?: string;
+  columns: Array<{ name: string; type: string }>;
+  splitField?: string;
+  // used to build dataset, without it time range search bar will not show
+  timeFieldName?: string;
+  timeRange?: TimeRange;
+  // used to build dataset
+  datasourceId?: string;
+  datasourceTitle?: string;
+  dashboardId?: string;
+}
+
+interface PreparedQuery {
+  dataset: Dataset;
+  language: string;
+  query: string;
+}
+
+interface VisualizationConfigResult {
+  success: true;
+  visConfig: RenderChartConfig;
+  query: PreparedQuery;
+  resolvedChartType: ChartType;
+  resolvedAxesMapping: AxisFieldNameMappings;
+}
+
+function buildEditorPath(
+  visConfig: RenderChartConfig,
+  query: PreparedQuery,
+  timeRange?: TimeRange,
+  dashboardId?: string,
+  dashboardName?: string
+): string {
+  const visState: Record<string, any> = {
+    chartType: visConfig.type,
+    axesMapping: visConfig.axesMapping,
+    styleOptions: visConfig.styles,
+  };
+  if (visConfig.splitField) {
+    visState.splitField = visConfig.splitField;
+  }
+
+  const vParam = rison.encode(visState);
+  const eqParam = rison.encode(query as Record<string, any>);
+
+  const gParam = timeRange
+    ? `&_g=${encodeURIComponent(rison.encode({ time: { from: timeRange.from, to: timeRange.to } }))}`
+    : '';
+
+  // Bind the visualization to the originating dashboard via `_c` (containerInfo),
+
+  const cParam = dashboardId
+    ? `&_c=${encodeURIComponent(
+        rison.encode({
+          originatingApp: 'dashboards',
+          containerInfo: {
+            containerId: dashboardId,
+            ...(dashboardName && { containerName: dashboardName }),
+          },
+        })
+      )}`
+    : '';
+
+  return `#/?_v=${encodeURIComponent(vParam)}&_eq=${encodeURIComponent(eqParam)}${gParam}${cParam}`;
+}
+
+/**
+ * Resolve axes mapping and chart type given the classified columns.
+ */
+function resolveChartFromSchema(
+  numericalColumns: VisColumn[],
+  categoricalColumns: VisColumn[],
+  dateColumns: VisColumn[],
+  potentialChartType?: string
+): {
+  chartType: ChartType;
+  axesMapping: AxisFieldNameMappings;
+} {
+  // 1. find all compatible rules with visualization registry
+  const { all: allMatches, exact: exactMatches } = visualizationRegistry.findRulesByColumns(
+    numericalColumns,
+    categoricalColumns,
+    dateColumns
+  );
+
+  const candidates: Array<{
+    chartType: ChartType;
+    priority: number;
+    axesMapping: AxisFieldNameMappings;
+  }> = [];
+  const seenChartTypes = new Set<string>();
+
+  for (const matches of [exactMatches, allMatches]) {
+    for (const { visType, rules } of matches) {
+      if (seenChartTypes.has(visType)) continue;
+      seenChartTypes.add(visType);
+      // 2. only provide the highest-priority rule for each chart type
+      const bestRule = rules.reduce((best, r) => (r.priority > best.priority ? r : best));
+      const axesMapping = visualizationRegistry.getAxesMappingByRule(
+        bestRule,
+        numericalColumns,
+        categoricalColumns,
+        dateColumns
+      );
+      if (Object.keys(axesMapping).length === 0) continue;
+
+      candidates.push({
+        chartType: visType as ChartType,
+        priority: bestRule.priority,
+        axesMapping,
+      });
+    }
+  }
+
+  // 3. If the user provided a potential chart-type, use it
+  if (potentialChartType) {
+    const matched = candidates.find(
+      (c) => c.chartType.toLowerCase() === potentialChartType.toLowerCase()
+    );
+    if (matched) {
+      return { chartType: matched.chartType, axesMapping: matched.axesMapping };
+    }
+    // chart is incompatible with the columns.
+    // the throw reaches the llm.
+    throw new Error(
+      `Chart type "${potentialChartType}" is not compatible with the query result columns. ` +
+        `Compatible chart types: [${candidates.map((c) => c.chartType).join(', ')}]. ` +
+        `Please adjust ppl query.`
+    );
+  }
+
+  // 4. No potential chart and candidates, use table
+  if (candidates.length === 0) {
+    // fallback to table vis
+    return { chartType: 'table', axesMapping: {} };
+  }
+
+  // 5. No potential chart, use the chart with highest-priority
+  const best = candidates.reduce((a, b) => (b.priority > a.priority ? b : a));
+  return { chartType: best.chartType, axesMapping: best.axesMapping };
+}
+
+/**
+ * Build the dataset manually + prepared query object from the tool args. The dataset is
+ * built manually and will not be created.
+ */
+function buildPreparedQuery(args: AutoVisualizationArgs): PreparedQuery {
+  const datasetId = args.datasourceId ? `${args?.datasourceId}_${args.indexName}` : args.indexName;
+  const dataset: Dataset = {
+    id: datasetId,
+    title: args.indexName,
+    type: DEFAULT_DATA.SET_TYPES.INDEX,
+    timeFieldName: args.timeFieldName,
+    ...(args.datasourceId && {
+      dataSource: {
+        id: args.datasourceId,
+        title: args?.datasourceTitle || '',
+        type: 'DATA_SOURCE',
+        version: '',
+      },
+    }),
+  };
+
+  return {
+    dataset,
+    language: 'PPL',
+    query: args.query,
+  };
+}
+
+/**
+ * Read the current dashboard id from the page context,
+ * Read lazily (only when building the editor URL) rather than injected
+ * into every tool call, since most tools don't need it.
+ */
+function getCurrentDashboardId(contextProvider?: ContextProviderStart): string | undefined {
+  const pageContexts = contextProvider?.getAssistantContextStore().getContextsByCategory('page');
+  const dashboardContext = pageContexts?.find((ctx) => {
+    const value = typeof ctx.value === 'string' ? JSON.parse(ctx.value) : ctx.value;
+    return value?.appId === 'dashboards';
+  });
+  if (!dashboardContext) return undefined;
+  const value =
+    typeof dashboardContext.value === 'string'
+      ? JSON.parse(dashboardContext.value)
+      : dashboardContext.value;
+  return value?.dashboardId;
+}
+
+async function getDashboardName(core: CoreStart, dashboardId: string): Promise<string | undefined> {
+  try {
+    const savedObject = await core.savedObjects.client.get<{ title?: string }>(
+      'dashboard',
+      dashboardId
+    );
+    return savedObject.attributes?.title;
+  } catch {
+    return undefined;
+  }
+}
+
+function getAbsoluteTimeRange(
+  data: DataPublicPluginStart,
+  timeRange?: TimeRange
+): TimeRange | undefined {
+  // if there is not timeRange in page context use global time filter
+  const range = timeRange ?? data.query.timefilter.timefilter.getTime();
+  const bounds = data.query.timefilter.timefilter.calculateBounds(range);
+  if (!bounds.min || !bounds.max) return undefined;
+  return { from: bounds.min.toISOString(), to: bounds.max.toISOString() };
+}
+
+/**
+ * Execute the PPL query and normalize the results into VisData.
+ */
+async function executePPLQuery(
+  preparedQueryObject: PreparedQuery,
+  core: CoreStart,
+  data: DataPublicPluginStart,
+  timeRange?: TimeRange,
+  abortSignal?: AbortSignal
+): Promise<VisData> {
+  const uiSettings = core.uiSettings;
+  const dataset = preparedQueryObject.dataset;
+
+  await data.query.queryString.getDatasetService().cacheDataset(
+    dataset,
+    {
+      uiSettings: core.uiSettings,
+      savedObjects: core.savedObjects,
+      notifications: core.notifications,
+      http: core.http,
+      data,
+    },
+    false
+  );
+  const dataView = await data.dataViews.get(dataset.id);
+
+  const size = uiSettings.get(SAMPLE_SIZE_SETTING);
+  const searchSource = await data.search.searchSource.create();
+
+  searchSource.setFields({
+    index: dataView,
+    size,
+    query: preparedQueryObject,
+    highlightAll: false,
+    version: false,
+
+    // Pass absolute time range so the PPL search interceptor injects
+    // it into the query instead of using the global timefilter.
+    ...(timeRange && dataset.timeFieldName ? { timeRange } : {}),
+  });
+
+  const languageConfig = data.query.queryString
+    .getLanguageService()
+    .getLanguage(preparedQueryObject.language);
+
+  // Execute query
+  const rawResults = await searchSource.fetch({
+    abortSignal,
+    withLongNumeralsSupport: await uiSettings.get('data:withLongNumerals'),
+    ...(languageConfig?.fields?.formatter ? { formatter: languageConfig.fields.formatter } : {}),
+  });
+
+  const rawResultsHit = rawResults.hits?.hits ?? [];
+  const fieldSchema = searchSource.getDataFrame()?.schema ?? [];
+  return normalizeResultRows(rawResultsHit, fieldSchema);
+}
+
+/**
+ * resolve the chart config from ppl execution columns results
+ */
+function buildVisConfig(args: AutoVisualizationArgs): VisualizationConfigResult {
+  const preparedQueryObject = buildPreparedQuery(args);
+
+  // 1. get normalized schema
+  const schema = (args.columns || []).map((col) => ({ name: col.name, type: col.type }));
+  const { numericalColumns, categoricalColumns, dateColumns } = normalizeResultRows([], schema);
+
+  // 2. resolve axes mapping and chart type
+  const matchChart = resolveChartFromSchema(
+    numericalColumns,
+    categoricalColumns,
+    dateColumns,
+    args.potentialChartType
+  );
+
+  // 3. build vis config
+  const defaultStyles = visualizationRegistry.getVisualization(matchChart.chartType)?.ui.style
+    .defaults;
+
+  const visConfig: RenderChartConfig = {
+    type: matchChart.chartType,
+    axesMapping: matchChart.axesMapping,
+    splitField: args.splitField,
+    styles: defaultStyles || {},
+  };
+
+  return {
+    visConfig,
+    query: preparedQueryObject,
+    success: true,
+    resolvedChartType: matchChart.chartType,
+    resolvedAxesMapping: matchChart.axesMapping,
+  };
+}
+
+/**
+ * Chart preview that executes the PPL query at render time to fetch the row data,
+ */
+function ChartPreview({
+  query,
+  visConfig,
+  core,
+  data,
+  timeRange,
+}: {
+  query: PreparedQuery;
+  visConfig: RenderChartConfig;
+  core: CoreStart;
+  data: DataPublicPluginStart;
+  timeRange?: TimeRange;
+}) {
+  const [visData, setVisData] = useState<VisData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+    executePPLQuery(query, core, data, timeRange, abortController.signal)
+      .then((result) => {
+        if (!cancelled) setVisData(result);
+      })
+      .catch((e) => {
+        if (!cancelled && !abortController.signal.aborted) {
+          setError(e instanceof Error ? e.message : 'Failed to load chart data');
+        }
+      });
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (error) {
+    return (
+      <EuiCallOut size="s" color="danger" title="Could not render chart">
+        <EuiText size="xs">{error}</EuiText>
+      </EuiCallOut>
+    );
+  }
+
+  if (!visData) {
+    return (
+      <div
+        style={{
+          height: 250,
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <EuiLoadingChart size="l" />
+      </div>
+    );
+  }
+
+  if (visData.transformedData.length === 0) {
+    return (
+      <div style={{ height: 250, width: '100%' }}>
+        <VisEditorNoResults />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <CommonVisualizationRender
+        visualizationData={visData}
+        visConfig={visConfig}
+        showRawTable={false}
+      />
+    </div>
+  );
+}
+
+function ArgsParameters({
+  args,
+  absoluteTimeRange,
+}: {
+  args: AutoVisualizationArgs;
+  absoluteTimeRange?: TimeRange;
+}) {
+  const displayArgs = absoluteTimeRange ? { ...args, timeRange: absoluteTimeRange } : args;
+  return (
+    <EuiAccordion id="auto-vis-args" buttonContent="Parameters" paddingSize="xs">
+      <EuiPanel hasBorder paddingSize="s" style={{ wordBreak: 'break-all' }} hasShadow={false}>
+        <EuiCodeBlock
+          language="json"
+          paddingSize="none"
+          fontSize="s"
+          transparentBackground
+          overflowHeight={150}
+          isCopyable
+        >
+          {JSON.stringify(displayArgs, null, 2)}
+        </EuiCodeBlock>
+      </EuiPanel>
+    </EuiAccordion>
+  );
+}
+
+function openVisualizationEditor(core: CoreStart, editorPath: string) {
+  const visEditorAppBase = core.http.basePath.prepend(`/app/${VISUALIZATION_EDITOR_APP_ID}`);
+  if (window.location.pathname.startsWith(visEditorAppBase)) {
+    // When already on the vis editor app, navigateToApp only calls history.push without
+    // remounting the page, so the new URL params are ignored by the already-initialized
+    // component. Use window.location.href instead to force a full navigation that
+    // unmounts and remounts the app.
+    window.location.href = `${visEditorAppBase}${editorPath}`;
+  } else {
+    core.application.navigateToApp(VISUALIZATION_EDITOR_APP_ID, { path: editorPath });
+  }
+}
+
+export function registerAutoVisualizationAction(
+  registerAction: ((action: any) => void) | undefined,
+  core: CoreStart,
+  data: DataPublicPluginStart,
+  contextProvider?: ContextProviderStart
+) {
+  if (!registerAction) return;
+
+  const renderAutoVisualization = ({
+    status,
+    args,
+    result,
+  }: RenderProps<AutoVisualizationArgs>) => {
+    if (status === 'complete' && result?.success) {
+      return (
+        <EuiPanel paddingSize="s" grow={false} hasShadow={false}>
+          {args && <ArgsParameters args={args} absoluteTimeRange={result.resolvedTimeRange} />}
+          <ChartPreview
+            query={result.preparedQuery}
+            visConfig={result.visConfig}
+            core={core}
+            data={data}
+            timeRange={result.resolvedTimeRange}
+          />
+          <EuiSpacer size="s" />
+          <EuiButton size="s" onClick={() => openVisualizationEditor(core, result.editorPath)}>
+            Open in Editor
+          </EuiButton>
+        </EuiPanel>
+      );
+    }
+
+    return null;
+  };
+
+  registerAction({
+    ...AutoVisMeta,
+    useCustomRenderer: true,
+    handler: async (args: AutoVisualizationArgs) => {
+      try {
+        const { visConfig, query, resolvedChartType, resolvedAxesMapping } = buildVisConfig(args);
+
+        const resolvedTimeRange = getAbsoluteTimeRange(data, args.timeRange);
+
+        const dashboardId = getCurrentDashboardId(contextProvider);
+
+        const dashboardName = dashboardId ? await getDashboardName(core, dashboardId) : undefined;
+        const editorPath = buildEditorPath(
+          visConfig,
+          query,
+          resolvedTimeRange,
+          dashboardId,
+          dashboardName
+        );
+
+        return {
+          success: true,
+          chartType: resolvedChartType,
+          resolvedAxesMapping,
+          query: args.query,
+          indexName: args.indexName,
+          editorPath,
+          visConfig,
+          preparedQuery: query,
+          resolvedTimeRange,
+          message: `Created ${resolvedChartType} visualization for ${args.indexName}`,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          query: args.query,
+          indexName: args.indexName,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        };
+      }
+    },
+    render: renderAutoVisualization,
+  });
+}

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
@@ -31,6 +31,12 @@ import { normalizeResultRows } from '../../../components/visualizations/utils/no
 import { visualizationRegistry } from '../../../components/visualizations/visualization_registry';
 import { SAMPLE_SIZE_SETTING, VISUALIZATION_EDITOR_APP_ID } from '../../../../common';
 import { VisEditorNoResults } from '../../../application/in_context_vis_editor/component/vis_editor_no_results';
+import {
+  TransformationService,
+  registerAllTransformations,
+  UrlTransformationState,
+} from '../../../components/data_transformations';
+import { OpenSearchSearchHit } from '../../../types/doc_views_types';
 import { AutoVisMeta } from './utils';
 
 export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
@@ -49,6 +55,11 @@ interface AutoVisualizationArgs {
   datasourceId?: string;
   datasourceTitle?: string;
   dashboardId?: string;
+  // Optional transformation pipeline applied to raw query results before rendering
+  transformations?: UrlTransformationState[];
+  // Optional sample row from the ppl_execute result — a single data row as a plain object.
+  // Used to derive the post-transformation column schema
+  sampleRow?: Record<string, unknown>;
 }
 
 interface PreparedQuery {
@@ -70,7 +81,8 @@ function buildEditorPath(
   query: PreparedQuery,
   timeRange?: TimeRange,
   dashboardId?: string,
-  dashboardName?: string
+  dashboardName?: string,
+  transformations?: UrlTransformationState[]
 ): string {
   const visState: Record<string, any> = {
     chartType: visConfig.type,
@@ -89,7 +101,6 @@ function buildEditorPath(
     : '';
 
   // Bind the visualization to the originating dashboard via `_c` (containerInfo),
-
   const cParam = dashboardId
     ? `&_c=${encodeURIComponent(
         rison.encode({
@@ -102,7 +113,13 @@ function buildEditorPath(
       )}`
     : '';
 
-  return `#/?_v=${encodeURIComponent(vParam)}&_eq=${encodeURIComponent(eqParam)}${gParam}${cParam}`;
+  // Encode transformations into _t so initUrlSync restores them directly.
+  const tParam =
+    transformations && transformations.length > 0
+      ? `&_t=${encodeURIComponent(rison.encode(transformations as any))}`
+      : '';
+
+  return `#/?_v=${encodeURIComponent(vParam)}&_eq=${encodeURIComponent(eqParam)}${gParam}${cParam}${tParam}`;
 }
 
 /**
@@ -172,7 +189,6 @@ function resolveChartFromSchema(
 
   // 4. No potential chart and candidates, use table
   if (candidates.length === 0) {
-    // fallback to table vis
     return { chartType: 'table', axesMapping: {} };
   }
 
@@ -201,12 +217,7 @@ function buildPreparedQuery(args: AutoVisualizationArgs): PreparedQuery {
       },
     }),
   };
-
-  return {
-    dataset,
-    language: 'PPL',
-    query: args.query,
-  };
+  return { dataset, language: 'PPL', query: args.query };
 }
 
 /**
@@ -260,7 +271,7 @@ async function executePPLQuery(
   data: DataPublicPluginStart,
   timeRange?: TimeRange,
   abortSignal?: AbortSignal
-): Promise<VisData> {
+): Promise<{ rawRows: OpenSearchSearchHit[]; rawSchema: Array<{ name?: string; type?: string }> }> {
   const uiSettings = core.uiSettings;
   const dataset = preparedQueryObject.dataset;
 
@@ -303,19 +314,62 @@ async function executePPLQuery(
     ...(languageConfig?.fields?.formatter ? { formatter: languageConfig.fields.formatter } : {}),
   });
 
-  const rawResultsHit = rawResults.hits?.hits ?? [];
-  const fieldSchema = searchSource.getDataFrame()?.schema ?? [];
-  return normalizeResultRows(rawResultsHit, fieldSchema);
+  return {
+    rawRows: rawResults.hits?.hits ?? [],
+    rawSchema: searchSource.getDataFrame()?.schema ?? [],
+  };
 }
 
 /**
- * resolve the chart config from ppl execution columns results
+ * Apply a UrlTransformationState[] pipeline to raw rows and return the result.
+ */
+function applyTransformationPipeline(
+  rawRows: OpenSearchSearchHit[],
+  rawSchema: Array<{ name?: string; type?: string }>,
+  transformations: UrlTransformationState[] | undefined
+): { rows: OpenSearchSearchHit[]; finalSchema: Array<{ name?: string; type?: string }> } {
+  if (!transformations || transformations.length === 0) {
+    return { rows: rawRows, finalSchema: rawSchema };
+  }
+  const service = new TransformationService();
+  registerAllTransformations(service);
+  service.restoreFromState(transformations);
+  return service.applyPipeline(rawRows, rawSchema);
+}
+
+// Derive the post-transformation schema without executing PPL given a sample row
+function deriveSchemaAfterTransformations(
+  originalSchema: Array<{ name?: string; type?: string }>,
+  transformations: UrlTransformationState[] | undefined,
+  sampleRow?: Record<string, unknown>
+): Array<{ name?: string; type?: string }> {
+  if (!transformations || transformations.length === 0 || !sampleRow) {
+    return originalSchema;
+  }
+
+  const rows: OpenSearchSearchHit[] = [{ _source: sampleRow } as OpenSearchSearchHit];
+
+  const service = new TransformationService();
+  registerAllTransformations(service);
+  service.restoreFromState(transformations);
+  const { finalSchema } = service.applyPipeline(rows, originalSchema);
+  return finalSchema;
+}
+
+/**
+ * resolve the chart config from ppl execution columns results.
  */
 function buildVisConfig(args: AutoVisualizationArgs): VisualizationConfigResult {
   const preparedQueryObject = buildPreparedQuery(args);
 
-  // 1. get normalized schema
-  const schema = (args.columns || []).map((col) => ({ name: col.name, type: col.type }));
+  // 1. get normalized schema — use post-transformation schema when available
+  const originalSchema = (args.columns || []).map((col) => ({ name: col.name, type: col.type }));
+  const schema = deriveSchemaAfterTransformations(
+    originalSchema,
+    args.transformations,
+    args.sampleRow
+  );
+
   const { numericalColumns, categoricalColumns, dateColumns } = normalizeResultRows([], schema);
 
   // 2. resolve axes mapping and chart type
@@ -355,12 +409,14 @@ function ChartPreview({
   core,
   data,
   timeRange,
+  transformations,
 }: {
   query: PreparedQuery;
   visConfig: RenderChartConfig;
   core: CoreStart;
   data: DataPublicPluginStart;
   timeRange?: TimeRange;
+  transformations?: UrlTransformationState[];
 }) {
   const [visData, setVisData] = useState<VisData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -368,9 +424,17 @@ function ChartPreview({
   useEffect(() => {
     let cancelled = false;
     const abortController = new AbortController();
+
     executePPLQuery(query, core, data, timeRange, abortController.signal)
-      .then((result) => {
-        if (!cancelled) setVisData(result);
+      .then(({ rawRows, rawSchema }) => {
+        if (cancelled) return;
+        // Apply transformation pipeline before normalizing into VisData columns.
+        const { rows: transformedRows, finalSchema } = applyTransformationPipeline(
+          rawRows,
+          rawSchema,
+          transformations
+        );
+        setVisData(normalizeResultRows(transformedRows, finalSchema));
       })
       .catch((e) => {
         if (!cancelled && !abortController.signal.aborted) {
@@ -489,6 +553,7 @@ export function registerAutoVisualizationAction(
             core={core}
             data={data}
             timeRange={result.resolvedTimeRange}
+            transformations={result.transformations}
           />
           <EuiSpacer size="s" />
           <EuiButton size="s" onClick={() => openVisualizationEditor(core, result.editorPath)}>
@@ -518,7 +583,8 @@ export function registerAutoVisualizationAction(
           query,
           resolvedTimeRange,
           dashboardId,
-          dashboardName
+          dashboardName,
+          args.transformations
         );
 
         return {
@@ -531,6 +597,7 @@ export function registerAutoVisualizationAction(
           visConfig,
           preparedQuery: query,
           resolvedTimeRange,
+          transformations: args.transformations,
           message: `Created ${resolvedChartType} visualization for ${args.indexName}`,
         };
       } catch (error) {

--- a/src/plugins/explore/public/components/visualizations/actions/get_transformation_schema_action.test.ts
+++ b/src/plugins/explore/public/components/visualizations/actions/get_transformation_schema_action.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerGetTransformationSchemaAction } from './get_transformation_schema_action';
+
+// The schemas imported from data_transformations are plain objects — no need to mock them.
+// We only need to verify the handler behaviour via the registered action.
+
+const registerAndGetAction = (): any => {
+  let captured: any;
+  const registerAction = jest.fn((action: any) => {
+    captured = action;
+  });
+  registerGetTransformationSchemaAction(registerAction);
+  return captured;
+};
+
+describe('registerGetTransformationSchemaAction', () => {
+  it('does nothing when registerAction is undefined', () => {
+    expect(() => registerGetTransformationSchemaAction(undefined as any)).not.toThrow();
+  });
+
+  it('registers an action with the correct tool name', () => {
+    const action = registerAndGetAction();
+    expect(action.name).toBe('get_transformation_schema');
+    expect(typeof action.handler).toBe('function');
+  });
+});
+
+describe('get_transformation_schema handler', () => {
+  it('returns schemas for all known definition ids', async () => {
+    const action = registerAndGetAction();
+    const knownIds = [
+      'limit',
+      'sort_by',
+      'filter',
+      'filter_fields',
+      'convert_field_type',
+      'group_by',
+      'extract_fields',
+      'add_field',
+    ];
+
+    const result = await action.handler({ definitionIds: knownIds });
+
+    expect(result.success).toBe(true);
+    expect(Object.keys(result.schemas)).toHaveLength(knownIds.length);
+    for (const id of knownIds) {
+      expect(result.schemas[id]).toBeDefined();
+      // Each schema should be an object with at least one field spec.
+      expect(typeof result.schemas[id]).toBe('object');
+      expect(result.schemas[id]).not.toHaveProperty('error');
+    }
+  });
+
+  it('returns a single schema for a single valid id', async () => {
+    const action = registerAndGetAction();
+    const result = await action.handler({ definitionIds: ['limit'] });
+
+    expect(result.success).toBe(true);
+    expect(result.schemas.limit).toBeDefined();
+    // The limit schema should describe a "limit" field of kind "number".
+    expect(result.schemas.limit.limit).toBeDefined();
+    expect(result.schemas.limit.limit.kind).toBe('number');
+  });
+
+  it('returns schemas for multiple ids in one call', async () => {
+    const action = registerAndGetAction();
+    const result = await action.handler({ definitionIds: ['limit', 'sort_by'] });
+
+    expect(result.success).toBe(true);
+    expect(result.schemas.limit).toBeDefined();
+    expect(result.schemas.sort_by).toBeDefined();
+  });
+
+  it('returns an error entry for an unknown id', async () => {
+    const action = registerAndGetAction();
+    const result = await action.handler({ definitionIds: ['nonexistent'] });
+
+    expect(result.success).toBe(false);
+    expect(result.schemas.nonexistent).toHaveProperty('error');
+    expect(result.schemas.nonexistent.error).toContain('nonexistent');
+    expect(result.schemas.nonexistent.error).toContain('Available types');
+  });
+
+  it('returns mixed results when some ids are valid and some are not', async () => {
+    const action = registerAndGetAction();
+    const result = await action.handler({ definitionIds: ['limit', 'bogus'] });
+
+    expect(result.success).toBe(false); // unknown.length > 0
+    expect(result.schemas.limit).toBeDefined();
+    expect(result.schemas.limit).not.toHaveProperty('error');
+    expect(result.schemas.bogus).toHaveProperty('error');
+  });
+
+  it('includes a helpful message pointing to auto_create_visualization', async () => {
+    const action = registerAndGetAction();
+    const result = await action.handler({ definitionIds: ['filter'] });
+
+    expect(result.message).toContain('auto_create_visualization');
+  });
+
+  it('message mentions all unknown ids when none are valid', async () => {
+    const action = registerAndGetAction();
+    const result = await action.handler({ definitionIds: ['bad1', 'bad2'] });
+
+    expect(result.message).toContain('Available');
+  });
+
+  describe('filter schema', () => {
+    it('exposes byFieldType with base, numerical, and date operator sets', async () => {
+      const action = registerAndGetAction();
+      const result = await action.handler({ definitionIds: ['filter'] });
+
+      const filterSchema = result.schemas.filter;
+      const operatorSpec = filterSchema.operator;
+      expect(operatorSpec).toBeDefined();
+      expect(operatorSpec.byFieldType).toBeDefined();
+      expect(operatorSpec.byFieldType.base.length).toBeGreaterThan(0);
+      expect(operatorSpec.byFieldType.numerical.length).toBeGreaterThan(0);
+      expect(operatorSpec.byFieldType.date.length).toBeGreaterThan(0);
+      // Base operators should include "equals"
+      expect(operatorSpec.byFieldType.base.map((o: any) => o.value)).toContain('equals');
+      // Numerical extras should include "greater_than"
+      expect(operatorSpec.byFieldType.numerical.map((o: any) => o.value)).toContain('greater_than');
+      // Date extras should include "is_earlier"
+      expect(operatorSpec.byFieldType.date.map((o: any) => o.value)).toContain('is_earlier');
+    });
+  });
+
+  describe('add_field schema', () => {
+    it('has a mode field with discriminates listing all mode-dependent fields', async () => {
+      const action = registerAndGetAction();
+      const result = await action.handler({ definitionIds: ['add_field'] });
+
+      const schema = result.schemas.add_field;
+      expect(schema.mode).toBeDefined();
+      expect(schema.mode.discriminates).toBeDefined();
+      expect(schema.mode.discriminates).toContain('field1');
+      expect(schema.mode.discriminates).toContain('unaryField');
+      expect(schema.mode.discriminates).toContain('crossFields');
+    });
+
+    it('documents binary, unary, and crossFields mode options', async () => {
+      const action = registerAndGetAction();
+      const result = await action.handler({ definitionIds: ['add_field'] });
+
+      const modeValues = result.schemas.add_field.mode.enumOptions.map((o: any) => o.value);
+      expect(modeValues).toContain('binary');
+      expect(modeValues).toContain('unary');
+      expect(modeValues).toContain('crossFields');
+    });
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/actions/get_transformation_schema_action.ts
+++ b/src/plugins/explore/public/components/visualizations/actions/get_transformation_schema_action.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  limitConfigSchema,
+  sortByConfigSchema,
+  filterConfigSchema,
+  filterFieldsConfigSchema,
+  convertFieldTypeConfigSchema,
+  groupByConfigSchema,
+  extractFieldsConfigSchema,
+  addFieldConfigSchema,
+  TransformationConfigSchema,
+} from '../../data_transformations';
+import { GetTransformationSchemaMeta } from './utils';
+
+const SCHEMA_REGISTRY: Record<string, TransformationConfigSchema> = {
+  limit: limitConfigSchema,
+  sort_by: sortByConfigSchema,
+  filter: filterConfigSchema,
+  filter_fields: filterFieldsConfigSchema,
+  convert_field_type: convertFieldTypeConfigSchema,
+  group_by: groupByConfigSchema,
+  extract_fields: extractFieldsConfigSchema,
+  add_field: addFieldConfigSchema,
+};
+
+const AVAILABLE_IDS = Object.keys(SCHEMA_REGISTRY);
+
+export function registerGetTransformationSchemaAction(
+  registerAction: ((action: any) => void) | undefined
+) {
+  if (!registerAction) return;
+
+  registerAction({
+    ...GetTransformationSchemaMeta,
+    handler: async (args: { definitionIds: string[] }) => {
+      const results: Record<string, TransformationConfigSchema | { error: string }> = {};
+
+      for (const id of args.definitionIds) {
+        const schema = SCHEMA_REGISTRY[id];
+        if (!schema) {
+          results[id] = {
+            error:
+              `Unknown transformation type "${id}". ` +
+              `Available types: [${AVAILABLE_IDS.join(', ')}].`,
+          };
+        } else {
+          results[id] = schema;
+        }
+      }
+
+      const found = args.definitionIds.filter((id) => SCHEMA_REGISTRY[id]);
+      const unknown = args.definitionIds.filter((id) => !SCHEMA_REGISTRY[id]);
+
+      return {
+        success: unknown.length === 0,
+        schemas: results,
+        message:
+          found.length > 0
+            ? `Returned schemas for: [${found.join(', ')}].` +
+              (unknown.length > 0 ? ` Unknown types: [${unknown.join(', ')}].` : '') +
+              ` Use each schema's field descriptions and enumOptions to build valid config objects, ` +
+              `then pass them in the transformations array of auto_create_visualization.`
+            : `No valid transformation types found. Available: [${AVAILABLE_IDS.join(', ')}].`,
+      };
+    },
+  });
+}

--- a/src/plugins/explore/public/components/visualizations/actions/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/actions/utils.ts
@@ -4,6 +4,7 @@
  */
 
 export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+export const GET_TRANSFORMATION_SCHEMA_TOOL_NAME = 'get_transformation_schema';
 
 const CHART_TYPE_INFO: Record<string, string> = {
   line: 'trends over time. Use when user asks about trends, changes over time, or time-series',
@@ -26,6 +27,27 @@ function buildChartTypeGuide(): string {
     .join('');
 }
 
+/**
+ * Brief one-liner per transformation type — enough to pick the right one.
+ * Full config schema is available on demand via get_transformation_schema.
+ */
+const TRANSFORMATION_BRIEF: Record<string, string> = {
+  limit: 'keep only the first N rows',
+  sort_by: 'sort rows by a field ascending or descending',
+  filter: 'filter rows where a field matches a condition',
+  filter_fields: 'include or exclude specific columns from every row',
+  convert_field_type: 'cast one or more fields to a different type',
+  group_by: 'group rows by a field and aggregate other fields per group',
+  extract_fields: 'flatten a nested object or JSON-string field into top-level columns',
+  add_field: 'create a new computed column from existing numerical fields',
+};
+
+function buildTransformationBrief(): string {
+  return Object.entries(TRANSFORMATION_BRIEF)
+    .map(([id, desc]) => `\n"${id}" — ${desc}`)
+    .join('');
+}
+
 export const AutoVisMeta = {
   name: AUTO_VISUALIZATION_TOOL_NAME,
   description:
@@ -35,8 +57,13 @@ export const AutoVisMeta = {
     '\n\nWORKFLOW (follow in order):' +
     '\n1. Always Call the index mapping tool to look up the timeFieldName; if it exists, pass it in.' +
     '\n2. Call the ppl_execute tool with the PPL query to run it and obtain the result column schema.' +
+    '\n3. (Optional) If the user wants data shaping (filtering, sorting, limiting, etc.), ' +
+    'decide which transformation types fit, call get_transformation_schema with all needed ' +
+    'type ids at once, then pass the filled-in transformations array to this tool.' +
     '\n\nCHART TYPE GUIDE (choose based on user intent and data shape):' +
-    buildChartTypeGuide(),
+    buildChartTypeGuide() +
+    '\n\nAVAILABLE TRANSFORMATION TYPES (pick one, then call get_transformation_schema for details):' +
+    buildTransformationBrief(),
 
   parameters: {
     type: 'object',
@@ -80,7 +107,7 @@ export const AutoVisMeta = {
       splitField: {
         type: 'string',
         description:
-          'Optional categorical or numerical field to split/facet the chart by (small multiples)' +
+          'Optional categorical or numerical field to split/facet the chart by (small multiples). ' +
           'Infer the user most likely wants.',
       },
       timeFieldName: {
@@ -89,7 +116,74 @@ export const AutoVisMeta = {
           'The time field name of the index (e.g. "@timestamp", "timestamp"). ' +
           'Get this from the index mapping.',
       },
+      transformations: {
+        type: 'array',
+        description:
+          'Optional data transformation pipeline applied to query results before rendering. ' +
+          'Each step runs in order. Call get_transformation_schema first to get the exact ' +
+          'config shape for the transformation type you want to use.',
+        items: {
+          type: 'object',
+          properties: {
+            definitionId: {
+              type: 'string',
+              description:
+                'Transformation type id. One of: "limit", "sort_by", "filter", ' +
+                '"filter_fields", "convert_field_type", "group_by", "extract_fields", "add_field".',
+            },
+            config: {
+              type: 'object',
+              description:
+                'Config object for this step. Call get_transformation_schema to get the ' +
+                'exact required shape for the chosen definitionId.',
+            },
+            hide: {
+              type: 'boolean',
+              description: 'Set to true to disable this step without removing it. Default false.',
+            },
+          },
+          required: ['definitionId', 'config'],
+        },
+      },
+      sampleRow: {
+        type: 'object',
+        description:
+          'Optional. A single data row from the ppl_execute result as a plain key-value object ' +
+          '(one entry from the datarows array, with column names as keys). ' +
+          'Required when transformations include types that add new columns ' +
+          '(for example: add_field, group_by,extract_fields) so the axes mapping can reflect the post-transformation schema. ' +
+          'Pass one representative row — the first non-null row is ideal.',
+      },
     },
     required: ['query', 'indexName', 'columns'],
+  },
+};
+
+export const GetTransformationSchemaMeta = {
+  name: GET_TRANSFORMATION_SCHEMA_TOOL_NAME,
+  description:
+    'Returns the complete config schema for one or more transformation types. ' +
+    'Call this after deciding which transformations you need from the AVAILABLE TRANSFORMATION TYPES ' +
+    'list in auto_create_visualization. You can request multiple schemas in one call — ' +
+    'pass all the types you plan to use at once to minimise round trips. ' +
+    'Each schema tells you exactly which config fields are required, what values are valid, ' +
+    'and how field type affects available options (e.g. filter operators). ' +
+    'Use the returned schemas to construct the config objects for the transformations array.',
+  parameters: {
+    type: 'object',
+    properties: {
+      definitionIds: {
+        type: 'array',
+        description:
+          'One or more transformation type ids to fetch schemas for. ' +
+          'Valid values: "limit", "sort_by", "filter", "filter_fields", ' +
+          '"convert_field_type", "group_by", "extract_fields", "add_field".',
+        items: {
+          type: 'string',
+        },
+        minItems: 1,
+      },
+    },
+    required: ['definitionIds'],
   },
 };

--- a/src/plugins/explore/public/components/visualizations/actions/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/actions/utils.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+
+const CHART_TYPE_INFO: Record<string, string> = {
+  line: 'trends over time. Use when user asks about trends, changes over time, or time-series',
+  bar: 'compare values across categories or time buckets. Use for comparisons, rankings, distributions across groups',
+  area: 'stacked/cumulative trends over time. Use for cumulative totals, composition over time',
+  pie: 'proportional breakdown of a whole. Use when user asks about proportions, shares, percentages, breakdown',
+  scatter: 'correlation between two numerical variables. Use color/size to add dimensions',
+  heatmap: 'density or intensity across two categorical dimensions',
+  metric: 'single aggregated number, optionally with sparkline. Use for KPIs, totals, counts',
+  gauge: 'single value against a threshold range',
+  bar_gauge: 'progress bars against threshold range',
+  histogram: 'frequency distribution of a numerical field (auto-binned)',
+  state_timeline: 'discrete status/value changes over time',
+  table: 'raw tabular display',
+};
+
+function buildChartTypeGuide(): string {
+  return Object.entries(CHART_TYPE_INFO)
+    .map(([type, desc]) => `\n"${type}" — ${desc}`)
+    .join('');
+}
+
+export const AutoVisMeta = {
+  name: AUTO_VISUALIZATION_TOOL_NAME,
+  description:
+    'Creates a visualization from a PPL query and its result column schema. This tool does NOT ' +
+    'execute the query itself — it resolves the axes mapping from the provided columns, renders a ' +
+    'chart preview, and provides an editor link.' +
+    '\n\nWORKFLOW (follow in order):' +
+    '\n1. Always Call the index mapping tool to look up the timeFieldName; if it exists, pass it in.' +
+    '\n2. Call the ppl_execute tool with the PPL query to run it and obtain the result column schema.' +
+    '\n\nCHART TYPE GUIDE (choose based on user intent and data shape):' +
+    buildChartTypeGuide(),
+
+  parameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description:
+          'The PPL query to visualize (e.g. "source=flights | stats avg(delay) by carrier"). ' +
+          'This must be the same query previously run via ppl_execute.',
+      },
+      indexName: {
+        type: 'string',
+        description: 'The index/dataset name to query',
+      },
+      potentialChartType: {
+        type: 'string',
+        description:
+          'Optional. The chart type you infer the user most likely wants, based on their input ' +
+          'The chart type must be on one of: "line", "bar", "area", "pie", "scatter", ' +
+          '"heatmap", "metric", "gauge", "histogram", "state_timeline", "table". ' +
+          'This is only a hint. Omit it when the user does not imply a specific chart type.',
+      },
+      columns: {
+        type: 'array',
+        description:
+          'The result column schema returned by ppl execution. Each column has a name and type ' +
+          '(e.g. "integer", "keyword", "date", "double", "long", "float", "text", "timestamp"). ' +
+          'Used to resolve which chart types and axes mappings are compatible.',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Field name' },
+            type: {
+              type: 'string',
+              description: 'Field type from the query result schema',
+            },
+          },
+          required: ['name', 'type'],
+        },
+      },
+      splitField: {
+        type: 'string',
+        description:
+          'Optional categorical or numerical field to split/facet the chart by (small multiples)' +
+          'Infer the user most likely wants.',
+      },
+      timeFieldName: {
+        type: 'string',
+        description:
+          'The time field name of the index (e.g. "@timestamp", "timestamp"). ' +
+          'Get this from the index mapping.',
+      },
+    },
+    required: ['query', 'indexName', 'columns'],
+  },
+};

--- a/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { skip } from 'rxjs/operators';
 import { ExploreEmbeddable } from './explore_embeddable';
 import { ExploreInput } from './types';
@@ -27,10 +27,25 @@ jest.mock('react-dom/client', () => ({
 
 // Mock the ExploreEmbeddableComponent
 jest.mock('./explore_embeddable_component', () => ({
-  ExploreEmbeddableComponent: jest.fn(() => (
-    <div data-test-subj="mockExploreEmbeddableComponent" />
-  )),
+  ExploreEmbeddableComponent: jest.fn(() => null),
 }));
+
+// Mock the PanelDataService singleton. The real getInstance() throws unless
+// PanelDataService.init() was called during plugin setup, which never happens
+// in this unit test — so fetch()/destroy() would blow up. Return a stub whose
+// setPanelData/removePanelData are no-ops.
+jest.mock('./panel_data_service', () => {
+  const mockPanelDataInstance = {
+    setPanelData: jest.fn(),
+    removePanelData: jest.fn(),
+  };
+  return {
+    PanelDataService: {
+      getInstance: jest.fn(() => mockPanelDataInstance),
+      init: jest.fn(),
+    },
+  };
+});
 
 // Mock the services
 jest.mock('../application/legacy/discover/opensearch_dashboards_services', () => {

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -66,6 +66,7 @@ import {
   TransformationService,
   registerAllTransformations,
 } from '../components/data_transformations';
+import { PanelDataService } from './panel_data_service';
 
 // TODO cleanup unused props
 export interface SearchProps {
@@ -657,6 +658,15 @@ export class ExploreEmbeddable
     this.searchProps.hits = transformedRows.length;
     this.searchProps.isLoading = false;
 
+    // Update shared panel data store so the global fetch_panel_data tool returns fresh data
+    const savedExploreId = this.savedExplore.id;
+    if (savedExploreId) {
+      PanelDataService.getInstance().setPanelData(savedExploreId, {
+        rows: transformedRows,
+        panelTitle: this.panelTitle || this.savedExplore.title,
+      });
+    }
+
     // set tabular for DataViewComponent to display via adapters.data.getTabular()
     if (this.inspectorAdaptors.data && visualizationData?.transformedData) {
       const allColumns = [
@@ -722,6 +732,10 @@ export class ExploreEmbeddable
     // Cleanup transformation service
     if (this.transformationService) {
       this.transformationService.destroy();
+    }
+
+    if (this.savedExplore.id) {
+      PanelDataService.getInstance().removePanelData(this.savedExplore.id);
     }
 
     if (this.abortController) {

--- a/src/plugins/explore/public/embeddable/index.ts
+++ b/src/plugins/explore/public/embeddable/index.ts
@@ -6,3 +6,4 @@
 export { EXPLORE_EMBEDDABLE_TYPE } from './constants';
 export * from './types';
 export * from './explore_embeddable_factory';
+export { PanelDataService } from './panel_data_service';

--- a/src/plugins/explore/public/embeddable/panel_data_service.test.ts
+++ b/src/plugins/explore/public/embeddable/panel_data_service.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PanelDataService, FETCH_PANEL_DATA_TOOL_NAME } from './panel_data_service';
+
+describe('PanelDataService', () => {
+  let registerAction: jest.Mock;
+  let unregisterAction: jest.Mock;
+
+  const getRegisteredAction = () => {
+    // The action object passed to the most recent registerAction call.
+    return registerAction.mock.calls[registerAction.mock.calls.length - 1][0];
+  };
+
+  beforeEach(() => {
+    // Reset the singleton so each test starts from a clean store + unregistered tool.
+    (PanelDataService as any).instance = null;
+
+    registerAction = jest.fn();
+    unregisterAction = jest.fn();
+
+    PanelDataService.init(registerAction, unregisterAction);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getInstance', () => {
+    it('returns the same instance across calls', () => {
+      expect(PanelDataService.getInstance()).toBe(PanelDataService.getInstance());
+    });
+  });
+
+  describe('setPanelData', () => {
+    it('registers the shared tool lazily on the first publish', () => {
+      const service = PanelDataService.getInstance();
+      expect(registerAction).not.toHaveBeenCalled();
+
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+
+      expect(registerAction).toHaveBeenCalledTimes(1);
+      expect(getRegisteredAction().name).toBe(FETCH_PANEL_DATA_TOOL_NAME);
+    });
+
+    it('registers the tool only once across multiple publishes', () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+      service.setPanelData('panel-2', { rows: [], panelTitle: 'Panel 2' });
+      service.setPanelData('panel-1', { rows: [{ a: 1 }], panelTitle: 'Panel 1' });
+
+      expect(registerAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fetch_panel_data handler', () => {
+    it('returns the formatted rows for a known panel', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', {
+        rows: [{ _source: { host: 'a' } }, { fields: { host: 'b' } }, { host: 'c' }],
+        panelTitle: 'Hosts',
+      });
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+
+      expect(result).toEqual({
+        success: true,
+        panelTitle: 'Hosts',
+        savedObjectId: 'panel-1',
+        rowCount: 3,
+        // _source, then fields, then the raw hit fallback.
+        rows: [{ host: 'a' }, { host: 'b' }, { host: 'c' }],
+      });
+    });
+
+    it('returns a not-loaded failure for an unknown panel', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'missing' });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('missing');
+    });
+
+    it('reflects the latest rows after an overwrite', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
+      service.setPanelData('panel-1', { rows: [{ v: 2 }, { v: 3 }], panelTitle: 'Panel 1' });
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+
+      expect(result.rowCount).toBe(2);
+      expect(result.rows).toEqual([{ v: 2 }, { v: 3 }]);
+    });
+  });
+
+  describe('removePanelData', () => {
+    it('drops the panel data so the handler reports it as unavailable', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
+
+      service.removePanelData('panel-1');
+
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('leaves the shared tool registered even after the last panel is removed', () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+
+      service.removePanelData('panel-1');
+
+      // No churn: the tool stays registered for the plugin's lifetime.
+      expect(unregisterAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all data and unregisters the tool', async () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
+      service.setPanelData('panel-2', { rows: [{ v: 2 }], panelTitle: 'Panel 2' });
+
+      service.reset();
+
+      expect(unregisterAction).toHaveBeenCalledTimes(1);
+      expect(unregisterAction).toHaveBeenCalledWith(FETCH_PANEL_DATA_TOOL_NAME);
+      // Store is cleared: the previously captured handler now finds nothing.
+      const result = await getRegisteredAction().handler({ savedObjectId: 'panel-1' });
+      expect(result.success).toBe(false);
+    });
+
+    it('is a no-op unregister when nothing was ever registered', () => {
+      const service = PanelDataService.getInstance();
+
+      service.reset();
+
+      expect(unregisterAction).not.toHaveBeenCalled();
+    });
+
+    it('re-registers on the next publish after reset', () => {
+      const service = PanelDataService.getInstance();
+      service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
+      service.reset();
+      registerAction.mockClear();
+
+      service.setPanelData('panel-2', { rows: [], panelTitle: 'Panel 2' });
+
+      expect(registerAction).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/plugins/explore/public/embeddable/panel_data_service.ts
+++ b/src/plugins/explore/public/embeddable/panel_data_service.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AssistantAction } from 'src/plugins/context_provider/public';
+
+export const FETCH_PANEL_DATA_TOOL_NAME = 'fetch_panel_data';
+
+interface PanelDataEntry {
+  rows: any[];
+  panelTitle: string;
+}
+
+type RegisterAction = (action: AssistantAction<any>) => void;
+type UnregisterAction = (id: string) => void;
+
+/**
+ * Global singleton that owns the shared panel-data store.
+ * fetch_panel_data tool is shared among all panels and it takes a
+ * savedObjectId argument and looks the panel up in the store
+ */
+export class PanelDataService {
+  private static instance: PanelDataService | null = null;
+
+  private readonly store = new Map<string, PanelDataEntry>();
+  private toolRegistered = false;
+
+  private registerAction: RegisterAction | undefined;
+  private unregisterAction: UnregisterAction | undefined;
+
+  private constructor() {}
+
+  static init(registerAction: RegisterAction, unregisterAction: UnregisterAction) {
+    PanelDataService.instance = new PanelDataService();
+    PanelDataService.instance.registerAction = registerAction;
+    PanelDataService.instance.unregisterAction = unregisterAction;
+  }
+
+  static getInstance(): PanelDataService {
+    if (!PanelDataService.instance) {
+      throw new Error(
+        'PanelDataService has not been initialized. Call PanelDataService.init() first.'
+      );
+    }
+    return PanelDataService.instance;
+  }
+
+  setPanelData(savedObjectId: string, entry: PanelDataEntry) {
+    this.store.set(savedObjectId, entry);
+    this.registerTool();
+  }
+
+  removePanelData(savedObjectId: string) {
+    this.store.delete(savedObjectId);
+  }
+
+  reset() {
+    this.store.clear();
+    this.unregisterTool();
+  }
+
+  private registerTool() {
+    if (this.toolRegistered || !this.registerAction) return;
+    this.toolRegistered = true;
+
+    this.registerAction({
+      name: FETCH_PANEL_DATA_TOOL_NAME,
+      description:
+        'Retrieves the underlying data rows from a dashboard panel by its saved object ID. ' +
+        'IMPORTANT: Do NOT call this tool for general questions like "summarize this", "what does this show", or "explain the chart" — ' +
+        'use the screenshot and visualization context already provided in the conversation for those. ' +
+        'ONLY call this tool when the user explicitly asks for specific data that requires exact values. ',
+      parameters: {
+        type: 'object',
+        properties: {
+          savedObjectId: {
+            type: 'string',
+            description: 'The saved explore object ID of the panel to fetch data from',
+          },
+        },
+        required: ['savedObjectId'],
+      },
+      handler: async (args: { savedObjectId: string }) => {
+        const entry = this.store.get(args.savedObjectId);
+        if (!entry) {
+          return {
+            success: false,
+            message: `No data available for panel ${args.savedObjectId}. The panel may not be loaded yet.`,
+          };
+        }
+
+        const formattedRows = entry.rows.map((hit: any) => hit._source || hit.fields || hit);
+        return {
+          success: true,
+          panelTitle: entry.panelTitle,
+          savedObjectId: args.savedObjectId,
+          rowCount: formattedRows.length,
+          rows: formattedRows,
+        };
+      },
+    });
+  }
+
+  private unregisterTool() {
+    if (!this.toolRegistered || !this.unregisterAction) return;
+    this.toolRegistered = false;
+    this.unregisterAction(FETCH_PANEL_DATA_TOOL_NAME);
+  }
+}

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -76,7 +76,7 @@ import {
   ExploreStartDependencies,
 } from './types';
 import { DocViewsRegistry } from './types/doc_views_types';
-import { ExploreEmbeddableFactory } from './embeddable';
+import { ExploreEmbeddableFactory, PanelDataService } from './embeddable';
 import { SAVED_OBJECT_TYPE } from './saved_explore/_saved_explore';
 import { DASHBOARD_ADD_PANEL_TRIGGER } from '../../dashboard/public';
 import { createAbortDataQueryAction } from './application/utils/state_management/actions/abort_controller';
@@ -96,6 +96,10 @@ import {
   registerDisabledPPLExecuteQueryAction,
   EXECUTE_PPL_QUERY_TOOL_DEFINITION,
 } from './components/query_panel/actions/ppl_execute_query_action';
+import {
+  registerAutoVisualizationAction,
+  AUTO_VISUALIZATION_TOOL_NAME,
+} from './components/visualizations/actions/auto_visualization_action';
 
 export class ExplorePlugin implements Plugin<
   ExplorePluginSetup,
@@ -135,6 +139,7 @@ export class ExplorePlugin implements Plugin<
   private editorAppStateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
   private editorStopUrlTracking?: () => void;
   private unregisterPPLExecuteQueryAction?: () => void;
+  private unregisterVisualizationTools?: () => void;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {}
 
@@ -884,13 +889,27 @@ export class ExplorePlugin implements Plugin<
     // Register disabled execute_ppl_query action as placeholder
     // This will be overridden when query panel mounts and restored when it unmounts
     if (plugins.contextProvider) {
-      registerDisabledPPLExecuteQueryAction(
-        plugins.contextProvider.actions.registerAssistantAction
-      );
+      const { registerAssistantAction, unregisterAssistantAction } =
+        plugins.contextProvider.actions;
+
+      registerDisabledPPLExecuteQueryAction(registerAssistantAction);
       this.unregisterPPLExecuteQueryAction = () =>
-        plugins.contextProvider!.actions.unregisterAssistantAction(
-          EXECUTE_PPL_QUERY_TOOL_DEFINITION.name
-        );
+        unregisterAssistantAction(EXECUTE_PPL_QUERY_TOOL_DEFINITION.name);
+
+      // Register visualization tool for AI-driven visualization creation
+      registerAutoVisualizationAction(
+        registerAssistantAction,
+        core,
+        plugins.data,
+        plugins.contextProvider
+      );
+
+      this.unregisterVisualizationTools = () => {
+        unregisterAssistantAction(AUTO_VISUALIZATION_TOOL_NAME);
+      };
+
+      // Inject contextProvider action helpers into PanelDataService
+      PanelDataService.init(registerAssistantAction, unregisterAssistantAction);
     }
 
     const savedExploreLoader = createSavedExploreLoader({
@@ -916,6 +935,9 @@ export class ExplorePlugin implements Plugin<
       this.editorStopUrlTracking();
     }
     this.unregisterPPLExecuteQueryAction?.();
+    this.unregisterVisualizationTools?.();
+    // cleanup shared panel-data store + fetch_panel_data tool.
+    PanelDataService.getInstance().reset();
   }
 
   private registerEmbeddable(

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -100,6 +100,8 @@ import {
   registerAutoVisualizationAction,
   AUTO_VISUALIZATION_TOOL_NAME,
 } from './components/visualizations/actions/auto_visualization_action';
+import { registerGetTransformationSchemaAction } from './components/visualizations/actions/get_transformation_schema_action';
+import { GET_TRANSFORMATION_SCHEMA_TOOL_NAME } from './components/visualizations/actions/utils';
 
 export class ExplorePlugin implements Plugin<
   ExplorePluginSetup,
@@ -904,8 +906,12 @@ export class ExplorePlugin implements Plugin<
         plugins.contextProvider
       );
 
+      // Register transformation schema lookup tool
+      registerGetTransformationSchemaAction(registerAssistantAction);
+
       this.unregisterVisualizationTools = () => {
         unregisterAssistantAction(AUTO_VISUALIZATION_TOOL_NAME);
+        unregisterAssistantAction(GET_TRANSFORMATION_SCHEMA_TOOL_NAME);
       };
 
       // Inject contextProvider action helpers into PanelDataService

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -157,9 +157,10 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       // Skip adding time filters if hideDatePicker is false. Let search strategy insert time filters.
       datasetService.getType(dataset.type)?.languageOverrides?.PPL?.hideDatePicker !== false
     ) {
+      // Prefer an explicit time range passed and fall back to the global timefilter.
       const timeFilter = PPLFilterUtils.getTimeFilterWhereClause(
         dataset.timeFieldName,
-        this.queryService.timefilter.timefilter.getTime(),
+        request.params?.body?.timeRange ?? this.queryService.timefilter.timefilter.getTime(),
         dataset.dataSource?.engineType ?? dataset.dataSource?.type
       );
       whereCommands.push(timeFilter);

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
@@ -170,23 +170,23 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
 
       // Send visualization screenshot to chat
       if (this.core.chat) {
-        // Create a message with the visualization image following AG-UI protocol
-        const imageMessage = {
-          role: 'user' as const,
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          content: [
+        await this.core.chat.sendMessageWithWindow(
+          [
             {
-              type: 'binary' as const,
-              mimeType: 'image/jpeg',
-              data: visualizationBase64,
+              type: 'image',
+              source: {
+                type: 'data',
+                value: visualizationBase64,
+                mimeType: 'image/jpeg',
+              },
+            },
+
+            {
+              type: 'text',
+              text: 'Give me a summary for the selected visualization',
             },
           ],
-        };
-
-        // sendMessageWithWindow will open the chat window and send the message
-        await this.core.chat.sendMessageWithWindow(
-          'Give me a summary for the selected visualization',
-          [imageMessage]
+          []
         );
       }
     } catch (error) {


### PR DESCRIPTION
### Description

This PR adds two new AI assistant tools to the Explore plugin that enable users to create visualizations — including data transformations — directly from natural language in the chat interface.

need to merge https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12424 first

### What was built
auto_create_visualization tool (refactored + extended)
The existing auto_create_visualization tool was extended with transformation pipeline support.


## Screenshot

[<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->](https://github.com/user-attachments/assets/afc8185c-e163-45c8-ac28-1fb5dfbc2722)

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
