### PR TITLE
Add hint for hidden AE data sources in legacy viz data source selectors

### DIFF
--- a/src/plugins/input_control_vis/public/components/editor/__snapshots__/list_control_editor.test.tsx.snap
+++ b/src/plugins/input_control_vis/public/components/editor/__snapshots__/list_control_editor.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`renders dynamic options should display disabled dynamic options with to
       }
     }
     controlIndex={0}
+    hasAnalyticEngine={false}
     indexPatternId="mockIndexPattern"
     onChange={[Function]}
   />
@@ -128,6 +129,7 @@ exports[`renders dynamic options should display dynamic options for string field
       }
     }
     controlIndex={0}
+    hasAnalyticEngine={false}
     indexPatternId="mockIndexPattern"
     onChange={[Function]}
   />
@@ -214,6 +216,7 @@ exports[`renders dynamic options should display size field when dynamic options 
       }
     }
     controlIndex={0}
+    hasAnalyticEngine={false}
     indexPatternId="mockIndexPattern"
     onChange={[Function]}
   />
@@ -331,6 +334,7 @@ exports[`renders should display chaining input when parents are provided 1`] = `
       }
     }
     controlIndex={0}
+    hasAnalyticEngine={false}
     indexPatternId="indexPattern1"
     onChange={[Function]}
   />
@@ -493,6 +497,7 @@ exports[`renders should not display any options until field is selected 1`] = `
       }
     }
     controlIndex={0}
+    hasAnalyticEngine={false}
     indexPatternId="mockIndexPattern"
     onChange={[Function]}
   />

--- a/src/plugins/input_control_vis/public/components/editor/__snapshots__/range_control_editor.test.tsx.snap
+++ b/src/plugins/input_control_vis/public/components/editor/__snapshots__/range_control_editor.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`renders RangeControlEditor 1`] = `
       }
     }
     controlIndex={0}
+    hasAnalyticEngine={false}
     indexPatternId="indexPattern1"
     onChange={[Function]}
   />

--- a/src/plugins/input_control_vis/public/components/editor/index_pattern_select_form_row.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/index_pattern_select_form_row.tsx
@@ -39,10 +39,18 @@ export type IndexPatternSelectFormRowUiProps = InjectedIntlProps & {
   controlIndex: number;
   IndexPatternSelect: ComponentType<IndexPatternSelectProps>;
   allowedIndexPatternIds: Set<string>;
+  hasAnalyticEngine?: boolean;
 };
 
 function IndexPatternSelectFormRowUi(props: IndexPatternSelectFormRowUiProps) {
-  const { controlIndex, indexPatternId, intl, onChange, allowedIndexPatternIds } = props;
+  const {
+    controlIndex,
+    indexPatternId,
+    intl,
+    onChange,
+    allowedIndexPatternIds,
+    hasAnalyticEngine,
+  } = props;
 
   const selectId = `indexPatternSelect-${controlIndex}`;
   // Create filter function based on allowed index pattern IDs
@@ -57,6 +65,15 @@ function IndexPatternSelectFormRowUi(props: IndexPatternSelectFormRowUiProps) {
         id: 'inputControl.editor.indexPatternSelect.patternLabel',
         defaultMessage: 'Index Pattern',
       })}
+      helpText={
+        hasAnalyticEngine
+          ? intl.formatMessage({
+              id: 'inputControl.editor.indexPatternSelect.optimizedEngineNotSupported',
+              defaultMessage:
+                "Controls support only DSL queries. Index patterns backed by Optimized engine (AnalyticEngine type) data sources aren't supported and don't appear in this list.",
+            })
+          : undefined
+      }
     >
       <props.IndexPatternSelect
         placeholder={intl.formatMessage({

--- a/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
@@ -51,6 +51,7 @@ interface ListControlEditorState {
   prevFieldName: string;
   IndexPatternSelect: ComponentType<IndexPatternSelectProps> | null;
   allowedIndexPatternIds: Set<string>;
+  hasAnalyticEngine: boolean;
 }
 
 interface ListControlEditorProps {
@@ -88,6 +89,7 @@ export class ListControlEditor extends PureComponent<
     prevFieldName: this.props.controlParams.fieldName,
     IndexPatternSelect: null,
     allowedIndexPatternIds: new Set(),
+    hasAnalyticEngine: false,
   };
 
   componentDidMount() {
@@ -124,15 +126,18 @@ export class ListControlEditor extends PureComponent<
   async getIndexPatternSelect() {
     const [, { data }] = await this.props.deps.core.getStartServices();
 
-    // Get allowed index pattern IDs (excluding AnalyticEngine)
-    const indexPatternList = await data.indexPatterns.getCache({
-      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-    });
+    const [allIndexPatterns, indexPatternList] = await Promise.all([
+      data.indexPatterns.getCache(),
+      data.indexPatterns.getCache({
+        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+      }),
+    ]);
     const allowedIndexPatternIds = new Set(indexPatternList?.map((i) => i.id) || []);
 
     this.setState({
       IndexPatternSelect: data.ui.IndexPatternSelect,
       allowedIndexPatternIds,
+      hasAnalyticEngine: (allIndexPatterns?.length ?? 0) > (indexPatternList?.length ?? 0),
     });
   }
 
@@ -322,6 +327,7 @@ export class ListControlEditor extends PureComponent<
           controlIndex={this.props.controlIndex}
           IndexPatternSelect={this.state.IndexPatternSelect}
           allowedIndexPatternIds={this.state.allowedIndexPatternIds}
+          hasAnalyticEngine={this.state.hasAnalyticEngine}
         />
 
         <FieldSelect

--- a/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
@@ -126,12 +126,10 @@ export class ListControlEditor extends PureComponent<
   async getIndexPatternSelect() {
     const [, { data }] = await this.props.deps.core.getStartServices();
 
-    const [allIndexPatterns, indexPatternList] = await Promise.all([
-      data.indexPatterns.getCache(),
-      data.indexPatterns.getCache({
-        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-      }),
-    ]);
+    const allIndexPatterns = await data.indexPatterns.getCache();
+    const indexPatternList = await data.indexPatterns.getCache({
+      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+    });
     const allowedIndexPatternIds = new Set(indexPatternList?.map((i) => i.id) || []);
 
     this.setState({

--- a/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
@@ -81,12 +81,10 @@ export class RangeControlEditor extends Component<
   async getIndexPatternSelect() {
     const [, { data }] = await this.props.deps.core.getStartServices();
 
-    const [allIndexPatterns, indexPatternList] = await Promise.all([
-      data.indexPatterns.getCache(),
-      data.indexPatterns.getCache({
-        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-      }),
-    ]);
+    const allIndexPatterns = await data.indexPatterns.getCache();
+    const indexPatternList = await data.indexPatterns.getCache({
+      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+    });
     const allowedIndexPatternIds = new Set(indexPatternList?.map((i) => i.id) || []);
 
     this.setState({

--- a/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
@@ -57,6 +57,7 @@ interface RangeControlEditorProps {
 interface RangeControlEditorState {
   IndexPatternSelect: ComponentType<IndexPatternSelectProps> | null;
   allowedIndexPatternIds: Set<string>;
+  hasAnalyticEngine: boolean;
 }
 
 function filterField(field: IFieldType) {
@@ -70,6 +71,7 @@ export class RangeControlEditor extends Component<
   state: RangeControlEditorState = {
     IndexPatternSelect: null,
     allowedIndexPatternIds: new Set(),
+    hasAnalyticEngine: false,
   };
 
   componentDidMount() {
@@ -79,15 +81,18 @@ export class RangeControlEditor extends Component<
   async getIndexPatternSelect() {
     const [, { data }] = await this.props.deps.core.getStartServices();
 
-    // Get allowed index pattern IDs (excluding AnalyticEngine)
-    const indexPatternList = await data.indexPatterns.getCache({
-      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-    });
+    const [allIndexPatterns, indexPatternList] = await Promise.all([
+      data.indexPatterns.getCache(),
+      data.indexPatterns.getCache({
+        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+      }),
+    ]);
     const allowedIndexPatternIds = new Set(indexPatternList?.map((i) => i.id) || []);
 
     this.setState({
       IndexPatternSelect: data.ui.IndexPatternSelect,
       allowedIndexPatternIds,
+      hasAnalyticEngine: (allIndexPatterns?.length ?? 0) > (indexPatternList?.length ?? 0),
     });
   }
 
@@ -106,6 +111,7 @@ export class RangeControlEditor extends Component<
           controlIndex={this.props.controlIndex}
           IndexPatternSelect={this.state.IndexPatternSelect}
           allowedIndexPatternIds={this.state.allowedIndexPatternIds}
+          hasAnalyticEngine={this.state.hasAnalyticEngine}
         />
 
         <FieldSelect

--- a/src/plugins/vis_builder/public/application/components/data_source_select.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_source_select.tsx
@@ -4,7 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { EuiIcon } from '@elastic/eui';
+import { EuiIcon, EuiText } from '@elastic/eui';
 import React, { useEffect } from 'react';
 import { SearchableDropdown, SearchableDropdownOption } from './searchable_dropdown';
 import { useIndexPatterns } from '../utils/use';
@@ -26,7 +26,7 @@ function toSearchableDropdownOption(indexPattern: IndexPattern): SearchableDropd
 }
 
 export const DataSourceSelect = () => {
-  const { indexPatterns, loading, error, selected } = useIndexPatterns();
+  const { indexPatterns, loading, error, selected, hasAnalyticEngine } = useIndexPatterns();
   const dispatch = useTypedDispatch();
 
   // If no index pattern is selected (e.g., the selected one was filtered out as AnalyticEngine),
@@ -36,6 +36,15 @@ export const DataSourceSelect = () => {
       dispatch(setIndexPattern(indexPatterns[0].id));
     }
   }, [loading, error, selected, indexPatterns, dispatch]);
+
+  const optimizedEngineNote = (
+    <EuiText size="xs" color="subdued" data-test-subj="vbDataSourceOptimizedEngineNote">
+      {i18n.translate('visBuilder.dataSource.optimizedEngineNotSupported', {
+        defaultMessage:
+          "VisBuilder supports only DSL queries. Index patterns backed by Optimized engine (AnalyticEngine type) data sources aren't supported and don't appear in this list.",
+      })}
+    </EuiText>
+  );
 
   // TODO: Should be a standard EUI component
   return (
@@ -54,6 +63,7 @@ export const DataSourceSelect = () => {
       loading={loading}
       options={indexPatterns.map(toSearchableDropdownOption)}
       equality={indexPatternEquality}
+      footer={hasAnalyticEngine ? optimizedEngineNote : undefined}
     />
   );
 };

--- a/src/plugins/vis_builder/public/application/components/searchable_dropdown.tsx
+++ b/src/plugins/vis_builder/public/application/components/searchable_dropdown.tsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect } from 'react';
+import { ReactNode, useState, useEffect } from 'react';
 import {
   EuiLoadingSpinner,
   EuiFormControlLayout,
   EuiPopoverTitle,
+  EuiPopoverFooter,
   EuiButtonEmpty,
   EuiPopover,
   EuiSelectable,
@@ -30,6 +31,7 @@ interface SearchableDropdownProps {
   loading: boolean;
   error?: Error;
   prepend: string;
+  footer?: ReactNode;
   // not just the first time!
   onOpen?: () => void;
   // @ts-expect-error TS7006 TODO(ts-error): fixme
@@ -51,6 +53,7 @@ export const SearchableDropdown = ({
   loading,
   prepend,
   onOpen,
+  footer,
 }: SearchableDropdownProps) => {
   const [localOptions, setLocalOptions] = useState<any[] | undefined>(undefined);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -176,7 +179,10 @@ export const SearchableDropdown = ({
   return (
     <div className="searchableDropdown">
       <EuiPopover button={formControl} isOpen={isPopoverOpen} closePopover={closePopover}>
-        <div className="searchableDropdown--fixedWidthChild">{selectable}</div>
+        <div className="searchableDropdown--fixedWidthChild">
+          {selectable}
+          {footer && <EuiPopoverFooter>{footer}</EuiPopoverFooter>}
+        </div>
       </EuiPopover>
     </div>
   );

--- a/src/plugins/vis_builder/public/application/utils/use/use_index_pattern.tsx
+++ b/src/plugins/vis_builder/public/application/utils/use/use_index_pattern.tsx
@@ -14,6 +14,7 @@ export const useIndexPatterns = () => {
   const [indexPatterns, setIndexPatterns] = useState<IndexPattern[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | undefined>(undefined);
+  const [hasAnalyticEngine, setHasAnalyticEngine] = useState<boolean>(false);
   const {
     services: { data, savedObjects },
   } = useOpenSearchDashboards<VisBuilderServices>();
@@ -22,8 +23,10 @@ export const useIndexPatterns = () => {
   if (!loading && !error && indexId) {
     foundSelected = indexPatterns.filter((p) => p.id === indexId)[0];
     // If the selected index pattern was filtered out (e.g., it's an AnalyticEngine data source),
-    // don't treat it as an error - it will be handled by selecting the first available pattern
-    if (foundSelected === undefined && indexPatterns.length === 0) {
+    // don't treat it as an error - it will be handled by selecting the first available pattern.
+    // When the list is empty *because* the only sources are Optimized engine (AnalyticEngine),
+    // skip the generic error so the dropdown can show a tailored empty-state message instead.
+    if (foundSelected === undefined && indexPatterns.length === 0 && !hasAnalyticEngine) {
       setError(new Error('No index patterns available'));
     }
   }
@@ -41,6 +44,7 @@ export const useIndexPatterns = () => {
 
         const indexPatternIds = new Set(indexPatternList.map((item) => item.id));
         setIndexPatterns(patterns.filter((i) => indexPatternIds.has(i.id)));
+        setHasAnalyticEngine(patterns.length > indexPatternIds.size);
       } catch (e) {
         setError(e as Error);
       } finally {
@@ -56,5 +60,6 @@ export const useIndexPatterns = () => {
     error,
     loading,
     selected: foundSelected,
+    hasAnalyticEngine,
   };
 };

--- a/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
@@ -30,7 +30,7 @@
 
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { useContext } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import {
   htmlIdGenerator,
   EuiCompressedFieldText,
@@ -140,6 +140,18 @@ export const IndexPattern = ({ fields, prefix, onChange, disabled, model: _model
     ? getDataSourceManagementSetup().dataSourceManagement.ui.DataSourceSelector
     : undefined;
 
+  const [hasAnalyticEngine, setHasAnalyticEngine] = useState(false);
+  const dataSourceFilter = useMemo(() => {
+    const baseFilter = createDataSourceFilterForAnalyticEngine();
+    return (dataSource) => {
+      const allowed = baseFilter(dataSource);
+      if (!allowed) {
+        setHasAnalyticEngine(true);
+      }
+      return allowed;
+    };
+  }, []);
+
   const isDefaultIndexPatternUsed = model.default_index_pattern && !model[indexPatternName];
   const intervalValidation = validateIntervalValue(model[intervalName]);
   const selectedTimeRangeOption = timeRangeOptions.find(
@@ -193,6 +205,14 @@ export const IndexPattern = ({ fields, prefix, onChange, disabled, model: _model
               label={i18n.translate('visTypeTimeseries.indexPattern.dataSourceLabel', {
                 defaultMessage: 'Data source',
               })}
+              helpText={
+                hasAnalyticEngine
+                  ? i18n.translate('visTypeTimeseries.indexPattern.optimizedEngineNotSupported', {
+                      defaultMessage:
+                        "TSVB supports only DSL queries. Optimized engine (AnalyticEngine type) data sources aren't supported and don't appear in this selector.",
+                    })
+                  : undefined
+              }
             >
               <DataSourceSelector
                 savedObjectsClient={getSavedObjectsClient().client}
@@ -206,7 +226,7 @@ export const IndexPattern = ({ fields, prefix, onChange, disabled, model: _model
                 compressed={true}
                 removePrepend={true}
                 isClearable={false}
-                dataSourceFilter={createDataSourceFilterForAnalyticEngine()}
+                dataSourceFilter={dataSourceFilter}
               />
             </EuiCompressedFormRow>
           </EuiFlexItem>

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -28,7 +28,13 @@
  * under the License.
  */
 
-import { EuiModalBody, EuiModalHeader, EuiModalHeaderTitle } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+} from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import React from 'react';
@@ -50,6 +56,7 @@ interface SearchSelectionProps {
 
 interface SearchSelectionState {
   indexPatternIds: Set<string>;
+  hasAnalyticEngine: boolean;
 }
 
 export class SearchSelection extends React.Component<SearchSelectionProps, SearchSelectionState> {
@@ -59,16 +66,21 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
     super(props);
     this.state = {
       indexPatternIds: new Set(),
+      hasAnalyticEngine: false,
     };
   }
 
   async componentDidMount() {
-    const indexPatternList = await this.props.data.indexPatterns.getCache({
-      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-    });
+    const [allIndexPatterns, indexPatternList] = await Promise.all([
+      this.props.data.indexPatterns.getCache(),
+      this.props.data.indexPatterns.getCache({
+        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+      }),
+    ]);
 
     this.setState({
       indexPatternIds: new Set(indexPatternList?.map((indexpattern) => indexpattern.id)),
+      hasAnalyticEngine: (allIndexPatterns?.length ?? 0) > (indexPatternList?.length ?? 0),
     });
   }
 
@@ -90,6 +102,22 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>
+          {this.state.hasAnalyticEngine && (
+            <>
+              <EuiCallOut
+                size="s"
+                iconType="iInCircle"
+                title={i18n.translate(
+                  'visualizations.newVisWizard.searchSelection.optimizedEngineNotSupported',
+                  {
+                    defaultMessage:
+                      "This visualization type supports only DSL queries. Index patterns and saved searches backed by Optimized engine (AnalyticEngine type) data sources aren't supported and are hidden from the list below.",
+                  }
+                )}
+              />
+              <EuiSpacer size="s" />
+            </>
+          )}
           <SavedObjectFinderUi
             key="searchSavedObjectFinder"
             onChoose={this.props.onSearchSelected}

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -71,12 +71,10 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
   }
 
   async componentDidMount() {
-    const [allIndexPatterns, indexPatternList] = await Promise.all([
-      this.props.data.indexPatterns.getCache(),
-      this.props.data.indexPatterns.getCache({
-        excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
-      }),
-    ]);
+    const allIndexPatterns = await this.props.data.indexPatterns.getCache();
+    const indexPatternList = await this.props.data.indexPatterns.getCache({
+      excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+    });
 
     this.setState({
       indexPatternIds: new Set(indexPatternList?.map((indexpattern) => indexpattern.id)),


### PR DESCRIPTION
### Description

Legacy visualization types (Visualize/aggregation-based, TSVB, Controls, and VisBuilder) only support DSL queries. Index patterns and data sources backed by **Optimized engine (AnalyticEngine type)** data sources are therefore filtered out of their data source / index pattern selectors. Today this filtering is silent — users with only Optimized engine sources see an empty or shortened list with no explanation, which looks like a bug.

This PR surfaces a short, contextual note wherever such sources are hidden, telling the user *why* they don't appear. The note is shown **only when Optimized engine sources actually exist and were hidden**, so users without any such sources see no change.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
