### PR TITLE
[Explore vis]fix: persist style panel mounted

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/component/visualization_editor_right_container.test.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/visualization_editor_right_container.test.tsx
@@ -67,11 +67,12 @@ describe('RightStyleOptionsPanel', () => {
     expect(screen.getByText('Visualize')).toBeInTheDocument();
   });
 
-  it('renders loading spinner when LOADING', () => {
+  it('renders loading spinner when LOADING but keeps style panel mounted (hidden)', () => {
     (useQueryBuilderState as jest.Mock).mockReturnValue(buildState(QueryExecutionStatus.LOADING));
     render(<RightStyleOptionsPanel />);
     expect(screen.getByTestId('loadingSpinner')).toBeInTheDocument();
-    expect(mockRenderStylePanel).not.toHaveBeenCalled();
+    expect(mockRenderStylePanel).toHaveBeenCalledWith({ className: 'visStylePanelBody' });
+    expect(screen.getByTestId('style-panel')).toBeInTheDocument();
   });
 
   it('renders style panel when READY', () => {

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/visualization_editor_right_container.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/visualization_editor_right_container.tsx
@@ -20,13 +20,7 @@ export const RightStyleOptionsPanel = React.memo(() => {
     queryStatus.status === QueryExecutionStatus.UNINITIALIZED ||
     queryStatus.status === QueryExecutionStatus.NO_RESULTS;
 
-  // Unmount the style panel to ensure outdated component state doesn't override current styles
-  if (queryStatus.status === QueryExecutionStatus.LOADING)
-    return (
-      <EuiPanel paddingSize="s" style={{ height: '100%' }} borderRadius="none" hasShadow={false}>
-        <StylePanelLoadingState />
-      </EuiPanel>
-    );
+  const isLoading = queryStatus.status === QueryExecutionStatus.LOADING;
 
   if (displayEmptyState) {
     return (
@@ -41,6 +35,9 @@ export const RightStyleOptionsPanel = React.memo(() => {
       </EuiPanel>
     );
   }
+
+  // keep the style panel mounted while loading and just hide it, so its component
+  // state (for example: including accordion open/closed state) is preserved across an Update.
   return (
     <EuiPanel
       paddingSize="s"
@@ -48,7 +45,10 @@ export const RightStyleOptionsPanel = React.memo(() => {
       borderRadius="none"
       hasShadow={false}
     >
-      {visualizationBuilder.renderStylePanel({ className: 'visStylePanelBody' })}
+      {isLoading && <StylePanelLoadingState />}
+      <div style={{ display: isLoading ? 'none' : 'block' }}>
+        {visualizationBuilder.renderStylePanel({ className: 'visStylePanelBody' })}
+      </div>
     </EuiPanel>
   );
 });

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.test.tsx
@@ -41,12 +41,16 @@ describe('AxesSelectPanel', () => {
       name: 'count',
       schema: VisFieldType.Numerical,
       column: 'count',
+      validValuesCount: 100,
+      uniqueValuesCount: 50,
     },
     {
       id: 2,
       name: 'price',
       schema: VisFieldType.Numerical,
       column: 'price',
+      validValuesCount: 100,
+      uniqueValuesCount: 60,
     },
   ];
 
@@ -56,6 +60,8 @@ describe('AxesSelectPanel', () => {
       name: 'category',
       schema: VisFieldType.Categorical,
       column: 'category',
+      validValuesCount: 100,
+      uniqueValuesCount: 10,
     },
   ];
 
@@ -65,6 +71,8 @@ describe('AxesSelectPanel', () => {
       name: 'timestamp',
       schema: VisFieldType.Date,
       column: 'timestamp',
+      validValuesCount: 100,
+      uniqueValuesCount: 80,
     },
   ];
 
@@ -129,7 +137,12 @@ describe('AxesSelectPanel', () => {
     expect(screen.getByText('Y-Axis')).toBeInTheDocument();
   });
 
-  it('calls updateVisualization when valid selection is made', () => {
+  it('does not call updateVisualization on initial render with existing mapping', () => {
+    mockVisualizationRegistry.findRuleByAxesMapping.mockReturnValue({
+      id: 'rule1',
+      matchIndex: [1, 1, 0],
+    });
+
     const propsWithMapping = {
       ...defaultProps,
       currentMapping: {
@@ -137,14 +150,9 @@ describe('AxesSelectPanel', () => {
         [AxisRole.Y]: [mockNumericalColumns[0]],
       },
     };
-    mockVisualizationRegistry.findRuleByAxesMapping.mockReturnValue({
-      id: 'rule1',
-      matchIndex: [1, 1, 0],
-    });
-
     render(<AxesSelectPanel {...propsWithMapping} />);
 
-    expect(mockUpdateVisualization).toHaveBeenCalled();
+    expect(mockUpdateVisualization).not.toHaveBeenCalled();
   });
 
   it('initializes with current mapping', () => {
@@ -164,25 +172,6 @@ describe('AxesSelectPanel', () => {
 
     expect(screen.getByText('X-Axis')).toBeInTheDocument();
     expect(screen.getByText('Y-Axis')).toBeInTheDocument();
-  });
-
-  it('updates available axis options when selection changes', () => {
-    mockVisualizationRegistry.findRuleByAxesMapping.mockReturnValue({
-      id: 'rule1',
-      matchIndex: [1, 1, 0],
-    });
-
-    const propsWithMapping = {
-      ...defaultProps,
-      currentMapping: {
-        [AxisRole.X]: [mockCategoricalColumns[0]],
-        [AxisRole.Y]: [mockNumericalColumns[0]],
-      },
-    };
-
-    render(<AxesSelectPanel {...propsWithMapping} />);
-
-    expect(mockUpdateVisualization).toHaveBeenCalled();
   });
 
   it('handles multiple axis roles correctly', () => {
@@ -220,6 +209,45 @@ describe('AxesSelectPanel', () => {
 
     const placeholders = screen.getAllByText('Select a field');
     expect(placeholders.length).toBeGreaterThan(0);
+  });
+
+  describe('user interaction', () => {
+    beforeEach(() => {
+      mockVisualizationRegistry.findRuleByAxesMapping.mockReturnValue({ id: 'rule1' });
+    });
+
+    it('opens popover when selector button is clicked', () => {
+      render(
+        <AxesSelectPanel
+          {...defaultProps}
+          currentMapping={{
+            [AxisRole.X]: [mockCategoricalColumns[0]],
+          }}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: 'category' });
+      fireEvent.click(button);
+
+      expect(screen.getByPlaceholderText('Filter list')).toBeInTheDocument();
+    });
+
+    it('calls updateVisualization when user removes a field', () => {
+      render(
+        <AxesSelectPanel
+          {...defaultProps}
+          currentMapping={{
+            [AxisRole.X]: [mockCategoricalColumns[0]],
+            [AxisRole.Y]: [mockNumericalColumns[0]],
+          }}
+        />
+      );
+
+      const removeButton = screen.getAllByLabelText('Remove field')[0];
+      fireEvent.click(removeButton);
+
+      expect(mockUpdateVisualization).toHaveBeenCalled();
+    });
   });
 
   describe('multi axis support', () => {

--- a/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/axes/axes_selector.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useRef, useEffect, useMemo, useState } from 'react';
 import { EuiSpacer, EuiFormRow, EuiSelectableOption } from '@elastic/eui';
 import { isEqual } from 'lodash';
 import { i18n } from '@osd/i18n';
@@ -123,38 +123,28 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
     Object.keys(mapping).forEach((role) => allAxisRolesFromSelection.add(role as AxisRole));
   });
 
-  useEffect(() => {
-    // Current selected axis mapping
-    const normalizedAxesSelections: AxisColumnMappings = {};
-    Object.entries(currentSelections).forEach(([key, value]) => {
-      if (value && value.length > 0) {
-        normalizedAxesSelections[key as AxisRole] = value;
-      }
-    });
-    const ruleToUse = visualizationRegistry.findRuleByAxesMapping(
-      chartTypeRef.current,
-      convertMappingsToStrings(normalizedAxesSelections),
-      [...numericalColumns, ...categoricalColumns, ...dateColumns]
-    );
+  const handleSelectionChange = useCallback(
+    (newSelections: AxisColumnMappings) => {
+      setCurrentSelections(newSelections);
 
-    // If rule can be found, update visualization with the new axes mapping
-    // Limitation: the current implementation will only call updateVisualization() when the select
-    // mapping is valid and has rule mapped, which means partial selections won't trigger visualization
-    // updates until they form a complete valid mapping configuration.
-    // From the user's perspective, this means no visual feedback is provided during the selection
-    // process until a complete valid configuration is achieved, potentially leading to confusion
-    // about whether their partial selections are having any effect.
-    if (ruleToUse) {
-      updateVisualization({ mappings: convertMappingsToStrings(normalizedAxesSelections) });
-    }
-  }, [
-    updateVisualization,
-    currentSelections,
-    visualizationRegistry,
-    numericalColumns,
-    categoricalColumns,
-    dateColumns,
-  ]);
+      const normalized: AxisColumnMappings = {};
+      Object.entries(newSelections).forEach(([key, value]) => {
+        if (value && value.length > 0) {
+          normalized[key as AxisRole] = value;
+        }
+      });
+
+      const ruleToUse = visualizationRegistry.findRuleByAxesMapping(
+        chartTypeRef.current,
+        convertMappingsToStrings(normalized),
+        [...numericalColumns, ...categoricalColumns, ...dateColumns]
+      );
+      if (ruleToUse) {
+        updateVisualization({ mappings: convertMappingsToStrings(normalized) });
+      }
+    },
+    [visualizationRegistry, numericalColumns, categoricalColumns, dateColumns, updateVisualization]
+  );
 
   const findColumns = useMemo(
     () => (type: VisFieldType) => {
@@ -249,13 +239,11 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
                         value={col.name}
                         options={getAxisOptions(axisRole)}
                         onRemove={() => {
-                          setCurrentSelections((prev) => {
-                            const updated = [...(prev[axisRole] ?? [])];
-                            updated.splice(index, 1);
-                            return {
-                              ...prev,
-                              [axisRole]: updated.length > 0 ? updated : undefined,
-                            };
+                          const updated = [...(currentSelections[axisRole] ?? [])];
+                          updated.splice(index, 1);
+                          handleSelectionChange({
+                            ...currentSelections,
+                            [axisRole]: updated.length > 0 ? updated : undefined,
                           });
                         }}
                         onChange={(_role, v) => {
@@ -266,10 +254,11 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
                           ];
                           const selectedCol = allColumns.find((c) => c.name === v);
                           if (selectedCol) {
-                            setCurrentSelections((prev) => {
-                              const updated = [...(prev[axisRole] ?? [])];
-                              updated[index] = selectedCol;
-                              return { ...prev, [axisRole]: updated };
+                            const updated = [...(currentSelections[axisRole] ?? [])];
+                            updated[index] = selectedCol;
+                            handleSelectionChange({
+                              ...currentSelections,
+                              [axisRole]: updated,
                             });
                           }
                         }}
@@ -295,10 +284,10 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
                       ];
                       const selectedCol = allColumns.find((c) => c.name === v);
                       if (selectedCol) {
-                        setCurrentSelections((prev) => ({
-                          ...prev,
-                          [axisRole]: [...(prev[axisRole] ?? []), selectedCol],
-                        }));
+                        handleSelectionChange({
+                          ...currentSelections,
+                          [axisRole]: [...(currentSelections[axisRole] ?? []), selectedCol],
+                        });
                       }
                     }}
                   />
@@ -316,18 +305,18 @@ export const AxesSelectPanel: React.FC<AxesSelectPanelProps> = ({
                   value={currentSelection[0]?.name || ''}
                   options={getAxisOptions(axisRole)}
                   onRemove={(role) => {
-                    setCurrentSelections((prev) => ({
-                      ...prev,
+                    handleSelectionChange({
+                      ...currentSelections,
                       [role]: undefined,
-                    }));
+                    });
                   }}
                   onChange={(role, v) => {
                     const allColumns = [...numericalColumns, ...categoricalColumns, ...dateColumns];
                     const selectedCol = allColumns.find((col) => col.name === v);
-                    setCurrentSelections((prev) => ({
-                      ...prev,
+                    handleSelectionChange({
+                      ...currentSelections,
                       [role]: selectedCol ? [selectedCol] : undefined,
-                    }));
+                    });
                   }}
                 />
               </EuiFormRow>


### PR DESCRIPTION
### Description

keep the style panel mounted while loading and just hide it, so its component state (for example: including accordion open/closed state) is preserved across an Update

## Screenshot

https://github.com/user-attachments/assets/fb8270f9-a06c-42eb-8e3f-e664ae343694


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
