### PR TITLE
fix: integrate with dynamic config service for maximum workspaces

### DIFF
--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -170,13 +170,6 @@ export const MAX_WORKSPACE_DESCRIPTION_LENGTH = 200;
  */
 export const DEFAULT_WORKSPACE_LIST_PER_PAGE = 999;
 
-/**
- * The page size used when listing workspaces solely to validate that the requested
- * ones exist. A large fixed value is enough here, so this path does not need to read
- * `workspace.maximum_workspaces`.
- */
-export const WORKSPACE_EXISTENCE_CHECK_PER_PAGE = 9999;
-
 export enum AssociationDataSourceModalMode {
   OpenSearchConnections = 'opensearch-connections',
   DirectQueryConnections = 'direction-query-connections',

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -164,11 +164,31 @@ export const CURRENT_USER_PLACEHOLDER = '%me%';
 export const MAX_WORKSPACE_NAME_LENGTH = 40;
 export const MAX_WORKSPACE_DESCRIPTION_LENGTH = 200;
 
+/**
+ * The page size used to fetch the full workspace list when
+ * `workspace.maximum_workspaces` is not configured.
+ */
+export const DEFAULT_WORKSPACE_LIST_PER_PAGE = 999;
+
+/**
+ * The page size used when listing workspaces solely to validate that the requested
+ * ones exist. A large fixed value is enough here, so this path does not need to read
+ * `workspace.maximum_workspaces`.
+ */
+export const WORKSPACE_EXISTENCE_CHECK_PER_PAGE = 9999;
+
 export enum AssociationDataSourceModalMode {
   OpenSearchConnections = 'opensearch-connections',
   DirectQueryConnections = 'direction-query-connections',
 }
 export const OPENSEARCHDASHBOARDS_CONFIG_PATH = 'opensearchDashboards';
+
+/**
+ * The namespace the workspace plugin config is stored under in the dynamic config
+ * service. It matches the plugin id, which is how the config path is derived when a
+ * plugin manifest does not declare an explicit `configPath`.
+ */
+export const WORKSPACE_PLUGIN_CONFIG_PATH = 'workspace';
 
 // Workspace will handle both data source and data connection type saved object.
 export const WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES = [

--- a/src/plugins/workspace/config.ts
+++ b/src/plugins/workspace/config.ts
@@ -12,3 +12,9 @@ export const configSchema = schema.object({
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;
+
+/**
+ * The subset of the workspace config which is exposed to the browser,
+ * see `exposeToBrowser` in `server/index.ts`.
+ */
+export type WorkspacePublicConfig = Pick<ConfigSchema, 'maximum_workspaces'>;

--- a/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
+++ b/src/plugins/workspace/public/components/workspace_picker_content/workspace_picker_content.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { i18n } from '@osd/i18n';
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { useObservable } from 'react-use';
 import moment from 'moment';
 import {
@@ -36,8 +36,28 @@ const getValidWorkspaceColor = (color?: string) =>
 
 interface UpdatedWorkspaceObject extends WorkspaceObject {
   accessTimeStamp?: number;
-  accessTimeDescription?: string;
 }
+
+/**
+ * The "Viewed 2 hours ago" / "Not visited recently" label for a row.
+ *
+ * Derived at render time rather than precomputed for the whole list:
+ * `moment().fromNow()` is comparatively expensive and only the handful of
+ * recently-visited workspaces (the recent log is capped at 10) produce a real
+ * timestamp, so precomputing it for every workspace cost one moment call per
+ * workspace on every `workspaceList$` emission.
+ */
+const getAccessTimeDescription = (accessTimeStamp?: number) =>
+  accessTimeStamp
+    ? i18n.translate('workspace.picker.accessTime.description', {
+        defaultMessage: 'Viewed {timeLabel}',
+        values: {
+          timeLabel: moment(accessTimeStamp).fromNow(),
+        },
+      })
+    : i18n.translate('workspace.picker.accessTime.not.visited', {
+        defaultMessage: 'Not visited recently',
+      });
 interface Props {
   coreStart: CoreStart;
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
@@ -73,23 +93,13 @@ export const WorkspacePickerContent = ({
 
   const updatedRecentWorkspaceList: UpdatedWorkspaceObject[] = useMemo(() => {
     const recentWorkspaces = recentWorkspaceManager.getRecentWorkspaces();
-    const updatedList = workspaceList.map((workspace) => {
-      const recentWorkspace = recentWorkspaces.find((recent) => recent.id === workspace.id);
-      return {
-        ...workspace,
-        accessTimeStamp: recentWorkspace?.timestamp,
-        accessTimeDescription: recentWorkspace
-          ? i18n.translate('workspace.picker.accessTime.description', {
-              defaultMessage: 'Viewed {timeLabel}',
-              values: {
-                timeLabel: moment(recentWorkspace.timestamp).fromNow(),
-              },
-            })
-          : i18n.translate('workspace.picker.accessTime.not.visited', {
-              defaultMessage: 'Not visited recently',
-            }),
-      };
-    });
+    // Index the recent entries by id: the previous `find` per workspace made this
+    // O(workspaces x recents), which is needless work on large workspace lists.
+    const timestampById = new Map(recentWorkspaces.map((recent) => [recent.id, recent.timestamp]));
+    const updatedList = workspaceList.map((workspace) => ({
+      ...workspace,
+      accessTimeStamp: timestampById.get(workspace.id),
+    }));
 
     return updatedList.sort(sortByRecentVisitedAndAlphabetical);
   }, [workspaceList]);
@@ -161,13 +171,17 @@ export const WorkspacePickerContent = ({
         coreStart.http
       );
 
+      const accessTimeDescription = getAccessTimeDescription(workspace.accessTimeStamp);
+
       return (
-        <>
+        // The key belongs on the outermost element returned into the array — it
+        // was previously set on the inner list item, leaving every array child
+        // unkeyed and forcing React into positional reconciliation.
+        <Fragment key={workspace.id}>
           <EuiHorizontalRule size="full" margin="none" />
           <EuiListGroupItem
             // using inline style to make sure that the list item will be expanded，className="eui-fullWidth" is not working, need to set minWidth
             style={{ width: '100%', minWidth: '0' }}
-            key={workspace.id}
             size="s"
             data-test-subj={`workspace-menu-item-${workspace.id}`}
             icon={
@@ -194,7 +208,7 @@ export const WorkspacePickerContent = ({
                       </EuiFlexItem>
                       <EuiFlexItem grow={1} style={{ position: 'absolute', right: '0px' }}>
                         <EuiText size="s" color="subdued">
-                          <small> {workspace.accessTimeDescription}</small>
+                          <small> {accessTimeDescription}</small>
                         </EuiText>
                       </EuiFlexItem>
                     </EuiFlexGroup>
@@ -219,7 +233,7 @@ export const WorkspacePickerContent = ({
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiText size="s" color="subdued">
-                      <small> {workspace.accessTimeDescription}</small>
+                      <small> {accessTimeDescription}</small>
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -230,7 +244,7 @@ export const WorkspacePickerContent = ({
               window.location.assign(useCaseURL);
             }}
           />
-        </>
+        </Fragment>
       );
     });
     return listItems;

--- a/src/plugins/workspace/public/index.ts
+++ b/src/plugins/workspace/public/index.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PluginInitializerContext } from 'opensearch-dashboards/public';
+import { WorkspacePublicConfig } from '../config';
 import { WorkspacePlugin } from './plugin';
 
-export function plugin() {
-  return new WorkspacePlugin();
+export function plugin(initializerContext: PluginInitializerContext<WorkspacePublicConfig>) {
+  return new WorkspacePlugin(initializerContext);
 }
 
 export { WorkspacePluginSetup, WorkspaceCollaborator } from './types';

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -14,6 +14,7 @@ import {
   WorkspaceAvailability,
   AppStatus,
   WorkspaceError,
+  PluginInitializerContext,
 } from 'opensearch-dashboards/public';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_DETAIL_APP_ID } from '../common/constants';
 import { savedObjectsManagementPluginMock } from '../../saved_objects_management/public/mocks';
@@ -26,6 +27,7 @@ import { navigationPluginMock } from '../../navigation/public/mocks';
 import * as registerDefaultCollaboratorTypesExports from './register_default_collaborator_types';
 import { AddCollaboratorsModal } from './components/add_collaborators_modal';
 import { dataPluginMock } from '../../data/public/mocks';
+import { WorkspacePublicConfig } from '../config';
 
 // Expect 6 app registrations: create, fatal error, detail, initial, navigation, collaborator and list apps.
 const registrationAppNumber = 7;
@@ -37,6 +39,16 @@ describe('Workspace plugin', () => {
     data: dataPluginMock.createStartContract(),
   });
   const getSetupMock = () => coreMock.createSetup();
+  const getInitializerContextMock = (
+    maximumWorkspaces?: number
+  ): PluginInitializerContext<WorkspacePublicConfig> => ({
+    ...coreMock.createPluginInitializerContext(),
+    config: {
+      // `get` is generic, so the value has to be cast the same way the core mock does.
+      get: <T extends object = WorkspacePublicConfig>() =>
+        ({ maximum_workspaces: maximumWorkspaces }) as T,
+    },
+  });
 
   beforeEach(() => {
     WorkspaceClientMock.mockClear();
@@ -46,7 +58,7 @@ describe('Workspace plugin', () => {
   it('#setup', async () => {
     const setupMock = getSetupMock();
     const savedObjectManagementSetupMock = savedObjectsManagementPluginMock.createSetupContract();
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {
       savedObjectsManagement: savedObjectManagementSetupMock,
       management: managementPluginMock.createSetupContract(),
@@ -57,7 +69,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#call savedObjectsClient.setCurrentWorkspace when current workspace id changed', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -72,7 +84,7 @@ describe('Workspace plugin', () => {
   it('#setup should register workspace list with a visible application and register to settingsAndSetup nav group', async () => {
     const setupMock = coreMock.createSetup();
     setupMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {});
 
     expect(setupMock.application.register).toHaveBeenCalledWith(
@@ -97,7 +109,7 @@ describe('Workspace plugin', () => {
   it('#setup should register workspace detail with a hidden application and not register to all nav group', async () => {
     const setupMock = coreMock.createSetup();
     setupMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {});
 
     expect(setupMock.application.register).toHaveBeenCalledWith(
@@ -121,7 +133,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should register workspace initial with a visible application', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {});
 
     expect(setupMock.application.register).toHaveBeenCalledWith(
@@ -144,7 +156,7 @@ describe('Workspace plugin', () => {
     setupMock.chrome.registerCollapsibleNavHeader.mockImplementation(
       (func) => (collapsibleNavHeaderImplementation = func)
     );
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {});
     expect(collapsibleNavHeaderImplementation()).toEqual(null);
     const startMock = coreMock.createStart();
@@ -164,7 +176,7 @@ describe('Workspace plugin', () => {
         },
       },
     };
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {
       contentManagement: {
         registerPage: jest.fn(),
@@ -194,7 +206,7 @@ describe('Workspace plugin', () => {
         },
       },
     };
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {
       contentManagement: {
         registerPage: jest.fn(),
@@ -219,7 +231,7 @@ describe('Workspace plugin', () => {
         },
       },
     };
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {
       contentManagement: {
         registerPage: jest.fn(),
@@ -229,7 +241,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should register workspace navigation with a visible application', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(setupMock, {});
     expect(setupMock.application.register).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -245,7 +257,7 @@ describe('Workspace plugin', () => {
       .spyOn(registerDefaultCollaboratorTypesExports, 'registerDefaultCollaboratorTypes')
       .mockImplementationOnce(registerDefaultCollaboratorTypesMock);
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     expect(registerDefaultCollaboratorTypesMock).not.toHaveBeenCalled();
     await workspacePlugin.setup(setupMock, {});
     expect(registerDefaultCollaboratorTypesMock).toHaveBeenCalled();
@@ -253,7 +265,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should return WorkspaceCollaboratorTypesService', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const result = await workspacePlugin.setup(setupMock, {});
 
     expect(result.collaboratorTypes).toBeInstanceOf(WorkspaceCollaboratorTypesService);
@@ -261,7 +273,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should return getAddCollaboratorsModal method', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const result = await workspacePlugin.setup(setupMock, {});
 
     expect(result.ui.AddCollaboratorsModal).toBe(AddCollaboratorsModal);
@@ -272,7 +284,7 @@ describe('Workspace plugin', () => {
 
     const setupMock = coreMock.createSetup();
 
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
 
     await workspacePlugin.setup(setupMock, {});
 
@@ -302,7 +314,7 @@ describe('Workspace plugin', () => {
       result: null,
     });
 
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     await workspacePlugin.setup(getSetupMock(), {});
 
     expect(WorkspaceClientMock).toHaveBeenCalledTimes(1);
@@ -322,7 +334,7 @@ describe('Workspace plugin', () => {
   it('#start when workspace id is in url and enterWorkspace return error', async () => {
     window.history.pushState({}, '', '/w/workspaceId/app');
 
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
 
     await workspacePlugin.setup(getSetupMock(), {});
 
@@ -356,7 +368,7 @@ describe('Workspace plugin', () => {
     startMock.workspaces.currentWorkspace$.next(workspaceObject);
     const breadcrumbs = new BehaviorSubject<ChromeBreadcrumb[]>([{ text: 'dashboards' }]);
     startMock.chrome.getBreadcrumbs$.mockReturnValue(breadcrumbs);
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     workspacePlugin.start(startMock, getMockDependencies());
     expect(startMock.chrome.setBreadcrumbs).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -382,7 +394,7 @@ describe('Workspace plugin', () => {
       { text: 'bar' },
     ]);
     startMock.chrome.getBreadcrumbs$.mockReturnValue(breadcrumbs);
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     workspacePlugin.start(startMock, getMockDependencies());
     expect(startMock.chrome.setBreadcrumbs).not.toHaveBeenCalled();
   });
@@ -390,7 +402,7 @@ describe('Workspace plugin', () => {
   it('#start should register workspace list card into new home page', async () => {
     const startMock = coreMock.createStart();
     startMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const mockDependencies = getMockDependencies();
     workspacePlugin.start(startMock, mockDependencies);
     expect(mockDependencies.contentManagement.registerContentProvider).toHaveBeenCalledWith(
@@ -401,7 +413,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should call navGroupUpdater$.next after currentWorkspace set', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -425,7 +437,7 @@ describe('Workspace plugin', () => {
   it('#start register workspace dropdown menu at left navigation bottom when start', async () => {
     const coreStart = coreMock.createStart();
     coreStart.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     workspacePlugin.start(coreStart, getMockDependencies());
 
     expect(coreStart.chrome.navControls.registerLeftBottom).toHaveBeenCalledTimes(1);
@@ -444,7 +456,7 @@ describe('Workspace plugin', () => {
     jest.spyOn(UseCaseService.prototype, 'start').mockImplementationOnce(() => ({
       getRegisteredUseCases$: jest.fn(() => registeredUseCases$),
     }));
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -465,7 +477,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should update nav group status after currentWorkspace set', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -489,7 +501,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should not be able to access app of which workspaceAvailability is set to insideWorkspace when out of workspace', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -516,7 +528,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should remove non-workspace chrome page search service', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -529,7 +541,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should update collaboratorsAppUpdater correctly if permission enabled', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -570,7 +582,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should update collaboratorsAppUpdater correctly if permission disabled', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -611,7 +623,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#stop should call unregisterNavGroupUpdater', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const unregisterNavGroupUpdater = jest.fn();
     setupMock.chrome.navGroup.registerNavGroupUpdater.mockReturnValueOnce(
@@ -641,7 +653,7 @@ describe('Workspace plugin', () => {
     jest.spyOn(UseCaseService.prototype, 'start').mockImplementationOnce(() => ({
       getRegisteredUseCases$: jest.fn(() => registeredUseCases$),
     }));
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -670,7 +682,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#stop should call collaboratorTypesService.stop', async () => {
-    const workspacePlugin = new WorkspacePlugin();
+    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
     const setupMock = getSetupMock();
     const stopMock = jest.fn();
     jest

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_NAV_GROUPS,
   NavGroupType,
   ALL_USE_CASE_ID,
+  PluginInitializerContext,
 } from 'opensearch-dashboards/public';
 import { getWorkspaceIdFromUrl } from 'opensearch-dashboards/public/utils';
 import {
@@ -76,6 +77,7 @@ import { WorkspaceValidationService } from './services/workspace_validation_serv
 import { workspaceSearchPages } from './components/global_search/search_pages_command';
 import { isNavGroupInFeatureConfigs } from '../../../core/public';
 import { searchAssets } from './components/global_search/search_assets_command';
+import { WorkspacePublicConfig } from '../config';
 
 type WorkspaceAppType = (
   params: AppMountParameters,
@@ -117,6 +119,10 @@ export class WorkspacePlugin implements Plugin<
   private workspaceValidationService = new WorkspaceValidationService();
   private collaboratorTypes = new WorkspaceCollaboratorTypesService();
   private collaboratorsAppUpdater$ = new BehaviorSubject<AppUpdater>(() => undefined);
+
+  constructor(
+    private readonly initializerContext: PluginInitializerContext<WorkspacePublicConfig>
+  ) {}
 
   private _changeSavedObjectCurrentWorkspace() {
     if (this.coreStart) {
@@ -301,7 +307,9 @@ export class WorkspacePlugin implements Plugin<
       core.http.basePath.getBasePath()
     );
 
-    await this.workspaceValidationService.setup(core, workspaceId);
+    await this.workspaceValidationService.setup(core, workspaceId, {
+      maximumWorkspaces: this.initializerContext.config.get().maximum_workspaces,
+    });
 
     const mountWorkspaceApp = async (params: AppMountParameters, renderApp: WorkspaceAppType) => {
       const [coreStart, { navigation, data }] = await core.getStartServices();

--- a/src/plugins/workspace/public/services/workspace_validation.service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_validation.service.test.ts
@@ -47,6 +47,16 @@ describe('WorkspaceValidationService', () => {
       expect(workspaceClientMock.enterWorkspace).toHaveBeenCalledTimes(1);
     });
 
+    it('should pass the maximum workspaces option to the workspace client', async () => {
+      const core = coreMock.createSetup();
+      const service = new WorkspaceValidationService();
+      await service.setup(core, 'test-workspace-123', { maximumWorkspaces: 5000 });
+
+      expect(WorkspaceClientMock).toHaveBeenCalledWith(core.http, core.workspaces, {
+        maximumWorkspaces: 5000,
+      });
+    });
+
     it('should not enter workspace it workspace id is not set', async () => {
       const core = coreMock.createSetup();
       const service = new WorkspaceValidationService();

--- a/src/plugins/workspace/public/services/workspace_validation_service.ts
+++ b/src/plugins/workspace/public/services/workspace_validation_service.ts
@@ -44,10 +44,10 @@ export class WorkspaceValidationService {
     });
   }
 
-  async setup(core: CoreSetup, workspaceId: string) {
+  async setup(core: CoreSetup, workspaceId: string, options: { maximumWorkspaces?: number } = {}) {
     this.workspaceId = workspaceId;
 
-    const workspaceClient = new WorkspaceClient(core.http, core.workspaces);
+    const workspaceClient = new WorkspaceClient(core.http, core.workspaces, options);
     await workspaceClient.init();
     core.workspaces.setClient(workspaceClient);
     this.workspaceClient = workspaceClient;

--- a/src/plugins/workspace/public/workspace_client.test.ts
+++ b/src/plugins/workspace/public/workspace_client.test.ts
@@ -5,14 +5,15 @@
 
 import { httpServiceMock, workspacesServiceMock } from '../../../core/public/mocks';
 import { WorkspaceClient } from './workspace_client';
+import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../common/constants';
 
-const getWorkspaceClient = () => {
+const getWorkspaceClient = (options?: { maximumWorkspaces?: number }) => {
   const httpSetupMock = httpServiceMock.createSetupContract();
   const workspaceMock = workspacesServiceMock.createSetupContract();
   return {
     httpSetupMock,
     workspaceMock,
-    workspaceClient: new WorkspaceClient(httpSetupMock, workspaceMock),
+    workspaceClient: new WorkspaceClient(httpSetupMock, workspaceMock, options),
   };
 };
 
@@ -24,7 +25,36 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+      }),
+    });
+  });
+
+  it('#init uses the configured maximum_workspaces as the page size', async () => {
+    const { workspaceClient, httpSetupMock } = getWorkspaceClient({ maximumWorkspaces: 5000 });
+    httpSetupMock.fetch.mockResolvedValue({
+      success: true,
+      result: { workspaces: [] },
+    });
+    await workspaceClient.init();
+    expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
+      method: 'POST',
+      body: JSON.stringify({
+        perPage: 5000,
+      }),
+    });
+    expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
+      method: 'POST',
+      body: JSON.stringify({
+        perPage: 5000,
+        permissionModes: ['library_write'],
+      }),
+    });
+    expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
+      method: 'POST',
+      body: JSON.stringify({
+        perPage: 5000,
+        permissionModes: ['write'],
       }),
     });
   });
@@ -113,14 +143,14 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
 
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
         permissionModes: ['library_write'],
       }),
     });
@@ -142,7 +172,7 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
   });
@@ -156,12 +186,12 @@ describe('#WorkspaceClient', () => {
       },
     });
     await workspaceClient.list({
-      perPage: 999,
+      perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
     });
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
   });
@@ -212,14 +242,14 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
 
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
         permissionModes: ['library_write'],
       }),
     });
@@ -276,7 +306,7 @@ describe('#WorkspaceClient', () => {
             },
           ],
           total: 1,
-          per_page: 999,
+          per_page: DEFAULT_WORKSPACE_LIST_PER_PAGE,
           page: 1,
         },
       })
@@ -396,7 +426,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 2, fail: 0, failedIds: [] });
@@ -419,7 +449,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 1, fail: 1, failedIds: ['bar'] });
@@ -442,7 +472,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 0, fail: 2, failedIds: ['foo', 'bar'] });
@@ -455,7 +485,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 999,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 0, fail: 0, failedIds: [] });

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../core/public';
 import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
 import { DataSourceAssociation } from './components/data_source_association/data_source_association';
+import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../common/constants';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -38,10 +39,21 @@ export class WorkspaceClient implements IWorkspaceClient {
   private http: HttpSetup;
   private workspaces: WorkspacesSetup;
   private isPermissionEnabled: boolean = false;
+  /**
+   * The page size used when fetching the full workspace list. It honors
+   * `workspace.maximum_workspaces` so that every workspace a user is allowed to
+   * create can also be listed.
+   */
+  private listPerPage: number;
 
-  constructor(http: HttpSetup, workspaces: WorkspacesSetup) {
+  constructor(
+    http: HttpSetup,
+    workspaces: WorkspacesSetup,
+    options: { maximumWorkspaces?: number } = {}
+  ) {
     this.http = http;
     this.workspaces = workspaces;
+    this.listPerPage = options.maximumWorkspaces ?? DEFAULT_WORKSPACE_LIST_PER_PAGE;
   }
 
   public setPermissionEnabled(enabled: boolean) {
@@ -107,17 +119,17 @@ export class WorkspaceClient implements IWorkspaceClient {
    */
   private async updateWorkspaceList(): Promise<void> {
     const result = await this.list({
-      perPage: 999,
+      perPage: this.listPerPage,
     });
 
     if (result?.success) {
       const [resultWithWritePermission, resultWithOwnerPermission] = await Promise.all([
         this.list({
-          perPage: 999,
+          perPage: this.listPerPage,
           permissionModes: [WorkspacePermissionMode.LibraryWrite],
         }),
         this.list({
-          perPage: 999,
+          perPage: this.listPerPage,
           permissionModes: [WorkspacePermissionMode.Write],
         }),
       ]);

--- a/src/plugins/workspace/server/index.ts
+++ b/src/plugins/workspace/server/index.ts
@@ -15,6 +15,9 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export const config: PluginConfigDescriptor = {
+  exposeToBrowser: {
+    maximum_workspaces: true,
+  },
   schema: configSchema,
 };
 

--- a/src/plugins/workspace/server/plugin.test.ts
+++ b/src/plugins/workspace/server/plugin.test.ts
@@ -478,20 +478,70 @@ describe('Workspace server plugin', () => {
         success: true,
         result: {
           total: 2,
-          per_page: 100,
+          per_page: 1,
           page: 1,
-          workspaces: [
-            { id: 'defaultWorkspace', name: 'default-workspace' },
-            { id: 'workspace-2', name: 'workspace-2' },
-          ],
+          workspaces: [{ id: 'workspace-2', name: 'workspace-2' }],
         },
+      });
+      // The default workspace is resolved by id, so it is honored even though it is
+      // not part of the workspace list page fetched above.
+      jest.spyOn(client, 'get').mockResolvedValue({
+        success: true,
+        result: { id: 'defaultWorkspace', name: 'default-workspace' },
+      });
+      const toolKitMock = httpServerMock.createToolkit();
+
+      await registerOnPostAuthFn(request, response, toolKitMock);
+      expect(client.get).toHaveBeenCalledWith({ request }, 'defaultWorkspace');
+      expect(response.redirected).toHaveBeenCalledWith({
+        headers: {
+          location: '/mock-server-basepath/w/defaultWorkspace/app/workspace_navigation',
+        },
+      });
+    });
+
+    it('with / request path and an inaccessible default workspace', async () => {
+      const request = httpServerMock.createOpenSearchDashboardsRequest({
+        path: '/',
+      });
+      setupMock.getStartServices.mockResolvedValue([
+        {
+          ...coreMock.createStart(),
+          uiSettings: {
+            asScopedToClient: () => ({
+              ...uiSettingsMock,
+              get: jest.fn().mockImplementation((key) => {
+                if (key === 'defaultWorkspace') {
+                  return Promise.resolve('defaultWorkspace');
+                }
+              }),
+            }),
+          },
+        },
+        {},
+        {},
+      ]);
+      const workspaceSetup = await workspacePlugin.setup(setupMock, mockDeps);
+      const client = workspaceSetup.client;
+      jest.spyOn(client, 'list').mockResolvedValue({
+        success: true,
+        result: {
+          total: 2,
+          per_page: 1,
+          page: 1,
+          workspaces: [{ id: 'workspace-2', name: 'workspace-2' }],
+        },
+      });
+      jest.spyOn(client, 'get').mockResolvedValue({
+        success: false,
+        error: 'Not found',
       });
       const toolKitMock = httpServerMock.createToolkit();
 
       await registerOnPostAuthFn(request, response, toolKitMock);
       expect(response.redirected).toHaveBeenCalledWith({
         headers: {
-          location: '/mock-server-basepath/w/defaultWorkspace/app/workspace_navigation',
+          location: '/mock-server-basepath/app/home',
         },
       });
     });

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -63,6 +63,7 @@ import { uiSettings } from './ui_settings';
 import { RepositoryWrapper } from './saved_objects/repository_wrapper';
 import { DataSourcePluginSetup } from '../../data_source/server';
 import { ConfigSchema } from '../config';
+import { WorkspaceConfigService } from './services';
 
 export interface WorkspacePluginDependencies {
   dataSource: DataSourcePluginSetup;
@@ -77,6 +78,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
   private workspaceSavedObjectsClientWrapper?: WorkspaceSavedObjectsClientWrapper;
   private workspaceUiSettingsClientWrapper?: WorkspaceUiSettingsClientWrapper;
   private workspaceConfig$: Observable<ConfigSchema>;
+  private readonly configService: WorkspaceConfigService;
   private env: PluginInitializerContext['env'];
   private aclEnforceEndpointPatterns: string[] = [];
 
@@ -131,7 +133,8 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     });
 
     this.workspaceSavedObjectsClientWrapper = new WorkspaceSavedObjectsClientWrapper(
-      this.permissionControl
+      this.permissionControl,
+      this.configService
     );
 
     core.savedObjects.addClientWrapper(
@@ -191,32 +194,36 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
           return toolkit.next();
         }
 
-        const workspaceListResponse = await this.client?.list(
-          { request },
-          { page: 1, perPage: 100 }
-        );
+        // Only the total and, when there is exactly one workspace, its id are needed
+        // here. Fetching a single page keeps this independent of how many workspaces
+        // the user has, so the default workspace below is resolved by id rather than
+        // by searching within an arbitrarily sized page.
+        const workspaceListResponse = await this.client?.list({ request }, { page: 1, perPage: 1 });
         const basePath = core.http.basePath.serverBasePath;
 
         if (workspaceListResponse?.success && workspaceListResponse.result.total > 0) {
           const workspaceList = workspaceListResponse.result.workspaces;
           // If user only has one workspace, go to overview page of that workspace
-          if (workspaceList.length === 1) {
+          if (workspaceListResponse.result.total === 1) {
             return response.redirected({
               headers: {
                 location: `${basePath}/w/${workspaceList[0].id}/app/${WORKSPACE_NAVIGATION_APP_ID}`,
               },
             });
           }
-          const defaultWorkspaceId = await uiSettingsClient.get(DEFAULT_WORKSPACE);
-          const defaultWorkspace = workspaceList.find(
-            (workspace) => workspace.id === defaultWorkspaceId
-          );
+          const defaultWorkspaceId = await uiSettingsClient.get<string>(DEFAULT_WORKSPACE);
+          // Resolve the default workspace directly so that it is honored no matter
+          // where it would have fallen in the workspace list. The client is scoped to
+          // the request, so this fails for a workspace the user cannot access.
+          const defaultWorkspaceResponse = defaultWorkspaceId
+            ? await this.client?.get({ request }, defaultWorkspaceId)
+            : undefined;
           // If user has a default workspace configured, go to overview page of that workspace
           // If user has more than one workspaces, go to homepage
-          if (defaultWorkspace) {
+          if (defaultWorkspaceResponse?.success) {
             return response.redirected({
               headers: {
-                location: `${basePath}/w/${defaultWorkspace.id}/app/${WORKSPACE_NAVIGATION_APP_ID}`,
+                location: `${basePath}/w/${defaultWorkspaceResponse.result.id}/app/${WORKSPACE_NAVIGATION_APP_ID}`,
               },
             });
           } else {
@@ -238,6 +245,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     this.logger = initializerContext.logger.get();
     this.globalConfig$ = initializerContext.config.legacy.globalConfig$;
     this.workspaceConfig$ = initializerContext.config.create();
+    this.configService = new WorkspaceConfigService(this.logger);
     this.env = initializerContext.env;
   }
 
@@ -251,9 +259,15 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     // setup new ui_setting user's default workspace
     core.uiSettings.register(uiSettings);
 
-    this.client = new WorkspaceClient(core, this.logger, {
-      maximum_workspaces: workspaceConfig.maximum_workspaces,
+    // The config is resolved per request through the dynamic config service so that a
+    // config store override is honored, falling back to the value read from
+    // `opensearch_dashboards.yml`.
+    this.configService.setup({
+      dynamicConfigService: core.dynamicConfigService,
+      staticConfig: workspaceConfig,
     });
+
+    this.client = new WorkspaceClient(core, this.logger, this.configService);
 
     this.aclEnforceEndpointPatterns = workspaceConfig.aclEnforceEndpointPatterns;
 

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -296,7 +296,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     core.savedObjects.addClientWrapper(
       PRIORITY_FOR_WORKSPACE_ID_CONSUMER_WRAPPER,
       WORKSPACE_ID_CONSUMER_WRAPPER_ID,
-      new WorkspaceIdConsumerWrapper(this.client, this.logger).wrapperFactory
+      new WorkspaceIdConsumerWrapper(this.client, this.logger, this.configService).wrapperFactory
     );
 
     const maxImportExportSize = core.savedObjects.getImportExportObjectLimit();

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
@@ -14,7 +14,8 @@ import {
 import { WorkspaceIdConsumerWrapper } from './workspace_id_consumer_wrapper';
 import { workspaceClientMock } from '../workspace_client.mock';
 import { SavedObjectsErrorHelpers } from '../../../../core/server';
-import { WORKSPACE_EXISTENCE_CHECK_PER_PAGE } from '../../common/constants';
+import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../../common/constants';
+import { createWorkspaceConfigServiceMock } from '../services/workspace_config_service.mock';
 
 describe('WorkspaceIdConsumerWrapper', () => {
   const requestHandlerContext = coreMock.createRequestHandlerContext();
@@ -121,7 +122,7 @@ describe('WorkspaceIdConsumerWrapper', () => {
       expect(mockedWorkspaceClient.list).toHaveBeenCalledTimes(1);
     });
 
-    it(`Should list workspaces with a large fixed page size`, async () => {
+    it(`Should list workspaces with the default page size`, async () => {
       const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
         mockedWorkspaceClient,
         logger
@@ -146,7 +147,71 @@ describe('WorkspaceIdConsumerWrapper', () => {
       );
 
       expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
-        perPage: WORKSPACE_EXISTENCE_CHECK_PER_PAGE,
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+      });
+    });
+
+    it(`Should list workspaces with the resolved maximum_workspaces as page size`, async () => {
+      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
+        mockedWorkspaceClient,
+        logger,
+        createWorkspaceConfigServiceMock({ maximum_workspaces: 5000 })
+      );
+      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+      updateWorkspaceState(mockRequest, {});
+      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
+        client: mockedClient,
+        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
+        request: mockRequest,
+      });
+
+      mockedWorkspaceClient.list.mockResolvedValueOnce({
+        success: true,
+        result: { workspaces: [{ id: 'foo' }, { id: 'bar' }] },
+      });
+
+      await mockedWrapperClient.create(
+        'dashboard',
+        { name: 'foo' },
+        { workspaces: ['foo', 'bar'] }
+      );
+
+      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
+        perPage: 5000,
+      });
+    });
+
+    it(`Should fall back to the default page size when maximum_workspaces cannot be resolved`, async () => {
+      const configServiceMock = createWorkspaceConfigServiceMock();
+      configServiceMock.scopedClient.getMaximumWorkspaces.mockRejectedValue(
+        new Error('config store unavailable')
+      );
+      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
+        mockedWorkspaceClient,
+        logger,
+        configServiceMock
+      );
+      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+      updateWorkspaceState(mockRequest, {});
+      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
+        client: mockedClient,
+        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
+        request: mockRequest,
+      });
+
+      mockedWorkspaceClient.list.mockResolvedValueOnce({
+        success: true,
+        result: { workspaces: [{ id: 'foo' }, { id: 'bar' }] },
+      });
+
+      await mockedWrapperClient.create(
+        'dashboard',
+        { name: 'foo' },
+        { workspaces: ['foo', 'bar'] }
+      );
+
+      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
+        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
       });
     });
   });

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
@@ -14,6 +14,7 @@ import {
 import { WorkspaceIdConsumerWrapper } from './workspace_id_consumer_wrapper';
 import { workspaceClientMock } from '../workspace_client.mock';
 import { SavedObjectsErrorHelpers } from '../../../../core/server';
+import { WORKSPACE_EXISTENCE_CHECK_PER_PAGE } from '../../common/constants';
 
 describe('WorkspaceIdConsumerWrapper', () => {
   const requestHandlerContext = coreMock.createRequestHandlerContext();
@@ -107,7 +108,7 @@ describe('WorkspaceIdConsumerWrapper', () => {
         },
       });
 
-      expect(
+      await expect(
         mockedWrapperClient.create(
           'dashboard',
           {
@@ -118,6 +119,35 @@ describe('WorkspaceIdConsumerWrapper', () => {
       ).rejects.toMatchInlineSnapshot(`[Error: Exist invalid workspaces]`);
       expect(mockedWorkspaceClient.get).toHaveBeenCalledTimes(0);
       expect(mockedWorkspaceClient.list).toHaveBeenCalledTimes(1);
+    });
+
+    it(`Should list workspaces with a large fixed page size`, async () => {
+      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
+        mockedWorkspaceClient,
+        logger
+      );
+      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
+      updateWorkspaceState(mockRequest, {});
+      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
+        client: mockedClient,
+        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
+        request: mockRequest,
+      });
+
+      mockedWorkspaceClient.list.mockResolvedValueOnce({
+        success: true,
+        result: { workspaces: [{ id: 'foo' }, { id: 'bar' }] },
+      });
+
+      await mockedWrapperClient.create(
+        'dashboard',
+        { name: 'foo' },
+        { workspaces: ['foo', 'bar'] }
+      );
+
+      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
+        perPage: WORKSPACE_EXISTENCE_CHECK_PER_PAGE,
+      });
     });
   });
 
@@ -250,7 +280,7 @@ describe('WorkspaceIdConsumerWrapper', () => {
         typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
         request: mockRequest,
       });
-      expect(
+      await expect(
         mockedWrapperClient.find({
           type: ['dashboard', 'visualization'],
           workspaces: ['foo', 'not-exist'],

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -22,7 +22,8 @@ import {
 } from '../../../../core/server';
 import { IWorkspaceClientImpl } from '../types';
 import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
-import { WORKSPACE_EXISTENCE_CHECK_PER_PAGE } from '../../common/constants';
+import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../../common/constants';
+import { IWorkspaceConfigService } from '../services';
 
 const UI_SETTINGS_SAVED_OBJECTS_TYPE = 'config';
 
@@ -39,6 +40,21 @@ const generateSavedObjectsForbiddenError = () =>
 
 export class WorkspaceIdConsumerWrapper {
   private readonly logger: Logger;
+
+  /**
+   * Resolves the page size used when listing workspaces to validate the requested ones
+   * exist. It honors `workspace.maximum_workspaces` so that workspaces beyond the
+   * default page size are not reported as invalid.
+   */
+  private async getWorkspaceListPerPage(request: OpenSearchDashboardsRequest): Promise<number> {
+    const maximumWorkspaces = await this.configService
+      ?.asScopedToRequest(request)
+      .getMaximumWorkspaces()
+      .catch(() => undefined);
+
+    return maximumWorkspaces ?? DEFAULT_WORKSPACE_LIST_PER_PAGE;
+  }
+
   private formatWorkspaceIdParams<T extends WorkspaceOptions>(
     request: OpenSearchDashboardsRequest,
     options?: T
@@ -92,7 +108,7 @@ export class WorkspaceIdConsumerWrapper {
             request: wrapperOptions.request,
           },
           {
-            perPage: WORKSPACE_EXISTENCE_CHECK_PER_PAGE,
+            perPage: await this.getWorkspaceListPerPage(wrapperOptions.request),
           }
         );
         if (workspaceList.success) {
@@ -250,7 +266,8 @@ export class WorkspaceIdConsumerWrapper {
 
   constructor(
     private readonly workspaceClient: IWorkspaceClientImpl,
-    logger: Logger
+    logger: Logger,
+    private readonly configService?: IWorkspaceConfigService
   ) {
     this.logger = logger;
   }

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../../core/server';
 import { IWorkspaceClientImpl } from '../types';
 import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
+import { WORKSPACE_EXISTENCE_CHECK_PER_PAGE } from '../../common/constants';
 
 const UI_SETTINGS_SAVED_OBJECTS_TYPE = 'config';
 
@@ -91,7 +92,7 @@ export class WorkspaceIdConsumerWrapper {
             request: wrapperOptions.request,
           },
           {
-            perPage: 9999,
+            perPage: WORKSPACE_EXISTENCE_CHECK_PER_PAGE,
           }
         );
         if (workspaceList.success) {

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
@@ -23,12 +23,20 @@ import {
   DATA_SOURCE_SAVED_OBJECT_TYPE,
   DATA_CONNECTION_SAVED_OBJECT_TYPE,
 } from '../../../data_source/common';
+import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../../common/constants';
+import {
+  createWorkspaceConfigServiceMock,
+  WorkspaceConfigServiceMock,
+} from '../services/workspace_config_service.mock';
 
 const DASHBOARD_ADMIN = 'dashboard_admin';
 const NO_DASHBOARD_ADMIN = 'no_dashboard_admin';
 const DATASOURCE_ADMIN = 'dataSource_admin';
 
-const generateWorkspaceSavedObjectsClientWrapper = (role = NO_DASHBOARD_ADMIN) => {
+const generateWorkspaceSavedObjectsClientWrapper = (
+  role = NO_DASHBOARD_ADMIN,
+  configServiceMock?: WorkspaceConfigServiceMock
+) => {
   const savedObjectsStore: SavedObject[] = [
     {
       type: 'dashboard',
@@ -213,7 +221,7 @@ const generateWorkspaceSavedObjectsClientWrapper = (role = NO_DASHBOARD_ADMIN) =
     clearSavedObjectsCache: jest.fn(),
   };
 
-  const wrapper = new WorkspaceSavedObjectsClientWrapper(permissionControlMock);
+  const wrapper = new WorkspaceSavedObjectsClientWrapper(permissionControlMock, configServiceMock);
   const scopedClientMock = savedObjectsClientMock.create();
   scopedClientMock.find.mockImplementation(async () => ({
     total: 1,
@@ -718,6 +726,46 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           workspaces: ['workspace-1'],
           workspacesSearchOperator: 'OR',
         });
+      });
+      it('should look up permitted workspaces with the default page size', async () => {
+        const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper();
+        await wrapper.find({ type: 'dashboard' });
+        expect(scopedClientMock.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'workspace',
+            perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+          })
+        );
+      });
+      it('should look up permitted workspaces with the resolved maximum_workspaces as page size', async () => {
+        const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper(
+          NO_DASHBOARD_ADMIN,
+          createWorkspaceConfigServiceMock({ maximum_workspaces: 5000 })
+        );
+        await wrapper.find({ type: 'dashboard' });
+        expect(scopedClientMock.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'workspace',
+            perPage: 5000,
+          })
+        );
+      });
+      it('should look up permitted workspaces with the default page size when maximum_workspaces cannot be resolved', async () => {
+        const configServiceMock = createWorkspaceConfigServiceMock();
+        configServiceMock.scopedClient.getMaximumWorkspaces.mockRejectedValue(
+          new Error('config store unavailable')
+        );
+        const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper(
+          NO_DASHBOARD_ADMIN,
+          configServiceMock
+        );
+        await wrapper.find({ type: 'dashboard' });
+        expect(scopedClientMock.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'workspace',
+            perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+          })
+        );
       });
       it('should call client.find with ACLSearchParams when only ACLSearchParams provided', async () => {
         const { wrapper, clientMock } = generateWorkspaceSavedObjectsClientWrapper();

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -37,8 +37,12 @@ import {
   WorkspacePermissionMode,
 } from '../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
-import { WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID } from '../../common/constants';
+import {
+  DEFAULT_WORKSPACE_LIST_PER_PAGE,
+  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
+} from '../../common/constants';
 import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
+import { IWorkspaceConfigService } from '../services';
 
 // Can't throw unauthorized for now, the page will be refreshed if unauthorized
 const generateWorkspacePermissionError = () =>
@@ -86,6 +90,20 @@ const getDefaultValuesForEmpty = <T>(values: T[] | undefined, defaultValues: T[]
 
 export class WorkspaceSavedObjectsClientWrapper {
   private getScopedClient?: SavedObjectsServiceStart['getScopedClient'];
+
+  /**
+   * Resolves the page size used when looking up every workspace the current user may
+   * read. It honors `workspace.maximum_workspaces` so that a user who is allowed to
+   * create N workspaces can also see saved objects in all N of them.
+   */
+  private async getWorkspaceListPerPage(request: OpenSearchDashboardsRequest): Promise<number> {
+    const maximumWorkspaces = await this.configService
+      ?.asScopedToRequest(request)
+      .getMaximumWorkspaces()
+      .catch(() => undefined);
+
+    return maximumWorkspaces ?? DEFAULT_WORKSPACE_LIST_PER_PAGE;
+  }
 
   private async validateObjectsPermissions(
     objects: Array<Pick<SavedObject, 'id' | 'type'>>,
@@ -512,7 +530,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       const permittedWorkspaceIds = (
         await this.getWorkspaceTypeEnabledClient(wrapperOptions.request).find({
           type: WORKSPACE_TYPE,
-          perPage: 999,
+          perPage: await this.getWorkspaceListPerPage(wrapperOptions.request),
           ACLSearchParams: {
             principals,
             permissionModes: [
@@ -686,5 +704,8 @@ export class WorkspaceSavedObjectsClientWrapper {
     };
   };
 
-  constructor(private readonly permissionControl: SavedObjectsPermissionControlContract) {}
+  constructor(
+    private readonly permissionControl: SavedObjectsPermissionControlContract,
+    private readonly configService?: IWorkspaceConfigService
+  ) {}
 }

--- a/src/plugins/workspace/server/services/index.ts
+++ b/src/plugins/workspace/server/services/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  WorkspaceConfigService,
+  IWorkspaceConfigService,
+  WorkspaceConfigServiceSetupDeps,
+} from './workspace_config_service';
+export { IScopedWorkspaceConfigClient } from './scoped_workspace_config_client';

--- a/src/plugins/workspace/server/services/scoped_workspace_config_client.ts
+++ b/src/plugins/workspace/server/services/scoped_workspace_config_client.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { UnwrapPromise } from '@osd/utility-types';
+import { CoreSetup, Logger, OpenSearchDashboardsRequest } from '../../../../core/server';
+import { ConfigSchema } from '../../config';
+import { WORKSPACE_PLUGIN_CONFIG_PATH } from '../../common/constants';
+
+/**
+ * `DynamicConfigServiceSetup` and `DynamicConfigServiceStart` are not exported from
+ * `core/server`, so derive them from the public `CoreSetup` contract.
+ */
+export type DynamicConfigServiceSetup = CoreSetup['dynamicConfigService'];
+type DynamicConfigServiceStart = UnwrapPromise<
+  ReturnType<DynamicConfigServiceSetup['getStartService']>
+>;
+
+/**
+ * Reads the workspace plugin config for a single request.
+ */
+export interface IScopedWorkspaceConfigClient {
+  /**
+   * The effective workspace config, preferring the dynamic config values over the ones
+   * read from `opensearch_dashboards.yml`.
+   */
+  get(): Promise<ConfigSchema>;
+  /**
+   * The effective `workspace.maximum_workspaces`, or undefined when neither source
+   * configures a usable maximum, which callers read as "no limit".
+   */
+  getMaximumWorkspaces(): Promise<number | undefined>;
+}
+
+export interface ScopedWorkspaceConfigClientDeps {
+  dynamicConfigService: DynamicConfigServiceSetup;
+  /**
+   * The config read from `opensearch_dashboards.yml`, used whenever the dynamic config
+   * service cannot answer.
+   */
+  staticConfig: ConfigSchema;
+  request: OpenSearchDashboardsRequest;
+  logger: Logger;
+}
+
+const toPositiveNumber = (value: unknown): number | undefined => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+export class ScopedWorkspaceConfigClient implements IScopedWorkspaceConfigClient {
+  /**
+   * Memoizes the lookup so that the several consumers involved in a single request
+   * resolve the config once.
+   */
+  private dynamicConfigPromise?: Promise<Partial<ConfigSchema> | undefined>;
+
+  constructor(private readonly deps: ScopedWorkspaceConfigClientDeps) {}
+
+  public async get(): Promise<ConfigSchema> {
+    return { ...this.deps.staticConfig, ...(await this.getDynamicConfig()) };
+  }
+
+  public async getMaximumWorkspaces(): Promise<number | undefined> {
+    const dynamicConfig = await this.getDynamicConfig();
+    // Fall back to the static value instead of to "no limit" when the dynamic value is
+    // missing or not a usable number.
+    return (
+      toPositiveNumber(dynamicConfig?.maximum_workspaces) ??
+      toPositiveNumber(this.deps.staticConfig.maximum_workspaces)
+    );
+  }
+
+  private async getDynamicConfig(): Promise<Partial<ConfigSchema> | undefined> {
+    if (!this.dynamicConfigPromise) {
+      this.dynamicConfigPromise = this.fetchDynamicConfig();
+    }
+    return this.dynamicConfigPromise;
+  }
+
+  /**
+   * The dynamic config client merges the config store value over the value from
+   * `opensearch_dashboards.yml`, so the yml value is still the effective one when the
+   * service is disabled (`dynamic_config_service.enabled: false`, the default) or when
+   * the store holds no override for this plugin.
+   *
+   * Returns undefined when the config cannot be resolved, so callers fall back to the
+   * statically read config rather than lose the setting entirely.
+   */
+  private async fetchDynamicConfig(): Promise<Partial<ConfigSchema> | undefined> {
+    const { dynamicConfigService, request, logger } = this.deps;
+
+    try {
+      const dynamicConfigServiceStart: DynamicConfigServiceStart =
+        await dynamicConfigService.getStartService();
+      // The async local store is only populated for authenticated requests, so derive
+      // the context from the request when it is absent.
+      const asyncLocalStorageContext =
+        dynamicConfigServiceStart.getAsyncLocalStore() ??
+        dynamicConfigServiceStart.createStoreFromRequest(request);
+
+      if (!asyncLocalStorageContext) {
+        throw new Error('Invalid request, not able to identify request context');
+      }
+
+      return (await dynamicConfigServiceStart
+        .getClient()
+        .getConfig(
+          { pluginConfigPath: WORKSPACE_PLUGIN_CONFIG_PATH },
+          { asyncLocalStorageContext }
+        )) as Partial<ConfigSchema>;
+    } catch (error) {
+      logger.warn(
+        `Failed to get ${WORKSPACE_PLUGIN_CONFIG_PATH} config from dynamic config service: ${error}`
+      );
+      return undefined;
+    }
+  }
+}

--- a/src/plugins/workspace/server/services/workspace_config_service.mock.ts
+++ b/src/plugins/workspace/server/services/workspace_config_service.mock.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConfigSchema } from '../../config';
+import { IScopedWorkspaceConfigClient } from './scoped_workspace_config_client';
+import { IWorkspaceConfigService } from './workspace_config_service';
+
+export type ScopedWorkspaceConfigClientMock = jest.Mocked<IScopedWorkspaceConfigClient>;
+
+export interface WorkspaceConfigServiceMock extends jest.Mocked<IWorkspaceConfigService> {
+  scopedClient: ScopedWorkspaceConfigClientMock;
+}
+
+/**
+ * A config service which resolves to the given config for every request. Pass a rejected
+ * `getMaximumWorkspaces` to exercise the fallbacks in the consumers.
+ */
+export const createWorkspaceConfigServiceMock = (
+  config: Partial<ConfigSchema> = {}
+): WorkspaceConfigServiceMock => {
+  const scopedClient: ScopedWorkspaceConfigClientMock = {
+    get: jest.fn().mockResolvedValue(config),
+    getMaximumWorkspaces: jest.fn().mockResolvedValue(config.maximum_workspaces),
+  };
+
+  return {
+    scopedClient,
+    asScopedToRequest: jest.fn().mockReturnValue(scopedClient),
+  };
+};

--- a/src/plugins/workspace/server/services/workspace_config_service.test.ts
+++ b/src/plugins/workspace/server/services/workspace_config_service.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpServerMock, loggingSystemMock } from '../../../../core/server/mocks';
+import { IDynamicConfigurationClient } from '../../../../core/server';
+import { WORKSPACE_PLUGIN_CONFIG_PATH } from '../../common/constants';
+import { ConfigSchema } from '../../config';
+import { DynamicConfigServiceSetup, WorkspaceConfigService } from './workspace_config_service';
+
+const createStartServiceMock = (
+  options: {
+    getConfig?: jest.Mock;
+    asyncLocalStore?: Map<string, any>;
+    storeFromRequest?: Map<string, any>;
+  } = {}
+) => {
+  const getConfig = options.getConfig ?? jest.fn().mockResolvedValue({});
+  // Only fall back to a populated store when the key is absent, so a test can opt into
+  // an unresolvable context by passing an explicit undefined.
+  const asyncLocalStore =
+    'asyncLocalStore' in options ? options.asyncLocalStore : new Map<string, any>([['a', 'b']]);
+  const storeFromRequest =
+    'storeFromRequest' in options
+      ? options.storeFromRequest
+      : new Map<string, any>([['a', 'from-request']]);
+  const client = { getConfig } as unknown as IDynamicConfigurationClient;
+
+  return {
+    getClient: jest.fn().mockReturnValue(client),
+    getAsyncLocalStore: jest.fn().mockReturnValue(asyncLocalStore),
+    createStoreFromRequest: jest.fn().mockReturnValue(storeFromRequest),
+  };
+};
+
+const staticConfig = (maximumWorkspaces?: number): ConfigSchema => ({
+  enabled: true,
+  maximum_workspaces: maximumWorkspaces,
+  aclEnforceEndpointPatterns: [],
+});
+
+describe('WorkspaceConfigService', () => {
+  const request = httpServerMock.createOpenSearchDashboardsRequest();
+  const logger = loggingSystemMock.create().get();
+
+  const setupService = (
+    startService: ReturnType<typeof createStartServiceMock>,
+    maximumWorkspaces?: number
+  ) => {
+    const dynamicConfigService = {
+      registerDynamicConfigClientFactory: jest.fn(),
+      registerAsyncLocalStoreRequestHeader: jest.fn(),
+      getStartService: jest.fn().mockResolvedValue(startService),
+    } as unknown as jest.Mocked<DynamicConfigServiceSetup>;
+
+    const service = new WorkspaceConfigService(logger);
+    service.setup({ dynamicConfigService, staticConfig: staticConfig(maximumWorkspaces) });
+
+    return service;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when asked for a client before setup', () => {
+    expect(() =>
+      new WorkspaceConfigService(logger).asScopedToRequest(request)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"WorkspaceConfigService#setup must be called before asScopedToRequest"`
+    );
+  });
+
+  describe('get', () => {
+    it('gets the config under the workspace plugin config path', async () => {
+      const getConfig = jest.fn().mockResolvedValue({ maximum_workspaces: 3000 });
+      const asyncLocalStore = new Map<string, any>([['header', 'value']]);
+      const service = setupService(createStartServiceMock({ getConfig, asyncLocalStore }), 100);
+
+      await expect(service.asScopedToRequest(request).get()).resolves.toEqual({
+        enabled: true,
+        maximum_workspaces: 3000,
+        aclEnforceEndpointPatterns: [],
+      });
+      expect(getConfig).toHaveBeenCalledWith(
+        { pluginConfigPath: WORKSPACE_PLUGIN_CONFIG_PATH },
+        { asyncLocalStorageContext: asyncLocalStore }
+      );
+    });
+
+    it('derives the context from the request when the async local store is absent', async () => {
+      const getConfig = jest.fn().mockResolvedValue({});
+      const storeFromRequest = new Map<string, any>([['a', 'from-request']]);
+      const startService = createStartServiceMock({
+        getConfig,
+        asyncLocalStore: undefined,
+        storeFromRequest,
+      });
+
+      await setupService(startService).asScopedToRequest(request).get();
+
+      expect(startService.createStoreFromRequest).toHaveBeenCalledWith(request);
+      expect(getConfig).toHaveBeenCalledWith(expect.anything(), {
+        asyncLocalStorageContext: storeFromRequest,
+      });
+    });
+
+    it('falls back to the static config and warns when no context can be resolved', async () => {
+      const service = setupService(
+        createStartServiceMock({ asyncLocalStore: undefined, storeFromRequest: undefined }),
+        100
+      );
+
+      await expect(service.asScopedToRequest(request).get()).resolves.toEqual(staticConfig(100));
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('falls back to the static config and warns when the client throws', async () => {
+      const service = setupService(
+        createStartServiceMock({
+          getConfig: jest.fn().mockRejectedValue(new Error('config store unavailable')),
+        }),
+        100
+      );
+
+      await expect(service.asScopedToRequest(request).get()).resolves.toEqual(staticConfig(100));
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('resolves the config once per scoped client', async () => {
+      const getConfig = jest.fn().mockResolvedValue({ maximum_workspaces: 3000 });
+      const client = setupService(createStartServiceMock({ getConfig })).asScopedToRequest(request);
+
+      await Promise.all([client.get(), client.get(), client.getMaximumWorkspaces()]);
+
+      expect(getConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getMaximumWorkspaces', () => {
+    it('prefers the dynamic config value', async () => {
+      const service = setupService(
+        createStartServiceMock({
+          getConfig: jest.fn().mockResolvedValue({ maximum_workspaces: 5000 }),
+        }),
+        100
+      );
+
+      await expect(service.asScopedToRequest(request).getMaximumWorkspaces()).resolves.toBe(5000);
+    });
+
+    it('falls back to the static value when the dynamic config has no maximum', async () => {
+      const service = setupService(createStartServiceMock(), 100);
+
+      await expect(service.asScopedToRequest(request).getMaximumWorkspaces()).resolves.toBe(100);
+    });
+
+    it('falls back to the static value when the dynamic config cannot be read', async () => {
+      const service = setupService(
+        createStartServiceMock({
+          getConfig: jest.fn().mockRejectedValue(new Error('config store unavailable')),
+        }),
+        100
+      );
+
+      await expect(service.asScopedToRequest(request).getMaximumWorkspaces()).resolves.toBe(100);
+    });
+
+    it('returns undefined when neither source configures a maximum', async () => {
+      const service = setupService(createStartServiceMock());
+
+      await expect(
+        service.asScopedToRequest(request).getMaximumWorkspaces()
+      ).resolves.toBeUndefined();
+    });
+
+    it('ignores non-positive and non-numeric values', async () => {
+      for (const maximumWorkspaces of [0, -1, 'not-a-number', null]) {
+        const service = setupService(
+          createStartServiceMock({
+            getConfig: jest.fn().mockResolvedValue({ maximum_workspaces: maximumWorkspaces }),
+          }),
+          100
+        );
+
+        await expect(service.asScopedToRequest(request).getMaximumWorkspaces()).resolves.toBe(100);
+      }
+    });
+  });
+});

--- a/src/plugins/workspace/server/services/workspace_config_service.ts
+++ b/src/plugins/workspace/server/services/workspace_config_service.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger, OpenSearchDashboardsRequest } from '../../../../core/server';
+import {
+  DynamicConfigServiceSetup,
+  IScopedWorkspaceConfigClient,
+  ScopedWorkspaceConfigClient,
+  ScopedWorkspaceConfigClientDeps,
+} from './scoped_workspace_config_client';
+
+/**
+ * Hands out request scoped config clients. Consumers depend on this instead of on the
+ * dynamic config service so that how the config is resolved stays in one place.
+ */
+export interface IWorkspaceConfigService {
+  asScopedToRequest(request: OpenSearchDashboardsRequest): IScopedWorkspaceConfigClient;
+}
+
+export type WorkspaceConfigServiceSetupDeps = Pick<
+  ScopedWorkspaceConfigClientDeps,
+  'dynamicConfigService' | 'staticConfig'
+>;
+
+/**
+ * Owns how the workspace plugin config is resolved on the server. The dynamic config
+ * service can only be talked to once a request comes in, so the service is set up during
+ * the plugin setup and resolves the config lazily, per request.
+ */
+export class WorkspaceConfigService implements IWorkspaceConfigService {
+  private deps?: WorkspaceConfigServiceSetupDeps;
+
+  constructor(private readonly logger: Logger) {}
+
+  public setup(deps: WorkspaceConfigServiceSetupDeps) {
+    this.deps = deps;
+  }
+
+  public asScopedToRequest(request: OpenSearchDashboardsRequest): IScopedWorkspaceConfigClient {
+    if (!this.deps) {
+      throw new Error('WorkspaceConfigService#setup must be called before asScopedToRequest');
+    }
+
+    return new ScopedWorkspaceConfigClient({ ...this.deps, request, logger: this.logger });
+  }
+}
+
+export { DynamicConfigServiceSetup, IScopedWorkspaceConfigClient };

--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -21,6 +21,7 @@ import {
   IUiSettingsClient,
 } from '../../../core/server';
 import { IRequestDetail } from './types';
+import { createWorkspaceConfigServiceMock } from './services/workspace_config_service.mock';
 
 const coreSetup = coreMock.createSetup();
 
@@ -131,9 +132,11 @@ describe('#WorkspaceClient', () => {
   });
 
   it('create# should call find when maximum workspaces are set', async () => {
-    const client = new WorkspaceClient(coreSetup, logger, {
-      maximum_workspaces: 1,
-    });
+    const client = new WorkspaceClient(
+      coreSetup,
+      logger,
+      createWorkspaceConfigServiceMock({ maximum_workspaces: 1 })
+    );
     client?.setSavedObjects(savedObjects);
 
     find.mockImplementation((findParams) => {

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -33,7 +33,7 @@ import {
   DATA_SOURCE_SAVED_OBJECT_TYPE,
   DATA_CONNECTION_SAVED_OBJECT_TYPE,
 } from '../../data_source/common';
-import { ConfigSchema } from '../config';
+import { IWorkspaceConfigService } from './services';
 
 const WORKSPACE_ID_SIZE = 6;
 
@@ -45,21 +45,17 @@ const WORKSPACE_NOT_FOUND_ERROR = i18n.translate('workspace.notFound.error', {
   defaultMessage: 'workspace not found',
 });
 
-interface ConfigType {
-  maximum_workspaces?: ConfigSchema['maximum_workspaces'];
-}
-
 export class WorkspaceClient implements IWorkspaceClientImpl {
   private setupDep: CoreSetup;
   private logger: Logger;
   private savedObjects?: SavedObjectsServiceStart;
   private uiSettings?: UiSettingsServiceStart;
-  private config?: ConfigType;
+  private configService?: IWorkspaceConfigService;
 
-  constructor(core: CoreSetup, logger: Logger, config?: ConfigType) {
+  constructor(core: CoreSetup, logger: Logger, configService?: IWorkspaceConfigService) {
     this.setupDep = core;
     this.logger = logger;
-    this.config = config;
+    this.configService = configService;
   }
 
   private getScopedClientWithoutPermission(
@@ -132,16 +128,19 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
         throw new Error(DUPLICATE_WORKSPACE_NAME_ERROR);
       }
 
-      if (this.config?.maximum_workspaces) {
+      const maximumWorkspaces = await this.configService
+        ?.asScopedToRequest(requestDetail.request)
+        .getMaximumWorkspaces();
+      if (maximumWorkspaces) {
         const workspaces = await clientWithoutPermission?.find({
           type: WORKSPACE_TYPE,
         });
-        if (workspaces && workspaces.total >= this.config.maximum_workspaces) {
+        if (workspaces && workspaces.total >= maximumWorkspaces) {
           throw new Error(
             i18n.translate('workspace.maximum.error', {
               defaultMessage: 'Maximum number of workspaces ({length}) reached',
               values: {
-                length: this.config.maximum_workspaces,
+                length: maximumWorkspaces,
               },
             })
           );


### PR DESCRIPTION
### Description

Previously the workspace list was fetched with a hard-coded `perPage: 999` in several places (both browser and server). When more than 999 workspaces existed, workspaces beyond that page were silently dropped — a user could not see or select them, and existence checks would incorrectly report valid workspaces as invalid. This change makes the workspace list honor the `workspace.maximum_workspaces` setting, and resolves that setting through the **dynamic config service** so a config-store override is picked up per request (falling back to the value from `opensearch_dashboards.yml`).

**Server side**

- Added a `WorkspaceConfigService` that is set up during plugin `setup` and hands out request-scoped config clients via `asScopedToRequest(request)`. Each `ScopedWorkspaceConfigClient` resolves the effective config through the dynamic config service, memoizing the lookup so the several consumers in one request only hit the config store once.
- Resolution order is dynamic config → `opensearch_dashboards.yml` → default, and every failure mode is non-fatal (a config-store outage falls back rather than failing a saved-objects `find`).
- Wired the shared service into `WorkspaceClient` and `WorkspaceSavedObjectsClientWrapper`, replacing their hard-coded page sizes so the create limit and the paging limit can never disagree.
- `WorkspaceIdConsumerWrapper` — which only lists workspaces to validate that requested IDs exist — now uses a large fixed page size (`WORKSPACE_EXISTENCE_CHECK_PER_PAGE = 9999`) rather than reading the dynamic config, since a large value is sufficient for that check and avoids a per-request lookup.

**Browser side**

- Exposed `maximum_workspaces` to the browser (`exposeToBrowser` in `server/index.ts`), plumbed it through the plugin initializer context, and passed it into `WorkspaceClient` and the workspace validation service so the public `list` calls page by the configured maximum instead of `999`.

Because `dynamic_config_service.enabled` defaults to `false`, the effective behavior is unchanged for existing deployments — the value continues to come from `opensearch_dashboards.yml`.

### Issues Resolved

<!-- List the issue this PR resolves, e.g. closes #1234 -->

## Screenshot

N/A — no UI changes; only the page size used to fetch the workspace list.

## Testing the changes

1. Set `workspace.maximum_workspaces` to a value larger than the previous `999` cap (e.g. `5000`) in `opensearch_dashboards.yml`.
2. Create more than 999 workspaces.
3. Confirm the workspace selector / list shows workspaces beyond the 999th.
4. Create a saved object referencing a workspace beyond the 999th and confirm it is no longer rejected as an "invalid workspace".
5. (Optional) With `dynamic_config_service.enabled: true` and a config store override for `workspace.maximum_workspaces`, confirm the override is honored per request without a restart.
6. Unit tests: `yarn test:jest src/plugins/workspace`.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
