### PR TITLE
fix(chat): show user message immediately with optimistic rendering

### DIFF
--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -109,6 +109,7 @@ interface ChatMessagesProps {
   layoutMode: ChatLayoutMode;
   timeline: Message[];
   isStreaming: boolean;
+  isValidating?: boolean;
   onResendMessage?: (message: Message) => void;
   onResendToolResult?: (params: {
     messageId: string;
@@ -299,6 +300,7 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
   layoutMode,
   timeline,
   isStreaming,
+  isValidating,
   onResendMessage,
   onResendToolResult,
   onApproveConfirmation,
@@ -680,6 +682,23 @@ const ChatMessagesComponent: React.FC<ChatMessagesProps> = ({
                 />
               ))}
             </EuiListGroup>
+          </div>
+        )}
+
+        {isValidating && (
+          <div className="chatMessages__loadingIndicator">
+            <div className="messageRow">
+              <div className="messageRow__icon">
+                <EuiIcon type="console" size="m" color="success" />
+              </div>
+              <div className="messageRow__content">
+                <div className="chatMessages__thinkingText">
+                  {i18n.translate('chat.messages.connecting', {
+                    defaultMessage: 'Connecting...',
+                  })}
+                </div>
+              </div>
+            </div>
           </div>
         )}
 

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -1074,6 +1074,180 @@ describe('ChatWindow', () => {
     });
   });
 
+  describe('optimistic user message rendering', () => {
+    it('should show user message immediately before data source validation completes', async () => {
+      // Make getCurrentDataSourceId take time to resolve
+      let resolveDataSource: (value: string) => void;
+      mockChatService.getCurrentDataSourceId.mockImplementation(
+        () => new Promise((resolve) => (resolveDataSource = resolve))
+      );
+
+      const { getByRole, getAllByText } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'hello world' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      // User message should appear immediately, even before validation resolves
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Text appears in both message bubble and conversation title header
+      expect(getAllByText('hello world').length).toBeGreaterThanOrEqual(1);
+
+      // Now resolve validation
+      await act(async () => {
+        resolveDataSource!('mock-ds-id');
+        await new Promise((r) => setTimeout(r, 0));
+      });
+    });
+
+    it('should show Connecting indicator while validating data source', async () => {
+      let resolveDataSource: (value: string | undefined) => void;
+      mockChatService.getCurrentDataSourceId.mockImplementation(
+        () => new Promise((resolve) => (resolveDataSource = resolve))
+      );
+
+      const { getByRole, getByText, queryByText } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'test message' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Should show "Connecting..." while validating
+      expect(getByText('Connecting...')).toBeTruthy();
+
+      // Resolve validation
+      await act(async () => {
+        resolveDataSource!('mock-ds-id');
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // "Connecting..." should disappear after validation completes
+      expect(queryByText('Connecting...')).toBeNull();
+    });
+
+    it('should disable input while validating', async () => {
+      let resolveDataSource: (value: string | undefined) => void;
+      mockChatService.getCurrentDataSourceId.mockImplementation(
+        () => new Promise((resolve) => (resolveDataSource = resolve))
+      );
+
+      const { getByRole } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'test' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Input should be disabled during validation
+      expect(input).toBeDisabled();
+
+      // Resolve validation
+      await act(async () => {
+        resolveDataSource!('mock-ds-id');
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Input should be re-enabled after validation
+      expect(input).not.toBeDisabled();
+    });
+
+    it('should prevent double-send while validating', async () => {
+      let resolveDataSource: (value: string | undefined) => void;
+      mockChatService.getCurrentDataSourceId.mockImplementation(
+        () => new Promise((resolve) => (resolveDataSource = resolve))
+      );
+
+      const { getByRole } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'first message' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Try to send again while first is validating — input is disabled so
+      // a programmatic send via ref or racing keydown should be guarded
+      expect(mockChatService.getUserMessage).toHaveBeenCalledTimes(1);
+
+      // Resolve validation
+      await act(async () => {
+        resolveDataSource!('mock-ds-id');
+        await new Promise((r) => setTimeout(r, 0));
+      });
+    });
+
+    it('should show user message then error when data source is unsupported', async () => {
+      mockChatService.getCurrentDataSourceId.mockResolvedValue('ds-analytic');
+      mockChatService.getAvailableDataSources.mockResolvedValue([]);
+      mockCore.savedObjects.client.get = jest.fn().mockResolvedValue({
+        attributes: { dataSourceEngineType: 'AnalyticEngine' },
+      });
+
+      const { getByRole, getAllByText, getByText } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'hello' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // User message should be visible (appears in message + header title)
+      expect(getAllByText('hello').length).toBeGreaterThanOrEqual(1);
+      // Error message should appear below
+      expect(getByText('The current data source does not support AI features.')).toBeTruthy();
+      // Should not send to agent
+      expect(mockChatService.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should show user message then data source selector when DS is invalid', async () => {
+      mockChatService.getCurrentDataSourceId.mockResolvedValue(undefined);
+      mockChatService.getAvailableDataSources.mockResolvedValue([
+        { id: 'ds-1', title: 'Source One' },
+      ]);
+
+      const { getByRole, getAllByText, getByText } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      const input = getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'my question' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // User message should be visible immediately (message + header title)
+      expect(getAllByText('my question').length).toBeGreaterThanOrEqual(1);
+      // DS selector should appear below
+      expect(getByText('Source One')).toBeTruthy();
+    });
+  });
+
   describe('error handling', () => {
     it('should handle sendMessage promise rejection', async () => {
       const ref = React.createRef<ChatWindowInstance>();

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -88,6 +88,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     const [availableDataSources, setAvailableDataSources] = useState<
       Array<{ id: string; title: string }>
     >([]);
+    const [isValidating, setIsValidating] = useState(false);
 
     const hasActiveToolCalls = useMemo(() => {
       if (toolCallStates instanceof Map) {
@@ -108,6 +109,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     // Use ref to track streaming state synchronously for React 18 compatibility
     // React 18 batches state updates, so we need a ref for immediate checks
     const isStreamingRef = useRef(false);
+    const isValidatingRef = useRef(false);
 
     const timelineRef = React.useRef<Message[]>(timeline);
 
@@ -348,10 +350,69 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       [chatService, pendingMessage, executeSlashCommand, subscribeToMessageStream, timeline]
     );
 
+    /**
+     * Validate the current data source before sending a message.
+     * Returns a result indicating whether the message can proceed.
+     */
+    const validateDataSource = useCallback(
+      async (
+        userMsg: UserMessage
+      ): Promise<
+        | { valid: true }
+        | { valid: false; reason: 'unsupported' | 'needs_selection' | 'no_data_sources' }
+      > => {
+        const currentDataSourceId = await chatService.getCurrentDataSourceId();
+
+        // 1. Check if current data source is unsupported (e.g. AnalyticEngine)
+        if (currentDataSourceId && (await isUnsupportedDataSource(currentDataSourceId))) {
+          const systemMsg: SystemMessage = {
+            id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+            role: 'system',
+            content: i18n.translate('chat.dataSourceUnsupported', {
+              defaultMessage: 'The current data source does not support AI features.',
+            }),
+          };
+          setTimeline((prev) => [...prev, systemMsg]);
+          return { valid: false, reason: 'unsupported' };
+        }
+
+        // 2. Check if current data source is valid (exists in available list)
+        const compatibleDataSources = await chatService.getAvailableDataSources();
+        const isValid =
+          currentDataSourceId && compatibleDataSources.some((ds) => ds.id === currentDataSourceId);
+
+        if (!isValid) {
+          if (compatibleDataSources.length >= 1) {
+            // Compatible data sources exist — prompt user to pick one.
+            // User message is already in timeline; handleDataSourceSelect will continue.
+            setPendingMessage(userMsg);
+            setAvailableDataSources(compatibleDataSources);
+            return { valid: false, reason: 'needs_selection' };
+          }
+
+          // 3. No data sources associated with this workspace
+          const infoMsg: Message = {
+            id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+            role: 'assistant',
+            content: i18n.translate('chat.noDataSourceMessage', {
+              defaultMessage:
+                'There are no data sources associated with this workspace. Please ask your workspace admin to associate data sources to this workspace.',
+            }),
+          };
+          setTimeline((prev) => [...prev, infoMsg]);
+          return { valid: false, reason: 'no_data_sources' };
+        }
+
+        return { valid: true };
+      },
+      [chatService, isUnsupportedDataSource]
+    );
+
     const handleSend = async (options?: { input?: string; messages?: Message[] }) => {
       const messageContent = options?.input ?? input.trim();
       // Use ref for immediate check since React 18 batches state updates
-      if (!messageContent || isStreamingRef.current || hasPendingResend) return;
+      if (!messageContent || isStreamingRef.current || isValidatingRef.current || hasPendingResend)
+        return;
 
       // Prepare additional messages for sending (but don't add to timeline yet)
       let additionalMessages = options?.messages ?? [];
@@ -375,65 +436,32 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
       setInput('');
 
+      // Show user message immediately (optimistic rendering)
+      const userMsg = chatService.getUserMessage(messageContent);
+      setTimeline((prev) => [...prev, userMsg]);
+
       // Merge additional messages with current timeline for sending
       const messagesToSend = [...timeline, ...additionalMessages];
 
-      // Validate data source before sending
-      const currentDataSourceId = await chatService.getCurrentDataSourceId();
+      // Show loading indicator while validating data source
+      isValidatingRef.current = true;
+      setIsValidating(true);
 
-      // 1. Check if current data source is unsupported
-      if (currentDataSourceId && (await isUnsupportedDataSource(currentDataSourceId))) {
-        const userMsg = chatService.getUserMessage(messageContent);
-        const systemMsg: SystemMessage = {
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          role: 'system',
-          content: i18n.translate('chat.dataSourceUnsupported', {
-            defaultMessage: 'The current data source does not support AI features.',
-          }),
-        };
-        setTimeline((prev) => [...prev, userMsg, systemMsg]);
-        return;
+      try {
+        const result = await validateDataSource(userMsg);
+        if (!result.valid) return;
+
+        // Check if this is a slash command — pass userMsg so executeSlashCommand
+        // can replace it (by id) with the resolved command message.
+        const handled = await executeSlashCommand(messageContent, messagesToSend, userMsg);
+        if (handled) return;
+
+        // Normal message flow — user message already in timeline, just stream
+        return subscribeToMessageStream(messagesToSend, userMsg);
+      } finally {
+        isValidatingRef.current = false;
+        setIsValidating(false);
       }
-
-      // 2. Check if current data source is valid (exists in available list)
-      const compatibleDataSources = await chatService.getAvailableDataSources();
-      const isValid =
-        currentDataSourceId && compatibleDataSources.some((ds) => ds.id === currentDataSourceId);
-
-      if (!isValid) {
-        if (compatibleDataSources.length >= 1) {
-          // Compatible data sources exist — prompt user to pick one.
-          // The user message is added to the timeline now so it stays visible while the
-          // selector is shown; handleDataSourceSelect replaces it once a source is chosen.
-          const userMsg = chatService.getUserMessage(messageContent);
-          setPendingMessage(userMsg);
-          setAvailableDataSources(compatibleDataSources);
-          setTimeline((prev) => [...prev, userMsg]);
-          return;
-        }
-
-        // 3. No data sources associated with this workspace
-        const userMsg = chatService.getUserMessage(messageContent);
-        const infoMsg: Message = {
-          id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-          role: 'assistant',
-          content: i18n.translate('chat.noDataSourceMessage', {
-            defaultMessage:
-              'There are no data sources associated with this workspace. Please ask your workspace admin to associate data sources to this workspace.',
-          }),
-        };
-        setTimeline((prev) => [...prev, userMsg, infoMsg]);
-        return;
-      }
-
-      // Check if this is a slash command
-      const handled = await executeSlashCommand(messageContent, messagesToSend);
-      if (handled) return;
-
-      // Normal message flow — add user message to timeline then stream
-      const userMsg = chatService.getUserMessage(messageContent);
-      setTimeline((prev) => [...prev, userMsg]);
-      return subscribeToMessageStream(messagesToSend, userMsg);
     };
 
     handleSendRef.current = handleSend;
@@ -543,6 +571,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       setPendingConfirmation(null);
       setPendingMessage(null);
       setAvailableDataSources([]);
+      isValidatingRef.current = false;
+      setIsValidating(false);
       confirmationService.cleanAll();
       setShowHistory(false);
     }, [chatService, confirmationService, eventHandler, stopStreaming]);
@@ -736,6 +766,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
               layoutMode={layoutMode}
               timeline={timeline}
               isStreaming={isStreaming}
+              isValidating={isValidating}
               onResendMessage={resendAvailable ? handleResendMessage : undefined}
               onResendToolResult={handleResendToolResult}
               onApproveConfirmation={handleApproveConfirmation}
@@ -808,7 +839,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
                 hasActiveToolCalls ||
                 hasPendingResend ||
                 !!pendingConfirmation ||
-                availableDataSources.length > 0
+                availableDataSources.length > 0 ||
+                isValidating
               }
               placeholder={
                 availableDataSources.length > 0


### PR DESCRIPTION
### Description

When a user sends a message in a new chat conversation, the message now appears instantly in the timeline instead of waiting for data source validation to complete.

Previously, `handleSend` awaited multiple async operations (data source resolution, compatibility check, available sources fetch) before inserting the user message into the timeline, causing a noticeable delay.

Changes:
- User message is inserted into the timeline immediately (optimistic rendering)
- A "Connecting..." loading indicator appears below the user message while validation runs
- Input is disabled during validation to prevent double-sends
- Data source validation logic extracted into a `validateDataSource` useCallback for clarity
- All error paths (unsupported DS, DS picker, no DS) append their responses below the already-visible user message

### Issues Resolved

Fixes delayed user message appearance when sending in a new chat conversation.

## Screenshot

https://github.com/user-attachments/assets/491e2588-1c9b-4ab1-a880-268e9b8630fb


## Testing the changes

1. Open the chat sidecar
2. Type a message and press Enter
3. Observe that the user message appears instantly in the timeline
4. A brief "Connecting..." indicator shows while data source is validated
5. After validation, the assistant response streams as usual

For error scenarios:
- With an AnalyticEngine data source: user message appears, then error message below
- With no default DS but alternatives available: user message appears, then DS selector below

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (67 tests pass for chat_window, 47 for chat_messages)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff