### PR TITLE
fix(dashboard): edit log table should be opened in discover

### DIFF
--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
@@ -30,6 +30,7 @@ import { useSearchContext } from '../query_panel/utils/use_search_context';
 import { ExploreServices } from '../../types';
 import { getVisualizationBuilder } from './visualization_builder';
 import { UrlTransformationState } from '../data_transformations';
+import { EXPLORE_LOGS_TAB_ID, ExploreFlavor } from '../../../common';
 
 export interface DashboardAttributes {
   title?: string;
@@ -104,8 +105,8 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
 
     const savedExploreWithState = saveStateToSavedObject(
       savedExplore,
-      // Don't store flavor for visualization snapshot
-      undefined,
+      // Don't store flavor for visualization snapshot except Logs table
+      activeTabId === EXPLORE_LOGS_TAB_ID ? ExploreFlavor.Logs : undefined,
       tabDefinition,
       {
         chartType: chartConfig?.type,


### PR DESCRIPTION
### Description
Fixed an issue that the Logs table opened in visualization editor, while it should be opened in discover
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
