### PR TITLE
fix(dashboard): explore embeddable edit routing for logs panels

### DIFF
--- a/src/plugins/explore/public/embeddable/explore_embeddable_factory.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable_factory.test.tsx
@@ -19,25 +19,26 @@ jest.mock('./explore_embeddable', () => {
 
 describe('ExploreEmbeddableFactory', () => {
   let factory: ExploreEmbeddableFactory;
+  const mockSavedExplore = {
+    id: 'test-id',
+    title: 'Test Explore',
+    description: 'Test description',
+    searchSource: {
+      getField: jest.fn((field) => {
+        if (field === 'index') {
+          return { id: 'test-index' };
+        }
+        if (field === 'query') {
+          return { query: 'test', language: 'kuery' };
+        }
+        return null;
+      }),
+    },
+    type: 'logs',
+  };
   const mockedGetServicesResults = {
     getSavedExploreUrlById: jest.fn().mockResolvedValue('saved-explore-url'),
-    getSavedExploreById: jest.fn().mockResolvedValue({
-      id: 'test-id',
-      title: 'Test Explore',
-      description: 'Test description',
-      searchSource: {
-        getField: jest.fn((field) => {
-          if (field === 'index') {
-            return { id: 'test-index' };
-          }
-          if (field === 'query') {
-            return { query: 'test', language: 'kuery' };
-          }
-          return null;
-        }),
-      },
-      type: 'logs',
-    }),
+    getSavedExploreById: jest.fn().mockResolvedValue(mockSavedExplore),
     addBasePath: jest.fn((path) => `/base${path}`),
     capabilities: {
       discover: {
@@ -218,7 +219,7 @@ describe('ExploreEmbeddableFactory', () => {
     expect(result).toBeInstanceOf(ErrorEmbeddable);
   });
 
-  test('createFromSavedObject creates an ExploreEmbeddable', async () => {
+  test('createFromSavedObject opens non-logs panels in visualization editor', async () => {
     const input = { id: 'test', timeRange: { from: 'now-15m', to: 'now' } };
 
     await factory.createFromSavedObject('test-id', input as any);
@@ -228,10 +229,35 @@ describe('ExploreEmbeddableFactory', () => {
           id: 'test-id',
           title: 'Test Explore',
         }),
-        editUrl: '/base/app/explore/logs/saved-explore-url',
-        editPath: 'saved-explore-url',
+        editUrl: '/base/app/visualization-editor#/edit/test-id',
+        editPath: '#/edit/test-id',
         editable: true,
         indexPatterns: [{ id: 'test-index' }],
+        editApp: 'visualization-editor',
+      }),
+      input,
+      mockStartServices.executeTriggerActions,
+      undefined
+    );
+  });
+
+  test('createFromSavedObject opens logs tab panels in Explore logs', async () => {
+    jest.spyOn(OsdServices, 'getServices').mockReturnValue({
+      ...mockedGetServicesResults,
+      getSavedExploreById: jest.fn().mockResolvedValue({
+        ...mockSavedExplore,
+        type: undefined,
+        uiState: JSON.stringify({ activeTab: 'logs' }),
+      }),
+    } as any);
+
+    const input = { id: 'test', timeRange: { from: 'now-15m', to: 'now' } };
+
+    await factory.createFromSavedObject('test-id', input as any);
+    expect(ExploreEmbeddable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editUrl: '/base/app/explore/logs/saved-explore-url',
+        editPath: 'saved-explore-url',
         editApp: 'explore/logs',
       }),
       input,
@@ -315,7 +341,7 @@ describe('ExploreEmbeddableFactory', () => {
     jest.spyOn(OsdServices, 'getServices').mockReturnValue({
       ...mockedGetServicesResults,
       getSavedExploreById: jest.fn().mockResolvedValue({
-        ...mockedGetServicesResults.getSavedExploreById(),
+        ...mockSavedExplore,
         searchSource: {
           getField: jest.fn(() => null),
         },

--- a/src/plugins/explore/public/embeddable/explore_embeddable_factory.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable_factory.tsx
@@ -23,7 +23,7 @@ import { ExploreInput, ExploreOutput } from './types';
 import { EXPLORE_EMBEDDABLE_TYPE } from './constants';
 import { ExploreEmbeddable } from './explore_embeddable';
 import { VisualizationRegistryService } from '../services/visualization_registry_service';
-import { ExploreFlavor, VISUALIZATION_EDITOR_APP_ID } from '../../common';
+import { EXPLORE_LOGS_TAB_ID, ExploreFlavor, VISUALIZATION_EDITOR_APP_ID } from '../../common';
 import { SavedExplore } from '../saved_explore';
 
 interface StartServices {
@@ -128,15 +128,17 @@ export class ExploreEmbeddableFactory implements EmbeddableFactoryDefinition<
       const indexPattern = savedObject.searchSource.getField('index');
       const { executeTriggerActions } = await this.getStartServices();
       const { ExploreEmbeddable: ExploreEmbeddableClass } = await import('./explore_embeddable');
-      const flavor = savedObject.type ?? ExploreFlavor.Logs;
-      const editUrl = savedObject.type
-        ? services.addBasePath(`/app/explore/${flavor}/${url}`)
+
+      const uiState = JSON.parse(savedObject.uiState || '{}');
+      const isLogs = uiState.activeTab === EXPLORE_LOGS_TAB_ID;
+
+      const editUrl = isLogs
+        ? services.addBasePath(`/app/explore/${ExploreFlavor.Logs}/${url}`)
         : services.addBasePath(`/app/${VISUALIZATION_EDITOR_APP_ID}#/edit/${savedObjectId}`);
 
-      // for in-context created visualization
-      const editPath = !savedObject.type ? `#/edit/${savedObjectId}` : url;
-
-      const editApp = !savedObject.type ? VISUALIZATION_EDITOR_APP_ID : `explore/${flavor}`;
+      // Log table opened in discover, other explore visualizations opened in visualization editor
+      const editPath = !isLogs ? `#/edit/${savedObjectId}` : url;
+      const editApp = !isLogs ? VISUALIZATION_EDITOR_APP_ID : `explore/${ExploreFlavor.Logs}`;
 
       return new ExploreEmbeddableClass(
         {


### PR DESCRIPTION
### Description
This PR fixed the Explore embeddable edit routing issue from dashboards.

Panels saved from the Explore logs tab open back in Explore logs when edited. All other Explore visualization panels to open in the visualization editor regardless of where they were created.



<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
