### PR TITLE
feat: enhance maximum workspace with pagination support and maximum_workspaces support in pageSize

### DIFF
--- a/src/core/types/workspace.ts
+++ b/src/core/types/workspace.ts
@@ -37,7 +37,12 @@ export enum WorkspacePermissionMode {
 
 export interface WorkspaceFindOptions {
   page?: number;
-  perPage?: number;
+  /**
+   * The page size for the `_list` API. A number pages as usual; the special
+   * `'maximum_workspaces'` sentinel (see `MAXIMUM_WORKSPACES_PER_PAGE` in the workspace
+   * plugin constants) tells the server to page by `workspace.maximum_workspaces`.
+   */
+  perPage?: number | 'maximum_workspaces';
   search?: string;
   searchFields?: string[];
   sortField?: string;

--- a/src/plugins/workspace/common/constants.ts
+++ b/src/plugins/workspace/common/constants.ts
@@ -170,6 +170,22 @@ export const MAX_WORKSPACE_DESCRIPTION_LENGTH = 200;
  */
 export const DEFAULT_WORKSPACE_LIST_PER_PAGE = 999;
 
+/**
+ * A sentinel value for the `_list` API `perPage` parameter. When passed, the server
+ * resolves the page size to `workspace.maximum_workspaces` (via the dynamic config
+ * service, falling back to {@link DEFAULT_WORKSPACE_LIST_PER_PAGE}) so that every
+ * workspace a user is allowed to create can also be listed. Any other numeric value
+ * pages as usual, keeping the default API behavior unchanged.
+ */
+export const MAXIMUM_WORKSPACES_PER_PAGE = 'maximum_workspaces' as const;
+
+/**
+ * The page size used when exhaustively fetching every workspace on the server side (see
+ * the workspace collection fetcher). A large but bounded value keeps each request cheap
+ * while still walking every page.
+ */
+export const WORKSPACE_FETCH_ALL_PER_PAGE = 1000;
+
 export enum AssociationDataSourceModalMode {
   OpenSearchConnections = 'opensearch-connections',
   DirectQueryConnections = 'direction-query-connections',

--- a/src/plugins/workspace/config.ts
+++ b/src/plugins/workspace/config.ts
@@ -12,9 +12,3 @@ export const configSchema = schema.object({
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;
-
-/**
- * The subset of the workspace config which is exposed to the browser,
- * see `exposeToBrowser` in `server/index.ts`.
- */
-export type WorkspacePublicConfig = Pick<ConfigSchema, 'maximum_workspaces'>;

--- a/src/plugins/workspace/public/index.ts
+++ b/src/plugins/workspace/public/index.ts
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from 'opensearch-dashboards/public';
-import { WorkspacePublicConfig } from '../config';
 import { WorkspacePlugin } from './plugin';
 
-export function plugin(initializerContext: PluginInitializerContext<WorkspacePublicConfig>) {
-  return new WorkspacePlugin(initializerContext);
+export function plugin() {
+  return new WorkspacePlugin();
 }
 
 export { WorkspacePluginSetup, WorkspaceCollaborator } from './types';

--- a/src/plugins/workspace/public/plugin.test.ts
+++ b/src/plugins/workspace/public/plugin.test.ts
@@ -14,7 +14,6 @@ import {
   WorkspaceAvailability,
   AppStatus,
   WorkspaceError,
-  PluginInitializerContext,
 } from 'opensearch-dashboards/public';
 import { WORKSPACE_FATAL_ERROR_APP_ID, WORKSPACE_DETAIL_APP_ID } from '../common/constants';
 import { savedObjectsManagementPluginMock } from '../../saved_objects_management/public/mocks';
@@ -27,7 +26,6 @@ import { navigationPluginMock } from '../../navigation/public/mocks';
 import * as registerDefaultCollaboratorTypesExports from './register_default_collaborator_types';
 import { AddCollaboratorsModal } from './components/add_collaborators_modal';
 import { dataPluginMock } from '../../data/public/mocks';
-import { WorkspacePublicConfig } from '../config';
 
 // Expect 6 app registrations: create, fatal error, detail, initial, navigation, collaborator and list apps.
 const registrationAppNumber = 7;
@@ -39,16 +37,6 @@ describe('Workspace plugin', () => {
     data: dataPluginMock.createStartContract(),
   });
   const getSetupMock = () => coreMock.createSetup();
-  const getInitializerContextMock = (
-    maximumWorkspaces?: number
-  ): PluginInitializerContext<WorkspacePublicConfig> => ({
-    ...coreMock.createPluginInitializerContext(),
-    config: {
-      // `get` is generic, so the value has to be cast the same way the core mock does.
-      get: <T extends object = WorkspacePublicConfig>() =>
-        ({ maximum_workspaces: maximumWorkspaces }) as T,
-    },
-  });
 
   beforeEach(() => {
     WorkspaceClientMock.mockClear();
@@ -58,7 +46,7 @@ describe('Workspace plugin', () => {
   it('#setup', async () => {
     const setupMock = getSetupMock();
     const savedObjectManagementSetupMock = savedObjectsManagementPluginMock.createSetupContract();
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {
       savedObjectsManagement: savedObjectManagementSetupMock,
       management: managementPluginMock.createSetupContract(),
@@ -69,7 +57,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#call savedObjectsClient.setCurrentWorkspace when current workspace id changed', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -84,7 +72,7 @@ describe('Workspace plugin', () => {
   it('#setup should register workspace list with a visible application and register to settingsAndSetup nav group', async () => {
     const setupMock = coreMock.createSetup();
     setupMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {});
 
     expect(setupMock.application.register).toHaveBeenCalledWith(
@@ -109,7 +97,7 @@ describe('Workspace plugin', () => {
   it('#setup should register workspace detail with a hidden application and not register to all nav group', async () => {
     const setupMock = coreMock.createSetup();
     setupMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {});
 
     expect(setupMock.application.register).toHaveBeenCalledWith(
@@ -133,7 +121,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should register workspace initial with a visible application', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {});
 
     expect(setupMock.application.register).toHaveBeenCalledWith(
@@ -156,7 +144,7 @@ describe('Workspace plugin', () => {
     setupMock.chrome.registerCollapsibleNavHeader.mockImplementation(
       (func) => (collapsibleNavHeaderImplementation = func)
     );
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {});
     expect(collapsibleNavHeaderImplementation()).toEqual(null);
     const startMock = coreMock.createStart();
@@ -176,7 +164,7 @@ describe('Workspace plugin', () => {
         },
       },
     };
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {
       contentManagement: {
         registerPage: jest.fn(),
@@ -206,7 +194,7 @@ describe('Workspace plugin', () => {
         },
       },
     };
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {
       contentManagement: {
         registerPage: jest.fn(),
@@ -231,7 +219,7 @@ describe('Workspace plugin', () => {
         },
       },
     };
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {
       contentManagement: {
         registerPage: jest.fn(),
@@ -241,7 +229,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should register workspace navigation with a visible application', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(setupMock, {});
     expect(setupMock.application.register).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -257,7 +245,7 @@ describe('Workspace plugin', () => {
       .spyOn(registerDefaultCollaboratorTypesExports, 'registerDefaultCollaboratorTypes')
       .mockImplementationOnce(registerDefaultCollaboratorTypesMock);
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     expect(registerDefaultCollaboratorTypesMock).not.toHaveBeenCalled();
     await workspacePlugin.setup(setupMock, {});
     expect(registerDefaultCollaboratorTypesMock).toHaveBeenCalled();
@@ -265,7 +253,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should return WorkspaceCollaboratorTypesService', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const result = await workspacePlugin.setup(setupMock, {});
 
     expect(result.collaboratorTypes).toBeInstanceOf(WorkspaceCollaboratorTypesService);
@@ -273,7 +261,7 @@ describe('Workspace plugin', () => {
 
   it('#setup should return getAddCollaboratorsModal method', async () => {
     const setupMock = coreMock.createSetup();
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const result = await workspacePlugin.setup(setupMock, {});
 
     expect(result.ui.AddCollaboratorsModal).toBe(AddCollaboratorsModal);
@@ -284,7 +272,7 @@ describe('Workspace plugin', () => {
 
     const setupMock = coreMock.createSetup();
 
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
 
     await workspacePlugin.setup(setupMock, {});
 
@@ -314,7 +302,7 @@ describe('Workspace plugin', () => {
       result: null,
     });
 
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     await workspacePlugin.setup(getSetupMock(), {});
 
     expect(WorkspaceClientMock).toHaveBeenCalledTimes(1);
@@ -334,7 +322,7 @@ describe('Workspace plugin', () => {
   it('#start when workspace id is in url and enterWorkspace return error', async () => {
     window.history.pushState({}, '', '/w/workspaceId/app');
 
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
 
     await workspacePlugin.setup(getSetupMock(), {});
 
@@ -368,7 +356,7 @@ describe('Workspace plugin', () => {
     startMock.workspaces.currentWorkspace$.next(workspaceObject);
     const breadcrumbs = new BehaviorSubject<ChromeBreadcrumb[]>([{ text: 'dashboards' }]);
     startMock.chrome.getBreadcrumbs$.mockReturnValue(breadcrumbs);
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     workspacePlugin.start(startMock, getMockDependencies());
     expect(startMock.chrome.setBreadcrumbs).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -394,7 +382,7 @@ describe('Workspace plugin', () => {
       { text: 'bar' },
     ]);
     startMock.chrome.getBreadcrumbs$.mockReturnValue(breadcrumbs);
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     workspacePlugin.start(startMock, getMockDependencies());
     expect(startMock.chrome.setBreadcrumbs).not.toHaveBeenCalled();
   });
@@ -402,7 +390,7 @@ describe('Workspace plugin', () => {
   it('#start should register workspace list card into new home page', async () => {
     const startMock = coreMock.createStart();
     startMock.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const mockDependencies = getMockDependencies();
     workspacePlugin.start(startMock, mockDependencies);
     expect(mockDependencies.contentManagement.registerContentProvider).toHaveBeenCalledWith(
@@ -413,7 +401,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should call navGroupUpdater$.next after currentWorkspace set', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -437,7 +425,7 @@ describe('Workspace plugin', () => {
   it('#start register workspace dropdown menu at left navigation bottom when start', async () => {
     const coreStart = coreMock.createStart();
     coreStart.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     workspacePlugin.start(coreStart, getMockDependencies());
 
     expect(coreStart.chrome.navControls.registerLeftBottom).toHaveBeenCalledTimes(1);
@@ -456,7 +444,7 @@ describe('Workspace plugin', () => {
     jest.spyOn(UseCaseService.prototype, 'start').mockImplementationOnce(() => ({
       getRegisteredUseCases$: jest.fn(() => registeredUseCases$),
     }));
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -477,7 +465,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should update nav group status after currentWorkspace set', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -501,7 +489,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should not be able to access app of which workspaceAvailability is set to insideWorkspace when out of workspace', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -528,7 +516,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should remove non-workspace chrome page search service', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -541,7 +529,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should update collaboratorsAppUpdater correctly if permission enabled', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -582,7 +570,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#start should update collaboratorsAppUpdater correctly if permission disabled', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -623,7 +611,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#stop should call unregisterNavGroupUpdater', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const unregisterNavGroupUpdater = jest.fn();
     setupMock.chrome.navGroup.registerNavGroupUpdater.mockReturnValueOnce(
@@ -653,7 +641,7 @@ describe('Workspace plugin', () => {
     jest.spyOn(UseCaseService.prototype, 'start').mockImplementationOnce(() => ({
       getRegisteredUseCases$: jest.fn(() => registeredUseCases$),
     }));
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const coreStart = coreMock.createStart();
     await workspacePlugin.setup(setupMock, {});
@@ -682,7 +670,7 @@ describe('Workspace plugin', () => {
   });
 
   it('#stop should call collaboratorTypesService.stop', async () => {
-    const workspacePlugin = new WorkspacePlugin(getInitializerContextMock());
+    const workspacePlugin = new WorkspacePlugin();
     const setupMock = getSetupMock();
     const stopMock = jest.fn();
     jest

--- a/src/plugins/workspace/public/plugin.ts
+++ b/src/plugins/workspace/public/plugin.ts
@@ -23,7 +23,6 @@ import {
   DEFAULT_NAV_GROUPS,
   NavGroupType,
   ALL_USE_CASE_ID,
-  PluginInitializerContext,
 } from 'opensearch-dashboards/public';
 import { getWorkspaceIdFromUrl } from 'opensearch-dashboards/public/utils';
 import {
@@ -77,7 +76,6 @@ import { WorkspaceValidationService } from './services/workspace_validation_serv
 import { workspaceSearchPages } from './components/global_search/search_pages_command';
 import { isNavGroupInFeatureConfigs } from '../../../core/public';
 import { searchAssets } from './components/global_search/search_assets_command';
-import { WorkspacePublicConfig } from '../config';
 
 type WorkspaceAppType = (
   params: AppMountParameters,
@@ -119,10 +117,6 @@ export class WorkspacePlugin implements Plugin<
   private workspaceValidationService = new WorkspaceValidationService();
   private collaboratorTypes = new WorkspaceCollaboratorTypesService();
   private collaboratorsAppUpdater$ = new BehaviorSubject<AppUpdater>(() => undefined);
-
-  constructor(
-    private readonly initializerContext: PluginInitializerContext<WorkspacePublicConfig>
-  ) {}
 
   private _changeSavedObjectCurrentWorkspace() {
     if (this.coreStart) {
@@ -307,9 +301,7 @@ export class WorkspacePlugin implements Plugin<
       core.http.basePath.getBasePath()
     );
 
-    await this.workspaceValidationService.setup(core, workspaceId, {
-      maximumWorkspaces: this.initializerContext.config.get().maximum_workspaces,
-    });
+    await this.workspaceValidationService.setup(core, workspaceId);
 
     const mountWorkspaceApp = async (params: AppMountParameters, renderApp: WorkspaceAppType) => {
       const [coreStart, { navigation, data }] = await core.getStartServices();

--- a/src/plugins/workspace/public/services/workspace_validation.service.test.ts
+++ b/src/plugins/workspace/public/services/workspace_validation.service.test.ts
@@ -47,16 +47,6 @@ describe('WorkspaceValidationService', () => {
       expect(workspaceClientMock.enterWorkspace).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass the maximum workspaces option to the workspace client', async () => {
-      const core = coreMock.createSetup();
-      const service = new WorkspaceValidationService();
-      await service.setup(core, 'test-workspace-123', { maximumWorkspaces: 5000 });
-
-      expect(WorkspaceClientMock).toHaveBeenCalledWith(core.http, core.workspaces, {
-        maximumWorkspaces: 5000,
-      });
-    });
-
     it('should not enter workspace it workspace id is not set', async () => {
       const core = coreMock.createSetup();
       const service = new WorkspaceValidationService();

--- a/src/plugins/workspace/public/services/workspace_validation_service.ts
+++ b/src/plugins/workspace/public/services/workspace_validation_service.ts
@@ -44,10 +44,10 @@ export class WorkspaceValidationService {
     });
   }
 
-  async setup(core: CoreSetup, workspaceId: string, options: { maximumWorkspaces?: number } = {}) {
+  async setup(core: CoreSetup, workspaceId: string) {
     this.workspaceId = workspaceId;
 
-    const workspaceClient = new WorkspaceClient(core.http, core.workspaces, options);
+    const workspaceClient = new WorkspaceClient(core.http, core.workspaces);
     await workspaceClient.init();
     core.workspaces.setClient(workspaceClient);
     this.workspaceClient = workspaceClient;

--- a/src/plugins/workspace/public/workspace_client.test.ts
+++ b/src/plugins/workspace/public/workspace_client.test.ts
@@ -5,55 +5,44 @@
 
 import { httpServiceMock, workspacesServiceMock } from '../../../core/public/mocks';
 import { WorkspaceClient } from './workspace_client';
-import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../common/constants';
+import { DEFAULT_WORKSPACE_LIST_PER_PAGE, MAXIMUM_WORKSPACES_PER_PAGE } from '../common/constants';
 
-const getWorkspaceClient = (options?: { maximumWorkspaces?: number }) => {
+const getWorkspaceClient = () => {
   const httpSetupMock = httpServiceMock.createSetupContract();
   const workspaceMock = workspacesServiceMock.createSetupContract();
   return {
     httpSetupMock,
     workspaceMock,
-    workspaceClient: new WorkspaceClient(httpSetupMock, workspaceMock, options),
+    workspaceClient: new WorkspaceClient(httpSetupMock, workspaceMock),
   };
 };
 
 describe('#WorkspaceClient', () => {
-  it('#init', async () => {
+  it('#init requests the maximum_workspaces page size so the server pages by it', async () => {
     const { workspaceClient, httpSetupMock, workspaceMock } = getWorkspaceClient();
-    await workspaceClient.init();
-    expect(workspaceMock.initialized$.getValue()).toEqual(true);
-    expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
-      method: 'POST',
-      body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
-      }),
-    });
-  });
-
-  it('#init uses the configured maximum_workspaces as the page size', async () => {
-    const { workspaceClient, httpSetupMock } = getWorkspaceClient({ maximumWorkspaces: 5000 });
     httpSetupMock.fetch.mockResolvedValue({
       success: true,
       result: { workspaces: [] },
     });
     await workspaceClient.init();
+    expect(workspaceMock.initialized$.getValue()).toEqual(true);
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 5000,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 5000,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
         permissionModes: ['library_write'],
       }),
     });
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: 5000,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
         permissionModes: ['write'],
       }),
     });
@@ -143,14 +132,14 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
 
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
         permissionModes: ['library_write'],
       }),
     });
@@ -172,7 +161,7 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
   });
@@ -242,14 +231,14 @@ describe('#WorkspaceClient', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
 
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
         permissionModes: ['library_write'],
       }),
     });
@@ -426,7 +415,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 2, fail: 0, failedIds: [] });
@@ -449,7 +438,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 1, fail: 1, failedIds: ['bar'] });
@@ -472,7 +461,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 0, fail: 2, failedIds: ['foo', 'bar'] });
@@ -485,7 +474,7 @@ describe('WorkspaceClient.batchDelete', () => {
     expect(httpSetupMock.fetch).toHaveBeenCalledWith('/api/workspaces/_list', {
       method: 'POST',
       body: JSON.stringify({
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       }),
     });
     expect(result).toEqual({ success: 0, fail: 0, failedIds: [] });

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../core/public';
 import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
 import { DataSourceAssociation } from './components/data_source_association/data_source_association';
-import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../common/constants';
+import { MAXIMUM_WORKSPACES_PER_PAGE } from '../common/constants';
 
 const WORKSPACES_API_BASE_URL = '/api/workspaces';
 
@@ -39,21 +39,10 @@ export class WorkspaceClient implements IWorkspaceClient {
   private http: HttpSetup;
   private workspaces: WorkspacesSetup;
   private isPermissionEnabled: boolean = false;
-  /**
-   * The page size used when fetching the full workspace list. It honors
-   * `workspace.maximum_workspaces` so that every workspace a user is allowed to
-   * create can also be listed.
-   */
-  private listPerPage: number;
 
-  constructor(
-    http: HttpSetup,
-    workspaces: WorkspacesSetup,
-    options: { maximumWorkspaces?: number } = {}
-  ) {
+  constructor(http: HttpSetup, workspaces: WorkspacesSetup) {
     this.http = http;
     this.workspaces = workspaces;
-    this.listPerPage = options.maximumWorkspaces ?? DEFAULT_WORKSPACE_LIST_PER_PAGE;
   }
 
   public setPermissionEnabled(enabled: boolean) {
@@ -118,18 +107,21 @@ export class WorkspaceClient implements IWorkspaceClient {
    * Fetch latest list of workspaces and update workspaceList$ to notify subscriptions
    */
   private async updateWorkspaceList(): Promise<void> {
+    // Request the `maximum_workspaces` page size so the server pages by
+    // `workspace.maximum_workspaces`, ensuring every workspace a user is allowed to
+    // create can also be listed.
     const result = await this.list({
-      perPage: this.listPerPage,
+      perPage: MAXIMUM_WORKSPACES_PER_PAGE,
     });
 
     if (result?.success) {
       const [resultWithWritePermission, resultWithOwnerPermission] = await Promise.all([
         this.list({
-          perPage: this.listPerPage,
+          perPage: MAXIMUM_WORKSPACES_PER_PAGE,
           permissionModes: [WorkspacePermissionMode.LibraryWrite],
         }),
         this.list({
-          perPage: this.listPerPage,
+          perPage: MAXIMUM_WORKSPACES_PER_PAGE,
           permissionModes: [WorkspacePermissionMode.Write],
         }),
       ]);

--- a/src/plugins/workspace/server/index.ts
+++ b/src/plugins/workspace/server/index.ts
@@ -15,9 +15,6 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export const config: PluginConfigDescriptor = {
-  exposeToBrowser: {
-    maximum_workspaces: true,
-  },
   schema: configSchema,
 };
 

--- a/src/plugins/workspace/server/plugin.ts
+++ b/src/plugins/workspace/server/plugin.ts
@@ -133,8 +133,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     });
 
     this.workspaceSavedObjectsClientWrapper = new WorkspaceSavedObjectsClientWrapper(
-      this.permissionControl,
-      this.configService
+      this.permissionControl
     );
 
     core.savedObjects.addClientWrapper(
@@ -296,7 +295,7 @@ export class WorkspacePlugin implements Plugin<WorkspacePluginSetup, WorkspacePl
     core.savedObjects.addClientWrapper(
       PRIORITY_FOR_WORKSPACE_ID_CONSUMER_WRAPPER,
       WORKSPACE_ID_CONSUMER_WRAPPER_ID,
-      new WorkspaceIdConsumerWrapper(this.client, this.logger, this.configService).wrapperFactory
+      new WorkspaceIdConsumerWrapper(this.client, this.logger).wrapperFactory
     );
 
     const maxImportExportSize = core.savedObjects.getImportExportObjectLimit();

--- a/src/plugins/workspace/server/routes/index.test.ts
+++ b/src/plugins/workspace/server/routes/index.test.ts
@@ -10,6 +10,7 @@ import { setupServer } from '../../../../core/server/test_utils';
 import { loggingSystemMock, dynamicConfigServiceMock } from '../../../../core/server/mocks';
 
 import { workspaceClientMock } from '../workspace_client.mock';
+import { MAXIMUM_WORKSPACES_PER_PAGE } from '../../common/constants';
 
 import { registerRoutes, WORKSPACES_API_BASE_URL } from './index';
 import { IWorkspaceClientImpl } from '../types';
@@ -28,6 +29,10 @@ describe(`Workspace routes`, () => {
     const router = httpSetup.createRouter('');
 
     mockedWorkspaceClient = workspaceClientMock.create();
+    (mockedWorkspaceClient.list as jest.Mock).mockResolvedValue({
+      success: true,
+      result: { workspaces: [], total: 0, per_page: 0, page: 1 },
+    });
 
     registerRoutes({
       router,
@@ -63,6 +68,51 @@ describe(`Workspace routes`, () => {
         features: ['use-case-observability'],
       })
     );
+  });
+
+  describe('_list', () => {
+    it('accepts the MAXIMUM_WORKSPACES_PER_PAGE sentinel and forwards it to the client', async () => {
+      await supertest(httpSetup.server.listener)
+        .post(`${WORKSPACES_API_BASE_URL}/_list`)
+        .send({ perPage: MAXIMUM_WORKSPACES_PER_PAGE })
+        .expect(200);
+
+      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ perPage: MAXIMUM_WORKSPACES_PER_PAGE })
+      );
+    });
+
+    it('defaults to a page size of 20 when perPage is omitted', async () => {
+      await supertest(httpSetup.server.listener)
+        .post(`${WORKSPACES_API_BASE_URL}/_list`)
+        .send({})
+        .expect(200);
+
+      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ perPage: 20 })
+      );
+    });
+
+    it('honors an explicit numeric perPage from the request', async () => {
+      await supertest(httpSetup.server.listener)
+        .post(`${WORKSPACES_API_BASE_URL}/_list`)
+        .send({ perPage: 10 })
+        .expect(200);
+
+      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ perPage: 10 })
+      );
+    });
+
+    it('rejects a perPage that is neither a number nor the sentinel', async () => {
+      await supertest(httpSetup.server.listener)
+        .post(`${WORKSPACES_API_BASE_URL}/_list`)
+        .send({ perPage: 'not-a-number' })
+        .expect(400);
+    });
   });
 
   /**

--- a/src/plugins/workspace/server/routes/index.ts
+++ b/src/plugins/workspace/server/routes/index.ts
@@ -15,6 +15,7 @@ import {
 import {
   MAX_WORKSPACE_NAME_LENGTH,
   MAX_WORKSPACE_DESCRIPTION_LENGTH,
+  MAXIMUM_WORKSPACES_PER_PAGE,
 } from '../../common/constants';
 import { IWorkspaceClientImpl, WorkspaceAttributeWithPermission } from '../types';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
@@ -141,7 +142,14 @@ export function registerRoutes({
         body: schema.object({
           search: schema.maybe(schema.string()),
           sortOrder: schema.maybe(schema.string()),
-          perPage: schema.number({ min: 0, defaultValue: 20 }),
+          // Accepts a number for regular paging, or the `MAXIMUM_WORKSPACES_PER_PAGE`
+          // sentinel to page by `workspace.maximum_workspaces` (resolved per request
+          // through the dynamic config service). Defaults to 20, keeping the original
+          // API behavior unchanged.
+          perPage: schema.oneOf(
+            [schema.number({ min: 0 }), schema.literal(MAXIMUM_WORKSPACES_PER_PAGE)],
+            { defaultValue: 20 }
+          ),
           page: schema.number({ min: 0, defaultValue: 1 }),
           sortField: schema.maybe(schema.string()),
           searchFields: schema.maybe(schema.arrayOf(schema.string())),
@@ -150,6 +158,8 @@ export function registerRoutes({
       },
     },
     router.handleLegacyErrors(async (context, req, res) => {
+      // The `perPage` value (including the `MAXIMUM_WORKSPACES_PER_PAGE` sentinel) is
+      // resolved inside `client.list`.
       const result = await client.list(
         {
           request: req,

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.test.ts
@@ -14,8 +14,7 @@ import {
 import { WorkspaceIdConsumerWrapper } from './workspace_id_consumer_wrapper';
 import { workspaceClientMock } from '../workspace_client.mock';
 import { SavedObjectsErrorHelpers } from '../../../../core/server';
-import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../../common/constants';
-import { createWorkspaceConfigServiceMock } from '../services/workspace_config_service.mock';
+import { MAXIMUM_WORKSPACES_PER_PAGE } from '../../common/constants';
 
 describe('WorkspaceIdConsumerWrapper', () => {
   const requestHandlerContext = coreMock.createRequestHandlerContext();
@@ -122,7 +121,7 @@ describe('WorkspaceIdConsumerWrapper', () => {
       expect(mockedWorkspaceClient.list).toHaveBeenCalledTimes(1);
     });
 
-    it(`Should list workspaces with the default page size`, async () => {
+    it(`Should list all workspaces via the MAXIMUM_WORKSPACES_PER_PAGE sentinel`, async () => {
       const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
         mockedWorkspaceClient,
         logger
@@ -147,71 +146,7 @@ describe('WorkspaceIdConsumerWrapper', () => {
       );
 
       expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
-      });
-    });
-
-    it(`Should list workspaces with the resolved maximum_workspaces as page size`, async () => {
-      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
-        mockedWorkspaceClient,
-        logger,
-        createWorkspaceConfigServiceMock({ maximum_workspaces: 5000 })
-      );
-      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
-      updateWorkspaceState(mockRequest, {});
-      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
-        client: mockedClient,
-        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
-        request: mockRequest,
-      });
-
-      mockedWorkspaceClient.list.mockResolvedValueOnce({
-        success: true,
-        result: { workspaces: [{ id: 'foo' }, { id: 'bar' }] },
-      });
-
-      await mockedWrapperClient.create(
-        'dashboard',
-        { name: 'foo' },
-        { workspaces: ['foo', 'bar'] }
-      );
-
-      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
-        perPage: 5000,
-      });
-    });
-
-    it(`Should fall back to the default page size when maximum_workspaces cannot be resolved`, async () => {
-      const configServiceMock = createWorkspaceConfigServiceMock();
-      configServiceMock.scopedClient.getMaximumWorkspaces.mockRejectedValue(
-        new Error('config store unavailable')
-      );
-      const workspaceIdConsumerWrapper = new WorkspaceIdConsumerWrapper(
-        mockedWorkspaceClient,
-        logger,
-        configServiceMock
-      );
-      const mockRequest = httpServerMock.createOpenSearchDashboardsRequest();
-      updateWorkspaceState(mockRequest, {});
-      const mockedWrapperClient = workspaceIdConsumerWrapper.wrapperFactory({
-        client: mockedClient,
-        typeRegistry: requestHandlerContext.savedObjects.typeRegistry,
-        request: mockRequest,
-      });
-
-      mockedWorkspaceClient.list.mockResolvedValueOnce({
-        success: true,
-        result: { workspaces: [{ id: 'foo' }, { id: 'bar' }] },
-      });
-
-      await mockedWrapperClient.create(
-        'dashboard',
-        { name: 'foo' },
-        { workspaces: ['foo', 'bar'] }
-      );
-
-      expect(mockedWorkspaceClient.list).toHaveBeenCalledWith(expect.anything(), {
-        perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
       });
     });
   });

--- a/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_id_consumer_wrapper.ts
@@ -22,8 +22,7 @@ import {
 } from '../../../../core/server';
 import { IWorkspaceClientImpl } from '../types';
 import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
-import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../../common/constants';
-import { IWorkspaceConfigService } from '../services';
+import { MAXIMUM_WORKSPACES_PER_PAGE } from '../../common/constants';
 
 const UI_SETTINGS_SAVED_OBJECTS_TYPE = 'config';
 
@@ -40,20 +39,6 @@ const generateSavedObjectsForbiddenError = () =>
 
 export class WorkspaceIdConsumerWrapper {
   private readonly logger: Logger;
-
-  /**
-   * Resolves the page size used when listing workspaces to validate the requested ones
-   * exist. It honors `workspace.maximum_workspaces` so that workspaces beyond the
-   * default page size are not reported as invalid.
-   */
-  private async getWorkspaceListPerPage(request: OpenSearchDashboardsRequest): Promise<number> {
-    const maximumWorkspaces = await this.configService
-      ?.asScopedToRequest(request)
-      .getMaximumWorkspaces()
-      .catch(() => undefined);
-
-    return maximumWorkspaces ?? DEFAULT_WORKSPACE_LIST_PER_PAGE;
-  }
 
   private formatWorkspaceIdParams<T extends WorkspaceOptions>(
     request: OpenSearchDashboardsRequest,
@@ -108,7 +93,7 @@ export class WorkspaceIdConsumerWrapper {
             request: wrapperOptions.request,
           },
           {
-            perPage: await this.getWorkspaceListPerPage(wrapperOptions.request),
+            perPage: MAXIMUM_WORKSPACES_PER_PAGE,
           }
         );
         if (workspaceList.success) {
@@ -266,8 +251,7 @@ export class WorkspaceIdConsumerWrapper {
 
   constructor(
     private readonly workspaceClient: IWorkspaceClientImpl,
-    logger: Logger,
-    private readonly configService?: IWorkspaceConfigService
+    logger: Logger
   ) {
     this.logger = logger;
   }

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.test.ts
@@ -23,20 +23,13 @@ import {
   DATA_SOURCE_SAVED_OBJECT_TYPE,
   DATA_CONNECTION_SAVED_OBJECT_TYPE,
 } from '../../../data_source/common';
-import { DEFAULT_WORKSPACE_LIST_PER_PAGE } from '../../common/constants';
-import {
-  createWorkspaceConfigServiceMock,
-  WorkspaceConfigServiceMock,
-} from '../services/workspace_config_service.mock';
+import { WORKSPACE_FETCH_ALL_PER_PAGE } from '../../common/constants';
 
 const DASHBOARD_ADMIN = 'dashboard_admin';
 const NO_DASHBOARD_ADMIN = 'no_dashboard_admin';
 const DATASOURCE_ADMIN = 'dataSource_admin';
 
-const generateWorkspaceSavedObjectsClientWrapper = (
-  role = NO_DASHBOARD_ADMIN,
-  configServiceMock?: WorkspaceConfigServiceMock
-) => {
+const generateWorkspaceSavedObjectsClientWrapper = (role = NO_DASHBOARD_ADMIN) => {
   const savedObjectsStore: SavedObject[] = [
     {
       type: 'dashboard',
@@ -221,7 +214,7 @@ const generateWorkspaceSavedObjectsClientWrapper = (
     clearSavedObjectsCache: jest.fn(),
   };
 
-  const wrapper = new WorkspaceSavedObjectsClientWrapper(permissionControlMock, configServiceMock);
+  const wrapper = new WorkspaceSavedObjectsClientWrapper(permissionControlMock);
   const scopedClientMock = savedObjectsClientMock.create();
   scopedClientMock.find.mockImplementation(async () => ({
     total: 1,
@@ -727,44 +720,49 @@ describe('WorkspaceSavedObjectsClientWrapper', () => {
           workspacesSearchOperator: 'OR',
         });
       });
-      it('should look up permitted workspaces with the default page size', async () => {
+      it('should look up permitted workspaces a page at a time at WORKSPACE_FETCH_ALL_PER_PAGE', async () => {
         const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper();
         await wrapper.find({ type: 'dashboard' });
         expect(scopedClientMock.find).toHaveBeenCalledWith(
           expect.objectContaining({
             type: 'workspace',
-            perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
+            perPage: WORKSPACE_FETCH_ALL_PER_PAGE,
+            page: 1,
           })
         );
       });
-      it('should look up permitted workspaces with the resolved maximum_workspaces as page size', async () => {
-        const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper(
-          NO_DASHBOARD_ADMIN,
-          createWorkspaceConfigServiceMock({ maximum_workspaces: 5000 })
-        );
+      it('should fan out every page when looking up permitted workspaces', async () => {
+        const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper();
+        const total = WORKSPACE_FETCH_ALL_PER_PAGE * 2 + 1;
+        // Two full pages, then a short final page. Mock by page since the pages after the
+        // first are requested in parallel.
+        scopedClientMock.find.mockImplementation(async ({ page }) => {
+          const savedObjects =
+            page === 3
+              ? [{ id: 'page3-0', type: 'workspace', score: 1, attributes: {}, references: [] }]
+              : new Array(WORKSPACE_FETCH_ALL_PER_PAGE).fill(0).map((_, i) => ({
+                  id: `page${page}-${i}`,
+                  type: 'workspace',
+                  score: 1,
+                  attributes: {},
+                  references: [],
+                }));
+          return {
+            total,
+            per_page: WORKSPACE_FETCH_ALL_PER_PAGE,
+            page: page as number,
+            saved_objects: savedObjects,
+          };
+        });
+
         await wrapper.find({ type: 'dashboard' });
+
+        expect(scopedClientMock.find).toHaveBeenCalledTimes(3);
         expect(scopedClientMock.find).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: 'workspace',
-            perPage: 5000,
-          })
+          expect.objectContaining({ type: 'workspace', page: 2 })
         );
-      });
-      it('should look up permitted workspaces with the default page size when maximum_workspaces cannot be resolved', async () => {
-        const configServiceMock = createWorkspaceConfigServiceMock();
-        configServiceMock.scopedClient.getMaximumWorkspaces.mockRejectedValue(
-          new Error('config store unavailable')
-        );
-        const { wrapper, scopedClientMock } = generateWorkspaceSavedObjectsClientWrapper(
-          NO_DASHBOARD_ADMIN,
-          configServiceMock
-        );
-        await wrapper.find({ type: 'dashboard' });
         expect(scopedClientMock.find).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: 'workspace',
-            perPage: DEFAULT_WORKSPACE_LIST_PER_PAGE,
-          })
+          expect.objectContaining({ type: 'workspace', page: 3 })
         );
       });
       it('should call client.find with ACLSearchParams when only ACLSearchParams provided', async () => {

--- a/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
+++ b/src/plugins/workspace/server/saved_objects/workspace_saved_objects_client_wrapper.ts
@@ -37,12 +37,9 @@ import {
   WorkspacePermissionMode,
 } from '../../../../core/server';
 import { SavedObjectsPermissionControlContract } from '../permission_control/client';
-import {
-  DEFAULT_WORKSPACE_LIST_PER_PAGE,
-  WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
-} from '../../common/constants';
+import { WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID } from '../../common/constants';
 import { validateIsWorkspaceDataSourceAndConnectionObjectType } from '../../common/utils';
-import { IWorkspaceConfigService } from '../services';
+import { fetchAllWorkspaces } from '../services';
 
 // Can't throw unauthorized for now, the page will be refreshed if unauthorized
 const generateWorkspacePermissionError = () =>
@@ -90,20 +87,6 @@ const getDefaultValuesForEmpty = <T>(values: T[] | undefined, defaultValues: T[]
 
 export class WorkspaceSavedObjectsClientWrapper {
   private getScopedClient?: SavedObjectsServiceStart['getScopedClient'];
-
-  /**
-   * Resolves the page size used when looking up every workspace the current user may
-   * read. It honors `workspace.maximum_workspaces` so that a user who is allowed to
-   * create N workspaces can also see saved objects in all N of them.
-   */
-  private async getWorkspaceListPerPage(request: OpenSearchDashboardsRequest): Promise<number> {
-    const maximumWorkspaces = await this.configService
-      ?.asScopedToRequest(request)
-      .getMaximumWorkspaces()
-      .catch(() => undefined);
-
-    return maximumWorkspaces ?? DEFAULT_WORKSPACE_LIST_PER_PAGE;
-  }
 
   private async validateObjectsPermissions(
     objects: Array<Pick<SavedObject, 'id' | 'type'>>,
@@ -528,9 +511,7 @@ export class WorkspaceSavedObjectsClientWrapper {
       }
       const principals = this.permissionControl.getPrincipalsFromRequest(wrapperOptions.request);
       const permittedWorkspaceIds = (
-        await this.getWorkspaceTypeEnabledClient(wrapperOptions.request).find({
-          type: WORKSPACE_TYPE,
-          perPage: await this.getWorkspaceListPerPage(wrapperOptions.request),
+        await fetchAllWorkspaces(this.getWorkspaceTypeEnabledClient(wrapperOptions.request), {
           ACLSearchParams: {
             principals,
             permissionModes: [
@@ -543,7 +524,7 @@ export class WorkspaceSavedObjectsClientWrapper {
           // or workspaces can not be found because workspace object do not have `workspaces` field.
           workspaces: null,
         })
-      ).saved_objects.map((item) => item.id);
+      ).map((item) => item.id);
 
       // Based on https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/core/server/ui_settings/create_or_upgrade_saved_config/get_upgradeable_config.ts#L49
       // we need to make sure the find call for upgrade config should be able to find all the global configs as it was before.
@@ -704,8 +685,5 @@ export class WorkspaceSavedObjectsClientWrapper {
     };
   };
 
-  constructor(
-    private readonly permissionControl: SavedObjectsPermissionControlContract,
-    private readonly configService?: IWorkspaceConfigService
-  ) {}
+  constructor(private readonly permissionControl: SavedObjectsPermissionControlContract) {}
 }

--- a/src/plugins/workspace/server/services/index.ts
+++ b/src/plugins/workspace/server/services/index.ts
@@ -9,3 +9,4 @@ export {
   WorkspaceConfigServiceSetupDeps,
 } from './workspace_config_service';
 export { IScopedWorkspaceConfigClient } from './scoped_workspace_config_client';
+export { fetchAllWorkspaces, FetchAllWorkspacesOptions } from './workspace_collection_fetcher';

--- a/src/plugins/workspace/server/services/workspace_collection_fetcher.test.ts
+++ b/src/plugins/workspace/server/services/workspace_collection_fetcher.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
+import { WORKSPACE_TYPE } from '../../../../core/server';
+import { WORKSPACE_FETCH_ALL_PER_PAGE } from '../../common/constants';
+import { fetchAllWorkspaces } from './workspace_collection_fetcher';
+
+const savedObject = (id: string) => ({
+  id,
+  type: WORKSPACE_TYPE,
+  score: 1,
+  attributes: {},
+  references: [],
+});
+
+const makePage = (page: number, ids: string[], total: number) => ({
+  total,
+  per_page: WORKSPACE_FETCH_ALL_PER_PAGE,
+  page,
+  saved_objects: ids.map(savedObject),
+});
+
+// A page of unique ids of the given size.
+const fullPage = (page: number, total: number) =>
+  makePage(
+    page,
+    new Array(WORKSPACE_FETCH_ALL_PER_PAGE).fill(0).map((_, i) => `page${page}-${i}`),
+    total
+  );
+
+describe('fetchAllWorkspaces', () => {
+  it('fetches a single page at WORKSPACE_FETCH_ALL_PER_PAGE when the total fits on one page', async () => {
+    const client = savedObjectsClientMock.create();
+    client.find.mockResolvedValueOnce(makePage(1, ['a', 'b', 'c'], 3));
+
+    const result = await fetchAllWorkspaces(client);
+
+    expect(client.find).toHaveBeenCalledTimes(1);
+    expect(client.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: WORKSPACE_TYPE,
+        page: 1,
+        perPage: WORKSPACE_FETCH_ALL_PER_PAGE,
+      })
+    );
+    expect(result).toHaveLength(3);
+  });
+
+  it('fans out the remaining pages in parallel based on the total from the first page', async () => {
+    const total = WORKSPACE_FETCH_ALL_PER_PAGE * 2 + 5;
+    const client = savedObjectsClientMock.create();
+    client.find.mockImplementation(async ({ page }) => {
+      if (page === 3) {
+        return makePage(3, ['tail-0', 'tail-1', 'tail-2', 'tail-3', 'tail-4'], total);
+      }
+      return fullPage(page as number, total);
+    });
+
+    const result = await fetchAllWorkspaces(client);
+
+    // Page 1 fetched to learn the total, then pages 2 and 3 requested.
+    expect(client.find).toHaveBeenCalledTimes(3);
+    expect(client.find).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }));
+    expect(client.find).toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
+    expect(result).toHaveLength(total);
+  });
+
+  it('de-duplicates workspaces by id across pages', async () => {
+    const total = WORKSPACE_FETCH_ALL_PER_PAGE + 2;
+    const client = savedObjectsClientMock.create();
+    client.find.mockImplementation(async ({ page }) => {
+      if (page === 2) {
+        // `dup` also appears on page 1, simulating a workspace that shifted across the
+        // page boundary between the parallel requests.
+        return makePage(2, ['dup', 'unique-2'], total);
+      }
+      return makePage(
+        1,
+        ['dup', ...new Array(WORKSPACE_FETCH_ALL_PER_PAGE - 1).fill(0).map((_, i) => `p1-${i}`)],
+        total
+      );
+    });
+
+    const result = await fetchAllWorkspaces(client);
+
+    const ids = result.map((item) => item.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.filter((id) => id === 'dup')).toHaveLength(1);
+    expect(ids).toContain('unique-2');
+  });
+
+  it('forwards the given find options', async () => {
+    const client = savedObjectsClientMock.create();
+    client.find.mockResolvedValueOnce(makePage(1, [], 0));
+
+    await fetchAllWorkspaces(client, { workspaces: null, ACLSearchParams: { principals: {} } });
+
+    expect(client.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaces: null,
+        ACLSearchParams: { principals: {} },
+      })
+    );
+  });
+});

--- a/src/plugins/workspace/server/services/workspace_collection_fetcher.ts
+++ b/src/plugins/workspace/server/services/workspace_collection_fetcher.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SavedObjectsClientContract,
+  SavedObjectsFindOptions,
+  SavedObjectsFindResult,
+  WorkspaceAttribute,
+  WORKSPACE_TYPE,
+} from '../../../../core/server';
+import { WORKSPACE_FETCH_ALL_PER_PAGE } from '../../common/constants';
+
+/**
+ * Find options accepted when exhaustively fetching workspaces. `type`, `page` and
+ * `perPage` are managed by the fetcher and therefore omitted.
+ */
+export type FetchAllWorkspacesOptions = Omit<SavedObjectsFindOptions, 'type' | 'page' | 'perPage'>;
+
+/**
+ * Exhaustively fetches every workspace saved object matching the given options at a fixed
+ * page size ({@link WORKSPACE_FETCH_ALL_PER_PAGE}). Use this on the server whenever the
+ * full set of workspaces is needed, rather than guessing a single large `perPage`.
+ *
+ * The first page is fetched to learn the total count, then the remaining pages are
+ * requested in parallel. Results are de-duplicated by workspace id, so a workspace that
+ * shifts across a page boundary between requests is not counted twice.
+ *
+ * The provided client must be able to read the hidden `WORKSPACE_TYPE` (e.g. created with
+ * `includedHiddenTypes: [WORKSPACE_TYPE]`).
+ *
+ * TODO: Support projected fields so callers that only need a subset (e.g. just the
+ * workspace id) can pass the fields to fetch, reducing the payload transferred per page.
+ */
+export const fetchAllWorkspaces = async (
+  client: SavedObjectsClientContract,
+  options: FetchAllWorkspacesOptions = {}
+): Promise<Array<SavedObjectsFindResult<WorkspaceAttribute>>> => {
+  const findPage = (page: number) =>
+    client.find<WorkspaceAttribute>({
+      ...options,
+      type: WORKSPACE_TYPE,
+      page,
+      perPage: WORKSPACE_FETCH_ALL_PER_PAGE,
+    });
+
+  const firstPage = await findPage(1);
+  const savedObjects = [...firstPage.saved_objects];
+
+  // Fan out the remaining pages in parallel based on the total reported by the first page.
+  const totalPages = Math.ceil(firstPage.total / WORKSPACE_FETCH_ALL_PER_PAGE);
+  if (totalPages > 1) {
+    const remainingPages = await Promise.all(
+      Array.from({ length: totalPages - 1 }, (_, index) => findPage(index + 2))
+    );
+    remainingPages.forEach((response) => savedObjects.push(...response.saved_objects));
+  }
+
+  // De-dup by workspace id, keeping the last occurrence, in case a workspace moved across
+  // a page boundary while the parallel requests were in flight.
+  const workspacesById = new Map<string, SavedObjectsFindResult<WorkspaceAttribute>>();
+  for (const savedObject of savedObjects) {
+    workspacesById.set(savedObject.id, savedObject);
+  }
+
+  return [...workspacesById.values()];
+};

--- a/src/plugins/workspace/server/workspace_client.test.ts
+++ b/src/plugins/workspace/server/workspace_client.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../core/server';
 import { IRequestDetail } from './types';
 import { createWorkspaceConfigServiceMock } from './services/workspace_config_service.mock';
+import { MAXIMUM_WORKSPACES_PER_PAGE, WORKSPACE_FETCH_ALL_PER_PAGE } from '../common/constants';
 
 const coreSetup = coreMock.createSetup();
 
@@ -163,6 +164,62 @@ describe('#WorkspaceClient', () => {
 
     expect(find).toHaveBeenCalledTimes(2);
     find.mockClear();
+  });
+
+  describe('list#', () => {
+    beforeEach(() => {
+      find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 0, page: 1 });
+    });
+
+    it('exhausts all pages at WORKSPACE_FETCH_ALL_PER_PAGE for the MAXIMUM_WORKSPACES_PER_PAGE sentinel', async () => {
+      const client = new WorkspaceClient(coreSetup, logger);
+      client?.setSavedObjects(savedObjects);
+
+      await client.list(mockRequestDetail, { perPage: MAXIMUM_WORKSPACES_PER_PAGE });
+
+      expect(find).toHaveBeenCalledWith(
+        expect.objectContaining({ perPage: WORKSPACE_FETCH_ALL_PER_PAGE, page: 1 })
+      );
+    });
+
+    it('walks every page for the sentinel until the total is reached', async () => {
+      const client = new WorkspaceClient(coreSetup, logger);
+      client?.setSavedObjects(savedObjects);
+
+      const total = WORKSPACE_FETCH_ALL_PER_PAGE + 2;
+      // Pages after the first are fanned out in parallel, so mock by page number.
+      find.mockImplementation(async ({ page }) => {
+        const count = page === 2 ? 2 : WORKSPACE_FETCH_ALL_PER_PAGE;
+        return {
+          total,
+          per_page: WORKSPACE_FETCH_ALL_PER_PAGE,
+          page,
+          saved_objects: new Array(count).fill(0).map((_, i) => ({
+            id: `page${page}-${i}`,
+            type: 'workspace',
+            attributes: {},
+            references: [],
+          })),
+        };
+      });
+
+      const result = await client.list(mockRequestDetail, {
+        perPage: MAXIMUM_WORKSPACES_PER_PAGE,
+      });
+
+      expect(find).toHaveBeenCalledTimes(2);
+      expect(result.success && result.result.workspaces).toHaveLength(total);
+    });
+
+    it('passes a numeric perPage through unchanged with a single find', async () => {
+      const client = new WorkspaceClient(coreSetup, logger);
+      client?.setSavedObjects(savedObjects);
+
+      await client.list(mockRequestDetail, { perPage: 10 });
+
+      expect(find).toHaveBeenCalledTimes(1);
+      expect(find).toHaveBeenCalledWith(expect.objectContaining({ perPage: 10 }));
+    });
   });
 
   it('update# should not call addToWorkspaces if no new data sources and data connections added', async () => {

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -28,12 +28,13 @@ import { generateRandomId, getDataSourcesList, checkAndSetDefaultDataSource } fr
 import {
   WORKSPACE_ID_CONSUMER_WRAPPER_ID,
   WORKSPACE_SAVED_OBJECTS_CLIENT_WRAPPER_ID,
+  MAXIMUM_WORKSPACES_PER_PAGE,
 } from '../common/constants';
 import {
   DATA_SOURCE_SAVED_OBJECT_TYPE,
   DATA_CONNECTION_SAVED_OBJECT_TYPE,
 } from '../../data_source/common';
-import { IWorkspaceConfigService } from './services';
+import { IWorkspaceConfigService, fetchAllWorkspaces } from './services';
 
 const WORKSPACE_ID_SIZE = 6;
 
@@ -209,12 +210,34 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
     options: WorkspaceFindOptions
   ): ReturnType<IWorkspaceClientImpl['list']> {
     try {
-      const { saved_objects: savedObjects, ...others } =
-        await this.getSavedObjectClientsFromRequestDetail(requestDetail).find<WorkspaceAttribute>({
-          ...options,
-          type: WORKSPACE_TYPE,
+      const client = this.getSavedObjectClientsFromRequestDetail(requestDetail);
+      const { perPage, ...findOptions } = options;
+
+      // The `MAXIMUM_WORKSPACES_PER_PAGE` sentinel means "give me every workspace", so
+      // exhaust all pages instead of guessing a single large page size. Any other value
+      // pages as usual, keeping the default behavior unchanged.
+      if (perPage === MAXIMUM_WORKSPACES_PER_PAGE) {
+        const savedObjects = await fetchAllWorkspaces(client, {
+          ...findOptions,
           ACLSearchParams: { permissionModes: options.permissionModes },
         });
+        return {
+          success: true,
+          result: {
+            page: 1,
+            per_page: savedObjects.length,
+            total: savedObjects.length,
+            workspaces: savedObjects.map((item) => this.getFlattenedResultWithSavedObject(item)),
+          },
+        };
+      }
+
+      const { saved_objects: savedObjects, ...others } = await client.find<WorkspaceAttribute>({
+        ...findOptions,
+        perPage,
+        type: WORKSPACE_TYPE,
+        ACLSearchParams: { permissionModes: options.permissionModes },
+      });
       return {
         success: true,
         result: {


### PR DESCRIPTION
### Description

Follow-up to #12479. That PR made the workspace list honor `workspace.maximum_workspaces`, but capped listing at a single guessed `perPage` and shipped the value to the browser via `exposeToBrowser` (which turned out not to work reliably). This PR replaces that with a server-side approach that (a) keeps the `_list` API's default behavior unchanged, and (b) exhaustively fetches every workspace on the server so the UI is never silently truncated.

**1. `MAXIMUM_WORKSPACES_PER_PAGE` sentinel for `_list`**

The `_list` API's `perPage` now accepts either a number (default `20`, unchanged) or the special string sentinel `'maximum_workspaces'`. A numeric value pages exactly as before; the sentinel tells the server "return every workspace." This keeps the public API backward-compatible — callers that omit `perPage` or pass a number are unaffected — while giving the workspace UI a way to opt into the full list. The browser `WorkspaceClient` sends the sentinel on its internal list calls; the sentinel is accepted by the route schema and resolved inside `WorkspaceClient.list`.

This removes the previous `exposeToBrowser` plumbing (`WorkspacePublicConfig`, the public plugin initializer-context wiring, and the `maximumWorkspaces` option on `WorkspaceClient` / the validation service), since the browser no longer needs the config value.

**2. `fetchAllWorkspaces` — a reusable "fetch every workspace" service**

New `server/services/workspace_collection_fetcher.ts` exposes `fetchAllWorkspaces(client, options)`, the single choke point for server-side "give me all workspaces" reads:

- Fetches page 1 at `WORKSPACE_FETCH_ALL_PER_PAGE` (1000) to learn the total, then **fans out the remaining pages in parallel** rather than walking them sequentially.
- **De-duplicates by workspace id**, keeping the last occurrence, so a workspace that shifts across a page boundary while the concurrent requests are in flight isn't double-counted.

All server-side consumers now funnel through it:
- `WorkspaceClient.list` delegates to it when the sentinel is passed.
- `WorkspaceSavedObjectsClientWrapper` uses it for the ACL-scoped "which workspaces can this user read" lookup (was a single capped `find`).
- `WorkspaceIdConsumerWrapper` passes the sentinel to `workspaceClient.list` for its existence check.

Their per-consumer `configService`/`getWorkspaceListPerPage` page-size logic was removed. `WorkspaceClient` keeps `configService` only for the create-limit check.

### Issues Resolved

<!-- e.g. closes #1234 -->

### Screenshot

N/A — no UI changes; only how the workspace list is paged/fetched on the server.

### Testing the changes

1. With more than 1000 workspaces (e.g. ~4000), open the workspace selector / list and confirm every workspace appears (previously capped).
2. Confirm `POST /api/workspaces/_list` with no `perPage` still returns 20 results, and with a numeric `perPage` pages as before.
3. Confirm `POST /api/workspaces/_list` with `{ "perPage": "maximum_workspaces" }` returns all workspaces.
4. Confirm saved-object access checks resolve correctly for a user with permissions on workspaces beyond the first page.
5. Unit tests: `yarn test:jest src/plugins/workspace`.

### Notes for reviewers

- **`per_page` in the sentinel response** equals the total workspace count (one collapsed page containing everything), not `1000` or `maximum_workspaces`. Consumers read `result.workspaces`, not `per_page`.
- **Parallel paging over a live index**: dedup handles double-counts; a concurrent insert/delete between the page-1 read and the fan-out could still slightly under/over-count. A fully consistent snapshot would need a point-in-time/scroll read — left as future work.
- `fetchAllWorkspaces` has a `TODO` for projected-fields support (fetch only needed fields, e.g. id, to shrink per-page payload).
- `src/core/types/workspace.ts` widens `WorkspaceFindOptions.perPage` to `number | 'maximum_workspaces'`; regenerating core's built type declarations may be needed after pulling.

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
