### PR TITLE
docs: regenerate _sidebar.md to include 3.8.0 release notes

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -218,6 +218,7 @@
     - [Opensearch dashboards.release notes 3.5.0](../release-notes/opensearch-dashboards.release-notes-3.5.0.md)
     - [Opensearch dashboards.release notes 3.6.0](../release-notes/opensearch-dashboards.release-notes-3.6.0.md)
     - [Opensearch dashboards.release notes 3.7.0](../release-notes/opensearch-dashboards.release-notes-3.7.0.md)
+    - [Opensearch dashboards.release notes 3.8.0](../release-notes/opensearch-dashboards.release-notes-3.8.0.md)
   - scripts
     - [README](../scripts/README.md)
   - [DOCS_README](DOCS_README.md)


### PR DESCRIPTION
### Description

The 3.8.0 release notes file (`release-notes/opensearch-dashboards.release-notes-3.8.0.md`) was added in #12438, but `docs/_sidebar.md` was not regenerated at the same time. As a result `main` is currently out of sync: running `yarn docs:generateDevDocs` produces a diff, which fails the **Check for dev docs changes** CI step on every open PR.

This PR runs `yarn docs:generateDevDocs` and commits the single missing entry.

### Issues Resolved

Fixes the `Check for dev docs changes` CI failure affecting all PRs.

### Screenshot

N/A (docs-only)

### Testing the changes

Ran `yarn docs:generateDevDocs`; the working tree is clean afterward.

### Check List
- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff.