### PR TITLE
[Workspace] Add a wizard to migrate assets that belong to no workspace

### DIFF
--- a/src/plugins/workspace/common/types.ts
+++ b/src/plugins/workspace/common/types.ts
@@ -38,3 +38,9 @@ export interface DataSourceConnection {
   description?: string;
   relatedConnections?: DataSourceConnection[];
 }
+
+export interface WorkspaceAssociateResult {
+  id: string;
+  type: string;
+  error?: string;
+}

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_modal.test.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_modal.test.tsx
@@ -1,0 +1,431 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, fireEvent, waitFor, screen, within } from '@testing-library/react';
+import { coreMock } from '../../../../../core/public/mocks';
+import { workspaceClientMock } from '../../../public/workspace_client.mock';
+import { OpenSearchDashboardsContextProvider } from '../../../../../plugins/opensearch_dashboards_react/public';
+import {
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+} from '../../../../data_source/common';
+import { AssetMigrationModal, AssetMigrationModalProps } from './asset_migration_modal';
+import { MIGRATION_PAGE_SIZE } from './types';
+import { getDataSourcesList } from '../../utils';
+
+// The modal resolves data source / data connection ids through `getDataSourcesList`. Mocking only
+// that export keeps the modal state machine under test while the rest of the (large) utils module --
+// including the real `findUnassignedAssets` / `countUnassignedAssets` the modal and review step rely
+// on -- keeps its actual implementation, so the find request contract is exercised for real.
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  getDataSourcesList: jest.fn(),
+}));
+
+const getDataSourcesListMock = getDataSourcesList as jest.Mock;
+const coreStartMock = coreMock.createStart();
+const savedObjectsFindMock = coreStartMock.savedObjects.client.find as jest.Mock;
+
+const MIGRATABLE_TYPES = ['dashboard', 'visualization', 'search'];
+
+// Two data sources + one data connection => a stable `dataSourceCount` of 3 in the summary.
+const dataSourceList = [
+  { id: 'ds-1', type: DATA_SOURCE_SAVED_OBJECT_TYPE, title: 'Data source 1' },
+  { id: 'ds-2', type: DATA_SOURCE_SAVED_OBJECT_TYPE, title: 'Data source 2' },
+  { id: 'dc-1', type: DATA_CONNECTION_SAVED_OBJECT_TYPE, title: 'Data connection 1' },
+];
+
+interface Asset {
+  id: string;
+  type: string;
+  title: string;
+}
+
+const toSavedObject = (asset: Asset) => ({
+  id: asset.id,
+  type: asset.type,
+  get: (field: string) => (field === 'title' ? asset.title : undefined),
+});
+
+/**
+ * A faithful stand-in for the unassigned result set the server pages through. The migration loop
+ * re-fetches the same page after a successful round because a success removes the asset from the
+ * set; modelling that removal here is what lets a single fixture drive the loop's real termination
+ * behaviour instead of a hand-scripted sequence of responses that could diverge from it.
+ */
+const createStore = (initial: Asset[]) => {
+  let assets = initial.map((asset) => ({ ...asset }));
+  return {
+    size: () => assets.length,
+    page: (page: number, perPage: number) =>
+      assets.slice((page - 1) * perPage, (page - 1) * perPage + perPage),
+    remove: (id: string, type: string) => {
+      assets = assets.filter((asset) => !(asset.id === id && asset.type === type));
+    },
+  };
+};
+
+type Store = ReturnType<typeof createStore>;
+
+const wireFind = (store: Store) => {
+  savedObjectsFindMock.mockImplementation((options: { perPage: number; page?: number }) => {
+    // `perPage: 0` is the count query (progress denominator and per-type breakdown); it must report
+    // the live remaining size so a retry's denominator reflects what is actually left.
+    if (options.perPage === 0) {
+      return Promise.resolve({ total: store.size(), savedObjects: [] });
+    }
+    const items = store.page(options.page ?? 1, options.perPage);
+    return Promise.resolve({ total: store.size(), savedObjects: items.map(toSavedObject) });
+  });
+};
+
+/** Every associated id succeeds and leaves the set, as a clean server round would. */
+const associateAllSuccess = (store: Store) =>
+  jest.fn(async (items: Asset[]) => {
+    items.forEach((item) => store.remove(item.id, item.type));
+    return { success: true, result: items.map(({ id, type }) => ({ id, type })) };
+  });
+
+/** Ids in `failingIds` come back with an error and stay unassigned; the rest succeed and leave. */
+const associateFailing = (failingIds: Set<string>) => (store: Store) =>
+  jest.fn(async (items: Asset[]) => ({
+    success: true,
+    result: items.map(({ id, type }) => {
+      if (failingIds.has(id)) {
+        return { id, type, error: `cannot migrate ${id}` };
+      }
+      store.remove(id, type);
+      return { id, type };
+    }),
+  }));
+
+const bulkAssets = (count: number, prefix: string, type = 'dashboard'): Asset[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `${prefix}-${String(index).padStart(3, '0')}`,
+    type,
+    title: `${prefix} ${index}`,
+  }));
+
+const idsOf = (items: Asset[]) => items.map((item) => item.id);
+
+const renderModal = ({
+  initialAssets = [],
+  create,
+  buildAssociate = associateAllSuccess,
+  existingWorkspaceNames = ['Existing WS'],
+  migratableTypes = MIGRATABLE_TYPES,
+  onClose = jest.fn(),
+}: {
+  initialAssets?: Asset[];
+  create?: jest.Mock;
+  buildAssociate?: (store: Store) => jest.Mock;
+  existingWorkspaceNames?: string[];
+  migratableTypes?: string[];
+  onClose?: jest.Mock;
+} = {}) => {
+  const store = createStore(initialAssets);
+  wireFind(store);
+  const workspaceClient = {
+    ...workspaceClientMock,
+    create: create ?? jest.fn().mockResolvedValue({ success: true, result: { id: 'ws-123' } }),
+    associate: buildAssociate(store),
+  };
+  const services = { ...coreStartMock, workspaceClient };
+  const props: AssetMigrationModalProps = { migratableTypes, existingWorkspaceNames, onClose };
+  const utils = render(
+    <OpenSearchDashboardsContextProvider services={services}>
+      <AssetMigrationModal {...props} />
+    </OpenSearchDashboardsContextProvider>
+  );
+  return { ...utils, store, workspaceClient, onClose };
+};
+
+const migratedStatValue = () =>
+  within(screen.getByText('Assets migrated').closest<HTMLElement>('.euiStat')!);
+const failedStatValue = () => within(screen.getByText('Failed').closest<HTMLElement>('.euiStat')!);
+
+describe('AssetMigrationModal', () => {
+  beforeEach(() => {
+    getDataSourcesListMock.mockResolvedValue(dataSourceList);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the review phase and dismissing from it reports no result so the caller does not refetch', () => {
+    const { getByTestId, onClose } = renderModal();
+
+    expect(getByTestId('assetMigrationReviewTable')).toBeInTheDocument();
+    expect(getByTestId('assetMigrationConfirmButton')).toHaveTextContent(
+      'Create workspace and migrate'
+    );
+    expect(screen.queryByTestId('assetMigrationRunningStep')).not.toBeInTheDocument();
+
+    // No run happened, so the listing the caller holds is still valid: closing must signal nothing.
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledWith(undefined);
+  });
+
+  it('rejects a blank name inline and never creates a workspace', () => {
+    const { getByTestId, workspaceClient } = renderModal();
+
+    fireEvent.change(getByTestId('assetMigrationWorkspaceName'), { target: { value: '   ' } });
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    expect(screen.getByText("Name can't be empty or blank.")).toBeInTheDocument();
+    expect(getByTestId('assetMigrationReviewTable')).toBeInTheDocument();
+    expect(screen.queryByTestId('assetMigrationRunningStep')).not.toBeInTheDocument();
+    expect(workspaceClient.create).not.toHaveBeenCalled();
+    expect(workspaceClient.associate).not.toHaveBeenCalled();
+  });
+
+  it('disables confirm on a duplicate name (case-insensitive, trimmed) so nothing is submitted', () => {
+    const { getByTestId, workspaceClient } = renderModal({
+      existingWorkspaceNames: ['Existing WS'],
+    });
+
+    fireEvent.change(getByTestId('assetMigrationWorkspaceName'), {
+      target: { value: '  existing ws  ' },
+    });
+
+    expect(
+      screen.getByText('A workspace with this name already exists. Enter a different name.')
+    ).toBeInTheDocument();
+    const confirmButton = getByTestId('assetMigrationConfirmButton');
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.click(confirmButton);
+    expect(workspaceClient.create).not.toHaveBeenCalled();
+    expect(workspaceClient.associate).not.toHaveBeenCalled();
+  });
+
+  it('happy path: walks every page, associating one bounded page at a time, and totals them', async () => {
+    // Sized off the real page size so the fixture keeps spanning exactly one full page plus a short
+    // one however the page size is tuned -- hard-coding a total silently stops testing the paging.
+    const shortPage = 3;
+    const initialAssets = bulkAssets(MIGRATION_PAGE_SIZE + shortPage, 'asset');
+    const { getByTestId, workspaceClient } = renderModal({ initialAssets });
+
+    fireEvent.change(getByTestId('assetMigrationWorkspaceName'), {
+      target: { value: '  My Migrated WS  ' },
+    });
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    // Running phase is visible before the async walk settles.
+    expect(getByTestId('assetMigrationRunningStep')).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(getByTestId('assetMigrationOpenWorkspaceButton')).toBeInTheDocument()
+    );
+
+    // One associate call per page, each carrying only that page's ids -- never the whole set.
+    expect(workspaceClient.associate).toHaveBeenCalledTimes(2);
+    expect(workspaceClient.associate.mock.calls[0][0]).toHaveLength(MIGRATION_PAGE_SIZE);
+    expect(idsOf(workspaceClient.associate.mock.calls[0][0])).toEqual(
+      idsOf(initialAssets.slice(0, MIGRATION_PAGE_SIZE))
+    );
+    expect(idsOf(workspaceClient.associate.mock.calls[1][0])).toEqual(
+      idsOf(initialAssets.slice(MIGRATION_PAGE_SIZE))
+    );
+
+    // The summary sums the pages, and create ran exactly once with the trimmed name + resolved ids.
+    expect(migratedStatValue().getByText(String(initialAssets.length))).toBeInTheDocument();
+    expect(failedStatValue().getByText('0')).toBeInTheDocument();
+    expect(workspaceClient.create).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'My Migrated WS' }),
+      expect.objectContaining({ dataSources: ['ds-1', 'ds-2'], dataConnections: ['dc-1'] })
+    );
+  });
+
+  it('partial failure: failures list holds only the failed ids and the counts are exact', async () => {
+    const initialAssets: Asset[] = [
+      { id: 'a1', type: 'dashboard', title: 'Dashboard One' },
+      { id: 'a2', type: 'visualization', title: 'Viz Two' },
+      { id: 'a3', type: 'search', title: 'Search Three' },
+    ];
+    const { getByTestId, workspaceClient } = renderModal({
+      initialAssets,
+      buildAssociate: associateFailing(new Set(['a1'])),
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    await waitFor(() => expect(getByTestId('assetMigrationResultTable')).toBeInTheDocument());
+
+    expect(migratedStatValue().getByText('2')).toBeInTheDocument();
+    expect(failedStatValue().getByText('1')).toBeInTheDocument();
+
+    // Only the failed asset is listed; the two successes carry no row.
+    const failureTable = getByTestId('assetMigrationResultTable');
+    expect(within(failureTable).getByText('Dashboard One')).toBeInTheDocument();
+    expect(within(failureTable).queryByText('Viz Two')).not.toBeInTheDocument();
+    expect(within(failureTable).queryByText('Search Three')).not.toBeInTheDocument();
+
+    // The failing id is never resubmitted within the same run.
+    const failedSubmissions = workspaceClient.associate.mock.calls.filter((call: Asset[][]) =>
+      idsOf(call[0]).includes('a1')
+    );
+    expect(failedSubmissions).toHaveLength(1);
+  });
+
+  it('a permanently failing asset terminates the run and is reported once, not retried forever', async () => {
+    const initialAssets: Asset[] = [{ id: 'fx', type: 'dashboard', title: 'Stuck Asset' }];
+    const { getByTestId, workspaceClient } = renderModal({
+      initialAssets,
+      buildAssociate: associateFailing(new Set(['fx'])),
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    // Reaching the result phase at all is the termination proof: a naive loop would re-submit the
+    // asset that never leaves the unassigned set and never finish.
+    await waitFor(() => expect(getByTestId('assetMigrationResultTable')).toBeInTheDocument());
+
+    expect(workspaceClient.associate).toHaveBeenCalledTimes(1);
+    expect(idsOf(workspaceClient.associate.mock.calls[0][0])).toEqual(['fx']);
+    expect(migratedStatValue().getByText('0')).toBeInTheDocument();
+    expect(failedStatValue().getByText('1')).toBeInTheDocument();
+    expect(
+      within(getByTestId('assetMigrationResultTable')).getByText('Stuck Asset')
+    ).toBeInTheDocument();
+  });
+
+  it('advances past a page that is entirely already-attempted instead of concluding it is done', async () => {
+    // A full page of permanently-stuck assets occupies page 1, pushing the migratable ones onto page
+    // 2. The loop must step past the stuck page rather than read an all-attempted page as "nothing
+    // left". Sized off the real page size so the stuck set keeps filling exactly one page.
+    const stuck = bulkAssets(MIGRATION_PAGE_SIZE, 'stuck');
+    const onPageTwo: Asset[] = [
+      { id: 'fresh-a', type: 'visualization', title: 'Fresh A' },
+      { id: 'fresh-b', type: 'visualization', title: 'Fresh B' },
+      { id: 'fresh-c', type: 'search', title: 'Fresh C' },
+    ];
+    const { getByTestId, workspaceClient } = renderModal({
+      initialAssets: [...stuck, ...onPageTwo],
+      buildAssociate: associateFailing(new Set(idsOf(stuck))),
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    await waitFor(() =>
+      expect(getByTestId('assetMigrationOpenWorkspaceButton')).toBeInTheDocument()
+    );
+
+    // The page-2 assets were reached and migrated despite page 1 being all-stuck.
+    expect(workspaceClient.associate).toHaveBeenCalledTimes(2);
+    expect(idsOf(workspaceClient.associate.mock.calls[0][0])).toEqual(idsOf(stuck));
+    expect(idsOf(workspaceClient.associate.mock.calls[1][0])).toEqual(idsOf(onPageTwo));
+    expect(migratedStatValue().getByText(String(onPageTwo.length))).toBeInTheDocument();
+    expect(failedStatValue().getByText(String(stuck.length))).toBeInTheDocument();
+  });
+
+  it('retry from the result view reuses the workspace and carries the earlier associated count', async () => {
+    const initialAssets: Asset[] = [
+      { id: 'a1', type: 'dashboard', title: 'Dashboard One' },
+      { id: 'a2', type: 'visualization', title: 'Viz Two' },
+      { id: 'a3', type: 'search', title: 'Search Three' },
+    ];
+    // `a1` fails only on its first attempt, so the retry can succeed it.
+    const create = jest.fn().mockResolvedValue({ success: true, result: { id: 'ws-123' } });
+    let a1Attempts = 0;
+    const buildAssociate = (store: Store) =>
+      jest.fn(async (items: Asset[]) => ({
+        success: true,
+        result: items.map(({ id, type }) => {
+          if (id === 'a1' && (a1Attempts += 1) === 1) {
+            return { id, type, error: 'transient' };
+          }
+          store.remove(id, type);
+          return { id, type };
+        }),
+      }));
+    const onClose = jest.fn();
+    const { getByTestId, workspaceClient } = renderModal({
+      initialAssets,
+      create,
+      buildAssociate,
+      onClose,
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+    await waitFor(() => expect(getByTestId('assetMigrationRetryFailedButton')).toBeInTheDocument());
+
+    fireEvent.click(getByTestId('assetMigrationRetryFailedButton'));
+
+    await waitFor(() => expect(migratedStatValue().getByText('3')).toBeInTheDocument());
+    expect(failedStatValue().getByText('0')).toBeInTheDocument();
+
+    // create ran once total; the retry resubmitted only the still-unassigned id, same workspace.
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.associate).toHaveBeenCalledTimes(2);
+    expect(workspaceClient.associate.mock.calls[1][0]).toEqual([{ id: 'a1', type: 'dashboard' }]);
+    expect(workspaceClient.associate.mock.calls[1][1]).toBe('ws-123');
+
+    // The merged associated count (2 carried + 1 new) reaches the close payload.
+    fireEvent.click(getByTestId('assetMigrationCloseButton'));
+    expect(onClose).toHaveBeenCalledWith({ migratedAssets: 3 });
+  });
+
+  it('surfaces a create failure on the name field and returns to review without a toast', async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue({ success: false, error: 'Server rejected the name' });
+    const { getByTestId, workspaceClient } = renderModal({
+      initialAssets: [{ id: 'a1', type: 'dashboard', title: 'Dashboard One' }],
+      create,
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    await waitFor(() => expect(screen.getByText('Server rejected the name')).toBeInTheDocument());
+    expect(getByTestId('assetMigrationReviewTable')).toBeInTheDocument();
+    expect(workspaceClient.associate).not.toHaveBeenCalled();
+    expect(coreStartMock.notifications.toasts.addDanger).not.toHaveBeenCalled();
+  });
+
+  /**
+   * An interrupted walk still moved whatever it moved, so it reports a real outcome instead of an
+   * error: the assets it associated stay associated, and the ones it never reached are still
+   * unassigned and still migratable.
+   */
+  it('reports an interrupted walk on the result view rather than discarding it', async () => {
+    const buildAssociate = () => jest.fn().mockRejectedValue(new Error('associate exploded'));
+    const { getByTestId } = renderModal({
+      initialAssets: [{ id: 'a1', type: 'dashboard', title: 'Dashboard One' }],
+      buildAssociate,
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+
+    await waitFor(() => expect(getByTestId('assetMigrationStopped')).toBeInTheDocument());
+    expect(screen.getByText('associate exploded')).toBeInTheDocument();
+    // A stop is not an error the user has to dismiss, and it must not read as a fresh start.
+    expect(coreStartMock.notifications.toasts.addDanger).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('assetMigrationWorkspaceName')).not.toBeInTheDocument();
+    // Nothing was associated, so the run offers to continue rather than claiming success.
+    expect(getByTestId('assetMigrationRetryFailedButton')).toHaveTextContent('Continue migrating');
+  });
+
+  it('refuses dismissal mid-run, explaining why instead of closing', async () => {
+    // A create that never settles pins the wizard in the running phase for the interaction.
+    const create = jest.fn(() => new Promise(() => {}));
+    const { getByTestId, onClose } = renderModal({
+      initialAssets: [{ id: 'a1', type: 'dashboard', title: 'Dashboard One' }],
+      create,
+    });
+
+    fireEvent.click(getByTestId('assetMigrationConfirmButton'));
+    expect(getByTestId('assetMigrationRunningStep')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Closes this modal window'));
+
+    await waitFor(() => expect(getByTestId('assetMigrationDismissBlocked')).toBeInTheDocument());
+    // Dismissal was refused: the caller was never told to close.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(getByTestId('assetMigrationRunningStep')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_modal.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_modal.tsx
@@ -1,0 +1,442 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { i18n } from '@osd/i18n';
+import {
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSmallButton,
+  EuiSmallButtonEmpty,
+} from '@elastic/eui';
+import { CoreStart, SavedObjectsStart } from 'opensearch-dashboards/public';
+import { ALL_USE_CASE_ID } from '../../../../../core/public';
+import { formatUrlWithWorkspaceId } from '../../../../../core/public/utils';
+import { CURRENT_USER_PLACEHOLDER, WORKSPACE_NAVIGATION_APP_ID } from '../../../common/constants';
+import { WorkspaceClient } from '../../workspace_client';
+import { countUnassignedAssets, findUnassignedAssets, formatError } from './utils';
+import {
+  CreatedWorkspace,
+  MAX_MIGRATION_BATCHES,
+  MIGRATION_PAGE_SIZE,
+  MigrationItem,
+  MigrationProgress,
+  MigrationSummary,
+} from './types';
+import { AssetMigrationReviewStep } from './asset_migration_review_step';
+import { AssetMigrationRunningStep } from './asset_migration_running_step';
+import { AssetMigrationResultStep } from './asset_migration_result_step';
+import {
+  DATA_CONNECTION_SAVED_OBJECT_TYPE,
+  DATA_SOURCE_SAVED_OBJECT_TYPE,
+} from '../../../../data_source/common';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { getDataSourcesList } from '../../utils';
+
+const DEFAULT_WORKSPACE_NAME = i18n.translate('workspace.assetMigration.defaultWorkspaceName', {
+  defaultMessage: 'Migrated assets',
+});
+
+const MODAL_WIDTH = 720;
+
+type Phase =
+  { name: 'review' } | { name: 'running' } | { name: 'result'; summary: MigrationSummary };
+
+export interface AssetMigrationModalProps {
+  migratableTypes: string[];
+  existingWorkspaceNames: string[];
+  onClose: (result?: { migratedAssets: number }) => void;
+}
+
+const assetKey = (asset: { id: string; type: string }) => `${asset.type}:${asset.id}`;
+
+const fetchDataSourceIds = async (client: SavedObjectsStart['client']) => {
+  const all = await getDataSourcesList(client);
+  return {
+    dataSources: all.filter((d) => d.type === DATA_SOURCE_SAVED_OBJECT_TYPE).map((d) => d.id),
+    dataConnections: all
+      .filter((d) => d.type === DATA_CONNECTION_SAVED_OBJECT_TYPE)
+      .map((d) => d.id),
+  };
+};
+
+export const AssetMigrationModal = ({
+  migratableTypes,
+  existingWorkspaceNames,
+  onClose,
+}: AssetMigrationModalProps) => {
+  const {
+    services: { savedObjects, application, notifications, workspaceClient, http },
+  } = useOpenSearchDashboards<CoreStart & { workspaceClient: WorkspaceClient }>();
+  const [phase, setPhase] = useState<Phase>({ name: 'review' });
+  /** Set when the user tries to dismiss the wizard mid-run, so the running view can explain why. */
+  const [dismissBlocked, setDismissBlocked] = useState(false);
+  const [progress, setProgress] = useState<MigrationProgress | undefined>();
+  const [workspaceName, setWorkspaceName] = useState(DEFAULT_WORKSPACE_NAME);
+  const [nameError, setNameError] = useState<string | undefined>();
+  const [createdWorkspace, setCreatedWorkspace] = useState<CreatedWorkspace | undefined>();
+  /**
+   * Assets moved into this workspace by earlier attempts.
+   *
+   * Every attempt after the first has to add this in: the assets an earlier attempt moved are now
+   * assigned, so they no longer answer the unassigned query and cannot be recounted. Without it the
+   * summary would describe only the last attempt rather than the workspace.
+   */
+  const [carriedAssociated, setCarriedAssociated] = useState(0);
+
+  /** A run can outlive the component, so every update after an await is gated on being mounted. */
+  const isMounted = useRef(true);
+  useEffect(
+    () => () => {
+      isMounted.current = false;
+    },
+    []
+  );
+
+  const duplicateNameHint = useMemo(() => {
+    if (createdWorkspace) {
+      return undefined;
+    }
+    const normalized = workspaceName.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    return existingWorkspaceNames.some((name) => name.trim().toLowerCase() === normalized)
+      ? i18n.translate('workspace.assetMigration.duplicateName', {
+          defaultMessage: 'A workspace with this name already exists. Enter a different name.',
+        })
+      : undefined;
+  }, [createdWorkspace, existingWorkspaceNames, workspaceName]);
+
+  const displayedNameError = nameError ?? duplicateNameHint;
+
+  const handleWorkspaceNameChange = useCallback((name: string) => {
+    setWorkspaceName(name);
+    setNameError(undefined);
+  }, []);
+
+  /**
+   * Migrate every unassigned asset into `workspaceId`, a bounded page at a time.
+   *
+   * Never throws: a walk that cannot continue returns what it managed to move plus the reason it
+   * stopped. The assets it already moved are moved for good, so discarding that to report only an
+   * error would understate what happened and leave the workspace's contents unexplained.
+   */
+  const migrateAllAssets = useCallback(
+    async (workspaceId: string, previouslyMigrated: number, estimatedTotal: number) => {
+      const attempted = new Set<string>();
+      const failures: MigrationItem[] = [];
+      let migrated = 0;
+      let batches = 0;
+      let stoppedReason: string | undefined;
+
+      try {
+        let progressed = true;
+        while (progressed) {
+          progressed = false;
+          let page = 1;
+
+          while (batches < MAX_MIGRATION_BATCHES) {
+            const { assets } = await findUnassignedAssets(savedObjects.client, migratableTypes, {
+              page,
+              perPage: MIGRATION_PAGE_SIZE,
+            });
+            if (!assets.length) {
+              break;
+            }
+
+            const unattempted = assets.filter((asset) => !attempted.has(assetKey(asset)));
+            if (!unattempted.length) {
+              page += 1;
+              continue;
+            }
+            unattempted.forEach((asset) => attempted.add(assetKey(asset)));
+            batches += 1;
+
+            const associateResult = await workspaceClient.associate(
+              unattempted.map((asset) => ({ id: asset.id, type: asset.type })),
+              workspaceId
+            );
+            if (!associateResult.success) {
+              // A whole request failed rather than individual assets, so the walk cannot carry on.
+              stoppedReason =
+                associateResult.error ||
+                i18n.translate('workspace.assetMigration.associateFailed', {
+                  defaultMessage: 'Failed to migrate assets',
+                });
+              return { migrated, failures, stoppedReason };
+            }
+
+            const titles = new Map(unattempted.map((asset) => [assetKey(asset), asset.title]));
+            (associateResult.result ?? []).forEach((result) => {
+              if (!result.error) {
+                migrated += 1;
+                return;
+              }
+              failures.push({ ...result, title: titles.get(assetKey(result)) ?? result.id });
+            });
+
+            progressed = true;
+            if (isMounted.current) {
+              setProgress({
+                migrated: previouslyMigrated + migrated,
+                failed: failures.length,
+                estimatedTotal,
+              });
+            }
+          }
+        }
+      } catch (e) {
+        // A rejected lookup or association stops the walk on the same terms as a failed response.
+        stoppedReason = formatError(e);
+      }
+
+      return { migrated, failures, stoppedReason };
+    },
+    [migratableTypes, savedObjects.client, workspaceClient]
+  );
+
+  /**
+   * Runs a migration, or resumes one.
+   *
+   * Both entry points -- confirming from the review view and retrying from either view -- go through
+   * here with no argument: what earlier attempts already moved is held in `carriedAssociated` rather
+   * than passed in, so a caller cannot forget to carry it.
+   */
+  const runMigration = useCallback(async () => {
+    const trimmedName = workspaceName.trim();
+    if (!createdWorkspace && !trimmedName) {
+      setNameError(
+        i18n.translate('workspace.assetMigration.nameRequired', {
+          defaultMessage: "Name can't be empty or blank.",
+        })
+      );
+      return;
+    }
+    setNameError(undefined);
+    // A fresh run starts without a refused-dismissal notice or a previous run's progress.
+    setDismissBlocked(false);
+    setProgress(undefined);
+    setPhase({ name: 'running' });
+
+    try {
+      let workspace = createdWorkspace;
+      if (!workspace) {
+        const { dataSources, dataConnections } = await fetchDataSourceIds(savedObjects.client);
+
+        const createResult = await workspaceClient.create(
+          { name: trimmedName, features: [`use-case-${ALL_USE_CASE_ID}`] },
+          {
+            // All users have Read and write permission for this workspace.
+            permissions: {
+              library_write: { users: ['*', CURRENT_USER_PLACEHOLDER] },
+              write: { users: [CURRENT_USER_PLACEHOLDER] },
+              read: { users: ['*'] },
+            },
+            dataSources,
+            dataConnections,
+          }
+        );
+
+        if (!createResult.success) {
+          if (!isMounted.current) {
+            return;
+          }
+          setPhase({ name: 'review' });
+          setNameError(
+            createResult.error ||
+              i18n.translate('workspace.assetMigration.createFailed', {
+                defaultMessage: 'Failed to create the workspace.',
+              })
+          );
+          return;
+        }
+
+        workspace = {
+          id: createResult.result.id,
+          name: trimmedName,
+          dataSourceCount: dataSources.length + dataConnections.length,
+        };
+        if (!isMounted.current) {
+          return;
+        }
+        setCreatedWorkspace(workspace);
+      }
+
+      const remaining = await countUnassignedAssets(savedObjects.client, migratableTypes);
+      if (!isMounted.current) {
+        return;
+      }
+      const estimatedTotal = carriedAssociated + remaining;
+      setProgress({ migrated: carriedAssociated, failed: 0, estimatedTotal });
+
+      const outcome = await migrateAllAssets(workspace.id, carriedAssociated, estimatedTotal);
+      if (!isMounted.current) {
+        return;
+      }
+
+      const associated = carriedAssociated + outcome.migrated;
+      setCarriedAssociated(associated);
+      setPhase({
+        name: 'result',
+        summary: {
+          // Assets migrated by an earlier attempt still count towards the total.
+          associated,
+          failed: outcome.failures.length,
+          dataSources: workspace.dataSourceCount,
+          failures: outcome.failures,
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+          stoppedReason: outcome.stoppedReason,
+        },
+      });
+    } catch (e) {
+      // Only the workspace creation and the initial count reach here; the walk reports its own
+      // interruption through `stoppedReason` instead of throwing.
+      if (!isMounted.current) {
+        return;
+      }
+      setPhase({ name: 'review' });
+      notifications.toasts.addDanger({
+        title: i18n.translate('workspace.assetMigration.failedTitle', {
+          defaultMessage: 'Failed to migrate assets',
+        }),
+        text: formatError(e),
+      });
+    }
+  }, [
+    carriedAssociated,
+    createdWorkspace,
+    migrateAllAssets,
+    migratableTypes,
+    notifications,
+    savedObjects,
+    workspaceClient,
+    workspaceName,
+  ]);
+
+  /** Every dismissal path goes through here. Ignores its argument: `EuiModal` passes a DOM event. */
+  const closeModal = useCallback(() => {
+    onClose(phase.name === 'result' ? { migratedAssets: phase.summary.associated } : undefined);
+  }, [onClose, phase]);
+
+  const openWorkspace = useCallback(
+    (workspaceId: string) => {
+      const url = formatUrlWithWorkspaceId(
+        application.getUrlForApp(WORKSPACE_NAVIGATION_APP_ID, { absolute: false }),
+        workspaceId,
+        http.basePath
+      );
+      application.navigateToUrl(url);
+    },
+    [application, http.basePath]
+  );
+
+  return (
+    <EuiModal
+      // Abandoning a run would leave the caller's listing stale and the next attempt would create a
+      // second workspace, so dismissal is refused. `EuiModal` always renders its own dismiss button
+      // and its class cannot be styled from a plugin, so the running view explains the refusal.
+      onClose={phase.name === 'running' ? () => setDismissBlocked(true) : closeModal}
+      style={{ width: MODAL_WIDTH }}
+      data-test-subj="assetMigrationModal"
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {phase.name === 'result'
+            ? phase.summary.failed
+              ? i18n.translate('workspace.assetMigration.resultTitleWithErrors', {
+                  defaultMessage: 'Migration finished with errors',
+                })
+              : i18n.translate('workspace.assetMigration.resultTitle', {
+                  defaultMessage: 'Migration complete',
+                })
+            : i18n.translate('workspace.assetMigration.title', {
+                defaultMessage: 'Migrate existing assets into a workspace',
+              })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        {phase.name === 'review' && (
+          <AssetMigrationReviewStep
+            migratableTypes={migratableTypes}
+            workspaceName={workspaceName}
+            onWorkspaceNameChange={handleWorkspaceNameChange}
+            nameError={displayedNameError}
+            createdWorkspace={createdWorkspace}
+          />
+        )}
+        {phase.name === 'running' && (
+          <AssetMigrationRunningStep
+            workspaceName={workspaceName}
+            progress={progress}
+            createdWorkspace={createdWorkspace}
+            dismissBlocked={dismissBlocked}
+          />
+        )}
+        {phase.name === 'result' && <AssetMigrationResultStep summary={phase.summary} />}
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        {phase.name === 'review' && (
+          <>
+            <EuiSmallButtonEmpty onClick={closeModal}>
+              {i18n.translate('workspace.assetMigration.cancel', { defaultMessage: 'Cancel' })}
+            </EuiSmallButtonEmpty>
+            <EuiSmallButton
+              fill
+              disabled={!!duplicateNameHint}
+              onClick={() => runMigration()}
+              data-test-subj="assetMigrationConfirmButton"
+            >
+              {createdWorkspace
+                ? i18n.translate('workspace.assetMigration.retry', {
+                    defaultMessage: 'Retry migration',
+                  })
+                : i18n.translate('workspace.assetMigration.confirm', {
+                    defaultMessage: 'Create workspace and migrate',
+                  })}
+            </EuiSmallButton>
+          </>
+        )}
+        {phase.name === 'result' && (
+          <>
+            {(!!phase.summary.failed || !!phase.summary.stoppedReason) && (
+              <EuiSmallButtonEmpty
+                onClick={() => runMigration()}
+                data-test-subj="assetMigrationRetryFailedButton"
+              >
+                {phase.summary.stoppedReason
+                  ? i18n.translate('workspace.assetMigration.resume', {
+                      defaultMessage: 'Continue migrating',
+                    })
+                  : i18n.translate('workspace.assetMigration.retryFailed', {
+                      defaultMessage: 'Retry failed assets',
+                    })}
+              </EuiSmallButtonEmpty>
+            )}
+            <EuiSmallButtonEmpty onClick={closeModal} data-test-subj="assetMigrationCloseButton">
+              {i18n.translate('workspace.assetMigration.close', { defaultMessage: 'Close' })}
+            </EuiSmallButtonEmpty>
+            <EuiSmallButton
+              fill
+              onClick={() => openWorkspace(phase.summary.workspaceId)}
+              data-test-subj="assetMigrationOpenWorkspaceButton"
+            >
+              {i18n.translate('workspace.assetMigration.openWorkspace', {
+                defaultMessage: 'Go to {name}',
+                values: { name: phase.summary.workspaceName },
+              })}
+            </EuiSmallButton>
+          </>
+        )}
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_result_step.test.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_result_step.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { AssetMigrationResultStep } from './asset_migration_result_step';
+import { ASSET_TABLE_PAGE_SIZE, MigrationItem, MigrationSummary } from './types';
+
+const makeFailures = (count: number, prefix: string): MigrationItem[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    type: i % 2 === 0 ? 'dashboard' : 'visualization',
+    title: `${prefix} asset ${i}`,
+    error: `error ${i}`,
+  }));
+
+const buildSummary = (overrides: Partial<MigrationSummary> = {}): MigrationSummary => ({
+  associated: 0,
+  failed: 0,
+  dataSources: 0,
+  failures: [],
+  workspaceId: 'ws-1',
+  workspaceName: 'Marketing',
+  ...overrides,
+});
+
+const RETRY_HINT = /run the migration again to retry them/i;
+
+const statTitles = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('.euiStat__title')).map((node) => node.textContent);
+
+describe('AssetMigrationResultStep', () => {
+  // The callout colour is the at-a-glance signal for the run's outcome, so each branch of the
+  // failed/associated combination has to map to a distinct colour.
+  describe('callout colour tracks the outcome', () => {
+    it('is success when nothing failed', () => {
+      const { container } = render(
+        <AssetMigrationResultStep summary={buildSummary({ associated: 20, failed: 0 })} />
+      );
+
+      expect(container.querySelector('.euiCallOut--success')).toBeInTheDocument();
+      expect(container.querySelector('.euiCallOut--warning')).toBeNull();
+      expect(container.querySelector('.euiCallOut--danger')).toBeNull();
+      expect(container.querySelector('.euiCallOutHeader__title')?.textContent).toBe(
+        '20 assets are now available in Marketing'
+      );
+    });
+
+    it('is warning when some succeeded and some failed', () => {
+      const { container } = render(
+        <AssetMigrationResultStep
+          summary={buildSummary({ associated: 3, failed: 2, failures: makeFailures(2, 'fail') })}
+        />
+      );
+
+      expect(container.querySelector('.euiCallOut--warning')).toBeInTheDocument();
+      expect(container.querySelector('.euiCallOut--success')).toBeNull();
+      expect(container.querySelector('.euiCallOut--danger')).toBeNull();
+    });
+
+    it('is danger with the "no assets migrated" title when none succeeded', () => {
+      const { container } = render(
+        <AssetMigrationResultStep
+          summary={buildSummary({ associated: 0, failed: 20, failures: makeFailures(20, 'fail') })}
+        />
+      );
+
+      expect(container.querySelector('.euiCallOut--danger')).toBeInTheDocument();
+      expect(container.querySelector('.euiCallOut--success')).toBeNull();
+      expect(container.querySelector('.euiCallOut--warning')).toBeNull();
+      expect(screen.getByText('No assets were migrated')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the three EuiStat figures in migrated/failed/dataSources order', () => {
+    const { container } = render(
+      <AssetMigrationResultStep
+        summary={buildSummary({
+          associated: 20,
+          failed: 5,
+          dataSources: 4,
+          failures: makeFailures(5, 'fail'),
+        })}
+      />
+    );
+
+    expect(statTitles(container)).toEqual(['20', '5', '4']);
+    expect(screen.getByText('Assets migrated')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('Data sources connected')).toBeInTheDocument();
+  });
+
+  // Successful assets are deliberately not listed: the table exists only for rows needing an action,
+  // so with no failures there is nothing to retry and nothing to show.
+  it('renders no failure table or retry hint when there are no failures', () => {
+    render(<AssetMigrationResultStep summary={buildSummary({ associated: 20, failed: 0 })} />);
+
+    expect(screen.queryByTestId('assetMigrationResultTable')).toBeNull();
+    expect(screen.queryByText(RETRY_HINT)).toBeNull();
+  });
+
+  describe('failure table', () => {
+    it('lists only failures with Asset, Type and the reason as readable text', () => {
+      render(
+        <AssetMigrationResultStep
+          summary={buildSummary({
+            associated: 1,
+            failed: 1,
+            failures: [{ id: 'e1', type: 'visualization', title: 'Broken viz', error: 'Boom!' }],
+          })}
+        />
+      );
+
+      const table = screen.getByTestId('assetMigrationResultTable');
+      expect(within(table).getByText('Broken viz')).toBeInTheDocument();
+      expect(within(table).getByText('visualization')).toBeInTheDocument();
+      // The reason is a plain cell value now, not hidden behind an icon tooltip a reader must hover.
+      expect(within(table).getByText('Boom!')).toBeInTheDocument();
+    });
+
+    /**
+     * The table paginates its own items. A controlled table would render every row it is handed and
+     * ignore the page, so the pager would be present but inert.
+     */
+    it('renders one page of rows at a time and can advance to the next', () => {
+      render(
+        <AssetMigrationResultStep
+          summary={buildSummary({ failed: 11, failures: makeFailures(11, 'fail') })}
+        />
+      );
+
+      const table = screen.getByTestId('assetMigrationResultTable');
+      expect(within(table).getAllByRole('row')).toHaveLength(ASSET_TABLE_PAGE_SIZE + 1); // + header
+      expect(within(table).queryByText('fail asset 10')).toBeNull();
+
+      fireEvent.click(screen.getByLabelText('Page 2 of 2'));
+
+      expect(within(table).getByText('fail asset 10')).toBeInTheDocument();
+      expect(within(table).queryByText('fail asset 0')).toBeNull();
+    });
+
+    // A row with no reason must still read as a failure rather than an empty cell.
+    it('falls back to "Error" when a failure carries no reason string', () => {
+      render(
+        <AssetMigrationResultStep
+          summary={buildSummary({
+            associated: 0,
+            failed: 1,
+            failures: [{ id: 'e1', type: 'dashboard', title: 'No reason' }],
+          })}
+        />
+      );
+
+      const table = screen.getByTestId('assetMigrationResultTable');
+      expect(within(table).getByText('Error')).toBeInTheDocument();
+    });
+
+    /**
+     * Every failure is listed, however many there are: the table paginates them, and the walk already
+     * holds one entry per attempted asset, so bounding this list would save nothing.
+     */
+    it('lists every failure, paging through them all', () => {
+      const total = 43;
+      render(
+        <AssetMigrationResultStep
+          summary={buildSummary({ failed: total, failures: makeFailures(total, 'fail') })}
+        />
+      );
+
+      const table = screen.getByTestId('assetMigrationResultTable');
+      expect(screen.getByText(String(total))).toBeInTheDocument();
+
+      const lastPage = Math.ceil(total / ASSET_TABLE_PAGE_SIZE);
+      fireEvent.click(screen.getByLabelText(`Page ${lastPage} of ${lastPage}`));
+      expect(within(table).getByText(`fail asset ${total - 1}`)).toBeInTheDocument();
+    });
+
+    it('shows the retry hint whenever there are failures', () => {
+      render(
+        <AssetMigrationResultStep
+          summary={buildSummary({ associated: 3, failed: 2, failures: makeFailures(2, 'fail') })}
+        />
+      );
+
+      expect(screen.getByText(RETRY_HINT)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_result_step.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_result_step.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+import {
+  EuiBasicTableColumn,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiSpacer,
+  EuiStat,
+  EuiText,
+} from '@elastic/eui';
+import {
+  ASSET_TABLE_PAGE_SIZE,
+  ASSET_TABLE_PAGE_SIZE_OPTIONS,
+  MigrationItem,
+  MigrationSummary,
+} from './types';
+
+export interface AssetMigrationResultStepProps {
+  summary: MigrationSummary;
+}
+
+const failureColumns: Array<EuiBasicTableColumn<MigrationItem>> = [
+  {
+    field: 'title',
+    name: i18n.translate('workspace.assetMigration.column.asset', { defaultMessage: 'Asset' }),
+  },
+  {
+    field: 'type',
+    name: i18n.translate('workspace.assetMigration.column.type', { defaultMessage: 'Type' }),
+    width: '160px',
+  },
+  {
+    field: 'error',
+    name: i18n.translate('workspace.assetMigration.column.error', { defaultMessage: 'Reason' }),
+    render: (error: string | undefined) =>
+      error || i18n.translate('workspace.assetMigration.unknownError', { defaultMessage: 'Error' }),
+  },
+];
+
+/**
+ * Reports what a run achieved.
+ *
+ * Only failures are listed: they are the rows that need an action, and a successful listing could
+ * reach tens of thousands of rows while saying nothing the migrated count does not already say.
+ *
+ * A run that stopped partway is reported as such rather than as a plain success or a plain error: the
+ * assets it moved are moved, and the ones it never reached are still unassigned and still migratable.
+ */
+export const AssetMigrationResultStep = ({ summary }: AssetMigrationResultStepProps) => (
+  <>
+    {summary.stoppedReason ? (
+      <EuiCallOut
+        size="s"
+        color="warning"
+        iconType="alert"
+        data-test-subj="assetMigrationStopped"
+        title={i18n.translate('workspace.assetMigration.result.stoppedTitle', {
+          defaultMessage: 'Migration stopped before it finished',
+        })}
+      >
+        <EuiText size="s">
+          <p>{summary.stoppedReason}</p>
+          <p>
+            <FormattedMessage
+              id="workspace.assetMigration.result.stoppedBody"
+              defaultMessage="{count, plural, one {# asset} other {# assets}} reached {name} and stayed there. The rest are still unassigned, so running the migration again continues from where this attempt stopped."
+              values={{
+                count: summary.associated,
+                name: <strong>{summary.workspaceName}</strong>,
+              }}
+            />
+          </p>
+        </EuiText>
+      </EuiCallOut>
+    ) : (
+      <EuiCallOut
+        size="s"
+        color={summary.failed ? (summary.associated ? 'warning' : 'danger') : 'success'}
+        iconType={summary.failed ? 'alert' : 'check'}
+        title={
+          summary.associated ? (
+            <FormattedMessage
+              id="workspace.assetMigration.result.successTitle"
+              defaultMessage="{count, plural, one {# asset is} other {# assets are}} now available in {name}"
+              values={{
+                count: summary.associated,
+                name: <strong>{summary.workspaceName}</strong>,
+              }}
+            />
+          ) : (
+            i18n.translate('workspace.assetMigration.result.noneTitle', {
+              defaultMessage: 'No assets were migrated',
+            })
+          )
+        }
+      />
+    )}
+    <EuiSpacer size="m" />
+
+    <EuiFlexGroup gutterSize="l">
+      <EuiFlexItem>
+        <EuiStat
+          titleSize="m"
+          title={summary.associated}
+          titleColor={summary.associated ? 'success' : 'subdued'}
+          description={i18n.translate('workspace.assetMigration.stat.migrated', {
+            defaultMessage: 'Assets migrated',
+          })}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiStat
+          titleSize="m"
+          title={summary.failed}
+          titleColor={summary.failed ? 'danger' : 'subdued'}
+          description={i18n.translate('workspace.assetMigration.stat.failed', {
+            defaultMessage: 'Failed',
+          })}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiStat
+          titleSize="m"
+          title={summary.dataSources}
+          description={i18n.translate('workspace.assetMigration.stat.dataSources', {
+            defaultMessage: 'Data sources connected',
+          })}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+
+    {!!summary.failures.length && (
+      <>
+        <EuiSpacer size="m" />
+        <EuiText size="s">
+          {i18n.translate('workspace.assetMigration.result.failureTableTitle', {
+            defaultMessage: 'Assets that could not be migrated',
+          })}
+        </EuiText>
+        <EuiSpacer size="xs" />
+        <EuiInMemoryTable
+          data-test-subj="assetMigrationResultTable"
+          items={summary.failures}
+          tableLayout="auto"
+          pagination={{
+            initialPageSize: ASSET_TABLE_PAGE_SIZE,
+            pageSizeOptions: ASSET_TABLE_PAGE_SIZE_OPTIONS,
+          }}
+          columns={failureColumns}
+        />
+        <EuiSpacer size="s" />
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('workspace.assetMigration.result.retryHint', {
+            defaultMessage:
+              'Failed assets are still unassigned, so you can run the migration again to retry them.',
+          })}
+        </EuiText>
+      </>
+    )}
+  </>
+);

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_review_step.test.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_review_step.test.tsx
@@ -1,0 +1,298 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { coreMock } from '../../../../../core/public/mocks';
+import { OpenSearchDashboardsContextProvider } from '../../../../../plugins/opensearch_dashboards_react/public';
+import {
+  AssetMigrationReviewStep,
+  AssetMigrationReviewStepProps,
+} from './asset_migration_review_step';
+import { CreatedWorkspace } from './types';
+
+const EXPLAIN_TITLE =
+  'These assets are not assigned to any workspace, so they are hidden from workspace views';
+const EXPLAIN_BODY =
+  'They were created before workspaces were enabled and still exist. Moving them into a workspace makes them visible again. Every unassigned asset is migrated, not only the ones shown below, and all data sources are connected to the new workspace so migrated dashboards keep rendering.';
+const FILTER_HINT = 'Search only changes what is listed here. Every asset is migrated regardless.';
+
+const MIGRATABLE_TYPES = ['visualization', 'dashboard', 'search'];
+
+interface AssetSpec {
+  id?: string;
+  type?: string;
+  title?: string;
+}
+
+const buildPage = (specs: AssetSpec[]) =>
+  specs.map((spec, index) => ({
+    id: spec.id ?? `id-${index}`,
+    type: spec.type ?? 'visualization',
+    title: spec.title ?? `asset-${index}`,
+  }));
+
+// Mirrors the saved object shape `findUnassignedAssets` reads: it maps `savedObject.get('title')`.
+const savedObjectFor = (asset: { id: string; type: string; title: string }) => ({
+  id: asset.id,
+  type: asset.type,
+  get: (field: string) => (field === 'title' ? asset.title : undefined),
+});
+
+interface FindScenario {
+  unassignedTotal?: number;
+  page?: { total: number; assets: Array<{ id: string; type: string; title: string }> };
+  pageError?: unknown;
+}
+
+/**
+ * One `find` stands in for both server calls the step makes: a single `perPage: 0` count over every
+ * migratable type, and the table page fetch at the real page size. Splitting on `perPage` lets one
+ * mock feed the two independently, which is exactly what the migrate-all invariant needs -- the count
+ * and the visible page can be made to disagree.
+ */
+const makeFind = ({
+  unassignedTotal = 0,
+  page = { total: 0, assets: [] },
+  pageError,
+}: FindScenario = {}) =>
+  jest.fn((options: any) => {
+    if (options.perPage === 0) {
+      return Promise.resolve({ total: unassignedTotal, savedObjects: [] });
+    }
+    if (pageError) {
+      return Promise.reject(pageError);
+    }
+    return Promise.resolve({ total: page.total, savedObjects: page.assets.map(savedObjectFor) });
+  });
+
+const DEFAULT_SCENARIO: FindScenario = {
+  unassignedTotal: 1,
+  page: { total: 1, assets: buildPage([{ type: 'visualization', title: 'Loaded row' }]) },
+};
+
+const renderStep = (
+  overrides: Partial<AssetMigrationReviewStepProps> = {},
+  find = makeFind(DEFAULT_SCENARIO)
+) => {
+  const coreStartMock = coreMock.createStart();
+  coreStartMock.savedObjects.client.find = find as any;
+  const onWorkspaceNameChange = jest.fn();
+  const props: AssetMigrationReviewStepProps = {
+    migratableTypes: overrides.migratableTypes ?? MIGRATABLE_TYPES,
+    workspaceName: overrides.workspaceName ?? '',
+    onWorkspaceNameChange,
+    nameError: overrides.nameError,
+    createdWorkspace: overrides.createdWorkspace,
+  };
+  const utils = render(
+    <OpenSearchDashboardsContextProvider services={coreStartMock as any}>
+      <AssetMigrationReviewStep {...props} />
+    </OpenSearchDashboardsContextProvider>
+  );
+  return { onWorkspaceNameChange, find, ...utils };
+};
+
+const pageFetches = (find: jest.Mock) => find.mock.calls.filter((call) => call[0].perPage !== 0);
+
+// Lets the mounted effects (debounced page fetch + unassigned count) settle before a test ends, so
+// their state writes happen inside `act` rather than after the component is torn down.
+const waitForFirstPage = () => screen.findByText('Loaded row');
+
+describe('AssetMigrationReviewStep', () => {
+  it('renders the explanatory callout title and body', async () => {
+    renderStep();
+    expect(screen.getByText(EXPLAIN_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(EXPLAIN_BODY)).toBeInTheDocument();
+    await waitForFirstPage();
+  });
+
+  it('shows the current workspaceName in the name field and reports typed changes', async () => {
+    const { onWorkspaceNameChange } = renderStep({ workspaceName: 'My name' });
+    const field = screen.getByTestId('assetMigrationWorkspaceName');
+    expect(field).toHaveValue('My name');
+
+    fireEvent.change(field, { target: { value: 'Migrated assets' } });
+    expect(onWorkspaceNameChange).toHaveBeenCalledWith('Migrated assets');
+    await waitForFirstPage();
+  });
+
+  it('marks the name field invalid and shows the inline error when nameError is passed', async () => {
+    renderStep({ nameError: 'Name is required' });
+    // The message is a form-row error, which EuiFormRow only renders when the row is invalid.
+    const errorNode = screen.getByText('Name is required');
+    expect(errorNode.closest('.euiFormErrorText')).not.toBeNull();
+    await waitForFirstPage();
+  });
+
+  it('locks the name field to the created workspace and shows the already-created help text', async () => {
+    const createdWorkspace: CreatedWorkspace = {
+      id: 'ws-1',
+      name: 'Existing workspace',
+      dataSourceCount: 2,
+    };
+    renderStep({ workspaceName: 'ignored typed value', createdWorkspace });
+
+    const field = screen.getByTestId('assetMigrationWorkspaceName');
+    expect(field).toBeDisabled();
+    // The locked field shows the created workspace name, never the (stale) typed value behind it.
+    expect(field).toHaveValue('Existing workspace');
+    expect(
+      screen.getByText(
+        'This workspace was already created. Retrying migrates into it rather than creating another one.'
+      )
+    ).toBeInTheDocument();
+    await waitForFirstPage();
+  });
+
+  /**
+   * The invariant this whole step is built around: the "will be migrated" figure comes from an
+   * unfiltered count, not from the table page. Here the count reports 25 while the page reports 2 --
+   * as it would under an active search -- so an implementation that read the page would understate the
+   * migration as 2. Asserting 25 (and the absence of 2) locks that the summary can never shrink with
+   * the view.
+   */
+  it('takes the migrate-all figure from the unfiltered count, not the table page', async () => {
+    renderStep(
+      {},
+      makeFind({
+        unassignedTotal: 25,
+        page: {
+          total: 2,
+          assets: buildPage([
+            { type: 'visualization', title: 'Viz A' },
+            { type: 'dashboard', title: 'Dash A' },
+          ]),
+        },
+      })
+    );
+
+    // Wait for the debounced page fetch to land its 2 rows before comparing against the summary.
+    const table = screen.getByTestId('assetMigrationReviewTable');
+    expect(await within(table).findByText('Viz A')).toBeInTheDocument();
+    expect(within(table).getByText('Dash A')).toBeInTheDocument();
+
+    // The summary counts every unassigned asset (25), not the 2 rows the page actually returned.
+    expect(screen.getByText('All 25 assets will be migrated:')).toBeInTheDocument();
+    expect(screen.queryByText('All 2 assets will be migrated:')).not.toBeInTheDocument();
+  });
+
+  /**
+   * Opening the wizard must cost exactly one count plus one page. This is what the absent type facet
+   * buys: establishing which types have assets would have needed a count per type, and no aggregation
+   * API exists to fold those into one request.
+   */
+  it('costs exactly one count and one page fetch on open', async () => {
+    const { find } = renderStep();
+    await waitForFirstPage();
+
+    const countCalls = find.mock.calls.filter(([options]: [any]) => options.perPage === 0);
+    expect(countCalls).toHaveLength(1);
+    expect(countCalls[0][0].type).toEqual(MIGRATABLE_TYPES);
+    expect(pageFetches(find)).toHaveLength(1);
+  });
+
+  it('shows the note that search and filter do not narrow what gets migrated', async () => {
+    renderStep();
+    expect(screen.getByText(FILTER_HINT)).toBeInTheDocument();
+    await waitForFirstPage();
+  });
+
+  it('issues a fresh find carrying the new page and perPage when the table page changes', async () => {
+    const { find } = renderStep(
+      {},
+      makeFind({
+        unassignedTotal: 25,
+        page: { total: 25, assets: buildPage([{ title: 'Row A' }]) },
+      })
+    );
+
+    await waitFor(() => expect(pageFetches(find).length).toBeGreaterThan(0));
+    const firstPage = pageFetches(find)[0][0];
+    expect(firstPage.page).toBe(1);
+    expect(firstPage.perPage).toBe(10);
+
+    fireEvent.click(screen.getByTestId('pagination-button-next'));
+
+    await waitFor(() => {
+      const latest = pageFetches(find).slice(-1)[0][0];
+      expect(latest.page).toBe(2);
+      expect(latest.perPage).toBe(10);
+    });
+  });
+
+  /**
+   * Pressing Enter is what commits a search box value into a request. `fireEvent.change` alone does
+   * not raise the field's `search` event that `onSearch` listens for, so Enter is simulated explicitly.
+   */
+  it('commits the typed text into a find carrying the search term when Enter is pressed', async () => {
+    const { find } = renderStep(
+      {},
+      makeFind({
+        unassignedTotal: 5,
+        page: { total: 5, assets: buildPage([{ title: 'Row A' }]) },
+      })
+    );
+
+    await waitFor(() => expect(pageFetches(find).length).toBeGreaterThan(0));
+    const searchBox = screen.getByTestId('assetMigrationSearchBar');
+    fireEvent.change(searchBox, { target: { value: 'sales' } });
+    fireEvent.keyUp(searchBox, { key: 'Enter', keyCode: 13 });
+
+    await waitFor(() => {
+      const searchCall = find.mock.calls.find((call) => call[0].search === 'sales*');
+      expect(searchCall).toBeTruthy();
+      expect(searchCall![0].searchFields).toEqual(['title']);
+    });
+  });
+
+  /**
+   * The search box is a plain keyword field now, not a query language: `type:dashboard` is just text
+   * matched against the title, never parsed into a type filter.
+   */
+  it('treats a colon in the search text as a literal keyword, not a type filter', async () => {
+    const { find } = renderStep(
+      {},
+      makeFind({
+        unassignedTotal: 5,
+        page: { total: 5, assets: buildPage([{ title: 'Row A' }]) },
+      })
+    );
+
+    await waitFor(() => expect(pageFetches(find).length).toBeGreaterThan(0));
+    const searchBox = screen.getByTestId('assetMigrationSearchBar');
+    fireEvent.change(searchBox, { target: { value: 'type:dashboard' } });
+    fireEvent.keyUp(searchBox, { key: 'Enter', keyCode: 13 });
+
+    await waitFor(() => {
+      const latest = pageFetches(find).slice(-1)[0][0];
+      expect(latest.search).toBe('type:dashboard*');
+      // The request's type list is always every migratable type; nothing derives from the search text.
+      expect(latest.type).toEqual(MIGRATABLE_TYPES);
+    });
+  });
+
+  /**
+   * A failed lookup must reach the table's error state. Falling back to an empty table would read as
+   * "nothing to migrate" -- the exact false conclusion this flow exists to prevent.
+   */
+  it('surfaces a find failure through the table error state, not as an empty table', async () => {
+    renderStep(
+      {},
+      makeFind({
+        unassignedTotal: 3,
+        pageError: { body: { message: 'find exploded' } },
+      })
+    );
+
+    expect(await screen.findByText('find exploded')).toBeInTheDocument();
+    // The empty-state copy must not be what the user sees when the fetch actually failed.
+    expect(screen.queryByText('No assets match this search.')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-result message when the page comes back with no assets', async () => {
+    renderStep({}, makeFind({ unassignedTotal: 4, page: { total: 0, assets: [] } }));
+    expect(await screen.findByText('No assets match this search.')).toBeInTheDocument();
+  });
+});

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_review_step.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_review_step.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+import {
+  EuiBasicTable,
+  EuiCallOut,
+  EuiCompressedFieldSearch,
+  EuiCompressedFieldText,
+  EuiCompressedFormRow,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { UnassignedAsset, countUnassignedAssets, findUnassignedAssets, formatError } from './utils';
+import { ASSET_TABLE_PAGE_SIZE, ASSET_TABLE_PAGE_SIZE_OPTIONS, CreatedWorkspace } from './types';
+
+export interface AssetMigrationReviewStepProps {
+  migratableTypes: string[];
+  workspaceName: string;
+  onWorkspaceNameChange: (name: string) => void;
+  nameError?: string;
+  createdWorkspace?: CreatedWorkspace;
+}
+
+/**
+ * Lets the administrator name the target workspace and browse what is about to be migrated.
+ *
+ * Paging and search are resolved by the server, so the table stays usable however many assets the
+ * deployment holds and never has to claim it is showing a sample.
+ */
+export const AssetMigrationReviewStep = ({
+  migratableTypes,
+  workspaceName,
+  onWorkspaceNameChange,
+  nameError,
+  createdWorkspace,
+}: AssetMigrationReviewStepProps) => {
+  const {
+    services: { savedObjects },
+  } = useOpenSearchDashboards<CoreStart>();
+
+  const [inputValue, setInputValue] = useState('');
+  const [search, setSearch] = useState('');
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(ASSET_TABLE_PAGE_SIZE);
+  /**
+   * How many assets the migration will move. Counted separately from the table, whose total describes
+   * whatever the current search matched.
+   */
+  const [migratableTotal, setMigratableTotal] = useState(0);
+  const [page, setPage] = useState<{ total: number; assets: UnassignedAsset[] }>({
+    total: 0,
+    assets: [],
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+
+  /** Only the newest request may write to state: overlapping searches can settle out of order. */
+  const latestRequest = useRef(0);
+
+  const fetchPage = useCallback(
+    async (request: { page: number; perPage: number; search?: string }) => {
+      const requestId = (latestRequest.current += 1);
+      setLoading(true);
+      try {
+        const result = await findUnassignedAssets(savedObjects.client, migratableTypes, request);
+        if (requestId !== latestRequest.current) {
+          return;
+        }
+        setPage(result);
+        setError(undefined);
+      } catch (e) {
+        if (requestId !== latestRequest.current) {
+          return;
+        }
+        setPage({ total: 0, assets: [] });
+        setError(formatError(e));
+      } finally {
+        if (requestId === latestRequest.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [migratableTypes, savedObjects.client]
+  );
+
+  useEffect(() => {
+    fetchPage({ page: pageIndex + 1, perPage: pageSize, search: search.trim() || undefined });
+  }, [fetchPage, pageIndex, pageSize, search]);
+
+  useEffect(() => {
+    let cancelled = false;
+    countUnassignedAssets(savedObjects.client, migratableTypes)
+      .then((total) => {
+        if (!cancelled) {
+          setMigratableTotal(total);
+        }
+      })
+      // A failure here is already visible through the table's own error state.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [migratableTypes, savedObjects.client]);
+
+  const onTableChange = ({ page: nextPage }: any) => {
+    if (!nextPage) {
+      return;
+    }
+    setPageIndex(nextPage.index);
+    setPageSize(nextPage.size);
+  };
+
+  return (
+    <>
+      <EuiCallOut
+        size="s"
+        iconType="iInCircle"
+        title={i18n.translate('workspace.assetMigration.explainTitle', {
+          defaultMessage:
+            'These assets are not assigned to any workspace, so they are hidden from workspace views',
+        })}
+      >
+        <EuiText size="s">
+          {i18n.translate('workspace.assetMigration.explainBody', {
+            defaultMessage:
+              'They were created before workspaces were enabled and still exist. Moving them into a workspace makes them visible again. Every unassigned asset is migrated, not only the ones shown below, and all data sources are connected to the new workspace so migrated dashboards keep rendering.',
+          })}
+        </EuiText>
+      </EuiCallOut>
+      <EuiSpacer size="s" />
+
+      <EuiCompressedFormRow
+        label={i18n.translate('workspace.assetMigration.nameLabel', {
+          defaultMessage: 'Workspace name',
+        })}
+        isInvalid={!!nameError}
+        error={nameError}
+        helpText={
+          createdWorkspace
+            ? i18n.translate('workspace.assetMigration.nameLockedHelp', {
+                defaultMessage:
+                  'This workspace was already created. Retrying migrates into it rather than creating another one.',
+              })
+            : undefined
+        }
+        fullWidth
+      >
+        <EuiCompressedFieldText
+          fullWidth
+          value={createdWorkspace?.name ?? workspaceName}
+          disabled={!!createdWorkspace}
+          isInvalid={!!nameError}
+          onChange={(event) => onWorkspaceNameChange(event.target.value)}
+          data-test-subj="assetMigrationWorkspaceName"
+        />
+      </EuiCompressedFormRow>
+      <EuiSpacer size="s" />
+
+      <EuiText size="s" data-test-subj="assetMigrationAssetCount">
+        <FormattedMessage
+          id="workspace.assetMigration.assetCount"
+          defaultMessage="All {total, plural, one {# asset} other {# assets}} will be migrated:"
+          values={{ total: migratableTotal }}
+        />
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <EuiText size="xs" color="subdued">
+        <em>
+          {i18n.translate('workspace.assetMigration.filterHint', {
+            defaultMessage:
+              'Search only changes what is listed here. Every asset is migrated regardless.',
+          })}
+        </em>
+      </EuiText>
+      <EuiSpacer size="s" />
+
+      <EuiCompressedFieldSearch
+        fullWidth
+        value={inputValue}
+        data-test-subj="assetMigrationSearchBar"
+        placeholder={i18n.translate('workspace.assetMigration.searchPlaceholder', {
+          defaultMessage: 'Search assets, then press Enter',
+        })}
+        onChange={(event) => setInputValue(event.target.value)}
+        onSearch={(value) => {
+          setSearch(value);
+          setPageIndex(0);
+        }}
+      />
+      <EuiSpacer size="s" />
+
+      <EuiBasicTable
+        data-test-subj="assetMigrationReviewTable"
+        loading={loading}
+        error={error}
+        items={page.assets}
+        tableLayout="auto"
+        noItemsMessage={i18n.translate('workspace.assetMigration.noMatches', {
+          defaultMessage: 'No assets match this search.',
+        })}
+        pagination={{
+          pageIndex,
+          pageSize,
+          totalItemCount: page.total,
+          pageSizeOptions: ASSET_TABLE_PAGE_SIZE_OPTIONS,
+        }}
+        onChange={onTableChange}
+        columns={[
+          {
+            field: 'title',
+            name: i18n.translate('workspace.assetMigration.column.title', {
+              defaultMessage: 'Title',
+            }),
+          },
+          {
+            field: 'type',
+            name: i18n.translate('workspace.assetMigration.column.type', {
+              defaultMessage: 'Type',
+            }),
+            width: '200px',
+          },
+        ]}
+      />
+    </>
+  );
+};

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_running_step.test.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_running_step.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import { AssetMigrationRunningStep } from './asset_migration_running_step';
+import { CreatedWorkspace, MigrationProgress } from './types';
+
+const createdWorkspace: CreatedWorkspace = {
+  id: 'ws-1',
+  name: 'Marketing',
+  dataSourceCount: 2,
+};
+
+const progress = (overrides: Partial<MigrationProgress> = {}): MigrationProgress => ({
+  migrated: 0,
+  failed: 0,
+  estimatedTotal: 0,
+  ...overrides,
+});
+
+describe('AssetMigrationRunningStep', () => {
+  it('renders the running-step container', () => {
+    render(<AssetMigrationRunningStep workspaceName="Marketing" />);
+    expect(screen.getByTestId('assetMigrationRunningStep')).toBeInTheDocument();
+  });
+
+  describe('step one - create the workspace', () => {
+    it('shows a spinner and "Creating workspace <name>..." (trimmed) before it exists', () => {
+      const { container } = render(<AssetMigrationRunningStep workspaceName="  Marketing  " />);
+      const step = screen.getByTestId('assetMigrationRunningStep');
+
+      expect(step.textContent).toContain('Creating workspace Marketing...');
+      expect(container.querySelector('.euiLoadingSpinner')).toBeInTheDocument();
+      // No success mark until the workspace is actually created.
+      expect(container.querySelector('[data-euiicon-type="checkInCircleFilled"]')).toBeNull();
+    });
+
+    it('shows a check mark and "Workspace <name> created" once it exists', () => {
+      const { container } = render(
+        <AssetMigrationRunningStep workspaceName="Marketing" createdWorkspace={createdWorkspace} />
+      );
+      const step = screen.getByTestId('assetMigrationRunningStep');
+
+      expect(step.textContent).toContain('Workspace Marketing created');
+      expect(
+        container.querySelector('[data-euiicon-type="checkInCircleFilled"]')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('step two - progress', () => {
+    /**
+     * The denominator only exists once the run has counted the assets. Until then the second line
+     * must stay indeterminate rather than invent a total or a filled bar.
+     */
+    it('shows the indeterminate copy and no progress bar while there is no estimate', () => {
+      const { rerender } = render(<AssetMigrationRunningStep workspaceName="Marketing" />);
+      expect(screen.getByTestId('assetMigrationProgressLabel').textContent).toBe(
+        'Migrating assets...'
+      );
+      expect(screen.queryByTestId('assetMigrationProgressBar')).not.toBeInTheDocument();
+
+      // A progress object that has not yet counted (estimatedTotal 0) is still indeterminate.
+      rerender(
+        <AssetMigrationRunningStep
+          workspaceName="Marketing"
+          createdWorkspace={createdWorkspace}
+          progress={progress({ estimatedTotal: 0 })}
+        />
+      );
+      expect(screen.getByTestId('assetMigrationProgressLabel').textContent).toBe(
+        'Migrating assets...'
+      );
+      expect(screen.queryByTestId('assetMigrationProgressBar')).not.toBeInTheDocument();
+    });
+
+    it('shows the labelled bar once an estimate is known, counting migrated plus failed', () => {
+      render(
+        <AssetMigrationRunningStep
+          workspaceName="Marketing"
+          createdWorkspace={createdWorkspace}
+          progress={progress({ migrated: 3, failed: 1, estimatedTotal: 12 })}
+        />
+      );
+
+      // done = migrated + failed = 4.
+      expect(screen.getByTestId('assetMigrationProgressLabel').textContent).toContain(
+        'Migrated 4 of about 12 assets...'
+      );
+      const bar = screen.getByTestId('assetMigrationProgressBar');
+      expect(bar.getAttribute('value')).toBe('4');
+      expect(bar.getAttribute('max')).toBe('12');
+    });
+
+    it('caps the bar value at the estimate when the run outruns it', () => {
+      render(
+        <AssetMigrationRunningStep
+          workspaceName="Marketing"
+          createdWorkspace={createdWorkspace}
+          progress={progress({ migrated: 30, failed: 0, estimatedTotal: 12 })}
+        />
+      );
+      // Assets created mid-run can push done past the starting estimate; the bar must not overflow.
+      expect(screen.getByTestId('assetMigrationProgressBar').getAttribute('value')).toBe('12');
+    });
+  });
+
+  describe('refused dismissal', () => {
+    it('says nothing about dismissal by default', () => {
+      render(<AssetMigrationRunningStep workspaceName="Marketing" />);
+      expect(screen.queryByTestId('assetMigrationDismissBlocked')).not.toBeInTheDocument();
+    });
+
+    /**
+     * A run cannot be abandoned and `EuiModal` gives no way to hide its dismiss button from a plugin,
+     * so the refusal is explained here rather than ignored silently.
+     */
+    it('explains the refusal once a dismissal was attempted', () => {
+      render(<AssetMigrationRunningStep workspaceName="Marketing" dismissBlocked />);
+      expect(screen.getByTestId('assetMigrationDismissBlocked').textContent).toContain(
+        'cannot be cancelled'
+      );
+    });
+  });
+});

--- a/src/plugins/workspace/public/components/asset_migration/asset_migration_running_step.tsx
+++ b/src/plugins/workspace/public/components/asset_migration/asset_migration_running_step.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiProgress,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { CreatedWorkspace, MigrationProgress } from './types';
+
+export interface AssetMigrationRunningStepProps {
+  workspaceName: string;
+  /** Absent until the run has counted what it is about to move. */
+  progress?: MigrationProgress;
+  createdWorkspace?: CreatedWorkspace;
+  /** Set when the user tried to dismiss the wizard mid-run, so the refusal can be explained. */
+  dismissBlocked?: boolean;
+}
+
+/**
+ * Reports the two operations the confirm button promises, each with its own state.
+ *
+ * A run walks the assets a page at a time and can last minutes, so the second step shows real
+ * progress. The denominator is what was there when the run started, hence "about".
+ */
+export const AssetMigrationRunningStep = ({
+  workspaceName,
+  progress,
+  createdWorkspace,
+  dismissBlocked,
+}: AssetMigrationRunningStepProps) => {
+  const done = progress ? progress.migrated + progress.failed : 0;
+  const hasEstimate = !!progress?.estimatedTotal;
+
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="m"
+        alignItems="flexStart"
+        data-test-subj="assetMigrationRunningStep"
+      >
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              {createdWorkspace ? (
+                <EuiIcon type="checkInCircleFilled" color="success" />
+              ) : (
+                <EuiLoadingSpinner size="m" />
+              )}
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                {createdWorkspace ? (
+                  <FormattedMessage
+                    id="workspace.assetMigration.running.workspaceCreated"
+                    defaultMessage="Workspace {name} created"
+                    values={{ name: <strong>{createdWorkspace.name}</strong> }}
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="workspace.assetMigration.running.creatingWorkspace"
+                    defaultMessage="Creating workspace {name}..."
+                    values={{ name: <strong>{workspaceName.trim()}</strong> }}
+                  />
+                )}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              {createdWorkspace ? (
+                <EuiLoadingSpinner size="m" />
+              ) : (
+                <EuiIcon type="dot" color="subdued" />
+              )}
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText
+                size="s"
+                color={createdWorkspace ? 'default' : 'subdued'}
+                data-test-subj="assetMigrationProgressLabel"
+              >
+                {hasEstimate ? (
+                  <FormattedMessage
+                    id="workspace.assetMigration.running.progress"
+                    defaultMessage="Migrated {done} of about {total} assets..."
+                    values={{ done, total: progress!.estimatedTotal }}
+                  />
+                ) : (
+                  i18n.translate('workspace.assetMigration.running.counting', {
+                    defaultMessage: 'Migrating assets...',
+                  })
+                )}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        {hasEstimate && (
+          <EuiFlexItem grow={false} style={{ width: '100%' }}>
+            <EuiProgress
+              size="s"
+              color="primary"
+              value={Math.min(done, progress!.estimatedTotal)}
+              max={progress!.estimatedTotal}
+              data-test-subj="assetMigrationProgressBar"
+            />
+          </EuiFlexItem>
+        )}
+
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('workspace.assetMigration.runningHint', {
+              defaultMessage: 'This may take a moment for a large number of assets.',
+            })}
+          </EuiText>
+        </EuiFlexItem>
+
+        {dismissBlocked && (
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="warning" data-test-subj="assetMigrationDismissBlocked">
+              {i18n.translate('workspace.assetMigration.dismissBlocked', {
+                defaultMessage:
+                  'The migration is still running and cannot be cancelled. This dialog closes on its own once it finishes.',
+              })}
+            </EuiText>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/src/plugins/workspace/public/components/asset_migration/index.ts
+++ b/src/plugins/workspace/public/components/asset_migration/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { AssetMigrationModal } from './asset_migration_modal';
+export { useUnassignedAssets } from './use_unassigned_assets';

--- a/src/plugins/workspace/public/components/asset_migration/types.ts
+++ b/src/plugins/workspace/public/components/asset_migration/types.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WorkspaceAssociateResult } from '../../../common/types';
+
+/** Default page size of the asset tables, and the sizes offered next to them. */
+export const ASSET_TABLE_PAGE_SIZE = 10;
+export const ASSET_TABLE_PAGE_SIZE_OPTIONS = [10, 15, 20];
+
+/**
+ * Assets fetched and associated per batch, and the cap on how many batches one run may issue.
+ *
+ * Their product is the most assets a single run can move. The cap is a liveness guarantee rather
+ * than a size limit: assets created while a run is walking keep giving it new work, so without a
+ * ceiling a run competing with a bulk import would never return -- and the wizard refuses to close
+ * while running.
+ */
+export const MIGRATION_PAGE_SIZE = 100;
+export const MAX_MIGRATION_BATCHES = 1000;
+
+/** An asset that could not be migrated, carrying the reason. */
+export type MigrationItem = WorkspaceAssociateResult & { title: string };
+
+/** Progress of a run in flight, updated after each round. */
+export interface MigrationProgress {
+  migrated: number;
+  failed: number;
+  estimatedTotal: number;
+}
+
+export interface MigrationSummary {
+  associated: number;
+  failed: number;
+  dataSources: number;
+  failures: MigrationItem[];
+  workspaceId: string;
+  workspaceName: string;
+  /**
+   * Why the run stopped before reaching the end of the unassigned set, when it did.
+   *
+   * Set when the walk itself could not continue -- an expired session, a dropped request -- as opposed
+   * to individual assets failing, which is what {@link failures} describes. The assets already moved
+   * stay moved, so the run still has a real outcome to report.
+   */
+  stoppedReason?: string;
+}
+
+/** The workspace created by a migration run, once it exists. */
+export interface CreatedWorkspace {
+  id: string;
+  name: string;
+  dataSourceCount: number;
+}

--- a/src/plugins/workspace/public/components/asset_migration/use_unassigned_assets.test.ts
+++ b/src/plugins/workspace/public/components/asset_migration/use_unassigned_assets.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { coreMock } from '../../../../../core/public/mocks';
+import { useUnassignedAssets } from './use_unassigned_assets';
+import { countUnassignedAssets } from './utils';
+
+// Mock only countUnassignedAssets so the hook test stays focused on the hook; the real
+// getMigratableAssetTypes must still run so we can prove which type set is passed downstream.
+jest.mock('./utils', () => {
+  const actual = jest.requireActual('./utils');
+  return {
+    ...actual,
+    countUnassignedAssets: jest.fn(),
+  };
+});
+
+const ALLOWED_TYPES_URL = '/api/opensearch-dashboards/management/saved_objects/_allowed_types';
+
+const countUnassignedAssetsMock = countUnassignedAssets as jest.Mock;
+
+const setup = () => {
+  const http = coreMock.createStart().http;
+  http.get = jest.fn();
+  const client = { find: jest.fn() } as any;
+  return { http, client };
+};
+
+describe('useUnassignedAssets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does nothing and issues no requests when disabled', async () => {
+    const { http, client } = setup();
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, false));
+
+    expect(result.current.total).toBe(0);
+    // A disabled hook must expose no leftover types, so the wizard can never open on stale metadata.
+    expect(result.current.types).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(http.get).not.toHaveBeenCalled();
+    expect(countUnassignedAssetsMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches _allowed_types then resolves the total and types when enabled', async () => {
+    const { http, client } = setup();
+    (http.get as jest.Mock).mockResolvedValue({ types: ['dashboard', 'visualization'] });
+    countUnassignedAssetsMock.mockResolvedValue(7);
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(http.get).toHaveBeenCalledWith(ALLOWED_TYPES_URL);
+    expect(result.current.total).toBe(7);
+    // The migratable types are handed to the wizard so opening it costs no further metadata request.
+    expect(result.current.types).toEqual(['dashboard', 'visualization']);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  /**
+   * The landing page must not pay for the asset list just to decide whether the entry point appears,
+   * so the hook counts and never fetches objects.
+   */
+  it('counts without ever fetching the asset list', async () => {
+    const { http, client } = setup();
+    (http.get as jest.Mock).mockResolvedValue({ types: ['dashboard'] });
+    countUnassignedAssetsMock.mockResolvedValue(3);
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(countUnassignedAssetsMock).toHaveBeenCalledTimes(1);
+    expect(result.current).not.toHaveProperty('assets');
+  });
+
+  it('exposes a type set excluding config, homepage, data-source and data-connection', async () => {
+    const { http, client } = setup();
+    (http.get as jest.Mock).mockResolvedValue({
+      types: ['config', 'homepage', 'data-source', 'data-connection', 'dashboard', 'visualization'],
+    });
+    countUnassignedAssetsMock.mockResolvedValue(0);
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, true));
+
+    await waitFor(() => expect(countUnassignedAssetsMock).toHaveBeenCalled());
+
+    const [passedClient, passedTypes] = countUnassignedAssetsMock.mock.calls[0];
+    expect(passedClient).toBe(client);
+    expect(passedTypes).toEqual(['dashboard', 'visualization']);
+    expect(passedTypes).not.toContain('config');
+    expect(passedTypes).not.toContain('homepage');
+    expect(passedTypes).not.toContain('data-source');
+    expect(passedTypes).not.toContain('data-connection');
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // The exposed types match exactly what was counted -- the wizard reuses this set verbatim.
+    expect(result.current.types).toEqual(['dashboard', 'visualization']);
+  });
+
+  it('sets error and resets total and types when _allowed_types rejects', async () => {
+    const { http, client } = setup();
+    (http.get as jest.Mock).mockRejectedValue({ body: { message: 'allowed types failed' } });
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, true));
+
+    await waitFor(() => expect(result.current.error).toBe('allowed types failed'));
+    expect(result.current.total).toBe(0);
+    expect(result.current.types).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(countUnassignedAssetsMock).not.toHaveBeenCalled();
+  });
+
+  it('sets error and resets total and types when the count rejects', async () => {
+    const { http, client } = setup();
+    (http.get as jest.Mock).mockResolvedValue({ types: ['dashboard'] });
+    countUnassignedAssetsMock.mockRejectedValue(new Error('count failed'));
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, true));
+
+    await waitFor(() => expect(result.current.error).toBe('count failed'));
+    expect(result.current.total).toBe(0);
+    expect(result.current.types).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('re-issues the lookup and clears a previous error on refresh', async () => {
+    const { http, client } = setup();
+    // First run fails.
+    (http.get as jest.Mock).mockRejectedValueOnce({ body: { message: 'transient failure' } });
+
+    const { result } = renderHook(() => useUnassignedAssets(http, client, true));
+
+    await waitFor(() => expect(result.current.error).toBe('transient failure'));
+
+    // Subsequent runs succeed.
+    (http.get as jest.Mock).mockResolvedValue({ types: ['dashboard'] });
+    countUnassignedAssetsMock.mockResolvedValue(2);
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.error).toBeUndefined());
+    expect(result.current.total).toBe(2);
+    expect(result.current.types).toEqual(['dashboard']);
+    // _allowed_types was fetched again (initial failed run + successful refresh).
+    expect((http.get as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/plugins/workspace/public/components/asset_migration/use_unassigned_assets.ts
+++ b/src/plugins/workspace/public/components/asset_migration/use_unassigned_assets.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { HttpSetup, SavedObjectsStart } from 'opensearch-dashboards/public';
+import { countUnassignedAssets, formatError, loadMigratableAssetTypes } from './utils';
+
+export interface UnassignedAssetsState {
+  total: number;
+  types: string[];
+  loading: boolean;
+  error?: string;
+}
+
+export interface UseUnassignedAssetsResult extends UnassignedAssetsState {
+  /** Re-run the lookup, to retry after a failure or after a migration changed the total. */
+  refresh: () => void;
+}
+
+/**
+ * Count the saved objects that belong to no workspace.
+ */
+export const useUnassignedAssets = (
+  http: HttpSetup,
+  client: SavedObjectsStart['client'],
+  enabled: boolean
+): UseUnassignedAssetsResult => {
+  const [state, setState] = useState<UnassignedAssetsState>({
+    total: 0,
+    types: [],
+    loading: enabled,
+  });
+
+  const fetchTotal = useCallback(async () => {
+    // The previous error is kept until the new outcome is known, so the caller's retry affordance
+    // stays mounted and can show that it is working.
+    setState((previous) => ({ ...previous, loading: true }));
+    try {
+      const types = await loadMigratableAssetTypes(http);
+      setState({ total: await countUnassignedAssets(client, types), types, loading: false });
+    } catch (e) {
+      setState({ total: 0, types: [], loading: false, error: formatError(e) });
+    }
+  }, [client, http]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ total: 0, types: [], loading: false });
+      return;
+    }
+    fetchTotal();
+  }, [enabled, fetchTotal]);
+
+  return { ...state, refresh: fetchTotal };
+};

--- a/src/plugins/workspace/public/components/asset_migration/utils.test.ts
+++ b/src/plugins/workspace/public/components/asset_migration/utils.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildUnassignedWorkspaceFilter,
+  countUnassignedAssets,
+  findUnassignedAssets,
+  loadMigratableAssetTypes,
+} from './utils';
+
+describe('buildUnassignedWorkspaceFilter', () => {
+  it('should build a negated exists clause for a single type', () => {
+    expect(buildUnassignedWorkspaceFilter(['dashboard'])).toBe('not (dashboard.workspaces: *)');
+  });
+
+  it('should OR one clause per type inside a single negation', () => {
+    expect(buildUnassignedWorkspaceFilter(['dashboard', 'index-pattern'])).toBe(
+      'not (dashboard.workspaces: * or index-pattern.workspaces: *)'
+    );
+  });
+
+  it('should emit exactly one clause per requested type', () => {
+    const types = ['dashboard', 'visualization', 'search', 'index-pattern'];
+    const filter = buildUnassignedWorkspaceFilter(types)!;
+
+    expect(filter.match(/\.workspaces: \*/g)).toHaveLength(types.length);
+    types.forEach((type) => {
+      expect(filter).toContain(`${type}.workspaces: *`);
+    });
+  });
+
+  it('should deduplicate types so the clause count still matches the distinct type set', () => {
+    expect(buildUnassignedWorkspaceFilter(['dashboard', 'dashboard'])).toBe(
+      'not (dashboard.workspaces: *)'
+    );
+  });
+
+  it('should return undefined for an empty type list rather than an always-true filter', () => {
+    expect(buildUnassignedWorkspaceFilter([])).toBeUndefined();
+  });
+
+  it('should ignore empty type names', () => {
+    expect(buildUnassignedWorkspaceFilter(['', 'dashboard'])).toBe('not (dashboard.workspaces: *)');
+    expect(buildUnassignedWorkspaceFilter(['', ''])).toBeUndefined();
+  });
+});
+
+describe('loadMigratableAssetTypes', () => {
+  const httpReporting = (types: string[]) =>
+    ({ get: jest.fn().mockResolvedValue({ types }) }) as any;
+
+  it('should narrow what saved objects management reports', async () => {
+    const http = httpReporting(['config', 'dashboard']);
+
+    await expect(loadMigratableAssetTypes(http)).resolves.toEqual(['dashboard']);
+    expect(http.get).toHaveBeenCalledWith(
+      '/api/opensearch-dashboards/management/saved_objects/_allowed_types'
+    );
+  });
+
+  it('should keep types a workspace may own', async () => {
+    await expect(
+      loadMigratableAssetTypes(httpReporting(['dashboard', 'visualization', 'index-pattern']))
+    ).resolves.toEqual(['dashboard', 'visualization', 'index-pattern']);
+  });
+
+  it('should drop per-user and global UI state types', async () => {
+    await expect(
+      loadMigratableAssetTypes(httpReporting(['config', 'homepage', 'dashboard']))
+    ).resolves.toEqual(['dashboard']);
+  });
+
+  it('should drop data source and data connection types', async () => {
+    await expect(
+      loadMigratableAssetTypes(httpReporting(['data-source', 'data-connection', 'search']))
+    ).resolves.toEqual(['search']);
+  });
+
+  it('should return an empty list when every type is excluded', async () => {
+    await expect(loadMigratableAssetTypes(httpReporting(['config', 'homepage']))).resolves.toEqual(
+      []
+    );
+  });
+});
+
+describe('countUnassignedAssets', () => {
+  it('should request a count only, never the objects', async () => {
+    const client = { find: jest.fn().mockResolvedValue({ total: 42, savedObjects: [] }) } as any;
+
+    await expect(countUnassignedAssets(client, ['dashboard'])).resolves.toBe(42);
+
+    const [findOptions, prependOptions] = client.find.mock.calls[0];
+    expect(findOptions.perPage).toBe(0);
+    expect(findOptions.fields).toBeUndefined();
+    expect(findOptions.type).toEqual(['dashboard']);
+    expect(findOptions.filter).toBe('not (dashboard.workspaces: *)');
+    expect(prependOptions).toEqual({ withoutClientBasePath: true });
+  });
+
+  it('should return zero without querying when there are no migratable types', async () => {
+    const client = { find: jest.fn() } as any;
+
+    await expect(countUnassignedAssets(client, [])).resolves.toBe(0);
+    expect(client.find).not.toHaveBeenCalled();
+  });
+
+  it('should treat a missing total as zero', async () => {
+    const client = { find: jest.fn().mockResolvedValue({}) } as any;
+
+    await expect(countUnassignedAssets(client, ['dashboard'])).resolves.toBe(0);
+  });
+});
+
+const makeSavedObject = (id: string, type: string, title?: string) => ({
+  id,
+  type,
+  get: (field: string) => (field === 'title' ? title : undefined),
+});
+
+describe('findUnassignedAssets', () => {
+  const migratableTypes = ['dashboard', 'visualization'];
+
+  const findMock = (savedObjects: any[] = [], total = savedObjects.length) =>
+    jest.fn().mockResolvedValue({ total, savedObjects });
+
+  /**
+   * The filter is built from one `<type>.workspaces: *` clause per type, so it must be derived from
+   * the exact same list as the `type` param -- any divergence silently changes the result set. A
+   * multi-type request can only sort on a root property, so grouping by type is the whole ordering.
+   */
+  it('sends the same type list to `type` and the filter, with sortField type for a multi-type query', async () => {
+    const client = { find: findMock() } as any;
+
+    await findUnassignedAssets(client, migratableTypes, { page: 2, perPage: 100 });
+
+    const [options, prepend] = client.find.mock.calls[0];
+    expect(options.type).toEqual(['dashboard', 'visualization']);
+    expect(options.filter).toBe('not (dashboard.workspaces: * or visualization.workspaces: *)');
+    expect(options.sortField).toBe('type');
+    expect(options.fields).toEqual(['title']);
+    expect(options.page).toBe(2);
+    expect(options.perPage).toBe(100);
+    expect(prepend).toEqual({ withoutClientBasePath: true });
+  });
+
+  it('omits sortField for a single-type query', async () => {
+    const client = { find: findMock() } as any;
+
+    await findUnassignedAssets(client, ['dashboard'], { page: 1, perPage: 100 });
+
+    expect(client.find.mock.calls[0][0].sortField).toBeUndefined();
+  });
+
+  // Search is opt-in: the core find route needs an explicit prefix pattern and searchFields, so
+  // neither may be sent when the caller supplied no search.
+  it('sends no search or searchFields when no search is given', async () => {
+    const client = { find: findMock() } as any;
+
+    await findUnassignedAssets(client, ['dashboard'], { page: 1, perPage: 100 });
+
+    const options = client.find.mock.calls[0][0];
+    expect(options.search).toBeUndefined();
+    expect(options.searchFields).toBeUndefined();
+  });
+
+  it('turns a given search into a title prefix query', async () => {
+    const client = { find: findMock() } as any;
+
+    await findUnassignedAssets(client, ['dashboard'], { page: 1, perPage: 100, search: 'sales' });
+
+    const options = client.find.mock.calls[0][0];
+    expect(options.search).toBe('sales*');
+    expect(options.searchFields).toEqual(['title']);
+  });
+
+  it('treats a blank search as no search', async () => {
+    const client = { find: findMock() } as any;
+
+    await findUnassignedAssets(client, ['dashboard'], { page: 1, perPage: 100, search: '   ' });
+
+    const options = client.find.mock.calls[0][0];
+    expect(options.search).toBeUndefined();
+    expect(options.searchFields).toBeUndefined();
+  });
+
+  it('issues no request at all for an empty migratable type list', async () => {
+    const client = { find: jest.fn() } as any;
+
+    await expect(findUnassignedAssets(client, [], { page: 1, perPage: 100 })).resolves.toEqual({
+      total: 0,
+      assets: [],
+    });
+    expect(client.find).not.toHaveBeenCalled();
+  });
+
+  it('maps the page to assets, falling back to the id when a title is missing', async () => {
+    const client = {
+      find: findMock(
+        [makeSavedObject('d1', 'dashboard', 'Sales'), makeSavedObject('v1', 'visualization')],
+        9
+      ),
+    } as any;
+
+    await expect(
+      findUnassignedAssets(client, migratableTypes, { page: 1, perPage: 100 })
+    ).resolves.toEqual({
+      total: 9,
+      assets: [
+        { id: 'd1', type: 'dashboard', title: 'Sales' },
+        { id: 'v1', type: 'visualization', title: 'v1' },
+      ],
+    });
+  });
+});

--- a/src/plugins/workspace/public/components/asset_migration/utils.ts
+++ b/src/plugins/workspace/public/components/asset_migration/utils.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpSetup, SavedObjectsStart } from 'opensearch-dashboards/public';
+import { WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES } from '../../../common/constants';
+
+/** Saved objects management owns the list of types the Assets page can display. */
+const ALLOWED_TYPES_URL = '/api/opensearch-dashboards/management/saved_objects/_allowed_types';
+
+/**
+ * Types kept out of asset migration. `config` and `homepage` hold per-user or global UI state that a
+ * workspace must not own, and data sources are connected to the new workspace at creation time.
+ */
+const MIGRATION_EXCLUDED_TYPES = [
+  'config',
+  'homepage',
+  ...WORKSPACE_DATA_SOURCE_AND_CONNECTION_OBJECT_TYPES,
+];
+
+export const formatError = (e: any): string => e?.body?.message || e?.message || String(e);
+
+export const loadMigratableAssetTypes = async (http: HttpSetup): Promise<string[]> => {
+  const { types } = await http.get<{ types: string[] }>(ALLOWED_TYPES_URL);
+  return types.filter((type) => !MIGRATION_EXCLUDED_TYPES.includes(type));
+};
+
+/**
+ * Build a KQL `filter` matching only objects whose `workspaces` field is absent.
+ *
+ * @param types saved object types to search, identical to the find request `type` param
+ * @returns a KQL filter expression, or undefined when `types` is empty
+ */
+export const buildUnassignedWorkspaceFilter = (types: string[]): string | undefined => {
+  const uniqueTypes = [...new Set(types)].filter(Boolean);
+  if (!uniqueTypes.length) {
+    return undefined;
+  }
+  return `not (${uniqueTypes.map((type) => `${type}.workspaces: *`).join(' or ')})`;
+};
+
+export interface UnassignedAsset {
+  id: string;
+  type: string;
+  title: string;
+}
+
+export interface UnassignedAssetQuery {
+  page: number;
+  perPage: number;
+  search?: string;
+}
+
+/**
+ * Count the unassigned saved objects of the given types, transferring none of them.
+ *
+ * `perPage: 0` reaches the saved objects repository as an OpenSearch `size: 0`, which returns the hit
+ * total and zero documents.
+ */
+export const countUnassignedAssets = async (
+  client: SavedObjectsStart['client'],
+  types: string[]
+): Promise<number> => {
+  const filter = buildUnassignedWorkspaceFilter(types);
+  if (!filter) {
+    return 0;
+  }
+
+  const response = await client.find(
+    { type: types, filter, perPage: 0, page: 1 },
+    { withoutClientBasePath: true }
+  );
+  return response?.total ?? 0;
+};
+
+/**
+ * Fetch one page of saved objects that belong to no workspace.
+ *
+ * Paging and search are resolved by the server, so no caller has to hold the whole set in memory and
+ * the reported `total` always describes the same result set as the returned page.
+ */
+export const findUnassignedAssets = async (
+  client: SavedObjectsStart['client'],
+  migratableTypes: string[],
+  query: UnassignedAssetQuery
+): Promise<{ total: number; assets: UnassignedAsset[] }> => {
+  const filter = buildUnassignedWorkspaceFilter(migratableTypes);
+  if (!filter) {
+    return { total: 0, assets: [] };
+  }
+
+  const search = query.search?.trim();
+  const response = await client.find<{ title?: string }>(
+    {
+      type: migratableTypes,
+      fields: ['title'],
+      filter,
+      perPage: query.perPage,
+      page: query.page,
+      ...(migratableTypes.length > 1 ? { sortField: 'type' } : {}),
+      ...(search ? { search: `${search}*`, searchFields: ['title'] } : {}),
+    },
+    { withoutClientBasePath: true }
+  );
+
+  return {
+    total: response?.total ?? 0,
+    assets: (response?.savedObjects ?? []).map((savedObject) => ({
+      id: savedObject.id,
+      type: savedObject.type,
+      title: savedObject.get('title') || savedObject.id,
+    })),
+  };
+};

--- a/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
@@ -73,35 +73,43 @@ exports[`WorkspaceInitial render workspace initial page normally when user is OS
                   class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter"
+                    class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                   >
                     <div
-                      class="euiPopover__anchor"
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <button
-                        class="euiButton euiButton--primary euiButton--small euiButton--fill"
-                        data-test-subj="workspace-initial-card-createWorkspace-button"
-                        type="button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
-                        <span
-                          class="euiButtonContent euiButton__content"
+                        <div
+                          class="euiPopover__anchor"
                         >
-                          <span
-                            class="euiButtonContent__icon"
-                            color="inherit"
-                            data-euiicon-type="plus"
-                          />
-                          <span
-                            class="euiButton__text"
+                          <button
+                            class="euiButton euiButton--primary euiButton--small euiButton--fill"
+                            data-test-subj="workspace-initial-card-createWorkspace-button"
+                            type="button"
                           >
-                            Create Workspace
-                              
                             <span
-                              data-euiicon-type="arrowDown"
-                            />
-                          </span>
-                        </span>
-                      </button>
+                              class="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                class="euiButtonContent__icon"
+                                color="inherit"
+                                data-euiicon-type="plus"
+                              />
+                              <span
+                                class="euiButton__text"
+                              >
+                                Create Workspace
+                                  
+                                <span
+                                  data-euiicon-type="arrowDown"
+                                />
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/plugins/workspace/public/components/workspace_initial/utils.test.ts
+++ b/src/plugins/workspace/public/components/workspace_initial/utils.test.ts
@@ -6,6 +6,7 @@
 import moment from 'moment';
 import { recentWorkspaceManager } from '../../recent_workspace_manager';
 import {
+  ASSET_MIGRATION_TOUR_STORAGE_KEY,
   WorkspaceFilterCriteria,
   buildWorkspaceFilterCriteria,
   filterWorkspaces,
@@ -13,7 +14,9 @@ import {
   getWorkspaceRole,
   getWorkspacesWithRecentMessage,
   isWorkspaceFilterActive,
+  readMigrationTourDismissed,
   sortByRecentVisitedAndAlphabetical,
+  writeMigrationTourDismissed,
 } from './utils';
 
 describe('getWorkspacesWithRecentMessage', () => {
@@ -219,5 +222,39 @@ describe('filterWorkspaces', () => {
     expect(
       filterWorkspaces(list, { searchQuery: 'payments', roles: ['readonly'], recency: 'all' })
     ).toEqual([]);
+  });
+});
+
+describe('asset migration tour flag', () => {
+  const KEY = ASSET_MIGRATION_TOUR_STORAGE_KEY;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('should report not dismissed when the flag is absent', () => {
+    expect(readMigrationTourDismissed()).toBe(false);
+  });
+
+  it('should report dismissed once the flag is written', () => {
+    writeMigrationTourDismissed();
+    expect(localStorage.getItem(KEY)).toBe('true');
+    expect(readMigrationTourDismissed()).toBe(true);
+  });
+
+  it('should fall back to not dismissed when reading storage throws', () => {
+    jest.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError');
+    });
+    expect(() => readMigrationTourDismissed()).not.toThrow();
+    expect(readMigrationTourDismissed()).toBe(false);
+  });
+
+  it('should swallow a write failure so dismissing the tour never breaks the page', () => {
+    jest.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    expect(() => writeMigrationTourDismissed()).not.toThrow();
   });
 });

--- a/src/plugins/workspace/public/components/workspace_initial/utils.ts
+++ b/src/plugins/workspace/public/components/workspace_initial/utils.ts
@@ -7,6 +7,24 @@ import { WorkspaceObject } from 'opensearch-dashboards/public';
 import moment from 'moment';
 import { recentWorkspaceManager } from '../../recent_workspace_manager';
 
+export const ASSET_MIGRATION_TOUR_STORAGE_KEY = 'workspace.assetMigration.tourDismissed';
+
+export const readMigrationTourDismissed = (): boolean => {
+  try {
+    return Boolean(localStorage.getItem(ASSET_MIGRATION_TOUR_STORAGE_KEY));
+  } catch {
+    return false;
+  }
+};
+
+export const writeMigrationTourDismissed = () => {
+  try {
+    localStorage.setItem(ASSET_MIGRATION_TOUR_STORAGE_KEY, 'true');
+  } catch {
+    // The in-memory state still hides the tour for this session.
+  }
+};
+
 export interface UpdatedWorkspaceObject extends WorkspaceObject {
   accessTimeStamp?: number;
   visitedMessage?: string;

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
@@ -18,6 +18,9 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiSmallButton,
+  EuiSmallButtonEmpty,
+  EuiToolTip,
+  EuiTourStep,
   EuiContextMenu,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
@@ -34,9 +37,12 @@ import {
   WorkspaceRecency,
   WorkspaceRoleFilter,
   buildWorkspaceFilterCriteria,
+  readMigrationTourDismissed,
+  writeMigrationTourDismissed,
 } from './utils';
 import { WorkspaceUseCaseFlyout } from '../workspace_form';
 import { navigateToWorkspacePageWithUseCase } from '../utils/workspace';
+import { AssetMigrationModal, useUnassignedAssets } from '../asset_migration';
 
 export interface WorkspaceInitialProps {
   registeredUseCases$: BehaviorSubject<WorkspaceUseCase[]>;
@@ -44,7 +50,7 @@ export interface WorkspaceInitialProps {
 
 export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps) => {
   const {
-    services: { application, chrome, workspaces, http, docLinks },
+    services: { application, chrome, workspaces, http, docLinks, savedObjects },
   } = useOpenSearchDashboards<CoreStart>();
   const isDashboardAdmin = !!application.capabilities.dashboards?.isDashboardAdmin;
   const availableUseCases = registeredUseCases$
@@ -86,6 +92,83 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
     );
   });
   const [isCreateWorkspacePopoverOpen, setIsCreateWorkspacePopoverOpen] = useState(false);
+
+  // Only a dashboard admin can migrate global assets to workspace.
+  const [isMigrationModalVisible, setIsMigrationModalVisible] = useState(false);
+  const unassignedAssets = useUnassignedAssets(http, savedObjects.client, isDashboardAdmin);
+  const hasUnassignedAssets = unassignedAssets.total > 0;
+
+  const [isMigrationTourDismissed, setIsMigrationTourDismissed] = useState(
+    readMigrationTourDismissed
+  );
+  const dismissMigrationTour = useCallback(() => {
+    writeMigrationTourDismissed();
+    setIsMigrationTourDismissed(true);
+  }, []);
+  const openMigrationModal = useCallback(() => {
+    dismissMigrationTour();
+    setIsMigrationModalVisible(true);
+  }, [dismissMigrationTour]);
+
+  const migrateAssetsButton = (
+    <EuiTourStep
+      content={
+        <EuiText size="s">
+          <p style={{ maxWidth: 260 }}>
+            {i18n.translate('workspace.initial.migrateAssets.tour.content', {
+              defaultMessage:
+                'These assets were created before workspaces existed, so they are hidden from every workspace view. Move them into a workspace to make them visible again.',
+            })}
+          </p>
+        </EuiText>
+      }
+      isStepOpen={!isMigrationTourDismissed}
+      minWidth={260}
+      onFinish={dismissMigrationTour}
+      step={1}
+      stepsTotal={1}
+      anchorPosition="downCenter"
+      ownFocus={false}
+      subtitle={i18n.translate('workspace.initial.migrateAssets.tour.subtitle', {
+        defaultMessage: "What's new",
+      })}
+      title={i18n.translate('workspace.initial.migrateAssets.tour.title', {
+        defaultMessage: 'You have assets outside any workspace',
+      })}
+    >
+      <EuiSmallButton
+        iconType="importAction"
+        data-test-subj="workspace-initial-migrateAssets-button"
+        onClick={openMigrationModal}
+      >
+        {i18n.translate('workspace.initial.migrateAssets.button', {
+          defaultMessage: 'Migrate existing assets ({total})',
+          values: { total: unassignedAssets.total },
+        })}
+      </EuiSmallButton>
+    </EuiTourStep>
+  );
+
+  /**
+   * Surfaced in place of the button when the lookup failed, because staying silent is
+   * indistinguishable from "nothing to migrate" -- exactly the false conclusion this flow exists to
+   * prevent. The reason goes in a tooltip and the label retries.
+   */
+  const migrateAssetsError = (
+    <EuiToolTip content={unassignedAssets.error}>
+      <EuiSmallButtonEmpty
+        color="danger"
+        iconType="alert"
+        isLoading={unassignedAssets.loading}
+        onClick={unassignedAssets.refresh}
+        data-test-subj="workspace-initial-migrateAssets-error"
+      >
+        {i18n.translate('workspace.initial.migrateAssets.error', {
+          defaultMessage: 'Retry checking for unmigrated assets',
+        })}
+      </EuiSmallButtonEmpty>
+    </EuiToolTip>
+  );
   const mountUserAccountRef = useRef<HTMLDivElement>(null);
   const mountSettingRef = useRef<HTMLDivElement>(null);
   const mountDevToolsRef = useRef<HTMLDivElement>(null);
@@ -199,7 +282,19 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
               })}
             </EuiText>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>{isDashboardAdmin && createWorkspacePopover}</EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            {isDashboardAdmin && (
+              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                {!!unassignedAssets.error && (
+                  <EuiFlexItem grow={false}>{migrateAssetsError}</EuiFlexItem>
+                )}
+                {hasUnassignedAssets && (
+                  <EuiFlexItem grow={false}>{migrateAssetsButton}</EuiFlexItem>
+                )}
+                <EuiFlexItem grow={false}>{createWorkspacePopover}</EuiFlexItem>
+              </EuiFlexGroup>
+            )}
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
       {workspaceList.length > 0 && (
@@ -300,6 +395,18 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
           availableUseCases={availableUseCases}
           onClose={handleFlyoutClose}
           defaultExpandUseCase={defaultExpandedUseCaseId}
+        />
+      )}
+      {isMigrationModalVisible && (
+        <AssetMigrationModal
+          migratableTypes={unassignedAssets.types}
+          existingWorkspaceNames={workspaceList.map((workspace) => workspace.name)}
+          onClose={(result) => {
+            setIsMigrationModalVisible(false);
+            if (result?.migratedAssets) {
+              unassignedAssets.refresh();
+            }
+          }}
         />
       )}
     </EuiPage>

--- a/src/plugins/workspace/public/workspace_client.ts
+++ b/src/plugins/workspace/public/workspace_client.ts
@@ -18,6 +18,7 @@ import {
   PermissionModeId,
 } from '../../../core/public';
 import { SavedObjectPermissions, WorkspaceAttributeWithPermission } from '../../../core/types';
+import { WorkspaceAssociateResult } from '../common/types';
 import { DataSourceAssociation } from './components/data_source_association/data_source_association';
 import { MAXIMUM_WORKSPACES_PER_PAGE } from '../common/constants';
 
@@ -395,7 +396,7 @@ export class WorkspaceClient implements IWorkspaceClient {
       savedObjects,
       workspaceId,
     };
-    const result = await this.safeFetch<Array<{ id: string; type: string }>>(path, {
+    const result = await this.safeFetch<WorkspaceAssociateResult[]>(path, {
       method: 'POST',
       body: JSON.stringify(body),
     });

--- a/src/plugins/workspace/server/types.ts
+++ b/src/plugins/workspace/server/types.ts
@@ -14,6 +14,8 @@ import {
   WorkspaceFindOptions,
 } from '../../../core/server';
 import { PermissionModeId } from '../../../core/server';
+import { WorkspaceAssociateResult } from '../common/types';
+
 export interface WorkspaceAttributeWithPermission extends WorkspaceAttribute {
   permissions?: Permissions;
   permissionMode?: PermissionModeId;
@@ -120,9 +122,9 @@ export interface IWorkspaceClientImpl {
    * If the association succeeds, the object is included in the result without an error.
    * If there is an issue associating an object, an error message is returned for that object.
    *
-   * @returns A promise that resolves to a response object containing an array of results for each object.
-   *          Each result will include the object's `id` and, if there was an error during association, an `error` field
-   *          with the error message.
+   * @returns A promise that resolves to a response object containing a result per object. Each
+   *          result carries the object's `id` and `type` -- both are needed because an id is only
+   *          unique within its type. A result without an `error` was associated successfully.
    *
    * @public
    */
@@ -130,7 +132,7 @@ export interface IWorkspaceClientImpl {
     requestDetail: IRequestDetail,
     workspaceId: string,
     objects: Array<{ id: string; type: string }>
-  ): Promise<IResponse<Array<{ id: string; error?: string }>>>;
+  ): Promise<IResponse<WorkspaceAssociateResult[]>>;
 
   /**
    * Dissociates a list of objects from the given workspace ID.

--- a/src/plugins/workspace/server/workspace_client.ts
+++ b/src/plugins/workspace/server/workspace_client.ts
@@ -23,6 +23,7 @@ import {
   IRequestDetail,
   WorkspaceAttributeWithPermission,
 } from './types';
+import { WorkspaceAssociateResult } from '../common/types';
 import { workspace } from './saved_objects';
 import { generateRandomId, getDataSourcesList, checkAndSetDefaultDataSource } from './utils';
 import {
@@ -446,17 +447,16 @@ export class WorkspaceClient implements IWorkspaceClientImpl {
     requestDetail: IRequestDetail,
     workspaceId: string,
     objects: Array<{ id: string; type: string }>
-  ): Promise<IResponse<Array<{ id: string; error?: string }>>> {
+  ): Promise<IResponse<WorkspaceAssociateResult[]>> {
     const savedObjectClient = this.getSavedObjectClientsFromRequestDetail(requestDetail);
     const promises = objects.map(async (obj) => {
       try {
         await savedObjectClient.addToWorkspaces(obj.type, obj.id, [workspaceId]);
-        return {
-          id: obj.id,
-        };
+        return { id: obj.id, type: obj.type };
       } catch (e) {
         return {
           id: obj.id,
+          type: obj.type,
           error: this.formatError(e),
         };
       }


### PR DESCRIPTION
### Description

Saved objects (focus on Kibana index) created before workspaces were enabled belong to no workspace. Every workspace view filters by the `workspaces` field, so those objects are invisible from inside any workspace even though they still exist in the index. An admin has no way to discover them and no supported way to move them, so the assets look permanently lost.

This adds a guided migration entry point on the workspace landing page. When unassigned assets exist, a dashboard admin sees `Migrate existing assets (N)`, which opens a three-phase wizard:

1. **Review** — explains why the assets are hidden, lets the admin name the target workspace, and lists every asset with search, a type filter and pagination. Search and filter only change what is listed; the whole set is always migrated.

3. **Running** — reports both operations the confirm button promises: creating the workspace, then migrating the assets. The wizard cannot be dismissed while it runs, because abandoning it would leave the caller's listing stale and a second click would create a second workspace.

4. **Result** — a success / warning / danger callout, counts for migrated, failed and connected data sources, a per-asset outcome table, and `Go to <workspace>` so the admin lands directly on the assets they thought were gone.

All data sources and data connections are connected to the new workspace at creation time, so migrated dashboards keep rendering.

A one-time tour points at the entry point, since an admin cannot otherwise discover that the assets exist. It is dismissed permanently on first use and its flag survives `localStorage` being unavailable.

Partial and interrupted runs are distinct outcomes. Individual assets can fail (the server associates each object independently and returns a per-object error) — those are listed with their reason and can be retried, since a failed asset is still unassigned. Separately, a whole request can fail (expired session, dropped connection, timeout), which stops the walk. The walk never throws: it returns what it moved plus a stoppedReason, so the assets already migrated are reported rather than discarded, and the result view offers Continue migrating instead of claiming success. Retrying reuses the created workspace rather than creating a second one, and carries the earlier count so the summary describes the workspace rather than only the last attempt.
<img width="738" height="786" alt="image" src="https://github.com/user-attachments/assets/f70c97f6-bca7-4707-8395-c36452043a77" />


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->
closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12429
## Screenshot


https://github.com/user-attachments/assets/cc9185d3-9ee7-4fb5-a686-75c95afa0ba1





## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
