### PR TITLE
feat(chat): add telemetry events for tool execution and window visibility

### DIFF
--- a/changelogs/fragments/12508.yml
+++ b/changelogs/fragments/12508.yml
@@ -1,0 +1,2 @@
+feat:
+- [Chat] Add telemetry events for tool execution and chat window visibility ([#12508](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12508))

--- a/changelogs/fragments/12508.yml
+++ b/changelogs/fragments/12508.yml
@@ -1,2 +1,0 @@
-feat:
-- [Chat] Add telemetry events for tool execution and chat window visibility ([#12508](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12508))

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -2339,4 +2339,37 @@ describe('ChatWindow', () => {
       expect(enabledInput.disabled).toBe(false);
     });
   });
+
+  describe('telemetry', () => {
+    it('should record chat_window_show event on mount', () => {
+      const mockRecorder = mockCore.telemetry.getPluginRecorder();
+
+      renderWithContext(<ChatWindow ref={React.createRef()} onClose={jest.fn()} />);
+
+      expect(mockRecorder.recordEvent).toHaveBeenCalledWith({
+        name: 'chat_window_show',
+        data: {},
+      });
+    });
+
+    it('should record chat_window_hide event on unmount', () => {
+      const mockRecorder = mockCore.telemetry.getPluginRecorder();
+
+      const { unmount } = renderWithContext(
+        <ChatWindow ref={React.createRef()} onClose={jest.fn()} />
+      );
+
+      // Not recorded while the window is still mounted.
+      expect(mockRecorder.recordEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'chat_window_hide' })
+      );
+
+      unmount();
+
+      expect(mockRecorder.recordEvent).toHaveBeenCalledWith({
+        name: 'chat_window_hide',
+        data: {},
+      });
+    });
+  });
 });

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -179,6 +179,14 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     // Initialize with fresh conversation on mount
     useMount(() => {
       chatService.newThread();
+
+      // Record window show telemetry
+      if (telemetryRecorder) {
+        telemetryRecorder.recordEvent({
+          name: 'chat_window_show',
+          data: {},
+        });
+      }
     });
 
     // Save conversation to history whenever timeline changes
@@ -193,6 +201,14 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       services.core.chat.resetThreadId();
       setPendingMessage(null);
       setAvailableDataSources([]);
+
+      // Record window hide telemetry
+      if (telemetryRecorder) {
+        telemetryRecorder.recordEvent({
+          name: 'chat_window_hide',
+          data: {},
+        });
+      }
     });
 
     // Cache data source compatibility check to avoid network call on every message

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -60,6 +60,9 @@ describe('ChatEventHandler', () => {
     // Reset confirmationService to approve by default
     mockConfirmationService.requestConfirmation = jest.fn().mockResolvedValue({ approved: true });
 
+    // Reset confirmation requirement to default (no confirmation needed).
+    mockAssistantActionService.isUserConfirmRequired = jest.fn().mockReturnValue(false);
+
     timeline = [];
     mockOnTimelineUpdate = jest.fn((updater) => {
       timeline = updater(timeline);
@@ -1366,6 +1369,152 @@ describe('ChatEventHandler', () => {
 
       // Verify success duration metric was NOT recorded
       expect(mockTelemetryRecorder.recordMetric).not.toHaveBeenCalled();
+    });
+
+    // Drives a tool call to a terminal state.
+    const runToolCall = async (toolCallId: string, toolName: string, argsDelta?: string) => {
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: toolName,
+      } as ToolCallStartEvent);
+
+      if (argsDelta !== undefined) {
+        await chatEventHandlerWithTelemetry.handleEvent({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId,
+          delta: argsDelta,
+        } as ToolCallArgsEvent);
+      }
+
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+    };
+
+    // Mock sendToolResult for paths that reach the send-result step.
+    const mockToolResultDispatch = (toolCallId: string) => {
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: {
+          subscribe: jest.fn().mockReturnValue({ add: jest.fn(), unsubscribe: jest.fn() }),
+        },
+        toolMessage: { id: `tool-result-${toolCallId}`, role: 'tool', content: 'r', toolCallId },
+      });
+    };
+
+    const expectToolExecuted = (data: { toolName: string; status: string; source: string }) =>
+      expect(mockTelemetryRecorder.recordEvent).toHaveBeenCalledWith({
+        name: 'chat_tool_executed',
+        data,
+      });
+
+    it('should record success when a registered action resolves', async () => {
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue('tool output');
+      mockToolResultDispatch('t1');
+
+      await runToolCall('t1', 'testTool', '{"key": "value"}');
+
+      expectToolExecuted({ toolName: 'testTool', status: 'success', source: 'local' });
+    });
+
+    it('should record failure when a registered action rejects', async () => {
+      mockAssistantActionService.executeAction = jest
+        .fn()
+        .mockRejectedValue(new Error('Tool blew up'));
+      mockToolResultDispatch('t2');
+
+      await runToolCall('t2', 'failingTool');
+
+      expectToolExecuted({ toolName: 'failingTool', status: 'failure', source: 'local' });
+    });
+
+    it('should record error when the handler itself throws', async () => {
+      // Malformed arguments trigger JSON.parse failure before tool execution.
+      mockToolResultDispatch('t3');
+
+      await runToolCall('t3', 'crashingTool', '{invalid json');
+
+      expectToolExecuted({ toolName: 'crashingTool', status: 'error', source: 'local' });
+    });
+
+    it('should not record telemetry when a pending confirmation is cancelled', async () => {
+      mockAssistantActionService.isUserConfirmRequired = jest.fn().mockReturnValue(true);
+      mockConfirmationService.requestConfirmation = jest
+        .fn()
+        .mockResolvedValue({ cancelled: true });
+
+      await runToolCall('t4', 'cancelledTool');
+
+      expect(mockTelemetryRecorder.recordEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'chat_tool_executed' })
+      );
+    });
+
+    it('should record rejected when the user denies confirmation', async () => {
+      mockAssistantActionService.isUserConfirmRequired = jest.fn().mockReturnValue(true);
+      mockConfirmationService.requestConfirmation = jest
+        .fn()
+        .mockResolvedValue({ approved: false });
+      mockToolResultDispatch('t5');
+
+      await runToolCall('t5', 'rejectedTool');
+
+      expectToolExecuted({ toolName: 'rejectedTool', status: 'rejected', source: 'local' });
+    });
+
+    it('should defer the agent-sourced event until TOOL_CALL_RESULT arrives', async () => {
+      // No registered action → tool is agent-handled, telemetry deferred.
+      mockAssistantActionService.hasAction = jest.fn().mockReturnValue(false);
+      mockAssistantActionService.executeAction = jest
+        .fn()
+        .mockRejectedValue(new Error('Action not found'));
+
+      await runToolCall('t6', 'agentTool');
+
+      expect(mockTelemetryRecorder.recordEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'chat_tool_executed' })
+      );
+
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: 't6',
+        content: 'agent produced this',
+      } as ToolCallResultEvent);
+
+      expectToolExecuted({ toolName: 'agentTool', status: 'success', source: 'agent' });
+    });
+
+    it('should never call executeAction for agent tools (no await before markToolPending)', async () => {
+      // Regression: agent tools call executeAgentTool directly, so executeAction
+      // is never invoked and markToolPending runs without delay.
+      mockAssistantActionService.hasAction = jest.fn().mockReturnValue(false);
+
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: 'msg-telemetry-7',
+      } as TextMessageStartEvent);
+
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: 't7',
+        toolCallName: 'raceTool',
+      } as ToolCallStartEvent);
+
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId: 't7',
+      } as ToolCallEndEvent);
+
+      expect(mockAssistantActionService.executeAction).not.toHaveBeenCalled();
+
+      await chatEventHandlerWithTelemetry.handleEvent({
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: 't7',
+        content: 'agent produced this',
+      } as ToolCallResultEvent);
+
+      expectToolExecuted({ toolName: 'raceTool', status: 'success', source: 'agent' });
     });
   });
 

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -383,6 +383,7 @@ export class ChatEventHandler {
 
     try {
       const isAgentTool = !this.assistantActionService.hasAction(toolCall.function.name);
+
       // Parse arguments
       const args =
         toolCall.function.arguments && !isAgentTool ? JSON.parse(toolCall.function.arguments) : {};
@@ -393,13 +394,17 @@ export class ChatEventHandler {
         args,
       });
 
-      // Execute the tool and update tool execution status
-      const result = await this.toolExecutor.executeTool(
-        toolCall.function.name,
-        args,
-        toolCallId,
-        await this.chatService.getCurrentDataSourceId()
-      );
+      // Agent tools skip `executeTool` entirely — its local-action path awaits
+      // `executeAction` even when guaranteed to fail, delaying `markToolPending`
+      // and opening a race with the agent's TOOL_CALL_RESULT.
+      const result = isAgentTool
+        ? await this.toolExecutor.executeAgentTool()
+        : await this.toolExecutor.executeTool(
+            toolCall.function.name,
+            args,
+            toolCallId,
+            await this.chatService.getCurrentDataSourceId()
+          );
 
       // Check if tool execution was cancelled (e.g., due to cleanup)
       if (result.cancelled) {
@@ -416,6 +421,9 @@ export class ChatEventHandler {
         this.assistantActionService.updateToolCallState(toolCallId, {
           status: 'failed',
         });
+
+        // Record rejected telemetry
+        this.recordToolExecuted(toolCall.function.name, 'rejected', 'local');
 
         // Clean up pending tool call
         this.pendingToolCalls.delete(toolCallId);
@@ -445,6 +453,13 @@ export class ChatEventHandler {
           status: 'complete',
           result: result.data,
         });
+
+        // Record tool execution telemetry
+        this.recordToolExecuted(
+          toolCall.function.name,
+          result.success ? 'success' : 'failure',
+          'local'
+        );
       }
     } catch (error: any) {
       // eslint-disable-next-line no-console
@@ -474,6 +489,9 @@ export class ChatEventHandler {
         status: 'failed',
         error: error instanceof Error ? error : new Error(error.message),
       });
+
+      // Record tool execution failure telemetry
+      this.recordToolExecuted(toolCall.function.name, 'error', 'local');
     } finally {
       // Clean up pending tool call
       this.pendingToolCalls.delete(toolCallId);
@@ -520,10 +538,37 @@ export class ChatEventHandler {
       result: resultContent,
     });
 
-    // Clear pending tool if it was an agent-only tool
+    // Record telemetry and clear pending entry. The guard prevents double-counting
+    // if a duplicate TOOL_CALL_RESULT arrives after the entry was already cleared.
     if (this.toolExecutor.isPendingAgentResponse(toolCallId)) {
+      const pendingTool = this.toolExecutor.getPendingTool(toolCallId);
+      this.recordToolExecuted(pendingTool?.name ?? 'unknown', 'success', 'agent');
       this.toolExecutor.clearPendingTool(toolCallId);
     }
+  }
+
+  /**
+   * Record a `chat_tool_executed` telemetry event.
+   * `source` distinguishes browser-executed actions ('local') from
+   * agent-executed tools reported via TOOL_CALL_RESULT ('agent').
+   */
+  private recordToolExecuted(
+    toolName: string,
+    status: 'success' | 'failure' | 'error' | 'rejected',
+    source: 'local' | 'agent'
+  ): void {
+    if (!this.telemetryRecorder) {
+      return;
+    }
+
+    this.telemetryRecorder.recordEvent({
+      name: 'chat_tool_executed',
+      data: {
+        toolName,
+        status,
+        source,
+      },
+    });
   }
 
   /**

--- a/src/plugins/chat/public/services/tool_executor.ts
+++ b/src/plugins/chat/public/services/tool_executor.ts
@@ -93,7 +93,7 @@ export class ToolExecutor {
       }
 
       // Otherwise, handle as agent-only tool
-      return await this.executeAgentTool(toolName, enrichedToolArgs);
+      return await this.executeAgentTool();
     } catch (error: any) {
       return {
         success: false,
@@ -141,9 +141,13 @@ export class ToolExecutor {
   }
 
   /**
-   * Execute agent-only tools that report results back via AG-UI events
+   * Execute agent-only tools that report results back via AG-UI events.
+   *
+   * Public so `ChatEventHandler` can bypass `executeTool`'s local-action path
+   * (which awaits `executeAction` even when doomed to fail) and call this directly.
+   * No parameters needed — the agent already has the tool name/args.
    */
-  private async executeAgentTool(_toolName: string, _toolArgs: any): Promise<ToolResult> {
+  async executeAgentTool(): Promise<ToolResult> {
     // Any tool that reaches here is assumed to be handled by the agent
     // The agent will send the results back via TOOL_CALL_RESULT events
     return {


### PR DESCRIPTION
### Description

Adds telemetry events to the chat plugin so tool usage and chat window engagement are observable. All events go through the existing `PluginTelemetryRecorder` scoped to the `chat` plugin, alongside the current `chat_interaction_*` events.

**`chat_tool_executed`** — emitted when a tool call reaches a terminal state.

| field | value |
|---|---|
| `toolName` | name of the tool |
| `source` | `local` for tools run in the browser as registered assistant actions, `agent` for tools the agent runs and reports back over `TOOL_CALL_RESULT` |
| `status` | `success`, `failure`, `error`, or `rejected` |

Statuses:

- `success` — the tool ran and returned a successful result.
- `failure` — a registered action rejected with a real error (an error whose message does not indicate the action is unregistered).
- `error` — something threw inside the tool-call handler itself, most realistically `JSON.parse` on malformed arguments.
- `rejected` — the user explicitly denied a confirmation prompt.

The two sources reach a terminal state on different code paths. Local tools finish inside `handleToolCallEnd`, but agent tools return early there on the `waitingForAgentResponse` branch and only complete when the agent reports back via `TOOL_CALL_RESULT`, so their event is recorded in `handleToolCallResult`.

`handleToolCallEnd` calls `ToolExecutor.executeAgentTool()` directly for tools it already knows are agent-routed (via `hasAction`), instead of going through `executeTool`'s local-action detour. That detour always awaits `assistantActionService.executeAction` at least once — even when it's guaranteed to fail for an agent tool — plus an unused data source lookup, which delayed `markToolPending` and left a window for the agent's own `TOOL_CALL_RESULT` to arrive and be processed first. `executeAgentTool` does no real async work, so calling it directly closes that window entirely rather than just narrowing it. `handleToolCallResult` still gates the telemetry event on `isPendingAgentResponse`, now purely to guard against double-counting a duplicate or replayed `TOOL_CALL_RESULT`.

**`chat_window_show`** / **`chat_window_hide`** — emitted when the chat window mounts and unmounts, which correspond to the sidecar being opened and closed (`ChatMountService` creates the React root on open and unmounts it on close).

#### Known gaps

Worth being explicit about, since they affect how the data should be read:

- `source: 'agent'` always reports `status: 'success'`. `TOOL_CALL_RESULT` carries only content, and the error-prefix convention used to mark failures is written by the local path only, so an agent-side tool failure is currently counted as a success. Distinguishing it would need a contract change on the agent side.
- An agent tool whose `TOOL_CALL_RESULT` never arrives — the run errors out, the user aborts, or the stream dies — emits nothing, so agent tool starts will exceed agent tool completions.
- Tools restored from `MESSAGES_SNAPSHOT` on conversation reload emit nothing, since that path only replaces the timeline.

### Issues Resolved

N/A — observability improvement.

## Screenshot

N/A — no UI changes.

## Testing the changes

9 new unit tests: 7 covering `chat_tool_executed` (one per status/source, plus a regression test asserting `executeAction` is never called for agent tools), and 2 covering window show/hide.

```
node scripts/jest.js src/plugins/chat --no-coverage
```

All 1014 chat plugin tests pass across 47 suites.

The two new tests that depend on mock routing were also verified in isolation to confirm they are not order-dependent:

```
node scripts/jest.js src/plugins/chat/public/services/chat_event_handler.test.ts \
  --testNamePattern="failure when a registered action rejects" --no-coverage
node scripts/jest.js src/plugins/chat/public/services/chat_event_handler.test.ts \
  --testNamePattern="agent-sourced" --no-coverage
```

This PR also resets `isUserConfirmRequired` in the `chat_event_handler` test suite's `beforeEach`. That suite already reset `hasAction` and `requestConfirmation` but not this one, so a test could inherit an override from a test declared above it.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff





