### PR TITLE
test: fix flaky telemetry_service test

### DIFF
--- a/src/plugins/telemetry/public/services/telemetry_service.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.test.ts
@@ -56,6 +56,20 @@ jest.mock('moment', () => {
 });
 
 describe('TelemetryService', () => {
+  // `reportOptInStatus` performs a real `fetch` call. Stub it so the tests that exercise it
+  // resolve immediately instead of hanging on a network request until the Jest timeout.
+  let originalFetch: (typeof window)['fetch'];
+
+  beforeAll(() => {
+    originalFetch = window.fetch;
+  });
+
+  // @ts-ignore
+  beforeEach(() => (window.fetch = jest.fn().mockResolvedValue({})));
+
+  // @ts-ignore
+  afterAll(() => (window.fetch = originalFetch));
+
   // TODO: enable this unit test when fetchTelemtry function is restored
   describe.skip('fetchTelemetry', () => {
     it('calls expected URL with 20 minutes - now', async () => {


### PR DESCRIPTION
### Description

Fixes a flaky unit test in `telemetry_service.test.ts` that intermittently timed out in CI with:

> thrown: "Exceeded timeout of 5000 ms for a test."
>
> `TelemetryService › setOptIn › calls reportOptInStatus if reportOptInStatusChange is true`

### Root cause

The failing test constructs `TelemetryService` with `reportOptInStatusChange: true`, causing `setOptIn()` to invoke `reportOptInStatus()`.

The mock implementation in `public/mocks.ts` intentionally delegates to the original `reportOptInStatus()` implementation, which performs a real `fetch()` request to `http://localhost`. Because this test suite never mocked `fetch`, the request could hang in Jest's jsdom environment until the default 5-second timeout expired, causing the intermittent failure.

The neighboring test (`adds an error toast on reportOptInStatus error`) did not exhibit the issue because it explicitly mocked `reportOptInStatus()` itself, avoiding the network call entirely.

### Fix

Mock the global `fetch` within the `TelemetryService` test suite, following the same approach already used in `telemetry_sender.test.ts`.

- Stub `global.fetch` in `beforeAll` to immediately resolve with a successful response.
- Restore the original implementation in `afterAll`.

This prevents `reportOptInStatus()` from making a real network request while preserving the production code path exercised by the test.

### Testing

- Verified the previously flaky test now completes consistently without timing out.
- Confirmed the full `telemetry_service.test.ts` suite passes.
- No production code changes; test-only fix.


### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
