### PR TITLE
Fix PromQL dataset not selectable in Dashboard Variables flyout

### DIFF
--- a/src/plugins/query_enhancements/public/datasets/prometheus_type.test.ts
+++ b/src/plugins/query_enhancements/public/datasets/prometheus_type.test.ts
@@ -197,7 +197,7 @@ describe('prometheusTypeConfig', () => {
       expect(prometheusTypeConfig.meta).toEqual({
         icon: expect.objectContaining({ type: expect.any(String) }),
         tooltip: 'Prometheus',
-        supportedAppNames: ['explore'],
+        supportedAppNames: ['explore', 'dashboard'],
       });
     });
   });

--- a/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
+++ b/src/plugins/query_enhancements/public/datasets/prometheus_type.ts
@@ -19,7 +19,7 @@ export const prometheusTypeConfig: DatasetTypeConfig = {
   meta: {
     icon: { type: PROMETHEUS_ICON },
     tooltip: 'Prometheus',
-    supportedAppNames: ['explore'],
+    supportedAppNames: ['explore', 'dashboard'],
   },
 
   toDataset: (path) => {


### PR DESCRIPTION
### Description

When creating a dashboard variable of type **Query** and switching the language to **PromQL**, the dataset selector was empty — no Prometheus data connection could be selected, so PromQL variables could not be created at all.

The Prometheus dataset type (`prometheusTypeConfig` in `query_enhancements`) declares which apps may use it via `meta.supportedAppNames`, which was set to `['explore']`. That value was correct when Prometheus was only consumed by the Explore app.

`DatasetSelect` filters candidate datasets by `typeConfig.meta.supportedAppNames.includes(appName)`, where `appName` is injected into the data-plugin context by the `createDatasetSelect` factory from the `appName` prop. The Dashboard Variables editor renders the selector with `appName="dashboard"`, so `'dashboard'` was never in the allow-list and every Prometheus connection was filtered out.

The Dashboard Variables feature (#11646) added `dashboard` as a new consumer of the PromQL dataset selector but did not extend the Prometheus type's `supportedAppNames`. PPL was unaffected because it uses the generic `index` / `index-pattern` dataset types, which declare no `supportedAppNames` and are therefore allowed in every app.
### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="552" height="239" alt="image" src="https://github.com/user-attachments/assets/74544739-770a-4501-9e85-92daea5daa5f" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
