### PR TITLE
Fix: Restore variable autocomplete in visualization query editor

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/hooks/use_query_panel_editor_props.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/hooks/use_query_panel_editor_props.ts
@@ -47,5 +47,6 @@ export const useQueryPanelEditorProps = (): QueryEditorProps => {
     getEditorContainerHeight,
     handleEditorChange: (updates) => queryBuilder.updateQueryEditorState(updates),
     focusShortcutId: 'vis_editor_focus_query_bar',
+    getVariableNames: () => queryBuilder.getVariableNames(),
   };
 };

--- a/src/plugins/explore/public/application/in_context_vis_editor/hooks/use_query_panel_editor_props.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/hooks/use_query_panel_editor_props.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../../types';
 import { QueryEditorProps } from '../../../components/query_panel/query_panel_editor/types';
 import { useQueryBuilderState } from './use_query_builder_state';
 import { EditorMode } from '../../utils/state_management/types';
 import { useEditorOperations } from './use_editor_operations';
+import { createVariableCompletionProvider } from '../utils/variable_completion_provider';
 
 export const useQueryPanelEditorProps = (): QueryEditorProps => {
   const { services } = useOpenSearchDashboards<ExploreServices>();
@@ -37,6 +38,13 @@ export const useQueryPanelEditorProps = (): QueryEditorProps => {
     return panelEl?.clientHeight ?? domNode?.parentElement?.clientHeight ?? 100;
   }, []);
 
+  // Contribute dashboard variable (`${var}`) suggestions as a completion extension so the
+  // shared query editor need not know about the dashboard-variables feature.
+  const completionProviders = useMemo(
+    () => [createVariableCompletionProvider(() => queryBuilder.getVariableNames())],
+    [queryBuilder]
+  );
+
   return {
     services,
     editorRef: queryBuilder.editorRef,
@@ -47,6 +55,6 @@ export const useQueryPanelEditorProps = (): QueryEditorProps => {
     getEditorContainerHeight,
     handleEditorChange: (updates) => queryBuilder.updateQueryEditorState(updates),
     focusShortcutId: 'vis_editor_focus_query_bar',
-    getVariableNames: () => queryBuilder.getVariableNames(),
+    completionProviders,
   };
 };

--- a/src/plugins/explore/public/application/in_context_vis_editor/utils/variable_completion_provider.test.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/utils/variable_completion_provider.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+jest.mock('@osd/monaco', () => ({
+  monaco: {
+    Range: jest.fn((sl: number, sc: number, el: number, ec: number) => ({ sl, sc, el, ec })),
+    languages: {
+      CompletionItemKind: { Variable: 4 },
+    },
+  },
+}));
+
+import { createVariableCompletionProvider } from './variable_completion_provider';
+
+const makeModel = (text: string) =>
+  ({
+    getValue: () => text,
+    getOffsetAt: () => text.length,
+  }) as any;
+
+const callProvider = (provider: any, text: string) =>
+  provider.provideCompletionItems(
+    makeModel(text),
+    { lineNumber: 1, column: text.length + 1 } as any,
+    {} as any,
+    {} as any
+  ) as any[];
+
+describe('createVariableCompletionProvider', () => {
+  it('exposes "$" as a trigger character', () => {
+    expect(createVariableCompletionProvider(() => []).triggerCharacters).toEqual(['$']);
+  });
+
+  it('suggests ${var} items when the caret follows "$"', () => {
+    const provider = createVariableCompletionProvider(() => ['env', 'service']);
+    const items = callProvider(provider, 'source=logs | where svc=$');
+
+    expect(items.map((i) => i.label)).toEqual(['${env}', '${service}']);
+    expect(items[0].insertText).toBe('${env}');
+    expect(items[0].detail).toBe('Dashboard variable');
+    expect(items[0].kind).toBe(4); // CompletionItemKind.Variable (mocked)
+  });
+
+  it('also matches the "${" prefix', () => {
+    const provider = createVariableCompletionProvider(() => ['env']);
+    const items = callProvider(provider, 'svc=${');
+    expect(items.map((i) => i.label)).toEqual(['${env}']);
+  });
+
+  it('returns [] when the caret is not after a "$"', () => {
+    const provider = createVariableCompletionProvider(() => ['env']);
+    expect(callProvider(provider, 'source=logs')).toEqual([]);
+  });
+
+  it('returns [] when there are no variable names', () => {
+    const provider = createVariableCompletionProvider(() => []);
+    expect(callProvider(provider, 'svc=$')).toEqual([]);
+  });
+
+  it('reads variable names lazily at completion time', () => {
+    let names: string[] = ['a'];
+    const provider = createVariableCompletionProvider(() => names);
+    expect(callProvider(provider, 'x=$').map((i) => i.label)).toEqual(['${a}']);
+    names = ['a', 'b'];
+    expect(callProvider(provider, 'x=$').map((i) => i.label)).toEqual(['${a}', '${b}']);
+  });
+});

--- a/src/plugins/explore/public/application/in_context_vis_editor/utils/variable_completion_provider.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/utils/variable_completion_provider.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { monaco } from '@osd/monaco';
+import type { EditorCompletionProvider } from '../../../components/query_panel/query_panel_editor/types';
+
+/**
+ * Completion extension that suggests dashboard variables (`${var}`) when the user types
+ * `$` or `${`.
+ */
+export const createVariableCompletionProvider = (
+  getVariableNames: () => string[]
+): EditorCompletionProvider => ({
+  triggerCharacters: ['$'],
+  provideCompletionItems: (model, position) => {
+    const variableNames = getVariableNames();
+    if (!variableNames.length) {
+      return [];
+    }
+
+    const offset = model.getOffsetAt(position);
+    const textBeforeCursor = model.getValue().substring(0, offset);
+    const dollarMatch = textBeforeCursor.match(/\$\{?(\w*)$/);
+    if (!dollarMatch) {
+      return [];
+    }
+
+    const fullPrefix = dollarMatch[0]; // e.g. "$", "$se", "${", "${se"
+    const range = new monaco.Range(
+      position.lineNumber,
+      position.column - fullPrefix.length,
+      position.lineNumber,
+      position.column
+    );
+
+    return variableNames.map((name) => ({
+      label: `\${${name}}`,
+      kind: monaco.languages.CompletionItemKind.Variable,
+      insertText: `\${${name}}`,
+      insertTextRules: undefined,
+      range,
+      detail: 'Dashboard variable',
+      sortText: `!${name}`,
+      documentation: {
+        value: `Reference variable **${name}** — will be replaced at query time`,
+        isTrusted: true,
+      },
+      command: {
+        id: 'editor.action.triggerSuggest',
+        title: 'Trigger Next Suggestion',
+      },
+    }));
+  },
+});

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/types.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/types.ts
@@ -59,4 +59,12 @@ export interface QueryEditorProps {
 
   // compute editor container height
   getEditorContainerHeight?: (domNode: HTMLElement | null) => number;
+
+  /**
+   * Optional provider for dashboard variable names. When supplied, typing `$` or `${`
+   * surfaces these names as autocomplete suggestions (e.g. `${myVar}`). Implemented as a
+   * getter so the editor always reads the latest names at completion time rather than a
+   * value captured when the editor mounted.
+   */
+  getVariableNames?: () => string[];
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/types.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/types.ts
@@ -23,6 +23,26 @@ import { EditorMode } from '../../../application/utils/state_management/types';
 
 export type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 
+/**
+ * A consumer-provided completion extension. Each extension contributes its own trigger
+ * characters and completion items, which are merged into the editor's built-in query
+ * suggestions. This keeps the shared editor agnostic of any specific feature.
+ */
+export interface EditorCompletionProvider {
+  /** Extra characters that should (re)trigger completion for this extension. */
+  triggerCharacters?: string[];
+  /**
+   * Contribute completion items for the current Monaco context. Called at completion
+   * time, so implementations may read the latest external state directly.
+   */
+  provideCompletionItems: (
+    model: monaco.editor.ITextModel,
+    position: monaco.Position,
+    context: monaco.languages.CompletionContext,
+    token: monaco.CancellationToken
+  ) => monaco.languages.CompletionItem[] | Promise<monaco.languages.CompletionItem[]>;
+}
+
 export type PartialQueryEditorState = Pick<
   QueryEditorState,
   'isQueryEditorDirty' | 'editorMode' | 'promptModeIsAvailable'
@@ -61,10 +81,10 @@ export interface QueryEditorProps {
   getEditorContainerHeight?: (domNode: HTMLElement | null) => number;
 
   /**
-   * Optional provider for dashboard variable names. When supplied, typing `$` or `${`
-   * surfaces these names as autocomplete suggestions (e.g. `${myVar}`). Implemented as a
-   * getter so the editor always reads the latest names at completion time rather than a
-   * value captured when the editor mounted.
+   * Optional completion extensions. Each contributes its own trigger characters and
+   * completion items, merged into the editor's built-in suggestions. Lets consumers
+   * inject domain-specific completions without the shared editor knowing about any
+   * particular feature.
    */
-  getVariableNames?: () => string[];
+  completionProviders?: EditorCompletionProvider[];
 }

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -82,6 +82,7 @@ jest.mock('@osd/monaco', () => ({
       registerCompletionItemProvider: jest.fn(() => ({ dispose: jest.fn() })),
       CompletionItemKind: {
         Keyword: 1,
+        Variable: 4,
       },
     },
     Range: jest.fn(),
@@ -1007,6 +1008,74 @@ describe('useQueryPanelEditor', () => {
 
       expect(syncPPLLintContext).not.toHaveBeenCalled();
       expect(revalidatePPLModel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dashboard variable suggestions', () => {
+    const runCompletion = async (props: any, model: any, column: number) => {
+      const { result } = renderHook(() => useQueryPanelEditor(props));
+      let list: any;
+      await act(async () => {
+        list = await result.current.suggestionProvider.provideCompletionItems(
+          model,
+          { lineNumber: 1, column } as any,
+          // @ts-expect-error TS2345 test stub
+          {},
+          { isCancellationRequested: false }
+        );
+      });
+      return list;
+    };
+
+    it('injects variable suggestions when the caret follows a "$"', async () => {
+      const model = {
+        getValue: () => 'source=logs | where svc=$',
+        getOffsetAt: () => 25,
+        getWordUntilPosition: () => ({ startColumn: 25, endColumn: 25 }),
+      } as any;
+
+      const list = await runCompletion(
+        buildProps({ getVariableNames: () => ['env', 'service'] }),
+        model,
+        26
+      );
+
+      const labels = list.suggestions.map((s: any) => s.label);
+      expect(labels).toEqual(expect.arrayContaining(['${env}', '${service}']));
+      const envSuggestion = list.suggestions.find((s: any) => s.label === '${env}');
+      expect(envSuggestion.insertText).toBe('${env}');
+      expect(envSuggestion.detail).toBe('Dashboard variable');
+    });
+
+    it('does not inject variable suggestions when the caret is not after a "$"', async () => {
+      const model = {
+        getValue: () => 'source=logs',
+        getOffsetAt: () => 11,
+        getWordUntilPosition: () => ({ startColumn: 8, endColumn: 11 }),
+      } as any;
+
+      const list = await runCompletion(
+        buildProps({ getVariableNames: () => ['env', 'service'] }),
+        model,
+        12
+      );
+
+      const labels = list.suggestions.map((s: any) => s.label);
+      expect(labels).not.toContain('${env}');
+      expect(labels).not.toContain('${service}');
+    });
+
+    it('is a no-op when getVariableNames is not provided', async () => {
+      const model = {
+        getValue: () => 'source=logs | where svc=$',
+        getOffsetAt: () => 25,
+        getWordUntilPosition: () => ({ startColumn: 25, endColumn: 25 }),
+      } as any;
+
+      const list = await runCompletion(buildProps(), model, 26);
+
+      const labels = list.suggestions.map((s: any) => s.label);
+      expect(labels).not.toContain('${env}');
     });
   });
 });

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.test.ts
@@ -1011,7 +1011,7 @@ describe('useQueryPanelEditor', () => {
     });
   });
 
-  describe('dashboard variable suggestions', () => {
+  describe('completion extensions (completionProviders)', () => {
     const runCompletion = async (props: any, model: any, column: number) => {
       const { result } = renderHook(() => useQueryPanelEditor(props));
       let list: any;
@@ -1024,58 +1024,96 @@ describe('useQueryPanelEditor', () => {
           { isCancellationRequested: false }
         );
       });
-      return list;
+      return { list, hook: result };
     };
 
-    it('injects variable suggestions when the caret follows a "$"', async () => {
-      const model = {
-        getValue: () => 'source=logs | where svc=$',
-        getOffsetAt: () => 25,
-        getWordUntilPosition: () => ({ startColumn: 25, endColumn: 25 }),
-      } as any;
+    const model = {
+      getValue: () => 'source=logs',
+      getOffsetAt: () => 11,
+      getWordUntilPosition: () => ({ startColumn: 8, endColumn: 11 }),
+    } as any;
 
-      const list = await runCompletion(
-        buildProps({ getVariableNames: () => ['env', 'service'] }),
-        model,
-        26
-      );
+    it('merges items contributed by a completion extension', async () => {
+      const extensionItem = { label: '${env}', insertText: '${env}', detail: 'Custom' };
+      const provider = {
+        triggerCharacters: ['$'],
+        provideCompletionItems: jest.fn().mockResolvedValue([extensionItem]),
+      };
 
-      const labels = list.suggestions.map((s: any) => s.label);
-      expect(labels).toEqual(expect.arrayContaining(['${env}', '${service}']));
-      const envSuggestion = list.suggestions.find((s: any) => s.label === '${env}');
-      expect(envSuggestion.insertText).toBe('${env}');
-      expect(envSuggestion.detail).toBe('Dashboard variable');
-    });
-
-    it('does not inject variable suggestions when the caret is not after a "$"', async () => {
-      const model = {
-        getValue: () => 'source=logs',
-        getOffsetAt: () => 11,
-        getWordUntilPosition: () => ({ startColumn: 8, endColumn: 11 }),
-      } as any;
-
-      const list = await runCompletion(
-        buildProps({ getVariableNames: () => ['env', 'service'] }),
+      const { list } = await runCompletion(
+        buildProps({ completionProviders: [provider] }),
         model,
         12
       );
 
-      const labels = list.suggestions.map((s: any) => s.label);
-      expect(labels).not.toContain('${env}');
-      expect(labels).not.toContain('${service}');
+      expect(provider.provideCompletionItems).toHaveBeenCalled();
+      expect(list.suggestions.map((s: any) => s.label)).toContain('${env}');
     });
 
-    it('is a no-op when getVariableNames is not provided', async () => {
-      const model = {
-        getValue: () => 'source=logs | where svc=$',
-        getOffsetAt: () => 25,
-        getWordUntilPosition: () => ({ startColumn: 25, endColumn: 25 }),
-      } as any;
+    it('isolates a throwing extension so other extensions and built-ins survive', async () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const bad = {
+        triggerCharacters: ['#'],
+        provideCompletionItems: jest.fn().mockRejectedValue(new Error('boom')),
+      };
+      const good = {
+        triggerCharacters: ['$'],
+        provideCompletionItems: jest
+          .fn()
+          .mockResolvedValue([{ label: '${ok}', insertText: '${ok}' }]),
+      };
 
-      const list = await runCompletion(buildProps(), model, 26);
+      const { list } = await runCompletion(
+        buildProps({ completionProviders: [bad, good] }),
+        model,
+        12
+      );
 
-      const labels = list.suggestions.map((s: any) => s.label);
-      expect(labels).not.toContain('${env}');
+      expect(bad.provideCompletionItems).toHaveBeenCalled();
+      expect(good.provideCompletionItems).toHaveBeenCalled();
+      // The failing extension must not prevent the healthy one's items from appearing.
+      expect(list.suggestions.map((s: any) => s.label)).toContain('${ok}');
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+
+    it('folds extension trigger characters into the suggestion provider', () => {
+      const provider = {
+        triggerCharacters: ['$', '@'],
+        provideCompletionItems: jest.fn().mockResolvedValue([]),
+      };
+      const { result } = renderHook(() =>
+        useQueryPanelEditor(buildProps({ completionProviders: [provider] }))
+      );
+      expect(result.current.suggestionProvider.triggerCharacters).toEqual(
+        expect.arrayContaining(['$', '@'])
+      );
+    });
+
+    it('does not fold extension trigger characters in prompt mode', () => {
+      const provider = {
+        triggerCharacters: ['$', '@'],
+        provideCompletionItems: jest.fn().mockResolvedValue([]),
+      };
+      const { result } = renderHook(() =>
+        useQueryPanelEditor(
+          buildProps({
+            completionProviders: [provider],
+            queryEditorState: {
+              editorMode: EditorMode.Prompt,
+              promptModeIsAvailable: true,
+              isQueryEditorDirty: false,
+            },
+          })
+        )
+      );
+      expect(result.current.suggestionProvider.triggerCharacters).toEqual(['=']);
+    });
+
+    it('is a no-op when no completionProviders are supplied', async () => {
+      const { list } = await runCompletion(buildProps(), model, 12);
+      // Only built-in suggestions (none from getQuerySuggestions mock) — no throw, valid list.
+      expect(Array.isArray(list.suggestions)).toBe(true);
     });
   });
 });

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -87,6 +87,7 @@ export const useQueryPanelEditor = (props: QueryEditorProps): UseQueryPanelEdito
     switchEditorMode,
     editorRef,
     getEditorContainerHeight,
+    getVariableNames,
   } = props;
 
   const { promptIsTyping, handleChangeForPromptIsTyping } = usePromptIsTyping();
@@ -420,6 +421,44 @@ export const useQueryPanelEditor = (props: QueryEditorProps): UseQueryPanelEdito
           },
         }));
 
+        // Inject dashboard variable suggestions when the user types '$' or '${'.
+        // Only relevant for consumers that provide variable names (e.g. the in-context
+        // visualization editor embedded in a dashboard); no-op otherwise.
+        const variableNames = getVariableNames?.() ?? [];
+        if (variableNames.length > 0) {
+          const offset = model.getOffsetAt(position);
+          const textBeforeCursor = model.getValue().substring(0, offset);
+          const dollarMatch = textBeforeCursor.match(/\$\{?(\w*)$/);
+          if (dollarMatch) {
+            const fullPrefix = dollarMatch[0]; // e.g. "$", "$se", "${", "${se"
+            const varRange = new monaco.Range(
+              position.lineNumber,
+              position.column - fullPrefix.length,
+              position.lineNumber,
+              position.column
+            );
+            variableNames.forEach((name) => {
+              monacoSuggestions.push({
+                label: `\${${name}}`,
+                kind: monaco.languages.CompletionItemKind.Variable,
+                insertText: `\${${name}}`,
+                insertTextRules: undefined,
+                range: varRange,
+                detail: 'Dashboard variable',
+                sortText: `!${name}`,
+                documentation: {
+                  value: `Reference variable **${name}** — will be replaced at query time`,
+                  isTrusted: true,
+                },
+                command: {
+                  id: 'editor.action.triggerSuggest',
+                  title: 'Trigger Next Suggestion',
+                },
+              });
+            });
+          }
+        }
+
         return {
           suggestions: monacoSuggestions,
           incomplete: false,
@@ -428,7 +467,7 @@ export const useQueryPanelEditor = (props: QueryEditorProps): UseQueryPanelEdito
         return { suggestions: [], incomplete: false };
       }
     },
-    [isPromptModeRef, queryLanguage, dataViews, services]
+    [isPromptModeRef, queryLanguage, dataViews, services, getVariableNames]
   );
 
   const suggestionProvider = useMemo(() => {

--- a/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
+++ b/src/plugins/explore/public/components/query_panel/query_panel_editor/use_query_panel_editor/use_query_panel_editor.ts
@@ -87,7 +87,7 @@ export const useQueryPanelEditor = (props: QueryEditorProps): UseQueryPanelEdito
     switchEditorMode,
     editorRef,
     getEditorContainerHeight,
-    getVariableNames,
+    completionProviders,
   } = props;
 
   const { promptIsTyping, handleChangeForPromptIsTyping } = usePromptIsTyping();
@@ -401,61 +401,40 @@ export const useQueryPanelEditor = (props: QueryEditorProps): UseQueryPanelEdito
 
         const filteredSuggestions = suggestions?.filter((s) => 'detail' in s) || [];
 
-        const monacoSuggestions = filteredSuggestions.map((s: any) => ({
-          label: s.text,
-          kind: s.type as monaco.languages.CompletionItemKind,
-          insertText: s.insertText ?? s.text,
-          insertTextRules: s.insertTextRules ?? undefined,
-          range: defaultRange,
-          detail: s.detail,
-          sortText: s.sortText,
-          documentation: s.documentation
-            ? {
-                value: s.documentation,
-                isTrusted: true,
-              }
-            : '',
-          command: {
-            id: 'editor.action.triggerSuggest',
-            title: 'Trigger Next Suggestion',
-          },
-        }));
-
-        // Inject dashboard variable suggestions when the user types '$' or '${'.
-        // Only relevant for consumers that provide variable names (e.g. the in-context
-        // visualization editor embedded in a dashboard); no-op otherwise.
-        const variableNames = getVariableNames?.() ?? [];
-        if (variableNames.length > 0) {
-          const offset = model.getOffsetAt(position);
-          const textBeforeCursor = model.getValue().substring(0, offset);
-          const dollarMatch = textBeforeCursor.match(/\$\{?(\w*)$/);
-          if (dollarMatch) {
-            const fullPrefix = dollarMatch[0]; // e.g. "$", "$se", "${", "${se"
-            const varRange = new monaco.Range(
-              position.lineNumber,
-              position.column - fullPrefix.length,
-              position.lineNumber,
-              position.column
-            );
-            variableNames.forEach((name) => {
-              monacoSuggestions.push({
-                label: `\${${name}}`,
-                kind: monaco.languages.CompletionItemKind.Variable,
-                insertText: `\${${name}}`,
-                insertTextRules: undefined,
-                range: varRange,
-                detail: 'Dashboard variable',
-                sortText: `!${name}`,
-                documentation: {
-                  value: `Reference variable **${name}** — will be replaced at query time`,
+        const monacoSuggestions: monaco.languages.CompletionItem[] = filteredSuggestions.map(
+          (s: any) => ({
+            label: s.text,
+            kind: s.type as monaco.languages.CompletionItemKind,
+            insertText: s.insertText ?? s.text,
+            insertTextRules: s.insertTextRules ?? undefined,
+            range: defaultRange,
+            detail: s.detail,
+            sortText: s.sortText,
+            documentation: s.documentation
+              ? {
+                  value: s.documentation,
                   isTrusted: true,
-                },
-                command: {
-                  id: 'editor.action.triggerSuggest',
-                  title: 'Trigger Next Suggestion',
-                },
-              });
-            });
+                }
+              : '',
+            command: {
+              id: 'editor.action.triggerSuggest',
+              title: 'Trigger Next Suggestion',
+            },
+          })
+        );
+
+        // Merge in consumer-provided completion extensions.
+        if (completionProviders?.length) {
+          for (const provider of completionProviders) {
+            try {
+              const extraItems = await provider.provideCompletionItems(model, position, _, token);
+              if (extraItems?.length) {
+                monacoSuggestions.push(...extraItems);
+              }
+            } catch (extensionError) {
+              // eslint-disable-next-line no-console
+              console.error('[QueryPanelEditor] completion extension failed:', extensionError);
+            }
           }
         }
 
@@ -467,19 +446,27 @@ export const useQueryPanelEditor = (props: QueryEditorProps): UseQueryPanelEdito
         return { suggestions: [], incomplete: false };
       }
     },
-    [isPromptModeRef, queryLanguage, dataViews, services, getVariableNames]
+    [isPromptModeRef, queryLanguage, dataViews, services, completionProviders]
   );
 
   const suggestionProvider = useMemo(() => {
     const languageTriggerCharacters =
       services?.data?.autocomplete?.getTriggerCharacters(queryLanguage);
+    const extensionTriggerCharacters = (completionProviders ?? []).flatMap(
+      (provider) => provider.triggerCharacters ?? []
+    );
     return {
       triggerCharacters: isPromptMode
         ? ['=']
-        : (languageTriggerCharacters ?? DEFAULT_TRIGGER_CHARACTERS),
+        : Array.from(
+            new Set([
+              ...(languageTriggerCharacters ?? DEFAULT_TRIGGER_CHARACTERS),
+              ...extensionTriggerCharacters,
+            ])
+          ),
       provideCompletionItems,
     };
-  }, [isPromptMode, provideCompletionItems, queryLanguage, services]);
+  }, [isPromptMode, provideCompletionItems, queryLanguage, services, completionProviders]);
 
   const handleRun = useCallback(() => {
     onRun(editorTextRef.current);


### PR DESCRIPTION
### Description

PR #11753 refactored the Explore query panel into a generic, prop-driven `QueryPanelEditor` and exposed it for reuse. During that extraction, the dashboard-variable autocomplete (`$` / `${var}` suggestions) that the in-context **visualization editor** previously offered was dropped: the suggestion-building logic lived in the now-removed private hooks, and the new generic editor's props contract had no notion of variables.

The data side was left intact but disconnected — `visualization_editor_page.tsx` still calls `queryBuilder.setVariableNames(...)`, and `queryBuilder.variableNames$` / `getVariableNames()` still exist — but nothing consumed them anymore. As a result, typing `$` in the visualization editor's query editor no longer suggested dashboard variables (regression from #11753).

* Add `EditorCompletionProvider` and an optional `completionProviders?: EditorCompletionProvider[]` array to `QueryEditorProps`. Each provider contributes its own `triggerCharacters` and `provideCompletionItems(model, position, context, token)`, merged into the shared editor's built-in suggestions — the shared editor stays agnostic of any specific feature.
* `useQueryPanelEditor.provideCompletionItems` now folds each provider's `triggerCharacters` into the suggestion provider's trigger set, and calls each provider's `provideCompletionItems` at completion time, merging returned items into the built-in suggestions. Each provider is isolated in its own try/catch so one failing extension can't break completions from the others or the built-ins.
* Add `createVariableCompletionProvider(getVariableNames)` (in the `explore` plugin's in-context vis-editor code, not in the shared editor) — a small factory that returns an `EditorCompletionProvider` suggesting `${name}` when the caret follows `$` or `${`. `getVariableNames` is a getter (not a snapshot array) so it always reads the latest names at completion time.
* Wire `useQueryPanelEditorProps` (in-context visualization editor) to pass `completionProviders: [createVariableCompletionProvider(() => queryBuilder.getVariableNames())]`, reconnecting the already-populated data source to the shared editor via the new extension point.

Explore/Discover pages do not pass `completionProviders` and are entirely unaffected. The dashboard variable creation flyout keeps its own editor and is out of scope for this change (a separate de-duplication opportunity that would first require relocating the shared editor to avoid a `dashboard → explore` dependency).





### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<img width="1374" height="845" alt="image" src="https://github.com/user-attachments/assets/dd63decf-ee4f-4d99-a4b1-ff4bfef0d1f9" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
