### PR TITLE
fix(variables): use correct dataset for prometheus data-connections

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_variables/query_panel/variable_query_panel.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/query_panel/variable_query_panel.tsx
@@ -294,7 +294,7 @@ export const VariableQueryPanel: React.FC<VariableQueryPanelProps> = ({
           selectionEnd: offset,
           language: effectiveLanguage,
           baseLanguage: currentLanguage,
-          indexPattern: currentDataView,
+          indexPattern: currentDataView ?? currentDataset,
           datasetType: currentDataset?.type,
           position,
           services: servicesWithAppName as any,


### PR DESCRIPTION
### Description

The variable query panel passed only `currentDataView` as the autocomplete indexPattern. For a Prometheus dataset `dataViews.get(id, onlyCheckCache=true)` returns undefined, so PromQL code completion fell back to the global dashboard query dataset, which can be an index pattern. Fall back to the locally selected dataset.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff