### PR TITLE
fix(chat): call executeAgentTool directly to close a TOOL_CALL_RESULT race

### DIFF
--- a/changelogs/fragments/12536.yml
+++ b/changelogs/fragments/12536.yml
@@ -1,0 +1,2 @@
+fix:
+- [Chat] Fix a race where an agent tool's TOOL_CALL_RESULT could be processed before the tool call was marked pending ([#12536](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12536))

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -355,6 +355,34 @@ describe('ChatEventHandler', () => {
       expect(toolMessages).toHaveLength(0);
     });
 
+    it('should never call executeAction for agent tools, so there is no await before markToolPending', async () => {
+      // Regression test for a real race: a backend agent's TOOL_CALL_RESULT could
+      // arrive and be processed before handleToolCallEnd's own async execution
+      // (routing through executeTool's local-action detour, which always awaits
+      // executeAction at least once even when doomed to fail) resolved and reached
+      // markToolPending. The fix is architectural, not timing-based: handleToolCallEnd
+      // calls `executeAgentTool` directly for tools it already knows are agent-routed
+      // (via `hasAction`), so `executeAction` — the only await that stood between
+      // computing `isAgentTool` and `markToolPending` — is never invoked on this path
+      // at all.
+      const toolCallId = 'tool-race-1';
+
+      mockAssistantActionService.hasAction.mockReturnValueOnce(false);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'raceTool',
+      } as ToolCallStartEvent);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      expect(mockAssistantActionService.executeAction).not.toHaveBeenCalled();
+    });
+
     it('should handle tool call result from agent', async () => {
       const toolCallId = 'tool-123';
 

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -393,13 +393,24 @@ export class ChatEventHandler {
         args,
       });
 
-      // Execute the tool and update tool execution status
-      const result = await this.toolExecutor.executeTool(
-        toolCall.function.name,
-        args,
-        toolCallId,
-        await this.chatService.getCurrentDataSourceId()
-      );
+      // Execute the tool and update tool execution status.
+      //
+      // Agent tools skip `executeTool`'s local-action detour entirely: that detour
+      // always awaits `assistantActionService.executeAction` at least once — even
+      // when it's guaranteed to fail with "not found" — plus a redundant data source
+      // fetch that `executeAgentTool` never uses. Those extra awaits delay
+      // `markToolPending` below and open a window for the agent's own
+      // TOOL_CALL_RESULT to arrive and be processed first. Calling `executeAgentTool`
+      // directly means the only await between computing `isAgentTool` and marking the
+      // tool pending is `executeAgentTool` itself, which does no real async work.
+      const result = isAgentTool
+        ? await this.toolExecutor.executeAgentTool()
+        : await this.toolExecutor.executeTool(
+            toolCall.function.name,
+            args,
+            toolCallId,
+            await this.chatService.getCurrentDataSourceId()
+          );
 
       // Check if tool execution was cancelled (e.g., due to cleanup)
       if (result.cancelled) {
@@ -520,7 +531,12 @@ export class ChatEventHandler {
       result: resultContent,
     });
 
-    // Clear pending tool if it was an agent-only tool
+    // Clear pending tool if it was an agent-only tool. `handleToolCallEnd` calls
+    // `executeAgentTool` directly for agent tools (skipping `executeTool`'s
+    // local-action detour, which always awaits at least once even when doomed to
+    // fail), so the only await between computing `isAgentTool` and `markToolPending`
+    // running is `executeAgentTool` itself, which does no real async work — there is
+    // no window for a same-toolCallId TOOL_CALL_RESULT to arrive first.
     if (this.toolExecutor.isPendingAgentResponse(toolCallId)) {
       this.toolExecutor.clearPendingTool(toolCallId);
     }

--- a/src/plugins/chat/public/services/tool_executor.ts
+++ b/src/plugins/chat/public/services/tool_executor.ts
@@ -93,7 +93,7 @@ export class ToolExecutor {
       }
 
       // Otherwise, handle as agent-only tool
-      return await this.executeAgentTool(toolName, enrichedToolArgs);
+      return await this.executeAgentTool();
     } catch (error: any) {
       return {
         success: false,
@@ -141,9 +141,20 @@ export class ToolExecutor {
   }
 
   /**
-   * Execute agent-only tools that report results back via AG-UI events
+   * Execute agent-only tools that report results back via AG-UI events.
+   *
+   * Public so `ChatEventHandler` can call it directly for tools it already knows are
+   * agent-routed (via `hasAction`), bypassing `executeTool`'s local-action detour —
+   * that detour always awaits at least once (`tryExecuteRegisteredAction`'s
+   * `executeAction` call) even when it's guaranteed to fail, which delays
+   * `markToolPending` and opens a window for the agent's `TOOL_CALL_RESULT` to arrive
+   * first.
+   *
+   * Takes no parameters: the tool name and args are never used in this branch. The
+   * agent already has them from the original AG-UI tool-call event and reports the
+   * result back independently over `TOOL_CALL_RESULT`.
    */
-  private async executeAgentTool(_toolName: string, _toolArgs: any): Promise<ToolResult> {
+  async executeAgentTool(): Promise<ToolResult> {
     // Any tool that reaches here is assumed to be handled by the agent
     // The agent will send the results back via TOOL_CALL_RESULT events
     return {


### PR DESCRIPTION
### Description

Fixes a race in the chat plugin's tool-calling flow: for a tool that the browser has no local registered action for (an "agent tool"), `TOOL_CALL_END` was routed through `ToolExecutor.executeTool`, which always tries the local-action path first via `assistantActionService.executeAction` — and always `await`s that call, even when it's certain to fail with a "not found" error for an agent tool. That extra await, plus an unused data source lookup on the same path, delayed the call to `markToolPending(toolCallId, ...)`, which is what records that a tool call is now waiting on the agent.

If the backend agent's own `TOOL_CALL_RESULT` event for that same tool call arrived and was processed during that delay, `handleToolCallResult` would find nothing marked pending for that `toolCallId` — the tool call was never actually recorded as agent-pending in time.

`handleToolCallEnd` already computes `isAgentTool = !hasAction(toolName)` up front. This PR uses that to skip `executeTool`'s local-action detour entirely for agent tools, calling `ToolExecutor.executeAgentTool()` directly instead. `executeAgentTool` does no real async work, so the only await between computing `isAgentTool` and reaching `markToolPending` is `executeAgentTool` itself — closing the race window rather than narrowing it.

`executeAgentTool` is now public (previously called only internally from `executeTool`) and takes no parameters, since the tool name and args were never used in its body — the agent already has them from the original AG-UI tool-call event and reports its own result back independently.

### Issues Resolved

N/A — bug fix, no linked issue.

## Screenshot

N/A — no UI changes.

## Testing the changes

One new regression test, added alongside the existing agent-tool coverage in `chat_event_handler.test.ts`:

```
node scripts/jest.js src/plugins/chat/public/services/chat_event_handler.test.ts src/plugins/chat/public/services/tool_executor.test.ts --no-coverage
```

The new test asserts `assistantActionService.executeAction` is never called for an agent tool, which is the concrete, verifiable form of "there's no await left to race against." I confirmed it's non-vacuous by reverting the source fix and rerunning: it fails against the pre-fix code (`executeAction` is called) and passes against the fix.

Full chat plugin suite: `node scripts/jest.js src/plugins/chat --no-coverage` — 1012 tests pass across 47 suites. Verified this branch introduces zero new TypeScript errors (35 pre-existing errors before and after this change, unrelated to these files).

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
