### PR TITLE
[Fix #11299] Add default sort by timestamp desc for PPL queries in Discover (#11299)

### DIFF
--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.test.ts
@@ -603,7 +603,7 @@ describe('PPLSearchInterceptor', () => {
         true
       );
       expect(result.query).toBe(
-        'source=test_index | WHERE @timestamp >= "2023-01-01" | WHERE field = "test" | fields *'
+        'source=test_index | WHERE @timestamp >= "2023-01-01" | WHERE field = "test" | fields * | sort - `@timestamp`'
       );
     });
 
@@ -662,7 +662,7 @@ describe('PPLSearchInterceptor', () => {
         mockTimeRange,
         undefined
       );
-      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields *');
+      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields * | sort - `@timestamp`');
     });
 
     it('should not append time filter when hideDatePicker is false', async () => {
@@ -708,7 +708,7 @@ describe('PPLSearchInterceptor', () => {
       const result = await (pplSearchInterceptor as any).buildQuery(mockRequest);
 
       expect(mockPPLFilterUtils.getTimeFilterWhereClause).not.toHaveBeenCalled();
-      expect(result.query).toBe('source=test_index | fields *');
+      expect(result.query).toBe('source=test_index | fields * | sort - `@timestamp`');
     });
 
     it('should handle query without dataset', async () => {
@@ -847,7 +847,7 @@ describe('PPLSearchInterceptor', () => {
 
       expect(mockPPLFilterUtils.convertFiltersToWhereClause).not.toHaveBeenCalled();
 
-      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields *');
+      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields * | sort - `@timestamp`');
     });
 
     it('should trim commands and join with proper spacing', async () => {
@@ -892,7 +892,7 @@ describe('PPLSearchInterceptor', () => {
 
       const result = await (pplSearchInterceptor as any).buildQuery(mockRequest);
 
-      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields *');
+      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields * | sort - `@timestamp`');
     });
 
     it('should not apply filters when skipFilters is true in request body', async () => {
@@ -948,7 +948,7 @@ describe('PPLSearchInterceptor', () => {
       expect(mockPPLFilterUtils.convertFiltersToWhereClause).not.toHaveBeenCalled();
       // Time filter should still be applied
       expect(mockPPLFilterUtils.getTimeFilterWhereClause).toHaveBeenCalled();
-      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields *');
+      expect(result.query).toBe('source=test_index | WHERE @timestamp >= "2023-01-01" | fields * | sort - `@timestamp`');
     });
 
     it('should apply filters when skipFilters is not set in request body', async () => {
@@ -1007,7 +1007,7 @@ describe('PPLSearchInterceptor', () => {
         true
       );
       expect(result.query).toBe(
-        'source=test_index | WHERE @timestamp >= "2023-01-01" | WHERE field = "test" | fields *'
+        'source=test_index | WHERE @timestamp >= "2023-01-01" | WHERE field = "test" | fields * | sort - `@timestamp`'
       );
     });
 

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -170,10 +170,20 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       query.dataset?.type === DATASET.S3 && !queryEndsWithHead(queryWithFilters)
         ? `${queryWithFilters} | head ${DEFAULT_PPL_ASYNC_HEAD_SIZE}`
         : queryWithFilters;
+    // NEW:
+    const needsSort =
+      dataset?.timeFieldName &&
+      !finalQuery.toLowerCase().includes('| sort ') &&
+      !finalQuery.toLowerCase().includes('|sort ') &&
+      !finalQuery.toLowerCase().includes('| stats ');
 
+    const sortedQuery = needsSort
+      ? `${finalQuery} | sort - \`${dataset.timeFieldName}\``
+      : finalQuery;
+    
     return {
       ...query,
-      query: finalQuery,
+      query: sortedQuery,
     };
   }
 

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -170,17 +170,37 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       query.dataset?.type === DATASET.S3 && !queryEndsWithHead(queryWithFilters)
         ? `${queryWithFilters} | head ${DEFAULT_PPL_ASYNC_HEAD_SIZE}`
         : queryWithFilters;
-    // NEW:
+
+    // Append default descending sort on time field to match legacy Discover behavior.
+    // Skip if the user has customized the query beyond source + where.
+    const queryLower = finalQuery.toLowerCase();
+
+    // `| fields *` is equivalent to selecting all fields and should not block sorting.
+    // Only skip sort for `| fields` with specific field projections (e.g. `| fields a, b`).
+    const hasFieldsProjection =
+      (queryLower.includes('| fields ') || queryLower.includes('|fields ')) &&
+      !queryLower.match(/\|\s*fields\s+\*/);
+
     const needsSort =
       dataset?.timeFieldName &&
-      !finalQuery.toLowerCase().includes('| sort ') &&
-      !finalQuery.toLowerCase().includes('|sort ') &&
-      !finalQuery.toLowerCase().includes('| stats ');
+      !queryLower.includes('| sort ') &&
+      !queryLower.includes('|sort ') &&
+      !queryLower.includes('| stats ') &&
+      !queryLower.includes('|stats ') &&
+      !hasFieldsProjection &&
+      !queryLower.includes('| head ') &&
+      !queryLower.includes('|head ') &&
+      !queryLower.includes('| rare ') &&
+      !queryLower.includes('|rare ') &&
+      !queryLower.includes('| top ') &&
+      !queryLower.includes('|top ') &&
+      !queryLower.includes('| rename ') &&
+      !queryLower.includes('|rename ');
 
     const sortedQuery = needsSort
       ? `${finalQuery} | sort - \`${dataset.timeFieldName}\``
       : finalQuery;
-    
+
     return {
       ...query,
       query: sortedQuery,


### PR DESCRIPTION
### Description

Adds a default descending sort on the time field for PPL search queries in the Explore Logs / Discover page, matching legacy Discover DSL behavior.

### Issue

Resolves https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11299

### Root Cause

`PPLSearchInterceptor.buildQuery()` in `src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts` assembles WHERE clauses for time range and filters but never appends a sort clause. Without it, high-volume indexes return documents in insertion order (oldest first), making it appear as though recent data is missing from the results table while the histogram correctly shows all data.

Legacy Discover (DSL) sends:
```json
"sort": [{"@timestamp": {"order": "desc"}}]
```
PPL Discover was sending:

~~~
source = `my-index-*` | WHERE `@timestamp` >= '...' AND `@timestamp` <= '...'
~~~
No sort = oldest documents fill the result set first.

After final query construction in buildQuery(), append | sort - \timeFieldName`` when:

- The dataset has a timeFieldName
- The query does not already contain a user-specified | sort
- The query is not a | stats aggregation
- This mirrors the pattern already used in `fetch_preview.ts` in "src/plugins/explore/public/application/pages/long_drilldown/hooks/"