### PR TITLE
fix(visualization): hide visualization single-item legends

### DIFF
--- a/src/plugins/explore/public/components/visualizations/custom_legend.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/custom_legend.test.tsx
@@ -53,6 +53,20 @@ describe('CustomLegend', () => {
     expect(getByTestId('customLegendItem-seriesC')).toBeInTheDocument();
   });
 
+  it('does not render when there is only one legend item', () => {
+    legend$.next({ default: [legendItems[0]] });
+
+    const { queryByTestId } = render(
+      <CustomLegend
+        legend$={legend$}
+        legendSelected$={legendSelected$}
+        highlightedLegendTarget$={highlightedLegendTarget$}
+      />
+    );
+
+    expect(queryByTestId('customLegend')).not.toBeInTheDocument();
+  });
+
   it('displays series names as labels', () => {
     const { getByTestId } = render(
       <CustomLegend

--- a/src/plugins/explore/public/components/visualizations/custom_legend.tsx
+++ b/src/plugins/explore/public/components/visualizations/custom_legend.tsx
@@ -57,7 +57,7 @@ export const CustomLegend: React.FC<CustomLegendProps> = ({
     highlightedLegendTarget$.next(undefined);
   }, [highlightedLegendTarget$]);
 
-  if (legendItems.length === 0) {
+  if (legendItems.length <= 1) {
     return null;
   }
 

--- a/src/plugins/explore/public/components/visualizations/split_container.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/split_container.test.tsx
@@ -112,4 +112,25 @@ describe('SplitContainer', () => {
     expect(global.ResizeObserver).toHaveBeenCalled();
     expect(mockObserve).toHaveBeenCalled();
   });
+
+  it('uses the default vertical item min height', () => {
+    const { container } = render(
+      <SplitContainer groups={createGroups(1)} layout="vertical" renderChart={mockRenderChart} />
+    );
+
+    expect(container.querySelector('.splitChartInstance')).toHaveStyle({ minHeight: '200px' });
+  });
+
+  it('uses a custom vertical item min height when provided', () => {
+    const { container } = render(
+      <SplitContainer
+        groups={createGroups(1)}
+        layout="vertical"
+        verticalItemMinHeight={60}
+        renderChart={mockRenderChart}
+      />
+    );
+
+    expect(container.querySelector('.splitChartInstance')).toHaveStyle({ minHeight: '60px' });
+  });
 });

--- a/src/plugins/explore/public/components/visualizations/split_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/split_container.tsx
@@ -13,6 +13,7 @@ interface SplitContainerProps {
   groups: string[];
   layout: SplitLayout;
   showLabel?: boolean;
+  verticalItemMinHeight?: number;
   renderChart: (groupKey: string) => React.ReactNode;
 }
 
@@ -31,6 +32,7 @@ export const SplitContainer: React.FC<SplitContainerProps> = ({
   groups,
   layout,
   showLabel = false,
+  verticalItemMinHeight = 200,
   renderChart,
 }) => {
   const [columns, setColumns] = useState(1);
@@ -63,7 +65,7 @@ export const SplitContainer: React.FC<SplitContainerProps> = ({
       return groups.map(() => ({ flex: 1, minWidth: 300 }));
     }
     if (layout === 'vertical') {
-      return groups.map(() => ({ flex: 1, minHeight: 200 }));
+      return groups.map(() => ({ flex: 1, minHeight: verticalItemMinHeight }));
     }
     const span = SUB_COLUMNS / columns;
     const itemsInLastRow = groups.length % columns || columns;
@@ -75,7 +77,7 @@ export const SplitContainer: React.FC<SplitContainerProps> = ({
       }
       return { gridColumn: `span ${span}` };
     });
-  }, [layout, columns, groups]);
+  }, [layout, columns, groups, verticalItemMinHeight]);
 
   const layoutClass = `splitContainer--${layout || 'auto'}`;
 

--- a/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
@@ -332,6 +332,7 @@ describe('VisualizationRender', () => {
     expect(mockSplitContainer.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         showLabel: true,
+        verticalItemMinHeight: 60,
       })
     );
 
@@ -341,6 +342,31 @@ describe('VisualizationRender', () => {
         renderContext: expect.objectContaining({
           seriesName: 'value1',
         }),
+      })
+    );
+  });
+
+  it('does not use compact split panel height for non-metric charts', () => {
+    const splitConfig: RenderChartConfig = {
+      type: 'bar',
+      styles: {
+        ...defaultBarChartStyles,
+      },
+      axesMapping: { x: 'field1', y: 'count' },
+      splitField: 'field1',
+    };
+
+    render(
+      <CommonVisualizationRender
+        visualizationData={mockVisData}
+        visConfig={splitConfig}
+        showRawTable={false}
+      />
+    );
+
+    expect(mockSplitContainer.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        verticalItemMinHeight: undefined,
       })
     );
   });

--- a/src/plugins/explore/public/components/visualizations/visualization_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.tsx
@@ -187,6 +187,7 @@ export const CommonVisualizationRender = ({
               groups={groups}
               layout={visConfig.splitLayout ?? 'auto'}
               showLabel={visConfig.showSplitLabel}
+              verticalItemMinHeight={visConfig.type === 'metric' ? 60 : undefined}
               renderChart={(groupKey) => (
                 <ChartRender
                   data={{ ...visualizationData }}


### PR DESCRIPTION
### Description

This PR updates Explore visualization rendering behavior in two places.

First, it hides the custom legend when there is only one legend item. After the legend refactor, chart builders can emit a legend item for a single generated series, which caused single-series visualizations such as bar and line charts to show a redundant legend. The custom legend now renders only when there are multiple legend targets.

Second, it limits the compact vertical split-panel height to metric visualizations. `SplitContainer` now accepts a configurable vertical item minimum height while keeping the default at `200px`; `VisualizationRender` passes the compact `60px` height only for split metric charts.


<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
Not multi-series, but still a legend is displayed:
<img width="740" height="424" alt="Screenshot 2026-08-06 at 13 58 44" src="https://github.com/user-attachments/assets/9df7cc29-efa2-4768-b4af-779f795eee5c" />

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
