### PR TITLE
Enhance capability of AI Chatbot in Discover page

### DIFF
--- a/src/core/public/notifications/toasts/error_toast.tsx
+++ b/src/core/public/notifications/toasts/error_toast.tsx
@@ -52,6 +52,7 @@ interface ErrorToastProps {
   toastMessage: string;
   openModal: OverlayStart['openModal'];
   i18nContext: () => I18nStart['Context'];
+  extraAction?: React.ReactNode;
 }
 
 interface RequestError extends Error {
@@ -127,6 +128,7 @@ export function ErrorToast({
   toastMessage,
   openModal,
   i18nContext,
+  extraAction,
 }: ErrorToastProps) {
   return (
     <React.Fragment>
@@ -142,6 +144,7 @@ export function ErrorToast({
             defaultMessage="See the full error"
           />
         </EuiButton>
+        {extraAction}
       </div>
     </React.Fragment>
   );

--- a/src/core/public/notifications/toasts/toasts_api.tsx
+++ b/src/core/public/notifications/toasts/toasts_api.tsx
@@ -30,6 +30,7 @@
 
 import { EuiGlobalToastListToast as EuiToast } from '@elastic/eui';
 
+import { ReactNode } from 'react';
 import * as Rx from 'rxjs';
 
 import { ErrorToast } from './error_toast';
@@ -91,6 +92,11 @@ export interface ErrorToastOptions extends ToastOptions {
    * The id of the error.
    */
   id?: string;
+  /**
+   * Optional extra content rendered below the "See the full error" action, allowing callers to
+   * attach custom affordances to the error toast.
+   */
+  extraAction?: ReactNode;
 }
 
 const normalizeToast = (toastOrTitle: ToastInput): ToastInputFields => {
@@ -253,7 +259,8 @@ export class ToastsApi implements IToasts {
    * @returns a {@link Toast}
    */
   public addError(error: Error, options: ErrorToastOptions) {
-    const message = options.toastMessage || error.message;
+    const { extraAction, ...toastOptions } = options;
+    const message = toastOptions.toastMessage || error.message;
     return this.add({
       color: 'danger',
       iconType: 'alert',
@@ -262,12 +269,13 @@ export class ToastsApi implements IToasts {
         <ErrorToast
           openModal={this.openModal.bind(this)}
           error={error}
-          title={options.title}
+          title={toastOptions.title}
           toastMessage={message}
           i18nContext={() => this.i18n!.Context}
+          extraAction={extraAction}
         />
       ),
-      ...options,
+      ...toastOptions,
     });
   }
 

--- a/src/plugins/data/public/chat_tools/time_range_tool_registration.tsx
+++ b/src/plugins/data/public/chat_tools/time_range_tool_registration.tsx
@@ -9,14 +9,17 @@ import { TimefilterContract } from '../query/timefilter';
 interface TimeRangeToolRegistrationProps {
   timefilter: TimefilterContract;
   useAssistantAction?: (config: any) => void;
+  enabled?: boolean;
 }
 
 export const TimeRangeToolRegistration: React.FC<TimeRangeToolRegistrationProps> = ({
   timefilter,
   useAssistantAction,
+  enabled = true,
 }) => {
   const useAssistantActionHook = useAssistantAction || (() => {});
   useAssistantActionHook({
+    enabled,
     name: 'update_time_range',
     description:
       'Updates the global time range filter. Use this tool once when the user requests to change, update, or set the time range (e.g., "last week", "last 24 hours", "today"). Do not call this tool multiple times for the same request or after the time range has already been updated.',

--- a/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
+++ b/src/plugins/data/public/query/query_string/language_service/lib/__snapshots__/query_result.test.tsx.snap
@@ -1,63 +1,73 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Query Result show error status with error message 2`] = `
-<EuiPopover
-  anchorPosition="downRight"
-  button={
-    <EuiButtonEmpty
-      className="editor__footerItem"
-      color="danger"
-      data-test-subj="queryResultErrorBtn"
-      iconSide="left"
-      iconType="alert"
-      onClick={[Function]}
-      size="xs"
-    >
-      <EuiText
-        className="editor__footerItem"
-        color="danger"
-        data-test-subj="editorFooterItem"
-        size="xs"
-      >
-        Error
-      </EuiText>
-    </EuiButtonEmpty>
-  }
-  closePopover={[Function]}
-  data-test-subj="queryResultError"
-  display="inlineBlock"
-  hasArrow={true}
-  isOpen={false}
-  ownFocus={true}
-  panelPaddingSize="s"
+<EuiFlexGroup
+  alignItems="center"
+  gutterSize="none"
+  responsive={false}
 >
-  <EuiPopoverTitle>
-    ERRORS
-  </EuiPopoverTitle>
-  <div
-    className="eui-textBreakWord"
-    data-test-subj="textBreakWord"
-    style={
-      Object {
-        "maxHeight": "250px",
-        "overflowY": "auto",
-        "width": "250px",
-      }
-    }
+  <EuiFlexItem
+    grow={false}
   >
-    <EuiText
-      size="s"
+    <EuiPopover
+      anchorPosition="downRight"
+      button={
+        <EuiButtonEmpty
+          className="editor__footerItem"
+          color="danger"
+          data-test-subj="queryResultErrorBtn"
+          iconSide="left"
+          iconType="alert"
+          onClick={[Function]}
+          size="xs"
+        >
+          <EuiText
+            className="editor__footerItem"
+            color="danger"
+            data-test-subj="editorFooterItem"
+            size="xs"
+          >
+            Error
+          </EuiText>
+        </EuiButtonEmpty>
+      }
+      closePopover={[Function]}
+      data-test-subj="queryResultError"
+      display="inlineBlock"
+      hasArrow={true}
+      isOpen={false}
+      ownFocus={true}
+      panelPaddingSize="s"
     >
-      <p>
-        <strong>
-          Message:
-        </strong>
-         
-        {"reason":"error reason","details":"error details","status":400}
-      </p>
-    </EuiText>
-  </div>
-</EuiPopover>
+      <EuiPopoverTitle>
+        ERRORS
+      </EuiPopoverTitle>
+      <div
+        className="eui-textBreakWord"
+        data-test-subj="textBreakWord"
+        style={
+          Object {
+            "maxHeight": "250px",
+            "overflowY": "auto",
+            "width": "250px",
+          }
+        }
+      >
+        <EuiText
+          size="s"
+        >
+          <p>
+            <strong>
+              Message:
+            </strong>
+             
+            {"reason":"error reason","details":"error details","status":400}
+          </p>
+        </EuiText>
+      </div>
+    </EuiPopover>
+  </EuiFlexItem>
+</EuiFlexGroup>
 `;
 
 exports[`Query Result shows loading status 1`] = `

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.test.tsx
@@ -4,8 +4,16 @@
  */
 
 import { mountWithIntl, shallowWithIntl } from 'test_utils/enzyme_helpers';
+import { BehaviorSubject } from 'rxjs';
 import { QueryResult } from './query_result';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
+
+jest.mock('../../../../../../opensearch_dashboards_react/public', () => ({
+  useOpenSearchDashboards: jest.fn(() => ({ services: {} })),
+}));
+
+const useOpenSearchDashboardsMock = useOpenSearchDashboards as jest.Mock;
 
 enum ResultStatus {
   UNINITIALIZED = 'uninitialized',
@@ -201,5 +209,91 @@ describe('Query Result', () => {
     await waitFor(() => {
       expect(screen.getByText('{"reason":"error message","status":400}')).toBeInTheDocument();
     });
+  });
+});
+
+describe('QueryResult - Ask AI for help', () => {
+  afterEach(() => {
+    useOpenSearchDashboardsMock.mockReturnValue({ services: {} });
+    jest.clearAllMocks();
+  });
+
+  const setServices = ({
+    appId = 'data-explorer',
+    chatAvailable = true,
+    sendMessageWithWindow = jest.fn().mockResolvedValue(undefined),
+  }: {
+    appId?: string;
+    chatAvailable?: boolean;
+    sendMessageWithWindow?: jest.Mock;
+  } = {}) => {
+    const services = {
+      application: { currentAppId$: new BehaviorSubject<string | undefined>(appId) },
+      chat: {
+        isAvailable: () => chatAvailable,
+        sendMessageWithWindow,
+      },
+    };
+    useOpenSearchDashboardsMock.mockReturnValue({ services });
+    return services;
+  };
+
+  const errorStatus = (resultsCount?: number) => ({
+    queryStatus: {
+      status: ResultStatus.ERROR,
+      resultsCount,
+      body: {
+        error: {
+          message: {
+            error: { reason: 'boom reason', details: 'boom details', type: 'search_phase' },
+            status: 400,
+          },
+        },
+      },
+    },
+  });
+
+  it('renders the button in Discover when errored with retained results and chat available', () => {
+    setServices();
+    render(<QueryResult {...errorStatus(5)} />);
+    expect(screen.getByTestId('discoverQueryErrorAskAiForHelp')).toBeInTheDocument();
+  });
+
+  it('does not render the button when there are no retained results', () => {
+    setServices();
+    render(<QueryResult {...errorStatus(0)} />);
+    expect(screen.queryByTestId('discoverQueryErrorAskAiForHelp')).toBeNull();
+  });
+
+  it('does not render the button when resultsCount is undefined', () => {
+    setServices();
+    render(<QueryResult {...errorStatus(undefined)} />);
+    expect(screen.queryByTestId('discoverQueryErrorAskAiForHelp')).toBeNull();
+  });
+
+  it('does not render the button outside classic Discover', () => {
+    setServices({ appId: 'explore/logs' });
+    render(<QueryResult {...errorStatus(5)} />);
+    expect(screen.queryByTestId('discoverQueryErrorAskAiForHelp')).toBeNull();
+  });
+
+  it('does not render the button when chat is unavailable', () => {
+    setServices({ chatAvailable: false });
+    render(<QueryResult {...errorStatus(5)} />);
+    expect(screen.queryByTestId('discoverQueryErrorAskAiForHelp')).toBeNull();
+  });
+
+  it('sends the error escalation message to chat on click', () => {
+    const sendMessageWithWindow = jest.fn().mockResolvedValue(undefined);
+    setServices({ sendMessageWithWindow });
+    render(<QueryResult {...errorStatus(5)} />);
+
+    fireEvent.click(screen.getByTestId('discoverQueryErrorAskAiForHelp'));
+
+    expect(sendMessageWithWindow).toHaveBeenCalledTimes(1);
+    const [message, attachments] = sendMessageWithWindow.mock.calls[0];
+    // `details` wins over `reason` in the extraction precedence.
+    expect(message).toContain('boom details');
+    expect(attachments).toEqual([]);
   });
 });

--- a/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/query_result.tsx
@@ -6,9 +6,41 @@
 import { i18n } from '@osd/i18n';
 
 import './_recent_query.scss';
-import { EuiButtonEmpty, EuiPopover, EuiText, EuiPopoverTitle } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiPopover,
+  EuiText,
+  EuiPopoverTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
 
 import { useEffect, useMemo, useState } from 'react';
+import { useObservable } from 'react-use';
+import { of } from 'rxjs';
+import { useOpenSearchDashboards } from '../../../../../../opensearch_dashboards_react/public';
+import { IDataPluginServices } from '../../../../types';
+
+const DISCOVER_APP_ID = 'data-explorer';
+
+const ASK_AI_ERROR_MESSAGE =
+  'My query on this page failed to run with the following error: "{error}". Please review my query, fix it, and run the corrected query on the page so I can see the results.';
+
+function extractErrorForAssistant(errorBody: any): string {
+  if (errorBody?.shortMessage) {
+    return errorBody.shortMessage;
+  }
+  const message = errorBody?.message;
+  const inner = errorBody?.attributes?.error || message?.error;
+  return (
+    (typeof inner === 'string'
+      ? inner
+      : inner?.root_cause?.[0]?.reason || inner?.details || inner?.reason) ||
+    (typeof message === 'string' ? message : undefined) ||
+    errorBody?.error ||
+    'Query execution failed'
+  );
+}
 
 export enum ResultStatus {
   UNINITIALIZED = 'uninitialized',
@@ -38,6 +70,7 @@ export interface QueryStatus {
   };
   elapsedMs?: number;
   startTime?: number;
+  resultsCount?: number;
 }
 
 // This is the time in milliseconds that the query will wait before showing the loading spinner
@@ -113,6 +146,22 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
     return `Unknown Error: ${String(message)}`;
   }, [props.queryStatus.body?.error]);
 
+  const { services } = useOpenSearchDashboards<IDataPluginServices>();
+  const currentAppId = useObservable(
+    services?.application?.currentAppId$ ?? of(undefined),
+    undefined
+  );
+  const showAskAiForHelp =
+    currentAppId === DISCOVER_APP_ID &&
+    (services?.chat?.isAvailable?.() ?? false) &&
+    (props.queryStatus.resultsCount ?? 0) > 0;
+
+  const onAskAiForHelp = () => {
+    const error = extractErrorForAssistant(props.queryStatus.body?.error);
+    const message = ASK_AI_ERROR_MESSAGE.replace('{error}', error);
+    services?.chat?.sendMessageWithWindow?.(message, []).catch(() => {});
+  };
+
   if (props.queryStatus.status === ResultStatus.LOADING) {
     const time = Math.floor(elapsedTime / 1000);
     const loadingText =
@@ -179,52 +228,76 @@ export function QueryResult(props: { queryStatus: QueryStatus }) {
   }
 
   return (
-    <EuiPopover
-      button={
-        <EuiButtonEmpty
-          iconSide="left"
-          iconType={'alert'}
-          size="xs"
-          onClick={onButtonClick}
-          data-test-subj="queryResultErrorBtn"
-          className="editor__footerItem"
-          color="danger"
+    <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiPopover
+          button={
+            <EuiButtonEmpty
+              iconSide="left"
+              iconType={'alert'}
+              size="xs"
+              onClick={onButtonClick}
+              data-test-subj="queryResultErrorBtn"
+              className="editor__footerItem"
+              color="danger"
+            >
+              <EuiText
+                size="xs"
+                color="danger"
+                className="editor__footerItem"
+                data-test-subj="editorFooterItem"
+              >
+                {i18n.translate('data.query.languageService.queryResults.error', {
+                  defaultMessage: `Error`,
+                })}
+              </EuiText>
+            </EuiButtonEmpty>
+          }
+          isOpen={isPopoverOpen}
+          closePopover={() => setPopover(false)}
+          panelPaddingSize="s"
+          anchorPosition={'downRight'}
+          data-test-subj="queryResultError"
         >
-          <EuiText
-            size="xs"
-            color="danger"
-            className="editor__footerItem"
-            data-test-subj="editorFooterItem"
+          <EuiPopoverTitle>ERRORS</EuiPopoverTitle>
+          <div
+            style={{ width: '250px', maxHeight: '250px', overflowY: 'auto' }}
+            className="eui-textBreakWord"
+            data-test-subj="textBreakWord"
           >
-            {i18n.translate('data.query.languageService.queryResults.error', {
-              defaultMessage: `Error`,
-            })}
-          </EuiText>
-        </EuiButtonEmpty>
-      }
-      isOpen={isPopoverOpen}
-      closePopover={() => setPopover(false)}
-      panelPaddingSize="s"
-      anchorPosition={'downRight'}
-      data-test-subj="queryResultError"
-    >
-      <EuiPopoverTitle>ERRORS</EuiPopoverTitle>
-      <div
-        style={{ width: '250px', maxHeight: '250px', overflowY: 'auto' }}
-        className="eui-textBreakWord"
-        data-test-subj="textBreakWord"
-      >
-        <EuiText size="s">
-          <p>
-            <strong>
-              {i18n.translate('data.query.languageService.queryResults.message', {
-                defaultMessage: `Message:`,
+            <EuiText size="s">
+              <p>
+                <strong>
+                  {i18n.translate('data.query.languageService.queryResults.message', {
+                    defaultMessage: `Message:`,
+                  })}
+                </strong>{' '}
+                {displayErrorMessage}
+              </p>
+            </EuiText>
+          </div>
+        </EuiPopover>
+      </EuiFlexItem>
+      {showAskAiForHelp && (
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            iconSide="left"
+            iconType={'generate'}
+            size="xs"
+            flush="left"
+            style={{ marginLeft: 8 }}
+            onClick={onAskAiForHelp}
+            data-test-subj="discoverQueryErrorAskAiForHelp"
+            className="editor__footerItem"
+          >
+            <EuiText size="xs" className="editor__footerItem" data-test-subj="editorFooterItem">
+              {i18n.translate('data.query.languageService.queryResults.askAI', {
+                defaultMessage: `Ask AI for help`,
               })}
-            </strong>{' '}
-            {displayErrorMessage}
-          </p>
-        </EuiText>
-      </div>
-    </EuiPopover>
+            </EuiText>
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
   );
 }

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -192,6 +192,7 @@ export function createSearchBar({ core, storage, data, contextProvider }: Statef
           <TimeRangeToolRegistration
             timefilter={data.query.timefilter.timefilter}
             useAssistantAction={contextProvider?.hooks?.useAssistantAction}
+            enabled={(query?.language || '').toUpperCase() !== 'SQL'}
           />
         )}
         <SearchBar

--- a/src/plugins/discover/public/actions/abort_data_query_action.ts
+++ b/src/plugins/discover/public/actions/abort_data_query_action.ts
@@ -14,7 +14,8 @@ export interface AbortDataQueryContext {
 // Create the action creator function
 export function createAbortDataQueryAction(
   refs: Array<React.MutableRefObject<{ abortController: AbortController | undefined }>>,
-  actionId: string
+  actionId: string,
+  onAbort?: (reason: string) => void
 ): ActionByType<typeof ACTION_ABORT_DATA_QUERY> {
   return createAction<typeof ACTION_ABORT_DATA_QUERY>({
     type: ACTION_ABORT_DATA_QUERY,
@@ -26,6 +27,7 @@ export function createAbortDataQueryAction(
           const controller = ref.current?.abortController;
           controller?.abort?.(context.reason);
         });
+        onAbort?.(context.reason);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(`[ACTION_ABORT_DATA_QUERY] Failed to abort data query:`, e);

--- a/src/plugins/discover/public/application/components/ask_error_button/ask_error_button.test.tsx
+++ b/src/plugins/discover/public/application/components/ask_error_button/ask_error_button.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { AskErrorButton } from './ask_error_button';
+
+jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
+  useOpenSearchDashboards: jest.fn(),
+}));
+
+const useOpenSearchDashboardsMock = useOpenSearchDashboards as jest.Mock;
+
+const TEST_ID = 'discoverQueryErrorAskAiForHelp';
+
+const setup = (options: { chatAvailable?: boolean } = {}) => {
+  const { chatAvailable = true } = options;
+  const sendMessageWithWindow = jest.fn().mockResolvedValue(undefined);
+  const isAvailable = jest.fn().mockReturnValue(chatAvailable);
+  useOpenSearchDashboardsMock.mockReturnValue({
+    services: { core: { chat: { isAvailable, sendMessageWithWindow } } },
+  });
+  return { sendMessageWithWindow, isAvailable };
+};
+
+describe('<AskErrorButton />', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders nothing when chat is unavailable', () => {
+    setup({ chatAvailable: false });
+    const { queryByTestId } = render(<AskErrorButton testSource={TEST_ID} />);
+    expect(queryByTestId(TEST_ID)).toBeNull();
+  });
+
+  it('renders nothing when the chat service is missing entirely', () => {
+    useOpenSearchDashboardsMock.mockReturnValue({ services: { core: {} } });
+    const { queryByTestId } = render(<AskErrorButton testSource={TEST_ID} />);
+    expect(queryByTestId(TEST_ID)).toBeNull();
+  });
+
+  it('renders the link when chat is available', () => {
+    setup();
+    const { getByTestId } = render(<AskErrorButton testSource={TEST_ID} />);
+    expect(getByTestId(TEST_ID)).toBeInTheDocument();
+  });
+
+  it('uses the provided testSource as the test id', () => {
+    setup();
+    const { getByTestId } = render(<AskErrorButton testSource="discoverNoResultsAskAiForHelp" />);
+    expect(getByTestId('discoverNoResultsAskAiForHelp')).toBeInTheDocument();
+  });
+
+  it('sends the error-specific message when an error is provided', () => {
+    const { sendMessageWithWindow } = setup();
+    const { getByTestId } = render(
+      <AskErrorButton getError={() => 'boom parse error'} testSource={TEST_ID} />
+    );
+
+    fireEvent.click(getByTestId(TEST_ID));
+
+    expect(sendMessageWithWindow).toHaveBeenCalledTimes(1);
+    const [message, attachments] = sendMessageWithWindow.mock.calls[0];
+    expect(message).toContain('failed to run with the following error: "boom parse error"');
+    expect(attachments).toEqual([]);
+  });
+
+  it('sends the no-results message when there is no error', () => {
+    const { sendMessageWithWindow } = setup();
+    const { getByTestId } = render(
+      <AskErrorButton getError={() => undefined} testSource={TEST_ID} />
+    );
+
+    fireEvent.click(getByTestId(TEST_ID));
+
+    const [message] = sendMessageWithWindow.mock.calls[0];
+    expect(message).toContain('returned no results');
+  });
+
+  it('sends the no-results message when no getError prop is passed', () => {
+    const { sendMessageWithWindow } = setup();
+    const { getByTestId } = render(<AskErrorButton testSource={TEST_ID} />);
+
+    fireEvent.click(getByTestId(TEST_ID));
+
+    const [message] = sendMessageWithWindow.mock.calls[0];
+    expect(message).toContain('returned no results');
+  });
+});

--- a/src/plugins/discover/public/application/components/ask_error_button/ask_error_button.tsx
+++ b/src/plugins/discover/public/application/components/ask_error_button/ask_error_button.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback } from 'react';
+import { EuiIcon, EuiLink } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { DiscoverViewServices } from '../../../build_services';
+
+const ASK_AI_NO_RESULTS_MESSAGE = `My query on this page returned no results. Please help me adjust it and run the corrected query on the page so I can see the data. Change only one thing at a time so it is clear which change helped, and stop as soon as results appear. Check the following in order: 1) Verify the fields I referenced actually exist. 2) Check whether the filter values are valid - a value I used may simply not exist in the data; try plausible alternative values or a broader condition. 3) Only if the fields and values both look correct, the time range is the likely cause - use a backend tool to find the most recent document matching the query, then widen the time range on page gradually rather than jumping straight to a very large window.`;
+
+const ASK_AI_ERROR_MESSAGE =
+  'My query on this page failed to run with the following error: "{error}". Please review my query, fix it, and run the corrected query on the page so I can see the results.';
+
+interface AskErrorButtonProps {
+  getError?: () => string | undefined;
+  testSource: string;
+}
+
+export const AskErrorButton = ({ getError, testSource }: AskErrorButtonProps) => {
+  const {
+    services: { core },
+  } = useOpenSearchDashboards<DiscoverViewServices>();
+
+  const onAskAI = useCallback(() => {
+    const error = getError?.();
+    const message = error
+      ? ASK_AI_ERROR_MESSAGE.replace('{error}', error)
+      : ASK_AI_NO_RESULTS_MESSAGE;
+    core.chat.sendMessageWithWindow(message, []).catch(() => {});
+  }, [core, getError]);
+
+  if (!(core?.chat?.isAvailable?.() ?? false)) {
+    return null;
+  }
+
+  return (
+    <EuiLink onClick={onAskAI} data-test-subj={testSource}>
+      <EuiIcon type="generate" size="m" />{' '}
+      {i18n.translate('discover.askErrorButton.askAI', {
+        defaultMessage: 'Ask AI for help',
+      })}
+    </EuiLink>
+  );
+};

--- a/src/plugins/discover/public/application/components/no_results/no_results.tsx
+++ b/src/plugins/discover/public/application/components/no_results/no_results.tsx
@@ -47,15 +47,23 @@ import {
   SavedQuery,
   SavedQueryService,
 } from '../../../../../data/public/';
+import { AskErrorButton } from '../ask_error_button/ask_error_button';
 
 interface Props {
   queryString: QueryStringContract;
   savedQuery: SavedQueryService;
   query: Query | undefined;
   timeFieldName?: string;
+  getQueryError?: () => string | undefined;
 }
 
-export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldName }: Props) => {
+export const DiscoverNoResults = ({
+  queryString,
+  query,
+  savedQuery,
+  timeFieldName,
+  getQueryError,
+}: Props) => {
   // Commented out due to no usage in code
   // See: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8149
   //
@@ -303,7 +311,11 @@ export const DiscoverNoResults = ({ queryString, query, savedQuery, timeFieldNam
                 {i18n.translate('discover.emptyPrompt.body', {
                   defaultMessage:
                     'Try selecting a different data source, expanding your time range or modifying the query & filters.',
-                })}
+                })}{' '}
+                <AskErrorButton
+                  getError={getQueryError}
+                  testSource="discoverNoResultsAskAiForHelp"
+                />
               </p>
             </EuiText>
           }

--- a/src/plugins/discover/public/application/components/uninitialized/uninitialized.tsx
+++ b/src/plugins/discover/public/application/components/uninitialized/uninitialized.tsx
@@ -31,12 +31,14 @@
 import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
 
 import { EuiSmallButton, EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent } from '@elastic/eui';
+import { AskErrorButton } from '../ask_error_button/ask_error_button';
 
 interface Props {
   onRefresh: () => void;
+  getQueryError?: () => string | undefined;
 }
 
-export const DiscoverUninitialized = ({ onRefresh }: Props) => {
+export const DiscoverUninitialized = ({ onRefresh, getQueryError }: Props) => {
   return (
     <I18nProvider>
       <EuiPage>
@@ -58,6 +60,15 @@ export const DiscoverUninitialized = ({ onRefresh }: Props) => {
                     id="discover.uninitializedText"
                     defaultMessage="Write a query, add some filters, or simply hit Refresh to retrieve results for the current query."
                   />
+                  {getQueryError && (
+                    <>
+                      {' '}
+                      <AskErrorButton
+                        getError={getQueryError}
+                        testSource="discoverQueryErrorAskAiForHelp"
+                      />
+                    </>
+                  )}
                 </p>
               }
               actions={

--- a/src/plugins/discover/public/application/view_components/actions/apply_query_action.test.tsx
+++ b/src/plugins/discover/public/application/view_components/actions/apply_query_action.test.tsx
@@ -1,0 +1,383 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '@testing-library/react';
+import { BehaviorSubject, Subject } from 'rxjs';
+
+// Mock use_search to avoid pulling in its heavy dependency graph. Only the ResultStatus enum is
+// used at runtime by the action module; the rest are type-only imports erased at compile time.
+jest.mock('../utils/use_search', () => ({
+  ResultStatus: {
+    UNINITIALIZED: 'uninitialized',
+    LOADING: 'loading',
+    READY: 'ready',
+    NO_RESULTS: 'none',
+    ERROR: 'error',
+  },
+}));
+
+import {
+  LANGUAGE_TOOLS,
+  buildToolDefinition,
+  APPLY_QUERY_TOOL_DEFINITIONS,
+  registerAllDisabledApplyQueryActions,
+  useApplyQueryAction,
+} from './apply_query_action';
+
+const READY = 'ready';
+const NO_RESULTS = 'none';
+const ERROR = 'error';
+
+describe('LANGUAGE_TOOLS / buildToolDefinition', () => {
+  it('defines the four expected language tools', () => {
+    expect(LANGUAGE_TOOLS.map((c) => c.toolName)).toEqual([
+      'apply_dql_query',
+      'apply_lucene_query',
+      'apply_ppl_query',
+      'apply_sql_query',
+    ]);
+  });
+
+  it('builds a definition with the tool name, query as required param, and from/to params', () => {
+    const def = buildToolDefinition({
+      languageKey: 'PPL',
+      displayName: 'PPL',
+      toolName: 'apply_ppl_query',
+    });
+    expect(def.name).toBe('apply_ppl_query');
+    expect(def.parameters.required).toEqual(['query']);
+    expect(Object.keys(def.parameters.properties)).toEqual(
+      expect.arrayContaining(['query', 'from', 'to'])
+    );
+  });
+
+  it('includes the display name and a language-only clause in the description', () => {
+    const def = buildToolDefinition({
+      languageKey: 'kuery',
+      displayName: 'DQL',
+      toolName: 'apply_dql_query',
+    });
+    expect(def.description).toContain('LANGUAGE FOR DQL ONLY');
+    expect(def.description).toContain('PROHIBITED');
+  });
+
+  it('adds the aggregation limitation only for kuery/lucene', () => {
+    const dql = buildToolDefinition({
+      languageKey: 'kuery',
+      displayName: 'DQL',
+      toolName: 'apply_dql_query',
+    });
+    const ppl = buildToolDefinition({
+      languageKey: 'PPL',
+      displayName: 'PPL',
+      toolName: 'apply_ppl_query',
+    });
+    expect(dql.description).toContain('cannot aggregate or sort');
+    expect(ppl.description).not.toContain('cannot aggregate or sort');
+  });
+
+  it('omits from/to params and time-filter guidance for SQL', () => {
+    const sql = buildToolDefinition({
+      languageKey: 'SQL',
+      displayName: 'OpenSearch SQL',
+      toolName: 'apply_sql_query',
+    });
+    // SQL has no global time picker, so it exposes only query + description.
+    expect(Object.keys(sql.parameters.properties)).toEqual(['query', 'description']);
+    expect(sql.description).not.toContain('should NOT contain time filters');
+
+    // Non-SQL languages still carry from/to and the time-filter guidance.
+    const ppl = buildToolDefinition({
+      languageKey: 'PPL',
+      displayName: 'PPL',
+      toolName: 'apply_ppl_query',
+    });
+    expect(Object.keys(ppl.parameters.properties)).toEqual(expect.arrayContaining(['from', 'to']));
+    expect(ppl.description).toContain('should NOT contain time filters');
+  });
+
+  it('exposes one definition per language tool', () => {
+    expect(APPLY_QUERY_TOOL_DEFINITIONS).toHaveLength(LANGUAGE_TOOLS.length);
+  });
+});
+
+describe('registerAllDisabledApplyQueryActions', () => {
+  it('does nothing when registerAction is undefined', () => {
+    expect(() => registerAllDisabledApplyQueryActions(undefined as any)).not.toThrow();
+  });
+
+  it('registers every language tool as disabled with a context-lost handler', async () => {
+    const registered: any[] = [];
+    registerAllDisabledApplyQueryActions((a) => registered.push(a));
+
+    expect(registered).toHaveLength(LANGUAGE_TOOLS.length);
+    expect(registered.every((a) => a.available === 'disabled')).toBe(true);
+
+    const result = await registered[0].handler();
+    expect(result.success).toBe(false);
+    expect(result.stop_tool_execution).toBe(true);
+    expect(result.context_lost).toBe(true);
+  });
+});
+
+interface Harness {
+  registered: any[];
+  registerAssistantAction: jest.Mock;
+  setQuery: jest.Mock;
+  setTime: jest.Mock;
+  updates$: Subject<any>;
+  data$: BehaviorSubject<any>;
+  refetch$: Subject<any>;
+  queryComplete$: Subject<any>;
+  queryAbort$: Subject<any>;
+  refetchSpy: jest.SpyInstance;
+  unmount: () => void;
+}
+
+function setup(options: { withContextProvider?: boolean; currentLanguage?: string } = {}): Harness {
+  const { withContextProvider = true, currentLanguage = 'PPL' } = options;
+  const registered: any[] = [];
+  const registerAssistantAction = jest.fn((a: any) => registered.push(a));
+  const setQuery = jest.fn();
+  const setTime = jest.fn();
+  const updates$ = new Subject<any>();
+  const currentQuery = { query: 'old query', language: currentLanguage, dataset: { id: 'logs-*' } };
+  const getQuery = jest.fn(() => currentQuery);
+
+  const services: any = {
+    contextProvider: withContextProvider ? { actions: { registerAssistantAction } } : undefined,
+    data: {
+      query: {
+        queryString: { getQuery, setQuery, getUpdates$: () => updates$ },
+        timefilter: { timefilter: { setTime } },
+      },
+    },
+  };
+
+  const data$ = new BehaviorSubject<any>({ status: 'uninitialized' });
+  const refetch$ = new Subject<any>();
+  const queryComplete$ = new Subject<any>();
+  const queryAbort$ = new Subject<any>();
+  const refetchSpy = jest.spyOn(refetch$, 'next');
+
+  const HarnessComponent = () => {
+    useApplyQueryAction(services, data$, refetch$, queryComplete$, queryAbort$);
+    return null;
+  };
+
+  const { unmount } = render(<HarnessComponent />);
+
+  return {
+    registered,
+    registerAssistantAction,
+    setQuery,
+    setTime,
+    updates$,
+    data$,
+    refetch$,
+    queryComplete$,
+    queryAbort$,
+    refetchSpy,
+    unmount,
+  };
+}
+
+const enabledActions = (registered: any[]) => registered.filter((a) => a.available === 'enabled');
+const lastEnabled = (registered: any[]) => enabledActions(registered).slice(-1)[0];
+
+describe('useApplyQueryAction', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('registers nothing when the contextProvider is unavailable', () => {
+    const { registerAssistantAction } = setup({ withContextProvider: false });
+    expect(registerAssistantAction).not.toHaveBeenCalled();
+  });
+
+  it('enables only the tool matching the current page language', () => {
+    const { registered } = setup({ currentLanguage: 'PPL' });
+    const enabled = enabledActions(registered);
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].name).toBe('apply_ppl_query');
+    expect(typeof enabled[0].handler).toBe('function');
+  });
+
+  it('swaps tools on a language switch: disables the previous, enables the new', () => {
+    const h = setup({ currentLanguage: 'kuery' });
+    // Initially DQL is enabled.
+    expect(lastEnabled(h.registered).name).toBe('apply_dql_query');
+
+    // Simulate the user switching the page language to PPL.
+    h.updates$.next({ query: 'x', language: 'PPL' });
+
+    const ppl = h.registered.filter((a) => a.name === 'apply_ppl_query').slice(-1)[0];
+    const dql = h.registered.filter((a) => a.name === 'apply_dql_query').slice(-1)[0];
+    expect(ppl.available).toBe('enabled');
+    expect(dql.available).toBe('disabled');
+  });
+
+  it('ignores query updates that do not change the language', () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const countBefore = h.registered.length;
+    h.updates$.next({ query: 'new text', language: 'PPL' });
+    expect(h.registered.length).toBe(countBefore);
+  });
+
+  it('restores all tools to disabled on unmount', () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    h.unmount();
+    const lastFour = h.registered.slice(-LANGUAGE_TOOLS.length);
+    expect(lastFour).toHaveLength(LANGUAGE_TOOLS.length);
+    expect(lastFour.every((a) => a.available === 'disabled')).toBe(true);
+  });
+
+  it('sets query + time range, forces a refetch, and reports success on READY', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs', from: 'now-1h', to: 'now' });
+
+    expect(h.setTime).toHaveBeenCalledWith({ from: 'now-1h', to: 'now' });
+    expect(h.setQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'source=logs', language: 'PPL' })
+    );
+    expect(h.refetchSpy).toHaveBeenCalled();
+
+    h.queryComplete$.next({
+      data: { status: READY, hits: 42 },
+      query: { query: 'source=logs', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(true);
+    expect(result.executed).toBe(true);
+    expect(result.resultsCount).toBe(42);
+    expect(result.message).toContain('Time range set to now-1h - now');
+  });
+
+  it('falls back to the returned row count when the total is unavailable', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    h.queryComplete$.next({
+      data: { status: READY, rows: [{}, {}, {}] },
+      query: { query: 'source=logs', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(true);
+    expect(result.resultsCount).toBe(3);
+  });
+
+  it('reports a genuine empty result set as success with zero results', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    h.queryComplete$.next({
+      data: { status: NO_RESULTS },
+      query: { query: 'source=logs', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(true);
+    expect(result.resultsCount).toBe(0);
+    expect(result.message).toContain('no results');
+  });
+
+  it('treats a NO_RESULTS with actualError (DQL parse error) as a failure', async () => {
+    const h = setup({ currentLanguage: 'kuery' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: '(response: 400' });
+    h.queryComplete$.next({
+      data: { status: NO_RESULTS },
+      query: { query: '(response: 400', language: 'kuery' },
+      actualError: 'Expected ")" but end of input found.',
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Expected ")" but end of input found.');
+  });
+
+  it('reports failure with the extracted reason when the query errors', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'bad' });
+    h.queryComplete$.next({
+      data: {
+        status: ERROR,
+        queryStatus: { body: { error: { message: { error: { reason: 'boom reason' } } } } },
+      },
+      query: { query: 'bad', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('boom reason');
+    expect(result.message).toContain('boom reason');
+  });
+
+  it('reports aborted when the query is explicitly cancelled (ABORT_DATA_QUERY_TRIGGER)', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    // No completion arrives; instead the query is explicitly cancelled (e.g. the user starts
+    // query-assist generation, which fires ABORT_DATA_QUERY_TRIGGER).
+    h.queryAbort$.next({ reason: 'trigger abort action if trying to use query assistant' });
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.stop_tool_execution).toBe(true);
+    expect(result.resultsCount).toBeUndefined();
+  });
+
+  it('waits for the real result on a passive re-fetch (does not report aborted on abort)', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    // A passive supersede (auto-refresh / same-query re-run) aborts the in-flight fetch, but the
+    // follow-up fetch for the SAME query completes successfully. No abort signal is emitted, so
+    // the handler must resolve with the real success result, not "aborted".
+    h.queryComplete$.next({
+      data: { status: READY, hits: 7 },
+      query: { query: 'source=logs', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(true);
+    expect(result.resultsCount).toBe(7);
+  });
+
+  it('reports aborted when the page query changes before completion arrives', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    // No completion for source=logs ever arrives; instead the page query moves on.
+    h.updates$.next({ query: 'source=other', language: 'PPL' });
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.stop_tool_execution).toBe(true);
+  });
+
+  it('reports aborted when the page language changes before completion arrives', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    // Language switched away from PPL - the completion for PPL will never match.
+    h.updates$.next({ query: 'source=logs', language: 'kuery' });
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.stop_tool_execution).toBe(true);
+  });
+});

--- a/src/plugins/discover/public/application/view_components/actions/apply_query_action.ts
+++ b/src/plugins/discover/public/application/view_components/actions/apply_query_action.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useRef } from 'react';
+import { useMount, useUnmount } from 'react-use';
+import { merge, Subscription } from 'rxjs';
+import { filter, first, map } from 'rxjs/operators';
+import { DiscoverServices } from '../../../build_services';
+import {
+  DataSubject,
+  QueryAbortSubject,
+  QueryCompleteSubject,
+  RefetchSubject,
+  ResultStatus,
+} from '../utils/use_search';
+import { extractQueryError } from '../utils/format_error';
+
+export interface LanguageToolConfig {
+  /** Language key stored on the query bar (matches query.language in page context). */
+  languageKey: string;
+  /** Human-facing display name used in descriptions and messages. */
+  displayName: string;
+  /** Unique assistant tool name for this language. */
+  toolName: string;
+}
+
+export const LANGUAGE_TOOLS: LanguageToolConfig[] = [
+  { languageKey: 'kuery', displayName: 'DQL', toolName: 'apply_dql_query' },
+  { languageKey: 'lucene', displayName: 'Lucene', toolName: 'apply_lucene_query' },
+  { languageKey: 'PPL', displayName: 'PPL', toolName: 'apply_ppl_query' },
+  { languageKey: 'SQL', displayName: 'OpenSearch SQL', toolName: 'apply_sql_query' },
+];
+
+export const buildToolDefinition = (cfg: LanguageToolConfig) => {
+  // SQL does not use the Discover time picker (from/to); time filtering is expressed in the query itself.
+  const isSql = cfg.languageKey.toUpperCase() === 'SQL';
+
+  const properties: Record<string, { type: string; description: string }> = {
+    query: {
+      type: 'string',
+      description: `The ${cfg.displayName} query to set in the query bar${
+        isSql ? '' : ' (without time filters)'
+      }`,
+    },
+    description: {
+      type: 'string',
+      description: 'Optional description of what the query does',
+    },
+  };
+
+  if (!isSql) {
+    properties.from = {
+      type: 'string',
+      description:
+        'Start time for the time range (e.g., "now-1h", "now-7d", "2024-01-01"). If provided, the time range will be updated.',
+    };
+    properties.to = {
+      type: 'string',
+      description:
+        'End time for the time range (e.g., "now", "2024-01-31"). If provided along with from, the time range will be updated.',
+    };
+  }
+
+  return {
+    name: cfg.toolName,
+    description: `Updates the Discover query bar with a ${cfg.displayName} query and runs the search in the classic Discover UI.
+    LANGUAGE FOR ${cfg.displayName.toUpperCase()} ONLY: This tool ALWAYS writes ${cfg.displayName}. You cannot change the query language yourself - it is controlled by the user on the page. if a request needs another language, only that language's apply-query tool can handle it.
+    WHEN TO USE: 
+      (1)Call this when the user wants to execute a ${cfg.displayName} query, filter, or search over the data shown in Discover, and when running the query and letting the user see the matching rows can answer user request - regardless of how the user phrases it (imperative like "show/list/filter/display/find", or interrogative/analytical like "is there any error?", "which orders are over $500?", "what errors happened on web-01?").
+      (2)If (1) is NOT met - i.e. you need the actual field values to analyze or generate a report - use backend data-retrieval tools with the same time range ${isSql ? '' : 'from/to'}: this ${cfg.toolName} tool only returns execution status (success/failure) and a result count, NOT the underlying data.
+      ${
+        ['kuery', 'lucene'].includes(cfg.languageKey.toLowerCase())
+          ? `
+      (3)${cfg.displayName} cannot aggregate or sort (e.g. top N, count, group by, sum, avg, percentile, sort/order by). If the request needs any of these, do NOT call this tool at all; instead compute the answer with a backend data-retrieval tool and report it to the user directly. Example: for "show repeat accounts", counting occurrences per account requires aggregation, so use a backend data-retrieval tool to compute the repeat accounts and tell the user the answer directly in this conversation - it is ABSOLUTELY FORBIDDEN to call this tool with the specific id (e.g. "account:212") in the UI.`
+          : ''
+      }
+    PROHIBITED: 
+      (1)It is STRICTLY FORBIDDEN to call this tool with a query that contains any literal value (ID, name, number, code, or any other specific value) extracted from a fixed value or list you fetched earlier in this conversation (e.g. "customer_id: ..."). In that case, simply report the backend result to the user directly in your reply, do NOT call this tool to mirror it in the UI. BEFORE calling this, you MUST explicitly verify: "Does the query contain any value (ID, number, name, code) retrieved from a previous tool call in this conversation?" - If YES → DO NOT call this tool.
+      (2)It is STRICTLY FORBIDDEN to guess fields when generating a query, only reference fields you already know exist (from IndexMappingTool).
+      ${
+        isSql
+          ? ''
+          : `
+      (3)The query should NOT contain time filters - use the from/to parameters to specify the time range.`
+      }`,
+    parameters: {
+      type: 'object' as const,
+      properties,
+      required: ['query'],
+    },
+  };
+};
+
+/** All four tool definitions (shape only, without handlers). */
+export const APPLY_QUERY_TOOL_DEFINITIONS = LANGUAGE_TOOLS.map(buildToolDefinition);
+
+// Handler used when a language tool is not the current page language (registered as disabled, so
+// it is filtered out of the assistant tool list and should never actually run).
+const createUnavailableHandler = (cfg: LanguageToolConfig) => async () => ({
+  success: false,
+  error: 'Tool not available - not the current query language',
+  message:
+    `The ${cfg.displayName} query tool is not available because the Discover query bar is not currently using ${cfg.displayName}. ` +
+    'Use the apply-query tool for the language the page is currently in. The query language is controlled by the user.',
+  stop_tool_execution: true,
+});
+
+// Builds the real handler for the tool that matches the current page language.
+const createApplyHandler =
+  (
+    cfg: LanguageToolConfig,
+    services: DiscoverServices,
+    data$: DataSubject,
+    refetch$: RefetchSubject,
+    queryComplete$: QueryCompleteSubject,
+    queryAbort$: QueryAbortSubject
+  ) =>
+  async (args: any) => {
+    try {
+      const { queryString, timefilter } = services.data.query;
+
+      const timeRangeMessage =
+        args.from && args.to ? ` Time range set to ${args.from} - ${args.to}.` : '';
+      if (args.from && args.to) {
+        timefilter.timefilter.setTime({ from: args.from, to: args.to });
+      }
+
+      // Force this tool's language, preserving the current dataset.
+      const currentQuery = queryString.getQuery();
+      const language = currentQuery.language || cfg.languageKey;
+      queryString.setQuery({
+        ...currentQuery,
+        query: args.query,
+        language,
+      });
+
+      // Race the possible outcomes so the tool never hangs, however long the query takes:
+      //  1. matched$: the real completion for THIS query/language arrives (success/failure).
+      //  2. queryChanged$: the page query/language moves away from what we set.
+      //  3. aborted$: the query is explicitly cancelled (e.g. the user starts query-assist).
+      const matched$ = queryComplete$.pipe(
+        filter((c) => c.query?.query === args.query && c.query?.language === language),
+        first(),
+        map((completion) => ({ type: 'completion' as const, completion }))
+      );
+      const queryChanged$ = queryString.getUpdates$().pipe(
+        filter((q) => q.query !== args.query || (q.language || cfg.languageKey) !== language),
+        first(),
+        map(() => ({ type: 'aborted' as const }))
+      );
+      const aborted$ = queryAbort$.pipe(
+        first(),
+        map(() => ({ type: 'aborted' as const }))
+      );
+      const outcomePromise = merge(matched$, queryChanged$, aborted$).pipe(first()).toPromise();
+
+      // Force a fetch even when the query/time is identical to the current
+      refetch$.next();
+
+      const outcome = await outcomePromise;
+
+      if (outcome?.type === 'aborted') {
+        return {
+          success: false,
+          executed: false,
+          query: args.query,
+          language,
+          message: `Query execution was cancelled or did not complete.`,
+          error: 'Query execution was interrupted',
+          stop_tool_execution: true,
+        };
+      }
+
+      const completion = outcome?.completion;
+      const finalData = completion?.data ?? data$.getValue();
+      const status = finalData.status;
+
+      if (status === ResultStatus.ERROR) {
+        const reason = extractQueryError(finalData.queryStatus?.body?.error);
+        return {
+          success: false,
+          executed: false,
+          query: args.query,
+          language,
+          message: `Query execution failed: ${reason}`,
+          error: reason,
+        };
+      }
+
+      if (status === ResultStatus.READY || status === ResultStatus.NO_RESULTS) {
+        // Handle special case: DQL/Lucene parse errors as NO_RESULTS
+        if (status === ResultStatus.NO_RESULTS && completion?.actualError) {
+          return {
+            success: false,
+            executed: false,
+            query: args.query,
+            language,
+            message: `Query execution failed: ${completion.actualError}`,
+            error: completion.actualError,
+          };
+        }
+
+        const noResults = status === ResultStatus.NO_RESULTS;
+        const resultsCount = noResults ? 0 : finalData.hits || finalData.rows?.length || undefined;
+        return {
+          success: true,
+          executed: true,
+          query: args.query,
+          language,
+          resultsCount,
+          timeRange: args.from && args.to ? { from: args.from, to: args.to } : undefined,
+          message: noResults
+            ? `Query executed successfully but returned no results.${timeRangeMessage}`
+            : `Query executed successfully and returned ${resultsCount} result(s).${timeRangeMessage}`,
+        };
+      }
+
+      // Did not complete (timed out, still loading, no dataset, or uninitialized).
+      return {
+        success: false,
+        executed: false,
+        query: args.query,
+        language,
+        message: `Query execution was cancelled or did not complete. Status: ${status}`,
+        error: 'Query execution was interrupted',
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        query: args.query,
+      };
+    }
+  };
+
+// Registers every language tool as disabled (used as a plugin-level placeholder and when the
+// Discover view unmounts / the user navigates away).
+export function registerAllDisabledApplyQueryActions(
+  registerAction: (action: any) => void | undefined
+) {
+  if (!registerAction) return;
+
+  LANGUAGE_TOOLS.forEach((cfg) => {
+    registerAction({
+      ...buildToolDefinition(cfg),
+      available: 'disabled',
+      handler: async () => ({
+        success: false,
+        error: 'STOP: Tool not available - context has changed',
+        message:
+          `The ${cfg.displayName} query tool is not available because the user is not in the Discover view. ` +
+          'Do not attempt to use any more tools. Explain that you cannot execute queries because they are no longer in the Discover context, ' +
+          'and suggest they navigate to the Discover view.',
+        stop_tool_execution: true,
+        context_lost: true,
+      }),
+    });
+  });
+}
+
+export function useApplyQueryAction(
+  services: DiscoverServices,
+  data$: DataSubject,
+  refetch$: RefetchSubject,
+  queryComplete$: QueryCompleteSubject,
+  queryAbort$: QueryAbortSubject
+) {
+  const registerAction = services.contextProvider?.actions?.registerAssistantAction;
+  const currentLanguageRef = useRef<string>();
+  const subscriptionRef = useRef<Subscription>();
+
+  useMount(() => {
+    if (!registerAction) return;
+
+    const queryString = services.data.query.queryString;
+
+    const findConfig = (language: string) =>
+      LANGUAGE_TOOLS.find((cfg) => cfg.languageKey.toLowerCase() === language.toLowerCase());
+
+    const enableTool = (cfg: LanguageToolConfig) =>
+      registerAction({
+        ...buildToolDefinition(cfg),
+        available: 'enabled',
+        handler: createApplyHandler(cfg, services, data$, refetch$, queryComplete$, queryAbort$),
+      });
+
+    const disableTool = (cfg: LanguageToolConfig) =>
+      registerAction({
+        ...buildToolDefinition(cfg),
+        available: 'disabled',
+        handler: createUnavailableHandler(cfg),
+      });
+
+    // Enable only the tool matching the current language. The other three stay disabled from the
+    // plugin-level placeholder registration, so they are excluded from the assistant tool list.
+    const initialLanguage = queryString.getQuery().language || 'kuery';
+    const initialCfg = findConfig(initialLanguage);
+    if (initialCfg) enableTool(initialCfg);
+    currentLanguageRef.current = initialLanguage;
+
+    // On a language switch, only the two affected tools change: disable the previous language's
+    // tool and enable the new one. Other query updates (text, dataset) are ignored.
+    subscriptionRef.current = queryString.getUpdates$().subscribe((query) => {
+      const nextLanguage = query.language || 'kuery';
+      if (nextLanguage === currentLanguageRef.current) return;
+
+      const prevCfg = findConfig(currentLanguageRef.current || '');
+      const nextCfg = findConfig(nextLanguage);
+      if (prevCfg) disableTool(prevCfg);
+      if (nextCfg) enableTool(nextCfg);
+      currentLanguageRef.current = nextLanguage;
+    });
+  });
+
+  // Cleanup: stop listening and restore all tools to the disabled placeholder state when the
+  // Discover view unmounts.
+  useUnmount(() => {
+    subscriptionRef.current?.unsubscribe();
+    if (registerAction) {
+      registerAllDisabledApplyQueryActions(registerAction);
+    }
+  });
+}

--- a/src/plugins/discover/public/application/view_components/canvas/index.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/index.tsx
@@ -11,6 +11,7 @@ import { DiscoverTable } from './discover_table';
 import { DiscoverChartContainer } from './discover_chart_container';
 import { useDiscoverContext } from '../context';
 import { ResultStatus, SearchData } from '../utils/use_search';
+import { extractQueryError } from '../utils/format_error';
 import { DiscoverNoResults } from '../../components/no_results/no_results';
 import { DiscoverNoIndexPatterns } from '../../components/no_index_patterns/no_index_patterns';
 import { DiscoverUninitialized } from '../../components/uninitialized/uninitialized';
@@ -132,6 +133,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, optionalRef }: Vie
           optionalRef,
         }}
         showSaveQuery={showSaveQuery}
+        resultsCount={rows?.length ?? 0}
       />
 
       {indexPattern ? (
@@ -142,6 +144,7 @@ export default function DiscoverCanvas({ setHeaderActionMenu, optionalRef }: Vie
               query={data.query.queryString.getQuery()}
               savedQuery={data.query.savedQueries}
               timeFieldName={timeField}
+              getQueryError={() => data$.getValue().actualError}
             />
           )}
           {fetchState.status === ResultStatus.UNINITIALIZED && (
@@ -149,7 +152,10 @@ export default function DiscoverCanvas({ setHeaderActionMenu, optionalRef }: Vie
           )}
           {fetchState.status === ResultStatus.LOADING && !rows?.length && <LoadingSpinner />}
           {fetchState.status === ResultStatus.ERROR && !rows?.length && (
-            <DiscoverUninitialized onRefresh={() => refetch$.next()} />
+            <DiscoverUninitialized
+              onRefresh={() => refetch$.next()}
+              getQueryError={() => extractQueryError(data$.getValue().queryStatus?.body?.error)}
+            />
           )}
           {(fetchState.status === ResultStatus.READY ||
             (fetchState.status === ResultStatus.LOADING && !!rows?.length) ||

--- a/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
+++ b/src/plugins/discover/public/application/view_components/canvas/top_nav.tsx
@@ -36,9 +36,15 @@ export interface TopNavProps {
   };
   showSaveQuery: boolean;
   isEnhancementsEnabled?: boolean;
+  resultsCount?: number;
 }
 
-export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavProps) => {
+export const TopNav = ({
+  opts,
+  showSaveQuery,
+  isEnhancementsEnabled,
+  resultsCount,
+}: TopNavProps) => {
   const { services } = useOpenSearchDashboards<DiscoverViewServices>();
   const { data$, inspectorAdapters, savedSearch, indexPattern } = useDiscoverContext();
   const [indexPatterns, setIndexPatterns] = useState<IndexPattern[] | undefined>(undefined);
@@ -189,7 +195,7 @@ export const TopNav = ({ opts, showSaveQuery, isEnhancementsEnabled }: TopNavPro
         datePickerRef={opts?.optionalRef?.datePickerRef}
         groupActions={showActionsInGroup}
         screenTitle={screenTitle}
-        queryStatus={queryStatus}
+        queryStatus={{ ...queryStatus, resultsCount }}
         showQueryBar={!!opts?.optionalRef?.datasetSelectorRef}
       />
     </>

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../../../opensearch_dashboards_react/public';
 import { getServices } from '../../../opensearch_dashboards_services';
 import { useSearch, SearchContextValue } from '../utils/use_search';
+import { useApplyQueryAction } from '../actions/apply_query_action';
 
 const SearchContext = React.createContext<SearchContextValue>({} as SearchContextValue);
 
@@ -31,19 +32,35 @@ export default function DiscoverContext({ children }: React.PropsWithChildren<Vi
   // language, dataset and time range in classic Discover. Classic Discover
   // stores the query one level deeper under `_q.query` (vs `_q` in Explore).
   const usePageContext = services.contextProvider?.hooks?.usePageContext || NOOP_PAGE_CONTEXT_HOOK;
+  const languageService = services.data?.query?.queryString?.getLanguageService?.();
   usePageContext({
     description: 'Discover application page context',
-    convert: (urlState: any) => ({
-      appId: 'discover',
-      timeRange: urlState?._g?.time,
-      query: {
-        query: urlState?._q?.query?.query || '',
-        language: urlState?._q?.query?.language || 'kuery',
-      },
-      dataset: urlState?._q?.query?.dataset,
-    }),
+    convert: (urlState: any) => {
+      const languageKey = urlState?._q?.query?.language || 'kuery';
+      const languageDisplayName = languageService?.getLanguage(languageKey)?.title;
+      const isSql = languageKey.toLowerCase() === 'sql';
+      return {
+        appId: 'discover',
+        ...(isSql ? {} : { timeRange: urlState?._g?.time }),
+        query: {
+          query: urlState?._q?.query?.query || '',
+          language: languageKey,
+          ...(languageDisplayName ? { languageDisplayName } : {}),
+        },
+        dataset: urlState?._q?.query?.dataset,
+      };
+    },
     categories: ['page', 'static'],
   });
+
+  // Register the apply query action for assistant integration
+  useApplyQueryAction(
+    services,
+    searchParams.data$,
+    searchParams.refetch$,
+    searchParams.queryComplete$,
+    searchParams.queryAbort$
+  );
 
   return (
     <OpenSearchDashboardsContextProvider services={services}>

--- a/src/plugins/discover/public/application/view_components/utils/format_error.test.ts
+++ b/src/plugins/discover/public/application/view_components/utils/format_error.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { extractQueryError } from './format_error';
+
+describe('extractQueryError', () => {
+  it('prefers shortMessage above everything else', () => {
+    const errorBody = {
+      shortMessage: 'Short and sweet',
+      message: { error: { reason: 'ignored reason' } },
+      attributes: { error: { reason: 'also ignored' } },
+    };
+    expect(extractQueryError(errorBody)).toBe('Short and sweet');
+  });
+
+  it('returns attributes.error when it is a string', () => {
+    expect(extractQueryError({ attributes: { error: 'attribute level error' } })).toBe(
+      'attribute level error'
+    );
+  });
+
+  it('prefers attributes.error over message.error', () => {
+    const errorBody = {
+      attributes: { error: { reason: 'from attributes' } },
+      message: { error: { reason: 'from message' } },
+    };
+    expect(extractQueryError(errorBody)).toBe('from attributes');
+  });
+
+  it('extracts the first root_cause reason from a structured error', () => {
+    const errorBody = {
+      message: {
+        error: {
+          root_cause: [{ reason: 'root cause reason' }, { reason: 'second cause' }],
+          reason: 'top level reason',
+        },
+      },
+    };
+    expect(extractQueryError(errorBody)).toBe('root cause reason');
+  });
+
+  it('falls back to details when there is no root_cause', () => {
+    const errorBody = { message: { error: { details: 'the details', reason: 'the reason' } } };
+    expect(extractQueryError(errorBody)).toBe('the details');
+  });
+
+  it('falls back to reason when there is no root_cause or details', () => {
+    const errorBody = { message: { error: { reason: 'just the reason' } } };
+    expect(extractQueryError(errorBody)).toBe('just the reason');
+  });
+
+  it('returns the message when it is a plain string', () => {
+    expect(extractQueryError({ message: 'plain string message' })).toBe('plain string message');
+  });
+
+  it('falls back to the top-level error string', () => {
+    expect(extractQueryError({ error: 'Bad Request' })).toBe('Bad Request');
+  });
+
+  it('returns the default message when nothing usable is present', () => {
+    expect(extractQueryError({})).toBe('Query execution failed');
+    expect(extractQueryError(undefined)).toBe('Query execution failed');
+    expect(extractQueryError(null)).toBe('Query execution failed');
+  });
+
+  it('returns the default message when a structured inner error has no usable fields', () => {
+    expect(extractQueryError({ message: { error: { type: 'SomeException' } } })).toBe(
+      'Query execution failed'
+    );
+  });
+});

--- a/src/plugins/discover/public/application/view_components/utils/format_error.ts
+++ b/src/plugins/discover/public/application/view_components/utils/format_error.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function extractQueryError(errorBody: any): string {
+  if (errorBody?.shortMessage) {
+    return errorBody.shortMessage;
+  }
+  const message = errorBody?.message;
+  const inner = errorBody?.attributes?.error || message?.error;
+  return (
+    (typeof inner === 'string'
+      ? inner
+      : inner?.root_cause?.[0]?.reason || inner?.details || inner?.reason) ||
+    (typeof message === 'string' ? message : undefined) ||
+    errorBody?.error ||
+    'Query execution failed'
+  );
+}

--- a/src/plugins/discover/public/application/view_components/utils/use_search.ts
+++ b/src/plugins/discover/public/application/view_components/utils/use_search.ts
@@ -13,9 +13,16 @@ import { useLocation } from 'react-router-dom';
 import { useEffectOnce } from 'react-use';
 import { RequestAdapter } from '../../../../../inspector/public';
 import { DiscoverViewServices } from '../../../build_services';
-import { Filter, search, syncQueryStateWithUrl, UI_SETTINGS } from '../../../../../data/public';
+import {
+  Filter,
+  Query,
+  search,
+  syncQueryStateWithUrl,
+  UI_SETTINGS,
+} from '../../../../../data/public';
 import { validateTimeRange } from '../../helpers/validate_time_range';
 import { updateSearchSource } from './update_search_source';
+import { extractQueryError } from './format_error';
 import { useIndexPattern } from './use_index_pattern';
 import { OpenSearchSearchHit } from '../../doc_views/doc_views_types';
 import { TimechartHeaderBucketInterval } from '../../components/chart/timechart_header';
@@ -96,12 +103,21 @@ export interface SearchData {
     elapsedMs?: number;
     startTime?: number;
   };
+  actualError?: string;
 }
 
 export type SearchRefetch = 'refetch' | undefined;
 
 export type DataSubject = BehaviorSubject<SearchData>;
 export type RefetchSubject = Subject<SearchRefetch>;
+
+export interface QueryCompletion {
+  data: SearchData;
+  query: Query;
+  actualError?: string;
+}
+export type QueryCompleteSubject = Subject<QueryCompletion>;
+export type QueryAbortSubject = Subject<AbortDataQueryContext>;
 
 /**
  * A hook that provides functionality for fetching and managing discover search data.
@@ -163,6 +179,9 @@ export const useSearch = (services: DiscoverViewServices) => {
   });
 
   const actionId = useRef(`ACTION_ABORT_DATA_QUERY_${uuidv4()}`);
+
+  // Emits when the current query is explicitly cancelled via ABORT_DATA_QUERY_TRIGGER.
+  const queryAbort$ = useMemo(() => new Subject<AbortDataQueryContext>(), []);
 
   const inspectorAdapters = {
     requests: new RequestAdapter(),
@@ -226,12 +245,14 @@ export const useSearch = (services: DiscoverViewServices) => {
     const id = actionId.current;
     uiActions.addTriggerAction(
       ABORT_DATA_QUERY_TRIGGER,
-      createAbortDataQueryAction([fetchForMaxCsvStateRef, fetchStateRef], id)
+      createAbortDataQueryAction([fetchForMaxCsvStateRef, fetchStateRef], id, (reason) =>
+        queryAbort$.next({ reason })
+      )
     );
     return () => {
       uiActions.detachAction(ABORT_DATA_QUERY_TRIGGER, id);
     };
-  }, [uiActions]);
+  }, [uiActions, queryAbort$]);
 
   useEffect(() => {
     data$.next({ ...data$.value, queryStatus: { startTime } });
@@ -249,22 +270,29 @@ export const useSearch = (services: DiscoverViewServices) => {
 
   const refetch$ = useMemo(() => new Subject<SearchRefetch>(), []);
 
+  // Payload emitted on `queryComplete$` whenever a fetch reaches a final outcome.
+  const queryComplete$ = useMemo(() => new Subject<QueryCompletion>(), []);
+
   const fetch = useCallback(async () => {
     const currentTime = Date.now();
+    const ranQuery = data.query.queryString.getQuery();
     let dataset = indexPattern;
     if (!dataset) {
       data$.next({
         status: shouldSearchOnPageLoad() ? ResultStatus.LOADING : ResultStatus.UNINITIALIZED,
         queryStatus: { startTime: currentTime },
       });
+      queryComplete$.next({ data: data$.getValue(), query: ranQuery });
       return;
     }
 
     if (!validateTimeRange(timefilter.getTime(), toastNotifications)) {
-      return data$.next({
+      data$.next({
         status: ResultStatus.NO_RESULTS,
         rows: [],
       });
+      queryComplete$.next({ data: data$.getValue(), query: ranQuery });
+      return;
     }
 
     // Abort any in-progress requests before fetching again
@@ -370,15 +398,23 @@ export const useSearch = (services: DiscoverViewServices) => {
           elapsedMs,
         },
       });
+      queryComplete$.next({ data: data$.getValue(), query: ranQuery });
     } catch (error: any) {
       // If the request was aborted then no need to surface this error in the UI
       if (error instanceof Error && error.name === 'AbortError') return;
 
       const queryLanguage = data.query.queryString.getQuery().language;
       if (queryLanguage === 'kuery' || queryLanguage === 'lucene') {
+        const actualError = extractQueryError(error?.body || error);
         data$.next({
           status: ResultStatus.NO_RESULTS,
           rows: [],
+          actualError,
+        });
+        queryComplete$.next({
+          data: data$.getValue(),
+          query: ranQuery,
+          actualError,
         });
 
         data.search.showError(error as Error);
@@ -440,6 +476,7 @@ export const useSearch = (services: DiscoverViewServices) => {
           elapsedMs,
         },
       });
+      queryComplete$.next({ data: data$.getValue(), query: ranQuery });
     } finally {
       initalSearchComplete.current = true;
     }
@@ -455,6 +492,7 @@ export const useSearch = (services: DiscoverViewServices) => {
     data$,
     shouldSearchOnPageLoad,
     inspectorAdapters.requests,
+    queryComplete$,
   ]);
 
   // This is a modified version of the above fetch that is to be used for CSV Download MAX option.
@@ -649,6 +687,8 @@ export const useSearch = (services: DiscoverViewServices) => {
   return {
     data$,
     refetch$,
+    queryComplete$,
+    queryAbort$,
     indexPattern,
     savedSearch,
     inspectorAdapters,

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -79,6 +79,10 @@ declare module '../../share/public' {
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { ExplorePluginSetup } from '../../explore/public';
 import { ContextProviderStart } from '../../context_provider/public';
+import {
+  APPLY_QUERY_TOOL_DEFINITIONS,
+  registerAllDisabledApplyQueryActions,
+} from './application/view_components/actions/apply_query_action';
 
 /**
  * @public
@@ -172,6 +176,7 @@ export class DiscoverPlugin implements Plugin<
   private servicesInitialized: boolean = false;
   private urlGenerator?: DiscoverStart['urlGenerator'];
   private initializeServices?: () => { core: CoreStart; plugins: DiscoverStartPlugins };
+  private unregisterApplyQueryAction?: () => void;
 
   setup(core: CoreSetup<DiscoverStartPlugins, DiscoverStart>, plugins: DiscoverSetupPlugins) {
     const baseUrl = core.http.basePath.prepend('/app/discover');
@@ -464,6 +469,16 @@ export class DiscoverPlugin implements Plugin<
 
     this.initializeServices();
 
+    // Register disabled apply_query action as placeholder.
+    // This will be overridden when the Discover view mounts and restored when it unmounts.
+    if (plugins.contextProvider) {
+      registerAllDisabledApplyQueryActions(plugins.contextProvider.actions.registerAssistantAction);
+      this.unregisterApplyQueryAction = () =>
+        APPLY_QUERY_TOOL_DEFINITIONS.forEach((definition) =>
+          plugins.contextProvider!.actions.unregisterAssistantAction(definition.name)
+        );
+    }
+
     return {
       urlGenerator: this.urlGenerator,
       savedSearchLoader: createSavedSearchesLoader({
@@ -480,6 +495,7 @@ export class DiscoverPlugin implements Plugin<
     if (this.stopUrlTracking) {
       this.stopUrlTracking();
     }
+    this.unregisterApplyQueryAction?.();
   }
 
   /**

--- a/src/plugins/query_enhancements/public/query_assist/components/ask_t2ppl_error_button.test.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/ask_t2ppl_error_button.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { ChatServiceStart } from '../../../../../core/public';
+import { AgentError } from '../utils';
+import { AskT2pplErrorButton } from './ask_t2ppl_error_button';
+
+const TEST_ID = 'testAskAiForHelp';
+
+const createChatService = () => {
+  const sendMessageWithWindow = jest.fn().mockResolvedValue(undefined);
+  return {
+    chatService: { sendMessageWithWindow } as unknown as ChatServiceStart,
+    sendMessageWithWindow,
+  };
+};
+
+describe('<AskT2pplErrorButton />', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders as an EuiLink by default', () => {
+    const { chatService } = createChatService();
+    const { getByTestId } = render(
+      <AskT2pplErrorButton
+        chatService={chatService}
+        error={new Error('boom')}
+        testSource={TEST_ID}
+      />
+    );
+    // EuiLink with an onClick renders a <button> too, so distinguish by class.
+    expect(getByTestId(TEST_ID).className).toContain('euiLink');
+  });
+
+  it('renders as an EuiButton when as="button"', () => {
+    const { chatService } = createChatService();
+    const { getByTestId } = render(
+      <AskT2pplErrorButton
+        as="button"
+        chatService={chatService}
+        error={new Error('boom')}
+        testSource={TEST_ID}
+      />
+    );
+    expect(getByTestId(TEST_ID).className).toContain('euiButton');
+  });
+
+  it('uses error.message as the reason for a plain Error and includes the question', () => {
+    const { chatService, sendMessageWithWindow } = createChatService();
+    const { getByTestId } = render(
+      <AskT2pplErrorButton
+        chatService={chatService}
+        error={new Error('something failed')}
+        question="show me errors"
+        testSource={TEST_ID}
+      />
+    );
+
+    fireEvent.click(getByTestId(TEST_ID));
+
+    const [message, attachments] = sendMessageWithWindow.mock.calls[0];
+    expect(message).toContain('from my question "show me errors"');
+    expect(message).toContain('Reason: something failed');
+    expect(message).not.toContain('Details:');
+    expect(attachments).toEqual([]);
+  });
+
+  it('omits the question phrase when no question is provided', () => {
+    const { chatService, sendMessageWithWindow } = createChatService();
+    const { getByTestId } = render(
+      <AskT2pplErrorButton
+        chatService={chatService}
+        error={new Error('failed')}
+        testSource={TEST_ID}
+      />
+    );
+
+    fireEvent.click(getByTestId(TEST_ID));
+
+    const [message] = sendMessageWithWindow.mock.calls[0];
+    expect(message).not.toContain('from my question');
+  });
+
+  it('uses the agent reason and extracted details for an AgentError', () => {
+    const { chatService, sendMessageWithWindow } = createChatService();
+    const agentError = new AgentError({
+      error: {
+        reason: 'Invalid Request',
+        details: `Error from remote service: ${JSON.stringify({
+          OriginalMessage: JSON.stringify({ error: 'index not found' }),
+        })}`,
+        type: 'IllegalArgumentException',
+      },
+      status: 400,
+    });
+
+    const { getByTestId } = render(
+      <AskT2pplErrorButton
+        chatService={chatService}
+        error={agentError}
+        question="q"
+        testSource={TEST_ID}
+      />
+    );
+
+    fireEvent.click(getByTestId(TEST_ID));
+
+    const [message] = sendMessageWithWindow.mock.calls[0];
+    expect(message).toContain('Reason: Invalid Request');
+    expect(message).toContain('Details: index not found');
+  });
+
+  it('does not throw when no chatService is provided', () => {
+    const { getByTestId } = render(
+      <AskT2pplErrorButton error={new Error('boom')} testSource={TEST_ID} />
+    );
+    expect(() => fireEvent.click(getByTestId(TEST_ID))).not.toThrow();
+  });
+});

--- a/src/plugins/query_enhancements/public/query_assist/components/ask_t2ppl_error_button.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/ask_t2ppl_error_button.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButton, EuiLink } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import React from 'react';
+import { ChatServiceStart } from '../../../../../core/public';
+import { AgentError, extractAgentErrorDetail } from '../utils';
+
+interface AskT2pplErrorButtonProps {
+  chatService?: ChatServiceStart;
+  error: Error;
+  question?: string;
+  as?: 'link' | 'button';
+  testSource: string;
+}
+
+/**
+ * An "Ask AI for help" affordance that escalates a failed T2PPL (text-to-PPL) generation to chat
+ * with the original question and error details.
+ */
+export const AskT2pplErrorButton: React.FC<AskT2pplErrorButtonProps> = ({
+  chatService,
+  error,
+  question,
+  as = 'link',
+  testSource,
+}) => {
+  const onAskAI = () => {
+    let reason = error.message;
+    let detail = '';
+    if (error instanceof AgentError) {
+      const {
+        error: { error: agentError },
+      } = error;
+      reason = agentError.reason;
+      detail = extractAgentErrorDetail(agentError.details);
+    }
+    const message = `The AI query assist failed to generate a query${
+      question ? ` from my question "${question}"` : ''
+    }. It returned with the error "Reason: ${reason}${
+      detail ? `; Details: ${detail}` : ''
+    }"\n\nPlease generate a working PPL query for this question and run it on the page, then explain why the original attempt failed.`;
+    chatService?.sendMessageWithWindow(message, []).catch(() => {});
+  };
+
+  if (as === 'button') {
+    return (
+      <EuiButton
+        size="s"
+        color="danger"
+        style={{ marginLeft: 8 }}
+        onClick={onAskAI}
+        data-test-subj={testSource}
+      >
+        {i18n.translate('queryEnhancements.queryAssist.error.askAI', {
+          defaultMessage: 'Ask AI for help',
+        })}
+      </EuiButton>
+    );
+  }
+
+  return (
+    <EuiLink onClick={onAskAI} data-test-subj={testSource}>
+      {i18n.translate('queryEnhancements.queryAssist.error.askAI', {
+        defaultMessage: 'Ask AI for help',
+      })}
+    </EuiLink>
+  );
+};

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_bar.tsx
@@ -19,6 +19,7 @@ import { getStorage, getUiActions } from '../../services';
 import { useGenerateQuery } from '../hooks';
 import { getPersistedLog, AgentError, ProhibitedQueryError } from '../utils';
 import { QueryAssistCallOut, QueryAssistCallOutType } from './call_outs';
+import { AskT2pplErrorButton } from './ask_t2ppl_error_button';
 import { QueryAssistInput } from './query_assist_input';
 import { QueryAssistSubmitButton } from './submit_button';
 import { useQueryAssist } from '../hooks';
@@ -28,8 +29,12 @@ interface QueryAssistInputProps {
   dependencies: QueryEditorExtensionDependencies;
 }
 
+const NOOP_DYNAMIC_CONTEXT_HOOK = (_options?: any): string => '';
+
 export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
   const { services } = useOpenSearchDashboards<IDataPluginServices>();
+  const useDynamicContext =
+    (services as any).contextProvider?.hooks?.useDynamicContext ?? NOOP_DYNAMIC_CONTEXT_HOOK;
   const queryString = services.data.query.queryString;
   const inputRef = useRef<HTMLInputElement>(null);
   const storage = getStorage();
@@ -47,7 +52,25 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
   );
   const selectedIndex = selectedDataset?.title;
   const previousQuestionRef = useRef<string>();
-  const { updateQueryState } = useQueryAssist();
+  const { queryState, updateQueryState } = useQueryAssist();
+
+  const naturalLanguageContextActive = !!queryState?.question;
+
+  useDynamicContext(
+    naturalLanguageContextActive
+      ? {
+          id: 'query-assist-natural-language-prompt',
+          description:
+            'The natural language question the user asked and the query generated from it with a standalone AI assist',
+          value: {
+            naturalLanguageQuestion: queryState.question,
+            generatedQuery: queryState.generatedQuery,
+          },
+          label: 'Natural language question',
+          categories: ['page', 'dynamic'],
+        }
+      : null
+  );
 
   useEffect(() => {
     const subscription = queryString.getUpdates$().subscribe((query) => {
@@ -86,7 +109,19 @@ export const QueryAssistBar: React.FC<QueryAssistInputProps> = (props) => {
         setCallOutType('invalid_query');
         setAgentError(error);
       } else {
-        services.notifications.toasts.addError(error, { title: 'Failed to generate results' });
+        const chatService = services.chat;
+        services.notifications.toasts.addError(error, {
+          title: 'Failed to generate results',
+          extraAction: chatService?.isAvailable?.() ? (
+            <AskT2pplErrorButton
+              as="button"
+              chatService={chatService}
+              error={error}
+              question={previousQuestionRef.current}
+              testSource="queryAssistGenerationErrorToastAskAiForHelp"
+            />
+          ) : undefined,
+        });
       }
       updateQueryState({
         question: previousQuestionRef.current,

--- a/src/plugins/query_enhancements/public/query_assist/components/query_assist_input.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/query_assist_input.tsx
@@ -88,7 +88,7 @@ export const QueryAssistInput: React.FC<QueryAssistInputProps> = (props) => {
           onKeyDown={(e) => setIsSuggestionsVisible(e.key !== 'Enter')}
           placeholder={props.placeholder}
           prepend={<EuiIcon type={assistantMark} />}
-          append={<WarningBadge error={props.error} />}
+          append={<WarningBadge error={props.error} question={props.previousQuestion} />}
           fullWidth
           compressed
         />

--- a/src/plugins/query_enhancements/public/query_assist/components/warning_badge.tsx
+++ b/src/plugins/query_enhancements/public/query_assist/components/warning_badge.tsx
@@ -15,13 +15,18 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import React, { SyntheticEvent, useEffect, useState } from 'react';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { IDataPluginServices } from '../../../../data/public';
 import { AgentError } from '../utils';
+import { AskT2pplErrorButton } from './ask_t2ppl_error_button';
 
 interface WarningBadgeProps {
   error: AgentError | undefined;
+  question?: string;
 }
 
 export const WarningBadge: React.FC<WarningBadgeProps> = (props) => {
+  const { services } = useOpenSearchDashboards<IDataPluginServices>();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [showMore, setShowMore] = useState(false);
 
@@ -38,6 +43,8 @@ export const WarningBadge: React.FC<WarningBadgeProps> = (props) => {
   const {
     error: { error, status },
   } = props.error;
+
+  const chatAvailable = services.chat?.isAvailable?.() ?? false;
 
   return (
     <div className="queryAssist__popoverWrapper">
@@ -124,19 +131,36 @@ export const WarningBadge: React.FC<WarningBadgeProps> = (props) => {
                 </dd>
               </>
             )}
-            <EuiLink onClick={() => setShowMore(!showMore)} data-test-subj="queryAssistErrorMore">
-              {showMore ? (
-                <FormattedMessage
-                  id="queryEnhancements.queryAssist.error.viewLess"
-                  defaultMessage="View Less"
-                />
-              ) : (
-                <FormattedMessage
-                  id="queryEnhancements.queryAssist.error.viewMore"
-                  defaultMessage="View More"
-                />
+            <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiLink
+                  onClick={() => setShowMore(!showMore)}
+                  data-test-subj="queryAssistErrorMore"
+                >
+                  {showMore ? (
+                    <FormattedMessage
+                      id="queryEnhancements.queryAssist.error.viewLess"
+                      defaultMessage="View Less"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="queryEnhancements.queryAssist.error.viewMore"
+                      defaultMessage="View More"
+                    />
+                  )}
+                </EuiLink>
+              </EuiFlexItem>
+              {chatAvailable && (
+                <EuiFlexItem grow={false}>
+                  <AskT2pplErrorButton
+                    chatService={services.chat}
+                    error={props.error}
+                    question={props.question}
+                    testSource="queryAssistGenerationErrorBadgeAskAiForHelp"
+                  />
+                </EuiFlexItem>
               )}
-            </EuiLink>
+            </EuiFlexGroup>
           </dl>
         </EuiText>
       </EuiPopover>

--- a/src/plugins/query_enhancements/public/query_assist/utils/errors.test.ts
+++ b/src/plugins/query_enhancements/public/query_assist/utils/errors.test.ts
@@ -5,7 +5,7 @@
 
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors';
 import { ERROR_DETAILS } from '../../../common';
-import { AgentError, formatError, ProhibitedQueryError } from './errors';
+import { AgentError, extractAgentErrorDetail, formatError, ProhibitedQueryError } from './errors';
 
 describe('formatError', () => {
   it('should return an error with a custom message for status code 429', () => {
@@ -79,5 +79,49 @@ describe('formatError', () => {
     const error = new Error('Some error');
     const formattedError = formatError(error);
     expect(formattedError).toEqual(error);
+  });
+});
+
+describe('extractAgentErrorDetail', () => {
+  it('returns the input unchanged when it is empty', () => {
+    expect(extractAgentErrorDetail('')).toBe('');
+  });
+
+  it('returns the input unchanged when there is no embedded JSON', () => {
+    expect(extractAgentErrorDetail('plain error text without json')).toBe(
+      'plain error text without json'
+    );
+  });
+
+  it('unwraps the real cause from an OriginalMessage wrapper', () => {
+    const details = `Error from remote service: ${JSON.stringify({
+      OriginalMessage: JSON.stringify({ error: 'the real cause' }),
+      StatusCode: 400,
+    })}`;
+    expect(extractAgentErrorDetail(details)).toBe('the real cause');
+  });
+
+  it('unwraps from Message when OriginalMessage is absent', () => {
+    const details = `wrapped: ${JSON.stringify({
+      Message: JSON.stringify({ error: 'message level cause' }),
+    })}`;
+    expect(extractAgentErrorDetail(details)).toBe('message level cause');
+  });
+
+  it('falls back to the inner message field when there is no inner error field', () => {
+    const details = JSON.stringify({
+      OriginalMessage: JSON.stringify({ message: 'inner message cause' }),
+    });
+    expect(extractAgentErrorDetail(details)).toBe('inner message cause');
+  });
+
+  it('returns the original details when the outer JSON has no usable inner payload', () => {
+    const details = JSON.stringify({ StatusCode: 500, SomethingElse: true });
+    expect(extractAgentErrorDetail(details)).toBe(details);
+  });
+
+  it('returns the original details when the embedded JSON is malformed', () => {
+    const details = 'Error from remote service: {not valid json';
+    expect(extractAgentErrorDetail(details)).toBe(details);
   });
 });

--- a/src/plugins/query_enhancements/public/query_assist/utils/errors.ts
+++ b/src/plugins/query_enhancements/public/query_assist/utils/errors.ts
@@ -38,6 +38,33 @@ export class AgentError extends Error {
   }
 }
 
+const parseEmbeddedJson = (value: unknown): any | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const jsonStart = value.indexOf('{');
+  if (jsonStart === -1) return undefined;
+  try {
+    return JSON.parse(value.slice(jsonStart));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The agent error `details` is often a wrapper string like
+ * `Error from remote service: {"OriginalMessage":"{...\"error\":\"<real cause>\"...}", ...}`.
+ */
+export const extractAgentErrorDetail = (details: string): string => {
+  if (!details) return details;
+  const outer = parseEmbeddedJson(details);
+  if (!outer) return details;
+  for (const candidate of [outer.OriginalMessage, outer.Message]) {
+    const inner = parseEmbeddedJson(candidate);
+    if (typeof inner?.error === 'string') return inner.error;
+    if (typeof inner?.message === 'string') return inner.message;
+  }
+  return details;
+};
+
 export const formatError = (error: ResponseError | Error): Error => {
   if ('body' in error) {
     if (error.body.statusCode === 429)


### PR DESCRIPTION
### Description
This PR enhances the capability of the AI Chatbot to help users on the Discover page. It adds three capabilities:

1. **apply_query assistant action**: provides a tool for the AI Chatbot to drive the query bar and the time range, and get back a success/failure status, resultCount, and errorMessage (if any).
    **Language-specific behavior for aggregation/sort requests**: 
    A separate tool is exposed per query language (apply_dql_query, apply_lucene_query, apply_ppl_query, apply_sql_query). **For DQL and Lucene**, the tool description explicitly forbids using it for questions that require aggregation or sorting (top N, count, group by, sum, avg, percentile, order by); in those cases the assistant should compute the answer with a backend data-retrieval tool (e.g. SearchIndexTool) and report it directly. **For PPL and SQL**, aggregation and sorting are part of the query language itself, so such requests are handled by running the query through this tool.
2. **"Ask AI for help" entry for empty and failed queries**: adds a button on the no-results and uninitialized states. Clicking it opens the chat with a pre-filled prompt describing the failure so the assistant can review and fix the query. The button is hidden when chat is unavailable.
3. **Enhanced T2PPL handling**: carries the natural-language question into the Chatbot context, and provides an "Ask AI for help" button when a T2PPL error surfaces.

## Screenshot

https://github.com/user-attachments/assets/cac94773-2c15-4744-9572-cbeb8df3f959


https://github.com/user-attachments/assets/fcc38f5c-fc98-4716-9759-40792a6a3a88


https://github.com/user-attachments/assets/01c5e4ac-757e-4be4-8599-b117ec2d1a7b



## Testing the changes

1. Ask query-related questions on the Discover page, causing the AI chatbot to invoke the apply_dql_query tool (or other apply_xxx_query tools) to modify the page.
**Test Cases**:
Ask questions in each query language and verify that the query is successfully modified. (e.g Filter orders above €300 last month) 
For aggregation/sorting questions in DQL/Lucene, the chatbot should query via backend tools and report the results to the user. (e.g. what's the top 3 selling categories?)(e.g. filter repeat customers for Angeldale)
For aggregation/sorting questions in SQL/PPL, the chatbot should modify the page query. (e.g. what's the top 3 selling categories?)(e.g. filter repeat customers for Angeldale)
Ask if the chatbot can help switch query language — chatbot should respond that it cannot. (e.g. Can you change the langue to PPL on the interface?)

2. One-click Chatbot Assistance in Discover Page
**Test Cases**:
When there are no results, click "Ask AI for help" — the chatbot should automatically open and fix the issue. (e.g. enter "response: 400" in DQL query)
When there is an error, click "Ask AI for help" — the chatbot should automatically open and fix the issue. (e.g. enter "response: (200" in DQL query)
In an index with more than 2000 fields, ask a BT2PPL question, then click "Ask AI for help" — the chatbot should automatically open and fix the issue. (e.g. ask BT2PPL "find record whose filed_1001 equals to 1001")

3. Support linking between BT2PPL and Chatbot in Discover page
**Test Cases**:
First ask a question in BT2PPL, then ask the chatbot to verify it understands what the original query was trying to do. (e.g. ask "find orders over 300" and then ask chatbot "do you know what I want on the page now?")
If the query generated by BT2PPL has an error, ask the chatbot to fix it. (e.g. ask a filed that do not exist, like "find orders with status = cancelled"), chatbot will check and explain that there is no such field to check order status.


### Check List

- [x] All tests pass
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using --signoff
