### PR TITLE
refactor(gauge): render gauge labels with React

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/17/rule_matching_vis_gauge.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/17/rule_matching_vis_gauge.spec.js
@@ -57,18 +57,12 @@ export const runCreateVisTests = () => {
       cy.explore.createVisualizationWithQuery(query, 'gauge', datasetName, {
         shouldManualSelectChartType: true,
       });
-      let beforeCanvasDataUrl;
-      cy.get('.exploreVisContainer canvas')
-        .should('be.visible')
-        .then((canvas) => {
-          beforeCanvasDataUrl = canvas[0].toDataURL(); // current representation of image
-        });
+
+      cy.get('.exploreVisContainer .gauge-title').should('be.visible');
+
       cy.getElementByTestId('showTitleSwitch').click();
-      // compare with new canvas
-      cy.get('.exploreVisContainer canvas').then((canvas) => {
-        const afterCanvasDataUrl = canvas[0].toDataURL();
-        expect(afterCanvasDataUrl).not.to.eq(beforeCanvasDataUrl);
-      });
+
+      cy.get('.exploreVisContainer .gauge-title').should('not.exist');
     });
     it('should add threshold for gauge chart and reflect immediatly to the gauge visualization', () => {
       const query = `source=${datasetName} | stats count()`;

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GaugeSeriesOption, CustomSeriesOption } from 'echarts';
-import { PipelineFn, EChartsSpecState, BaseChartStyle } from '../utils/echarts_spec';
+import { GaugeSeriesOption } from 'echarts';
+import { VisColumn } from '../types';
 import { GaugeChartStyle } from './gauge_vis_config';
-import { getSeriesDisplayName } from '../utils/series';
 import { calculateValue } from '../utils/calculation';
-import { getUnitById, showDisplayValue } from '../style_panel/unit/collection';
+import { getUnitById } from '../style_panel/unit/collection';
 import {
   getMaxAndMinBase,
   mergeThresholdsWithBase,
@@ -16,271 +15,293 @@ import {
 } from '../style_panel/threshold/threshold_utils';
 import { getColors, DEFAULT_GREY } from '../theme/default_colors';
 
-export const createGaugeSeries =
-  ({ styles, seriesFields }: { styles: GaugeChartStyle; seriesFields: string[] }): PipelineFn =>
-  (state) => {
-    const { transformedData = [], axisColumnMappings } = state;
-    const newState = { ...state };
+const GAUGE_RADIUS = '92%';
+const GAUGE_CENTER: [string, string] = ['50%', '60%'];
+const GAUGE_START_ANGLE = 200;
+const GAUGE_END_ANGLE = -20;
+const GAUGE_ARC_WIDTH = 12;
 
-    const series: Array<GaugeSeriesOption | CustomSeriesOption> = [];
+export interface GaugeTextRenderData {
+  value: string;
+  unit?: string;
+  unitFirst: boolean;
+  title?: {
+    valueFieldName: string;
+    customTitle?: string;
+  };
+  valueColor: string;
+  titleColor: string;
+  unitColor: string;
+}
 
-    // TODO use instance width and height
-    const fontSizeFactor = 12;
+interface GaugeArcRenderData {
+  calculatedValue: number | undefined;
+  minBase: number;
+  maxBase: number;
+  normalizedThresholds: Array<[number, string]>;
+  valueArcColor: string;
+}
 
-    seriesFields.forEach((item: string) => {
-      if (!transformedData.length || !Array.isArray(transformedData[0])) {
-        // No dataset/header row available; keep rendering stable.
-        return;
-      }
+interface GaugeRenderData {
+  arc: GaugeArcRenderData;
+  text: GaugeTextRenderData;
+}
 
-      const seriesDisplayName = getSeriesDisplayName(
-        item,
-        Object.values(axisColumnMappings).flat()
-      );
+interface BuildGaugeRenderDataArgs {
+  transformedData: any[][];
+  styles: GaugeChartStyle;
+  valueColumn: VisColumn;
+}
 
-      const numericalValues: number[] = [];
+const isValidDisplayNumber = (value: unknown): value is number =>
+  value !== undefined && typeof value === 'number' && !isNaN(value);
 
-      const seriesIndex = transformedData[0].indexOf(item);
-
-      if (seriesIndex < 0) return;
-      for (let i = 1; i < transformedData.length; i++) {
-        numericalValues.push(transformedData[i][seriesIndex]);
-      }
-
-      const calculatedValue = calculateValue(numericalValues, styles.valueCalculation);
-      const validValues = numericalValues.filter((v) => !isNaN(v));
-      const maxNumber = validValues.length > 0 ? Math.max(...validValues) : 0;
-      const minNumber = validValues.length > 0 ? Math.min(...validValues) : 0;
-
-      const isValidNumber =
-        calculatedValue !== undefined &&
-        typeof calculatedValue === 'number' &&
-        !isNaN(calculatedValue);
-
-      const selectedUnit = getUnitById(styles?.unitId);
-
-      const displayValue = showDisplayValue(isValidNumber, selectedUnit, calculatedValue);
-
-      const { minBase, maxBase } = getMaxAndMinBase(
-        minNumber,
-        maxNumber,
-        styles?.min,
-        styles?.max,
-        calculatedValue
-      );
-
-      const { textColor, mergedThresholds } = mergeThresholdsWithBase(
-        minBase,
-        maxBase,
-        styles?.thresholdOptions?.baseColor,
-        styles?.thresholdOptions?.thresholds,
-        calculatedValue
-      );
-
-      const targetThreshold = locateThreshold(mergedThresholds, calculatedValue);
-
-      const valueArcColor = targetThreshold?.color ?? 'transparent';
-
-      // Gauge colors are defined as “up to this point”, not “from this point” — each [percent, color] means use this color until this percent.
-      const normalizeThresholds =
-        maxBase > minBase
-          ? mergedThresholds.map((t, index) => {
-              if (index > 0)
-                return [
-                  (t.value - minBase) / (maxBase - minBase),
-                  mergedThresholds[index - 1].color,
-                ];
-              return [0, t.color];
-            })
-          : [];
-
-      if (normalizeThresholds.length > 0) {
-        normalizeThresholds.push([1, mergedThresholds[mergedThresholds.length - 1].color]);
-      }
-
-      const thresholdArc = {
-        type: 'gauge',
-        center: ['50%', '60%'],
-        startAngle: 200,
-        radius: '100%',
-        endAngle: -20,
-        z: 5,
-        min: minBase,
-        max: maxBase,
-        tooltip: { show: false },
-        progress: {
-          show: true,
-          width: fontSizeFactor + 2,
-          itemStyle: {
-            color: getColors().backgroundShade,
-          },
-        },
-        pointer: {
-          show: false,
-        },
-        axisLine: {
-          lineStyle: {
-            width: fontSizeFactor + 4,
-            ...(normalizeThresholds.length > 0 && { color: normalizeThresholds }),
-          },
-        },
-        axisTick: {
-          show: false,
-        },
-        splitLine: {
-          show: false,
-        },
-        axisLabel: {
-          show: false,
-        },
-        anchor: {
-          show: false,
-        },
-        title: {
-          show: false,
-        },
-        detail: {
-          show: false,
-        },
-        data: [
-          {
-            value: maxBase,
-            name: styles?.title || seriesDisplayName,
-          },
-        ],
-      } as GaugeSeriesOption;
-
-      const valueArc: GaugeSeriesOption = {
-        type: 'gauge',
-        center: ['50%', '60%'],
-        radius: '100%',
-        startAngle: 200,
-        endAngle: -20,
-        z: 10,
-        min: minBase,
-        max: maxBase,
-        tooltip: { show: false },
-        itemStyle: {
-          color: valueArcColor,
-        },
-        progress: {
-          show: true,
-          width: fontSizeFactor,
-        },
-        pointer: {
-          show: false,
-        },
-
-        axisLine: {
-          show: true,
-          lineStyle: {
-            width: fontSizeFactor,
-            color: [
-              [1, DEFAULT_GREY], // remaining grey part
-            ],
-          },
-        },
-        axisTick: {
-          show: false,
-        },
-        splitLine: {
-          show: false,
-        },
-        axisLabel: {
-          show: false,
-        },
-        detail: {
-          show: false,
-        },
-        data: [
-          {
-            value: calculatedValue,
-          },
-        ],
-      };
-
-      const textCustom: CustomSeriesOption = {
-        type: 'custom',
-        coordinateSystem: 'polar',
-        tooltip: { show: false },
-        data: [
-          {
-            value: calculatedValue,
-          },
-        ],
-        renderItem(params, api) {
-          const width = api.getWidth();
-          const height = api.getHeight();
-
-          const textSizeFactor = Math.min(width, height) / 20;
-          const valueFontSize = 2 * textSizeFactor * (selectedUnit?.fontScale ?? 1);
-          const titleFontSize = textSizeFactor / 2;
-          return {
-            type: 'group',
-            x: width * 0.5,
-            y: height * 0.6,
-            children: [
-              {
-                type: 'text' as const,
-                style: {
-                  x: 0,
-                  y: -2 * textSizeFactor * (selectedUnit?.fontScale ?? 1),
-                  text: displayValue as string,
-                  textAlign: 'center',
-                  fontSize: valueFontSize,
-                  fontWeight: 'bold',
-                  fill: styles?.useThresholdColor ? textColor : getColors().text,
-                },
-              },
-              ...(styles.showTitle
-                ? [
-                    {
-                      type: 'text' as const,
-                      style: {
-                        x: 0,
-                        y: textSizeFactor * (selectedUnit?.fontScale ?? 1),
-                        text: styles?.title || seriesDisplayName,
-                        textAlign: 'center',
-                        fontSize: titleFontSize,
-                        fill: getColors().text,
-                      },
-                    },
-                  ]
-                : []),
-            ],
-          };
-        },
-      };
-
-      series.push(valueArc);
-      series.push(thresholdArc);
-      series.push(textCustom);
-    });
-
-    newState.series = series;
-
-    return newState;
+const createGaugeText = ({
+  calculatedValue,
+  selectedUnit,
+  styles,
+  valueFieldName,
+  textColor,
+}: {
+  calculatedValue: number | undefined;
+  selectedUnit: ReturnType<typeof getUnitById>;
+  styles: GaugeChartStyle;
+  valueFieldName: string;
+  textColor: string;
+}): GaugeTextRenderData => {
+  const isValidNumber = isValidDisplayNumber(calculatedValue);
+  const effectiveTextColor = styles.useThresholdColor ? textColor : getColors().text;
+  const baseText = {
+    unitFirst: false,
+    ...(styles.showTitle && {
+      title: {
+        valueFieldName,
+        customTitle: styles.title || undefined,
+      },
+    }),
+    valueColor: effectiveTextColor,
+    titleColor: getColors().text,
+    unitColor: effectiveTextColor,
   };
 
-export const assembleGaugeSpec = <T extends BaseChartStyle>(
-  state: EChartsSpecState<T>
-): EChartsSpecState<T> => {
-  const { baseConfig, transformedData = [], series } = state;
+  if (!isValidNumber) {
+    return {
+      ...baseText,
+      value: '-',
+    };
+  }
 
-  const spec = {
-    ...baseConfig,
-    // Polar coordinate for text layer
-    angleAxis: { show: false },
-    radiusAxis: {
+  if (selectedUnit?.display) {
+    const unitDisplay = selectedUnit.display(calculatedValue, selectedUnit.symbol);
+    const segments = unitDisplay.segments;
+
+    if (!segments?.length) {
+      return {
+        ...baseText,
+        value: String(unitDisplay.label),
+      };
+    }
+
+    const unitSegment = segments.find((segment) => segment.type === 'unit');
+    const valueSegment = segments.find((segment) => segment.type === 'value');
+
+    return {
+      ...baseText,
+      value: valueSegment !== undefined ? String(valueSegment.value) : String(unitDisplay.label),
+      unit: unitSegment !== undefined ? String(unitSegment.value) : undefined,
+      unitFirst: segments[0]?.type === 'unit',
+    };
+  }
+
+  return {
+    ...baseText,
+    value: `${Math.round(calculatedValue * 100) / 100}`,
+    unit: selectedUnit?.symbol,
+  };
+};
+
+export const buildGaugeRenderData = ({
+  transformedData,
+  styles,
+  valueColumn,
+}: BuildGaugeRenderDataArgs): GaugeRenderData | undefined => {
+  if (!transformedData.length || !Array.isArray(transformedData[0])) {
+    return undefined;
+  }
+
+  const field = valueColumn.column;
+  const seriesIndex = transformedData[0].indexOf(field);
+
+  if (seriesIndex < 0) return undefined;
+
+  const numericalValues: any[] = [];
+  for (let i = 1; i < transformedData.length; i++) {
+    numericalValues.push(transformedData[i][seriesIndex]);
+  }
+
+  const calculatedValue = calculateValue(numericalValues, styles.valueCalculation);
+  const validValues = numericalValues.filter((value) => !isNaN(value));
+  const maxNumber = validValues.length > 0 ? Math.max(...validValues) : 0;
+  const minNumber = validValues.length > 0 ? Math.min(...validValues) : 0;
+  const selectedUnit = getUnitById(styles.unitId);
+
+  const { minBase, maxBase } = getMaxAndMinBase(
+    minNumber,
+    maxNumber,
+    styles.min,
+    styles.max,
+    calculatedValue
+  );
+
+  const { textColor, mergedThresholds } = mergeThresholdsWithBase(
+    minBase,
+    maxBase,
+    styles.thresholdOptions?.baseColor,
+    styles.thresholdOptions?.thresholds,
+    calculatedValue
+  );
+
+  const targetThreshold = locateThreshold(mergedThresholds, calculatedValue);
+  const valueArcColor = targetThreshold?.color ?? 'transparent';
+
+  // Gauge colors are defined as "up to this point", not "from this point".
+  const normalizedThresholds: Array<[number, string]> =
+    maxBase > minBase
+      ? mergedThresholds.map((threshold, index) => {
+          if (index > 0) {
+            return [
+              (threshold.value - minBase) / (maxBase - minBase),
+              mergedThresholds[index - 1].color,
+            ];
+          }
+          return [0, threshold.color];
+        })
+      : [];
+
+  if (normalizedThresholds.length > 0) {
+    normalizedThresholds.push([1, mergedThresholds[mergedThresholds.length - 1].color]);
+  }
+
+  return {
+    arc: {
+      calculatedValue,
+      minBase,
+      maxBase,
+      normalizedThresholds,
+      valueArcColor,
+    },
+    text: createGaugeText({
+      calculatedValue,
+      selectedUnit,
+      styles,
+      valueFieldName: valueColumn.name,
+      textColor,
+    }),
+  };
+};
+
+const createThresholdArc = (arc: GaugeArcRenderData): GaugeSeriesOption =>
+  ({
+    type: 'gauge',
+    center: GAUGE_CENTER,
+    startAngle: GAUGE_START_ANGLE,
+    radius: GAUGE_RADIUS,
+    endAngle: GAUGE_END_ANGLE,
+    z: 5,
+    min: arc.minBase,
+    max: arc.maxBase,
+    tooltip: { show: false },
+    progress: {
+      show: true,
+      width: GAUGE_ARC_WIDTH + 2,
+      itemStyle: {
+        color: getColors().backgroundShade,
+      },
+    },
+    pointer: {
       show: false,
     },
-    polar: {
-      center: ['50%', '60%'],
-      radius: '100%',
+    axisLine: {
+      lineStyle: {
+        width: GAUGE_ARC_WIDTH + 4,
+        ...(arc.normalizedThresholds.length > 0 && { color: arc.normalizedThresholds }),
+      },
     },
-    dataset: { source: transformedData },
-    series,
-  };
+    axisTick: {
+      show: false,
+    },
+    splitLine: {
+      show: false,
+    },
+    axisLabel: {
+      show: false,
+    },
+    anchor: {
+      show: false,
+    },
+    title: {
+      show: false,
+    },
+    detail: {
+      show: false,
+    },
+    data: [
+      {
+        value: arc.maxBase,
+      },
+    ],
+  }) as GaugeSeriesOption;
 
-  return { ...state, spec };
-};
+const createValueArc = (arc: GaugeArcRenderData): GaugeSeriesOption => ({
+  type: 'gauge',
+  center: GAUGE_CENTER,
+  radius: GAUGE_RADIUS,
+  startAngle: GAUGE_START_ANGLE,
+  endAngle: GAUGE_END_ANGLE,
+  z: 10,
+  min: arc.minBase,
+  max: arc.maxBase,
+  tooltip: { show: false },
+  itemStyle: {
+    color: arc.valueArcColor,
+  },
+  progress: {
+    show: true,
+    width: GAUGE_ARC_WIDTH,
+  },
+  pointer: {
+    show: false,
+  },
+  axisLine: {
+    show: true,
+    lineStyle: {
+      width: GAUGE_ARC_WIDTH,
+      color: [
+        [1, DEFAULT_GREY], // remaining grey part
+      ],
+    },
+  },
+  axisTick: {
+    show: false,
+  },
+  splitLine: {
+    show: false,
+  },
+  axisLabel: {
+    show: false,
+  },
+  title: {
+    show: false,
+  },
+  detail: {
+    show: false,
+  },
+  data: [
+    {
+      value: arc.calculatedValue,
+    },
+  ],
+});
+
+export const createGaugeSeries = (arc?: GaugeArcRenderData): GaugeSeriesOption[] =>
+  arc ? [createValueArc(arc), createThresholdArc(arc)] : [];

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
@@ -3,290 +3,314 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GaugeSeriesOption, CustomSeriesOption } from 'echarts';
-import { PipelineFn, EChartsSpecState, BaseChartStyle } from '../utils/echarts_spec';
+import { GaugeSeriesOption } from 'echarts';
+import { VisColumn } from '../types';
 import { GaugeChartStyle } from './gauge_vis_config';
-import { getSeriesDisplayName } from '../utils/series';
 import { calculateValue } from '../utils/calculation';
-import { getUnitById, showDisplayValue } from '../style_panel/unit/collection';
+import { getUnitById } from '../style_panel/unit/collection';
 import {
   getMaxAndMinBase,
   mergeThresholdsWithBase,
   locateThreshold,
 } from '../style_panel/threshold/threshold_utils';
 import { getColors, DEFAULT_GREY } from '../theme/default_colors';
+import { formatDecimal } from '../utils/data_transformation';
 
-export const createGaugeSeries =
-  ({ styles, seriesFields }: { styles: GaugeChartStyle; seriesFields: string[] }): PipelineFn =>
-  (state) => {
-    const { transformedData = [], axisColumnMappings } = state;
-    const newState = { ...state };
+const GAUGE_RADIUS = '92%';
+const GAUGE_CENTER: [string, string] = ['50%', '60%'];
+const GAUGE_START_ANGLE = 200;
+const GAUGE_END_ANGLE = -20;
+const GAUGE_ARC_WIDTH = 12;
 
-    const series: Array<GaugeSeriesOption | CustomSeriesOption> = [];
+export interface GaugeTextRenderData {
+  value: string;
+  unit?: string;
+  unitSuffix?: string;
+  unitFirst: boolean;
+  title?: {
+    valueFieldName: string;
+    customTitle?: string;
+  };
+  valueColor: string;
+  titleColor: string;
+  unitColor: string;
+}
 
-    // TODO use instance width and height
-    const fontSizeFactor = 12;
+interface GaugeArcRenderData {
+  calculatedValue: number | undefined;
+  minBase: number;
+  maxBase: number;
+  normalizedThresholds: Array<[number, string]>;
+  valueArcColor: string;
+}
 
-    seriesFields.forEach((item: string) => {
-      if (!transformedData.length || !Array.isArray(transformedData[0])) {
-        // No dataset/header row available; keep rendering stable.
-        return;
-      }
+interface GaugeRenderData {
+  arc: GaugeArcRenderData;
+  text: GaugeTextRenderData;
+}
 
-      const seriesDisplayName = getSeriesDisplayName(
-        item,
-        Object.values(axisColumnMappings).flat()
-      );
+interface BuildGaugeRenderDataArgs {
+  transformedData: any[][];
+  styles: GaugeChartStyle;
+  valueColumn: VisColumn;
+}
 
-      const numericalValues: number[] = [];
+const isValidDisplayNumber = (value: unknown): value is number =>
+  value !== undefined && typeof value === 'number' && !isNaN(value);
 
-      const seriesIndex = transformedData[0].indexOf(item);
-
-      if (seriesIndex < 0) return;
-      for (let i = 1; i < transformedData.length; i++) {
-        numericalValues.push(transformedData[i][seriesIndex]);
-      }
-
-      const calculatedValue = calculateValue(numericalValues, styles.valueCalculation);
-      const validValues = numericalValues.filter((v) => !isNaN(v));
-      const maxNumber = validValues.length > 0 ? Math.max(...validValues) : 0;
-      const minNumber = validValues.length > 0 ? Math.min(...validValues) : 0;
-
-      const isValidNumber =
-        calculatedValue !== undefined &&
-        typeof calculatedValue === 'number' &&
-        !isNaN(calculatedValue);
-
-      const selectedUnit = getUnitById(styles?.unitId);
-
-      const displayValue = showDisplayValue(
-        isValidNumber,
-        selectedUnit,
-        calculatedValue,
-        styles?.decimals,
-        styles?.unitSuffix
-      );
-
-      const { minBase, maxBase } = getMaxAndMinBase(
-        minNumber,
-        maxNumber,
-        styles?.min,
-        styles?.max,
-        calculatedValue
-      );
-
-      const { textColor, mergedThresholds } = mergeThresholdsWithBase(
-        minBase,
-        maxBase,
-        styles?.thresholdOptions?.baseColor,
-        styles?.thresholdOptions?.thresholds,
-        calculatedValue
-      );
-
-      const targetThreshold = locateThreshold(mergedThresholds, calculatedValue);
-
-      const valueArcColor = targetThreshold?.color ?? 'transparent';
-
-      // Gauge colors are defined as “up to this point”, not “from this point” — each [percent, color] means use this color until this percent.
-      const normalizeThresholds =
-        maxBase > minBase
-          ? mergedThresholds.map((t, index) => {
-              if (index > 0)
-                return [
-                  (t.value - minBase) / (maxBase - minBase),
-                  mergedThresholds[index - 1].color,
-                ];
-              return [0, t.color];
-            })
-          : [];
-
-      if (normalizeThresholds.length > 0) {
-        normalizeThresholds.push([1, mergedThresholds[mergedThresholds.length - 1].color]);
-      }
-
-      const thresholdArc = {
-        type: 'gauge',
-        center: ['50%', '60%'],
-        startAngle: 200,
-        radius: '100%',
-        endAngle: -20,
-        z: 5,
-        min: minBase,
-        max: maxBase,
-        tooltip: { show: false },
-        progress: {
-          show: true,
-          width: fontSizeFactor + 2,
-          itemStyle: {
-            color: getColors().backgroundShade,
-          },
-        },
-        pointer: {
-          show: false,
-        },
-        axisLine: {
-          lineStyle: {
-            width: fontSizeFactor + 4,
-            ...(normalizeThresholds.length > 0 && { color: normalizeThresholds }),
-          },
-        },
-        axisTick: {
-          show: false,
-        },
-        splitLine: {
-          show: false,
-        },
-        axisLabel: {
-          show: false,
-        },
-        anchor: {
-          show: false,
-        },
-        title: {
-          show: false,
-        },
-        detail: {
-          show: false,
-        },
-        data: [
-          {
-            value: maxBase,
-            name: styles?.title || seriesDisplayName,
-          },
-        ],
-      } as GaugeSeriesOption;
-
-      const valueArc: GaugeSeriesOption = {
-        type: 'gauge',
-        center: ['50%', '60%'],
-        radius: '100%',
-        startAngle: 200,
-        endAngle: -20,
-        z: 10,
-        min: minBase,
-        max: maxBase,
-        tooltip: { show: false },
-        itemStyle: {
-          color: valueArcColor,
-        },
-        progress: {
-          show: true,
-          width: fontSizeFactor,
-        },
-        pointer: {
-          show: false,
-        },
-
-        axisLine: {
-          show: true,
-          lineStyle: {
-            width: fontSizeFactor,
-            color: [
-              [1, DEFAULT_GREY], // remaining grey part
-            ],
-          },
-        },
-        axisTick: {
-          show: false,
-        },
-        splitLine: {
-          show: false,
-        },
-        axisLabel: {
-          show: false,
-        },
-        detail: {
-          show: false,
-        },
-        data: [
-          {
-            value: calculatedValue,
-          },
-        ],
-      };
-
-      const textCustom: CustomSeriesOption = {
-        type: 'custom',
-        coordinateSystem: 'polar',
-        tooltip: { show: false },
-        data: [
-          {
-            value: calculatedValue,
-          },
-        ],
-        renderItem(params, api) {
-          const width = api.getWidth();
-          const height = api.getHeight();
-
-          const textSizeFactor = Math.min(width, height) / 20;
-          const valueFontSize = 2 * textSizeFactor * (selectedUnit?.fontScale ?? 1);
-          const titleFontSize = textSizeFactor / 2;
-          return {
-            type: 'group',
-            x: width * 0.5,
-            y: height * 0.6,
-            children: [
-              {
-                type: 'text' as const,
-                style: {
-                  x: 0,
-                  y: -2 * textSizeFactor * (selectedUnit?.fontScale ?? 1),
-                  text: displayValue as string,
-                  textAlign: 'center',
-                  fontSize: valueFontSize,
-                  fontWeight: 'bold',
-                  fill: styles?.useThresholdColor ? textColor : getColors().text,
-                },
-              },
-              ...(styles.showTitle
-                ? [
-                    {
-                      type: 'text' as const,
-                      style: {
-                        x: 0,
-                        y: textSizeFactor * (selectedUnit?.fontScale ?? 1),
-                        text: styles?.title || seriesDisplayName,
-                        textAlign: 'center',
-                        fontSize: titleFontSize,
-                        fill: getColors().text,
-                      },
-                    },
-                  ]
-                : []),
-            ],
-          };
-        },
-      };
-
-      series.push(valueArc);
-      series.push(thresholdArc);
-      series.push(textCustom);
-    });
-
-    newState.series = series;
-
-    return newState;
+const createGaugeText = ({
+  calculatedValue,
+  selectedUnit,
+  styles,
+  valueFieldName,
+  textColor,
+}: {
+  calculatedValue: number | undefined;
+  selectedUnit: ReturnType<typeof getUnitById>;
+  styles: GaugeChartStyle;
+  valueFieldName: string;
+  textColor: string;
+}): GaugeTextRenderData => {
+  const isValidNumber = isValidDisplayNumber(calculatedValue);
+  const effectiveTextColor = styles.useThresholdColor ? textColor : getColors().text;
+  const baseText = {
+    unitFirst: false,
+    ...(styles.showTitle && {
+      title: {
+        valueFieldName,
+        customTitle: styles.title || undefined,
+      },
+    }),
+    valueColor: effectiveTextColor,
+    titleColor: getColors().text,
+    unitColor: effectiveTextColor,
   };
 
-export const assembleGaugeSpec = <T extends BaseChartStyle>(
-  state: EChartsSpecState<T>
-): EChartsSpecState<T> => {
-  const { baseConfig, transformedData = [], series } = state;
+  if (!isValidNumber) {
+    return {
+      ...baseText,
+      value: '-',
+    };
+  }
 
-  const spec = {
-    ...baseConfig,
-    // Polar coordinate for text layer
-    angleAxis: { show: false },
-    radiusAxis: {
+  if (selectedUnit?.display) {
+    const unitDisplay = selectedUnit.display(
+      calculatedValue,
+      selectedUnit.symbol,
+      styles.decimals
+    );
+    const segments = unitDisplay.segments;
+
+    if (!segments?.length) {
+      return {
+        ...baseText,
+        value: String(unitDisplay.label),
+        unitSuffix: styles.unitSuffix,
+      };
+    }
+
+    const unitSegment = segments.find((segment) => segment.type === 'unit');
+    const valueSegment = segments.find((segment) => segment.type === 'value');
+
+    return {
+      ...baseText,
+      value: valueSegment !== undefined ? String(valueSegment.value) : String(unitDisplay.label),
+      unit: unitSegment !== undefined ? String(unitSegment.value) : undefined,
+      unitSuffix: styles.unitSuffix,
+      unitFirst: segments[0]?.type === 'unit',
+    };
+  }
+
+  return {
+    ...baseText,
+    value: formatDecimal(calculatedValue, styles.decimals),
+    unit: selectedUnit?.symbol,
+    unitSuffix: styles.unitSuffix,
+  };
+};
+
+export const buildGaugeRenderData = ({
+  transformedData,
+  styles,
+  valueColumn,
+}: BuildGaugeRenderDataArgs): GaugeRenderData | undefined => {
+  if (!transformedData.length || !Array.isArray(transformedData[0])) {
+    return undefined;
+  }
+
+  const field = valueColumn.column;
+  const seriesIndex = transformedData[0].indexOf(field);
+
+  if (seriesIndex < 0) return undefined;
+
+  const numericalValues: any[] = [];
+  for (let i = 1; i < transformedData.length; i++) {
+    numericalValues.push(transformedData[i][seriesIndex]);
+  }
+
+  const calculatedValue = calculateValue(numericalValues, styles.valueCalculation);
+  const validValues = numericalValues.filter((value) => !isNaN(value));
+  const maxNumber = validValues.length > 0 ? Math.max(...validValues) : 0;
+  const minNumber = validValues.length > 0 ? Math.min(...validValues) : 0;
+  const selectedUnit = getUnitById(styles.unitId);
+
+  const { minBase, maxBase } = getMaxAndMinBase(
+    minNumber,
+    maxNumber,
+    styles.min,
+    styles.max,
+    calculatedValue
+  );
+
+  const { textColor, mergedThresholds } = mergeThresholdsWithBase(
+    minBase,
+    maxBase,
+    styles.thresholdOptions?.baseColor,
+    styles.thresholdOptions?.thresholds,
+    calculatedValue
+  );
+
+  const targetThreshold = locateThreshold(mergedThresholds, calculatedValue);
+  const valueArcColor = targetThreshold?.color ?? 'transparent';
+
+  // Gauge colors are defined as "up to this point", not "from this point".
+  const normalizedThresholds: Array<[number, string]> =
+    maxBase > minBase
+      ? mergedThresholds.map((threshold, index) => {
+          if (index > 0) {
+            return [
+              (threshold.value - minBase) / (maxBase - minBase),
+              mergedThresholds[index - 1].color,
+            ];
+          }
+          return [0, threshold.color];
+        })
+      : [];
+
+  if (normalizedThresholds.length > 0) {
+    normalizedThresholds.push([1, mergedThresholds[mergedThresholds.length - 1].color]);
+  }
+
+  return {
+    arc: {
+      calculatedValue,
+      minBase,
+      maxBase,
+      normalizedThresholds,
+      valueArcColor,
+    },
+    text: createGaugeText({
+      calculatedValue,
+      selectedUnit,
+      styles,
+      valueFieldName: valueColumn.name,
+      textColor,
+    }),
+  };
+};
+
+const createThresholdArc = (arc: GaugeArcRenderData): GaugeSeriesOption =>
+  ({
+    type: 'gauge',
+    center: GAUGE_CENTER,
+    startAngle: GAUGE_START_ANGLE,
+    radius: GAUGE_RADIUS,
+    endAngle: GAUGE_END_ANGLE,
+    z: 5,
+    min: arc.minBase,
+    max: arc.maxBase,
+    tooltip: { show: false },
+    progress: {
+      show: true,
+      width: GAUGE_ARC_WIDTH + 2,
+      itemStyle: {
+        color: getColors().backgroundShade,
+      },
+    },
+    pointer: {
       show: false,
     },
-    polar: {
-      center: ['50%', '60%'],
-      radius: '100%',
+    axisLine: {
+      lineStyle: {
+        width: GAUGE_ARC_WIDTH + 4,
+        ...(arc.normalizedThresholds.length > 0 && { color: arc.normalizedThresholds }),
+      },
     },
-    dataset: { source: transformedData },
-    series,
-  };
+    axisTick: {
+      show: false,
+    },
+    splitLine: {
+      show: false,
+    },
+    axisLabel: {
+      show: false,
+    },
+    anchor: {
+      show: false,
+    },
+    title: {
+      show: false,
+    },
+    detail: {
+      show: false,
+    },
+    data: [
+      {
+        value: arc.maxBase,
+      },
+    ],
+  }) as GaugeSeriesOption;
 
-  return { ...state, spec };
-};
+const createValueArc = (arc: GaugeArcRenderData): GaugeSeriesOption => ({
+  type: 'gauge',
+  center: GAUGE_CENTER,
+  radius: GAUGE_RADIUS,
+  startAngle: GAUGE_START_ANGLE,
+  endAngle: GAUGE_END_ANGLE,
+  z: 10,
+  min: arc.minBase,
+  max: arc.maxBase,
+  tooltip: { show: false },
+  itemStyle: {
+    color: arc.valueArcColor,
+  },
+  progress: {
+    show: true,
+    width: GAUGE_ARC_WIDTH,
+  },
+  pointer: {
+    show: false,
+  },
+  axisLine: {
+    show: true,
+    lineStyle: {
+      width: GAUGE_ARC_WIDTH,
+      color: [
+        [1, DEFAULT_GREY], // remaining grey part
+      ],
+    },
+  },
+  axisTick: {
+    show: false,
+  },
+  splitLine: {
+    show: false,
+  },
+  axisLabel: {
+    show: false,
+  },
+  title: {
+    show: false,
+  },
+  detail: {
+    show: false,
+  },
+  data: [
+    {
+      value: arc.calculatedValue,
+    },
+  ],
+});
+
+export const createGaugeSeries = (arc?: GaugeArcRenderData): GaugeSeriesOption[] =>
+  arc ? [createValueArc(arc), createThresholdArc(arc)] : [];

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
@@ -94,11 +94,7 @@ const createGaugeText = ({
   }
 
   if (selectedUnit?.display) {
-    const unitDisplay = selectedUnit.display(
-      calculatedValue,
-      selectedUnit.symbol,
-      styles.decimals
-    );
+    const unitDisplay = selectedUnit.display(calculatedValue, selectedUnit.symbol, styles.decimals);
     const segments = unitDisplay.segments;
 
     if (!segments?.length) {

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.scss
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.scss
@@ -1,0 +1,65 @@
+.gauge-component {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.gauge-chart {
+  width: 100%;
+  height: 100%;
+}
+
+.gauge-text-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.gauge-text-content {
+  position: absolute;
+  top: 55%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 0 $euiSizeM;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.gauge-value {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  max-width: 100%;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gauge-value-number,
+.gauge-value-unit {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gauge-value-unit--suffix {
+  margin-left: 0.2em;
+}
+
+.gauge-title {
+  max-width: 100%;
+  margin-top: $euiSizeS;
+  font-weight: 400;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import { GaugeChartRender } from './gauge_component';
+
+jest.mock('../echarts_render', () => ({
+  EchartsRender: jest.fn(() => <div data-test-subj="gaugeEchartsRender" />),
+}));
+
+describe('GaugeChartRender', () => {
+  beforeEach(() => {
+    global.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the gauge chart and html text overlay', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '9.25',
+          title: {
+            valueFieldName: 'Value',
+          },
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#111111',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('gaugeEchartsRender')).toBeInTheDocument();
+    expect(screen.getByText('9.25')).toBeInTheDocument();
+    expect(screen.getByText('Value')).toBeInTheDocument();
+  });
+
+  it('renders suffix units separately from value text', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '30',
+          unit: 'ms',
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('30')).toHaveClass('gauge-value-number');
+    expect(screen.getByText('ms')).toHaveClass('gauge-value-unit--suffix');
+  });
+
+  it('renders prefix units before the value', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '30',
+          unit: '$',
+          unitFirst: true,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    const value = screen.getByText('30');
+    const unit = screen.getByText('$');
+
+    expect(unit.compareDocumentPosition(value)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('uses the series name for split auto titles', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        seriesName="jpg"
+        text={{
+          value: '30',
+          title: {
+            valueFieldName: 'COUNT()',
+          },
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('jpg')).toBeInTheDocument();
+    expect(screen.queryByText('COUNT()')).not.toBeInTheDocument();
+    expect(screen.queryByText('jpg COUNT()')).not.toBeInTheDocument();
+  });
+
+  it('prefixes custom titles with the series name', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        seriesName="jpg"
+        text={{
+          value: '30',
+          title: {
+            valueFieldName: 'COUNT()',
+            customTitle: 'Custom title',
+          },
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('jpg Custom title')).toBeInTheDocument();
+    expect(screen.queryByText('Custom title')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import { GaugeChartRender } from './gauge_component';
+
+jest.mock('../echarts_render', () => ({
+  EchartsRender: jest.fn(() => <div data-test-subj="gaugeEchartsRender" />),
+}));
+
+describe('GaugeChartRender', () => {
+  beforeEach(() => {
+    global.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the gauge chart and html text overlay', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '9.25',
+          title: {
+            valueFieldName: 'Value',
+          },
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#111111',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('gaugeEchartsRender')).toBeInTheDocument();
+    expect(screen.getByText('9.25')).toBeInTheDocument();
+    expect(screen.getByText('Value')).toBeInTheDocument();
+  });
+
+  it('renders suffix units separately from value text', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '30',
+          unit: 'ms',
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('30')).toHaveClass('gauge-value-number');
+    expect(screen.getByText('ms')).toHaveClass('gauge-value-unit--suffix');
+  });
+
+  it('renders prefix units before the value', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '30',
+          unit: '$',
+          unitFirst: true,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    const value = screen.getByText('30');
+    const unit = screen.getByText('$');
+
+    expect(unit.compareDocumentPosition(value)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('renders rate-style custom suffixes directly after the formatted value', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        text={{
+          value: '30.00',
+          unit: '$',
+          unitSuffix: '/sec',
+          unitFirst: true,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('/sec')).toHaveStyle({ marginLeft: '0' });
+  });
+
+  it('uses the series name for split auto titles', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        seriesName="jpg"
+        text={{
+          value: '30',
+          title: {
+            valueFieldName: 'COUNT()',
+          },
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('jpg')).toBeInTheDocument();
+    expect(screen.queryByText('COUNT()')).not.toBeInTheDocument();
+    expect(screen.queryByText('jpg COUNT()')).not.toBeInTheDocument();
+  });
+
+  it('prefixes custom titles with the series name', () => {
+    render(
+      <GaugeChartRender
+        spec={{ series: [] }}
+        seriesName="jpg"
+        text={{
+          value: '30',
+          title: {
+            valueFieldName: 'COUNT()',
+            customTitle: 'Custom title',
+          },
+          unitFirst: false,
+          valueColor: '#111111',
+          titleColor: '#222222',
+          unitColor: '#333333',
+        }}
+      />
+    );
+
+    expect(screen.getByText('jpg Custom title')).toBeInTheDocument();
+    expect(screen.queryByText('Custom title')).not.toBeInTheDocument();
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { debounce } from 'lodash';
+import { EChartsOption } from 'echarts';
+import { EchartsRender } from '../echarts_render';
+import { appendUnitSuffix } from '../style_panel/unit/collection';
+import { GaugeTextRenderData } from './gauge_chart_utils';
+
+import './gauge_component.scss';
+
+interface GaugeChartRenderProps {
+  spec: EChartsOption;
+  text?: GaugeTextRenderData;
+  seriesName?: string;
+}
+
+const constrainFontSizeByWidth = ({
+  containerWidth,
+  text,
+  fontSize,
+  minSize,
+  maxSize,
+  paddingRatio = 0.2,
+  charWidthRatio = 0.6,
+}: {
+  containerWidth: number;
+  text: string;
+  fontSize: number;
+  minSize: number;
+  maxSize: number;
+  paddingRatio?: number;
+  charWidthRatio?: number;
+}) => {
+  if (!text || containerWidth <= 0) {
+    return Math.max(minSize, Math.min(maxSize, fontSize));
+  }
+
+  const availableWidth = containerWidth * (1 - paddingRatio);
+  const maxSizeByWidth = availableWidth / (text.length * charWidthRatio);
+  return Math.max(minSize, Math.min(maxSize, fontSize, maxSizeByWidth));
+};
+
+export const GaugeChartRender: React.FC<GaugeChartRenderProps> = ({ spec, text, seriesName }) => {
+  const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handlerRef = useRef(
+    debounce((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainerDimensions({ width, height });
+      }
+    }, 100)
+  );
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const handler = handlerRef.current;
+    const resizeObserver = new ResizeObserver(handler);
+    resizeObserver.observe(element);
+
+    return () => {
+      handler.cancel();
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  const title = (() => {
+    if (!text?.title) {
+      return undefined;
+    }
+    if (seriesName) {
+      return text.title.customTitle ? `${seriesName} ${text.title.customTitle}` : seriesName;
+    }
+    return text.title.customTitle ?? text.title.valueFieldName;
+  })();
+
+  const valueWithUnit =
+    text && text.unitFirst
+      ? `${text.unit ?? ''}${text.value}`
+      : `${text?.value ?? ''}${text?.unit ?? ''}`;
+  const fullValueText = appendUnitSuffix(valueWithUnit, text?.unitSuffix);
+
+  const fontSizes = useMemo(() => {
+    if (!text) {
+      return { value: 40, title: 12, unit: 18 };
+    }
+
+    const { width, height } = containerDimensions;
+    const measuredSize = width > 0 && height > 0 ? Math.min(width, height) : 400;
+    const valueSize = constrainFontSizeByWidth({
+      containerWidth: width || measuredSize,
+      text: fullValueText,
+      fontSize: measuredSize * 0.15,
+      minSize: 16,
+      maxSize: 72,
+    });
+    const titleSize = constrainFontSizeByWidth({
+      containerWidth: width || measuredSize,
+      text: title ?? '',
+      fontSize: measuredSize * 0.05,
+      minSize: 14,
+      maxSize: 36,
+    });
+    const unitSize = text.unitFirst ? valueSize * 0.85 : valueSize * 0.45;
+
+    return {
+      value: valueSize,
+      title: titleSize,
+      unit: unitSize,
+    };
+  }, [containerDimensions, fullValueText, text, title]);
+
+  return (
+    <div className="gauge-component" ref={containerRef}>
+      {text && (
+        <div className="gauge-text-overlay">
+          <div className="gauge-text-content">
+            <div className="gauge-value" title={fullValueText}>
+              {text.unitFirst && text.unit && (
+                <span
+                  className="gauge-value-unit"
+                  style={{ color: text.unitColor, fontSize: fontSizes.unit }}
+                >
+                  {text.unit}
+                </span>
+              )}
+              <span
+                className="gauge-value-number"
+                style={{ color: text.valueColor, fontSize: fontSizes.value }}
+              >
+                {text.value}
+              </span>
+              {!text.unitFirst && text.unit && (
+                <span
+                  className="gauge-value-unit gauge-value-unit--suffix"
+                  style={{ color: text.unitColor, fontSize: fontSizes.unit }}
+                >
+                  {text.unit}
+                </span>
+              )}
+              {text.unitSuffix && (
+                <span
+                  className="gauge-value-unit gauge-value-custom-suffix"
+                  style={{
+                    color: text.unitColor,
+                    fontSize: fontSizes.unit,
+                    marginLeft: text.unitSuffix.startsWith('/') ? 0 : '0.2em',
+                  }}
+                >
+                  {text.unitSuffix}
+                </span>
+              )}
+            </div>
+            {title && (
+              <div
+                className="gauge-title"
+                title={title}
+                style={{ color: text.titleColor, fontSize: fontSizes.title }}
+              >
+                {title}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+      <div className="gauge-chart">
+        <EchartsRender spec={spec} />
+      </div>
+    </div>
+  );
+};

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
@@ -46,20 +46,17 @@ const constrainFontSizeByWidth = ({
 export const GaugeChartRender: React.FC<GaugeChartRenderProps> = ({ spec, text, seriesName }) => {
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
-  const handlerRef = useRef(
-    debounce((entries: ResizeObserverEntry[]) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setContainerDimensions({ width, height });
-      }
-    }, 100)
-  );
 
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
 
-    const handler = handlerRef.current;
+    const handler = debounce((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainerDimensions({ width, height });
+      }
+    }, 100);
     const resizeObserver = new ResizeObserver(handler);
     resizeObserver.observe(element);
 

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { debounce } from 'lodash';
+import { EChartsOption } from 'echarts';
+import { EchartsRender } from '../echarts_render';
+import { GaugeTextRenderData } from './gauge_chart_utils';
+
+import './gauge_component.scss';
+
+interface GaugeChartRenderProps {
+  spec: EChartsOption;
+  text?: GaugeTextRenderData;
+  seriesName?: string;
+}
+
+const constrainFontSizeByWidth = ({
+  containerWidth,
+  text,
+  fontSize,
+  minSize,
+  maxSize,
+  paddingRatio = 0.2,
+  charWidthRatio = 0.6,
+}: {
+  containerWidth: number;
+  text: string;
+  fontSize: number;
+  minSize: number;
+  maxSize: number;
+  paddingRatio?: number;
+  charWidthRatio?: number;
+}) => {
+  if (!text || containerWidth <= 0) {
+    return Math.max(minSize, Math.min(maxSize, fontSize));
+  }
+
+  const availableWidth = containerWidth * (1 - paddingRatio);
+  const maxSizeByWidth = availableWidth / (text.length * charWidthRatio);
+  return Math.max(minSize, Math.min(maxSize, fontSize, maxSizeByWidth));
+};
+
+export const GaugeChartRender: React.FC<GaugeChartRenderProps> = ({ spec, text, seriesName }) => {
+  const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handlerRef = useRef(
+    debounce((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainerDimensions({ width, height });
+      }
+    }, 100)
+  );
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const handler = handlerRef.current;
+    const resizeObserver = new ResizeObserver(handler);
+    resizeObserver.observe(element);
+
+    return () => {
+      handler.cancel();
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  const title = (() => {
+    if (!text?.title) {
+      return undefined;
+    }
+    if (seriesName) {
+      return text.title.customTitle ? `${seriesName} ${text.title.customTitle}` : seriesName;
+    }
+    return text.title.customTitle ?? text.title.valueFieldName;
+  })();
+
+  const fullValueText =
+    text && text.unitFirst
+      ? `${text.unit ?? ''}${text.value}`
+      : `${text?.value ?? ''}${text?.unit ?? ''}`;
+
+  const fontSizes = useMemo(() => {
+    if (!text) {
+      return { value: 40, title: 12, unit: 18 };
+    }
+
+    const { width, height } = containerDimensions;
+    const measuredSize = width > 0 && height > 0 ? Math.min(width, height) : 400;
+    const valueSize = constrainFontSizeByWidth({
+      containerWidth: width || measuredSize,
+      text: fullValueText,
+      fontSize: measuredSize * 0.15,
+      minSize: 16,
+      maxSize: 72,
+    });
+    const titleSize = constrainFontSizeByWidth({
+      containerWidth: width || measuredSize,
+      text: title ?? '',
+      fontSize: measuredSize * 0.05,
+      minSize: 14,
+      maxSize: 36,
+    });
+    const unitSize = text.unitFirst ? valueSize * 0.85 : valueSize * 0.45;
+
+    return {
+      value: valueSize,
+      title: titleSize,
+      unit: unitSize,
+    };
+  }, [containerDimensions, fullValueText, text, title]);
+
+  return (
+    <div className="gauge-component" ref={containerRef}>
+      {text && (
+        <div className="gauge-text-overlay">
+          <div className="gauge-text-content">
+            <div className="gauge-value" title={fullValueText}>
+              {text.unitFirst && text.unit && (
+                <span
+                  className="gauge-value-unit"
+                  style={{ color: text.unitColor, fontSize: fontSizes.unit }}
+                >
+                  {text.unit}
+                </span>
+              )}
+              <span
+                className="gauge-value-number"
+                style={{ color: text.valueColor, fontSize: fontSizes.value }}
+              >
+                {text.value}
+              </span>
+              {!text.unitFirst && text.unit && (
+                <span
+                  className="gauge-value-unit gauge-value-unit--suffix"
+                  style={{ color: text.unitColor, fontSize: fontSizes.unit }}
+                >
+                  {text.unit}
+                </span>
+              )}
+            </div>
+            {title && (
+              <div
+                className="gauge-title"
+                title={title}
+                style={{ color: text.titleColor, fontSize: fontSizes.title }}
+              >
+                {title}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+      <div className="gauge-chart">
+        <EchartsRender spec={spec} />
+      </div>
+    </div>
+  );
+};

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_component.tsx
@@ -47,20 +47,17 @@ const constrainFontSizeByWidth = ({
 export const GaugeChartRender: React.FC<GaugeChartRenderProps> = ({ spec, text, seriesName }) => {
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
-  const handlerRef = useRef(
-    debounce((entries: ResizeObserverEntry[]) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setContainerDimensions({ width, height });
-      }
-    }, 100)
-  );
 
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
 
-    const handler = handlerRef.current;
+    const handler = debounce((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainerDimensions({ width, height });
+      }
+    }, 100);
     const resizeObserver = new ResizeObserver(handler);
     resizeObserver.observe(element);
 

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.test.tsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import { createGaugeConfig, defaultGaugeChartStyles } from './gauge_vis_config';
 import { GaugeVisStyleControls } from './gauge_vis_options';
+import { GaugeChartRender } from './gauge_component';
+import { VisFieldType } from '../types';
 
 // Mock the React.createElement function
 jest.mock('react', () => ({
@@ -54,5 +56,27 @@ describe('createGaugeConfig', () => {
     renderFunction(mockProps);
     // Verify that React.createElement was called with the correct arguments
     expect(React.createElement).toHaveBeenCalledWith(GaugeVisStyleControls, mockProps);
+  });
+
+  it('passes render context series name to GaugeChartRender', () => {
+    const config = createGaugeConfig();
+    const renderFunction = config.getRules()[0].render;
+    const valueColumn = {
+      id: 1,
+      name: 'COUNT()',
+      schema: VisFieldType.Numerical,
+      column: 'count',
+    };
+
+    const renderedGauge = renderFunction({
+      data: [{ count: 519, extension: 'jpg' }],
+      allData: [{ count: 519, extension: 'jpg' }],
+      styleOptions: config.ui.style.defaults,
+      axisColumnMappings: { value: [valueColumn] },
+      renderContext: { seriesName: 'jpg' },
+    }) as React.ReactElement;
+
+    expect(renderedGauge.type).toBe(GaugeChartRender);
+    expect(renderedGauge.props.seriesName).toBe('jpg');
   });
 });

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
@@ -10,7 +10,7 @@ import { ThresholdOptions, AxisRole, VisFieldType, Threshold, StandardOptions } 
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
 import { createGauge } from './to_expression';
-import { EchartsRender } from '../echarts_render';
+import { GaugeChartRender } from './gauge_component';
 
 export interface GaugeChartStyleOptions extends StandardOptions {
   showTitle?: boolean;
@@ -64,10 +64,16 @@ export const createGaugeConfig = (): VisualizationType<'gauge'> => ({
         render(props) {
           const value = props.axisColumnMappings.value?.[0];
           if (!value) throw Error('Missing axis config for gauge chart');
-          const spec = createGauge(props.data, props.styleOptions, {
+          const gauge = createGauge(props.data, props.styleOptions, {
             [AxisRole.Value]: value,
           });
-          return <EchartsRender spec={spec ?? {}} />;
+          return (
+            <GaugeChartRender
+              spec={gauge.spec}
+              text={gauge.text}
+              seriesName={props.renderContext?.seriesName}
+            />
+          );
         },
       },
     ];

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
@@ -10,7 +10,7 @@ import { ThresholdOptions, AxisRole, VisFieldType, Threshold } from '../types';
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
 import { createGauge } from './to_expression';
-import { EchartsRender } from '../echarts_render';
+import { GaugeChartRender } from './gauge_component';
 
 export interface GaugeChartStyleOptions {
   showTitle?: boolean;
@@ -64,10 +64,16 @@ export const createGaugeConfig = (): VisualizationType<'gauge'> => ({
         render(props) {
           const value = props.axisColumnMappings.value?.[0];
           if (!value) throw Error('Missing axis config for gauge chart');
-          const spec = createGauge(props.data, props.styleOptions, {
+          const gauge = createGauge(props.data, props.styleOptions, {
             [AxisRole.Value]: value,
           });
-          return <EchartsRender spec={spec ?? {}} />;
+          return (
+            <GaugeChartRender
+              spec={gauge.spec}
+              text={gauge.text}
+              seriesName={props.renderContext?.seriesName}
+            />
+          );
         },
       },
     ];

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_options.test.tsx
@@ -54,12 +54,14 @@ jest.mock('../style_panel/standard_options/standard_options_panel', () => ({
 describe('GaugeVisStyleControls', () => {
   const mockProps: GaugeVisStyleControlsProps = {
     axisColumnMappings: {
-      value: {
-        id: 1,
-        name: 'value',
-        schema: VisFieldType.Numerical,
-        column: 'field-1',
-      },
+      value: [
+        {
+          id: 1,
+          name: 'value',
+          schema: VisFieldType.Numerical,
+          column: 'field-1',
+        },
+      ],
     },
     updateVisualization: jest.fn(),
     styleOptions: defaultGaugeChartStyles,
@@ -105,7 +107,9 @@ describe('GaugeVisStyleControls', () => {
     };
     render(<GaugeVisStyleControls {...propsWithTitle} />);
 
-    expect(screen.getByPlaceholderText('Title')).toBeInTheDocument();
+    const titleInput = screen.getByPlaceholderText('Auto');
+    expect(titleInput).toBeInTheDocument();
+    expect(titleInput).toHaveValue('');
   });
 
   it('calls onStyleChange when title is changed', async () => {
@@ -115,7 +119,7 @@ describe('GaugeVisStyleControls', () => {
     };
     render(<GaugeVisStyleControls {...propsWithTitle} />);
 
-    const titleInput = screen.getByPlaceholderText('Title');
+    const titleInput = screen.getByPlaceholderText('Auto');
     await fireEvent.change(titleInput, {
       target: { value: 'New Title' },
     });

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_options.tsx
@@ -8,7 +8,6 @@ import { isEmpty } from 'lodash';
 import { i18n } from '@osd/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSwitch, EuiSpacer } from '@elastic/eui';
 import { GaugeChartStyle } from './gauge_vis_config';
-import { AxisRole } from '../types';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
 import { StyleControlsProps } from '../utils/use_visualization_types';
 import { StyleAccordion } from '../style_panel/style_accordion';
@@ -78,11 +77,9 @@ export const GaugeVisStyleControls: React.FC<GaugeVisStyleControlsProps> = ({
               {styleOptions.showTitle && (
                 <EuiFormRow>
                   <DebouncedFieldText
-                    value={
-                      styleOptions.title || axisColumnMappings[AxisRole.Value]?.[0]?.name || ''
-                    }
+                    value={styleOptions.title}
                     placeholder={i18n.translate('explore.vis.gauge.title', {
-                      defaultMessage: 'Title',
+                      defaultMessage: 'Auto',
                     })}
                     onChange={(text) => updateStyleOption('title', text)}
                   />

--- a/src/plugins/explore/public/components/visualizations/gauge/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/to_expression.test.ts
@@ -22,21 +22,94 @@ describe('createGauge', () => {
   };
 
   it('creates an ECharts gauge spec with series and dataset', () => {
-    const spec = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
+    const gauge = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
 
-    expect(spec).toHaveProperty('dataset');
-    expect(spec).toHaveProperty('series');
-    expect(spec).toHaveProperty('polar');
-    // @ts-expect-error TS18048 TODO(ts-upgrade): fixme
-    expect(Array.isArray(spec.series)).toBe(true);
+    expect(gauge.spec).toHaveProperty('dataset');
+    expect(gauge.spec).toHaveProperty('series');
+    expect(gauge.text).toMatchObject({
+      value: '30',
+      title: {
+        valueFieldName: 'value',
+      },
+    });
+    expect(Array.isArray(gauge.spec.series)).toBe(true);
   });
 
-  it('produces gauge-type series', () => {
-    const spec = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
+  it('produces arc-only gauge-type series', () => {
+    const gauge = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
 
-    // @ts-expect-error TS18048 TODO(ts-upgrade): fixme
-    const gaugeSeries = spec.series.filter((s: any) => s.type === 'gauge');
-    expect(gaugeSeries.length).toBeGreaterThanOrEqual(1);
+    const gaugeSeries = (gauge.spec.series as any[]).filter((s: any) => s.type === 'gauge');
+    const customSeries = (gauge.spec.series as any[]).filter((s: any) => s.type === 'custom');
+    expect(gaugeSeries).toHaveLength(2);
+    expect(customSeries).toHaveLength(0);
+  });
+
+  it('adds internal padding around gauge arcs', () => {
+    const gauge = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
+
+    const gaugeSeries = (gauge.spec.series as any[]).filter((s: any) => s.type === 'gauge');
+    expect(gaugeSeries.every((series: any) => series.radius === '92%')).toBe(true);
+  });
+
+  it('renders zero as a valid value', () => {
+    const gauge = createGauge([{ value: 0 }], defaultGaugeChartStyles, mockAxisColumnMappings);
+
+    expect(gauge.text).toMatchObject({
+      value: '0',
+    });
+  });
+
+  it('splits formatted units from value text when unit formatter provides segments', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, unitId: 'millisecond' },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      value: '30',
+      unit: 'milliseconds',
+      unitFirst: false,
+    });
+  });
+
+  it('supports prefix units', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, unitId: 'dollars' },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      value: '30',
+      unit: '$',
+      unitFirst: true,
+    });
+  });
+
+  it('keeps custom title separate from auto title for renderer-level title composition', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, title: 'Custom title' },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      title: {
+        valueFieldName: 'value',
+        customTitle: 'Custom title',
+      },
+    });
+  });
+
+  it('omits title render data when show title is disabled', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, showTitle: false },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).not.toHaveProperty('title');
   });
 
   it('throws when no value column is provided', () => {

--- a/src/plugins/explore/public/components/visualizations/gauge/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/to_expression.test.ts
@@ -22,21 +22,114 @@ describe('createGauge', () => {
   };
 
   it('creates an ECharts gauge spec with series and dataset', () => {
-    const spec = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
+    const gauge = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
 
-    expect(spec).toHaveProperty('dataset');
-    expect(spec).toHaveProperty('series');
-    expect(spec).toHaveProperty('polar');
-    // @ts-expect-error TS18048 TODO(ts-upgrade): fixme
-    expect(Array.isArray(spec.series)).toBe(true);
+    expect(gauge.spec).toHaveProperty('dataset');
+    expect(gauge.spec).toHaveProperty('series');
+    expect(gauge.text).toMatchObject({
+      value: '30',
+      title: {
+        valueFieldName: 'value',
+      },
+    });
+    expect(Array.isArray(gauge.spec.series)).toBe(true);
   });
 
-  it('produces gauge-type series', () => {
-    const spec = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
+  it('produces arc-only gauge-type series', () => {
+    const gauge = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
 
-    // @ts-expect-error TS18048 TODO(ts-upgrade): fixme
-    const gaugeSeries = spec.series.filter((s: any) => s.type === 'gauge');
-    expect(gaugeSeries.length).toBeGreaterThanOrEqual(1);
+    const gaugeSeries = (gauge.spec.series as any[]).filter((s: any) => s.type === 'gauge');
+    const customSeries = (gauge.spec.series as any[]).filter((s: any) => s.type === 'custom');
+    expect(gaugeSeries).toHaveLength(2);
+    expect(customSeries).toHaveLength(0);
+  });
+
+  it('adds internal padding around gauge arcs', () => {
+    const gauge = createGauge(mockData, defaultGaugeChartStyles, mockAxisColumnMappings);
+
+    const gaugeSeries = (gauge.spec.series as any[]).filter((s: any) => s.type === 'gauge');
+    expect(gaugeSeries.every((series: any) => series.radius === '92%')).toBe(true);
+  });
+
+  it('renders zero as a valid value', () => {
+    const gauge = createGauge([{ value: 0 }], defaultGaugeChartStyles, mockAxisColumnMappings);
+
+    expect(gauge.text).toMatchObject({
+      value: '0',
+    });
+  });
+
+  it('splits formatted units from value text when unit formatter provides segments', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, unitId: 'millisecond' },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      value: '30',
+      unit: 'milliseconds',
+      unitFirst: false,
+    });
+  });
+
+  it('supports prefix units', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, unitId: 'dollars' },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      value: '30',
+      unit: '$',
+      unitFirst: true,
+    });
+  });
+
+  it('preserves decimal formatting and custom unit suffixes', () => {
+    const gauge = createGauge(
+      mockData,
+      {
+        ...defaultGaugeChartStyles,
+        unitId: 'dollars',
+        decimals: 2,
+        unitSuffix: '/sec',
+      },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      value: '30.00',
+      unit: '$',
+      unitSuffix: '/sec',
+      unitFirst: true,
+    });
+  });
+
+  it('keeps custom title separate from auto title for renderer-level title composition', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, title: 'Custom title' },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).toMatchObject({
+      title: {
+        valueFieldName: 'value',
+        customTitle: 'Custom title',
+      },
+    });
+  });
+
+  it('omits title render data when show title is disabled', () => {
+    const gauge = createGauge(
+      mockData,
+      { ...defaultGaugeChartStyles, showTitle: false },
+      mockAxisColumnMappings
+    );
+
+    expect(gauge.text).not.toHaveProperty('title');
   });
 
   it('throws when no value column is provided', () => {

--- a/src/plugins/explore/public/components/visualizations/gauge/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/to_expression.ts
@@ -5,9 +5,9 @@
 
 import { GaugeChartStyle } from './gauge_vis_config';
 import { AxisRole, VisColumn } from '../types';
-import { createGaugeSeries, assembleGaugeSpec } from './gauge_chart_utils';
-import { pipe, createBaseConfig } from '../utils/echarts_spec';
-import { convertTo2DArray, transform } from '../utils/data_transformation';
+import { buildGaugeRenderData, createGaugeSeries } from './gauge_chart_utils';
+import { convertTo2DArray } from '../utils/data_transformation';
+import { createBaseConfig } from '../utils/echarts_spec';
 
 export const createGauge = (
   transformedData: Array<Record<string, any>>,
@@ -15,16 +15,25 @@ export const createGauge = (
   axisColumnMappings: { [AxisRole.Value]: VisColumn }
 ) => {
   const valueColumn = axisColumnMappings[AxisRole.Value];
-
-  const result = pipe(
-    transform(convertTo2DArray()),
-    createBaseConfig({}),
-    createGaugeSeries({ styles: styleOptions, seriesFields: [valueColumn.column] }),
-    assembleGaugeSpec
-  )({
+  const tableData = convertTo2DArray()(transformedData);
+  const baseConfig = createBaseConfig({})({
     data: transformedData,
     styles: styleOptions,
     axisColumnMappings,
+  }).baseConfig;
+
+  const gaugeData = buildGaugeRenderData({
+    transformedData: tableData,
+    styles: styleOptions,
+    valueColumn,
   });
-  return result.spec;
+
+  return {
+    spec: {
+      ...baseConfig,
+      dataset: { source: tableData },
+      series: createGaugeSeries(gaugeData?.arc),
+    },
+    text: gaugeData?.text,
+  };
 };

--- a/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
@@ -286,14 +286,6 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
   // State for container dimensions
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
   const overlayRef = useRef<HTMLDivElement>(null);
-  const handlerRef = useRef(
-    debounce((entries: ResizeObserverEntry[]) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setContainerDimensions({ width, height });
-      }
-    }, 100)
-  );
 
   // Calculate text data with memoization
   const textData = useMemo(() => {
@@ -308,7 +300,12 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
     const element = overlayRef.current;
     if (!element) return;
 
-    const handler = handlerRef.current;
+    const handler = debounce((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainerDimensions({ width, height });
+      }
+    }, 100);
     const resizeObserver = new ResizeObserver(handler);
 
     resizeObserver.observe(element);

--- a/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
@@ -275,14 +275,6 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
   // State for container dimensions
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
   const overlayRef = useRef<HTMLDivElement>(null);
-  const handlerRef = useRef(
-    debounce((entries: ResizeObserverEntry[]) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setContainerDimensions({ width, height });
-      }
-    }, 100)
-  );
 
   // Calculate text data with memoization
   const textData = useMemo(() => {
@@ -297,7 +289,12 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
     const element = overlayRef.current;
     if (!element) return;
 
-    const handler = handlerRef.current;
+    const handler = debounce((entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainerDimensions({ width, height });
+      }
+    }, 100);
     const resizeObserver = new ResizeObserver(handler);
 
     resizeObserver.observe(element);

--- a/src/plugins/explore/public/components/visualizations/split_container.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/split_container.test.tsx
@@ -133,4 +133,25 @@ describe('SplitContainer', () => {
 
     expect(container.querySelector('.splitChartInstance')).toHaveStyle({ minHeight: '60px' });
   });
+
+  it('uses 300px as the default horizontal item min width', () => {
+    const { container } = render(
+      <SplitContainer groups={createGroups(1)} layout="horizontal" renderChart={mockRenderChart} />
+    );
+
+    expect(container.querySelector('.splitChartInstance')).toHaveStyle({ minWidth: '300px' });
+  });
+
+  it('uses the configured horizontal item min width', () => {
+    const { container } = render(
+      <SplitContainer
+        groups={createGroups(1)}
+        layout="horizontal"
+        horizontalItemMinWidth={180}
+        renderChart={mockRenderChart}
+      />
+    );
+
+    expect(container.querySelector('.splitChartInstance')).toHaveStyle({ minWidth: '180px' });
+  });
 });

--- a/src/plugins/explore/public/components/visualizations/split_container.tsx
+++ b/src/plugins/explore/public/components/visualizations/split_container.tsx
@@ -14,6 +14,7 @@ interface SplitContainerProps {
   layout: SplitLayout;
   showLabel?: boolean;
   verticalItemMinHeight?: number;
+  horizontalItemMinWidth?: number;
   renderChart: (groupKey: string) => React.ReactNode;
 }
 
@@ -28,11 +29,14 @@ export function getColumnCount(width: number): number {
   return 1;
 }
 
+const DEFAULT_HORIZONTAL_ITEM_MIN_WIDTH = 300;
+
 export const SplitContainer: React.FC<SplitContainerProps> = ({
   groups,
   layout,
   showLabel = false,
   verticalItemMinHeight = 200,
+  horizontalItemMinWidth = DEFAULT_HORIZONTAL_ITEM_MIN_WIDTH,
   renderChart,
 }) => {
   const [columns, setColumns] = useState(1);
@@ -62,7 +66,7 @@ export const SplitContainer: React.FC<SplitContainerProps> = ({
 
   const itemStyles = useMemo((): React.CSSProperties[] => {
     if (layout === 'horizontal') {
-      return groups.map(() => ({ flex: 1, minWidth: 300 }));
+      return groups.map(() => ({ flex: 1, minWidth: horizontalItemMinWidth }));
     }
     if (layout === 'vertical') {
       return groups.map(() => ({ flex: 1, minHeight: verticalItemMinHeight }));
@@ -77,7 +81,7 @@ export const SplitContainer: React.FC<SplitContainerProps> = ({
       }
       return { gridColumn: `span ${span}` };
     });
-  }, [layout, columns, groups, verticalItemMinHeight]);
+  }, [layout, columns, groups, verticalItemMinHeight, horizontalItemMinWidth]);
 
   const layoutClass = `splitContainer--${layout || 'auto'}`;
 

--- a/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
@@ -457,6 +457,57 @@ describe('VisualizationRender', () => {
     );
   });
 
+  it.each(['gauge', 'pie'] as ChartType[])(
+    'uses compact horizontal split item width for %s charts',
+    (chartType) => {
+      const config: RenderChartConfig = {
+        type: chartType,
+        styles: {},
+        axesMapping: { value: 'count' },
+        splitField: 'field1',
+        splitLayout: 'horizontal',
+      };
+
+      const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+      const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(config);
+      const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+      render(
+        <VisualizationRender data$={data$} config$={visConfig$} showRawTable$={showRawTable$} />
+      );
+
+      expect(mockSplitContainer.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          horizontalItemMinWidth: 180,
+        })
+      );
+    }
+  );
+
+  it('uses the default horizontal split item width for other charts', () => {
+    const config: RenderChartConfig = {
+      type: 'line',
+      styles: {},
+      axesMapping: { value: 'count' },
+      splitField: 'field1',
+      splitLayout: 'horizontal',
+    };
+
+    const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+    const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(config);
+    const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+    render(
+      <VisualizationRender data$={data$} config$={visConfig$} showRawTable$={showRawTable$} />
+    );
+
+    expect(mockSplitContainer.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        horizontalItemMinWidth: undefined,
+      })
+    );
+  });
+
   it('returns null when no matching rule is found', () => {
     mockFindRuleByAxesMapping.mockReturnValue(null);
 

--- a/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
@@ -371,6 +371,57 @@ describe('VisualizationRender', () => {
     );
   });
 
+  it.each(['gauge', 'pie'] as ChartType[])(
+    'uses compact horizontal split item width for %s charts',
+    (chartType) => {
+      const config: RenderChartConfig = {
+        type: chartType,
+        styles: {},
+        axesMapping: { value: 'count' },
+        splitField: 'field1',
+        splitLayout: 'horizontal',
+      };
+
+      const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+      const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(config);
+      const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+      render(
+        <VisualizationRender data$={data$} config$={visConfig$} showRawTable$={showRawTable$} />
+      );
+
+      expect(mockSplitContainer.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          horizontalItemMinWidth: 180,
+        })
+      );
+    }
+  );
+
+  it('uses the default horizontal split item width for other charts', () => {
+    const config: RenderChartConfig = {
+      type: 'line',
+      styles: {},
+      axesMapping: { value: 'count' },
+      splitField: 'field1',
+      splitLayout: 'horizontal',
+    };
+
+    const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+    const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(config);
+    const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+    render(
+      <VisualizationRender data$={data$} config$={visConfig$} showRawTable$={showRawTable$} />
+    );
+
+    expect(mockSplitContainer.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        horizontalItemMinWidth: undefined,
+      })
+    );
+  });
+
   it('returns null when no matching rule is found', () => {
     mockFindRuleByAxesMapping.mockReturnValue(null);
 

--- a/src/plugins/explore/public/components/visualizations/visualization_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.tsx
@@ -52,6 +52,8 @@ const defaultStyleOptions: TableChartStyle = {
 };
 
 const CUSTOM_LEGEND_CHART_TYPES = ['area', 'line', 'bar', 'pie', 'scatter', 'state_timeline'];
+const COMPACT_HORIZONTAL_SPLIT_CHART_TYPES = ['gauge', 'pie'];
+const COMPACT_HORIZONTAL_SPLIT_MIN_WIDTH = 180;
 
 export const CommonVisualizationRender = ({
   visualizationData,
@@ -69,6 +71,11 @@ export const CommonVisualizationRender = ({
   ).current;
   const legend$ = useRef(new BehaviorSubject<Record<string, LegendItem[]>>({})).current;
   const supportsCustomLegend = CUSTOM_LEGEND_CHART_TYPES.includes(visConfig?.type ?? '');
+  const horizontalSplitMinWidth = COMPACT_HORIZONTAL_SPLIT_CHART_TYPES.includes(
+    visConfig?.type ?? ''
+  )
+    ? COMPACT_HORIZONTAL_SPLIT_MIN_WIDTH
+    : undefined;
 
   useEffect(() => {
     if (!supportsCustomLegend) {
@@ -191,6 +198,7 @@ export const CommonVisualizationRender = ({
               layout={visConfig.splitLayout ?? 'auto'}
               showLabel={visConfig.showSplitLabel}
               verticalItemMinHeight={visConfig.type === 'metric' ? 60 : undefined}
+              horizontalItemMinWidth={horizontalSplitMinWidth}
               renderChart={(groupKey) => (
                 <ChartRender
                   data={{ ...visualizationData }}

--- a/src/plugins/explore/public/components/visualizations/visualization_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.tsx
@@ -50,6 +50,8 @@ const defaultStyleOptions: TableChartStyle = {
 };
 
 const CUSTOM_LEGEND_CHART_TYPES = ['area', 'line', 'bar', 'pie', 'scatter', 'state_timeline'];
+const COMPACT_HORIZONTAL_SPLIT_CHART_TYPES = ['gauge', 'pie'];
+const COMPACT_HORIZONTAL_SPLIT_MIN_WIDTH = 180;
 
 export const CommonVisualizationRender = ({
   visualizationData,
@@ -66,6 +68,11 @@ export const CommonVisualizationRender = ({
   ).current;
   const legend$ = useRef(new BehaviorSubject<Record<string, LegendItem[]>>({})).current;
   const supportsCustomLegend = CUSTOM_LEGEND_CHART_TYPES.includes(visConfig?.type ?? '');
+  const horizontalSplitMinWidth = COMPACT_HORIZONTAL_SPLIT_CHART_TYPES.includes(
+    visConfig?.type ?? ''
+  )
+    ? COMPACT_HORIZONTAL_SPLIT_MIN_WIDTH
+    : undefined;
 
   useEffect(() => {
     if (!supportsCustomLegend) {
@@ -188,6 +195,7 @@ export const CommonVisualizationRender = ({
               layout={visConfig.splitLayout ?? 'auto'}
               showLabel={visConfig.showSplitLabel}
               verticalItemMinHeight={visConfig.type === 'metric' ? 60 : undefined}
+              horizontalItemMinWidth={horizontalSplitMinWidth}
               renderChart={(groupKey) => (
                 <ChartRender
                   data={{ ...visualizationData }}


### PR DESCRIPTION
### Description
Refactors gauge chart text rendering so the title, value, and unit are rendered with React instead of an ECharts custom series. This makes gauge text layout easier to control from the component layer and keeps the ECharts spec focused on rendering gauge arcs.

This also updates gauge title behavior:

- `Show title` defaults to on.
- Empty title input means `Auto`.
- Non-split gauges use the value field name as the auto title.
- Split gauges use the series name as the auto title.
- Split gauges with a custom title render as `<series name> <custom title>`.
- Disabling `Show title` hides the title entirely.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
