### PR TITLE
fix: histogram bucket precision

### DIFF
--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createHistogramSeries } from './histogram_chart_utils';
+import { createHistogramSeries, formatHistogramBucketValue } from './histogram_chart_utils';
 import { defaultHistogramChartStyles } from './histogram_vis_config';
 import { ThresholdMode } from '../types';
 
@@ -24,6 +24,22 @@ jest.mock('../utils/utils', () => ({
   generateThresholdLines: jest.fn(() => ({})),
   getValueColorByThreshold: jest.fn(() => '#00BFB3'),
 }));
+
+describe('formatHistogramBucketValue', () => {
+  it.each([
+    [1, 0, '1'],
+    [1.7999999999999998, 1, '1.8'],
+    [2.0000000000000004, 1, '2'],
+    [1.4999999999999998, 2, '1.5'],
+    [-1.7999999999999998, 1, '-1.8'],
+    [1234567890123, 0, '1234567890123'],
+    [1000000000000.2, 1, '1000000000000.2'],
+    ['not available', 0, 'not available'],
+    [undefined, 0, 'undefined'],
+  ])('formats %p with bucket precision %p as %p', (value, bucketPrecision, expected) => {
+    expect(formatHistogramBucketValue(value, bucketPrecision)).toBe(expected);
+  });
+});
 
 describe('createHistogramSeries', () => {
   const mockStyles = {
@@ -249,6 +265,78 @@ describe('createHistogramSeries', () => {
         : result.baseConfig!.tooltip;
       expect(tooltip!.show).toBe(false);
     });
+
+    it('should format floating-point bucket values cleanly in tooltip', () => {
+      const options = {
+        styles: {
+          ...mockStyles,
+          tooltipOptions: { mode: 'all' as const },
+        },
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [1.8, 2, 5],
+        ],
+        axisColumnMappings: {},
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+      const tooltip = Array.isArray(result.baseConfig!.tooltip)
+        ? result.baseConfig!.tooltip[0]
+        : result.baseConfig!.tooltip;
+
+      expect(
+        (tooltip!.formatter as Function)({
+          dimensionNames: ['start', 'end', 'count'],
+          seriesId: 'count',
+          seriesName: 'count',
+          value: [1.7999999999999998, 2.0000000000000004, 5],
+        })
+      ).toContain('1.8 - 2');
+    });
+
+    it('should not round tooltip metric values as bucket boundaries', () => {
+      const options = {
+        styles: {
+          ...mockStyles,
+          tooltipOptions: { mode: 'all' as const },
+        },
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [0, 1, 1234567890123],
+        ],
+        axisColumnMappings: {},
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+      const tooltip = Array.isArray(result.baseConfig!.tooltip)
+        ? result.baseConfig!.tooltip[0]
+        : result.baseConfig!.tooltip;
+
+      expect(
+        (tooltip!.formatter as Function)({
+          dimensionNames: ['start', 'end', 'count'],
+          seriesId: 'count',
+          seriesName: 'count',
+          value: [0, 1, 1234567890123],
+        })
+      ).toContain('<b>1234567890123</b>');
+    });
   });
 
   describe('series encoding', () => {
@@ -310,6 +398,114 @@ describe('createHistogramSeries', () => {
       expect(result.xAxisConfig.interval).toBe(10);
       expect(result.xAxisConfig.type).toBe('value');
       expect(result.xAxisConfig.name).toBe('X Axis');
+    });
+
+    it('should format floating-point x-axis labels cleanly', () => {
+      const options = {
+        styles: mockStyles,
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [1, 1.2, 5],
+          [1.7999999999999998, 2, 8],
+        ],
+        axisColumnMappings: {},
+        xAxisConfig: {
+          type: 'value' as const,
+        },
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+
+      expect(result.xAxisConfig.interval).toBe(0.2);
+      expect(result.xAxisConfig.axisLabel.formatter(1.7999999999999998)).toBe('1.8');
+    });
+
+    it('should not format decimal interval artifacts as intentional precision', () => {
+      const options = {
+        styles: mockStyles,
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [1, 1.2, 5],
+          [2, 2.2, 8],
+        ],
+        axisColumnMappings: {},
+        xAxisConfig: {
+          type: 'value' as const,
+        },
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+
+      expect(result.xAxisConfig.interval).toBe(0.2);
+      expect(result.xAxisConfig.axisLabel.formatter(1.2000000000000002)).toBe('1.2');
+    });
+
+    it('should preserve large integer x-axis labels', () => {
+      const options = {
+        styles: mockStyles,
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [1234567890123, 1234567890124, 5],
+        ],
+        axisColumnMappings: {},
+        xAxisConfig: {
+          type: 'value' as const,
+        },
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+
+      expect(result.xAxisConfig.axisLabel.formatter(1234567890123)).toBe('1234567890123');
+    });
+
+    it('should preserve large decimal x-axis labels at bucket precision', () => {
+      const options = {
+        styles: mockStyles,
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [1000000000000, 1000000000000.2, 5],
+        ],
+        axisColumnMappings: {},
+        xAxisConfig: {
+          type: 'value' as const,
+        },
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+
+      expect(result.xAxisConfig.axisLabel.formatter(1000000000000.2)).toBe('1000000000000.2');
     });
 
     it('should not create xAxisConfig when it does not already exist', () => {

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
@@ -9,6 +9,7 @@ import { getSeriesDisplayName } from '../utils/series';
 import { generateThresholdLines, getValueColorByThreshold } from '../utils/utils';
 import { HistogramChartStyle } from './histogram_vis_config';
 import { getColors } from '../theme/default_colors';
+import { getDecimalPrecision, roundToPrecision } from '../utils/data_transformation';
 
 interface Options {
   styles: HistogramChartStyle;
@@ -16,6 +17,16 @@ interface Options {
   binEndField: string;
   seriesFields: string[] | ((headers?: string[]) => string[]);
 }
+
+export const formatHistogramBucketValue = (value: unknown, bucketPrecision: number): string => {
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue)) {
+    return String(value);
+  }
+
+  return roundToPrecision(numericValue, bucketPrecision).toString();
+};
 
 export const createHistogramSeries =
   <T extends BaseChartStyle>(options: Options): PipelineFn<T> =>
@@ -40,7 +51,17 @@ export const createHistogramSeries =
     const binEndIndex = headers.indexOf(binEndField);
     const firstRow = transformedData[1];
     const lastRow = transformedData[transformedData.length - 1];
-    const bucketSize = firstRow[binEndIndex] - firstRow[binStartIndex];
+    // Use the stored bucket boundary values to decide label precision. Computing
+    // precision from the derived interval can introduce binary floating-point
+    // artifacts, for example 1.2 - 1 -> 0.19999999999999996.
+    const bucketPrecision = Math.max(
+      getDecimalPrecision(Number(firstRow[binStartIndex])),
+      getDecimalPrecision(Number(firstRow[binEndIndex]))
+    );
+    const bucketSize = roundToPrecision(
+      firstRow[binEndIndex] - firstRow[binStartIndex],
+      bucketPrecision
+    );
     const min = firstRow[binStartIndex];
     const max = lastRow[binEndIndex];
 
@@ -109,9 +130,19 @@ export const createHistogramSeries =
         if (!Array.isArray(params) && Array.isArray(params.value)) {
           const dimensionNames = params.dimensionNames ?? [];
           const bucketStart =
-            format.encodeHTML(String(params.value[dimensionNames.indexOf(binStartField)])) ?? '-';
+            format.encodeHTML(
+              formatHistogramBucketValue(
+                params.value[dimensionNames.indexOf(binStartField)],
+                bucketPrecision
+              )
+            ) ?? '-';
           const bucketEnd =
-            format.encodeHTML(String(params.value[dimensionNames.indexOf(binEndField)])) ?? '-';
+            format.encodeHTML(
+              formatHistogramBucketValue(
+                params.value[dimensionNames.indexOf(binEndField)],
+                bucketPrecision
+              )
+            ) ?? '-';
           const value =
             format.encodeHTML(
               String(params.value[dimensionNames.indexOf(params.seriesId ?? '')])
@@ -140,6 +171,10 @@ export const createHistogramSeries =
       xAxisConfig.min = min;
       xAxisConfig.max = max;
       xAxisConfig.interval = bucketSize;
+      xAxisConfig.axisLabel = {
+        ...xAxisConfig.axisLabel,
+        formatter: (value: unknown) => formatHistogramBucketValue(value, bucketPrecision),
+      };
       newState.xAxisConfig = xAxisConfig;
     }
 

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/bin.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/bin.test.ts
@@ -255,6 +255,60 @@ describe('bin', () => {
   });
 
   describe('nice number rounding', () => {
+    it('should use whole-number auto buckets for integer-valued data', () => {
+      const data = [
+        { value: 1 },
+        { value: 2 },
+        { value: 3 },
+        { value: 4 },
+        { value: 5 },
+        { value: 6 },
+      ];
+
+      const result = bin({
+        bin: { count: 30 },
+        binField: 'value',
+      })(data);
+
+      expect(result).toEqual([
+        { start: 1, end: 2, value: 1 },
+        { start: 2, end: 3, value: 1 },
+        { start: 3, end: 4, value: 1 },
+        { start: 4, end: 5, value: 1 },
+        { start: 5, end: 6, value: 1 },
+        { start: 6, end: 7, value: 1 },
+      ]);
+    });
+
+    it('should preserve explicit decimal bucket sizes', () => {
+      const data = [{ value: 1 }, { value: 2 }];
+
+      const result = bin({
+        bin: { size: 0.2 },
+        binField: 'value',
+      })(data);
+
+      expect(result).toEqual([
+        { start: 1, end: 1.2, value: 1 },
+        { start: 2, end: 2.2, value: 1 },
+      ]);
+    });
+
+    it('should keep sub-unit auto buckets for decimal-valued data', () => {
+      const data = [{ value: 0.1 }, { value: 0.2 }, { value: 0.9 }];
+
+      const result = bin({
+        bin: { count: 4 },
+        binField: 'value',
+      })(data);
+
+      expect(result).toEqual([
+        { start: 0, end: 0.2, value: 1 },
+        { start: 0.2, end: 0.4, value: 1 },
+        { start: 0.8, end: 1, value: 1 },
+      ]);
+    });
+
     it('should round step to nice numbers for count-based binning', () => {
       const data = [{ value: 0 }, { value: 37 }];
 

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/bin.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/bin.ts
@@ -5,6 +5,7 @@
 
 import { AggregationType } from '../../types';
 import { aggregateValues } from './utils/aggregation';
+import { getDecimalPrecision, roundToPrecision } from './utils/number';
 
 interface BinConfig {
   count?: number;
@@ -136,9 +137,11 @@ export const bin =
       return [];
     }
 
+    const numericValues = validRecords.map((row) => Number(row[binField]));
+
     // Calculate min and max
-    const min = Math.min(...validRecords.map((row) => Number(row[binField])));
-    const max = Math.max(...validRecords.map((row) => Number(row[binField])));
+    const min = Math.min(...numericValues);
+    const max = Math.max(...numericValues);
 
     // Handle single value case
     if (min === max) {
@@ -161,9 +164,11 @@ export const bin =
 
     // Calculate bin step size
     let step: number;
-    if (binConfig?.size) {
+    const explicitSize = binConfig?.size;
+    const hasExplicitSize = explicitSize !== undefined && explicitSize > 0;
+    if (hasExplicitSize) {
       // Priority 1: Use explicit size (don't round - user wants exact size)
-      step = binConfig.size;
+      step = explicitSize;
     } else if (binConfig?.count) {
       // Priority 2: Calculate from count and round to nice number
       const rawStep = (max - min) / binConfig.count;
@@ -174,16 +179,24 @@ export const bin =
       step = getNiceNumber(rawStep);
     }
 
+    // Auto buckets should respect integer-valued result data. A count-like field with
+    // values 1..6 should use bucket size 1 instead of fractional buckets like 0.2.
+    if (!hasExplicitSize && step < 1 && numericValues.every(Number.isInteger)) {
+      step = 1;
+    }
+
+    const precision = getDecimalPrecision(step);
+
     // Align bin start to a nice boundary (round down to nearest multiple of step)
     // Example: min=42.2, step=5 → binStart=40 (gives bins like 40-45, 45-50, etc.)
-    const binStart = Math.floor(min / step) * step;
+    const binStart = roundToPrecision(Math.floor(min / step) * step, precision);
 
     // Generate bin ranges
     const bins: BinRange[] = [];
     let currentBinStart = binStart;
 
     while (currentBinStart <= max) {
-      const binEnd = currentBinStart + step;
+      const binEnd = roundToPrecision(currentBinStart + step, precision);
       bins.push({
         start: currentBinStart,
         end: binEnd,
@@ -195,22 +208,22 @@ export const bin =
     // Assign data points to bins
     for (const row of validRecords) {
       const binValue = Number(row[binField]);
-
-      // Find the appropriate bin using [start, end) convention
-      const binIndex = bins.findIndex((binRange) => {
+      const targetBin = bins.find((binRange) => {
         return binValue >= binRange.start && binValue < binRange.end;
       });
 
-      if (binIndex !== -1) {
-        if (valueField) {
-          const aggValue = Number(row[valueField]);
-          if (!isNaN(aggValue)) {
-            bins[binIndex].values.push(aggValue);
-          }
-        } else {
-          // For counting, just push a placeholder
-          bins[binIndex].values.push(1);
+      if (!targetBin) {
+        continue;
+      }
+
+      if (valueField) {
+        const aggValue = Number(row[valueField]);
+        if (!isNaN(aggValue)) {
+          targetBin.values.push(aggValue);
         }
+      } else {
+        // For counting, just push a placeholder
+        targetBin.values.push(1);
       }
     }
 

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/index.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/index.ts
@@ -16,5 +16,6 @@ export type { TransformFn } from './transform';
 export { aggregateValues } from './utils/aggregation';
 export { roundToTimeUnit } from './utils/time';
 export { normalizeEmptyValue } from './utils/normalization';
+export { getDecimalPrecision, roundToPrecision } from './utils/number';
 
 export { map, pick } from './common';

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/number.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/number.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getDecimalPrecision, roundToPrecision } from './number';
+
+describe('number utils', () => {
+  describe('getDecimalPrecision', () => {
+    it.each([
+      [1, 0],
+      [0.2, 1],
+      [0.25, 2],
+      [0.001, 3],
+      [1e-7, 7],
+      [1.25e-7, 9],
+      [1e-20, 20],
+    ])('returns %p decimal places for %p', (value, expected) => {
+      expect(getDecimalPrecision(value)).toBe(expected);
+    });
+  });
+
+  describe('roundToPrecision', () => {
+    it.each([
+      [1.7999999999999998, 1, 1.8],
+      [2.0000000000000004, 1, 2],
+      [1.4999999999999998, 2, 1.5],
+      [-1.7999999999999998, 1, -1.8],
+      [1234567890123, 0, 1234567890123],
+      [1000000000000.2, 1, 1000000000000.2],
+      [1, 17, 1],
+      [1e-20, 20, 1e-20],
+    ])('rounds %p to %p decimal places as %p', (value, precision, expected) => {
+      expect(roundToPrecision(value, precision)).toBe(expected);
+    });
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/number.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/number.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Returns the number of decimal places implied by a numeric value.
+ * For example, 1 -> 0, 0.2 -> 1, 0.25 -> 2, and 1e-7 -> 7.
+ */
+export const getDecimalPrecision = (value: number): number => {
+  const valueString = value.toString().toLowerCase();
+
+  if (valueString.includes('e-')) {
+    const [coefficient, exponent] = valueString.split('e-');
+    const coefficientDecimals = coefficient.split('.')[1]?.length ?? 0;
+    return Number(exponent) + coefficientDecimals;
+  }
+
+  return valueString.split('.')[1]?.length ?? 0;
+};
+
+/**
+ * Rounds a value to the requested number of decimal places.
+ * For example, roundToPrecision(1.7999999999999998, 1) -> 1.8.
+ */
+export const roundToPrecision = (value: number, precision: number): number => {
+  const factor = Math.pow(10, precision);
+  return Number((Math.round(value * factor) / factor).toFixed(precision));
+};


### PR DESCRIPTION
### Description

Clamp auto bucket sizing to whole-number steps for integer-valued histogram data, so count-like fields do not produce fractional buckets when bucket count is high.

Add shared numeric helpers for decimal precision and precision rounding, and use them to round generated bucket boundaries and histogram bucket labels. Format tooltip and x-axis bucket boundaries with bucket-boundary precision so binary floating-point artifacts such as 1.7999999999999998 and 1.2000000000000002 are not shown to users.
<!-- Describe what this change achieves-->

### Issues Resolved
Resolved https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12539
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
