### PR TITLE
fix(data): use explicit query comparison instead of lodash isEqual

### DIFF
--- a/src/plugins/data/public/ui/search_bar/create_search_bar.test.ts
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.test.ts
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use it except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the defaultOnQuerySubmit handler and isEqualQuery helper.
+ *
+ * Regression test for https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12522
+ *
+ * The bug: _.isEqual(payload.query, currentQuery) returns false when
+ * payload.query has `dataset: undefined` as an own enumerable property
+ * while currentQuery lacks the `dataset` key entirely. This causes the
+ * refresh button to become non-functional because the `else` branch is
+ * never reached.
+ *
+ * The fix: use an explicit field comparison (isEqualQuery) that only
+ * checks `query` and `language` fields, ignoring structural differences
+ * in optional properties.
+ */
+
+import { isEqualQuery } from './create_search_bar';
+
+describe('Query comparison (fix for #12522)', () => {
+  it('should return true for identical queries', () => {
+    const q1 = { query: 'foo', language: 'kql' };
+    const q2 = { query: 'foo', language: 'kql' };
+    expect(isEqualQuery(q1, q2)).toBe(true);
+  });
+
+  it('should return true when one query has dataset: undefined and the other lacks the key entirely', () => {
+    // This is the exact bug scenario from #12522
+    const payloadQuery = { query: 'foo', language: 'kql', dataset: undefined };
+    const currentQuery = { query: 'foo', language: 'kql' };
+    // isEqualQuery only checks query + language, so this should be equal
+    expect(isEqualQuery(payloadQuery, currentQuery)).toBe(true);
+    // Verify that _.isEqual would disagree (document the bug)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const isEqual = require('lodash').isEqual;
+    expect(isEqual(payloadQuery, currentQuery)).toBe(false);
+  });
+
+  it('should return true for queries with different optional fields but same core fields', () => {
+    const q1 = { query: 'bar', language: 'ppl', profile: true };
+    const q2 = { query: 'bar', language: 'ppl' };
+    expect(isEqualQuery(q1, q2)).toBe(true);
+  });
+
+  it('should return false when query strings differ', () => {
+    const q1 = { query: 'foo', language: 'kql' };
+    const q2 = { query: 'bar', language: 'kql' };
+    expect(isEqualQuery(q1, q2)).toBe(false);
+  });
+
+  it('should return false when languages differ', () => {
+    const q1 = { query: 'foo', language: 'kql' };
+    const q2 = { query: 'foo', language: 'ppl' };
+    expect(isEqualQuery(q1, q2)).toBe(false);
+  });
+
+  it('should return true when both are undefined', () => {
+    expect(isEqualQuery(undefined, undefined)).toBe(true);
+  });
+
+  it('should return false when only one is undefined', () => {
+    const q = { query: 'foo', language: 'kql' };
+    expect(isEqualQuery(undefined, q)).toBe(false);
+    expect(isEqualQuery(q, undefined)).toBe(false);
+  });
+
+  it('should return true when both are the same reference', () => {
+    const q = { query: 'foo', language: 'kql' };
+    expect(isEqualQuery(q, q)).toBe(true);
+  });
+});

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -81,6 +81,16 @@ const defaultOnRefreshChange = (queryService: QueryStart) => {
   };
 };
 
+// Compare Query objects by their meaningful fields only,
+// ignoring structural differences like missing optional keys
+// (e.g., payload.query has `dataset: undefined` but currentQuery
+// doesn't have the `dataset` key at all — which should be equal).
+export const isEqualQuery = (a: Query | undefined, b: Query | undefined): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.query === b.query && a.language === b.language;
+};
+
 // Respond to user changing the query string or time settings
 const defaultOnQuerySubmit = (
   props: StatefulSearchBarProps,
@@ -94,7 +104,7 @@ const defaultOnQuerySubmit = (
   return (payload: { dateRange: TimeRange; query?: Query }) => {
     const isUpdate =
       !_.isEqual(timefilter.getTime(), payload.dateRange) ||
-      !_.isEqual(payload.query, currentQuery);
+      !isEqualQuery(payload.query, currentQuery);
     if (isUpdate) {
       timefilter.setTime(payload.dateRange);
       if (payload.query) {


### PR DESCRIPTION
Replace _.isEqual(payload.query, currentQuery) with a custom isEqualQuery helper that only compares the query and language fields.

The bug: _.isEqual treats an object with dataset: undefined as unequal to one that lacks the dataset key entirely. This caused the Discover tab's refresh button to silently stop triggering refetches after state transitions.

Fixes #12522

Co-Authored-By: Bug Analysis by @lbeltran-dev

 ### Description

 Fix the Discover tab's refresh button becoming non-functional after state transitions.

 The root cause was _.isEqual(payload.query, currentQuery) returning false when payload.query had dataset: undefined
  as an own enumerable property while currentQuery lacked the dataset key entirely. This is a known limitation of
 deep equality checks — the presence of an undefined value is treated as structurally different from the absence of
 the key.

 The fix introduces a custom isEqualQuery helper that explicitly compares only the meaningful fields (query and
 language), ignoring structural differences in optional properties. This ensures the refresh button correctly
 detects when a query update is needed.

 ### Issues Resolved

 Fixes #12522

 Screenshot

 <!-- No UI changes — this is a logic fix in the search bar component -->

 Testing the changes

 1. Unit tests: Run the new test suite for create_search_bar:
    ```bash
      yarn test:jest src/plugins/data/public/ui/search_bar/create_search_bar.test.ts
    ```
    All 8 tests pass, including the regression test for the dataset: undefined edge case.

 2. Full unit test suite:
    ```bash
      yarn test:jest
    ```
    All 3072 test suites pass (29608 tests), with no regressions from this change.

 3. Integration tests:
    ```bash
      yarn test:jest_integration
    ```
    Passes (the single pre-existing failure in basic_optimization.test.ts is unrelated to this PR).

 4. Manual verification:
     - Open OpenSearch Dashboards and navigate to the Discover tab.
     - Execute a search, then click the refresh button multiple times.
     - Verify that each refresh triggers a new data fetch (check the network tab or loading spinner).
     - Repeat after filtering by a time range and switching between query languages (KQL/PPL).

 ### Check List

 - [x] All tests pass
     - [x] yarn test:jest
     - [x] yarn test:jest_integration
 - [x] New functionality includes testing.
 - [ ] New functionality has been documented.
 - [x] Commits are signed per the DCO using --signoff