### PR TITLE
[Backport 2.19] fix(capabilities): bound input and linearize loops in /api/core/capabilities

### DIFF
--- a/src/core/server/capabilities/integration_tests/capabilities_service.test.ts
+++ b/src/core/server/capabilities/integration_tests/capabilities_service.test.ts
@@ -29,12 +29,14 @@
  */
 
 import supertest from 'supertest';
+import { BehaviorSubject } from 'rxjs';
+import { ByteSizeValue } from '@osd/config-schema';
 import { REPO_ROOT } from '@osd/dev-utils';
 import { HttpService, InternalHttpServiceSetup } from '../../http';
 import { contextServiceMock } from '../../context/context_service.mock';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
 import { Env } from '../../config';
-import { getEnvOptions } from '../../config/mocks';
+import { configServiceMock, getEnvOptions } from '../../config/mocks';
 import { CapabilitiesService, CapabilitiesSetup } from '..';
 import { createHttpServer } from '../../http/test_utils';
 import { dynamicConfigServiceMock } from '../../config/dynamic_config_service.mock';
@@ -109,6 +111,74 @@ describe('CapabilitiesService', () => {
           "workspaces": Object {},
         }
       `);
+    });
+
+    describe('request body schema bounds', () => {
+      beforeEach(async () => {
+        await server.stop();
+        const configService = configServiceMock.create();
+        configService.atPath.mockReturnValue(
+          new BehaviorSubject({
+            hosts: ['localhost'],
+            maxPayload: new ByteSizeValue(10 * 1024 * 1024),
+            autoListen: true,
+            ssl: { enabled: false },
+            compression: { enabled: true },
+            xsrf: { disableProtection: true, whitelist: [] },
+            customResponseHeaders: {},
+            requestId: { allowFromAnyIp: true, ipAllowlist: [] },
+            keepaliveTimeout: 120_000,
+            socketTimeout: 120_000,
+          } as any)
+        );
+        server = createHttpServer({ configService });
+        httpSetup = await server.setup({
+          context: contextServiceMock.createSetupContract(),
+        });
+        service = new CapabilitiesService({
+          coreId,
+          env,
+          logger: loggingSystemMock.create(),
+          configService: {} as any,
+          dynamicConfigService: dynamicConfigServiceMock.create(),
+        });
+        serviceSetup = await service.setup({ http: httpSetup });
+        await server.start({
+          dynamicConfigService: dynamicConfigServiceMock.createInternalStartContract(),
+        });
+      });
+
+      it('accepts an applications array at the maximum allowed size (1000)', async () => {
+        const applications = Array.from({ length: 1000 }, (_, i) => `app-${i}`);
+        await supertest(httpSetup.server.listener)
+          .post('/api/core/capabilities')
+          .send({ applications })
+          .expect(200);
+      });
+
+      it('rejects an applications array larger than 1000 entries', async () => {
+        const applications = Array.from({ length: 1001 }, (_, i) => `app-${i}`);
+        await supertest(httpSetup.server.listener)
+          .post('/api/core/capabilities')
+          .send({ applications })
+          .expect(400);
+      });
+
+      it('rejects an application id longer than 256 characters', async () => {
+        const tooLong = 'a'.repeat(257);
+        await supertest(httpSetup.server.listener)
+          .post('/api/core/capabilities')
+          .send({ applications: [tooLong] })
+          .expect(400);
+      });
+
+      it('accepts an application id of exactly 256 characters', async () => {
+        const maxLen = 'a'.repeat(256);
+        await supertest(httpSetup.server.listener)
+          .post('/api/core/capabilities')
+          .send({ applications: [maxLen] })
+          .expect(200);
+      });
     });
   });
 });

--- a/src/core/server/capabilities/resolve_capabilities.test.ts
+++ b/src/core/server/capabilities/resolve_capabilities.test.ts
@@ -174,4 +174,72 @@ describe('resolveCapabilities', () => {
       },
     });
   });
+
+  describe('applications merge into navLinks', () => {
+    it('adds each application id to navLinks as true', async () => {
+      const result = await resolveCapabilities(defaultCaps, [], request, ['app_a', 'app_b']);
+      expect(result.navLinks).toEqual({
+        app_a: true,
+        app_b: true,
+      });
+    });
+
+    it('preserves existing navLinks entries not listed in applications', async () => {
+      const caps = {
+        ...defaultCaps,
+        navLinks: {
+          existing_app: false,
+        },
+      };
+      const result = await resolveCapabilities(caps, [], request, ['new_app']);
+      expect(result.navLinks).toEqual({
+        existing_app: false,
+        new_app: true,
+      });
+    });
+
+    it('overwrites an existing navLinks entry when the application id is listed', async () => {
+      const caps = {
+        ...defaultCaps,
+        navLinks: {
+          app_a: false,
+        },
+      };
+      const result = await resolveCapabilities(caps, [], request, ['app_a']);
+      expect(result.navLinks).toEqual({
+        app_a: true,
+      });
+    });
+
+    it('does not mutate the caller-provided navLinks when applications are supplied', async () => {
+      const originalNavLinks = { existing: false };
+      const caps = {
+        ...defaultCaps,
+        navLinks: originalNavLinks,
+      };
+      await resolveCapabilities(caps, [], request, ['app_a']);
+      expect(originalNavLinks).toEqual({ existing: false });
+    });
+
+    it('is tolerant of an empty applications array', async () => {
+      const caps = {
+        ...defaultCaps,
+        navLinks: { kept: true },
+      };
+      const result = await resolveCapabilities(caps, [], request, []);
+      expect(result.navLinks).toEqual({ kept: true });
+    });
+
+    it('resolves in reasonable time for the maximum allowed input', async () => {
+      const applications = Array.from({ length: 1000 }, (_, i) => `app_${i}`);
+      const switchers = Array.from(
+        { length: 10 },
+        () => (_req: OpenSearchDashboardsRequest, caps: Capabilities) => caps
+      );
+      const start = Date.now();
+      const result = await resolveCapabilities(defaultCaps, switchers, request, applications);
+      expect(Date.now() - start).toBeLessThan(1000);
+      expect(Object.keys(result.navLinks)).toHaveLength(1000);
+    });
+  });
 });

--- a/src/core/server/capabilities/resolve_capabilities.ts
+++ b/src/core/server/capabilities/resolve_capabilities.ts
@@ -53,44 +53,35 @@ export const resolveCapabilities = async (
   request: OpenSearchDashboardsRequest,
   applications: string[]
 ): Promise<Capabilities> => {
-  const mergedCaps = cloneDeep({
-    ...capabilities,
-    navLinks: applications.reduce(
-      (acc, app) => ({
-        ...acc,
-        [app]: true,
-      }),
-      capabilities.navLinks
-    ),
-  });
-  return switchers.reduce(async (caps, switcher) => {
-    const resolvedCaps = await caps;
-    const changes = await switcher(request, resolvedCaps);
-    return recursiveApplyChanges(resolvedCaps, changes);
-  }, Promise.resolve(mergedCaps));
+  const mergedCaps = cloneDeep(capabilities);
+  for (const app of applications) {
+    mergedCaps.navLinks[app] = true;
+  }
+  let resolved: Capabilities = mergedCaps;
+  for (const switcher of switchers) {
+    const changes = await switcher(request, resolved);
+    resolved = recursiveApplyChanges(resolved, changes);
+  }
+  return resolved;
 };
 
 function recursiveApplyChanges<
   TDestination extends Record<string, any>,
   TSource extends Record<string, any>
 >(destination: TDestination, source: TSource): TDestination {
-  return Object.keys(destination)
-    .map((key) => {
-      const orig = destination[key];
-      const changed = source[key];
-      if (changed == null) {
-        return [key, orig];
-      }
-      if (typeof orig === 'object' && typeof changed === 'object') {
-        return [key, recursiveApplyChanges(orig, changed)];
-      }
-      return [key, typeof orig === typeof changed ? changed : orig];
-    })
-    .reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: value,
-      }),
-      {} as TDestination
-    );
+  const result = {} as Record<string, any>;
+  for (const key of Object.keys(destination)) {
+    const orig = destination[key];
+    const changed = source[key];
+    if (changed == null) {
+      result[key] = orig;
+      continue;
+    }
+    if (typeof orig === 'object' && typeof changed === 'object') {
+      result[key] = recursiveApplyChanges(orig, changed);
+      continue;
+    }
+    result[key] = typeof orig === typeof changed ? changed : orig;
+  }
+  return result as TDestination;
 }

--- a/src/core/server/capabilities/routes/resolve_capabilities.ts
+++ b/src/core/server/capabilities/routes/resolve_capabilities.ts
@@ -32,6 +32,10 @@ import { schema } from '@osd/config-schema';
 import { IRouter } from '../../http';
 import { CapabilitiesResolver } from '../resolve_capabilities';
 
+const MAX_APPLICATIONS = 1000;
+
+const MAX_APPLICATION_ID_LENGTH = 256;
+
 export function registerCapabilitiesRoutes(router: IRouter, resolver: CapabilitiesResolver) {
   router.post(
     {
@@ -41,7 +45,9 @@ export function registerCapabilitiesRoutes(router: IRouter, resolver: Capabiliti
       },
       validate: {
         body: schema.object({
-          applications: schema.arrayOf(schema.string()),
+          applications: schema.arrayOf(schema.string({ maxLength: MAX_APPLICATION_ID_LENGTH }), {
+            maxSize: MAX_APPLICATIONS,
+          }),
         }),
       },
     },


### PR DESCRIPTION
### Description

Backport of #12292 to the `2.19` branch.

Bounds the request schema for `POST /api/core/capabilities` — the `applications` array is capped at 1000 entries and each entry at 256 characters — and replaces the spread-inside-reduce patterns in `resolveCapabilities` and `recursiveApplyChanges` with single linear passes.

Resolver semantics are unchanged: caller input is not mutated, switchers cannot add or remove capabilities, and type-mismatch values fall back to the original value.

The cherry-pick applied cleanly with no conflicts. Both schema options used here (`maxSize` on `schema.arrayOf`, `maxLength` on `schema.string`) are already implemented in `@osd/config-schema` on `2.19`, and the test harness dependencies (`configServiceMock`, `dynamic_config_service.mock`, `ByteSizeValue`) all exist on this branch.

### Issues Resolved

Backport of #12292.

### Changelog

None. The original PR did not carry a changelog fragment.

### Check List

- [ ] All tests pass — the repo test suite was not run locally; relying on CI. Behavioral equivalence between the previous and new resolver was verified separately against the cases below.
- [x] New functionality includes testing (tests carried over from #12292)
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`