### PR TITLE
chore(deps): bump @opensearch-project/oui from 1.24.1 to 1.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "@aws-sdk/credential-provider-node": "^3.972.10",
     "@dagrejs/dagre": "^1.1.5",
     "@elastic/datemath": "5.0.3",
-    "@elastic/eui": "npm:@opensearch-project/oui@1.24.1",
+    "@elastic/eui": "npm:@opensearch-project/oui@1.24.2",
     "@elastic/good": "^9.0.1-kibana3",
     "@elastic/numeral": "2.5.1",
     "@elastic/request-crypto": "2.0.2",

--- a/packages/osd-ui-framework/package.json
+++ b/packages/osd-ui-framework/package.json
@@ -15,7 +15,7 @@
     "@cfaester/enzyme-adapter-react-18": "^0.8.0"
   },
   "devDependencies": {
-    "@elastic/eui": "npm:@opensearch-project/oui@1.24.1",
+    "@elastic/eui": "npm:@opensearch-project/oui@1.24.2",
     "@osd/babel-preset": "1.0.0",
     "@osd/optimizer": "1.0.0",
     "comment-stripper": "^0.0.4",

--- a/packages/osd-ui-shared-deps/package.json
+++ b/packages/osd-ui-shared-deps/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@elastic/charts": "71.8.1",
-    "@elastic/eui": "npm:@opensearch-project/oui@1.24.1",
+    "@elastic/eui": "npm:@opensearch-project/oui@1.24.2",
     "@elastic/numeral": "2.5.1",
     "@opensearch/datemath": "5.0.3",
     "@osd/i18n": "1.0.0",

--- a/test/interpreter_functional/plugins/osd_tp_run_pipeline/package.json
+++ b/test/interpreter_functional/plugins/osd_tp_run_pipeline/package.json
@@ -12,7 +12,7 @@
     "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
-    "@elastic/eui": "npm:@opensearch-project/oui@1.24.1",
+    "@elastic/eui": "npm:@opensearch-project/oui@1.24.2",
     "@osd/plugin-helpers": "1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/test/plugin_functional/plugins/osd_sample_panel_action/package.json
+++ b/test/plugin_functional/plugins/osd_sample_panel_action/package.json
@@ -12,7 +12,7 @@
     "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
-    "@elastic/eui": "npm:@opensearch-project/oui@1.24.1",
+    "@elastic/eui": "npm:@opensearch-project/oui@1.24.2",
     "react": "^18.2.0"
   }
 }

--- a/test/plugin_functional/plugins/osd_tp_custom_visualizations/package.json
+++ b/test/plugin_functional/plugins/osd_tp_custom_visualizations/package.json
@@ -12,7 +12,7 @@
     "build": "../../../../scripts/use_node ../../../../scripts/remove.js './target' && tsc"
   },
   "devDependencies": {
-    "@elastic/eui": "npm:@opensearch-project/oui@1.24.1",
+    "@elastic/eui": "npm:@opensearch-project/oui@1.24.2",
     "@osd/plugin-helpers": "1.0.0",
     "react": "^18.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2308,10 +2308,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-2.14.0.tgz#d95243369de3b08c1986d2c871a0522546e4363f"
   integrity sha512-2MPb4JhCz6wO9meq5bOMqWxvW0uzsmkYvKjFRcIY/R1pPdcxHJsRfxCb4x4Ibg3gs6DjN2+O70zHYllJ6Mjo4w==
 
-"@elastic/eui@npm:@opensearch-project/oui@1.24.1":
-  version "1.24.1"
-  resolved "https://registry.yarnpkg.com/@opensearch-project/oui/-/oui-1.24.1.tgz#6e4babafc1e2b1bf8c9b325bea318b6514937ea6"
-  integrity sha512-NaqPaVhj/jXuamAnn71hGfnMq1nCXD0ANqjZC1r+v/LorNpZutb2PwvvV9mUKwYaUJJTDOuFt1BZyHAXF29CSQ==
+"@elastic/eui@npm:@opensearch-project/oui@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@opensearch-project/oui/-/oui-1.24.2.tgz#8a8dc8e725fbdf0dd573348d4697ce8acccd757f"
+  integrity sha512-ogsZesUw/ll3wrvNwE7AG/ZQEAzSuhPlBQAkLd9k5jDGuC/iRYXeVsc2nCLsY8u7CU4MFqzbI14MmN8NXGkm3Q==
   dependencies:
     "@types/chroma-js" "^2.4.0"
     "@types/react-beautiful-dnd" "^13.1.3"


### PR DESCRIPTION
### Description
Bumps `@elastic/eui` (aliased to `@opensearch-project/oui`) from 1.24.1 to 1.24.2 across all six package.json declarations, per the single-version-dependencies convention.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff