### PR TITLE
fix(visualizations): cap horizontal vislib legend height

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/_vislib_vis_type.scss
+++ b/src/plugins/vis_type_vislib/public/vislib/_vislib_vis_type.scss
@@ -14,10 +14,18 @@
 
   &.visLib--legend-top {
     flex-direction: column-reverse;
+
+    .visLib__legend {
+      max-height: 50px;
+    }
   }
 
   &.visLib--legend-bottom {
     flex-direction: column;
+
+    .visLib__legend {
+      max-height: 50px;
+    }
   }
 }
 


### PR DESCRIPTION
### Description
This PR prevents Vislib legends from consuming too much vertical space when legends are positioned at the top or bottom of a visualization.

When a visualization has many field values, the horizontal legend can grow across multiple rows and compress the chart area until the visualization is difficult to read. This change caps the top/bottom legend container height so the chart keeps usable space and the legend can scroll instead of hiding the chart.

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
### Before
<img width="715" height="398" alt="Screenshot 2026-08-11 at 13 30 54" src="https://github.com/user-attachments/assets/f6109182-461b-442d-9fab-52a845786321" />


### After
<img width="720" height="400" alt="Screenshot 2026-08-11 at 13 30 32" src="https://github.com/user-attachments/assets/59c8379f-f54a-4514-ac9d-ac7262c0892f" />

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
