### PR TITLE
[Variables] Add Text variable type and "Allow custom values" toggle

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_variables/text_value_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/text_value_editor.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { EuiFieldText, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { VariableWithState } from '../../../variables/types';
+import './variable_selector.scss';
+
+export interface TextValueEditorProps {
+  variable: VariableWithState;
+  onValuesChange: (variableId: string, values: string[]) => void;
+}
+
+/**
+ * Free-text input for Text-type variables.
+ * Commits the value on blur or Enter so dependent query variables
+ * only re-run once the user has finished typing.
+ */
+export const TextValueEditor: React.FC<TextValueEditorProps> = ({ variable, onValuesChange }) => {
+  const committedValue = variable.current?.[0] ?? '';
+  const [draft, setDraft] = useState(committedValue);
+
+  useEffect(() => {
+    setDraft(committedValue);
+  }, [committedValue]);
+
+  const commit = useCallback(() => {
+    if (draft !== committedValue) {
+      onValuesChange(variable.id, draft ? [draft] : []);
+    }
+  }, [draft, committedValue, variable.id, onValuesChange]);
+
+  const displayLabel = variable.label || variable.name;
+  // Base width on the committed value, not the in-progress draft — sizing off
+  // draft would make the box jitter on every keystroke.
+  const calculatedWidth = Math.max(
+    120,
+    Math.min(Math.max(committedValue.length, displayLabel.length) * 8 + 40, 400)
+  );
+
+  return (
+    <EuiToolTip content={variable.description} position="bottom">
+      <div
+        className="variableSelectorContainer"
+        data-label={displayLabel}
+        data-test-subj={`variable-${variable.name}`}
+        style={{ width: `${calculatedWidth}px` }}
+      >
+        <EuiFieldText
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commit();
+            }
+          }}
+          placeholder={i18n.translate('dashboard.variables.textInputPlaceholder', {
+            defaultMessage: 'Enter value...',
+          })}
+          data-test-subj="variable-text-input"
+          className="variableTextInput"
+          compressed
+          controlOnly
+        />
+      </div>
+    </EuiToolTip>
+  );
+};

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from 'react-dom/test-utils';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+// @ts-expect-error TS2306 TODO(ts-error): fixme
+import { findTestSubject } from '@elastic/eui/lib/test';
+
+// The query panel pulls in monaco and the services context; it is never rendered
+// for Text/Custom variables, so stubbing it keeps these tests focused.
+jest.mock('./query_panel/variable_query_panel', () => ({
+  VariableQueryPanel: () => <div data-test-subj="mockVariableQueryPanel" />,
+}));
+
+import { VariableEditorFlyout } from './variable_editor_flyout';
+import { Variable, VariableType } from '../../../variables/types';
+
+const textVariable = (overrides: Partial<Variable> = {}): Variable =>
+  ({
+    id: 'text-1',
+    name: 'keyword',
+    type: VariableType.Text,
+    current: ['timeout'],
+    ...overrides,
+  }) as Variable;
+
+const customVariable = (overrides: Partial<Variable> = {}): Variable =>
+  ({
+    id: 'custom-1',
+    name: 'env',
+    type: VariableType.Custom,
+    current: ['dev'],
+    customOptions: ['dev', 'prod'],
+    ...overrides,
+  }) as Variable;
+
+function mountEditor(existingVariable?: Variable) {
+  const onSave = jest.fn().mockResolvedValue(undefined);
+  const onClose = jest.fn();
+  const component = mountWithIntl(
+    <VariableEditorFlyout
+      onClose={onClose}
+      onSave={onSave}
+      existingVariable={existingVariable}
+      existingVariables={existingVariable ? [existingVariable] : []}
+    />
+  );
+  return { component, onSave, onClose };
+}
+
+async function clickSave(component: any) {
+  await act(async () => {
+    findTestSubject(component, 'variableEditorSave').simulate('click');
+  });
+  component.update();
+}
+
+describe('VariableEditorFlyout — Text variables', () => {
+  it('renders the Value field seeded from the current value', () => {
+    const { component } = mountEditor(textVariable());
+
+    const value = findTestSubject(component, 'variableEditorTextValue');
+    expect(value.length).toBe(1);
+    expect(value.props().value).toBe('timeout');
+  });
+
+  it('renders an empty Value field when the variable has no value', () => {
+    const { component } = mountEditor(textVariable({ current: undefined }));
+
+    expect(findTestSubject(component, 'variableEditorTextValue').props().value).toBe('');
+  });
+
+  it('hides Sort, multi-select and Include All for Text', () => {
+    const { component } = mountEditor(textVariable());
+
+    expect(findTestSubject(component, 'variableEditorSort').length).toBe(0);
+    expect(findTestSubject(component, 'variableEditorMulti').length).toBe(0);
+    expect(findTestSubject(component, 'variableEditorIncludeAll').length).toBe(0);
+  });
+
+  it('does not render the query panel or custom options for Text', () => {
+    const { component } = mountEditor(textVariable());
+
+    expect(findTestSubject(component, 'mockVariableQueryPanel').length).toBe(0);
+    expect(findTestSubject(component, 'variableEditorCustomValues').length).toBe(0);
+  });
+
+  it('saves the edited value into `current`', async () => {
+    const { component, onSave } = mountEditor(textVariable());
+
+    findTestSubject(component, 'variableEditorTextValue').simulate('change', {
+      target: { value: 'latency' },
+    });
+    await clickSave(component);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'keyword',
+        type: VariableType.Text,
+        current: ['latency'],
+      })
+    );
+  });
+
+  it('trims the value before saving', async () => {
+    const { component, onSave } = mountEditor(textVariable());
+
+    findTestSubject(component, 'variableEditorTextValue').simulate('change', {
+      target: { value: '  spaced  ' },
+    });
+    await clickSave(component);
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ current: ['spaced'] }));
+  });
+
+  it('saves an undefined current when the value is cleared (value is optional)', async () => {
+    const { component, onSave } = mountEditor(textVariable());
+
+    findTestSubject(component, 'variableEditorTextValue').simulate('change', {
+      target: { value: '' },
+    });
+    await clickSave(component);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ current: undefined }));
+  });
+
+  it('does not persist multi/includeAll/sort for Text', async () => {
+    const { component, onSave } = mountEditor(textVariable());
+
+    await clickSave(component);
+
+    // These are not applicable to Text, so the keys are omitted entirely rather
+    // than sent as undefined.
+    const payload = onSave.mock.calls[0][0];
+    expect(payload).not.toHaveProperty('multi');
+    expect(payload).not.toHaveProperty('includeAll');
+    expect(payload).not.toHaveProperty('sort');
+  });
+
+  it('offers Text in the type selector', () => {
+    const { component } = mountEditor(textVariable());
+
+    expect(findTestSubject(component, 'variableEditorType').text()).toContain('Text');
+  });
+});
+
+describe('VariableEditorFlyout — non-Text regression', () => {
+  it('still renders Sort and multi-select for Custom variables', () => {
+    const { component } = mountEditor(customVariable());
+
+    expect(findTestSubject(component, 'variableEditorSort').length).toBe(1);
+    expect(findTestSubject(component, 'variableEditorMulti').length).toBe(1);
+  });
+
+  it('renders custom options and no Text Value field for Custom variables', () => {
+    const { component } = mountEditor(customVariable());
+
+    expect(findTestSubject(component, 'variableEditorCustomValues').length).toBe(1);
+    expect(findTestSubject(component, 'variableEditorTextValue').length).toBe(0);
+  });
+
+  it('still saves multi/includeAll/sort for Custom variables', async () => {
+    const { component, onSave } = mountEditor(customVariable());
+
+    await clickSave(component);
+
+    const payload = onSave.mock.calls[0][0];
+    expect(payload.type).toBe(VariableType.Custom);
+    expect(payload).toHaveProperty('multi');
+    expect(payload).toHaveProperty('includeAll');
+    expect(payload).toHaveProperty('sort');
+    expect(payload.current).toBeUndefined();
+  });
+});
+
+describe('VariableEditorFlyout — allowCustomValue', () => {
+  it('renders the Allow custom values switch for Custom variables', () => {
+    const { component } = mountEditor(customVariable());
+
+    expect(findTestSubject(component, 'variableEditorAllowCustomValue').length).toBe(1);
+  });
+
+  it('does not render the Allow custom values switch for Text variables', () => {
+    const { component } = mountEditor(textVariable());
+
+    expect(findTestSubject(component, 'variableEditorAllowCustomValue').length).toBe(0);
+  });
+
+  it('reflects the existing allowCustomValue state', () => {
+    const { component } = mountEditor(customVariable({ allowCustomValue: true }));
+
+    expect(
+      findTestSubject(component, 'variableEditorAllowCustomValue').props()['aria-checked']
+    ).toBe(true);
+  });
+
+  it('defaults to off for a variable that never set it', () => {
+    const { component } = mountEditor(customVariable());
+
+    expect(
+      findTestSubject(component, 'variableEditorAllowCustomValue').props()['aria-checked']
+    ).toBe(false);
+  });
+
+  it('saves allowCustomValue when toggled on', async () => {
+    const { component, onSave } = mountEditor(customVariable());
+
+    findTestSubject(component, 'variableEditorAllowCustomValue').simulate('click');
+    await clickSave(component);
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ allowCustomValue: true }));
+  });
+
+  it('saves allowCustomValue=false when toggled off', async () => {
+    const { component, onSave } = mountEditor(customVariable({ allowCustomValue: true }));
+
+    findTestSubject(component, 'variableEditorAllowCustomValue').simulate('click');
+    await clickSave(component);
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ allowCustomValue: false }));
+  });
+
+  it('does not send allowCustomValue for Text variables', async () => {
+    const { component, onSave } = mountEditor(textVariable());
+
+    await clickSave(component);
+
+    expect(onSave.mock.calls[0][0]).not.toHaveProperty('allowCustomValue');
+  });
+});

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.test.tsx
@@ -36,6 +36,19 @@ const customVariable = (overrides: Partial<Variable> = {}): Variable =>
     ...overrides,
   }) as Variable;
 
+const queryVariable = (overrides: Partial<Variable> = {}): Variable =>
+  ({
+    id: 'query-1',
+    name: 'service',
+    type: VariableType.Query,
+    current: ['api'],
+    query: '| fields service',
+    language: 'PPL',
+    dataset: { id: 'ds-1', title: 'logs', type: 'INDEX_PATTERN' },
+    valueField: 'service',
+    ...overrides,
+  }) as Variable;
+
 function mountEditor(existingVariable?: Variable) {
   const onSave = jest.fn().mockResolvedValue(undefined);
   const onClose = jest.fn();
@@ -230,5 +243,27 @@ describe('VariableEditorFlyout — allowCustomValue', () => {
     await clickSave(component);
 
     expect(onSave.mock.calls[0][0]).not.toHaveProperty('allowCustomValue');
+  });
+
+  // The toggle sits in the `type !== Text` block, so Query gets it as well as
+  // Custom. Covered explicitly because the two types take different save paths.
+  it('renders the Allow custom values switch for Query variables', () => {
+    const { component } = mountEditor(queryVariable());
+
+    expect(findTestSubject(component, 'variableEditorAllowCustomValue').length).toBe(1);
+  });
+
+  it('reflects and saves allowCustomValue for Query variables', async () => {
+    const { component, onSave } = mountEditor(queryVariable({ allowCustomValue: true }));
+
+    expect(
+      findTestSubject(component, 'variableEditorAllowCustomValue').props()['aria-checked']
+    ).toBe(true);
+
+    await clickSave(component);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ type: VariableType.Query, allowCustomValue: true })
+    );
   });
 });

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
@@ -33,7 +33,7 @@ import { IVariableInterpolationService } from '../../../variables/variable_inter
 
 export interface VariableEditorFlyoutProps {
   onClose: () => void;
-  onSave: (variable: Omit<Variable, 'id' | 'current'>) => Promise<void>;
+  onSave: (variable: Omit<Variable, 'id'>) => Promise<void>;
   existingVariable?: Variable;
   existingVariables?: Variable[];
   interpolationService?: IVariableInterpolationService;
@@ -510,7 +510,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
               onChange={(t) => {
                 setType(t);
                 setError(null);
-                setIsPreviewValid(t !== VariableType.Query);
+                setIsPreviewValid(false);
               }}
               data-test-subj="variableEditorType"
               compressed

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
@@ -334,7 +334,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
     if (!validateForm()) return;
 
     setIsSaving(true);
-    const variableConfig: Omit<Variable, 'id' | 'current'> = {
+    const variableConfig: Omit<Variable, 'id'> = {
       name: name.trim(),
       label: label.trim() || undefined,
       description: description.trim() || undefined,

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_editor_flyout.tsx
@@ -80,6 +80,28 @@ const variableTypeOptions = [
       </>
     ),
   },
+  {
+    value: VariableType.Text,
+    inputDisplay: i18n.translate('dashboard.variableEditor.typeText', {
+      defaultMessage: 'Text',
+    }),
+    dropdownDisplay: (
+      <>
+        <strong>
+          {i18n.translate('dashboard.variableEditor.typeText', {
+            defaultMessage: 'Text',
+          })}
+        </strong>
+        <EuiText size="s" color="subdued">
+          <p className="ouiTextColor--subdued">
+            {i18n.translate('dashboard.variableEditor.typeText.description', {
+              defaultMessage: 'A free-form text input with no option list',
+            })}
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
 ];
 
 interface CustomOptionRow {
@@ -121,6 +143,9 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
   );
   const [multi, setMulti] = useState(existingVariable?.multi || false);
   const [includeAll, setIncludeAll] = useState(existingVariable?.includeAll || false);
+  const [allowCustomValue, setAllowCustomValue] = useState(
+    existingVariable?.allowCustomValue || false
+  );
   const [sort, setSort] = useState<VariableSortOrder>(
     existingVariable?.sort || VariableSortOrder.Disabled
   );
@@ -138,11 +163,14 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
   const [labelField, setLabelField] = useState(
     existingVariable?.type === VariableType.Query ? (existingVariable.labelField ?? '') : ''
   );
+  const [textValue, setTextValue] = useState(
+    existingVariable?.type === VariableType.Text ? (existingVariable.current?.[0] ?? '') : ''
+  );
 
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // When editing an existing variable, assume preview is valid (user already saved it before)
-  // For new variables, require preview before saving
+  // For new variables, require preview before saving (Query type only — Text/Custom have no preview step)
   const [isPreviewValid, setIsPreviewValid] = useState(
     Boolean(existingVariable && existingVariable.type === VariableType.Query)
   );
@@ -311,9 +339,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
       label: label.trim() || undefined,
       description: description.trim() || undefined,
       type,
-      multi,
-      includeAll,
-      sort,
+      ...(type !== VariableType.Text && { multi, includeAll, sort, allowCustomValue }),
     };
 
     if (type === VariableType.Query) {
@@ -337,6 +363,10 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
           };
         }),
       });
+    } else if (type === VariableType.Text) {
+      Object.assign(variableConfig, {
+        current: textValue.trim() ? [textValue.trim()] : undefined,
+      });
     }
 
     await onSave(variableConfig);
@@ -355,8 +385,10 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
     customValues,
     multi,
     includeAll,
+    allowCustomValue,
     sort,
     regex,
+    textValue,
     onSave,
     validateForm,
   ]);
@@ -478,7 +510,7 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
               onChange={(t) => {
                 setType(t);
                 setError(null);
-                setIsPreviewValid(false);
+                setIsPreviewValid(t !== VariableType.Query);
               }}
               data-test-subj="variableEditorType"
               compressed
@@ -635,90 +667,123 @@ export const VariableEditorFlyout: React.FC<VariableEditorFlyoutProps> = ({
               )}
             </>
           )}
-        </EuiFlexItem>
 
-        <EuiHorizontalRule margin="none" />
-
-        <EuiFlexItem>
-          <EuiFormRow
-            label={i18n.translate('dashboard.variableEditor.sortLabel', {
-              defaultMessage: 'Sort',
-            })}
-            helpText={i18n.translate('dashboard.variableEditor.sortLabelHelp', {
-              defaultMessage: 'How options are sorted in the dropdown',
-            })}
-          >
-            <EuiSuperSelect
-              options={[
-                {
-                  value: VariableSortOrder.Disabled,
-                  inputDisplay: i18n.translate('dashboard.variableEditor.sortDisabled', {
-                    defaultMessage: 'Disabled',
-                  }),
-                },
-                {
-                  value: VariableSortOrder.AlphabeticalAsc,
-                  inputDisplay: i18n.translate('dashboard.variableEditor.sortAlphaAsc', {
-                    defaultMessage: 'Alphabetical (asc)',
-                  }),
-                },
-                {
-                  value: VariableSortOrder.AlphabeticalDesc,
-                  inputDisplay: i18n.translate('dashboard.variableEditor.sortAlphaDesc', {
-                    defaultMessage: 'Alphabetical (desc)',
-                  }),
-                },
-                {
-                  value: VariableSortOrder.NumericalAsc,
-                  inputDisplay: i18n.translate('dashboard.variableEditor.sortNumAsc', {
-                    defaultMessage: 'Numerical (asc)',
-                  }),
-                },
-                {
-                  value: VariableSortOrder.NumericalDesc,
-                  inputDisplay: i18n.translate('dashboard.variableEditor.sortNumDesc', {
-                    defaultMessage: 'Numerical (desc)',
-                  }),
-                },
-              ]}
-              valueOfSelected={sort}
-              onChange={(v) => setSort(v)}
-              data-test-subj="variableEditorSort"
-              compressed
-            />
-          </EuiFormRow>
-          <EuiFormRow>
-            <EuiSwitch
-              label={i18n.translate('dashboard.variableEditor.multiLabel', {
-                defaultMessage: 'Allow multiple selections',
+          {type === VariableType.Text && (
+            <EuiFormRow
+              label={i18n.translate('dashboard.variableEditor.textValueLabel', {
+                defaultMessage: 'Value',
               })}
-              checked={multi}
-              onChange={(e) => {
-                const checked = e.target.checked;
-                setMulti(checked);
-                if (!checked) {
-                  setIncludeAll(false);
-                }
-              }}
-              data-test-subj="variableEditorMulti"
-              compressed
-            />
-          </EuiFormRow>
-
-          {multi && (
-            <EuiFormRow>
-              <EuiSwitch
-                label={i18n.translate('dashboard.variableEditor.includeAllLabel', {
-                  defaultMessage: 'Include All option',
-                })}
-                checked={includeAll}
-                onChange={(e) => setIncludeAll(e.target.checked)}
-                data-test-subj="variableEditorIncludeAll"
+              helpText={i18n.translate('dashboard.variableEditor.textValueHelp', {
+                defaultMessage: 'Free-form text value for this variable',
+              })}
+            >
+              <EuiFieldText
+                value={textValue}
+                onChange={(e) => setTextValue(e.target.value)}
+                data-test-subj="variableEditorTextValue"
                 compressed
               />
             </EuiFormRow>
           )}
         </EuiFlexItem>
+
+        {type !== VariableType.Text && (
+          <>
+            <EuiHorizontalRule margin="none" />
+
+            <EuiFlexItem>
+              <EuiFormRow
+                label={i18n.translate('dashboard.variableEditor.sortLabel', {
+                  defaultMessage: 'Sort',
+                })}
+                helpText={i18n.translate('dashboard.variableEditor.sortLabelHelp', {
+                  defaultMessage: 'How options are sorted in the dropdown',
+                })}
+              >
+                <EuiSuperSelect
+                  options={[
+                    {
+                      value: VariableSortOrder.Disabled,
+                      inputDisplay: i18n.translate('dashboard.variableEditor.sortDisabled', {
+                        defaultMessage: 'Disabled',
+                      }),
+                    },
+                    {
+                      value: VariableSortOrder.AlphabeticalAsc,
+                      inputDisplay: i18n.translate('dashboard.variableEditor.sortAlphaAsc', {
+                        defaultMessage: 'Alphabetical (asc)',
+                      }),
+                    },
+                    {
+                      value: VariableSortOrder.AlphabeticalDesc,
+                      inputDisplay: i18n.translate('dashboard.variableEditor.sortAlphaDesc', {
+                        defaultMessage: 'Alphabetical (desc)',
+                      }),
+                    },
+                    {
+                      value: VariableSortOrder.NumericalAsc,
+                      inputDisplay: i18n.translate('dashboard.variableEditor.sortNumAsc', {
+                        defaultMessage: 'Numerical (asc)',
+                      }),
+                    },
+                    {
+                      value: VariableSortOrder.NumericalDesc,
+                      inputDisplay: i18n.translate('dashboard.variableEditor.sortNumDesc', {
+                        defaultMessage: 'Numerical (desc)',
+                      }),
+                    },
+                  ]}
+                  valueOfSelected={sort}
+                  onChange={(v) => setSort(v)}
+                  data-test-subj="variableEditorSort"
+                  compressed
+                />
+              </EuiFormRow>
+              <EuiFormRow>
+                <EuiSwitch
+                  label={i18n.translate('dashboard.variableEditor.allowCustomValueLabel', {
+                    defaultMessage: 'Allow custom values',
+                  })}
+                  checked={allowCustomValue}
+                  onChange={(e) => setAllowCustomValue(e.target.checked)}
+                  data-test-subj="variableEditorAllowCustomValue"
+                  compressed
+                />
+              </EuiFormRow>
+              <EuiFormRow>
+                <EuiSwitch
+                  label={i18n.translate('dashboard.variableEditor.multiLabel', {
+                    defaultMessage: 'Allow multiple selections',
+                  })}
+                  checked={multi}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setMulti(checked);
+                    if (!checked) {
+                      setIncludeAll(false);
+                    }
+                  }}
+                  data-test-subj="variableEditorMulti"
+                  compressed
+                />
+              </EuiFormRow>
+
+              {multi && (
+                <EuiFormRow>
+                  <EuiSwitch
+                    label={i18n.translate('dashboard.variableEditor.includeAllLabel', {
+                      defaultMessage: 'Include All option',
+                    })}
+                    checked={includeAll}
+                    onChange={(e) => setIncludeAll(e.target.checked)}
+                    data-test-subj="variableEditorIncludeAll"
+                    compressed
+                  />
+                </EuiFormRow>
+              )}
+            </EuiFlexItem>
+          </>
+        )}
         <EuiHorizontalRule margin="none" />
         <EuiFlexItem grow={false}>
           <EuiFlexGroup justifyContent="spaceBetween">

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_management_flyout.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_management_flyout.tsx
@@ -41,6 +41,7 @@ export interface VariableManagementFlyoutProps {
 const variableTypeLabels: Record<VariableType, string> = {
   [VariableType.Query]: 'Query',
   [VariableType.Custom]: 'Custom',
+  [VariableType.Text]: 'Text',
 };
 
 export const VariableManagementFlyout: React.FC<VariableManagementFlyoutProps> = ({

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variable_selector.scss
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variable_selector.scss
@@ -64,6 +64,26 @@
   cursor: help !important;
 }
 
+// Text-type variable input — strip EuiFieldText's own border/background so it
+// visually merges into the shared .variableSelectorContainer card, and match
+// the compact line-height/height used by the popover button (ValueSelector)
+// so Text and Query/Custom variables render at the same height.
+.variableTextInput {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  height: $euiFontSizeS * 1.5; // matches EuiText size="s" line-height used by ValueSelector
+  font-size: $euiFontSizeS;
+  line-height: $euiFontSizeS * 1.5;
+
+  &:focus,
+  &:focus-within {
+    box-shadow: none !important;
+    background: transparent !important;
+  }
+}
+
 .manageVariablesButton {
   border-color: $euiColorMediumShade !important;
   color: $euiColorDarkShade !important;

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.test.tsx
@@ -1,0 +1,571 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { KeyboardEvent, ReactNode } from 'react';
+import type { ReactWrapper } from 'enzyme';
+import { BehaviorSubject } from 'rxjs';
+import { EuiPopover, EuiSelectable } from '@elastic/eui';
+import { act } from 'react-dom/test-utils';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+// @ts-expect-error TS2306 TODO(ts-error): fixme
+import { findTestSubject } from '@elastic/eui/lib/test';
+
+import { VariablesBar } from './variables_bar';
+import { VariableService } from '../../../variables/variable_service';
+import { VariableType, VariableWithState } from '../../../variables/types';
+
+const makeTextVariable = (overrides: Partial<VariableWithState> = {}): VariableWithState =>
+  ({
+    id: 'text-1',
+    name: 'keyword',
+    type: VariableType.Text,
+    current: ['timeout'],
+    options: [],
+    ...overrides,
+  }) as VariableWithState;
+
+const makeCustomVariable = (overrides: Partial<VariableWithState> = {}): VariableWithState =>
+  ({
+    id: 'custom-1',
+    name: 'env',
+    type: VariableType.Custom,
+    current: ['dev'],
+    customOptions: ['dev', 'prod'],
+    options: [{ value: 'dev' }, { value: 'prod' }],
+    ...overrides,
+  }) as VariableWithState;
+
+/**
+ * VariablesBar only consumes getVariables$() and updateVariableValue(), so a
+ * minimal fake keeps these tests focused on the bar's own rendering/commit logic.
+ */
+function createFakeService(initial: VariableWithState[]) {
+  const variables$ = new BehaviorSubject<VariableWithState[]>(initial);
+  const updateVariableValue = jest.fn();
+  const service = {
+    getVariables$: () => variables$,
+    updateVariableValue,
+  } as unknown as VariableService;
+  return { service, variables$, updateVariableValue };
+}
+
+function mountBar(variables: VariableWithState[], isEditMode = false) {
+  const { service, variables$, updateVariableValue } = createFakeService(variables);
+  const component = mountWithIntl(
+    <VariablesBar variableService={service} isEditMode={isEditMode} />
+  );
+  return { component, variables$, updateVariableValue };
+}
+
+describe('VariablesBar — Text variables', () => {
+  it('renders a free-text input for a Text variable', () => {
+    const { component } = mountBar([makeTextVariable()]);
+
+    const input = findTestSubject(component, 'variable-text-input');
+    expect(input.length).toBe(1);
+    expect(input.props().value).toBe('timeout');
+  });
+
+  it('renders the popover selector (not a text input) for non-Text variables', () => {
+    const { component } = mountBar([makeCustomVariable()]);
+
+    expect(findTestSubject(component, 'variable-text-input').length).toBe(0);
+    expect(findTestSubject(component, 'variable-selector-button').length).toBe(1);
+  });
+
+  it('renders the correct control per type when both are present', () => {
+    const { component } = mountBar([makeCustomVariable(), makeTextVariable()]);
+
+    expect(findTestSubject(component, 'variable-text-input').length).toBe(1);
+    expect(findTestSubject(component, 'variable-selector-button').length).toBe(1);
+  });
+
+  it('shows an empty input when the Text variable has no value', () => {
+    const { component } = mountBar([makeTextVariable({ current: undefined })]);
+
+    expect(findTestSubject(component, 'variable-text-input').props().value).toBe('');
+  });
+
+  it('commits the typed value on Enter', () => {
+    const { component, updateVariableValue } = mountBar([makeTextVariable()]);
+
+    const input = findTestSubject(component, 'variable-text-input');
+    input.simulate('change', { target: { value: 'latency' } });
+    input.simulate('keydown', { key: 'Enter' });
+
+    expect(updateVariableValue).toHaveBeenCalledTimes(1);
+    expect(updateVariableValue).toHaveBeenCalledWith('text-1', ['latency']);
+  });
+
+  it('commits the typed value on blur', () => {
+    const { component, updateVariableValue } = mountBar([makeTextVariable()]);
+
+    const input = findTestSubject(component, 'variable-text-input');
+    input.simulate('change', { target: { value: 'latency' } });
+    input.simulate('blur');
+
+    expect(updateVariableValue).toHaveBeenCalledTimes(1);
+    expect(updateVariableValue).toHaveBeenCalledWith('text-1', ['latency']);
+  });
+
+  it('does not commit while typing (only on Enter/blur)', () => {
+    const { component, updateVariableValue } = mountBar([makeTextVariable()]);
+
+    findTestSubject(component, 'variable-text-input').simulate('change', {
+      target: { value: 'part' },
+    });
+
+    expect(updateVariableValue).not.toHaveBeenCalled();
+  });
+
+  it('does not commit when the value is unchanged', () => {
+    const { component, updateVariableValue } = mountBar([makeTextVariable()]);
+
+    const input = findTestSubject(component, 'variable-text-input');
+    input.simulate('change', { target: { value: 'timeout' } });
+    input.simulate('keydown', { key: 'Enter' });
+
+    expect(updateVariableValue).not.toHaveBeenCalled();
+  });
+
+  it('commits an empty selection when the value is cleared', () => {
+    const { component, updateVariableValue } = mountBar([makeTextVariable()]);
+
+    const input = findTestSubject(component, 'variable-text-input');
+    input.simulate('change', { target: { value: '' } });
+    input.simulate('blur');
+
+    expect(updateVariableValue).toHaveBeenCalledWith('text-1', []);
+  });
+
+  it('ignores other keys', () => {
+    const { component, updateVariableValue } = mountBar([makeTextVariable()]);
+
+    const input = findTestSubject(component, 'variable-text-input');
+    input.simulate('change', { target: { value: 'latency' } });
+    input.simulate('keydown', { key: 'a' });
+
+    expect(updateVariableValue).not.toHaveBeenCalled();
+  });
+
+  it('re-syncs the input when the variable value changes externally', () => {
+    const { component, variables$ } = mountBar([makeTextVariable()]);
+
+    // e.g. the value was changed from the variable editor — the bar must pick it up.
+    act(() => {
+      variables$.next([makeTextVariable({ current: ['changed-elsewhere'] })]);
+    });
+    component.update();
+
+    expect(findTestSubject(component, 'variable-text-input').props().value).toBe(
+      'changed-elsewhere'
+    );
+  });
+
+  it('uses the label as the container label when provided', () => {
+    const { component } = mountBar([makeTextVariable({ label: 'Search keyword' })]);
+
+    const container = findTestSubject(component, 'variable-keyword');
+    expect(container.props()['data-label']).toBe('Search keyword');
+  });
+
+  it('falls back to the name when no label is set', () => {
+    const { component } = mountBar([makeTextVariable()]);
+
+    expect(findTestSubject(component, 'variable-keyword').props()['data-label']).toBe('keyword');
+  });
+
+  it('does not render hidden Text variables', () => {
+    const { component } = mountBar([makeTextVariable({ hide: true })]);
+
+    expect(findTestSubject(component, 'variable-text-input').length).toBe(0);
+  });
+});
+
+/**
+ * The popover's option rows are virtualized, so under jsdom (zero-height
+ * container) EuiSelectable renders zero rows and enzyme's simulated change on
+ * the EUI search input never reaches searchProps.onSearch. Asserting on that
+ * rendered content would pass or fail for the wrong reason.
+ *
+ * All of the add-custom-value logic lives in the props handed to EuiSelectable
+ * (options / onChange / searchProps / listProps), so these tests drive those
+ * props directly instead. Returns a getter, since every interaction re-renders.
+ */
+function openSelector(component: ReactWrapper) {
+  findTestSubject(component, 'variable-selector-button').simulate('click');
+  component.update();
+  return () => {
+    component.update();
+    return component.find(EuiSelectable).props() as unknown as SelectableProps;
+  };
+}
+
+interface SelectableOption {
+  label: string;
+  key?: string;
+  checked?: 'on' | 'off';
+  append?: unknown;
+  'data-test-subj'?: string;
+}
+
+interface SelectableProps {
+  options: SelectableOption[];
+  onChange: (options: SelectableOption[]) => void;
+  listProps?: { onFocusBadge?: boolean };
+  searchProps: {
+    placeholder: string;
+    onSearch?: (term: string) => void;
+    onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  };
+}
+
+type MockedKeyEvent = KeyboardEvent<HTMLInputElement> & {
+  preventDefault: jest.Mock;
+  stopPropagation: jest.Mock;
+};
+
+const keyEvent = (key: string): MockedKeyEvent =>
+  ({
+    key,
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+  }) as unknown as MockedKeyEvent;
+
+/** Marks the option at `index` as checked, the way EuiSelectable would. */
+const check = (options: SelectableOption[], index: number): SelectableOption[] =>
+  options.map((option, i) => (i === index ? { ...option, checked: 'on' } : option));
+
+describe('VariablesBar — allowCustomValue: the pending "add" row', () => {
+  it('offers the typed value as the first row, with a hint and unchecked', () => {
+    const { component } = mountBar([makeCustomVariable({ allowCustomValue: true })]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+
+    const [first, ...rest] = getProps().options;
+    expect(first.label).toBe('p99');
+    expect(first.checked).toBeUndefined();
+    expect(mountWithIntl(<div>{first.append as ReactNode}</div>).text()).toBe('Hit enter to add');
+    // The real options keep their place after it.
+    expect(rest.map((option) => option.label)).toEqual(['dev', 'prod']);
+  });
+
+  it('does not offer a value that is already an option', () => {
+    const { component } = mountBar([makeCustomVariable({ allowCustomValue: true })]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('prod');
+    });
+
+    expect(getProps().options.map((option) => option.label)).toEqual(['dev', 'prod']);
+    expect(getProps().options.some((option) => option.append)).toBe(false);
+  });
+
+  it('does not offer a value that was already committed', () => {
+    const { component } = mountBar([
+      makeCustomVariable({ allowCustomValue: true, multi: true, current: ['dev', 'p99'] }),
+    ]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+
+    expect(getProps().options.some((option) => option.append)).toBe(false);
+  });
+
+  it('does not wire up the add-value hooks when the feature is off', () => {
+    const { component } = mountBar([makeCustomVariable()]);
+    const getProps = openSelector(component);
+
+    expect(getProps().searchProps.onSearch).toBeUndefined();
+    expect(getProps().searchProps.placeholder).toBe('Contains...');
+  });
+
+  it('advertises the add affordance in the search placeholder when the feature is on', () => {
+    const { component } = mountBar([makeCustomVariable({ allowCustomValue: true })]);
+
+    expect(openSelector(component)().searchProps.placeholder).toBe('Contains... or type to add');
+  });
+
+  it("hides EUI's per-row enter badge only while a value is pending", () => {
+    const { component } = mountBar([makeCustomVariable({ allowCustomValue: true })]);
+    const getProps = openSelector(component);
+
+    expect(getProps().listProps).toBeUndefined();
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+
+    // The badge tracks EuiSelectable's own focused row, but Enter adds the pending
+    // value instead — leaving it visible would point it at the wrong row.
+    expect(getProps().listProps).toEqual({ onFocusBadge: false });
+  });
+});
+
+describe('VariablesBar — allowCustomValue: committing', () => {
+  it('commits the typed value exactly once on Enter for a single-select variable', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true, multi: false }),
+    ]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+    const event = keyEvent('Enter');
+    act(() => {
+      getProps().searchProps.onKeyDown(event);
+    });
+
+    expect(updateVariableValue).toHaveBeenCalledTimes(1);
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['p99']);
+    // Regression guard. Without stopPropagation, EuiSelectable's own Enter handler
+    // also runs and, under singleSelection, its onAddOption clears `checked` on
+    // every option and re-checks by object identity — a stale identity then emits
+    // an all-unchecked array, which wipes the variable's value.
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces the selection for a single-select variable', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true, multi: false, current: ['dev'] }),
+    ]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+    act(() => {
+      getProps().searchProps.onKeyDown(keyEvent('Enter'));
+    });
+
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['p99']);
+  });
+
+  it('appends to the selection for a multi-select variable', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true, multi: true, current: ['dev', 'prod'] }),
+    ]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+    act(() => {
+      getProps().searchProps.onKeyDown(keyEvent('Enter'));
+    });
+
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['dev', 'prod', 'p99']);
+  });
+
+  it('commits when the row is picked instead of typing Enter', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true, multi: true, current: ['dev'] }),
+    ]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+    act(() => {
+      getProps().onChange(check(getProps().options, 0));
+    });
+
+    // Not stored as an ordinary selection — the row is a synthetic affordance.
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['dev', 'p99']);
+  });
+
+  it('leaves a plain Enter to EuiSelectable when there is nothing to add', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true }),
+    ]);
+    const getProps = openSelector(component);
+
+    // 'dev' is an existing option, so no value is pending.
+    act(() => {
+      getProps().searchProps.onSearch!('dev');
+    });
+    const event = keyEvent('Enter');
+    act(() => {
+      getProps().searchProps.onKeyDown(event);
+    });
+
+    expect(updateVariableValue).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('ignores keys other than Enter', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true }),
+    ]);
+    const getProps = openSelector(component);
+
+    act(() => {
+      getProps().searchProps.onSearch!('p99');
+    });
+    act(() => {
+      getProps().searchProps.onKeyDown(keyEvent('a'));
+    });
+
+    expect(updateVariableValue).not.toHaveBeenCalled();
+  });
+
+  it('closes the popover after a single-select commit but keeps it open for multi', () => {
+    // Assert our own isOpen state rather than whether the panel is still mounted:
+    // EuiPopover keeps the panel around during its close transition.
+    const isOpen = (wrapper: ReactWrapper) => {
+      wrapper.update();
+      return wrapper.find(EuiPopover).first().props().isOpen;
+    };
+
+    const single = mountBar([makeCustomVariable({ allowCustomValue: true, multi: false })]);
+    const singleProps = openSelector(single.component);
+    expect(isOpen(single.component)).toBe(true);
+    act(() => {
+      singleProps().searchProps.onSearch!('p99');
+    });
+    act(() => {
+      singleProps().searchProps.onKeyDown(keyEvent('Enter'));
+    });
+    expect(isOpen(single.component)).toBe(false);
+
+    const multi = mountBar([makeCustomVariable({ allowCustomValue: true, multi: true })]);
+    const multiProps = openSelector(multi.component);
+    act(() => {
+      multiProps().searchProps.onSearch!('p99');
+    });
+    act(() => {
+      multiProps().searchProps.onKeyDown(keyEvent('Enter'));
+    });
+    expect(isOpen(multi.component)).toBe(true);
+  });
+});
+
+describe('VariablesBar — allowCustomValue: committed values in the list', () => {
+  it('renders committed off-list values as checked rows', () => {
+    const { component } = mountBar([
+      makeCustomVariable({
+        allowCustomValue: true,
+        multi: true,
+        current: ['dev', 'p99', 'p50'],
+      }),
+    ]);
+
+    const options = openSelector(component)().options;
+    expect(options.map((option) => option.label)).toEqual(['dev', 'prod', 'p99', 'p50']);
+
+    // They need real rows, otherwise they would be invisible and un-deselectable.
+    const custom = options.filter(
+      (option) => option['data-test-subj'] === 'variable-custom-value-option'
+    );
+    expect(custom.map((option) => option.label)).toEqual(['p99', 'p50']);
+    expect(custom.every((option) => option.checked === 'on')).toBe(true);
+  });
+
+  it('de-selects a committed custom value through its row', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({ allowCustomValue: true, multi: true, current: ['dev', 'p99'] }),
+    ]);
+    const getProps = openSelector(component);
+
+    const options = getProps().options;
+    const withoutP99 = options.map((option) =>
+      option.label === 'p99' ? { ...option, checked: undefined } : option
+    );
+    act(() => {
+      getProps().onChange(withoutP99);
+    });
+
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['dev']);
+  });
+
+  it('does not fabricate rows for off-list values when the feature is off', () => {
+    const { component } = mountBar([makeCustomVariable({ multi: true, current: ['dev', 'p99'] })]);
+
+    expect(openSelector(component)().options.map((option) => option.label)).toEqual([
+      'dev',
+      'prod',
+    ]);
+  });
+
+  it('keeps custom values when "All" is checked', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({
+        allowCustomValue: true,
+        multi: true,
+        includeAll: true,
+        current: ['p99'],
+      }),
+    ]);
+    const getProps = openSelector(component);
+
+    const options = getProps().options;
+    const allIndex = options.findIndex((option) => option.label === 'All');
+    act(() => {
+      getProps().onChange(check(options, allIndex));
+    });
+
+    // "All" covers the listed options only.
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['dev', 'prod', 'p99']);
+  });
+
+  it('keeps custom values when "All" is unchecked', () => {
+    const { component, updateVariableValue } = mountBar([
+      makeCustomVariable({
+        allowCustomValue: true,
+        multi: true,
+        includeAll: true,
+        current: ['dev', 'prod', 'p99'],
+      }),
+    ]);
+    const getProps = openSelector(component);
+
+    const options = getProps().options;
+    const uncheckedAll = options.map((option) =>
+      option.label === 'All' ? { ...option, checked: undefined } : option
+    );
+    act(() => {
+      getProps().onChange(uncheckedAll);
+    });
+
+    expect(updateVariableValue).toHaveBeenCalledWith('custom-1', ['p99']);
+  });
+
+  it('counts custom values in the multi-select badge', () => {
+    const { component } = mountBar([
+      makeCustomVariable({
+        allowCustomValue: true,
+        multi: true,
+        current: ['dev', 'custom-a', 'custom-b'],
+      }),
+    ]);
+
+    expect(findTestSubject(component, 'variable-selector-button').text()).toContain('3');
+  });
+
+  it('does not claim plain "All" when custom values are also selected', () => {
+    const { component } = mountBar([
+      makeCustomVariable({
+        allowCustomValue: true,
+        multi: true,
+        includeAll: true,
+        // every listed option plus an off-list value
+        current: ['dev', 'prod', 'custom-a'],
+      }),
+    ]);
+
+    const buttonText = findTestSubject(component, 'variable-selector-button').text();
+    expect(buttonText).not.toBe('All');
+    expect(buttonText).toContain('3');
+  });
+});

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
@@ -157,7 +157,9 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
 
   const commitCustomValue = useCallback(() => {
     if (!pendingCustomValue) return;
-    const next = variable.multi ? [...selectedValues, pendingCustomValue] : [pendingCustomValue];
+    const next = variable.multi
+      ? Array.from(new Set([...selectedValues, pendingCustomValue]))
+      : [pendingCustomValue];
     onValuesChange(variable.id, next);
     // Keep the search term: the value now renders as a checked row that still
     // matches it, which is the only confirmation this popover can show.

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
@@ -19,10 +19,11 @@ import {
   EuiPanel,
   EuiLoadingSpinner,
   EuiIconTip,
+  EuiFieldText,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { VariableService } from '../../../variables/variable_service';
-import { VariableWithState } from '../../../variables/types';
+import { VariableType, VariableWithState } from '../../../variables/types';
 import {
   buildVariableOptionDisplayTextMap,
   getVariableOptionDisplayText,
@@ -49,15 +50,28 @@ interface ValueSelectorProps {
 const ALL_OPTION_VALUE = '__all__';
 // EuiSelectable emits display labels on change, so namespaced keys carry the stored values.
 const OPTION_VALUE_KEY_PREFIX = '__value:';
+// Key of the synthetic "add the value you just typed" row. Never a stored value.
+const ADD_CUSTOM_VALUE_KEY = '__addCustomValue__';
 
 const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
 
   // Parse current selected values
   const currentValue = variable.current;
   const selectedValues = useMemo(() => {
     return currentValue ?? [];
   }, [currentValue]);
+
+  const allowCustomValue = !!variable.allowCustomValue;
+
+  // Committed values that are not in the generated/static option list.
+  const customSelectedValues = useMemo(() => {
+    if (!allowCustomValue) return [];
+    return selectedValues.filter(
+      (value) => !variable.options.some((option) => option.value === value)
+    );
+  }, [allowCustomValue, selectedValues, variable.options]);
 
   // Check if "All" is currently selected (all real options are selected)
   const isAllSelected = useMemo(() => {
@@ -73,9 +87,35 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
     [variable.options]
   );
 
+  // The typed term, unless it is already an option or an already-committed value.
+  const pendingCustomValue = useMemo(() => {
+    if (!allowCustomValue) return '';
+    const term = searchTerm.trim();
+    if (!term) return '';
+    const alreadyExists =
+      variable.options.some((option) => option.value === term) || selectedValues.includes(term);
+    return alreadyExists ? '' : term;
+  }, [allowCustomValue, searchTerm, variable.options, selectedValues]);
+
   // Convert to EuiSelectable options format, prepend "All" if enabled
   const selectableOptions: EuiSelectableOption[] = useMemo(() => {
     const options: EuiSelectableOption[] = [];
+
+    // First row, under the search box. Label is the term itself so EuiSelectable's
+    // filtering keeps it visible.
+    if (pendingCustomValue) {
+      options.push({
+        label: pendingCustomValue,
+        key: ADD_CUSTOM_VALUE_KEY,
+        append: (
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('dashboard.variables.hitEnterToAdd', {
+              defaultMessage: 'Hit enter to add',
+            })}
+          </EuiText>
+        ),
+      });
+    }
 
     if (variable.includeAll && variable.multi && variable.options.length > 0) {
       options.push({
@@ -93,6 +133,16 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
       });
     });
 
+    // Committed off-list values need rows too, or they cannot be de-selected.
+    customSelectedValues.forEach((value) => {
+      options.push({
+        label: value,
+        key: `${OPTION_VALUE_KEY_PREFIX}${value}`,
+        checked: 'on',
+        'data-test-subj': 'variable-custom-value-option',
+      });
+    });
+
     return options;
   }, [
     variable.options,
@@ -101,32 +151,54 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
     selectedValues,
     isAllSelected,
     optionDisplayTextMap,
+    customSelectedValues,
+    pendingCustomValue,
   ]);
+
+  const commitCustomValue = useCallback(() => {
+    if (!pendingCustomValue) return;
+    const next = variable.multi ? [...selectedValues, pendingCustomValue] : [pendingCustomValue];
+    onValuesChange(variable.id, next);
+    // Keep the search term: the value now renders as a checked row that still
+    // matches it, which is the only confirmation this popover can show.
+    if (!variable.multi) {
+      setIsOpen(false);
+    }
+  }, [pendingCustomValue, variable.multi, variable.id, selectedValues, onValuesChange]);
 
   const handleChange = useCallback(
     (newOptions: EuiSelectableOption[]) => {
+      // Synthetic "add" row: commit a custom value instead of storing a selection.
+      const addCustomOption = newOptions.find((opt) => opt.key === ADD_CUSTOM_VALUE_KEY);
+      if (addCustomOption?.checked === 'on') {
+        commitCustomValue();
+        return;
+      }
+
       // Check if "All" option exists and was toggled
       const allOption = newOptions.find((opt) => opt.key === ALL_OPTION_VALUE);
       const allIsChecked = allOption?.checked === 'on';
 
       if (variable.includeAll && variable.multi && allOption) {
         if (allIsChecked && !isAllSelected) {
-          // "All" was just checked → select all real options
-          onValuesChange(
-            variable.id,
-            variable.options.map((option) => option.value)
-          );
+          // "All" covers the listed options only; custom values are kept.
+          onValuesChange(variable.id, [
+            ...variable.options.map((option) => option.value),
+            ...customSelectedValues,
+          ]);
           return;
         } else if (!allIsChecked && isAllSelected) {
-          // "All" was just unchecked → deselect all
-          onValuesChange(variable.id, []);
+          onValuesChange(variable.id, [...customSelectedValues]);
           return;
         }
       }
 
-      // Normal selection: filter out the "All" pseudo-option
+      // Normal selection: filter out the "All" and "add custom value" pseudo-options
       const values = newOptions
-        .filter((opt) => opt.checked === 'on' && opt.key !== ALL_OPTION_VALUE)
+        .filter(
+          (opt) =>
+            opt.checked === 'on' && opt.key !== ALL_OPTION_VALUE && opt.key !== ADD_CUSTOM_VALUE_KEY
+        )
         .map((opt) =>
           typeof opt.key === 'string' && opt.key.startsWith(OPTION_VALUE_KEY_PREFIX)
             ? opt.key.slice(OPTION_VALUE_KEY_PREFIX.length)
@@ -145,7 +217,9 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
       variable.multi,
       variable.options,
       isAllSelected,
+      customSelectedValues,
       onValuesChange,
+      commitCustomValue,
     ]
   );
 
@@ -170,7 +244,8 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
     if (isError) {
       return i18n.translate('dashboard.variables.error', { defaultMessage: 'Error' });
     }
-    if (isAllSelected) {
+    // Only a plain "All" when nothing off-list is also selected.
+    if (isAllSelected && customSelectedValues.length === 0) {
       return i18n.translate('dashboard.variables.allSelected', { defaultMessage: 'All' });
     }
     if (selectedValues.length > 0) {
@@ -186,7 +261,8 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
     }
     return i18n.translate('dashboard.variables.selectValue', { defaultMessage: 'Select value' });
   };
-  const selectedCount = isAllSelected ? variable.options.length : selectedValues.length;
+  // Already includes custom values; the old isAllSelected special-case was equivalent.
+  const selectedCount = selectedValues.length;
   const displayLabel = variable.label || variable.name;
   const calculatedMinWidth = Math.max(60, displayLabel.length * 5 + 60);
 
@@ -265,12 +341,26 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
         onChange={handleChange}
         searchable
         searchProps={{
-          placeholder: i18n.translate('dashboard.variables.searchPlaceholder', {
-            defaultMessage: 'Contains...',
-          }),
+          placeholder: allowCustomValue
+            ? i18n.translate('dashboard.variables.searchOrAddPlaceholder', {
+                defaultMessage: 'Contains... or type to add',
+              })
+            : i18n.translate('dashboard.variables.searchPlaceholder', {
+                defaultMessage: 'Contains...',
+              }),
           compressed: true,
+          // onSearch receives the raw string; onChange would give (options, value).
+          onSearch: allowCustomValue ? setSearchTerm : undefined,
+          onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter' && pendingCustomValue) {
+              e.preventDefault();
+              e.stopPropagation();
+              commitCustomValue();
+            }
+          },
         }}
         height={300}
+        listProps={pendingCustomValue ? { onFocusBadge: false } : undefined}
         singleSelection={variable.multi ? false : 'always'}
         emptyMessage={i18n.translate('dashboard.variables.noOptions', {
           defaultMessage: 'No options available',
@@ -284,6 +374,63 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
         )}
       </EuiSelectable>
     </EuiPopover>
+  );
+};
+
+/**
+ * Free-text input for Text-type variables.
+ * Commits the value on blur or Enter so dependent query variables
+ * only re-run once the user has finished typing.
+ */
+const TextValueEditor: React.FC<ValueSelectorProps> = ({ variable, onValuesChange }) => {
+  const committedValue = variable.current?.[0] ?? '';
+  const [draft, setDraft] = useState(committedValue);
+
+  useEffect(() => {
+    setDraft(committedValue);
+  }, [committedValue]);
+
+  const commit = useCallback(() => {
+    if (draft !== committedValue) {
+      onValuesChange(variable.id, draft ? [draft] : []);
+    }
+  }, [draft, committedValue, variable.id, onValuesChange]);
+
+  const displayLabel = variable.label || variable.name;
+  // Base width on the committed value, not the in-progress draft — sizing off
+  // draft would make the box jitter on every keystroke.
+  const calculatedWidth = Math.max(
+    120,
+    Math.min(Math.max(committedValue.length, displayLabel.length) * 8 + 40, 400)
+  );
+
+  return (
+    <EuiToolTip content={variable.description} position="bottom">
+      <div
+        className="variableSelectorContainer"
+        data-label={displayLabel}
+        data-test-subj={`variable-${variable.name}`}
+        style={{ width: `${calculatedWidth}px` }}
+      >
+        <EuiFieldText
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commit();
+            }
+          }}
+          placeholder={i18n.translate('dashboard.variables.textPlaceholder', {
+            defaultMessage: 'Enter value...',
+          })}
+          data-test-subj="variable-text-input"
+          className="variableTextInput"
+          compressed
+          controlOnly
+        />
+      </div>
+    </EuiToolTip>
   );
 };
 
@@ -388,7 +535,11 @@ export const VariablesBar: React.FC<VariablesBarProps> = ({
             <EuiFlexItem key={variable.id} grow={false}>
               <EuiFlexGroup gutterSize="xs" alignItems="center">
                 <EuiFlexItem grow={false}>
-                  <ValueSelector variable={variable} onValuesChange={handleValueChange} />
+                  {variable.type === VariableType.Text ? (
+                    <TextValueEditor variable={variable} onValuesChange={handleValueChange} />
+                  ) : (
+                    <ValueSelector variable={variable} onValuesChange={handleValueChange} />
+                  )}
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_variables/variables_bar.tsx
@@ -19,7 +19,6 @@ import {
   EuiPanel,
   EuiLoadingSpinner,
   EuiIconTip,
-  EuiFieldText,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { VariableService } from '../../../variables/variable_service';
@@ -28,6 +27,7 @@ import {
   buildVariableOptionDisplayTextMap,
   getVariableOptionDisplayText,
 } from '../../../variables/variable_option_display_utils';
+import { TextValueEditor } from './text_value_editor';
 import './variable_selector.scss';
 
 export interface VariablesBarProps {
@@ -376,63 +376,6 @@ const ValueSelector: React.FC<ValueSelectorProps> = ({ variable, onValuesChange 
         )}
       </EuiSelectable>
     </EuiPopover>
-  );
-};
-
-/**
- * Free-text input for Text-type variables.
- * Commits the value on blur or Enter so dependent query variables
- * only re-run once the user has finished typing.
- */
-const TextValueEditor: React.FC<ValueSelectorProps> = ({ variable, onValuesChange }) => {
-  const committedValue = variable.current?.[0] ?? '';
-  const [draft, setDraft] = useState(committedValue);
-
-  useEffect(() => {
-    setDraft(committedValue);
-  }, [committedValue]);
-
-  const commit = useCallback(() => {
-    if (draft !== committedValue) {
-      onValuesChange(variable.id, draft ? [draft] : []);
-    }
-  }, [draft, committedValue, variable.id, onValuesChange]);
-
-  const displayLabel = variable.label || variable.name;
-  // Base width on the committed value, not the in-progress draft — sizing off
-  // draft would make the box jitter on every keystroke.
-  const calculatedWidth = Math.max(
-    120,
-    Math.min(Math.max(committedValue.length, displayLabel.length) * 8 + 40, 400)
-  );
-
-  return (
-    <EuiToolTip content={variable.description} position="bottom">
-      <div
-        className="variableSelectorContainer"
-        data-label={displayLabel}
-        data-test-subj={`variable-${variable.name}`}
-        style={{ width: `${calculatedWidth}px` }}
-      >
-        <EuiFieldText
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              commit();
-            }
-          }}
-          placeholder={i18n.translate('dashboard.variables.textPlaceholder', {
-            defaultMessage: 'Enter value...',
-          })}
-          data-test-subj="variable-text-input"
-          className="variableTextInput"
-          compressed
-          controlOnly
-        />
-      </div>
-    </EuiToolTip>
   );
 };
 

--- a/src/plugins/dashboard/public/variables/types.ts
+++ b/src/plugins/dashboard/public/variables/types.ts
@@ -9,6 +9,7 @@
 export enum VariableType {
   Query = 'query',
   Custom = 'custom',
+  Text = 'text',
 }
 
 /**
@@ -31,6 +32,8 @@ export interface VariableMeta {
   includeAll?: boolean;
   /** Hide variable from UI */
   hide?: boolean;
+  /** Allow adding custom values */
+  allowCustomValue?: boolean;
   /** Description */
   description?: string;
   /** Sort order for options */
@@ -92,10 +95,14 @@ export interface QueryVariable extends VariableMeta, VariableQueryParams {
   useTimeFilter?: boolean;
 }
 
+export interface TextVariable extends VariableMeta {
+  type: VariableType.Text;
+}
+
 /**
  * Union of all persisted variable types.
  */
-export type Variable = CustomVariable | QueryVariable;
+export type Variable = CustomVariable | QueryVariable | TextVariable;
 
 /**
  * Option value type for query variables

--- a/src/plugins/dashboard/public/variables/variable_interpolation_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_interpolation_service.test.ts
@@ -7,7 +7,13 @@ import {
   VariableInterpolationService,
   createNoOpVariableInterpolationService,
 } from './variable_interpolation_service';
-import { VariableType, VariableWithState, CustomVariable, VariableState } from './types';
+import {
+  VariableType,
+  VariableWithState,
+  CustomVariable,
+  TextVariable,
+  VariableState,
+} from './types';
 
 type CustomVariableWithState = CustomVariable & VariableState;
 
@@ -29,6 +35,18 @@ const makeMultiVar = (overrides: Partial<CustomVariableWithState> = {}): Variabl
   multi: true,
   customOptions: ['us-east', 'us-west', 'eu-west'],
   options: [{ value: 'us-east' }, { value: 'us-west' }, { value: 'eu-west' }],
+  ...overrides,
+});
+
+type TextVariableWithState = TextVariable & VariableState;
+
+// Text variables have no options; `current` holds the free-form value.
+const makeTextVar = (overrides: Partial<TextVariableWithState> = {}): VariableWithState => ({
+  id: '3',
+  name: 'keyword',
+  type: VariableType.Text,
+  current: ['timeout'],
+  options: [],
   ...overrides,
 });
 
@@ -281,6 +299,57 @@ describe('VariableInterpolationService', () => {
       const svc = new VariableInterpolationService(() => [makeCustomVar()]);
       const vars = svc.getVariables();
       expect(vars[0].values).toBeUndefined();
+    });
+  });
+
+  describe('interpolate — Text variables', () => {
+    it('should interpolate a Text variable value', () => {
+      const svc = new VariableInterpolationService(() => [makeTextVar()]);
+      expect(svc.interpolate('source=logs | where msg = $keyword', 'PPL')).toBe(
+        'source=logs | where msg = timeout'
+      );
+    });
+
+    it('should interpolate a Text variable with braced syntax', () => {
+      const svc = new VariableInterpolationService(() => [makeTextVar()]);
+      expect(svc.interpolate('source=logs | where msg = ${keyword}', 'PPL')).toBe(
+        'source=logs | where msg = timeout'
+      );
+    });
+
+    it('should escape PPL single quotes in a free-form Text value', () => {
+      const svc = new VariableInterpolationService(() => [makeTextVar({ current: ["o'brien"] })]);
+      expect(svc.interpolate("source=logs | where user = '$keyword'", 'PPL')).toBe(
+        "source=logs | where user = 'o''brien'"
+      );
+    });
+
+    it('should escape PromQL regex metacharacters in a free-form Text value', () => {
+      const svc = new VariableInterpolationService(() => [makeTextVar({ current: ['/api/v1.*'] })]);
+      expect(svc.interpolate('http_requests{path=~"$keyword"}', 'PROMQL')).toBe(
+        'http_requests{path=~"/api/v1\\.\\*"}'
+      );
+    });
+
+    it('should treat a Text variable as single-valued even with several current entries', () => {
+      // Text is always single-valued (multi is not applicable), so it must not be
+      // formatted with the multi-value syntax.
+      const svc = new VariableInterpolationService(() => [makeTextVar({ current: ['a', 'b'] })]);
+      const vars = svc.getVariables();
+      expect(vars[0].multi).toBeFalsy();
+      expect(vars[0].values).toBeUndefined();
+    });
+
+    it('should interpolate an empty string when a Text variable has no value', () => {
+      const svc = new VariableInterpolationService(() => [makeTextVar({ current: undefined })]);
+      expect(svc.interpolate('source=logs | where msg = $keyword', 'PPL')).toBe(
+        'source=logs | where msg = '
+      );
+    });
+
+    it('should expose a Text variable through getCurrentValues', () => {
+      const svc = new VariableInterpolationService(() => [makeTextVar()]);
+      expect(svc.getCurrentValues()).toEqual({ keyword: 'timeout' });
     });
   });
 

--- a/src/plugins/dashboard/public/variables/variable_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.test.ts
@@ -29,10 +29,10 @@ function makeQueryResult(
 ) {
   return values.length > 0
     ? {
-      rows: values.map((value) => ({ [field]: value })),
-      fields: [field],
-      fieldTypes: { [field]: optionType },
-    }
+        rows: values.map((value) => ({ [field]: value })),
+        fields: [field],
+        fieldTypes: { [field]: optionType },
+      }
     : { rows: [], fields: [], fieldTypes: {} };
 }
 
@@ -1834,15 +1834,72 @@ describe('VariableService', () => {
       expect(values.v1).toEqual(['seeded']);
     });
 
-    it('should carry over the existing value when switching to Text without an explicit current', async () => {
+    it('should clear the value when switching to Text without an explicit current', async () => {
+      // A selection over an option list is meaningless as a Text value, and the
+      // editor's Value field is empty on a type switch — so the result must be empty
+      // too, otherwise the saved value would not match what the user saw.
       const { service } = createService(
         [makeCustomVariable({ id: 'v1', name: 'v1', current: ['dev'] })],
         'dashboard-1'
       );
       await service.updateVariable('v1', { type: VariableType.Text } as Partial<Variable>);
 
-      const values = getCurrentValues(service);
-      expect(values.v1).toEqual(['dev']);
+      expect(service.getVariables()[0].current).toBeUndefined();
+    });
+
+    it('should clear a multi-select selection when switching to Text', async () => {
+      const { service } = createService(
+        [makeCustomVariable({ id: 'v1', name: 'v1', multi: true, current: ['dev', 'prod'] })],
+        'dashboard-1'
+      );
+      await service.updateVariable('v1', { type: VariableType.Text } as Partial<Variable>);
+
+      expect(service.getVariables()[0].current).toBeUndefined();
+    });
+
+    it('should truncate an explicitly supplied multi-value current when switching to Text', async () => {
+      const { service } = createService(
+        [makeCustomVariable({ id: 'v1', name: 'v1', multi: true })],
+        'dashboard-1'
+      );
+      await service.updateVariable('v1', {
+        type: VariableType.Text,
+        current: ['a', 'b'],
+      } as Partial<Variable>);
+
+      expect(getCurrentValues(service).v1).toEqual(['a']);
+    });
+
+    it('should drop option-shaping fields when switching to Text', async () => {
+      const { service } = createService(
+        [
+          makeCustomVariable({
+            id: 'v1',
+            name: 'v1',
+            label: 'My label',
+            description: 'My description',
+            hide: true,
+            multi: true,
+            includeAll: true,
+            allowCustomValue: true,
+            sort: VariableSortOrder.AlphabeticalAsc,
+          }),
+        ],
+        'dashboard-1'
+      );
+      await service.updateVariable('v1', { type: VariableType.Text } as Partial<Variable>);
+
+      const updated = service.getVariables()[0];
+      // Everything that only makes sense for an option list is gone...
+      expect(updated).not.toHaveProperty('multi');
+      expect(updated).not.toHaveProperty('includeAll');
+      expect(updated).not.toHaveProperty('allowCustomValue');
+      expect(updated).not.toHaveProperty('sort');
+      expect(updated).not.toHaveProperty('customOptions');
+      // ...while the type-agnostic fields survive.
+      expect(updated.label).toBe('My label');
+      expect(updated.description).toBe('My description');
+      expect(updated.hide).toBe(true);
     });
 
     it('should apply a new current when the editor saves a new value', async () => {

--- a/src/plugins/dashboard/public/variables/variable_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.test.ts
@@ -4,7 +4,14 @@
  */
 
 import { VariableService } from './variable_service';
-import { Variable, VariableType, VariableSortOrder, CustomVariable, QueryVariable } from './types';
+import {
+  Variable,
+  VariableType,
+  VariableSortOrder,
+  CustomVariable,
+  QueryVariable,
+  TextVariable,
+} from './types';
 import { VariableInterpolationService } from './variable_interpolation_service';
 
 jest.mock('./variable_query_utils', () => ({
@@ -22,10 +29,10 @@ function makeQueryResult(
 ) {
   return values.length > 0
     ? {
-        rows: values.map((value) => ({ [field]: value })),
-        fields: [field],
-        fieldTypes: { [field]: optionType },
-      }
+      rows: values.map((value) => ({ [field]: value })),
+      fields: [field],
+      fieldTypes: { [field]: optionType },
+    }
     : { rows: [], fields: [], fieldTypes: {} };
 }
 
@@ -59,6 +66,16 @@ function makeCustomVariable(overrides: Partial<CustomVariable> = {}): CustomVari
     type: VariableType.Custom,
     current: ['dev'],
     customOptions: ['dev', 'staging', 'prod'],
+    ...overrides,
+  };
+}
+
+function makeTextVariable(overrides: Partial<TextVariable> = {}): TextVariable {
+  return {
+    id: 'text-1',
+    name: 'keyword',
+    type: VariableType.Text,
+    current: undefined,
     ...overrides,
   };
 }
@@ -1612,6 +1629,254 @@ describe('VariableService', () => {
         } as any)
       ).resolves.toBeUndefined();
       expect(throwingSink).toHaveBeenCalled();
+    });
+  });
+
+  describe('allowCustomValue — Custom reconcile', () => {
+    it('drops off-list values when allowCustomValue is off (default)', async () => {
+      const { service } = createService(
+        [makeCustomVariable({ id: 'v1', name: 'v1', current: ['off-list'] })],
+        'dashboard-1'
+      );
+
+      await service.updateVariable('v1', { customOptions: ['dev', 'prod'] } as Partial<Variable>);
+
+      expect(getCurrentValues(service).v1).toEqual(['dev']);
+    });
+
+    it('also drops off-list values when allowCustomValue is on (matches Grafana)', async () => {
+      const { service } = createService(
+        [
+          makeCustomVariable({
+            id: 'v1',
+            name: 'v1',
+            current: ['off-list'],
+            allowCustomValue: true,
+          }),
+        ],
+        'dashboard-1'
+      );
+
+      await service.updateVariable('v1', { customOptions: ['dev', 'prod'] } as Partial<Variable>);
+
+      expect(getCurrentValues(service).v1).toEqual(['dev']);
+    });
+
+    it('keeps only the listed values from a mixed multi-select selection', async () => {
+      const { service } = createService(
+        [
+          makeCustomVariable({
+            id: 'v1',
+            name: 'v1',
+            multi: true,
+            current: ['dev', 'off-list'],
+            allowCustomValue: true,
+          }),
+        ],
+        'dashboard-1'
+      );
+
+      await service.updateVariable('v1', { customOptions: ['dev', 'prod'] } as Partial<Variable>);
+
+      expect(getCurrentValues(service).v1).toEqual(['dev']);
+    });
+
+    it('falls back to the first option when no selected value survives', async () => {
+      const { service } = createService(
+        [
+          makeCustomVariable({
+            id: 'v1',
+            name: 'v1',
+            current: ['off-list-a'],
+            allowCustomValue: true,
+          }),
+        ],
+        'dashboard-1'
+      );
+
+      await service.updateVariable('v1', { customOptions: ['dev'] } as Partial<Variable>);
+
+      expect(getCurrentValues(service).v1).toEqual(['dev']);
+    });
+
+    // This is the guarantee that actually makes the feature work: a value committed
+    // from the variable bar is never reconciled away.
+    it('never prunes an off-list value committed via updateVariableValue', () => {
+      const { service } = createService([
+        makeCustomVariable({ id: 'v1', name: 'v1', allowCustomValue: true }),
+      ]);
+
+      service.updateVariableValue('v1', ['typed-off-list']);
+
+      expect(getCurrentValues(service).v1).toEqual(['typed-off-list']);
+    });
+
+    it('keeps an off-list value across unrelated variable edits', async () => {
+      const { service } = createService(
+        [
+          makeCustomVariable({
+            id: 'v1',
+            name: 'v1',
+            current: ['off-list'],
+            allowCustomValue: true,
+          }),
+        ],
+        'dashboard-1'
+      );
+
+      // Only the label changed — the option list is untouched, so no reconcile runs.
+      await service.updateVariable('v1', { label: 'New Label' } as Partial<Variable>);
+
+      expect(getCurrentValues(service).v1).toEqual(['off-list']);
+    });
+
+    it('persists allowCustomValue when adding a variable', async () => {
+      const { service } = createService([], 'dashboard-1');
+      await service.addVariable({
+        name: 'env',
+        type: VariableType.Custom,
+        customOptions: ['dev'],
+        allowCustomValue: true,
+      } as Omit<Variable, 'id'>);
+
+      expect(service.getVariables()[0].allowCustomValue).toBe(true);
+    });
+
+    it('keeps allowCustomValue across a type switch', async () => {
+      const { service } = createService(
+        [makeCustomVariable({ id: 'v1', name: 'v1', allowCustomValue: true })],
+        'dashboard-1'
+      );
+
+      await service.updateVariable('v1', {
+        type: VariableType.Query,
+        query: 'source=logs | fields env',
+        language: 'PPL',
+      } as Partial<Variable>);
+
+      expect(service.getVariables()[0].allowCustomValue).toBe(true);
+    });
+
+    it('never prunes Query variable values on refresh, regardless of the flag', async () => {
+      mockExecuteVariableQuery.mockResolvedValueOnce(makeQueryResult(['a', 'b']));
+      const { service } = createService([
+        makeQueryVariable({ id: 'q1', name: 'q1', current: ['off-list'] }),
+      ]);
+
+      await service.refreshVariableOptions('q1');
+
+      expect(getCurrentValues(service).q1).toEqual(['off-list']);
+    });
+  });
+
+  describe('Text variables', () => {
+    it('should use the initial value supplied to addVariable as current', async () => {
+      const { service } = createService([], 'dashboard-1');
+      await service.addVariable({
+        name: 'keyword',
+        type: VariableType.Text,
+        current: ['hello'],
+      } as Omit<TextVariable, 'id' | 'current'> & { current?: string[] });
+
+      const values = getCurrentValues(service);
+      expect(values.keyword).toEqual(['hello']);
+    });
+
+    it('should leave current undefined when no initial value is provided', async () => {
+      const { service } = createService([], 'dashboard-1');
+      await service.addVariable({
+        name: 'keyword',
+        type: VariableType.Text,
+      } as Omit<TextVariable, 'id' | 'current'>);
+
+      const values = getCurrentValues(service);
+      expect(values.keyword).toEqual([]);
+    });
+
+    it('should have no options and never enter loading/error state', () => {
+      const { service } = createService([makeTextVariable({ current: ['abc'] })]);
+      const vars = service.getVariablesWithState();
+      expect(vars[0].options).toEqual([]);
+      expect(vars[0].loading).toBeFalsy();
+      expect(vars[0].error).toBeFalsy();
+    });
+
+    it('should update current value via updateVariableValue', () => {
+      const { service } = createService([makeTextVariable({ current: ['saved'] })]);
+      service.updateVariableValue('text-1', ['typed-value']);
+
+      const values = getCurrentValues(service);
+      expect(values.keyword).toEqual(['typed-value']);
+    });
+
+    it('should not be included in refreshAllVariableOptions / refreshTimeFilteredVariableOptions', async () => {
+      const { service } = createService([
+        makeTextVariable(),
+        makeQueryVariable({ id: 'query-1', name: 'service' }),
+      ]);
+
+      await service.refreshAllVariableOptions();
+      // Only the query variable should have triggered a fetch; Text has no query path.
+      expect(mockExecuteVariableQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('should apply the editor-supplied current when switching an existing variable to Text', async () => {
+      const { service } = createService(
+        [makeCustomVariable({ id: 'v1', name: 'v1' })],
+        'dashboard-1'
+      );
+      await service.updateVariable('v1', {
+        type: VariableType.Text,
+        current: ['seeded'],
+      } as Partial<Variable>);
+
+      const values = getCurrentValues(service);
+      expect(values.v1).toEqual(['seeded']);
+    });
+
+    it('should carry over the existing value when switching to Text without an explicit current', async () => {
+      const { service } = createService(
+        [makeCustomVariable({ id: 'v1', name: 'v1', current: ['dev'] })],
+        'dashboard-1'
+      );
+      await service.updateVariable('v1', { type: VariableType.Text } as Partial<Variable>);
+
+      const values = getCurrentValues(service);
+      expect(values.v1).toEqual(['dev']);
+    });
+
+    it('should apply a new current when the editor saves a new value', async () => {
+      const { service } = createService(
+        [makeTextVariable({ id: 'v1', name: 'v1', current: ['old'] })],
+        'dashboard-1'
+      );
+      await service.updateVariable('v1', { current: ['new'] } as Partial<TextVariable>);
+
+      const values = getCurrentValues(service);
+      expect(values.v1).toEqual(['new']);
+    });
+
+    it('should leave current untouched when updateVariable does not change it', async () => {
+      const { service } = createService(
+        [makeTextVariable({ id: 'v1', name: 'v1', current: ['live-value'] })],
+        'dashboard-1'
+      );
+
+      // e.g. only the label changed — current should be left exactly as-is.
+      await service.updateVariable('v1', { label: 'New Label' } as Partial<TextVariable>);
+
+      const values = getCurrentValues(service);
+      expect(values.v1).toEqual(['live-value']);
+    });
+
+    it('should interpolate a Text variable value as a plain escaped string', () => {
+      const { service } = createService([makeTextVariable({ current: ["o'brien"] })]);
+      const interpolation = new (jest.requireActual(
+        './variable_interpolation_service'
+      ).VariableInterpolationService)(() => service.getVariablesWithState());
+
+      const result = interpolation.interpolate('source=logs | where msg = $keyword', 'PPL');
+      expect(result).toBe("source=logs | where msg = o''brien");
     });
   });
 });

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -15,6 +15,7 @@ import {
   VariableSortOrder,
   QueryVariable,
   CustomVariable,
+  TextVariable,
   VariableState,
   VariableWithState,
   VariableOption,
@@ -183,15 +184,18 @@ export class VariableService {
   /**
    * Add a new variable.
    */
-  public async addVariable(variable: Omit<Variable, 'id' | 'current'>): Promise<void> {
+  public async addVariable(variable: Omit<Variable, 'id'>): Promise<void> {
     const id = this.generateId();
     const newVariable = this.buildVariable(id, variable);
 
     // Initialize runtime state
     const initialRuntimeState = this.deriveRuntimeState(newVariable);
-    const current =
-      initialRuntimeState.options.length > 0 ? [initialRuntimeState.options[0].value] : undefined;
-    newVariable.current = current;
+    if (newVariable.type === VariableType.Text) {
+      newVariable.current = variable.current;
+    } else {
+      newVariable.current =
+        initialRuntimeState.options.length > 0 ? [initialRuntimeState.options[0].value] : undefined;
+    }
 
     const updatedVariables = [...this.getVariables(), newVariable];
 
@@ -234,8 +238,12 @@ export class VariableService {
         loading: false,
         error: undefined,
       };
-      updatedVariable.current =
-        newRuntimeState.options.length > 0 ? [newRuntimeState.options[0].value] : undefined;
+      if (updatedVariable.type === VariableType.Text) {
+        updatedVariable.current = (updates as Partial<Variable>).current ?? existing.current;
+      } else {
+        updatedVariable.current =
+          newRuntimeState.options.length > 0 ? [newRuntimeState.options[0].value] : undefined;
+      }
     } else {
       updatedVariable = { ...existing, ...updates } as Variable;
 
@@ -564,6 +572,7 @@ export class VariableService {
       current: undefined,
       multi: input.multi,
       includeAll: input.includeAll,
+      allowCustomValue: input.allowCustomValue,
       hide: input.hide,
       description: input.description,
       sort: input.sort,
@@ -591,6 +600,12 @@ export class VariableService {
           type: VariableType.Custom,
           customOptions: this.normalizeCustomOptions(v.customOptions),
         } as CustomVariable;
+      }
+      case VariableType.Text: {
+        return {
+          ...base,
+          type: VariableType.Text,
+        } as TextVariable;
       }
       default:
         return base as Variable;

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -239,7 +239,8 @@ export class VariableService {
         error: undefined,
       };
       if (updatedVariable.type === VariableType.Text) {
-        updatedVariable.current = (updates as Partial<Variable>).current ?? existing.current;
+        const next = updates.current;
+        updatedVariable.current = next && next.length > 0 ? [next[0]] : undefined;
       } else {
         updatedVariable.current =
           newRuntimeState.options.length > 0 ? [newRuntimeState.options[0].value] : undefined;
@@ -564,17 +565,20 @@ export class VariableService {
   }
 
   private buildVariable(id: string, input: Omit<Variable, 'id' | 'current'>): Variable {
-    const base: Omit<Variable, 'type'> & { type: VariableType } = {
+    const base = {
       id,
       name: input.name,
       label: input.label,
       type: input.type,
       current: undefined,
+      hide: input.hide,
+      description: input.description,
+    };
+
+    const optionMeta = {
       multi: input.multi,
       includeAll: input.includeAll,
       allowCustomValue: input.allowCustomValue,
-      hide: input.hide,
-      description: input.description,
       sort: input.sort,
     };
 
@@ -583,6 +587,7 @@ export class VariableService {
         const v = input as Omit<QueryVariable, 'id' | 'current'>;
         return {
           ...base,
+          ...optionMeta,
           type: VariableType.Query,
           query: v.query ?? '',
           language: v.language,
@@ -597,6 +602,7 @@ export class VariableService {
         const v = input as Omit<CustomVariable, 'id' | 'current'>;
         return {
           ...base,
+          ...optionMeta,
           type: VariableType.Custom,
           customOptions: this.normalizeCustomOptions(v.customOptions),
         } as CustomVariable;
@@ -608,7 +614,7 @@ export class VariableService {
         } as TextVariable;
       }
       default:
-        return base as Variable;
+        return { ...base, ...optionMeta } as Variable;
     }
   }
 


### PR DESCRIPTION
### Description

Implements both enhancements requested in #12552 for Dashboard Variables.

**1. New `Text` variable type**

A free-form text input with no option list, rendered inline in the variables bar.

- The value commits on blur or `Enter`, not on every keystroke, so a dependent viz does not re-run its query per character.
- `current` is the single source of truth. The editor's "Value" field and the variables bar read and write that same field.
- Sort / Allow multiple selections / Include All / Allow custom values are hidden for this type and are not written to the saved object at all.

**2. `Allow custom values` toggle (Query and Custom variables)**

When enabled, a value that is not in the generated/static option list can be committed from the variables bar. Typing in the dropdown's search box offers the typed value as the first row, labelled `Hit enter to add`; pressing `Enter` or clicking the row commits it. Multi-select appends, single-select replaces.

The flag is purely a UI capability switch — the data layer has no special case for it:

| Path | Behaviour | Where |
|---|---|---|
| Value committed from the variables bar | Preserved (never reconciled) | `updateVariableValue` |
| Query variable refresh / options re-fetch | Preserved | `resolveCurrentValueForQuery` (pre-existing, unconditional) |
| Dashboard reload | Preserved (only `options` is recomputed, `current` is untouched) | `initialize` + `deriveRuntimeState` |
| **Author edits a Custom variable's option list** | **Off-list values are dropped, falling back to the new options** | `resolveCurrentValueForCustom` |

**Storage model**

A custom value lives only in `current`. It is never written back into the variable's definition (`customOptions` for Custom, `query` for Query), so it is a selection, not part of the option list. `allowCustomValue` itself is a persisted boolean.

### Issues Resolved

closes #12552

## Screenshot
Text variable
<img width="561" height="674" alt="image" src="https://github.com/user-attachments/assets/58b2149e-808c-434c-b4dd-b057aa06807b" />

Allow custom values

<img width="340" height="183" alt="image" src="https://github.com/user-attachments/assets/3d05be81-4da5-47fe-a196-4b7829dbd84a" />


<!-- attach: the dropdown with the "Hit enter to add" row, and the Text variable
     in the variables bar + its editor -->

## Testing the changes

**Text variable**

1. Open a dashboard in an Observability workspace, enter edit mode, and add a variable of type `Text` with an initial value.
2. Confirm the editor hides Sort / Allow multiple selections / Include All.
3. Reference it from a panel title as `$<name>` and confirm the title updates as the value changes.
4. Type a new value in the variables bar and press `Enter`; reopen the variable's editor and confirm the "Value" field shows what you just typed.
5. Save the dashboard, hard-reload, and confirm the value is restored.
6. Confirm the input height and width match the neighbouring Query/Custom controls.

**Allow custom values**

7. Turn `Allow custom values` on for a multi-select Custom variable. Open it, type a value that is not in the list, and confirm the first row shows the typed value with `Hit enter to add` on the right and that no `⏎` badge is shown.
8. Press `Enter`. The value is appended, the count badge increments, and the row becomes a checked row.
9. Repeat with a mouse click on that row instead of `Enter`.
10. Type a term that partially matches a real option and confirm the pending row is ordered before the matching option.
11. Type a value that is already an option, or already committed, and confirm no pending row is offered and the `⏎` badge returns.
12. De-select a committed custom value through its row and confirm it is removed.
13. Repeat 7-9 on a single-select variable and confirm the value is replaced and the popover closes. With no pending value, `ArrowDown` + `Enter` must still select the focused real option.
14. Repeat on a Query variable, then reload the page so the options are re-fetched, and confirm the custom value survives.
15. On a variable with `Allow custom values` off, confirm the placeholder is `Contains...`, no pending row appears, and behaviour is unchanged.
16. Save and inspect `variablesJSON`: custom values are in `current`, `allowCustomValue` is persisted, and `customOptions` / `query` are unchanged.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff