### PR TITLE
fix: [bug] Statistics tab hit counter mixes buckets and documents for PPL aggregation queries (#12535)

### DIFF
--- a/src/plugins/explore/public/application/utils/hooks/use_bucket_count_results.test.tsx
+++ b/src/plugins/explore/public/application/utils/hooks/use_bucket_count_results.test.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { useBucketCountResults } from './use_bucket_count_results';
+import { prepareBucketCountCacheKey } from '../state_management/actions/query_actions';
+import {
+  resultsInitialState,
+  resultsReducer,
+  queryInitialState,
+  queryReducer,
+  resultsCache,
+  clearResultsCache,
+} from '../state_management/slices';
+
+jest.mock('../state_management/actions/query_actions', () => ({
+  prepareBucketCountCacheKey: jest.fn().mockReturnValue('bucketCount:source=logs | stats count()'),
+}));
+
+const mockPrepareBucketCountCacheKey = prepareBucketCountCacheKey as jest.MockedFunction<
+  typeof prepareBucketCountCacheKey
+>;
+
+interface MockRootState {
+  query: { query: string; language?: string };
+  results: { [key: string]: any };
+}
+
+const createMockStore = (initialState: MockRootState) => {
+  const preloadedState = {
+    query: {
+      ...queryInitialState,
+      ...initialState.query,
+    },
+    results: {
+      ...resultsInitialState,
+      ...initialState.results,
+    },
+  };
+
+  return configureStore({
+    reducer: {
+      query: queryReducer,
+      results: resultsReducer,
+    },
+    preloadedState,
+  });
+};
+
+const renderHookWithStore = (store: any) => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return renderHook(() => useBucketCountResults(), { wrapper });
+};
+
+describe('useBucketCountResults', () => {
+  const cacheKey = 'bucketCount:source=logs | stats count()';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrepareBucketCountCacheKey.mockReturnValue(cacheKey);
+  });
+
+  afterEach(() => {
+    clearResultsCache();
+  });
+
+  it('should return bucketCount when results exist with a numeric count value', () => {
+    const cacheData = {
+      hits: {
+        hits: [{ _source: { bucket_count: 849 } }],
+        total: 1,
+      },
+    };
+    resultsCache.set(cacheKey, cacheData as any);
+
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by status' },
+      results: { [cacheKey]: { total: 1, elapsedMs: 10, hasResults: true } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBe(849);
+  });
+
+  it('should return undefined when no results in cache', () => {
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by status' },
+      results: {},
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBeUndefined();
+  });
+
+  it('should return undefined when results have no hits', () => {
+    const cacheData = {
+      hits: {
+        hits: [],
+        total: 0,
+      },
+    };
+    resultsCache.set(cacheKey, cacheData as any);
+
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by status' },
+      results: { [cacheKey]: { total: 0, elapsedMs: 10, hasResults: false } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBeUndefined();
+  });
+
+  it('should return undefined when first hit has no _source', () => {
+    const cacheData = {
+      hits: {
+        hits: [{ _index: 'test' }],
+        total: 1,
+      },
+    };
+    resultsCache.set(cacheKey, cacheData as any);
+
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by status' },
+      results: { [cacheKey]: { total: 1, elapsedMs: 10, hasResults: true } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBeUndefined();
+  });
+
+  it('should return undefined when _source value is not a number', () => {
+    const cacheData = {
+      hits: {
+        hits: [{ _source: { bucket_count: 'not a number' } }],
+        total: 1,
+      },
+    };
+    resultsCache.set(cacheKey, cacheData as any);
+
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by status' },
+      results: { [cacheKey]: { total: 1, elapsedMs: 10, hasResults: true } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBeUndefined();
+  });
+
+  it('should handle large bucket counts', () => {
+    const cacheData = {
+      hits: {
+        hits: [{ _source: { bucket_count: 2000000 } }],
+        total: 1,
+      },
+    };
+    resultsCache.set(cacheKey, cacheData as any);
+
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by user_id' },
+      results: { [cacheKey]: { total: 1, elapsedMs: 10, hasResults: true } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBe(2000000);
+  });
+
+  it('should return 1 for stats without group by', () => {
+    const cacheData = {
+      hits: {
+        hits: [{ _source: { bucket_count: 1 } }],
+        total: 1,
+      },
+    };
+    resultsCache.set(cacheKey, cacheData as any);
+
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count()' },
+      results: { [cacheKey]: { total: 1, elapsedMs: 10, hasResults: true } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBe(1);
+  });
+
+  it('should return undefined when metadata exists but cache is empty', () => {
+    // Don't set anything in resultsCache
+    const store = createMockStore({
+      query: { query: 'source=logs | stats count() by status' },
+      results: { [cacheKey]: { total: 1, elapsedMs: 10, hasResults: true } },
+    });
+
+    const { result } = renderHookWithStore(store);
+    expect(result.current.bucketCount).toBeUndefined();
+  });
+});

--- a/src/plugins/explore/public/application/utils/hooks/use_bucket_count_results.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_bucket_count_results.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { RootState } from '../state_management/store';
+import { prepareBucketCountCacheKey } from '../state_management/actions/query_actions';
+import { resultsCache } from '../state_management/slices';
+
+/**
+ * Hook for reading bucket count result from result slice.
+ * Returns the total number of aggregation buckets for PPL stats queries.
+ */
+export const useBucketCountResults = () => {
+  const query = useSelector((state: RootState) => state.query);
+
+  const cacheKey = useMemo(() => {
+    return prepareBucketCountCacheKey(query);
+  }, [query]);
+
+  const metadata = useSelector((state: RootState) => (cacheKey ? state.results[cacheKey] : null));
+  const results = metadata ? (resultsCache.get(cacheKey) ?? null) : null;
+
+  // The bucket count query appends `| stats count() as bucket_count` which produces a single
+  // row with a guaranteed field name. Fall back to common aliases in case of older backends.
+  const bucketCount = useMemo(() => {
+    if (!results?.hits?.hits?.length) return undefined;
+    const firstHit = results.hits.hits[0];
+    if (!firstHit?._source) return undefined;
+    const source = firstHit._source as Record<string, unknown>;
+    const count = source.bucket_count ?? source['count()'] ?? source.count;
+    return typeof count === 'number' ? count : undefined;
+  }, [results]);
+
+  return { bucketCount };
+};

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -47,6 +47,7 @@ jest.mock('./utils', () => ({
     toDate: 'now',
     timeFieldName: 'endTime',
   })),
+  queryHasStats: jest.fn(() => false),
 }));
 
 import { configureStore } from '@reduxjs/toolkit';

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -40,12 +40,13 @@ import {
   HistogramDataProcessor,
   ProcessedSearchResults,
 } from '../../interfaces';
-import { defaultPreparePplQuery } from '../../languages';
+import { defaultPreparePplQuery, addPPLSourceClause } from '../../languages';
 import {
   HistogramConfig,
   buildPPLHistogramQuery,
   processRawResultsForHistogram,
   createHistogramConfigWithInterval,
+  queryHasStats,
 } from './utils';
 import { getCurrentFlavor } from '../../../../helpers/get_flavor_from_app_id';
 import { ExploreFlavor } from '../../../../../common';
@@ -110,6 +111,22 @@ export const prepareHistogramCacheKey = (query: Query, hasBreakdown?: boolean): 
   return hasBreakdown
     ? `histogram:breakdown:${defaultPrepareQueryString(query)}`
     : `histogram:${defaultPrepareQueryString(query)}`;
+};
+
+/**
+ * Prepare cache key for bucket count queries (used for aggregation queries)
+ */
+export const prepareBucketCountCacheKey = (query: Query): string => {
+  return `bucketCount:${prepareBucketCountQueryString(query)}`;
+};
+
+/**
+ * Prepare the bucket count query string by appending | stats count() to the original query.
+ * This returns a single row with the total number of aggregation buckets.
+ */
+export const prepareBucketCountQueryString = (query: Query): string => {
+  const withSource = addPPLSourceClause(query);
+  return `${withSource.query} | stats count() as bucket_count`;
 };
 
 /**
@@ -306,6 +323,26 @@ export const executeQueries = createAsyncThunk<
         interval,
       })
     );
+  }
+
+  // Execute bucket count query for aggregation queries (non-blocking)
+  // This appends | stats count() to get the true total bucket count
+  const originalQueryString = typeof query.query === 'string' ? query.query : '';
+  if (query.language === 'PPL' && queryHasStats(originalQueryString)) {
+    const bucketCountCacheKey = prepareBucketCountCacheKey(query);
+    const bucketCountQueryStatus = state.queryEditor.queryStatusMap[bucketCountCacheKey];
+    const needsBucketCountQuery =
+      !bucketCountQueryStatus ||
+      bucketCountQueryStatus?.status === QueryExecutionStatus.UNINITIALIZED;
+    if (needsBucketCountQuery) {
+      dispatch(
+        executeBucketCountQuery({
+          services,
+          cacheKey: bucketCountCacheKey,
+          queryString: prepareBucketCountQueryString(query),
+        })
+      );
+    }
   }
 
   // Wait only for data table query to complete (not histogram)
@@ -852,6 +889,55 @@ export const executeTabQuery = createAsyncThunk<
   );
 
   return queryBaseResult;
+});
+
+/**
+ * Execute bucket count query for aggregation queries.
+ * Appends | stats count() to get the total number of buckets without fetch_size limiting.
+ * Returns a single row with the count value.
+ *
+ * Errors are silently suppressed because this is a supplementary query — if it fails
+ * (e.g. unsupported syntax, bad field), the table and histogram should still render
+ * normally. On failure, a terminal NO_RESULTS status is dispatched so the query status
+ * doesn't get stuck at LOADING.
+ */
+export const executeBucketCountQuery = createAsyncThunk<
+  any,
+  {
+    services: ExploreServices;
+    cacheKey: string;
+    queryString: string;
+  },
+  { state: RootState }
+>('query/executeBucketCountQuery', async (params, thunkAPI) => {
+  const { dispatch } = thunkAPI;
+  const { cacheKey } = params;
+  try {
+    return await executeQueryBase(
+      {
+        ...params,
+        includeHistogram: false,
+        interval: undefined,
+        avoidDispatchingError: () => true,
+      },
+      thunkAPI
+    );
+  } catch {
+    // Silently swallow — this is a supplementary query. Dispatch a terminal status
+    // so the query doesn't stay stuck at LOADING in queryStatusMap.
+    dispatch(
+      setIndividualQueryStatus({
+        cacheKey,
+        status: {
+          status: QueryExecutionStatus.NO_RESULTS,
+          startTime: undefined,
+          elapsedMs: undefined,
+          error: undefined,
+        },
+      })
+    );
+    return undefined;
+  }
 });
 
 /**

--- a/src/plugins/explore/public/application/utils/state_management/actions/utils.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/utils.test.ts
@@ -153,6 +153,127 @@ describe('Utils - Histogram Breakdown Support', () => {
     });
   });
 
+  describe('queryHasStats', () => {
+    it('should detect stats in a simple aggregation query', () => {
+      expect(utils.queryHasStats('source=logs | stats count() by status')).toBe(true);
+    });
+
+    it('should detect stats case-insensitively', () => {
+      expect(utils.queryHasStats('source=logs | STATS count() by status')).toBe(true);
+      expect(utils.queryHasStats('source=logs | Stats count() by host')).toBe(true);
+    });
+
+    it('should detect stats with extra whitespace', () => {
+      expect(utils.queryHasStats('source=logs |   stats count()')).toBe(true);
+    });
+
+    it('should return false for queries without stats', () => {
+      expect(utils.queryHasStats('source=logs | where status = 200')).toBe(false);
+      expect(utils.queryHasStats('source=logs | head 100')).toBe(false);
+    });
+
+    it('should return false for empty query', () => {
+      expect(utils.queryHasStats('')).toBe(false);
+    });
+
+    it('should not match stats inside subquery brackets', () => {
+      expect(utils.queryHasStats('source=logs | where id in [source=other | stats count()]')).toBe(
+        false
+      );
+    });
+
+    it('should detect stats in main query even with subquery', () => {
+      expect(
+        utils.queryHasStats(
+          'source=logs | where id in [source=other | head 10] | stats count() by host'
+        )
+      ).toBe(true);
+    });
+
+    it('should not match "stats" that is not preceded by a pipe', () => {
+      expect(utils.queryHasStats('source=stats_index')).toBe(false);
+    });
+
+    it('should not match stats inside single-quoted string', () => {
+      expect(utils.queryHasStats("source=logs | where message = '| stats count()'")).toBe(false);
+    });
+
+    it('should not match stats inside double-quoted string', () => {
+      expect(utils.queryHasStats('source=logs | where message = "| stats count()"')).toBe(false);
+    });
+
+    it('should detect stats after a quoted string containing stats', () => {
+      expect(
+        utils.queryHasStats("source=logs | where msg = '| stats x' | stats count() by host")
+      ).toBe(true);
+    });
+
+    it('should not match stats inside a string with doubled-quote escaping', () => {
+      expect(utils.queryHasStats("source=logs | where msg = 'it''s | stats count()'")).toBe(false);
+    });
+
+    it('should not match stats inside multiline subquery brackets', () => {
+      expect(
+        utils.queryHasStats('source=logs | where id in [\nsource=other\n| stats count() by id\n]')
+      ).toBe(false);
+    });
+
+    it('should not detect other aggregation or non-aggregation PPL commands', () => {
+      // Other aggregation-like commands (not stats)
+      expect(utils.queryHasStats('source=logs | chart count() by status')).toBe(false);
+      expect(utils.queryHasStats('source=logs | timechart span=1h count()')).toBe(false);
+      expect(utils.queryHasStats('source=logs | top 5 status')).toBe(false);
+      expect(utils.queryHasStats('source=logs | rare status')).toBe(false);
+      expect(utils.queryHasStats('source=logs | eventstats count() by status')).toBe(false);
+      expect(utils.queryHasStats('source=logs | streamstats count() by status')).toBe(false);
+      expect(utils.queryHasStats('source=logs | patterns message')).toBe(false);
+      expect(utils.queryHasStats('source=logs | transpose')).toBe(false);
+      expect(utils.queryHasStats('source=logs | xyseries extension bytes clientip')).toBe(false);
+      expect(utils.queryHasStats('source=logs | timewrap 1d')).toBe(false);
+      expect(utils.queryHasStats('source=logs | addtotals')).toBe(false);
+      expect(utils.queryHasStats('source=logs | addcoltotals')).toBe(false);
+      // Document filtering/transformation commands
+      expect(utils.queryHasStats('source=logs | where status = 200')).toBe(false);
+      expect(utils.queryHasStats('source=logs | head 100')).toBe(false);
+      expect(utils.queryHasStats('source=logs | sort - timestamp')).toBe(false);
+      expect(utils.queryHasStats('source=logs | dedup status')).toBe(false);
+      expect(utils.queryHasStats('source=logs | fields status, host')).toBe(false);
+      expect(utils.queryHasStats('source=logs | rename status as code')).toBe(false);
+      expect(utils.queryHasStats('source=logs | eval new_field = status + 1')).toBe(false);
+      expect(utils.queryHasStats('source=logs | parse message "(?<ip>\\d+)"')).toBe(false);
+      expect(utils.queryHasStats('source=logs | grok message "%{IP:ip}"')).toBe(false);
+      expect(utils.queryHasStats('source=logs | rex field=message "(?<ip>\\d+)"')).toBe(false);
+      expect(utils.queryHasStats('source=logs | fillnull with 0')).toBe(false);
+      expect(utils.queryHasStats('source=logs | flatten nested_field')).toBe(false);
+      expect(utils.queryHasStats('source=logs | expand multi_value')).toBe(false);
+      expect(utils.queryHasStats('source=logs | trendline sma(5, bytes)')).toBe(false);
+      expect(utils.queryHasStats('source=logs | lookup accounts uid')).toBe(false);
+      expect(utils.queryHasStats('source=logs | join left=l right=r on id')).toBe(false);
+      expect(utils.queryHasStats('source=logs | regex message="error.*"')).toBe(false);
+      expect(utils.queryHasStats('source=logs | table status, host, message')).toBe(false);
+      expect(utils.queryHasStats('source=logs | mvcombine message')).toBe(false);
+      expect(utils.queryHasStats('source=logs | mvexpand multi_value')).toBe(false);
+      expect(utils.queryHasStats('source=logs | convert num(bytes)')).toBe(false);
+      expect(utils.queryHasStats('source=logs | replace "error" with "err" in message')).toBe(
+        false
+      );
+      expect(utils.queryHasStats('source=logs | reverse')).toBe(false);
+      expect(utils.queryHasStats('source=logs | spath input=json_field')).toBe(false);
+      expect(utils.queryHasStats('source=logs | ad')).toBe(false);
+      expect(utils.queryHasStats('source=logs | append [source=other]')).toBe(false);
+      expect(utils.queryHasStats('source=logs | appendcol [source=other]')).toBe(false);
+      expect(utils.queryHasStats('source=logs | appendpipe [stats count()]')).toBe(false);
+      expect(utils.queryHasStats('source=logs | bin span=1h timestamp')).toBe(false);
+      expect(utils.queryHasStats('source=logs | describe')).toBe(false);
+      expect(utils.queryHasStats('source=logs | explain')).toBe(false);
+      expect(utils.queryHasStats('source=logs | fieldformat bytes=num_format(bytes)')).toBe(false);
+      expect(utils.queryHasStats('source=logs | kmeans centroids=3')).toBe(false);
+      expect(utils.queryHasStats('source=logs | ml action=predict')).toBe(false);
+      expect(utils.queryHasStats('source=logs | nomv multi_value')).toBe(false);
+      expect(utils.queryHasStats('source=logs | search status=200')).toBe(false);
+    });
+  });
+
   describe('buildPPLHistogramQuery', () => {
     it('should return original query when aggs is missing', () => {
       const query = 'source=logs';

--- a/src/plugins/explore/public/application/utils/state_management/actions/utils.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/utils.ts
@@ -104,12 +104,45 @@ export function fillMissingTimestamps(
 }
 
 /**
+ * Masks subquery brackets and quoted string literals in a PPL query so that command-detection
+ * regexes only match top-level pipes.
+ *
+ * - Brackets: `[...]` content is replaced with NUL characters. Uses [\s\S]*? to cross newlines.
+ * - Quotes: single- and double-quoted strings are replaced with NUL characters so that
+ *   `| stats` inside a string literal (e.g. `where msg = '| stats count()'`) is not matched.
+ *
+ * Shared by queryEndsWithHead and queryHasStats.
+ */
+const maskPPLSubqueriesAndStrings = (queryString: string): string => {
+  // First mask quoted strings (handles escaped quotes within)
+  let masked = queryString.replace(/'(?:[^'\\]|\\.)*'/g, (match) => '\0'.repeat(match.length));
+  masked = masked.replace(/"(?:[^"\\]|\\.)*"/g, (match) => '\0'.repeat(match.length));
+  // Then mask bracket subqueries ([\s\S]*? crosses newlines)
+  masked = masked.replace(/\[[\s\S]*?\]/g, (match) => '\0'.repeat(match.length));
+  return masked;
+};
+
+/**
  * Checks if the main query ends with a head command (optionally followed by `from N` or `| where`).
- * Subquery brackets [...] are masked so that head inside subqueries is ignored.
+ * Subquery brackets and quoted strings are masked so that head inside them is ignored.
  */
 export const queryEndsWithHead = (queryString: string): boolean => {
-  const masked = queryString.replace(/\[.*?\]/g, (match) => '\0'.repeat(match.length));
+  const masked = maskPPLSubqueriesAndStrings(queryString);
   return /\|\s*head\b(\s+\d+)?(\s+from\s+\d+)?\s*(\|\s*where\b.*)?\s*$/i.test(masked);
+};
+
+/**
+ * Checks if a PPL query contains a `stats` command, whose output rows are aggregation
+ * buckets rather than documents. Subquery brackets and quoted strings are masked so that
+ * `stats` inside them is ignored.
+ *
+ * Used to detect queries where the hit counter should show bucket count separately from
+ * document count. Other aggregating commands (chart, timechart, top, rare, etc.) will be
+ * added in a follow-up PR once stripStatsFromQuery is extended to handle them.
+ */
+export const queryHasStats = (queryString: string): boolean => {
+  const masked = maskPPLSubqueriesAndStrings(queryString);
+  return /\|\s*stats\b/i.test(masked);
 };
 
 export const buildPPLHistogramQuery = (query: string, histogramConfig: HistogramConfig): string => {

--- a/src/plugins/explore/public/components/tabs/action_bar/action_bar.test.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/action_bar.test.tsx
@@ -6,10 +6,10 @@
 import { render, screen } from '@testing-library/react';
 import { ActionBar } from './action_bar';
 
-// Mock the child component
-jest.mock('./results_action_bar/results_action_bar', () => ({
-  DiscoverResultsActionBar: () => <div data-test-subj="discoverResultsActionBar" />,
-}));
+// Mock the child component, capturing props for assertions
+const mockDiscoverResultsActionBar = jest.fn((_props: any) => (
+  <div data-test-subj="discoverResultsActionBar" />
+));
 
 // Mock the hooks and context
 jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
@@ -93,13 +93,29 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../../../application/utils/state_management/actions/query_actions', () => ({
   defaultPrepareQueryString: () => 'source=logs',
+  prepareBucketCountCacheKey: () => 'bucketCount:source=logs | stats count()',
 }));
 
+let mockQueryHasStats = false;
 jest.mock('../../../application/utils/state_management/actions/utils', () => ({
   queryEndsWithHead: () => false,
+  queryHasStats: () => mockQueryHasStats,
+}));
+
+let mockBucketCount: number | undefined;
+jest.mock('../../../application/utils/hooks/use_bucket_count_results', () => ({
+  useBucketCountResults: () => ({ bucketCount: mockBucketCount }),
+}));
+
+jest.mock('./results_action_bar/results_action_bar', () => ({
+  DiscoverResultsActionBar: (props: any) => mockDiscoverResultsActionBar(props),
 }));
 
 describe('ActionBar', () => {
+  beforeEach(() => {
+    mockDiscoverResultsActionBar.mockClear();
+  });
+
   test('should render the action bar component', () => {
     render(<ActionBar />);
     expect(screen.getByTestId('discoverResultsActionBar')).toBeInTheDocument();
@@ -108,5 +124,65 @@ describe('ActionBar', () => {
   test('should render without crashing when no results', () => {
     render(<ActionBar />);
     expect(screen.getByTestId('discoverResultsActionBar')).toBeInTheDocument();
+  });
+
+  test('should pass hits from histogram results for non-aggregation queries', () => {
+    render(<ActionBar />);
+
+    expect(mockDiscoverResultsActionBar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hits: expect.anything(),
+        bucketCount: undefined,
+      })
+    );
+  });
+});
+
+describe('ActionBar with aggregation query', () => {
+  beforeEach(() => {
+    mockDiscoverResultsActionBar.mockClear();
+    mockQueryHasStats = false;
+    mockBucketCount = undefined;
+  });
+
+  test('should pass bucketCount when query has stats', () => {
+    mockQueryHasStats = true;
+    mockBucketCount = 5050;
+
+    render(<ActionBar />);
+
+    expect(mockDiscoverResultsActionBar).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketCount: 5050 })
+    );
+  });
+
+  test('should not pass bucketCount when query does not have stats', () => {
+    render(<ActionBar />);
+
+    expect(mockDiscoverResultsActionBar).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketCount: undefined })
+    );
+  });
+
+  test('should degrade to standard format when bucketCount is unavailable', () => {
+    mockQueryHasStats = true;
+
+    render(<ActionBar />);
+
+    // When bucketCount query hasn't returned, degrade to standard format
+    expect(mockDiscoverResultsActionBar).toHaveBeenCalledWith(
+      expect.objectContaining({ bucketCount: undefined })
+    );
+  });
+
+  test('should pass both hits and bucketCount when both are available', () => {
+    mockQueryHasStats = true;
+    mockBucketCount = 5050;
+
+    render(<ActionBar />);
+
+    expect(mockDiscoverResultsActionBar).toHaveBeenCalledWith(
+      expect.objectContaining({ hits: expect.anything(), bucketCount: 5050 })
+    );
   });
 });

--- a/src/plugins/explore/public/components/tabs/action_bar/action_bar.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/action_bar.tsx
@@ -10,14 +10,21 @@ import { DiscoverResultsActionBar } from './results_action_bar/results_action_ba
 import { ExploreServices } from '../../../types';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { useSelector } from '../../../application/legacy/discover/application/utils/state_management';
-import { selectSavedSearch } from '../../../application/utils/state_management/selectors';
+import {
+  selectSavedSearch,
+  selectActiveTabId,
+} from '../../../application/utils/state_management/selectors';
 import { useDatasetContext } from '../../../application/context';
-import { ExploreFlavor } from '../../../../common';
+import { ExploreFlavor, EXPLORE_LOGS_TAB_ID } from '../../../../common';
 import { useTabResults } from '../../../application/utils/hooks/use_tab_results';
 import { useHistogramResults } from '../../../application/utils/hooks/use_histogram_results';
+import { useBucketCountResults } from '../../../application/utils/hooks/use_bucket_count_results';
 import { RootState } from '../../../application/utils/state_management/store';
 import { defaultPrepareQueryString } from '../../../application/utils/state_management/actions/query_actions';
-import { queryEndsWithHead } from '../../../application/utils/state_management/actions/utils';
+import {
+  queryEndsWithHead,
+  queryHasStats,
+} from '../../../application/utils/state_management/actions/utils';
 
 interface ActionBarProps {
   filteredRowsCount?: number;
@@ -32,7 +39,9 @@ const ActionBarComponent = ({ filteredRowsCount }: ActionBarProps = {}) => {
   const { dataset } = useDatasetContext();
   const { results } = useTabResults();
   const { results: histogramResults } = useHistogramResults();
+  const { bucketCount } = useBucketCountResults();
   const query = useReduxSelector((state: RootState) => state.query);
+  const activeTabId = useReduxSelector(selectActiveTabId);
   const { core, inspector, inspectorAdapters, slotRegistry } = services;
   const savedSearch = useSelector(selectSavedSearch);
 
@@ -55,15 +64,26 @@ const ActionBarComponent = ({ filteredRowsCount }: ActionBarProps = {}) => {
   };
 
   const rows = results?.hits?.hits || [];
-  // When query has head command, just show row count (no "X of Y" total)
+  // For aggregation queries (stats/chart/timechart), use the bucket count from the dedicated
+  // count query and show the histogram document total separately.
+  // For head queries, hide the denominator entirely.
   const queryString = query.language === 'PPL' ? defaultPrepareQueryString(query) : '';
+  const originalQueryString = typeof query.query === 'string' ? query.query : '';
   const hasHead = query.language === 'PPL' && queryEndsWithHead(queryString);
+  const hasStats = query.language === 'PPL' && queryHasStats(originalQueryString);
   const totalHits = hasHead ? undefined : histogramResults?.hits.total;
+  // For aggregation queries, use the bucket count from the dedicated count query.
+  // Only show bucket format on Statistics/Visualization tabs where rows are actual buckets.
+  // On Logs tab, rows are documents (stripStatsFromQuery removes the stats clause).
+  // When the count query hasn't returned or failed, degrade to the standard hits format.
+  const isLogsTab = activeTabId === EXPLORE_LOGS_TAB_ID;
+  const effectiveBucketCount = hasStats && !isLogsTab ? bucketCount : undefined;
   const elapsedMs = results?.elapsedMs;
 
   return (
     <DiscoverResultsActionBar
       hits={totalHits}
+      bucketCount={effectiveBucketCount}
       showResetButton={!!savedSearch}
       resetQuery={() => {
         core.application.navigateToApp('explore', {

--- a/src/plugins/explore/public/components/tabs/action_bar/hits_counter/hits_counter.test.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/hits_counter/hits_counter.test.tsx
@@ -127,3 +127,75 @@ describe('hits counter', () => {
     expect(props.onResetQuery).toHaveBeenCalled();
   });
 });
+
+describe('hits counter - aggregation format', () => {
+  let props: HitsCounterProps;
+  let component: ReactWrapper<HitsCounterProps>;
+
+  beforeAll(() => {
+    props = {
+      onResetQuery: jest.fn(),
+      showResetButton: false,
+      hits: 2540,
+      bucketCount: 849,
+      rows: Array(500).fill({
+        fields: {},
+        sort: [],
+        _source: {},
+        _id: '1',
+        _index: 'idx1',
+        _type: '',
+        _score: 1,
+      }),
+      elapsedMs: 66,
+    };
+  });
+
+  it('should render aggregation format with bucketCount and hits', () => {
+    component = mountWithIntl(<HitsCounter {...props} />);
+    const bucketCountEl = findTestSubject(component, 'discoverQueryBucketCount');
+    expect(bucketCountEl.text()).toBe('849');
+    const hitsEl = findTestSubject(component, 'discoverQueryHits');
+    expect(hitsEl.text()).toBe('2,540');
+  });
+
+  it('should render rowsCount in aggregation format', () => {
+    component = mountWithIntl(<HitsCounter {...props} />);
+    const rowsEl = findTestSubject(component, 'discoverQueryRowsCount');
+    expect(rowsEl.text()).toBe('500');
+  });
+
+  it('should render elapsedMs in aggregation format', () => {
+    component = mountWithIntl(<HitsCounter {...props} />);
+    const elapsedEl = findTestSubject(component, 'discoverQueryElapsedMs');
+    expect(elapsedEl.text()).toBe('66');
+  });
+
+  it('should render formatted large numbers in aggregation format', () => {
+    component = mountWithIntl(<HitsCounter {...props} hits={2000000} bucketCount={5050} />);
+    const bucketCountEl = findTestSubject(component, 'discoverQueryBucketCount');
+    expect(bucketCountEl.text()).toBe('5,050');
+    const hitsEl = findTestSubject(component, 'discoverQueryHits');
+    expect(hitsEl.text()).toBe('2,000,000');
+  });
+
+  it('should not render bucketCount element when bucketCount is undefined', () => {
+    component = mountWithIntl(<HitsCounter {...props} bucketCount={undefined} />);
+    expect(component.exists('[data-test-subj="discoverQueryBucketCount"]')).toBeFalsy();
+  });
+
+  it('should fall back to standard format when hits is defined but bucketCount is not', () => {
+    component = mountWithIntl(<HitsCounter {...props} hits={2852} bucketCount={undefined} />);
+    expect(component.exists('[data-test-subj="discoverQueryBucketCount"]')).toBeFalsy();
+    const hitsEl = findTestSubject(component, 'discoverQueryHits');
+    expect(hitsEl.text()).toBe('2,852');
+  });
+
+  it('should fall back to no-hits format when both hits and bucketCount are undefined', () => {
+    component = mountWithIntl(<HitsCounter {...props} hits={undefined} bucketCount={undefined} />);
+    expect(component.exists('[data-test-subj="discoverQueryHits"]')).toBeFalsy();
+    expect(component.exists('[data-test-subj="discoverQueryBucketCount"]')).toBeFalsy();
+    const rowsEl = findTestSubject(component, 'discoverQueryRowsCount');
+    expect(rowsEl.text()).toBe('500');
+  });
+});

--- a/src/plugins/explore/public/components/tabs/action_bar/hits_counter/hits_counter.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/hits_counter/hits_counter.tsx
@@ -41,6 +41,10 @@ export interface HitsCounterProps {
    */
   hits?: number;
   /**
+   * total bucket count for aggregation queries (shown as denominator instead of hits)
+   */
+  bucketCount?: number;
+  /**
    * displays the reset button
    */
   showResetButton: boolean;
@@ -64,6 +68,7 @@ export interface HitsCounterProps {
 
 export function HitsCounter({
   hits,
+  bucketCount,
   showResetButton,
   onResetQuery,
   rows,
@@ -84,7 +89,31 @@ export function HitsCounter({
       >
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued">
-            {hits ? (
+            {hits && bucketCount ? (
+              <FormattedMessage
+                id="explore.discover.hitsAggregationResultTitle"
+                defaultMessage="{rowsCount} / {bucketCount} {bucketCountRaw, plural, one {bucket} other {buckets}} · {hits} hits · {elapsedMs} ms"
+                values={{
+                  rowsCount: (
+                    <strong data-test-subj="discoverQueryRowsCount">
+                      {rowsCount.toLocaleString()}
+                    </strong>
+                  ),
+                  hits: <strong data-test-subj="discoverQueryHits">{hits.toLocaleString()}</strong>,
+                  bucketCount: (
+                    <strong data-test-subj="discoverQueryBucketCount">
+                      {bucketCount.toLocaleString()}
+                    </strong>
+                  ),
+                  bucketCountRaw: bucketCount,
+                  elapsedMs: (
+                    <strong data-test-subj="discoverQueryElapsedMs">
+                      {elapsedMs ? elapsedMs.toLocaleString() : elapsedMs}
+                    </strong>
+                  ),
+                }}
+              />
+            ) : hits ? (
               <FormattedMessage
                 id="explore.discover.hitsResultTitle"
                 defaultMessage="{rowsCount} / {hits} hits · {elapsedMs} ms"

--- a/src/plugins/explore/public/components/tabs/action_bar/results_action_bar/results_action_bar.tsx
+++ b/src/plugins/explore/public/components/tabs/action_bar/results_action_bar/results_action_bar.tsx
@@ -31,6 +31,7 @@ import { SlotItemsForType } from '../../../../services/slot_registry';
 
 export interface DiscoverResultsActionBarProps {
   hits?: number;
+  bucketCount?: number;
   showResetButton?: boolean;
   resetQuery(): void;
   rows?: OpenSearchSearchHit[];
@@ -43,6 +44,7 @@ export interface DiscoverResultsActionBarProps {
 
 export const DiscoverResultsActionBar = ({
   hits,
+  bucketCount,
   showResetButton = false,
   resetQuery,
   rows,
@@ -84,6 +86,7 @@ export const DiscoverResultsActionBar = ({
           <EuiFlexItem grow={false}>
             <HitsCounter
               hits={hits}
+              bucketCount={bucketCount}
               showResetButton={showResetButton}
               onResetQuery={resetQuery}
               rows={rows}


### PR DESCRIPTION
### Description
Fix the hit counter in the Explore Statistics and Visualization tab to correctly display units for PPL aggregation `stats` queries.

Previously, when running a PPL aggregation query (e.g. `source=logs | stats count() by status`), the hit counter displayed `6 / 2852 hits` where 6 is the number of aggregation buckets (result rows) and 2852 is the total document count from the histogram query. These are incomparable units.

This change introduces a lightweight background query that appends `| stats count()` to the original aggregation query to retrieve the true total bucket count. 

By design the query is lightweight. Looking at the performance between the added bucketcount query and without it there is no significant change. No major performance/complexity concerns.

The hit counter now displays aggregation results in a new format that clearly separates bucket count from document count:

**Display formats:**
- **Non-aggregation** (e.g. `source=logs`): `500 / 3,000 hits · 105 ms` (unchanged) (Also unchanged for aggregation queries on the Logs tabs)
- **Aggregation (Only `stats`)** (e.g. `source=logs | stats count() by extension`): `6 / 6 buckets · 3,000 hits · 32 ms`
- **Aggregation (capped) (Only `stats`)** (e.g. `stats count() by span(@timestamp, 1ms), extension`): `500 / 2,973 buckets · 3,000 hits · 30 ms`
- **Head query** (e.g. `source=logs | head 100`): `100 hits · 53 ms` (unchanged)

**Changes:**
- Added shared `maskPPLSubqueriesAndStrings` helper that masks bracket subqueries (multiline-aware) and quoted string literals, used by both `queryEndsWithHead` and `queryHasStats`
- Added `queryHasStats()` utility to detect PPL `stats` commands
- Added `executeBucketCountQuery` thunk that runs `{query} | stats count()` in the background to get the true bucket total
- Added `useBucketCountResults` hook to read the bucket count from the result cache
- Updated `action_bar.tsx` to pass `bucketCount` for aggregation queries
- Updated `HitsCounter` to render a three-way display format (aggregation with buckets / standard / no-hits)
- Added comprehensive unit tests for all new functionality

### Issues Resolved

Fixes #12535 

## Screenshot

<img width="1261" height="891" alt="Screenshot 2026-08-14 at 10 33 34 AM" src="https://github.com/user-attachments/assets/40760c9c-5edb-4146-9030-a79d18639dfc" />
<img width="1258" height="895" alt="Screenshot 2026-08-14 at 10 33 52 AM" src="https://github.com/user-attachments/assets/ca435f39-a6b8-4a4f-a8f9-4433c9c29fc1" />

## Testing the changes

1. Open Explore -> Logs
2. Run a non-aggregation query (e.g. `source=<index>`): verify it shows `X / Y hits · Z ms`
3. Run an aggregation query (e.g. `source=<index> | stats count() by <field>`): verify it shows `X / X buckets · Y hits · Z ms`
4. Run a high-cardinality aggregation (e.g. `source=<index> | stats count() by span(@timestamp, 1ms), extension`): verify it shows `500 / N buckets · Y hits · Z ms` where N > 500
5. Run a stats query without group by (e.g. `source=<index> | stats count()`): verify it shows `1 / 1 buckets · Y hits · Z ms`
6. Run a head query (e.g. `source=<index> | head 100`): verify it shows `100 hits · Z ms`
7. Run a query with stats inside a quoted string (e.g. `source=<index> | where msg = '| stats count()'`): verify it shows the standard format, not the aggregation format

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
