### PR TITLE
feat(chrome): support dynamic active nav links

### DIFF
--- a/src/core/public/chrome/chrome_service.mock.ts
+++ b/src/core/public/chrome/chrome_service.mock.ts
@@ -99,6 +99,7 @@ const createStartContractMock = () => {
       registerSearchCommand: jest.fn(),
     },
     setAppTitle: jest.fn(),
+    setActiveNavLink: jest.fn(),
     setIsVisible: jest.fn(),
     getIsVisible$: jest.fn(),
     setHeaderVariant: jest.fn(),

--- a/src/core/public/chrome/chrome_service.test.ts
+++ b/src/core/public/chrome/chrome_service.test.ts
@@ -218,6 +218,64 @@ describe('start', () => {
       // Verify that the Header component renders without errors
       expect(headerComponent).toBeDefined();
     });
+
+    it('updates, clears, and resets the active nav link id and completes on stop', async () => {
+      const service = new ChromeService();
+      const startDeps = defaultStartDeps([new FakeApp('data-explorer'), new FakeApp('dashboard')]);
+      service.setup({
+        uiSettings: startDeps.uiSettings,
+        injectedMetadata: startDeps.injectedMetadata,
+      });
+      const chrome = await service.start(startDeps);
+      const header = shallow(React.createElement(() => chrome.getHeaderComponent()));
+      const activeNavLinkId$ = header.prop('activeNavLinkId$') as Rx.Observable<string | undefined>;
+      const emissions = activeNavLinkId$.pipe(toArray()).toPromise();
+
+      startDeps.application.navigateToApp('data-explorer');
+      chrome.setActiveNavLink('discover', 'data-explorer');
+      chrome.setActiveNavLink('view-b', 'data-explorer');
+      chrome.setActiveNavLink(undefined, 'data-explorer');
+      startDeps.application.navigateToApp('dashboard');
+      service.stop();
+
+      await expect(emissions).resolves.toEqual([
+        undefined,
+        'data-explorer',
+        'discover',
+        'view-b',
+        'data-explorer',
+        'dashboard',
+      ]);
+    });
+
+    it('ignores late active nav link writes and clears from the previous application', async () => {
+      const service = new ChromeService();
+      const startDeps = defaultStartDeps([new FakeApp('data-explorer'), new FakeApp('dashboard')]);
+      service.setup({
+        uiSettings: startDeps.uiSettings,
+        injectedMetadata: startDeps.injectedMetadata,
+      });
+      const chrome = await service.start(startDeps);
+      const header = shallow(React.createElement(() => chrome.getHeaderComponent()));
+      const activeNavLinkId$ = header.prop('activeNavLinkId$') as Rx.Observable<string | undefined>;
+      const emissions = activeNavLinkId$.pipe(toArray()).toPromise();
+
+      startDeps.application.navigateToApp('data-explorer');
+      chrome.setActiveNavLink('discover', 'data-explorer');
+      startDeps.application.navigateToApp('dashboard');
+      chrome.setActiveNavLink('dashboard-detail', 'dashboard');
+      chrome.setActiveNavLink('discover', 'data-explorer');
+      chrome.setActiveNavLink(undefined, 'data-explorer');
+      service.stop();
+
+      await expect(emissions).resolves.toEqual([
+        undefined,
+        'data-explorer',
+        'discover',
+        'dashboard',
+        'dashboard-detail',
+      ]);
+    });
   });
 
   describe('visibility', () => {

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -42,7 +42,7 @@ import {
   ReplaySubject,
   Subscription,
 } from 'rxjs';
-import { map, switchMap, takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, map, switchMap, takeUntil } from 'rxjs/operators';
 import { EuiLink } from '@elastic/eui';
 import { mountReactNode } from '../utils/mount';
 import { InternalApplicationStart } from '../application';
@@ -283,6 +283,7 @@ export class ChromeService {
     const helpSupportUrl$ = new BehaviorSubject<string>(OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK);
     const isNavDrawerLocked$ = new BehaviorSubject(localStorage.getItem(IS_LOCKED_KEY) === 'true');
     const sidecarConfig$ = overlays.sidecar.getSidecarConfig$();
+    const activeNavLinkId$ = new BehaviorSubject<string | undefined>(undefined);
 
     const navControls = this.navControls.start();
     const navLinks = this.navLinks.start({ application, http });
@@ -299,12 +300,14 @@ export class ChromeService {
 
     const globalSearch = this.globalSearch.start();
 
-    // Track the current app id synchronously so the nav-popover navigateToApp
-    // wrapper (below) can tell same-app from cross-app navigation.
+    // Track the current app id synchronously so active nav link writes can be scoped to their
+    // owning app and the nav-popover navigateToApp wrapper (below) can tell same-app from
+    // cross-app navigation.
     let currentAppId: string | undefined;
     // erase chrome fields from a previous app while switching to a next app
     application.currentAppId$.subscribe((appId) => {
       currentAppId = appId;
+      activeNavLinkId$.next(appId);
       helpExtension$.next(undefined);
       breadcrumbs$.next([]);
       badge$.next(undefined);
@@ -441,6 +444,7 @@ export class ChromeService {
           http={http}
           loadingCount$={http.getLoadingCount$()}
           application={application}
+          activeNavLinkId$={activeNavLinkId$.pipe(distinctUntilChanged(), takeUntil(this.stop$))}
           appTitle$={appTitle$.pipe(takeUntil(this.stop$))}
           badge$={badge$.pipe(takeUntil(this.stop$))}
           basePath={http.basePath}
@@ -488,6 +492,11 @@ export class ChromeService {
       ),
 
       setAppTitle: (appTitle: string) => appTitle$.next(appTitle),
+
+      setActiveNavLink: (navLinkId: string | undefined, expectedAppId: string) => {
+        if (currentAppId !== expectedAppId) return;
+        activeNavLinkId$.next(navLinkId ?? expectedAppId);
+      },
 
       getIsVisible$: () => this.isVisible$,
 
@@ -638,6 +647,14 @@ export interface ChromeStart {
    * of mounting applications.
    */
   setAppTitle(appTitle: string): void;
+
+  /**
+   * Overrides the nav link shown as active while `expectedAppId` is the current application.
+   * Pass `undefined` to restore that application's own nav link.
+   * Calls from applications that are no longer current are ignored.
+   * The override is reset automatically whenever the current application changes.
+   */
+  setActiveNavLink(navLinkId: string | undefined, expectedAppId: string): void;
 
   /**
    * Get an observable of the current visibility state of the chrome.

--- a/src/core/public/chrome/integration_tests/active_nav_link.test.tsx
+++ b/src/core/public/chrome/integration_tests/active_nav_link.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React, { act } from 'react';
+import { createMemoryHistory } from 'history';
+import { shallow } from 'enzyme';
+import { Observable } from 'rxjs';
+
+import { ApplicationService } from '../../application/application_service';
+import { createRenderer } from '../../application/integration_tests/utils';
+import { contextServiceMock } from '../../context/context_service.mock';
+import { docLinksServiceMock } from '../../doc_links/doc_links_service.mock';
+import { httpServiceMock } from '../../http/http_service.mock';
+import { injectedMetadataServiceMock } from '../../injected_metadata/injected_metadata_service.mock';
+import { keyboardShortcutServiceMock } from '../../keyboard_shortcut/keyboard_shortcut_service.mock';
+import { notificationServiceMock } from '../../notifications/notifications_service.mock';
+import { overlayServiceMock } from '../../overlays/overlay_service.mock';
+import { uiSettingsServiceMock } from '../../ui_settings/ui_settings_service.mock';
+import { workspacesServiceMock } from '../../workspace/workspaces_service.mock';
+import { ChromeService } from '../chrome_service';
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
+describe('active nav link application lifecycle', () => {
+  it('keeps app B active when app A writes after its asynchronous mount resumes', async () => {
+    const history = createMemoryHistory();
+    const http = httpServiceMock.createSetupContract();
+    const applicationService = new ApplicationService();
+    const chromeService = new ChromeService();
+    const startServicesDeferred = createDeferred();
+    const lateWriteCompleted = createDeferred();
+    const dataExplorerUnmount = jest.fn();
+    const dashboardUnmount = jest.fn();
+
+    http.post.mockResolvedValue({
+      catalogue: {},
+      management: {},
+      navLinks: {},
+      workspaces: {},
+    });
+
+    const applicationSetup = applicationService.setup({
+      context: contextServiceMock.createSetupContract(),
+      history,
+      http,
+    });
+
+    const dataExplorerMount = jest.fn(async () => {
+      await startServicesDeferred.promise;
+      chromeStart.setActiveNavLink('discover', 'data-explorer');
+      lateWriteCompleted.resolve();
+      return dataExplorerUnmount;
+    });
+    const dashboardMount = jest.fn(() => dashboardUnmount);
+
+    applicationSetup.register(Symbol(), {
+      id: 'data-explorer',
+      title: 'Data Explorer',
+      mount: dataExplorerMount,
+    });
+    applicationSetup.register(Symbol(), {
+      id: 'dashboard',
+      title: 'Dashboard',
+      mount: dashboardMount,
+    });
+
+    const workspaces = workspacesServiceMock.createStartContract();
+    const applicationStart = await applicationService.start({
+      http,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces,
+    });
+    const uiSettings = uiSettingsServiceMock.createStartContract();
+    const injectedMetadata = injectedMetadataServiceMock.createStartContract();
+
+    chromeService.setup({ uiSettings, injectedMetadata });
+    const chromeStart = await chromeService.start({
+      application: applicationStart,
+      docLinks: docLinksServiceMock.createStartContract(),
+      http,
+      injectedMetadata,
+      notifications: notificationServiceMock.createStartContract(),
+      uiSettings,
+      overlays: overlayServiceMock.createStartContract(),
+      workspaces,
+      keyboardShortcut: keyboardShortcutServiceMock.createStart(),
+    });
+
+    const setActiveNavLinkSpy = jest.spyOn(chromeStart, 'setActiveNavLink');
+    const header = shallow(React.createElement(() => chromeStart.getHeaderComponent()));
+    const activeNavLinkId$ = header.prop('activeNavLinkId$') as Observable<string | undefined>;
+    const activeNavLinkIds: Array<string | undefined> = [];
+    const subscription = activeNavLinkId$.subscribe((appId) => activeNavLinkIds.push(appId));
+    const renderApplication = createRenderer(applicationStart.getComponent());
+    const applicationWrapper = await renderApplication();
+
+    try {
+      await act(async () => {
+        await applicationStart.navigateToApp('data-explorer');
+      });
+      await renderApplication();
+
+      expect(dataExplorerMount).toHaveBeenCalledTimes(1);
+      expect(activeNavLinkIds.at(-1)).toBe('data-explorer');
+      expect(setActiveNavLinkSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await applicationStart.navigateToApp('dashboard');
+      });
+      await renderApplication();
+
+      expect(dashboardMount).toHaveBeenCalledTimes(1);
+      expect(history.location.pathname).toBe('/app/dashboard');
+      expect(activeNavLinkIds.at(-1)).toBe('dashboard');
+
+      const activeNavLinkIdsAfterDashboardMount = [...activeNavLinkIds];
+
+      await act(async () => {
+        startServicesDeferred.resolve();
+        await lateWriteCompleted.promise;
+      });
+
+      expect(setActiveNavLinkSpy).toHaveBeenCalledWith('discover', 'data-explorer');
+      expect(dashboardMount.mock.invocationCallOrder[0]).toBeLessThan(
+        setActiveNavLinkSpy.mock.invocationCallOrder[0]
+      );
+      expect(activeNavLinkIds).toEqual(activeNavLinkIdsAfterDashboardMount);
+      expect(activeNavLinkIds.at(-1)).toBe('dashboard');
+      expect(history.location.pathname).toBe('/app/dashboard');
+    } finally {
+      startServicesDeferred.resolve();
+      if (dataExplorerMount.mock.calls.length > 0) {
+        await lateWriteCompleted.promise;
+      }
+      subscription.unsubscribe();
+      header.unmount();
+      applicationWrapper?.unmount();
+      chromeService.stop();
+      applicationService.stop();
+      jest.restoreAllMocks();
+    }
+  });
+});

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -2,6 +2,55 @@
 
 exports[`Header handles visibility and lock changes 1`] = `
 <Header
+  activeNavLinkId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
   appTitle$={
     BehaviorSubject {
       "_isScalar": false,
@@ -204,43 +253,6 @@ exports[`Header handles visibility and lock changes 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -7473,91 +7485,52 @@ exports[`Header handles visibility and lock changes 1`] = `
     </div>
     <CollapsibleNav
       appId$={
-        Observable {
+        BehaviorSubject {
           "_isScalar": false,
-          "source": Subject {
-            "_isScalar": false,
-            "closed": false,
-            "hasError": false,
-            "isStopped": false,
-            "observers": Array [
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
+          "_value": undefined,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
                   "_subscriptions": null,
                   "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
                 },
                 "isStopped": false,
-                "syncErrorThrowable": true,
+                "syncErrorThrowable": false,
                 "syncErrorThrown": false,
                 "syncErrorValue": null,
               },
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
-                },
-                "isStopped": false,
-                "syncErrorThrowable": true,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-            ],
-            "thrownError": null,
-          },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
         }
       }
       basePath={
@@ -8388,6 +8361,55 @@ exports[`Header handles visibility and lock changes 1`] = `
 
 exports[`Header renders application header without title 1`] = `
 <Header
+  activeNavLinkId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
   appTitle$={
     BehaviorSubject {
       "_isScalar": false,
@@ -8553,43 +8575,6 @@ exports[`Header renders application header without title 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -11609,91 +11594,52 @@ exports[`Header renders application header without title 1`] = `
     </div>
     <CollapsibleNav
       appId$={
-        Observable {
+        BehaviorSubject {
           "_isScalar": false,
-          "source": Subject {
-            "_isScalar": false,
-            "closed": false,
-            "hasError": false,
-            "isStopped": false,
-            "observers": Array [
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
+          "_value": undefined,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
                   "_subscriptions": null,
                   "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
                 },
                 "isStopped": false,
-                "syncErrorThrowable": true,
+                "syncErrorThrowable": false,
                 "syncErrorThrown": false,
                 "syncErrorValue": null,
               },
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
-                },
-                "isStopped": false,
-                "syncErrorThrowable": true,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-            ],
-            "thrownError": null,
-          },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
         }
       }
       basePath={
@@ -12018,6 +11964,55 @@ exports[`Header renders application header without title 1`] = `
 
 exports[`Header renders condensed header 1`] = `
 <Header
+  activeNavLinkId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
   appTitle$={
     BehaviorSubject {
       "_isScalar": false,
@@ -12220,43 +12215,6 @@ exports[`Header renders condensed header 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -18069,91 +18027,52 @@ exports[`Header renders condensed header 1`] = `
     </div>
     <CollapsibleNav
       appId$={
-        Observable {
+        BehaviorSubject {
           "_isScalar": false,
-          "source": Subject {
-            "_isScalar": false,
-            "closed": false,
-            "hasError": false,
-            "isStopped": false,
-            "observers": Array [
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
+          "_value": undefined,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
                   "_subscriptions": null,
                   "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
                 },
                 "isStopped": false,
-                "syncErrorThrowable": true,
+                "syncErrorThrowable": false,
                 "syncErrorThrown": false,
                 "syncErrorValue": null,
               },
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
-                },
-                "isStopped": false,
-                "syncErrorThrowable": true,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-            ],
-            "thrownError": null,
-          },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
         }
       }
       basePath={
@@ -18441,6 +18360,55 @@ exports[`Header renders condensed header 1`] = `
 
 exports[`Header renders page header with application title 1`] = `
 <Header
+  activeNavLinkId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
   appTitle$={
     BehaviorSubject {
       "_isScalar": false,
@@ -18606,43 +18574,6 @@ exports[`Header renders page header with application title 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -21942,91 +21873,52 @@ exports[`Header renders page header with application title 1`] = `
     </div>
     <CollapsibleNav
       appId$={
-        Observable {
+        BehaviorSubject {
           "_isScalar": false,
-          "source": Subject {
-            "_isScalar": false,
-            "closed": false,
-            "hasError": false,
-            "isStopped": false,
-            "observers": Array [
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
+          "_value": undefined,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
                   "_subscriptions": null,
                   "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
                 },
                 "isStopped": false,
-                "syncErrorThrowable": true,
+                "syncErrorThrowable": false,
                 "syncErrorThrown": false,
                 "syncErrorValue": null,
               },
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
-                },
-                "isStopped": false,
-                "syncErrorThrowable": true,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-            ],
-            "thrownError": null,
-          },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
         }
       }
       basePath={
@@ -22351,6 +22243,55 @@ exports[`Header renders page header with application title 1`] = `
 
 exports[`Header toggles primary navigation menu when clicked 1`] = `
 <Header
+  activeNavLinkId$={
+    BehaviorSubject {
+      "_isScalar": false,
+      "_value": undefined,
+      "closed": false,
+      "hasError": false,
+      "isStopped": false,
+      "observers": Array [
+        Subscriber {
+          "_parentOrParents": null,
+          "_subscriptions": Array [
+            SubjectSubscription {
+              "_parentOrParents": [Circular],
+              "_subscriptions": null,
+              "closed": false,
+              "subject": [Circular],
+              "subscriber": [Circular],
+            },
+          ],
+          "closed": false,
+          "destination": SafeSubscriber {
+            "_complete": undefined,
+            "_context": [Circular],
+            "_error": undefined,
+            "_next": [Function],
+            "_parentOrParents": null,
+            "_parentSubscriber": [Circular],
+            "_subscriptions": null,
+            "closed": false,
+            "destination": Object {
+              "closed": true,
+              "complete": [Function],
+              "error": [Function],
+              "next": [Function],
+            },
+            "isStopped": false,
+            "syncErrorThrowable": false,
+            "syncErrorThrown": false,
+            "syncErrorValue": null,
+          },
+          "isStopped": false,
+          "syncErrorThrowable": true,
+          "syncErrorThrown": false,
+          "syncErrorValue": null,
+        },
+      ],
+      "thrownError": null,
+    }
+  }
   appTitle$={
     BehaviorSubject {
       "_isScalar": false,
@@ -22553,43 +22494,6 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
           "hasError": false,
           "isStopped": false,
           "observers": Array [
-            Subscriber {
-              "_parentOrParents": null,
-              "_subscriptions": Array [
-                SubjectSubscription {
-                  "_parentOrParents": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "subject": [Circular],
-                  "subscriber": [Circular],
-                },
-              ],
-              "closed": false,
-              "destination": SafeSubscriber {
-                "_complete": undefined,
-                "_context": [Circular],
-                "_error": undefined,
-                "_next": [Function],
-                "_parentOrParents": null,
-                "_parentSubscriber": [Circular],
-                "_subscriptions": null,
-                "closed": false,
-                "destination": Object {
-                  "closed": true,
-                  "complete": [Function],
-                  "error": [Function],
-                  "next": [Function],
-                },
-                "isStopped": false,
-                "syncErrorThrowable": false,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-              "isStopped": false,
-              "syncErrorThrowable": true,
-              "syncErrorThrown": false,
-              "syncErrorValue": null,
-            },
             Subscriber {
               "_parentOrParents": null,
               "_subscriptions": Array [
@@ -28402,91 +28306,52 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
     </div>
     <CollapsibleNav
       appId$={
-        Observable {
+        BehaviorSubject {
           "_isScalar": false,
-          "source": Subject {
-            "_isScalar": false,
-            "closed": false,
-            "hasError": false,
-            "isStopped": false,
-            "observers": Array [
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
+          "_value": undefined,
+          "closed": false,
+          "hasError": false,
+          "isStopped": false,
+          "observers": Array [
+            Subscriber {
+              "_parentOrParents": null,
+              "_subscriptions": Array [
+                SubjectSubscription {
+                  "_parentOrParents": [Circular],
                   "_subscriptions": null,
                   "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
+                  "subject": [Circular],
+                  "subscriber": [Circular],
+                },
+              ],
+              "closed": false,
+              "destination": SafeSubscriber {
+                "_complete": undefined,
+                "_context": [Circular],
+                "_error": undefined,
+                "_next": [Function],
+                "_parentOrParents": null,
+                "_parentSubscriber": [Circular],
+                "_subscriptions": null,
+                "closed": false,
+                "destination": Object {
+                  "closed": true,
+                  "complete": [Function],
+                  "error": [Function],
+                  "next": [Function],
                 },
                 "isStopped": false,
-                "syncErrorThrowable": true,
+                "syncErrorThrowable": false,
                 "syncErrorThrown": false,
                 "syncErrorValue": null,
               },
-              Subscriber {
-                "_parentOrParents": null,
-                "_subscriptions": Array [
-                  SubjectSubscription {
-                    "_parentOrParents": [Circular],
-                    "_subscriptions": null,
-                    "closed": false,
-                    "subject": [Circular],
-                    "subscriber": [Circular],
-                  },
-                ],
-                "closed": false,
-                "destination": SafeSubscriber {
-                  "_complete": undefined,
-                  "_context": [Circular],
-                  "_error": undefined,
-                  "_next": [Function],
-                  "_parentOrParents": null,
-                  "_parentSubscriber": [Circular],
-                  "_subscriptions": null,
-                  "closed": false,
-                  "destination": Object {
-                    "closed": true,
-                    "complete": [Function],
-                    "error": [Function],
-                    "next": [Function],
-                  },
-                  "isStopped": false,
-                  "syncErrorThrowable": false,
-                  "syncErrorThrown": false,
-                  "syncErrorValue": null,
-                },
-                "isStopped": false,
-                "syncErrorThrowable": true,
-                "syncErrorThrown": false,
-                "syncErrorValue": null,
-              },
-            ],
-            "thrownError": null,
-          },
+              "isStopped": false,
+              "syncErrorThrowable": true,
+              "syncErrorThrown": false,
+              "syncErrorValue": null,
+            },
+          ],
+          "thrownError": null,
         }
       }
       basePath={

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -57,6 +57,7 @@ function mockProps() {
     http,
     application,
     opensearchDashboardsVersion: '1.0.0',
+    activeNavLinkId$: new BehaviorSubject<string | undefined>(undefined),
     appTitle$: new BehaviorSubject('test'),
     badge$: new BehaviorSubject(undefined),
     breadcrumbs$: new BehaviorSubject([]),
@@ -203,6 +204,21 @@ describe('Header', () => {
 
     expect(component.find('CollapsibleNavGroupEnabled').exists()).toBeTruthy();
   });
+
+  it.each([
+    [false, 'CollapsibleNav'],
+    [true, 'CollapsibleNavGroupEnabled'],
+  ])(
+    'passes the resolved active nav link id (nav groups enabled: %s)',
+    (navGroupEnabled, navName) => {
+      const activeNavLinkId$ = new BehaviorSubject<string | undefined>('discover');
+      const props = { ...mockProps(), activeNavLinkId$, navGroupEnabled };
+
+      const component = mountWithIntl(<Header {...props} />);
+
+      expect(component.find(navName).prop('appId$')).toBe(activeNavLinkId$);
+    }
+  );
 
   it('toggles primary navigation menu when clicked', () => {
     const branding = {

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -99,6 +99,7 @@ export interface HeaderProps {
   http: HttpStart;
   opensearchDashboardsVersion: string;
   application: InternalApplicationStart;
+  activeNavLinkId$: Observable<string | undefined>;
   appTitle$: Observable<string>;
   badge$: Observable<ChromeBadge | undefined>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
@@ -732,7 +733,7 @@ export function Header({
 
         {navGroupEnabled ? (
           <CollapsibleNavGroupEnabled
-            appId$={application.currentAppId$}
+            appId$={observables.activeNavLinkId$}
             collapsibleNavHeaderRender={collapsibleNavHeaderRender}
             id={navId}
             navLinks$={observables.navLinks$}
@@ -764,7 +765,7 @@ export function Header({
           />
         ) : (
           <CollapsibleNav
-            appId$={application.currentAppId$}
+            appId$={observables.activeNavLinkId$}
             collapsibleNavHeaderRender={collapsibleNavHeaderRender}
             id={navId}
             isLocked={isLocked}

--- a/src/core/public/chrome/ui/header/nav_link.test.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.test.tsx
@@ -16,8 +16,8 @@ describe('isActiveNavLink', () => {
     expect(isActiveNavLink('data-explorer', 'data-explorer')).toBe(true);
   });
 
-  it('should return true if the appId is "data-explorer" and linkId is "discover"', () => {
-    expect(isActiveNavLink('data-explorer', 'discover')).toBe(true);
+  it('should return false when the active nav link id and link id do not match', () => {
+    expect(isActiveNavLink('data-explorer', 'discover')).toBe(false);
   });
 
   it('should return true if the appId is "explore" and linkId is "explore"', () => {
@@ -58,10 +58,7 @@ describe('createEuiListItem', () => {
     expect(listItem).toHaveProperty('href', mockProps.link.href);
     expect(listItem).toHaveProperty('data-test-subj', mockProps.dataTestSubj);
     expect(listItem).toHaveProperty('onClick');
-    expect(listItem).toHaveProperty(
-      'isActive',
-      isActiveNavLink(mockProps.appId, mockProps.link.id)
-    );
+    expect(listItem).toHaveProperty('isActive', true);
     expect(listItem).toHaveProperty('isDisabled', mockProps.link.disabled);
   });
 });

--- a/src/core/public/chrome/ui/header/nav_link.tsx
+++ b/src/core/public/chrome/ui/header/nav_link.tsx
@@ -40,14 +40,8 @@ import { formatUrlWithWorkspaceId } from '../../../utils';
 export const isModifiedOrPrevented = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
   event.metaKey || event.altKey || event.ctrlKey || event.shiftKey || event.defaultPrevented;
 
-// TODO: replace hard-coded values with a registration function, so that apps can control active nav links similar to breadcrumbs
-const aliasedApps: { [key: string]: string[] } = {
-  discover: ['data-explorer'],
-  explore: ['explore'],
-};
-
-export const isActiveNavLink = (appId: string | undefined, linkId: string): boolean =>
-  !!(appId === linkId || aliasedApps[linkId]?.includes(appId || ''));
+export const isActiveNavLink = (activeNavLinkId: string | undefined, linkId: string): boolean =>
+  activeNavLinkId === linkId;
 
 interface Props {
   link: ChromeNavLink;

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -354,6 +354,7 @@ export interface ChromeStart {
     navLinks: ChromeNavLinks;
     recentlyAccessed: ChromeRecentlyAccessed;
     removeApplicationClass(className: string): void;
+    setActiveNavLink(navLinkId: string | undefined, expectedAppId: string): void;
     setAppTitle(appTitle: string): void;
     setBadge(badge?: ChromeBadge): void;
     setBrand(brand: ChromeBrand): void;

--- a/src/plugins/data_explorer/README.md
+++ b/src/plugins/data_explorer/README.md
@@ -51,6 +51,7 @@ For an application to be registered as a view within Data Explorer, it needs to 
 interface ViewDefinition<T = any> {
   readonly id: string;
   readonly title: string;
+  readonly activeNavLinkId?: string;
   readonly ui?: {
     defaults: DefaultViewState | (() => DefaultViewState) | (() => Promise<DefaultViewState>);
     slice: Slice<T>;
@@ -70,6 +71,9 @@ interface ViewDefinition<T = any> {
   readonly shouldShow?: (state: any) => boolean;
 }
 ```
+
+`activeNavLinkId` identifies the navigation link marked as active while the view is selected. If
+it is omitted, Data Explorer's host navigation link is used.
 
 ---
 

--- a/src/plugins/data_explorer/public/plugin.test.ts
+++ b/src/plugins/data_explorer/public/plugin.test.ts
@@ -7,6 +7,19 @@ import { coreMock } from '../../../core/public/mocks';
 import { DEFAULT_NAV_GROUPS } from '../../../core/public';
 import { DataExplorerPlugin } from './plugin';
 import { dataPluginMock } from '../../data/public/mocks';
+import { embeddablePluginMock } from '../../embeddable/public/mocks';
+import { expressionsPluginMock } from '../../expressions/public/mocks';
+import { PLUGIN_ID } from '../common';
+import { renderApp } from './application';
+import { getPreloadedStore } from './utils/state_management';
+
+jest.mock('./application', () => ({
+  renderApp: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('./utils/state_management', () => ({
+  getPreloadedStore: jest.fn(async () => ({ store: {}, unsubscribe: jest.fn() })),
+}));
 
 const getSetupDeps = () => ({
   data: dataPluginMock.createSetupContract(),
@@ -45,5 +58,44 @@ describe('DataExplorerPlugin', () => {
         }),
       ])
     );
+  });
+
+  it('sets the initial view active nav link during mount without clearing it on unmount', async () => {
+    const coreStart = coreMock.createStart();
+    const pluginsStart = {
+      data: dataPluginMock.createStartContract(),
+      embeddable: embeddablePluginMock.createStartContract(),
+      expressions: expressionsPluginMock.createStartContract(),
+    };
+    const setupMock = coreMock.createSetup({ pluginStartDeps: pluginsStart });
+    setupMock.getStartServices.mockResolvedValue([coreStart, pluginsStart, {}]);
+    const pluginInstance = new DataExplorerPlugin();
+    const setup = pluginInstance.setup(setupMock, getSetupDeps());
+    setup.registerView({
+      id: 'discover',
+      title: 'Discover',
+      activeNavLinkId: 'discover',
+    } as any);
+    const dataExplorerApp = setupMock.application.register.mock.calls
+      .map(([app]) => app)
+      .find(({ id }) => id === 'data-explorer');
+
+    const unmount = await dataExplorerApp!.mount({
+      element: document.createElement('div'),
+      history: {
+        location: { pathname: '/discover', search: '', hash: '' },
+        listen: jest.fn(() => jest.fn()),
+      },
+    } as any);
+
+    expect(coreStart.chrome.setActiveNavLink).toHaveBeenCalledWith('discover', PLUGIN_ID);
+    expect(coreStart.chrome.setActiveNavLink.mock.invocationCallOrder[0]).toBeLessThan(
+      (getPreloadedStore as jest.Mock).mock.invocationCallOrder[0]
+    );
+    expect(renderApp).toHaveBeenCalled();
+
+    const callsBeforeUnmount = coreStart.chrome.setActiveNavLink.mock.calls.length;
+    unmount();
+    expect(coreStart.chrome.setActiveNavLink).toHaveBeenCalledTimes(callsBeforeUnmount);
   });
 });

--- a/src/plugins/data_explorer/public/plugin.ts
+++ b/src/plugins/data_explorer/public/plugin.ts
@@ -91,10 +91,16 @@ export class DataExplorerPlugin implements Plugin<
       navLinkStatus: AppNavLinkStatus.hidden,
       workspaceAvailability: WorkspaceAvailability.insideWorkspace,
       mount: async (params: AppMountParameters) => {
-        // Load application bundle
+        const [coreStart, pluginsStart] = await core.getStartServices();
+        const viewRegistry = viewService.start();
+        const initialViewId = params.history.location.pathname.split('/').filter(Boolean)[0];
+        const initialView = initialViewId ? viewRegistry.get(initialViewId) : undefined;
+
+        coreStart.chrome.setActiveNavLink(initialView?.activeNavLinkId, PLUGIN_ID);
+
+        // Load application bundle after setting the initial active nav link.
         const { renderApp } = await import('./application');
 
-        const [coreStart, pluginsStart] = await core.getStartServices();
         this.currentHistory = params.history;
 
         // make sure the index pattern list is up to date
@@ -111,7 +117,7 @@ export class DataExplorerPlugin implements Plugin<
             useHash: coreStart.uiSettings.get('state:storeInSessionStorage'),
             ...withNotifyOnErrors(coreStart.notifications.toasts),
           }),
-          viewRegistry: viewService.start(),
+          viewRegistry,
         };
 
         // Get start services as specified in opensearch_dashboards.json

--- a/src/plugins/data_explorer/public/services/view_service/types.ts
+++ b/src/plugins/data_explorer/public/services/view_service/types.ts
@@ -23,6 +23,7 @@ export type ViewProps = AppMountParameters;
 export interface ViewDefinition<T = any> {
   readonly id: string;
   readonly title: string;
+  readonly activeNavLinkId?: string;
   readonly ui?: {
     defaults: DefaultViewState | (() => DefaultViewState) | (() => Promise<DefaultViewState>);
     slice: Slice<T>;

--- a/src/plugins/data_explorer/public/services/view_service/view.ts
+++ b/src/plugins/data_explorer/public/services/view_service/view.ts
@@ -9,6 +9,7 @@ type IView = ViewDefinition;
 export class View implements IView {
   public readonly id: string;
   public readonly title: string;
+  public readonly activeNavLinkId: IView['activeNavLinkId'];
   public readonly ui: IView['ui'];
   public readonly defaultPath: string;
   public readonly appExtentions: IView['appExtentions'];
@@ -20,6 +21,7 @@ export class View implements IView {
   constructor(options: ViewDefinition) {
     this.id = options.id;
     this.title = options.title;
+    this.activeNavLinkId = options.activeNavLinkId;
     this.ui = options.ui;
     this.defaultPath = options.defaultPath;
     this.appExtentions = options.appExtentions;

--- a/src/plugins/data_explorer/public/services/view_service/view_service.test.ts
+++ b/src/plugins/data_explorer/public/services/view_service/view_service.test.ts
@@ -42,12 +42,16 @@ describe('TypeService', () => {
   });
 
   describe('#start', () => {
-    test('should return registered view if it exists', () => {
+    test('should return registered view with optional active nav link metadata', () => {
       const { registerView } = service.setup();
-      registerView(createViewDefinition({ id: 'view-1' }));
+      registerView(createViewDefinition({ id: 'view-1', activeNavLinkId: 'view-1-nav' }));
+      registerView(createViewDefinition({ id: 'view-2' }));
 
       const { get } = service.start();
-      expect(get('view-1')).toEqual(expect.objectContaining({ id: 'view-1' }));
+      expect(get('view-1')).toEqual(
+        expect.objectContaining({ id: 'view-1', activeNavLinkId: 'view-1-nav' })
+      );
+      expect(get('view-2')?.activeNavLinkId).toBeUndefined();
       expect(get('view-something')).toBeUndefined();
     });
 

--- a/src/plugins/data_explorer/public/utils/use/use_view.test.ts
+++ b/src/plugins/data_explorer/public/utils/use/use_view.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useParams } from 'react-router-dom';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { PLUGIN_ID } from '../../../common';
+import { useTypedDispatch, useTypedSelector } from '../state_management';
+import { useView } from './use_view';
+
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('../../../../opensearch_dashboards_react/public', () => ({
+  useOpenSearchDashboards: jest.fn(),
+}));
+
+jest.mock('../state_management', () => ({
+  useTypedDispatch: jest.fn(),
+  useTypedSelector: jest.fn(),
+}));
+
+describe('useView', () => {
+  const setActiveNavLink = jest.fn();
+  const dispatch = jest.fn();
+  const views = {
+    discover: { id: 'discover', activeNavLinkId: 'discover' },
+    'view-b': { id: 'view-b', activeNavLinkId: 'view-b-nav' },
+    'view-without-nav-link': { id: 'view-without-nav-link' },
+  };
+  let appId: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appId = 'discover';
+    (useParams as jest.Mock).mockImplementation(() => ({ appId }));
+    (useTypedSelector as jest.Mock).mockReturnValue(undefined);
+    (useTypedDispatch as jest.Mock).mockReturnValue(dispatch);
+    (useOpenSearchDashboards as jest.Mock).mockReturnValue({
+      services: {
+        chrome: { setActiveNavLink },
+        viewRegistry: {
+          get: jest.fn((id: keyof typeof views) => views[id]),
+        },
+      },
+    });
+  });
+
+  it('updates the active nav link when the route view changes without a host remount', () => {
+    const { rerender, unmount } = renderHook(() => useView());
+
+    expect(setActiveNavLink).toHaveBeenLastCalledWith('discover', PLUGIN_ID);
+
+    act(() => {
+      appId = 'view-b';
+      rerender();
+    });
+    expect(setActiveNavLink).toHaveBeenLastCalledWith('view-b-nav', PLUGIN_ID);
+
+    act(() => {
+      appId = 'view-without-nav-link';
+      rerender();
+    });
+    expect(setActiveNavLink).toHaveBeenLastCalledWith(undefined, PLUGIN_ID);
+
+    act(() => {
+      appId = 'unknown';
+      rerender();
+    });
+    expect(setActiveNavLink).toHaveBeenLastCalledWith(undefined, PLUGIN_ID);
+
+    const callsBeforeUnmount = setActiveNavLink.mock.calls.length;
+    unmount();
+    expect(setActiveNavLink).toHaveBeenCalledTimes(callsBeforeUnmount);
+  });
+});

--- a/src/plugins/data_explorer/public/utils/use/use_view.ts
+++ b/src/plugins/data_explorer/public/utils/use/use_view.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { PLUGIN_ID } from '../../../common';
 import { DataExplorerServices } from '../../types';
 import { useTypedDispatch, useTypedSelector } from '../state_management';
 import { setView } from '../state_management/metadata_slice';
@@ -13,7 +14,7 @@ import { setView } from '../state_management/metadata_slice';
 export const useView = () => {
   const viewId = useTypedSelector((state) => state.metadata.view);
   const {
-    services: { viewRegistry },
+    services: { chrome, viewRegistry },
   } = useOpenSearchDashboards<DataExplorerServices>();
   const dispatch = useTypedDispatch();
   const { appId } = useParams<{ appId: string }>();
@@ -22,14 +23,17 @@ export const useView = () => {
     if (!viewId) return undefined;
     return viewRegistry.get(viewId);
   }, [viewId, viewRegistry]);
+  const routeView = useMemo(() => viewRegistry.get(appId), [appId, viewRegistry]);
+
+  useLayoutEffect(() => {
+    chrome.setActiveNavLink(routeView?.activeNavLinkId, PLUGIN_ID);
+  }, [chrome, routeView]);
 
   useEffect(() => {
-    const currentView = viewRegistry.get(appId);
+    if (!routeView) return;
 
-    if (!currentView) return;
-
-    dispatch(setView(currentView?.id));
-  }, [appId, dispatch, viewRegistry]);
+    dispatch(setView(routeView.id));
+  }, [dispatch, routeView]);
 
   return { view, viewRegistry };
 };

--- a/src/plugins/discover/public/plugin.test.ts
+++ b/src/plugins/discover/public/plugin.test.ts
@@ -36,10 +36,17 @@ describe('DiscoverPlugin', () => {
     const setupMock = coreMock.createSetup();
     const initializerContext = coreMock.createPluginInitializerContext();
     const pluginInstance = new DiscoverPlugin(initializerContext);
+    const setupDeps = getSetupDeps();
     expect(() =>
       // @ts-expect-error TS2345 TODO(ts-error): fixme
-      pluginInstance.setup(setupMock, getSetupDeps())
+      pluginInstance.setup(setupMock, setupDeps)
     ).not.toThrow();
+    expect(setupDeps.dataExplorer.registerView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'discover',
+        activeNavLinkId: 'discover',
+      })
+    );
     expect(setupMock.chrome.navGroup.addNavLinksToGroup).toHaveBeenCalledTimes(5);
   });
 

--- a/src/plugins/discover/public/plugin.ts
+++ b/src/plugins/discover/public/plugin.ts
@@ -388,6 +388,7 @@ export class DiscoverPlugin implements Plugin<
     plugins.dataExplorer.registerView<DiscoverState>({
       id: PLUGIN_ID,
       title: 'Discover',
+      activeNavLinkId: PLUGIN_ID,
       defaultPath: '#/',
       appExtentions: {
         savedObject: {


### PR DESCRIPTION
### Description

Replaces the hard-coded active-navigation aliases with an app-scoped Chrome API.
Applications can override the active nav link only while they own the current mount.
`ChromeService` resets the active link on application changes and rejects late writes or
clears when `expectedAppId` no longer matches the current application, preventing an
asynchronous Data Explorer mount from overwriting Dashboard navigation state.

Discover now declares `activeNavLinkId` through Data Explorer view metadata. Data Explorer
applies the metadata before the initial view renders and updates it with route-driven view
changes without remounting the host application. Both legacy and nav-group navigation
consume the same active-link observable.

### Issues Resolved

Closes #5608

## Screenshot
 
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/555535e7-0f76-4911-a9a1-37f9dafa107d" />
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/c060f65d-416e-49e7-9263-7e072371c98e" />


Local visual verification shows Discover highlighted while the hidden Data Explorer host
renders the view, and Dashboard highlighted after cross-application navigation.

## Testing the changes

Automated validation performed:

- Focused Jest unit tests: 7/7 suites, 64/64 tests, and 20/20 snapshots passed.
- Focused Jest integration test: 1/1 suite and 1/1 test passed, covering a delayed mount
  attempting to write after navigation to another application.
- ESLint passed with no diagnostics for all changed TypeScript files.
- `yarn typecheck` passed with no TypeScript errors.
- `git diff --check`, commit checks, and the pre-commit i18n/ESLint checks passed.
- A prior full `yarn test:jest_integration` run passed 55/56 suites. The sole failure was
  the unchanged, unrelated
  `packages/osd-optimizer/src/integration_tests/basic_optimization.test.ts`; therefore the
  complete integration suite is not reported as green.

Visual verification is semantically **PASS** in both legacy and nav-group-enabled side
navigation:

- Discover remains active after redirecting to the Data Explorer host.
- Dashboard replaces Discover as active after navigation.
- With Data Explorer chunks delayed, Dashboard remains active after release; no stale
  Data Explorer mount rebounds the navigation state.
- The nav-group script's reported `FAIL` is a documented detector false negative: its
  whitespace-bounded regex does not recognize the BEM class `nav-link-item--active`.
  The correct item retained that class and the Dashboard URL remained stable in all 32/32
  post-release samples.

`yarn docs:acceptApiChanges` is not green: it is blocked in `build:types` by the same 85
TS2883/TS4023/TS4053/TS5011 errors reproduced on a clean `upstream/main` worktree. The
normalized baseline comparison is identical (0-byte diff), with no errors in files changed
by this PR. The included API report contains only the expected `ChromeStart` signature and
matches the public interface.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest` — only the focused unit suites above were run
  - [ ] `yarn test:jest_integration` — 55/56 suites; unrelated optimizer failure documented above
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
