### PR TITLE
[Explore] Stop the Patterns tab running the raw user query after a reload

### DIFF
--- a/src/plugins/explore/public/application/register_tabs.test.ts
+++ b/src/plugins/explore/public/application/register_tabs.test.ts
@@ -11,6 +11,7 @@ import {
   EXPLORE_VISUALIZATION_TAB_ID,
   EXPLORE_STATISTICS_TAB_ID,
   EXPLORE_METRICS_EXPLORE_TAB_ID,
+  EXPLORE_PATTERNS_TAB_ID,
 } from '../../common';
 import { ExploreServices } from '../types';
 
@@ -211,5 +212,53 @@ describe('registerBuiltInTabs - SQL Language Restrictions', () => {
       const sqlTabs = getSqlEnabledTabsForFlavor(ExploreFlavor.Metrics);
       expect(sqlTabs.length).toBe(0);
     });
+  });
+});
+
+describe('registerBuiltInTabs - patterns prepareQuery when the patterns field is unknown', () => {
+  // Reproduces the post-refresh state: `resultsCache` is in-memory only, so after a
+  // page reload the logs tab has no cached results and `findDefaultPatternsField`
+  // throws. `state.tab.patterns.patternsField` is likewise empty because it is not
+  // persisted to the URL.
+  const registerPatternsTab = () => {
+    const tabRegistry = new TabRegistryService();
+    const services = {
+      uiSettings: {
+        get: jest.fn((key: string) => key === 'explore:experimental'),
+      },
+      store: {
+        getState: jest.fn().mockReturnValue({
+          tab: { patterns: { patternsField: '', usingRegexPatterns: false } },
+          query: { language: 'PPL' },
+        }),
+        dispatch: jest.fn(),
+      },
+      // No logs results cached => findDefaultPatternsField throws.
+      tabRegistry,
+    } as unknown as ExploreServices;
+    registerBuiltInTabs(tabRegistry, services, ExploreFlavor.Logs);
+    return tabRegistry.getTab(EXPLORE_PATTERNS_TAB_ID)!;
+  };
+
+  it('does not fall back to executing the raw user query', () => {
+    const patternsTab = registerPatternsTab();
+    const userQuery = { query: 'source = my_index', language: 'PPL' } as any;
+
+    const prepared = patternsTab.prepareQuery!(userQuery);
+
+    // Returning the user's own query makes the patterns tab execute a plain search
+    // under its own cache key; the container then reads raw documents through the
+    // patterns column mapping and renders garbage (SQL) or nothing (PPL).
+    expect(prepared).not.toBe('source = my_index');
+  });
+
+  it('produces no query at all rather than a wrong one', () => {
+    const patternsTab = registerPatternsTab();
+    const prepared = patternsTab.prepareQuery!({
+      query: 'source = my_index',
+      language: 'PPL',
+    } as any);
+
+    expect(prepared).toBe('');
   });
 });

--- a/src/plugins/explore/public/application/register_tabs.test.ts
+++ b/src/plugins/explore/public/application/register_tabs.test.ts
@@ -248,8 +248,32 @@ describe('registerBuiltInTabs - patterns prepareQuery when the patterns field is
 
     // Returning the user's own query makes the patterns tab execute a plain search
     // under its own cache key; the container then reads raw documents through the
-    // patterns column mapping and renders garbage (SQL) or nothing (PPL).
+    // patterns column mapping, and the fixed PPL field names match nothing.
     expect(prepared).not.toBe('source = my_index');
+  });
+
+  // The other throw in findDefaultPatternsField: logs hits are present but none of
+  // the fields is string-typed. Same catch, so the tab reports itself unbuildable
+  // and ErrorGuard renders the field picker instead of a blank panel.
+  it('produces no query when logs results exist but hold no string field', () => {
+    const tabRegistry = new TabRegistryService();
+    const services = {
+      uiSettings: { get: jest.fn((key: string) => key === 'explore:experimental') },
+      store: {
+        getState: jest.fn().mockReturnValue({
+          tab: { patterns: { patternsField: '', usingRegexPatterns: false } },
+          query: { language: 'PPL' },
+        }),
+        dispatch: jest.fn(),
+      },
+      tabRegistry,
+    } as unknown as ExploreServices;
+    registerBuiltInTabs(tabRegistry, services, ExploreFlavor.Logs);
+    const patternsTab = tabRegistry.getTab(EXPLORE_PATTERNS_TAB_ID)!;
+
+    expect(patternsTab.prepareQuery!({ query: 'source = my_index', language: 'PPL' } as any)).toBe(
+      ''
+    );
   });
 
   it('produces no query at all rather than a wrong one', () => {

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -115,7 +115,17 @@ export const registerBuiltInTabs = (
           try {
             patternsField = findDefaultPatternsField(services);
           } catch {
-            return preparedQuery.query;
+            // The patterns field is derived from the logs tab's cached results, which
+            // live in memory only -- after a page reload there are none, and
+            // `patternsField` is not persisted to the URL either, so this is the normal
+            // state on every refresh until the logs query has run once.
+            //
+            // Returning the user's own query here would make the patterns tab execute a
+            // plain search under its own cache key; the container then reads raw
+            // documents through the patterns column mapping and renders nonsense.
+            // Return no query instead: `executeTabQuery` skips empty cache keys, so the
+            // tab simply stays uninitialized until the field can be resolved.
+            return '';
           }
         }
 

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -115,16 +115,11 @@ export const registerBuiltInTabs = (
           try {
             patternsField = findDefaultPatternsField(services);
           } catch {
-            // The patterns field is derived from the logs tab's cached results, which
-            // live in memory only -- after a page reload there are none, and
-            // `patternsField` is not persisted to the URL either, so this is the normal
-            // state on every refresh until the logs query has run once.
-            //
-            // Returning the user's own query here would make the patterns tab execute a
-            // plain search under its own cache key; the container then reads raw
-            // documents through the patterns column mapping and renders nonsense.
-            // Return no query instead: `executeTabQuery` skips empty cache keys, so the
-            // tab simply stays uninitialized until the field can be resolved.
+            // The field comes from the logs tab's in-memory results, so this is the
+            // normal state after every reload until the logs query has run once.
+            // Returning the user's own query would make `Tabs.onTabClick` run a plain
+            // search under the patterns cache key and render it through the patterns
+            // column mapping. Return no query instead.
             return '';
           }
         }

--- a/src/plugins/explore/public/application/utils/hooks/use_cannot_build_tab_query.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_cannot_build_tab_query.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { RootState } from '../state_management/store';
+import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
+import { selectPatternsField } from '../state_management/selectors';
+
+/**
+ * True when a tab's `prepareQuery` returns an empty string, meaning it cannot yet
+ * build a query. Such a tab has no cache key, so it records no status to key off.
+ */
+export const useCannotBuildTabQuery = (registryTab?: TabDefinition) => {
+  const query = useSelector((state: RootState) => state.query);
+  // Re-runs the memo once the user picks a field.
+  const patternsField = useSelector(selectPatternsField);
+
+  return useMemo(() => {
+    if (!registryTab?.prepareQuery) {
+      return false;
+    }
+    return !registryTab.prepareQuery(query);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [registryTab, query, patternsField]);
+};

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -1786,6 +1786,33 @@ describe('Query Actions - Comprehensive Test Suite', () => {
       );
     });
 
+    // A tab whose prepareQuery cannot yet build a query returns '' -- see the patterns
+    // tab, whose field is derived from logs results that are gone after a page reload.
+    it('does not run anything when the cache key is empty', async () => {
+      const thunk = executeTabQuery({
+        services: mockServices,
+        cacheKey: '',
+        queryString: '',
+      });
+      await thunk(mockDispatch, mockGetState, undefined);
+
+      expect(mockSearchSource.fetch).not.toHaveBeenCalled();
+      expect(setResults).not.toHaveBeenCalled();
+    });
+
+    // The BRAIN retry in register_tabs deliberately passes a queryString that
+    // differs from its cacheKey, so the guard must not key off queryString.
+    it('still runs when only the query string differs from the cache key', async () => {
+      const thunk = executeTabQuery({
+        services: mockServices,
+        cacheKey: 'some-key',
+        queryString: 'source=logs',
+      });
+      await thunk(mockDispatch, mockGetState, undefined);
+
+      expect(mockSearchSource.fetch).toHaveBeenCalled();
+    });
+
     it('should handle missing services gracefully', async () => {
       const params = {
         services: undefined as any,

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -1798,6 +1798,15 @@ describe('Query Actions - Comprehensive Test Suite', () => {
 
       expect(mockSearchSource.fetch).not.toHaveBeenCalled();
       expect(setResults).not.toHaveBeenCalled();
+      // The tab must stay uninitialized rather than stuck on a spinner.
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'queryEditor/setIndividualQueryStatus',
+          payload: expect.objectContaining({
+            status: expect.objectContaining({ status: QueryExecutionStatus.LOADING }),
+          }),
+        })
+      );
     });
 
     // The BRAIN retry in register_tabs deliberately passes a queryString that

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -404,10 +404,14 @@ export const executeQueries = createAsyncThunk<
     activeTabCacheKey = activeTabPrepareQuery(query);
   }
 
-  // Check what needs execution
+  // Check what needs execution. An empty key means that tab's `prepareQuery`
+  // cannot build a query yet, so there is nothing to run.
   const needsVisualizationTabQuery =
-    visualizationTabCacheKey !== defaultCacheKey && !results[visualizationTabCacheKey];
+    !!visualizationTabCacheKey &&
+    visualizationTabCacheKey !== defaultCacheKey &&
+    !results[visualizationTabCacheKey];
   const needsActiveTabQuery =
+    !!activeTabCacheKey &&
     activeTabCacheKey !== visualizationTabCacheKey &&
     activeTabCacheKey !== defaultCacheKey &&
     !results[activeTabCacheKey];

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -812,6 +812,18 @@ export const executeTabQuery = createAsyncThunk<
   const { services } = params;
   const { getState } = thunkAPI;
 
+  // A tab whose `prepareQuery` cannot yet build a query returns an empty string
+  // (see the patterns tab in `register_tabs`). Executing that would send an empty
+  // query to the backend and cache the response under an empty key, so skip it and
+  // leave the tab uninitialized until the tab can produce a real query.
+  //
+  // Gated on cacheKey alone: most callers pass the same value for both, but the
+  // BRAIN retry in `register_tabs` deliberately passes a queryString that differs
+  // from its cacheKey, and that path should keep running.
+  if (!params.cacheKey) {
+    return;
+  }
+
   /**
    * below activeTabCustomQueryErrorHandler logic to be removed when datasets
    * contain information about query engine versions

--- a/src/plugins/explore/public/components/tabs/error_guard/error_guard.test.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/error_guard.test.tsx
@@ -6,13 +6,23 @@
 import { render, screen } from '@testing-library/react';
 import { ErrorGuard } from './error_guard';
 import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
+import { EXPLORE_PATTERNS_TAB_ID } from '../../../../common';
 
 // Mock the useTabError hook
 jest.mock('../../../application/utils/hooks/use_tab_error', () => ({
   useTabError: jest.fn(),
 }));
 
+jest.mock('../../../application/utils/hooks/use_cannot_build_tab_query', () => ({
+  useCannotBuildTabQuery: jest.fn(() => false),
+}));
+
+jest.mock('./patterns_error_guard', () => ({
+  PatternsErrorGuard: () => <div>patterns empty state</div>,
+}));
+
 import { useTabError } from '../../../application/utils/hooks/use_tab_error';
+import { useCannotBuildTabQuery } from '../../../application/utils/hooks/use_cannot_build_tab_query';
 
 const mockUseTabError = useTabError as jest.MockedFunction<typeof useTabError>;
 
@@ -40,6 +50,20 @@ describe('ErrorGuard', () => {
 
     expect(screen.getByText('Child Content')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the patterns empty state when the tab cannot build a query', () => {
+    mockUseTabError.mockReturnValue(undefined);
+    (useCannotBuildTabQuery as jest.Mock).mockReturnValue(true);
+
+    render(
+      <ErrorGuard registryTab={{ ...mockTabDefinition, id: EXPLORE_PATTERNS_TAB_ID }}>
+        <div>child</div>
+      </ErrorGuard>
+    );
+
+    expect(screen.getByText('patterns empty state')).toBeInTheDocument();
+    expect(screen.queryByText('child')).not.toBeInTheDocument();
   });
 
   it('renders error panel when there is an error', () => {

--- a/src/plugins/explore/public/components/tabs/error_guard/error_guard.tsx
+++ b/src/plugins/explore/public/components/tabs/error_guard/error_guard.tsx
@@ -11,6 +11,7 @@ import { EuiErrorBoundary, EuiFlexGroup, EuiIcon, EuiTitle } from '@elastic/eui'
 import { ErrorCodeBlock } from './error_code_block';
 import { TabDefinition } from '../../../services/tab_registry/tab_registry_service';
 import { useTabError } from '../../../application/utils/hooks/use_tab_error';
+import { useCannotBuildTabQuery } from '../../../application/utils/hooks/use_cannot_build_tab_query';
 import { EXPLORE_PATTERNS_TAB_ID } from '../../../../common';
 import { PatternsErrorGuard } from './patterns_error_guard';
 
@@ -31,14 +32,19 @@ export interface ErrorGuardProps {
 
 export const ErrorGuard = ({ registryTab, children }: ErrorGuardProps): JSX.Element | null => {
   const error = useTabError(registryTab);
+  const cannotBuildQuery = useCannotBuildTabQuery(registryTab);
+
+  // No cache key means no recorded error to key off, so the patterns tab would
+  // otherwise lose the empty state that lets the user pick a field.
+  if (registryTab.id === EXPLORE_PATTERNS_TAB_ID && (error != null || cannotBuildQuery)) {
+    return <PatternsErrorGuard registryTab={registryTab} />;
+  }
 
   if (error == null) {
     return <EuiErrorBoundary>{children}</EuiErrorBoundary>;
   }
 
-  return registryTab.id === EXPLORE_PATTERNS_TAB_ID ? (
-    <PatternsErrorGuard registryTab={registryTab} />
-  ) : (
+  return (
     <EuiErrorBoundary>
       <EuiFlexGroup direction="column" alignItems="center" className="exploreErrorGuard">
         <EuiIcon type="alert" size="xl" color="red" />

--- a/src/plugins/explore/public/components/tabs/tabs.tsx
+++ b/src/plugins/explore/public/components/tabs/tabs.tsx
@@ -63,6 +63,8 @@ export const ExploreTabs = () => {
       const activeTab = services.tabRegistry.getTab(tabId);
       const prepareQuery = activeTab?.prepareQuery || defaultPrepareQueryString;
       const newTabCacheKey = prepareQuery(query);
+      // An empty key means the tab cannot build a query yet.
+      if (!newTabCacheKey) return;
 
       const needsExecution = !results[newTabCacheKey];
 


### PR DESCRIPTION

### Description

The Patterns tab derives its patterns field from the logs tab's cached results. `resultsCache` is in-memory only, so after a page reload there are no cached results and `findDefaultPatternsField` throws. `state.tab.patterns.patternsField` is not persisted to the URL either, so this is the normal state on every refresh until the logs query has run once.

`prepareQuery` caught that and returned the user's own query. The Patterns tab then executed a plain search under its own cache key, and the container read those raw documents through the patterns column mapping.

On PPL the container looks up fixed field names (`patterns_field`, `pattern_count`, `sample_logs`). None exist on a raw document, so every row is filtered out and the tab is silently blank — which is why this has gone unnoticed. Any consumer that reads the columns positionally instead surfaces arbitrary document fields as the pattern, count and sample.

This change returns no query instead, and skips execution for an empty cache key in `executeTabQuery`, so the tab stays uninitialized until the field can be resolved rather than showing a wrong answer. The guard lives in `executeTabQuery` because five call sites dispatch it.

### Issues Resolved

N/A

## Screenshot


https://github.com/user-attachments/assets/e58d317f-0613-4003-883f-6983d0641b80


## Testing the changes

1. Open Explore → Logs with any index pattern and run a query.
2. Switch to the Patterns tab and confirm patterns render.
3. Refresh the browser and go straight to the Patterns tab. Before this change a request for the bare user query is issued under the patterns tab's cache key and the table renders empty. After it, no request is issued and the tab stays uninitialized.
4. Go back to Logs, run the query, return to Patterns — patterns render normally.

Unit tests were added for both halves and both fail against the previous behavior: `register_tabs.test.ts` asserts `prepareQuery` returns an empty string rather than the user's query when the patterns field cannot be resolved, and `query_actions.test.ts` asserts `executeTabQuery` performs no fetch for an empty cache key or query string.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff