### PR TITLE
[Explore] Escape backslashes in PPL string literals and field identifiers

### DIFF
--- a/src/plugins/agent_traces/public/application/pages/traces/trace_details/data_fetching/ppl_request_helpers.test.tsx
+++ b/src/plugins/agent_traces/public/application/pages/traces/trace_details/data_fetching/ppl_request_helpers.test.tsx
@@ -179,7 +179,31 @@ describe('ppl_request_helpers', () => {
     it('escapes string values', () => {
       expect(escapePPLValue('test')).toBe('"test"');
       expect(escapePPLValue('test"quote')).toBe('"test\\"quote"');
-      expect(escapePPLValue('test\\backslash')).toBe('"test\\backslash"');
+    });
+
+    // The PPL lexer treats `\` as an escape character
+    // (DQUOTA_STRING: '"' ( '\\'. | '""' | ~('"'|'\\') )* '"'), so backslashes
+    // must be doubled or the literal terminates early and spills into the query.
+    it('doubles backslashes', () => {
+      expect(escapePPLValue('test\\backslash')).toBe('"test\\\\backslash"');
+    });
+
+    it('escapes a backslash that precedes a quote', () => {
+      // Without doubling, this emits "a\\"b" — the lexer consumes \\ as an
+      // escaped backslash, then " closes the literal early.
+      expect(escapePPLValue('a\\"b')).toBe('"a\\\\\\"b"');
+    });
+
+    it('escapes a trailing backslash', () => {
+      // Without doubling, this emits "a\" — the closing quote is escaped and
+      // the string literal never terminates.
+      expect(escapePPLValue('a\\')).toBe('"a\\\\"');
+    });
+
+    it('escapes backslashes inside stringified objects', () => {
+      // JSON.stringify already emits {"path":"C:\\logs"}; escaping then doubles
+      // each of those backslashes and escapes each quote.
+      expect(escapePPLValue({ path: 'C:\\logs' })).toBe('"{\\"path\\":\\"C:\\\\\\\\logs\\"}"');
     });
 
     it('handles number values', () => {

--- a/src/plugins/agent_traces/public/application/pages/traces/trace_details/data_fetching/ppl_request_helpers.tsx
+++ b/src/plugins/agent_traces/public/application/pages/traces/trace_details/data_fetching/ppl_request_helpers.tsx
@@ -100,9 +100,26 @@ export const executePPLQuery = async (
   return response;
 };
 
+/**
+ * Escape the body of a PPL double-quoted string literal.
+ *
+ * The PPL lexer rule is
+ *   DQUOTA_STRING: '"' ( '\\'. | '""' | ~('"'|'\\') )* '"'
+ * so a backslash escapes the character after it. Escaping only the quotes is
+ * therefore not enough: a value ending in `\`, or containing `\` immediately
+ * before a `"`, emits a literal that terminates early and spills the remainder
+ * into the surrounding query. Backslashes must be doubled first, then quotes.
+ *
+ * NOTE: duplicated in
+ * src/plugins/explore/public/application/pages/traces/trace_details/server/ppl_request_helpers.tsx
+ * — keep the two in sync.
+ */
+const escapePPLStringBody = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
 export const escapePPLValue = (value: any): string => {
   if (typeof value === 'string') {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return `"${escapePPLStringBody(value)}"`;
   } else if (typeof value === 'number') {
     return value.toString();
   } else if (typeof value === 'boolean') {
@@ -110,7 +127,7 @@ export const escapePPLValue = (value: any): string => {
   } else if (value === null || value === undefined) {
     return `"${value}"`;
   } else {
-    return `"${JSON.stringify(value).replace(/"/g, '\\"')}"`;
+    return `"${escapePPLStringBody(JSON.stringify(value))}"`;
   }
 };
 

--- a/src/plugins/explore/public/application/pages/traces/trace_details/server/ppl_request_helpers.test.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/server/ppl_request_helpers.test.tsx
@@ -9,6 +9,7 @@ import {
   buildPPLQueryRequest,
   executePPLQuery,
   escapePPLValue,
+  escapePplIdentifier,
   PPLService,
 } from './ppl_request_helpers';
 
@@ -175,11 +176,60 @@ describe('ppl_request_helpers', () => {
     });
   });
 
+  describe('escapePplIdentifier', () => {
+    it('wraps a field name in backticks', () => {
+      expect(escapePplIdentifier('message')).toBe('`message`');
+    });
+
+    it('leaves field names containing dots and dashes intact', () => {
+      expect(escapePplIdentifier('http.request-id')).toBe('`http.request-id`');
+    });
+
+    // BQUOTA_STRING: '`' ( '\\'. | '``' | ~('`'|'\\') )* '`'
+    it('doubles embedded backticks', () => {
+      expect(escapePplIdentifier('we`ird')).toBe('`we``ird`');
+    });
+
+    it('doubles backslashes', () => {
+      expect(escapePplIdentifier('back\\slash')).toBe('`back\\\\slash`');
+    });
+
+    it('neutralizes a field name that would otherwise close the identifier', () => {
+      // A raw `${field}` interpolation of this value would end the identifier
+      // and append an arbitrary command to the query.
+      expect(escapePplIdentifier('a` | fields *')).toBe('`a`` | fields *`');
+    });
+  });
+
   describe('escapePPLValue', () => {
     it('escapes string values', () => {
       expect(escapePPLValue('test')).toBe('"test"');
       expect(escapePPLValue('test"quote')).toBe('"test\\"quote"');
-      expect(escapePPLValue('test\\backslash')).toBe('"test\\backslash"');
+    });
+
+    // The PPL lexer treats `\` as an escape character
+    // (DQUOTA_STRING: '"' ( '\\'. | '""' | ~('"'|'\\') )* '"'), so backslashes
+    // must be doubled or the literal terminates early and spills into the query.
+    it('doubles backslashes', () => {
+      expect(escapePPLValue('test\\backslash')).toBe('"test\\\\backslash"');
+    });
+
+    it('escapes a backslash that precedes a quote', () => {
+      // Without doubling, this emits "a\\"b" — the lexer consumes \\ as an
+      // escaped backslash, then " closes the literal early.
+      expect(escapePPLValue('a\\"b')).toBe('"a\\\\\\"b"');
+    });
+
+    it('escapes a trailing backslash', () => {
+      // Without doubling, this emits "a\" — the closing quote is escaped and
+      // the string literal never terminates.
+      expect(escapePPLValue('a\\')).toBe('"a\\\\"');
+    });
+
+    it('escapes backslashes inside stringified objects', () => {
+      // JSON.stringify already emits {"path":"C:\\logs"}; escaping then doubles
+      // each of those backslashes and escapes each quote.
+      expect(escapePPLValue({ path: 'C:\\logs' })).toBe('"{\\"path\\":\\"C:\\\\\\\\logs\\"}"');
     });
 
     it('handles number values', () => {

--- a/src/plugins/explore/public/application/pages/traces/trace_details/server/ppl_request_helpers.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/server/ppl_request_helpers.tsx
@@ -105,10 +105,23 @@ export const executePPLQuery = async (
   return response;
 };
 
+/**
+ * Escape the body of a PPL double-quoted string literal.
+ *
+ * The PPL lexer rule is
+ *   DQUOTA_STRING: '"' ( '\\'. | '""' | ~('"'|'\\') )* '"'
+ * so a backslash escapes the character after it. Escaping only the quotes is
+ * therefore not enough: a value ending in `\`, or containing `\` immediately
+ * before a `"`, emits a literal that terminates early and spills the remainder
+ * into the surrounding query. Backslashes must be doubled first, then quotes.
+ */
+const escapePPLStringBody = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
 // Escape a value for use in PPL queries
 export const escapePPLValue = (value: any): string => {
   if (typeof value === 'string') {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return `"${escapePPLStringBody(value)}"`;
   } else if (typeof value === 'number') {
     return value.toString();
   } else if (typeof value === 'boolean') {
@@ -116,9 +129,20 @@ export const escapePPLValue = (value: any): string => {
   } else if (value === null || value === undefined) {
     return `"${value}"`;
   } else {
-    return `"${JSON.stringify(value).replace(/"/g, '\\"')}"`;
+    return `"${escapePPLStringBody(JSON.stringify(value))}"`;
   }
 };
+
+/**
+ * Quote a field name as a PPL backtick-delimited identifier.
+ *
+ * Mirrors {@link escapePPLValue} for the identifier position. The lexer rule is
+ *   BQUOTA_STRING: '`' ( '\\'. | '``' | ~('`'|'\\') )* '`'
+ * so both backslashes and backticks need escaping; interpolating a field name
+ * raw lets a name containing either break out of the identifier.
+ */
+export const escapePplIdentifier = (identifier: string): string =>
+  `\`${String(identifier).replace(/\\/g, '\\\\').replace(/`/g, '``')}\``;
 
 // Base PPL Service class with core functionality
 export class PPLService {

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.ts
@@ -20,15 +20,18 @@ import { ExploreServices } from '../../../types';
 import { setPatternsField } from '../../../application/utils/state_management/slices/tab/tab_slice';
 import { resultsCache } from '../../../application/utils/state_management/slices';
 import { prepareQueryForLanguage } from '../../../application/utils/languages';
-import { escapePPLValue } from '../../../application/pages/traces/trace_details/server/ppl_request_helpers';
+import {
+  escapePPLValue,
+  escapePplIdentifier,
+} from '../../../application/pages/traces/trace_details/server/ppl_request_helpers';
 
 // Small functions returning the two pattern queries
 export const regexPatternQuery = (queryBase: string, patternsField: string) => {
-  return `${queryBase} | patterns \`${patternsField}\` | stats count() as ${COUNT_FIELD}, take(\`${patternsField}\`, 1) as ${SAMPLE_FIELD} by patterns_field | sort - ${COUNT_FIELD} | fields ${PATTERNS_FIELD}, ${COUNT_FIELD}, ${SAMPLE_FIELD}`;
+  return `${queryBase} | patterns ${escapePplIdentifier(patternsField)} | stats count() as ${COUNT_FIELD}, take(${escapePplIdentifier(patternsField)}, 1) as ${SAMPLE_FIELD} by patterns_field | sort - ${COUNT_FIELD} | fields ${PATTERNS_FIELD}, ${COUNT_FIELD}, ${SAMPLE_FIELD}`;
 };
 
 export const brainPatternQuery = (queryBase: string, patternsField: string) => {
-  return `${queryBase} | patterns \`${patternsField}\` method=brain mode=label | stats count() as ${COUNT_FIELD}, take(\`${patternsField}\`, 1) as ${SAMPLE_FIELD} by patterns_field | sort - ${COUNT_FIELD} | fields ${PATTERNS_FIELD}, ${COUNT_FIELD}, ${SAMPLE_FIELD}`;
+  return `${queryBase} | patterns ${escapePplIdentifier(patternsField)} method=brain mode=label | stats count() as ${COUNT_FIELD}, take(${escapePplIdentifier(patternsField)}, 1) as ${SAMPLE_FIELD} by patterns_field | sort - ${COUNT_FIELD} | fields ${PATTERNS_FIELD}, ${COUNT_FIELD}, ${SAMPLE_FIELD}`;
 };
 
 export const regexUpdateSearchPatternQuery = (
@@ -36,7 +39,7 @@ export const regexUpdateSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `${queryBase} | patterns \`${patternsField}\` | where patterns_field = ${escapePPLValue(
+  return `${queryBase} | patterns ${escapePplIdentifier(patternsField)} | where patterns_field = ${escapePPLValue(
     patternString
   )}`;
 };
@@ -46,7 +49,7 @@ export const brainUpdateSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `${queryBase} | patterns \`${patternsField}\` method=brain mode=label | where patterns_field = ${escapePPLValue(
+  return `${queryBase} | patterns ${escapePplIdentifier(patternsField)} method=brain mode=label | where patterns_field = ${escapePPLValue(
     patternString
   )}`;
 };
@@ -56,7 +59,7 @@ export const regexExcludeSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `${queryBase} | patterns \`${patternsField}\` | where patterns_field != ${escapePPLValue(
+  return `${queryBase} | patterns ${escapePplIdentifier(patternsField)} | where patterns_field != ${escapePPLValue(
     patternString
   )}`;
 };
@@ -66,7 +69,7 @@ export const brainExcludeSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `${queryBase} | patterns \`${patternsField}\` method=brain mode=label | where patterns_field != ${escapePPLValue(
+  return `${queryBase} | patterns ${escapePplIdentifier(patternsField)} method=brain mode=label | where patterns_field != ${escapePPLValue(
     patternString
   )}`;
 };
@@ -118,7 +121,7 @@ export const createSearchPatternQueryWithSlice = (
       )}${sortClause} | head ${pageSize} from ${pageOffset}`
     : `${
         preparedQuery.query
-      } | patterns \`${patternsField}\` method=brain mode=label | fields patterns_field${
+      } | patterns ${escapePplIdentifier(patternsField)} method=brain mode=label | fields patterns_field${
         timeField ? `, ${timeField}` : ''
       }, ${patternsField} | where patterns_field = ${escapePPLValue(
         patternString


### PR DESCRIPTION

### Description

Two escaping defects on the PPL path, both reachable without any SQL involvement.

`escapePPLValue` does not escape backslashes. The PPL lexer treats `\` as an escape character (`DQUOTA_STRING: '"' ( '\\'. | '""' | ~('"'|'\\') )* '"'`), so escaping only the quotes is not enough: a value ending in `\`, or containing `\` immediately before a `"`, terminates the string literal early and spills the remainder of the value into the surrounding query. Backslashes are now doubled before quotes are escaped. The function is duplicated verbatim in the `explore` and `agent_traces` plugins; both copies are fixed and cross-referenced in comments. Deduplicating them would mean one plugin importing the other's `public/`, which is a larger architectural call than this change should make.

`patternsField` is interpolated into a backtick identifier with no escaping. `BQUOTA_STRING` has the same backslash rule plus double-backtick escaping. That field is restored verbatim from the `_a` URL parameter, so a crafted field name can close the identifier and append arbitrary PPL to the query. This adds `escapePplIdentifier` and applies it to the nine interpolation sites in the patterns query builders.

Output is byte-identical for ordinary field names and values, so this is a no-op for every real query. The existing tests asserted the unescaped pass-through behavior; they are updated and extended with the trailing-backslash, backslash-before-quote and stringified-object cases.

### Issues Resolved

N/A

## Screenshot

No UI change — output is byte-identical for ordinary values.

## Testing the changes

Verified against a live OpenSearch 3.8 cluster with `opensearch-sql 3.8.0.0`. `escapePplIdentifier('message')` still produces `` `message` `` unchanged, a field name crafted to close the identifier is neutralized, and values containing a backslash, an escaped quote, or a trailing backslash all round-trip correctly.

Unit tests: 53 across the two `ppl_request_helpers` suites, and 983 across `patterns_table` and both `trace_details` trees.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff