### PR TITLE
[Explore] Add the Patterns tab for SQL

### DIFF
--- a/src/plugins/explore/public/application/register_tabs.test.ts
+++ b/src/plugins/explore/public/application/register_tabs.test.ts
@@ -14,6 +14,7 @@ import {
   EXPLORE_PATTERNS_TAB_ID,
 } from '../../common';
 import { ExploreServices } from '../types';
+import { BRAIN_QUERY_OLD_ENGINE_ERROR_PREFIX } from '../components/patterns_table/utils/constants';
 
 // Mock tab components to avoid React rendering during tests
 jest.mock('../components/tabs/logs_tab', () => ({
@@ -212,6 +213,96 @@ describe('registerBuiltInTabs - SQL Language Restrictions', () => {
       const sqlTabs = getSqlEnabledTabsForFlavor(ExploreFlavor.Metrics);
       expect(sqlTabs.length).toBe(0);
     });
+  });
+});
+
+describe('registerBuiltInTabs - patterns tab under SQL', () => {
+  const BRAIN_OLD_ENGINE_ERROR = {
+    status: 400,
+    error: {
+      details: `${BRAIN_QUERY_OLD_ENGINE_ERROR_PREFIX} [1:30]`,
+    },
+  } as any;
+
+  const registerWithLanguage = (language: string) => {
+    const tabRegistry = new TabRegistryService();
+    const dispatch = jest.fn();
+    const services = {
+      uiSettings: { get: jest.fn((key: string) => key === 'explore:experimental') },
+      store: {
+        getState: jest.fn().mockReturnValue({
+          tab: { patterns: { patternsField: 'message', usingRegexPatterns: false } },
+          query: { language, query: 'SELECT * FROM my_index' },
+        }),
+        dispatch,
+      },
+      tabRegistry,
+    } as unknown as ExploreServices;
+    registerBuiltInTabs(tabRegistry, services, ExploreFlavor.Logs);
+    return { tab: tabRegistry.getTab(EXPLORE_PATTERNS_TAB_ID)!, dispatch };
+  };
+
+  it('offers the tab for SQL as well as PPL', () => {
+    const { tab } = registerWithLanguage('SQL');
+
+    expect(tab.supportedLanguages).toContain('SQL');
+    expect(tab.supportedLanguages).toContain('PPL');
+  });
+
+  it('builds the REPLACE-based aggregation instead of a PPL `patterns` pipeline', () => {
+    const { tab } = registerWithLanguage('SQL');
+
+    const prepared = tab.prepareQuery!({
+      query: 'SELECT * FROM my_index',
+      language: 'SQL',
+    } as any);
+
+    expect(prepared).toContain('REPLACE(');
+    expect(prepared).toContain('GROUP BY pattern');
+    // `patterns` and its brain method exist only in PPL.
+    expect(prepared).not.toContain('| patterns');
+    expect(prepared).not.toContain('method=brain');
+  });
+
+  it('ignores usingRegexPatterns, which only selects between the two PPL methods', () => {
+    const tabRegistry = new TabRegistryService();
+    const services = {
+      uiSettings: { get: jest.fn((key: string) => key === 'explore:experimental') },
+      store: {
+        getState: jest.fn().mockReturnValue({
+          tab: { patterns: { patternsField: 'message', usingRegexPatterns: true } },
+          query: { language: 'SQL', query: 'SELECT * FROM my_index' },
+        }),
+        dispatch: jest.fn(),
+      },
+      tabRegistry,
+    } as unknown as ExploreServices;
+    registerBuiltInTabs(tabRegistry, services, ExploreFlavor.Logs);
+
+    const prepared = tabRegistry.getTab(EXPLORE_PATTERNS_TAB_ID)!.prepareQuery!({
+      query: 'SELECT * FROM my_index',
+      language: 'SQL',
+    } as any);
+
+    expect(prepared).toContain('REPLACE(');
+    expect(prepared).not.toContain('| patterns');
+  });
+
+  // handleQueryError is shared by both languages, but its only branch retries with a
+  // PPL pipeline. Letting a SQL error reach it would send PPL syntax to the SQL
+  // endpoint under a cache key the tab never reads, leaving the tab on a stale status.
+  it('does not run the PPL brain fallback when a SQL query fails', () => {
+    const { tab, dispatch } = registerWithLanguage('SQL');
+
+    expect(tab.handleQueryError!(BRAIN_OLD_ENGINE_ERROR, 'some-cache-key')).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('still runs the brain fallback for PPL', () => {
+    const { tab, dispatch } = registerWithLanguage('PPL');
+
+    expect(tab.handleQueryError!(BRAIN_OLD_ENGINE_ERROR, 'some-cache-key')).toBe(true);
+    expect(dispatch).toHaveBeenCalled();
   });
 });
 

--- a/src/plugins/explore/public/application/register_tabs.test.ts
+++ b/src/plugins/explore/public/application/register_tabs.test.ts
@@ -214,6 +214,55 @@ describe('registerBuiltInTabs - SQL Language Restrictions', () => {
       expect(sqlTabs.length).toBe(0);
     });
   });
+
+  // What a tab can render is not the same question as which language a session
+  // opens in. Spelling PPL as EXPLORE_DEFAULT_LANGUAGE conflated the two.
+  describe('independence from the default language', () => {
+    const registerWithDefaultLanguage = (defaultLanguage: string) => {
+      let tabs: Array<{ id: string; supportedLanguages: string[] }> = [];
+      jest.isolateModules(() => {
+        jest.doMock('../../common', () => ({
+          ...jest.requireActual('../../common'),
+          EXPLORE_DEFAULT_LANGUAGE: defaultLanguage,
+        }));
+        /* eslint-disable @typescript-eslint/no-var-requires */
+        const tabs_ = require('./register_tabs');
+        const registry_ = require('../services/tab_registry/tab_registry_service');
+        /* eslint-enable @typescript-eslint/no-var-requires */
+        const register = tabs_.registerBuiltInTabs;
+        const registry = new registry_.TabRegistryService();
+        register(registry, createMockServices(true) as ExploreServices, ExploreFlavor.Logs);
+        tabs = registry.getAllTabs();
+      });
+      return tabs;
+    };
+
+    it('keeps PPL on every tab even when the default language is SQL', () => {
+      const tabs = registerWithDefaultLanguage('SQL');
+
+      expect(tabs.length).toBeGreaterThan(0);
+      tabs.forEach((tab) => {
+        expect(tab.supportedLanguages).toContain('PPL');
+      });
+    });
+
+    it('never repeats a language within one tab', () => {
+      const tabs = registerWithDefaultLanguage('SQL');
+
+      tabs.forEach((tab) => {
+        expect(tab.supportedLanguages).toEqual(Array.from(new Set(tab.supportedLanguages)));
+      });
+    });
+
+    it('declares the same languages whatever the default is', () => {
+      const asPpl = registerWithDefaultLanguage('PPL');
+      const asSql = registerWithDefaultLanguage('SQL');
+
+      expect(asSql.map((tab) => [tab.id, tab.supportedLanguages])).toEqual(
+        asPpl.map((tab) => [tab.id, tab.supportedLanguages])
+      );
+    });
+  });
 });
 
 describe('registerBuiltInTabs - patterns tab under SQL', () => {

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -28,6 +28,7 @@ import {
   brainPatternQuery,
   findDefaultPatternsField,
   regexPatternQuery,
+  sqlPatternQuery,
 } from '../components/patterns_table/utils/utils';
 import { setUsingRegexPatterns } from './utils/state_management/slices/tab/tab_slice';
 import { executeTabQuery } from './utils/state_management/actions/query_actions';
@@ -102,7 +103,7 @@ export const registerBuiltInTabs = (
       }),
       flavor: [ExploreFlavor.Logs],
       order: 15,
-      supportedLanguages: [EXPLORE_DEFAULT_LANGUAGE],
+      supportedLanguages: [EXPLORE_DEFAULT_LANGUAGE, 'SQL'],
 
       prepareQuery: (query) => {
         const state = services.store.getState();
@@ -122,6 +123,12 @@ export const registerBuiltInTabs = (
             // column mapping. Return no query instead.
             return '';
           }
+        }
+
+        // SQL only supports the simple/regex method (REPLACE-based); the PPL
+        // `patterns` command and its brain method are not available in SQL.
+        if (query.language === 'SQL') {
+          return sqlPatternQuery(preparedQuery.query, patternsField);
         }
 
         if (state.tab.patterns.usingRegexPatterns)

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -141,6 +141,18 @@ export const registerBuiltInTabs = (
         const state = services.store.getState();
 
         /**
+         * The BRAIN fallback below is PPL-only: it retries with `regexPatternQuery`,
+         * which emits PPL pipe syntax. SQL has no brain method and never produces
+         * this error, but the handler is language-agnostic -- so a SQL 400 whose
+         * details happened to match the prefix would dispatch a PPL query against
+         * the SQL endpoint under a cache key the tab never reads, leaving it stuck
+         * on a stale status. Bail out early for SQL and let the normal error show.
+         */
+        if (state.query.language === 'SQL') {
+          return false;
+        }
+
+        /**
          * The below conditional is checking for the error returned when attempting to use a BRAIN
          * query on an older version of the querying engine. If this error appears, an attempt is made
          * to switch over to a patterns query which works on older versions of the querying engine.

--- a/src/plugins/explore/public/application/register_tabs.ts
+++ b/src/plugins/explore/public/application/register_tabs.ts
@@ -13,7 +13,6 @@ import { TabDefinition, TabRegistryService } from '../services/tab_registry/tab_
 import { ExploreServices } from '../types';
 import {
   ExploreFlavor,
-  EXPLORE_DEFAULT_LANGUAGE,
   EXPLORE_LOGS_TAB_ID,
   EXPLORE_VISUALIZATION_TAB_ID,
   EXPLORE_PATTERNS_TAB_ID,
@@ -85,10 +84,7 @@ export const registerBuiltInTabs = (
       flavor: [ExploreFlavor.Logs, ExploreFlavor.Traces],
       order: 10,
       // SQL is only supported for Logs flavor, not Traces
-      supportedLanguages:
-        registryFlavor === ExploreFlavor.Logs
-          ? [EXPLORE_DEFAULT_LANGUAGE, 'SQL']
-          : [EXPLORE_DEFAULT_LANGUAGE],
+      supportedLanguages: registryFlavor === ExploreFlavor.Logs ? ['PPL', 'SQL'] : ['PPL'],
       component: LogsTab,
     };
     tabRegistry.registerTab(logsTabDefinition);
@@ -103,7 +99,7 @@ export const registerBuiltInTabs = (
       }),
       flavor: [ExploreFlavor.Logs],
       order: 15,
-      supportedLanguages: [EXPLORE_DEFAULT_LANGUAGE, 'SQL'],
+      supportedLanguages: ['PPL', 'SQL'],
 
       prepareQuery: (query) => {
         const state = services.store.getState();
@@ -217,10 +213,10 @@ export const registerBuiltInTabs = (
     // SQL only for Logs, PROMQL for Metrics, PPL only for Traces
     supportedLanguages:
       registryFlavor === ExploreFlavor.Metrics
-        ? [EXPLORE_DEFAULT_LANGUAGE, 'PROMQL']
+        ? ['PPL', 'PROMQL']
         : registryFlavor === ExploreFlavor.Logs
-          ? [EXPLORE_DEFAULT_LANGUAGE, 'SQL']
-          : [EXPLORE_DEFAULT_LANGUAGE],
+          ? ['PPL', 'SQL']
+          : ['PPL'],
 
     // Prepare query based on language
     prepareQuery: (query) => {
@@ -238,10 +234,7 @@ export const registerBuiltInTabs = (
     }),
     flavor: [ExploreFlavor.Logs],
     order: 17,
-    supportedLanguages:
-      registryFlavor === ExploreFlavor.Logs
-        ? [EXPLORE_DEFAULT_LANGUAGE, 'SQL']
-        : [EXPLORE_DEFAULT_LANGUAGE],
+    supportedLanguages: registryFlavor === ExploreFlavor.Logs ? ['PPL', 'SQL'] : ['PPL'],
 
     // Prepare query based on language
     prepareQuery: (query) => {
@@ -261,7 +254,7 @@ export const registerBuiltInTabs = (
       }),
       flavor: [ExploreFlavor.Logs],
       order: 25,
-      supportedLanguages: [EXPLORE_DEFAULT_LANGUAGE],
+      supportedLanguages: ['PPL'],
       component: FieldStatsTab,
     });
   }

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.test.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.test.tsx
@@ -247,16 +247,35 @@ describe('PatternsContainer', () => {
     const PATTERN_COL = 'pattern';
     const COUNT_COL = 'COUNT(*)';
     const SAMPLE_COL = "IFNULL(MIN(sample), '')";
+    const TOTAL_COL = 'MAX(doc_total)';
 
+    const FULL_SCHEMA = [
+      { name: PATTERN_COL },
+      { name: COUNT_COL },
+      { name: SAMPLE_COL },
+      { name: TOTAL_COL },
+    ];
+
+    /**
+     * @param rows [pattern, count, sample] triples
+     * @param docTotal value of the matched-document column, omitted to model a
+     *                 response that predates that column
+     */
     const sqlResults = (
       rows: Array<[string, number, string]>,
-      schema = [{ name: PATTERN_COL }, { name: COUNT_COL }, { name: SAMPLE_COL }]
+      docTotal?: number,
+      schema = docTotal === undefined ? FULL_SCHEMA.slice(0, 3) : FULL_SCHEMA
     ) => ({
       results: {
         fieldSchema: schema,
         hits: {
           hits: rows.map(([pattern, count, sample]) => ({
-            _source: { [PATTERN_COL]: pattern, [COUNT_COL]: count, [SAMPLE_COL]: sample },
+            _source: {
+              [PATTERN_COL]: pattern,
+              [COUNT_COL]: count,
+              [SAMPLE_COL]: sample,
+              ...(docTotal === undefined ? {} : { [TOTAL_COL]: docTotal }),
+            },
           })),
           total: rows.length,
         },
@@ -310,7 +329,7 @@ describe('PatternsContainer', () => {
       // Rows came back but the schema is short, so no row can be addressed. The
       // container distinguishes this from "no results" and says so.
       mockUseTabResults.mockReturnValueOnce(
-        sqlResults([['<*> <*>', 30, 'Calculated quote']], [{ name: PATTERN_COL }]) as any
+        sqlResults([['<*> <*>', 30, 'Calculated quote']], undefined, [{ name: PATTERN_COL }]) as any
       );
 
       render(<PatternsContainer />);
@@ -321,7 +340,41 @@ describe('PatternsContainer', () => {
 
     // The histogram query is language-gated off for SQL, so its total is 0 and every
     // ratio would come out Infinity, rendering the column as '—' on every row.
-    it('derives the ratio denominator from the pattern counts, not the histogram total', () => {
+    it('takes the ratio denominator from the matched-document column', () => {
+      const items = renderSqlItems(
+        sqlResults(
+          [
+            ['<*> <*>', 30, 'Calculated quote'],
+            ['<*> <*> <*>', 10, 'Ad service starting.'],
+          ],
+          40
+        )
+      );
+
+      // 40 from the column, not the mocked histogram total of 2096.
+      expect(items[0].ratio).toBeCloseTo(30 / 40);
+      expect(items[1].ratio).toBeCloseTo(10 / 40);
+    });
+
+    // The engine caps the response at plugins.query.size_limit, so the returned
+    // groups can be a subset of the result. Summing their counts would normalize
+    // that subset to 100% and overstate every ratio.
+    it('does not renormalize to the returned groups when the response was truncated', () => {
+      const items = renderSqlItems(
+        sqlResults(
+          [
+            ['<*> <*>', 30, 'Calculated quote'],
+            ['<*> <*> <*>', 10, 'Ad service starting.'],
+          ],
+          1000
+        )
+      );
+
+      expect(items[0].ratio).toBeCloseTo(30 / 1000);
+      expect(items[0].ratio).not.toBeCloseTo(30 / 40);
+    });
+
+    it('falls back to the sum of counts when the column is absent', () => {
       const items = renderSqlItems(
         sqlResults([
           ['<*> <*>', 30, 'Calculated quote'],
@@ -329,9 +382,7 @@ describe('PatternsContainer', () => {
         ])
       );
 
-      // 30 + 10 = 40, not the mocked histogram total of 2096.
       expect(items[0].ratio).toBeCloseTo(30 / 40);
-      expect(items[1].ratio).toBeCloseTo(10 / 40);
     });
 
     it('leaves the sample unhighlighted, as PPL does on its own simple-pattern path', () => {

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.test.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.test.tsx
@@ -241,9 +241,10 @@ describe('PatternsContainer', () => {
   });
 
   describe('SQL', () => {
-    // The engine returns each unaliased column's name as the raw SELECT-list text, and
-    // OSD keys `_source` by that name, so these keys are deliberately ugly.
-    const PATTERN_COL = "REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>')";
+    // The names the engine actually returns for `sqlPatternQuery`, verified on both
+    // the V2 and analytics-engine paths: the aliased column comes back under its
+    // alias, the unaliased ones under their raw SELECT-list text.
+    const PATTERN_COL = 'pattern';
     const COUNT_COL = 'COUNT(*)';
     const SAMPLE_COL = "IFNULL(MIN(sample), '')";
 
@@ -345,5 +346,28 @@ describe('PatternsContainer', () => {
     render(<PatternsContainer />);
 
     expect(highlightLogUsingPattern).toHaveBeenCalled();
+  });
+
+  // The schema callout is a SQL-only diagnostic. PPL drops rows whose sample or
+  // count is null, and when that leaves nothing it renders nothing -- saying the
+  // schema was unexpected would be both new and wrong, since the schema is fine.
+  it('renders nothing for PPL when every row is dropped', () => {
+    mockUseTabResults.mockReturnValueOnce({
+      results: {
+        hits: {
+          hits: [
+            { _source: { patterns_field: 'Linux', pattern_count: 20, sample_logs: null } },
+            { _source: { patterns_field: 'Debian', pattern_count: 18, sample_logs: [] } },
+          ],
+          total: 2,
+        },
+      },
+      status: { status: QueryExecutionStatus.READY },
+    } as any);
+
+    render(<PatternsContainer />);
+
+    expect(screen.queryByText('Expected schema not found')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mocked-patterns-table')).not.toBeInTheDocument();
   });
 });

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.test.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.test.tsx
@@ -8,6 +8,7 @@ import { render, screen } from '@testing-library/react';
 import { PatternsContainer } from './patterns_container';
 import { mockPatternItems } from './utils/patterns_table.stubs';
 import { QueryExecutionStatus } from '../../application/utils/state_management/types';
+import { highlightLogUsingPattern } from './utils/utils';
 
 jest.mock('./patterns_table', () => ({
   PatternsTable: (props: any) => (
@@ -57,48 +58,32 @@ jest.mock('../tabs/action_bar/patterns_settings/patterns_settings_popover_conten
   PatternsSettingsPopoverContent: () => <div data-test-subj="mocked-patterns-settings" />,
 }));
 
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn((selector) => {
-    if (selector.toString().includes('selectQuery')) {
-      return { query: 'test query', language: 'PPL' };
-    }
-    if (selector.toString().includes('selectResults')) {
-      return {
-        'default-query': {
-          hits: {
-            hits: mockPatternItems.map((item) => ({
-              _source: {
-                // using string literals instead of constants to avoid jest errors
-                sample_logs: [item.sample],
-                pattern_count: item.count,
-                patterns_field: 'test pattern',
-              },
-            })),
-            total: 2096,
-          },
-        },
-      };
-    }
-    if (selector.toString().includes('state.ui.activeTabId')) {
-      return 'patterns';
-    }
-    if (
-      selector.toString().includes('selectPatternsField') ||
-      selector.toString().includes('patternsField')
-    ) {
-      return 'message';
-    }
-    if (
-      selector.toString().includes('selectUsingRegexPatterns') ||
-      selector.toString().includes('usingRegexPatterns')
-    ) {
-      return false;
-    }
-    return {};
-  }),
-  useDispatch: jest.fn(() => jest.fn()),
-  connect: jest.fn(() => (Component: React.ComponentType<any>) => Component),
-}));
+// Mutable so a test can switch the active language; the `mock` prefix is what lets
+// the hoisted jest.mock factory below close over it.
+let mockLanguage = 'PPL';
+
+// Selectors are reselect `createSelector` results, so their source text carries no
+// identifying name -- matching on `selector.toString()` never fires and every
+// useSelector call falls through. Dispatch on function identity instead.
+jest.mock('react-redux', () => {
+  const selectors = jest.requireActual('../../application/utils/state_management/selectors');
+  return {
+    useSelector: jest.fn((selector) => {
+      if (selector === selectors.selectQuery) {
+        return { query: 'test query', language: mockLanguage };
+      }
+      if (selector === selectors.selectPatternsField) {
+        return 'message';
+      }
+      if (selector === selectors.selectUsingRegexPatterns) {
+        return false;
+      }
+      return {};
+    }),
+    useDispatch: jest.fn(() => jest.fn()),
+    connect: jest.fn(() => (Component: React.ComponentType<any>) => Component),
+  };
+});
 
 jest.mock('../../application/utils/state_management/actions/query_actions', () => ({
   defaultPrepareQueryString: jest.fn().mockReturnValue('default-query'),
@@ -253,5 +238,112 @@ describe('PatternsContainer', () => {
 
     expect(items[1].pattern).toBe('Debian GNU/Linux');
     expect(items[1].count).toBe(18);
+  });
+
+  describe('SQL', () => {
+    // The engine returns each unaliased column's name as the raw SELECT-list text, and
+    // OSD keys `_source` by that name, so these keys are deliberately ugly.
+    const PATTERN_COL = "REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>')";
+    const COUNT_COL = 'COUNT(*)';
+    const SAMPLE_COL = "IFNULL(MIN(sample), '')";
+
+    const sqlResults = (
+      rows: Array<[string, number, string]>,
+      schema = [{ name: PATTERN_COL }, { name: COUNT_COL }, { name: SAMPLE_COL }]
+    ) => ({
+      results: {
+        fieldSchema: schema,
+        hits: {
+          hits: rows.map(([pattern, count, sample]) => ({
+            _source: { [PATTERN_COL]: pattern, [COUNT_COL]: count, [SAMPLE_COL]: sample },
+          })),
+          total: rows.length,
+        },
+      },
+      status: { status: QueryExecutionStatus.READY },
+    });
+
+    const renderSqlItems = (results: any) => {
+      mockUseTabResults.mockReturnValueOnce(results);
+      const { getByTestId } = render(<PatternsContainer />);
+      return JSON.parse(getByTestId('mocked-patterns-table').getAttribute('data-items') || '[]');
+    };
+
+    beforeEach(() => {
+      mockLanguage = 'SQL';
+    });
+
+    afterEach(() => {
+      mockLanguage = 'PPL';
+    });
+
+    it('addresses the columns by position rather than by PPL field name', () => {
+      const items = renderSqlItems(
+        sqlResults([
+          ['<*> <*>', 30, 'Calculated quote'],
+          ['<*> <*> <*>', 10, 'Ad service starting.'],
+        ])
+      );
+
+      expect(items).toHaveLength(2);
+      expect(items[0].pattern).toBe('<*> <*>');
+      expect(items[0].count).toBe(30);
+      expect(items[0].sample).toBe('Calculated quote');
+    });
+
+    it('keeps the empty-pattern group, whose pattern and sample are both empty strings', () => {
+      // Documents missing the patterns field aggregate into this group via IFNULL.
+      // Only null/undefined should be dropped, never ''.
+      const items = renderSqlItems(
+        sqlResults([
+          ['<*> <*>', 30, 'Calculated quote'],
+          ['', 3, ''],
+        ])
+      );
+
+      expect(items).toHaveLength(2);
+      expect(items[1]).toMatchObject({ pattern: '', count: 3, sample: '' });
+    });
+
+    it('reports an unexpected schema rather than rendering a blank table', () => {
+      // Rows came back but the schema is short, so no row can be addressed. The
+      // container distinguishes this from "no results" and says so.
+      mockUseTabResults.mockReturnValueOnce(
+        sqlResults([['<*> <*>', 30, 'Calculated quote']], [{ name: PATTERN_COL }]) as any
+      );
+
+      render(<PatternsContainer />);
+
+      expect(screen.getByText('Expected schema not found')).toBeInTheDocument();
+      expect(screen.queryByTestId('mocked-patterns-table')).not.toBeInTheDocument();
+    });
+
+    // The histogram query is language-gated off for SQL, so its total is 0 and every
+    // ratio would come out Infinity, rendering the column as '—' on every row.
+    it('derives the ratio denominator from the pattern counts, not the histogram total', () => {
+      const items = renderSqlItems(
+        sqlResults([
+          ['<*> <*>', 30, 'Calculated quote'],
+          ['<*> <*> <*>', 10, 'Ad service starting.'],
+        ])
+      );
+
+      // 30 + 10 = 40, not the mocked histogram total of 2096.
+      expect(items[0].ratio).toBeCloseTo(30 / 40);
+      expect(items[1].ratio).toBeCloseTo(10 / 40);
+    });
+
+    it('leaves the sample unhighlighted, as PPL does on its own simple-pattern path', () => {
+      const items = renderSqlItems(sqlResults([['<*> <*>', 30, 'Calculated quote']]));
+
+      expect(items[0].highlightedSample).toBeUndefined();
+      expect(highlightLogUsingPattern).not.toHaveBeenCalled();
+    });
+  });
+
+  it('still highlights the sample for PPL brain patterns', () => {
+    render(<PatternsContainer />);
+
+    expect(highlightLogUsingPattern).toHaveBeenCalled();
   });
 });

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
@@ -101,64 +101,69 @@ const PatternsContainerContent = ({
   );
 
   const logsTotal = histogramResults?.hits.total || 0;
-  const hits = useMemo(() => {
+
+  // SQL patterns come back as unaliased columns ([pattern, COUNT(*), MIN(sample)] by
+  // position) rather than the PPL field names, and the sample is a scalar rather than
+  // PPL's take(field, 1) array. Normalize both shapes into { pattern, count, sample }.
+  const isSqlPatterns = originalQuery?.language === 'SQL';
+  const patternRows = useMemo(() => {
     const rawHits = patternResults?.hits?.hits || [];
+    const schema = (patternResults as any)?.fieldSchema || [];
 
-    // Filter out rows where any required field is null
-    return rawHits.filter((row: any) => {
-      if (!row || !row._source) return false;
+    return rawHits
+      .map((row: any) => {
+        const source = row?._source;
+        if (!source) return null;
 
-      const source = row._source;
+        let pattern;
+        let count;
+        let sample;
 
-      // If ANY required field is null/undefined, reject the entire row
-      if (
-        source[PATTERNS_FIELD] == null ||
-        source[COUNT_FIELD] == null ||
-        source[SAMPLE_FIELD] == null
-      ) {
-        return false;
-      }
+        if (isSqlPatterns) {
+          const patternKey = schema[0]?.name ?? 'pattern';
+          const countKey = schema[1]?.name ?? 'COUNT(*)';
+          const sampleKey = schema[2]?.name ?? 'MIN(sample)';
+          pattern = source[patternKey];
+          count = source[countKey];
+          sample = source[sampleKey];
+        } else {
+          pattern = source[PATTERNS_FIELD];
+          count = source[COUNT_FIELD];
+          // PPL sample is an array (take(field, 1))
+          sample = Array.isArray(source[SAMPLE_FIELD]) ? source[SAMPLE_FIELD][0] : undefined;
+        }
 
-      // For SAMPLE_FIELD, also check if it's an array with a non-null first element
-      if (
-        !Array.isArray(source[SAMPLE_FIELD]) ||
-        source[SAMPLE_FIELD].length === 0 ||
-        source[SAMPLE_FIELD][0] == null
-      ) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [patternResults?.hits.hits]);
+        if (pattern == null || count == null || sample == null) return null;
+        return { pattern, count, sample };
+      })
+      .filter(Boolean) as Array<{ pattern: string; count: number; sample: string }>;
+  }, [patternResults, isSqlPatterns]);
 
   const items: PatternItem[] = useMemo(
     () =>
-      hits?.map((row: any) => ({
+      patternRows.map((row) => ({
         // not including null check for logs total, the table will handle errors and we want to
         //    display the other information if it can appear fine
-        ratio: row._source[COUNT_FIELD] / logsTotal,
-        count: row._source[COUNT_FIELD],
-        // SAMPLE_FIELD needs [0] because the sample will be an array, but we're showing a 'sample' so 0th is fine
-        sample: row._source[SAMPLE_FIELD][0],
-        highlightedSample: usingRegexPatterns
-          ? undefined
-          : highlightLogUsingPattern(
-              row._source[SAMPLE_FIELD][0],
-              row._source[PATTERNS_FIELD],
-              isDarkMode
-            ),
-        pattern: row._source[PATTERNS_FIELD],
+        ratio: row.count / logsTotal,
+        count: row.count,
+        sample: row.sample,
+        // SQL uses the simple (regex) method, whose punctuation-only anchors make the
+        // token highlighter mis-align — same reason PPL's usingRegexPatterns path skips it.
+        highlightedSample:
+          isSqlPatterns || usingRegexPatterns
+            ? undefined
+            : highlightLogUsingPattern(row.sample, row.pattern, isDarkMode),
+        pattern: row.pattern,
       })),
-    [hits, logsTotal, usingRegexPatterns, isDarkMode]
+    [patternRows, logsTotal, usingRegexPatterns, isSqlPatterns, isDarkMode]
   );
 
   // Notify parent of filtered count change (optional callback)
   useEffect(() => {
-    if (onFilteredCountChange && hits) {
-      onFilteredCountChange(hits.length);
+    if (onFilteredCountChange) {
+      onFilteredCountChange(patternRows.length);
     }
-  }, [hits, onFilteredCountChange]);
+  }, [patternRows, onFilteredCountChange]);
 
   if (status?.status === QueryExecutionStatus.LOADING) {
     return (
@@ -186,21 +191,17 @@ const PatternsContainerContent = ({
     );
   }
 
-  const hit = hits?.[0];
-  if (!hit) {
+  if (!patternRows.length) {
+    // If rows came back but none matched the expected pattern columns, the response schema
+    // is unexpected; otherwise there is simply nothing to display.
+    const rawHits = patternResults?.hits?.hits || [];
+    if (rawHits.length > 0) {
+      const title = i18n.translate('explore.patterns.schemaUnexpected', {
+        defaultMessage: 'Expected schema not found',
+      });
+      return <EuiCallOut title={title} color="danger" iconType="alert" />;
+    }
     return null;
-  }
-
-  // Check if the hit has all required fields in hit._source
-  const requiredFields = [COUNT_FIELD, SAMPLE_FIELD, PATTERNS_FIELD];
-  const hasAllRequiredFields = requiredFields.every((field) => field in hit._source);
-
-  if (!hasAllRequiredFields) {
-    // doesn't match normal fields or calcite fields
-    const title = i18n.translate('explore.patterns.schemaUnexpected', {
-      defaultMessage: 'Expected schema not found',
-    });
-    return <EuiCallOut title={title} color="danger" iconType="alert" />;
   }
 
   return (

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
@@ -15,6 +15,7 @@ import {
   createExcludeSearchPatternQuery,
   createSearchPatternQuery,
   highlightLogUsingPattern,
+  isValidFiniteNumber,
 } from './utils/utils';
 import {
   selectPatternsField,
@@ -149,14 +150,24 @@ const PatternsContainerContent = ({
   // Denominator for the event ratio. PPL reads the total from the histogram
   // query, but the histogram is not issued for SQL (see the language guard in
   // `executeQueries`), so that total is always 0 and every ratio would come out
-  // Infinity -- rendering the whole column as '—'. The pattern rows already sum
-  // to the population the ratio is *about*, so use that for SQL. This keeps the
-  // column meaningful without depending on SQL histogram support landing first.
-  const logsTotal = useMemo(
-    () =>
-      isSqlPatterns ? patternRows.reduce((sum, row) => sum + (row.count || 0), 0) : histogramTotal,
-    [isSqlPatterns, patternRows, histogramTotal]
-  );
+  // Infinity -- rendering the whole column as '—'.
+  //
+  // The SQL query carries the count of matched documents in a fourth column
+  // (MAX(doc_total)). Summing the returned counts instead would be wrong when the
+  // engine caps the response at `plugins.query.size_limit`: the groups that came
+  // back would be normalized to 100% and every ratio overstated. Falls back to the
+  // sum when the column is absent, so a response predating this shape still renders.
+  const logsTotal = useMemo(() => {
+    if (!isSqlPatterns) return histogramTotal;
+
+    const totalColumn = ((patternResults as any)?.fieldSchema || [])[3];
+    const reportedTotal = totalColumn?.name
+      ? patternResults?.hits?.hits?.[0]?._source?.[totalColumn.name]
+      : undefined;
+    if (isValidFiniteNumber(reportedTotal) && reportedTotal > 0) return reportedTotal;
+
+    return patternRows.reduce((sum, row) => sum + (row.count || 0), 0);
+  }, [isSqlPatterns, patternResults, patternRows, histogramTotal]);
 
   const items: PatternItem[] = useMemo(
     () =>

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
@@ -217,10 +217,10 @@ const PatternsContainerContent = ({
   }
 
   if (!patternRows.length) {
-    // If rows came back but none matched the expected pattern columns, the response schema
-    // is unexpected; otherwise there is simply nothing to display.
+    // SQL addresses the columns through the response schema, so rows arriving with
+    // no usable schema is worth reporting. PPL keeps returning nothing, as before.
     const rawHits = patternResults?.hits?.hits || [];
-    if (rawHits.length > 0) {
+    if (isSqlPatterns && rawHits.length > 0) {
       const title = i18n.translate('explore.patterns.schemaUnexpected', {
         defaultMessage: 'Expected schema not found',
       });

--- a/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
+++ b/src/plugins/explore/public/components/patterns_table/patterns_container.tsx
@@ -100,7 +100,7 @@ const PatternsContainerContent = ({
     [originalQuery, selectedPatternsField, usingRegexPatterns, redirectToLogsWithQuery]
   );
 
-  const logsTotal = histogramResults?.hits.total || 0;
+  const histogramTotal = histogramResults?.hits.total || 0;
 
   // SQL patterns come back as unaliased columns ([pattern, COUNT(*), MIN(sample)] by
   // position) rather than the PPL field names, and the sample is a scalar rather than
@@ -120,12 +120,15 @@ const PatternsContainerContent = ({
         let sample;
 
         if (isSqlPatterns) {
-          const patternKey = schema[0]?.name ?? 'pattern';
-          const countKey = schema[1]?.name ?? 'COUNT(*)';
-          const sampleKey = schema[2]?.name ?? 'MIN(sample)';
-          pattern = source[patternKey];
-          count = source[countKey];
-          sample = source[sampleKey];
+          // Columns are read by position. The engine returns each unaliased
+          // column's `name` as the raw SELECT-list text, and OSD keys `_source`
+          // by that name (aliases are returned separately and dropped), so the
+          // schema is the only reliable way to address them.
+          const [patternCol, countCol, sampleCol] = schema;
+          if (!patternCol?.name || !countCol?.name || !sampleCol?.name) return null;
+          pattern = source[patternCol.name];
+          count = source[countCol.name];
+          sample = source[sampleCol.name];
         } else {
           pattern = source[PATTERNS_FIELD];
           count = source[COUNT_FIELD];
@@ -133,11 +136,27 @@ const PatternsContainerContent = ({
           sample = Array.isArray(source[SAMPLE_FIELD]) ? source[SAMPLE_FIELD][0] : undefined;
         }
 
+        // Note for SQL: the empty-pattern group (documents whose patterns field
+        // is missing) has pattern === '' and sample === '', which survive this
+        // check -- only null/undefined are dropped. The outer IFNULL on MIN
+        // guarantees the sample is never null, so that group is not lost.
         if (pattern == null || count == null || sample == null) return null;
         return { pattern, count, sample };
       })
       .filter(Boolean) as Array<{ pattern: string; count: number; sample: string }>;
   }, [patternResults, isSqlPatterns]);
+
+  // Denominator for the event ratio. PPL reads the total from the histogram
+  // query, but the histogram is not issued for SQL (see the language guard in
+  // `executeQueries`), so that total is always 0 and every ratio would come out
+  // Infinity -- rendering the whole column as '—'. The pattern rows already sum
+  // to the population the ratio is *about*, so use that for SQL. This keeps the
+  // column meaningful without depending on SQL histogram support landing first.
+  const logsTotal = useMemo(
+    () =>
+      isSqlPatterns ? patternRows.reduce((sum, row) => sum + (row.count || 0), 0) : histogramTotal,
+    [isSqlPatterns, patternRows, histogramTotal]
+  );
 
   const items: PatternItem[] = useMemo(
     () =>
@@ -147,8 +166,14 @@ const PatternsContainerContent = ({
         ratio: row.count / logsTotal,
         count: row.count,
         sample: row.sample,
-        // SQL uses the simple (regex) method, whose punctuation-only anchors make the
-        // token highlighter mis-align — same reason PPL's usingRegexPatterns path skips it.
+        // Highlighting is skipped for the simple pattern method, in SQL exactly
+        // as in PPL's usingRegexPatterns path -- SQL only has the simple method.
+        // It is not that the highlighter mis-aligns: it aligns correctly and
+        // reproduces the sample byte-for-byte. The problem is density. Simple
+        // patterns replace every alphanumeric run, so the same log line comes
+        // back as ~25 alternating fragments instead of brain's ~6 contiguous
+        // ones, at the same ~66% coverage -- the highlight stops distinguishing
+        // anything and reads as noise.
         highlightedSample:
           isSqlPatterns || usingRegexPatterns
             ? undefined

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
@@ -10,11 +10,15 @@ import {
   brainUpdateSearchPatternQuery,
   createExcludeSearchPatternQuery,
   createSearchPatternQuery,
+  escapeSqlValue,
   findDefaultPatternsField,
   highlightLogUsingPattern,
   isValidFiniteNumber,
   regexExcludeSearchPatternQuery,
   regexUpdateSearchPatternQuery,
+  sqlExcludeSearchPatternQuery,
+  sqlPatternQuery,
+  sqlUpdateSearchPatternQuery,
 } from './utils';
 import { setPatternsField } from '../../../application/utils/state_management/slices/tab/tab_slice';
 import * as queryActions from '../../../application/utils/state_management/actions/query_actions';
@@ -194,6 +198,85 @@ describe('utils', () => {
       expect(result).toBe(
         'my raw query | patterns `message` | where patterns_field != "Error <*>"'
       );
+    });
+  });
+
+  describe('SQL pattern queries', () => {
+    const queryBase = 'SELECT * FROM my_index';
+    const patternsField = 'message';
+    const patternString = '<*> /<*>/<*>';
+
+    describe('escapeSqlValue', () => {
+      it('wraps a value in single quotes', () => {
+        expect(escapeSqlValue('api')).toBe("'api'");
+      });
+
+      it('doubles embedded single quotes', () => {
+        expect(escapeSqlValue("o'brien")).toBe("'o''brien'");
+        expect(escapeSqlValue("''")).toBe("''''''");
+      });
+
+      it('coerces non-string values to string', () => {
+        expect(escapeSqlValue(123 as any)).toBe("'123'");
+      });
+    });
+
+    describe('sqlPatternQuery', () => {
+      it('builds a REPLACE-based GROUP BY query with unaliased aggregates', () => {
+        expect(sqlPatternQuery(queryBase, patternsField)).toBe(
+          'SELECT pattern, COUNT(*), MIN(sample) ' +
+            "FROM (SELECT REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') AS pattern, `message` AS sample " +
+            'FROM (SELECT * FROM my_index) sub_inner) sub ' +
+            'GROUP BY pattern ORDER BY COUNT(*) DESC'
+        );
+      });
+    });
+
+    describe('sqlUpdateSearchPatternQuery', () => {
+      it('builds a filter-for query using = on the REPLACE expression', () => {
+        expect(sqlUpdateSearchPatternQuery(queryBase, patternsField, patternString)).toBe(
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') = '<*> /<*>/<*>'"
+        );
+      });
+
+      it('escapes single quotes in the pattern string', () => {
+        expect(sqlUpdateSearchPatternQuery(queryBase, patternsField, "o'brien")).toContain(
+          "= 'o''brien'"
+        );
+      });
+    });
+
+    describe('sqlExcludeSearchPatternQuery', () => {
+      it('builds a filter-out query using <> on the REPLACE expression', () => {
+        expect(sqlExcludeSearchPatternQuery(queryBase, patternsField, patternString)).toBe(
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') <> '<*> /<*>/<*>'"
+        );
+      });
+    });
+
+    describe('createSearchPatternQuery (SQL branch)', () => {
+      it('produces the SQL filter-for query when language is SQL', () => {
+        const query = { query: queryBase, language: 'SQL' };
+        expect(createSearchPatternQuery(query, patternsField, false, patternString)).toBe(
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') = '<*> /<*>/<*>'"
+        );
+      });
+
+      it('ignores usingRegexPatterns for SQL (only the simple method exists)', () => {
+        const query = { query: queryBase, language: 'SQL' };
+        const withRegex = createSearchPatternQuery(query, patternsField, true, patternString);
+        const withoutRegex = createSearchPatternQuery(query, patternsField, false, patternString);
+        expect(withRegex).toBe(withoutRegex);
+      });
+    });
+
+    describe('createExcludeSearchPatternQuery (SQL branch)', () => {
+      it('produces the SQL filter-out query when language is SQL', () => {
+        const query = { query: queryBase, language: 'SQL' };
+        expect(createExcludeSearchPatternQuery(query, patternsField, false, patternString)).toBe(
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') <> '<*> /<*>/<*>'"
+        );
+      });
     });
   });
 

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
@@ -295,11 +295,55 @@ describe('utils', () => {
     describe('sqlPatternQuery', () => {
       it('builds a REPLACE-based GROUP BY query with unaliased aggregates', () => {
         expect(sqlPatternQuery(queryBase, patternsField)).toBe(
-          "SELECT pattern, COUNT(*), IFNULL(MIN(sample), '') " +
+          "SELECT pattern, COUNT(*), IFNULL(MIN(sample), ''), MAX(doc_total) " +
             "FROM (SELECT REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>') AS pattern, " +
-            '`message` AS sample ' +
+            '`message` AS sample, COUNT(*) OVER () AS doc_total ' +
             'FROM (SELECT * FROM my_index) sub_inner) sub ' +
             'GROUP BY pattern ORDER BY COUNT(*) DESC'
+        );
+      });
+
+      // The engine caps the response at plugins.query.size_limit, so the returned
+      // groups can be a subset. COUNT(*) OVER () is evaluated on the inner relation,
+      // before grouping and before the cap, so the ratio denominator survives it.
+      it('carries the matched-document count in its own column', () => {
+        const query = sqlPatternQuery(queryBase, patternsField);
+
+        expect(query).toContain('COUNT(*) OVER () AS doc_total');
+        expect(query).toContain('MAX(doc_total)');
+      });
+    });
+
+    // `FROM (SELECT ...;) sub` makes the engine read the terminator as part of the
+    // index name and fail with IndexNotFoundException.
+    describe('trailing statement terminator', () => {
+      const terminated = 'SELECT * FROM my_index;';
+
+      it('is dropped before the query is embedded as a subquery', () => {
+        expect(sqlPatternQuery(terminated, patternsField)).toContain(
+          'FROM (SELECT * FROM my_index) sub_inner'
+        );
+        expect(sqlPatternQuery(terminated, patternsField)).not.toContain('my_index;');
+      });
+
+      it('is dropped for the filter-for and filter-out queries too', () => {
+        expect(sqlUpdateSearchPatternQuery(terminated, patternsField, patternString)).toContain(
+          'FROM (SELECT * FROM my_index) sub'
+        );
+        expect(sqlExcludeSearchPatternQuery(terminated, patternsField, patternString)).toContain(
+          'FROM (SELECT * FROM my_index) sub'
+        );
+      });
+
+      it('tolerates whitespace and repeats around the terminator', () => {
+        expect(sqlPatternQuery('SELECT * FROM my_index ; ; ', patternsField)).toContain(
+          'FROM (SELECT * FROM my_index) sub_inner'
+        );
+      });
+
+      it('leaves a terminator inside a string literal alone', () => {
+        expect(sqlPatternQuery("SELECT * FROM my_index WHERE a = 'x;y';", patternsField)).toContain(
+          "FROM (SELECT * FROM my_index WHERE a = 'x;y') sub_inner"
         );
       });
     });

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.test.ts
@@ -11,6 +11,7 @@ import {
   createExcludeSearchPatternQuery,
   createSearchPatternQuery,
   escapeSqlValue,
+  escapeSqlIdentifier,
   findDefaultPatternsField,
   highlightLogUsingPattern,
   isValidFiniteNumber,
@@ -219,13 +220,84 @@ describe('utils', () => {
       it('coerces non-string values to string', () => {
         expect(escapeSqlValue(123 as any)).toBe("'123'");
       });
+
+      // SQUOTA_STRING honors backslash escapes as well as '' doubling, so a
+      // backslash before a quote would otherwise end the literal early. These
+      // values are reachable from indexed content (Windows paths, stack traces).
+      it('escapes a backslash that precedes a quote', () => {
+        expect(escapeSqlValue("path\\'s")).toBe("'path\\\\''s'");
+      });
+
+      it('escapes a trailing backslash', () => {
+        expect(escapeSqlValue('a\\')).toBe("'a\\\\'");
+      });
+
+      it('escapes backslashes before doubling quotes, not after', () => {
+        // Wrong order would emit 'a\'' — the \' is consumed as an escaped quote.
+        expect(escapeSqlValue("a\\'")).toBe("'a\\\\'''");
+      });
+    });
+
+    describe('escapeSqlIdentifier', () => {
+      it('wraps a field name in backticks', () => {
+        expect(escapeSqlIdentifier('message')).toBe('`message`');
+      });
+
+      it('leaves dotted and hyphenated field names intact', () => {
+        expect(escapeSqlIdentifier('http.request-id')).toBe('`http.request-id`');
+      });
+
+      it('doubles embedded backticks', () => {
+        expect(escapeSqlIdentifier('we`ird')).toBe('`we``ird`');
+      });
+
+      it('neutralizes a field name that would otherwise close the identifier', () => {
+        // patternsField is restored verbatim from the _a URL parameter.
+        expect(escapeSqlIdentifier('a`, (SELECT 1) x FROM y -- ')).toBe(
+          '`a``, (SELECT 1) x FROM y -- `'
+        );
+      });
+    });
+
+    describe('NULL handling', () => {
+      // Grouping by a nullable key fails the whole request with HTTP 500
+      // "[BUG] Unreachable, Comparing with NULL or MISSING is undefined", so a
+      // single document missing the field breaks the tab on real log indices.
+      it('guards the patterns field with IFNULL in the grouping expression', () => {
+        expect(sqlPatternQuery(queryBase, patternsField)).toContain(
+          "REPLACE(IFNULL(`message`, ''),"
+        );
+      });
+
+      // IFNULL(field,'') on a text field keeps OpenSearchTextType while '' does
+      // not, so MIN over a group holding both a missing and an empty-string
+      // document throws "compare expected value have same type" (HTTP 400).
+      it('projects the sample raw and guards the aggregate instead', () => {
+        const q = sqlPatternQuery(queryBase, patternsField);
+        expect(q).toContain('`message` AS sample');
+        expect(q).toContain("IFNULL(MIN(sample), '')");
+        expect(q).not.toContain('MIN(IFNULL(');
+      });
+
+      it('guards the patterns field with IFNULL in the filter-for query', () => {
+        expect(sqlUpdateSearchPatternQuery(queryBase, patternsField, patternString)).toContain(
+          "REPLACE(IFNULL(`message`, ''),"
+        );
+      });
+
+      it('guards the patterns field with IFNULL in the filter-out query', () => {
+        expect(sqlExcludeSearchPatternQuery(queryBase, patternsField, patternString)).toContain(
+          "REPLACE(IFNULL(`message`, ''),"
+        );
+      });
     });
 
     describe('sqlPatternQuery', () => {
       it('builds a REPLACE-based GROUP BY query with unaliased aggregates', () => {
         expect(sqlPatternQuery(queryBase, patternsField)).toBe(
-          'SELECT pattern, COUNT(*), MIN(sample) ' +
-            "FROM (SELECT REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') AS pattern, `message` AS sample " +
+          "SELECT pattern, COUNT(*), IFNULL(MIN(sample), '') " +
+            "FROM (SELECT REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>') AS pattern, " +
+            '`message` AS sample ' +
             'FROM (SELECT * FROM my_index) sub_inner) sub ' +
             'GROUP BY pattern ORDER BY COUNT(*) DESC'
         );
@@ -235,7 +307,7 @@ describe('utils', () => {
     describe('sqlUpdateSearchPatternQuery', () => {
       it('builds a filter-for query using = on the REPLACE expression', () => {
         expect(sqlUpdateSearchPatternQuery(queryBase, patternsField, patternString)).toBe(
-          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') = '<*> /<*>/<*>'"
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>') = '<*> /<*>/<*>'"
         );
       });
 
@@ -249,7 +321,7 @@ describe('utils', () => {
     describe('sqlExcludeSearchPatternQuery', () => {
       it('builds a filter-out query using <> on the REPLACE expression', () => {
         expect(sqlExcludeSearchPatternQuery(queryBase, patternsField, patternString)).toBe(
-          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') <> '<*> /<*>/<*>'"
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>') <> '<*> /<*>/<*>'"
         );
       });
     });
@@ -258,7 +330,7 @@ describe('utils', () => {
       it('produces the SQL filter-for query when language is SQL', () => {
         const query = { query: queryBase, language: 'SQL' };
         expect(createSearchPatternQuery(query, patternsField, false, patternString)).toBe(
-          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') = '<*> /<*>/<*>'"
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>') = '<*> /<*>/<*>'"
         );
       });
 
@@ -274,7 +346,7 @@ describe('utils', () => {
       it('produces the SQL filter-out query when language is SQL', () => {
         const query = { query: queryBase, language: 'SQL' };
         expect(createExcludeSearchPatternQuery(query, patternsField, false, patternString)).toBe(
-          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(`message`, '[a-zA-Z0-9]+', '<*>') <> '<*> /<*>/<*>'"
+          "SELECT * FROM (SELECT * FROM my_index) sub WHERE REPLACE(IFNULL(`message`, ''), '[a-zA-Z0-9]+', '<*>') <> '<*> /<*>/<*>'"
         );
       });
     });
@@ -560,6 +632,37 @@ describe('utils', () => {
       expect(setPatternsField).toHaveBeenCalledWith('field2');
       expect(services.store.dispatch).toHaveBeenCalled();
       expect(queryActions.defaultPrepareQueryString).toHaveBeenCalledWith(state.query);
+    });
+
+    it('should recognize the mapping types SQL reports instead of `string`', () => {
+      resultsCache.set('default-query', {
+        fieldSchema: [
+          { name: 'serviceName', type: 'keyword' },
+          { name: 'body', type: 'text' },
+          { name: 'time', type: 'timestamp' },
+        ],
+        hits: {
+          hits: [
+            {
+              _source: {
+                serviceName: 'cartService',
+                body: 'GetCartAsync called with userId=abc123',
+                time: '2026-08-10T00:00:00Z',
+              },
+            },
+          ],
+        },
+      } as any);
+
+      const state = { query: { language: 'SQL' }, results: {} } as any;
+      mockGetState.mockReturnValue(state);
+      const services = {
+        store: { dispatch: jest.fn(), getState: mockGetState },
+        tabRegistry: { getTab: jest.fn().mockReturnValue({ id: 'logs' }) },
+      } as any;
+
+      expect(findDefaultPatternsField(services)).toBe('body');
+      expect(setPatternsField).toHaveBeenCalledWith('body');
     });
 
     it('should handle non-string values in _source correctly', () => {

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.ts
@@ -31,6 +31,32 @@ export const brainPatternQuery = (queryBase: string, patternsField: string) => {
   return `${queryBase} | patterns \`${patternsField}\` method=brain mode=label | stats count() as ${COUNT_FIELD}, take(\`${patternsField}\`, 1) as ${SAMPLE_FIELD} by patterns_field | sort - ${COUNT_FIELD} | fields ${PATTERNS_FIELD}, ${COUNT_FIELD}, ${SAMPLE_FIELD}`;
 };
 
+/**
+ * SQL equivalent of the simple (regex) pattern query.
+ *
+ * The analytics engine has no REGEXP_REPLACE, but Calcite's REPLACE is
+ * regex-capable, so REPLACE(field, '[a-zA-Z0-9]+', '<*>') reproduces PPL's
+ * simple-patterns output exactly (e.g. `<*> /<*>/<*> <*>/<*>.<*>`).
+ *
+ * The engine does not honor outer-SELECT aliases in this GROUP BY context (same
+ * quirk as the SQL histogram's COUNT(*)), so the columns are left unaliased and
+ * come back, in order, as [pattern, COUNT(*), MIN(sample)] — mapped to
+ * patterns_field / pattern_count / sample_logs by position downstream. The
+ * sample uses MIN(field) (a deterministic real log) in place of PPL's
+ * take(field, 1).
+ */
+export const SQL_PATTERN_TOKEN_REGEX = '[a-zA-Z0-9]+';
+export const SQL_PATTERN_PLACEHOLDER = '<*>';
+
+export const sqlPatternQuery = (queryBase: string, patternsField: string) => {
+  const field = `\`${patternsField}\``;
+  return (
+    `SELECT pattern, COUNT(*), MIN(sample) ` +
+    `FROM (SELECT REPLACE(${field}, '${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}') AS pattern, ${field} AS sample FROM (${queryBase}) sub_inner) sub ` +
+    `GROUP BY pattern ORDER BY COUNT(*) DESC`
+  );
+};
+
 export const regexUpdateSearchPatternQuery = (
   queryBase: string,
   patternsField: string,
@@ -71,6 +97,31 @@ export const brainExcludeSearchPatternQuery = (
   )}`;
 };
 
+// Wraps a value as a single-quoted SQL string literal, doubling any embedded single quotes.
+export const escapeSqlValue = (value: string) => `'${String(value).replace(/'/g, "''")}'`;
+
+// SQL filter-for: keep only rows whose simple pattern matches patternString.
+export const sqlUpdateSearchPatternQuery = (
+  queryBase: string,
+  patternsField: string,
+  patternString: string
+) => {
+  return `SELECT * FROM (${queryBase}) sub WHERE REPLACE(\`${patternsField}\`, '${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}') = ${escapeSqlValue(
+    patternString
+  )}`;
+};
+
+// SQL filter-out: exclude rows whose simple pattern matches patternString.
+export const sqlExcludeSearchPatternQuery = (
+  queryBase: string,
+  patternsField: string,
+  patternString: string
+) => {
+  return `SELECT * FROM (${queryBase}) sub WHERE REPLACE(\`${patternsField}\`, '${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}') <> ${escapeSqlValue(
+    patternString
+  )}`;
+};
+
 export const createSearchPatternQuery = (
   query: Query,
   patternsField: string,
@@ -78,6 +129,9 @@ export const createSearchPatternQuery = (
   patternString: string
 ) => {
   const queryString = typeof query.query === 'string' ? query.query : '';
+  if (query.language === 'SQL') {
+    return sqlUpdateSearchPatternQuery(queryString, patternsField, patternString);
+  }
   return usingRegexPatterns
     ? regexUpdateSearchPatternQuery(queryString, patternsField, patternString)
     : brainUpdateSearchPatternQuery(queryString, patternsField, patternString);
@@ -90,6 +144,9 @@ export const createExcludeSearchPatternQuery = (
   patternString: string
 ) => {
   const queryString = typeof query.query === 'string' ? query.query : '';
+  if (query.language === 'SQL') {
+    return sqlExcludeSearchPatternQuery(queryString, patternsField, patternString);
+  }
   return usingRegexPatterns
     ? regexExcludeSearchPatternQuery(queryString, patternsField, patternString)
     : brainExcludeSearchPatternQuery(queryString, patternsField, patternString);
@@ -109,6 +166,15 @@ export const createSearchPatternQueryWithSlice = (
 
   const preparedQuery = prepareQueryForLanguage(query);
   const sortClause = timeField ? ` | sort - ${timeField}` : '';
+
+  if (query.language === 'SQL') {
+    const sqlSort = timeField ? ` ORDER BY \`${timeField}\` DESC` : '';
+    return `${sqlUpdateSearchPatternQuery(
+      preparedQuery.query,
+      patternsField,
+      patternString
+    )}${sqlSort} LIMIT ${pageSize} OFFSET ${pageOffset}`;
+  }
 
   return usingRegexPatterns
     ? `${regexUpdateSearchPatternQuery(

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.ts
@@ -78,6 +78,14 @@ const sqlPatternExpression = (patternsField: string) =>
   `REPLACE(IFNULL(${escapeSqlIdentifier(patternsField)}, ''), ` +
   `'${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}')`;
 
+/**
+ * The editor accepts a trailing statement terminator, but a subquery cannot carry
+ * one: `FROM (SELECT * FROM idx;) sub` makes the engine read `idx;` as the index
+ * name and fail with IndexNotFoundException. Only trailing terminators are removed,
+ * so a `;` inside a string literal is left alone.
+ */
+export const asSqlSubquery = (queryBase: string) => String(queryBase).replace(/[\s;]+$/, '');
+
 export const sqlPatternQuery = (queryBase: string, patternsField: string) => {
   const field = escapeSqlIdentifier(patternsField);
   // The sample column is projected RAW and the null-guard is applied to the
@@ -86,10 +94,19 @@ export const sqlPatternQuery = (queryBase: string, patternsField: string) => {
   // containing both a missing document and an empty-string document throws
   // "compare expected value have same type" (HTTP 400). Guarding the aggregate
   // instead of its input avoids mixing the two types inside the comparison.
+  //
+  // MAX(doc_total) carries the number of documents the user's query matched.
+  // The engine caps the response at `plugins.query.size_limit` (10,000 by
+  // default), so on a high-cardinality field the returned groups are only part
+  // of the result -- summing their counts would normalize that subset to 100%
+  // and overstate every ratio. COUNT(*) OVER () is evaluated on the inner
+  // relation, before grouping and before the cap, so it survives truncation and
+  // also reveals it: the returned counts sum to less than this total.
   return (
-    `SELECT pattern, COUNT(*), IFNULL(MIN(sample), '') ` +
+    `SELECT pattern, COUNT(*), IFNULL(MIN(sample), ''), MAX(doc_total) ` +
     `FROM (SELECT ${sqlPatternExpression(patternsField)} AS pattern, ` +
-    `${field} AS sample FROM (${queryBase}) sub_inner) sub ` +
+    `${field} AS sample, COUNT(*) OVER () AS doc_total ` +
+    `FROM (${asSqlSubquery(queryBase)}) sub_inner) sub ` +
     `GROUP BY pattern ORDER BY COUNT(*) DESC`
   );
 };
@@ -166,7 +183,7 @@ export const sqlUpdateSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `SELECT * FROM (${queryBase}) sub WHERE ${sqlPatternExpression(
+  return `SELECT * FROM (${asSqlSubquery(queryBase)}) sub WHERE ${sqlPatternExpression(
     patternsField
   )} = ${escapeSqlValue(patternString)}`;
 };
@@ -177,7 +194,7 @@ export const sqlExcludeSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `SELECT * FROM (${queryBase}) sub WHERE ${sqlPatternExpression(
+  return `SELECT * FROM (${asSqlSubquery(queryBase)}) sub WHERE ${sqlPatternExpression(
     patternsField
   )} <> ${escapeSqlValue(patternString)}`;
 };

--- a/src/plugins/explore/public/components/patterns_table/utils/utils.ts
+++ b/src/plugins/explore/public/components/patterns_table/utils/utils.ts
@@ -34,25 +34,62 @@ export const brainPatternQuery = (queryBase: string, patternsField: string) => {
 /**
  * SQL equivalent of the simple (regex) pattern query.
  *
- * The analytics engine has no REGEXP_REPLACE, but Calcite's REPLACE is
- * regex-capable, so REPLACE(field, '[a-zA-Z0-9]+', '<*>') reproduces PPL's
- * simple-patterns output exactly (e.g. `<*> /<*>/<*> <*>/<*>.<*>`).
+ * OpenSearch SQL has no REGEXP_REPLACE token at any version -- it is a syntax
+ * error -- so REPLACE is the only option. It works because the V2 engine
+ * implements REPLACE with Java's `String.replaceAll`
+ * (sql: core/.../expression/text/TextFunctions.java), which treats `from_str`
+ * as a regex. That reproduces PPL's Calcite simple-patterns output exactly:
+ * both emit REGEXP_REPLACE(field, '[a-zA-Z0-9]+', '<*>').
  *
- * The engine does not honor outer-SELECT aliases in this GROUP BY context (same
- * quirk as the SQL histogram's COUNT(*)), so the columns are left unaliased and
- * come back, in order, as [pattern, COUNT(*), MIN(sample)] — mapped to
- * patterns_field / pattern_count / sample_logs by position downstream. The
- * sample uses MIN(field) (a deterministic real log) in place of PPL's
- * take(field, 1).
+ * Caveat, deliberately recorded: this behavior is undocumented and contradicts
+ * `docs/user/dql/functions.rst`, which describes REPLACE as literal substring
+ * replacement, and no SQL-side integration test pins it. See the tracking issue
+ * linked from the PR before relying on it more widely.
+ *
+ * Columns are left unaliased and read back by position as
+ * [pattern, COUNT(*), MIN(sample)]. The engine does return aliases, but OSD
+ * drops them: `getFields` keys `_source` by column *name*
+ * (src/plugins/data/common/data_frames/utils.ts), so an aliased column would
+ * arrive under the raw expression text. Positional access is safe here because
+ * the response schema and datarows are built in one pass from the same
+ * projection, so schema order == SELECT-list order.
+ *
+ * The sample uses MIN(field) (a deterministic real log line) in place of PPL's
+ * take(field, 1). NOTE: MIN on a keyword field is rejected when the aggregation
+ * pushes down ("Field [x] of type [keyword] is not supported for aggregation
+ * [min]"); it works here only because the derived table blocks pushdown. Do not
+ * "optimize" the subquery nesting away.
  */
 export const SQL_PATTERN_TOKEN_REGEX = '[a-zA-Z0-9]+';
 export const SQL_PATTERN_PLACEHOLDER = '<*>';
 
+/**
+ * The pattern-bearing expression, with a NULL guard.
+ *
+ * Grouping by a nullable key makes the V2 engine fail the whole request with
+ * HTTP 500 "[BUG] Unreachable, Comparing with NULL or MISSING is undefined" --
+ * so a single document missing the patterns field breaks the tab, which is the
+ * common case on real log indices. IFNULL collapses those documents into an
+ * empty-pattern group, matching what Calcite-PPL does via
+ * CASE(SEARCH(field, Sarg['';NULL AS TRUE]), '', REGEXP_REPLACE(...)), so the
+ * counts reconcile with the PPL tab rather than silently differing.
+ */
+const sqlPatternExpression = (patternsField: string) =>
+  `REPLACE(IFNULL(${escapeSqlIdentifier(patternsField)}, ''), ` +
+  `'${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}')`;
+
 export const sqlPatternQuery = (queryBase: string, patternsField: string) => {
-  const field = `\`${patternsField}\``;
+  const field = escapeSqlIdentifier(patternsField);
+  // The sample column is projected RAW and the null-guard is applied to the
+  // aggregate instead. IFNULL(field, '') on a `text` field returns a value that
+  // keeps OpenSearchTextType while the '' literal does not, so MIN over a group
+  // containing both a missing document and an empty-string document throws
+  // "compare expected value have same type" (HTTP 400). Guarding the aggregate
+  // instead of its input avoids mixing the two types inside the comparison.
   return (
-    `SELECT pattern, COUNT(*), MIN(sample) ` +
-    `FROM (SELECT REPLACE(${field}, '${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}') AS pattern, ${field} AS sample FROM (${queryBase}) sub_inner) sub ` +
+    `SELECT pattern, COUNT(*), IFNULL(MIN(sample), '') ` +
+    `FROM (SELECT ${sqlPatternExpression(patternsField)} AS pattern, ` +
+    `${field} AS sample FROM (${queryBase}) sub_inner) sub ` +
     `GROUP BY pattern ORDER BY COUNT(*) DESC`
   );
 };
@@ -97,8 +134,31 @@ export const brainExcludeSearchPatternQuery = (
   )}`;
 };
 
-// Wraps a value as a single-quoted SQL string literal, doubling any embedded single quotes.
-export const escapeSqlValue = (value: string) => `'${String(value).replace(/'/g, "''")}'`;
+/**
+ * Wrap a value as a single-quoted SQL string literal.
+ *
+ * The lexer rule is
+ *   SQUOTA_STRING: '\'' ( '\\'. | '\'\'' | ~('\''|'\\') )* '\''
+ * so it honors both `''` and backslash escapes. Doubling the quotes alone is
+ * therefore not enough: a value containing `\` immediately before a `'` (or a
+ * trailing `\`) terminates the literal early and spills into the statement.
+ * Backslashes must be escaped first, then quotes.
+ *
+ * This is reachable from indexed document content -- Windows paths, escaped
+ * JSON and stack traces all produce patterns containing `\'`.
+ */
+export const escapeSqlValue = (value: string) =>
+  `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
+
+/**
+ * Quote a field name as a backtick-delimited SQL identifier.
+ *
+ * BQUOTA_STRING has the same backslash rule plus '``' doubling. patternsField
+ * is restored verbatim from the `_a` URL parameter, so interpolating it raw
+ * lets a crafted field name close the identifier and append arbitrary SQL.
+ */
+export const escapeSqlIdentifier = (identifier: string) =>
+  `\`${String(identifier).replace(/\\/g, '\\\\').replace(/`/g, '``')}\``;
 
 // SQL filter-for: keep only rows whose simple pattern matches patternString.
 export const sqlUpdateSearchPatternQuery = (
@@ -106,9 +166,9 @@ export const sqlUpdateSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `SELECT * FROM (${queryBase}) sub WHERE REPLACE(\`${patternsField}\`, '${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}') = ${escapeSqlValue(
-    patternString
-  )}`;
+  return `SELECT * FROM (${queryBase}) sub WHERE ${sqlPatternExpression(
+    patternsField
+  )} = ${escapeSqlValue(patternString)}`;
 };
 
 // SQL filter-out: exclude rows whose simple pattern matches patternString.
@@ -117,9 +177,9 @@ export const sqlExcludeSearchPatternQuery = (
   patternsField: string,
   patternString: string
 ) => {
-  return `SELECT * FROM (${queryBase}) sub WHERE REPLACE(\`${patternsField}\`, '${SQL_PATTERN_TOKEN_REGEX}', '${SQL_PATTERN_PLACEHOLDER}') <> ${escapeSqlValue(
-    patternString
-  )}`;
+  return `SELECT * FROM (${queryBase}) sub WHERE ${sqlPatternExpression(
+    patternsField
+  )} <> ${escapeSqlValue(patternString)}`;
 };
 
 export const createSearchPatternQuery = (
@@ -168,7 +228,7 @@ export const createSearchPatternQueryWithSlice = (
   const sortClause = timeField ? ` | sort - ${timeField}` : '';
 
   if (query.language === 'SQL') {
-    const sqlSort = timeField ? ` ORDER BY \`${timeField}\` DESC` : '';
+    const sqlSort = timeField ? ` ORDER BY ${escapeSqlIdentifier(timeField)} DESC` : '';
     return `${sqlUpdateSearchPatternQuery(
       preparedQuery.query,
       patternsField,
@@ -315,6 +375,10 @@ export const highlightLogUsingPattern = (
   }
 };
 
+// `fieldSchema` carries the backend's own type names. PPL and the analytics engine
+// report `string`; SQL on the V2 engine reports the OpenSearch mapping type instead.
+const STRING_FIELD_TYPES = ['string', 'text', 'keyword'];
+
 /**
  * Selects the most likely patterns field by finding the string field with the longest value.
  * This function identifies the field most suitable for pattern analysis by comparing the length
@@ -345,7 +409,7 @@ export const findDefaultPatternsField = (services: ExploreServices): string => {
 
   // Get fields
   const filteredFields = logResults?.fieldSchema?.filter((field: Partial<IFieldType>) => {
-    return field.type === 'string';
+    return STRING_FIELD_TYPES.includes(field.type as string);
   });
 
   if (!logResults?.hits?.hits?.[0]) {


### PR DESCRIPTION
### Description

Enables the Patterns tab when the query language is SQL, behind the existing `explore.sqlSupport.enabled` flag.

This picks up @ritvibhatt's work from #12325 (her commit is preserved with authorship intact) and adds the fixes needed to make it correct on real indices. Every issue below was reproduced against a live cluster; none were catchable by the existing unit tests, which assert generated-SQL string equality and so cannot detect a query the engine rejects or answers wrongly.

On how SQL patterns are computed: OpenSearch SQL has no `REGEXP_REPLACE` token at any version — it is a syntax error — so `REPLACE` is the only option. It works because the V2 engine implements `REPLACE` with Java's `String.replaceAll`, making the second argument a regex. This reproduces PPL's Calcite simple-patterns output exactly, since both emit `REGEXP_REPLACE(field, '[a-zA-Z0-9]+', '<*>')`. That behavior is undocumented and contradicts `docs/user/dql/functions.rst`, which describes `REPLACE` as literal substring replacement, and no SQL-side integration test pins it. Tracking issue: TBD.

Fixes on top of #12325:

1. A document missing the patterns field returned HTTP 500 for the whole query (`[BUG] Unreachable, Comparing with NULL or MISSING is undefined`). Grouping by a nullable key fails in the V2 engine, so one such document broke the tab, which is the common case on log indices. Guarded with `IFNULL(field, '')`, matching Calcite-PPL's own guard so the empty group's count reconciles with the PPL tab.

2. `MIN(IFNULL(<text field>, ''))` returned HTTP 400 whenever a group contained both a missing document and an empty string, because `IFNULL` preserves `OpenSearchTextType` while the `''` literal does not. Since `findDefaultPatternsField` prefers the longest string field, this is the default case on real log indices. The sample is now projected raw and the guard applied to the aggregate instead.

3. `escapeSqlValue` broke on a backslash immediately before a quote — a log line containing `path\'s` produced a pattern that returned HTTP 400 `ParserException` on click-to-filter. `SQUOTA_STRING` honors both doubled quotes and backslash escapes, so backslashes are now escaped first.

4. `patternsField` and `timeFieldName` were interpolated into backticks raw. Both are restored verbatim from the `_a` URL parameter, so a crafted field name could close the identifier. Added `escapeSqlIdentifier`.

5. The event ratio divided by the histogram total, which is never produced for SQL because histograms are language-gated off, so every ratio was `Infinity` and the column rendered as a dash on every row. For SQL the denominator is now the sum of the returned pattern counts, which removes the dependency on SQL histogram support landing first.

6. `handleQueryError` is language-agnostic but its BRAIN fallback emits PPL. A SQL 400 matching the prefix would have dispatched a PPL query at the SQL endpoint under a cache key the tab never reads. It now bails out early for SQL.

This also corrects three code comments from #12325 that were factually wrong (Calcite is not in the SQL execution path, Calcite's `REPLACE` is literal, and the engine does return column aliases — OSD drops them), and records the `MIN(keyword)` pushdown hazard so nobody optimizes the derived-table nesting away.

### Verification

Run against both engines with identical data, to confirm one query behaves the same whether or not the Analytics Engine is enabled:

| | stock OpenSearch 3.8 (V2) | Analytics Engine 3.9 (DataFusion) |
|---|---|---|
| `REPLACE('abc123 def456','[a-zA-Z0-9]+','<*>')` | `<*> <*>` | `<*> <*>` |
| full patterns query, 245-doc index | 4 groups / 245 | 4 groups / 245, identical keys |
| full patterns query, 16,286-doc OTEL index | 13 groups / 16,286 | 13 groups / 16,286, identical keys and counts |
| drill-down `WHERE REPLACE(...) = '<pattern>'` | 240 rows | 240 rows |
| injected `TIMESTAMP()` time filter | 126 rows | 126 rows |

Group keys and counts are also byte-identical to PPL `patterns` with the simple method, verified on a 14,074-document index: 97 groups, every document accounted for.


## Screenshot


https://github.com/user-attachments/assets/2aece30f-954c-4576-af66-eab9e47066bd



## Testing the changes

Requires `explore.sqlSupport.enabled: true` and the `explore:experimental` uiSetting.

1. In Explore → Logs, select an index pattern and switch the language to SQL.
2. Confirm the Patterns tab is now offered, and that SQL is selectable while on the Patterns tab.
3. Run `SELECT * FROM <index>` (remove the seeded `LIMIT`) and open Patterns. Event ratio shows percentages and the counts sum to the document total for the time range. An index with documents missing the patterns field yields an empty-pattern group rather than an error.
4. Click filter for and filter out on a row whose sample contains a backslash — both should return rows rather than a parser error.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff