### PR TITLE
Map the `permissions` and `workspaces` fields on multi-tenancy tenant index

### DIFF
--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.test.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.test.ts
@@ -29,13 +29,43 @@
  */
 
 import { IndexMapping, SavedObjectsTypeMappingDefinitions } from './../../mappings';
-import { buildActiveMappings, diffMappings } from './build_active_mappings';
+import {
+  buildActiveMappings,
+  diffMappings,
+  setConditionalFieldFlags,
+} from './build_active_mappings';
 import { configMock } from '../../../config/mocks';
 
 describe('buildActiveMappings', () => {
+  // The flags are process-wide, so a test that records them would change every mapping built after.
+  afterEach(() =>
+    setConditionalFieldFlags({ permissionsEnabled: false, workspacesEnabled: false })
+  );
+
   test('creates a strict mapping', () => {
     const mappings = buildActiveMappings({});
     expect(mappings.dynamic).toEqual('strict');
+  });
+
+  test('maps the conditional fields from the recorded flags when no configuration is supplied', () => {
+    // Reproduces the multi-tenancy callers, which have no access to the raw configuration.
+    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: true });
+
+    const mappings = buildActiveMappings({});
+
+    expect(mappings.properties).toHaveProperty('permissions');
+    expect(mappings.properties).toHaveProperty('workspaces');
+  });
+
+  test('prefers a supplied configuration over the recorded flags', () => {
+    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: true });
+    const rawConfig = configMock.create();
+    rawConfig.get.mockReturnValue(false);
+
+    const mappings = buildActiveMappings({}, rawConfig);
+
+    expect(mappings.properties).not.toHaveProperty('permissions');
+    expect(mappings.properties).not.toHaveProperty('workspaces');
   });
 
   test('combines all mappings and includes core mappings', () => {

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.test.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.test.ts
@@ -34,7 +34,6 @@ import {
   diffMappings,
   setConditionalFieldFlags,
 } from './build_active_mappings';
-import { configMock } from '../../../config/mocks';
 
 describe('buildActiveMappings', () => {
   // The flags are process-wide, so a test that records them would change every mapping built after.
@@ -47,22 +46,8 @@ describe('buildActiveMappings', () => {
     expect(mappings.dynamic).toEqual('strict');
   });
 
-  test('maps the conditional fields from the recorded flags when no configuration is supplied', () => {
-    // Reproduces the multi-tenancy callers, which have no access to the raw configuration.
-    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: true });
-
+  test('omits the conditional fields unless the recorded flags enable them', () => {
     const mappings = buildActiveMappings({});
-
-    expect(mappings.properties).toHaveProperty('permissions');
-    expect(mappings.properties).toHaveProperty('workspaces');
-  });
-
-  test('prefers a supplied configuration over the recorded flags', () => {
-    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: true });
-    const rawConfig = configMock.create();
-    rawConfig.get.mockReturnValue(false);
-
-    const mappings = buildActiveMappings({}, rawConfig);
 
     expect(mappings.properties).not.toHaveProperty('permissions');
     expect(mappings.properties).not.toHaveProperty('workspaces');
@@ -124,15 +109,13 @@ describe('buildActiveMappings', () => {
   });
 
   test('permissions field is added when permission control flag is enabled', () => {
-    const rawConfig = configMock.create();
-    rawConfig.get.mockReturnValue(true);
-    expect(buildActiveMappings({}, rawConfig)).toHaveProperty('properties.permissions');
+    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: false });
+    expect(buildActiveMappings({})).toHaveProperty('properties.permissions');
   });
 
   test('workspaces field is added when workspace feature flag is enabled', () => {
-    const rawConfig = configMock.create();
-    rawConfig.get.mockReturnValue(true);
-    expect(buildActiveMappings({}, rawConfig)).toHaveProperty('properties.workspaces');
+    setConditionalFieldFlags({ permissionsEnabled: false, workspacesEnabled: true });
+    expect(buildActiveMappings({})).toHaveProperty('properties.workspaces');
   });
 });
 

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
@@ -42,6 +42,22 @@ import {
   SavedObjectsTypeMappingDefinitions,
 } from './../../mappings';
 
+/** Which root fields saved object indices carry beyond the ones the type registry defines. */
+export interface ConditionalFieldFlags {
+  readonly permissionsEnabled: boolean;
+  readonly workspacesEnabled: boolean;
+}
+
+let conditionalFieldFlags: ConditionalFieldFlags = {
+  permissionsEnabled: false,
+  workspacesEnabled: false,
+};
+
+/** Records the flags for callers that cannot supply the raw configuration. Called once, at setup. */
+export function setConditionalFieldFlags(flags: ConditionalFieldFlags) {
+  conditionalFieldFlags = flags;
+}
+
 /**
  * Creates an index mapping with the core properties required by saved object
  * indices, as well as the specified additional properties.
@@ -55,8 +71,17 @@ export function buildActiveMappings(
   const mapping = defaultMapping();
 
   let mergedProperties = validateAndMerge(mapping.properties, typeDefinitions);
-  // if permission control for saved objects is enabled, the permissions field should be added to the mapping
-  if (opensearchDashboardsRawConfig?.get('savedObjects.permission.enabled')) {
+
+  // A supplied configuration is authoritative. An absent one means the caller has no access to it,
+  // not that the features are off.
+  const permissionsEnabled = opensearchDashboardsRawConfig
+    ? !!opensearchDashboardsRawConfig.get('savedObjects.permission.enabled')
+    : conditionalFieldFlags.permissionsEnabled;
+  const workspacesEnabled = opensearchDashboardsRawConfig
+    ? !!opensearchDashboardsRawConfig.get('workspace.enabled')
+    : conditionalFieldFlags.workspacesEnabled;
+
+  if (permissionsEnabled) {
     const principals: SavedObjectsFieldMapping = {
       properties: {
         users: {
@@ -79,7 +104,7 @@ export function buildActiveMappings(
     });
   }
 
-  if (opensearchDashboardsRawConfig?.get('workspace.enabled')) {
+  if (workspacesEnabled) {
     mergedProperties = validateAndMerge(mapping.properties, {
       workspaces: {
         type: 'keyword',

--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
@@ -34,7 +34,6 @@
 
 import crypto from 'crypto';
 import { cloneDeep, mapValues } from 'lodash';
-import { Config } from '@osd/config';
 import {
   IndexMapping,
   SavedObjectsFieldMapping,
@@ -53,7 +52,7 @@ let conditionalFieldFlags: ConditionalFieldFlags = {
   workspacesEnabled: false,
 };
 
-/** Records the flags for callers that cannot supply the raw configuration. Called once, at setup. */
+/** Records the conditional-field decision. Called once, during core setup. */
 export function setConditionalFieldFlags(flags: ConditionalFieldFlags) {
   conditionalFieldFlags = flags;
 }
@@ -65,23 +64,13 @@ export function setConditionalFieldFlags(flags: ConditionalFieldFlags) {
  * @param typeDefinitions - the type definitions to build mapping from.
  */
 export function buildActiveMappings(
-  typeDefinitions: SavedObjectsTypeMappingDefinitions | SavedObjectsMappingProperties,
-  opensearchDashboardsRawConfig?: Config
+  typeDefinitions: SavedObjectsTypeMappingDefinitions | SavedObjectsMappingProperties
 ): IndexMapping {
   const mapping = defaultMapping();
 
   let mergedProperties = validateAndMerge(mapping.properties, typeDefinitions);
 
-  // A supplied configuration is authoritative. An absent one means the caller has no access to it,
-  // not that the features are off.
-  const permissionsEnabled = opensearchDashboardsRawConfig
-    ? !!opensearchDashboardsRawConfig.get('savedObjects.permission.enabled')
-    : conditionalFieldFlags.permissionsEnabled;
-  const workspacesEnabled = opensearchDashboardsRawConfig
-    ? !!opensearchDashboardsRawConfig.get('workspace.enabled')
-    : conditionalFieldFlags.workspacesEnabled;
-
-  if (permissionsEnabled) {
+  if (conditionalFieldFlags.permissionsEnabled) {
     const principals: SavedObjectsFieldMapping = {
       properties: {
         users: {
@@ -104,7 +93,7 @@ export function buildActiveMappings(
     });
   }
 
-  if (workspacesEnabled) {
+  if (conditionalFieldFlags.workspacesEnabled) {
     mergedProperties = validateAndMerge(mapping.properties, {
       workspaces: {
         type: 'keyword',

--- a/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
@@ -71,15 +71,7 @@ describe('IndexMigrator', () => {
     const { client } = testOpts;
 
     testOpts.mappingProperties = { foo: { type: 'long' } as any };
-    const rawConfig = configMock.create();
-    rawConfig.get.mockImplementation((path) => {
-      if (path === 'savedObjects.permission.enabled') {
-        return true;
-      } else {
-        return false;
-      }
-    });
-    testOpts.opensearchDashboardsRawConfig = rawConfig;
+    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: false });
 
     withIndex(client, { index: { statusCode: 404 }, alias: { statusCode: 404 } });
 
@@ -158,15 +150,7 @@ describe('IndexMigrator', () => {
     const { client } = testOpts;
 
     testOpts.mappingProperties = { foo: { type: 'long' } as any };
-    const rawConfig = configMock.create();
-    rawConfig.get.mockImplementation((path) => {
-      if (path === 'workspace.enabled') {
-        return true;
-      } else {
-        return false;
-      }
-    });
-    testOpts.opensearchDashboardsRawConfig = rawConfig;
+    setConditionalFieldFlags({ permissionsEnabled: false, workspacesEnabled: true });
 
     withIndex(client, { index: { statusCode: 404 }, alias: { statusCode: 404 } });
 

--- a/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
@@ -37,6 +37,7 @@ import { IndexMigrator } from './index_migrator';
 import { MigrationOpts } from './migration_context';
 import { loggingSystemMock } from '../../../logging/logging_system.mock';
 import { configMock } from '../../../config/mocks';
+import { setConditionalFieldFlags } from './build_active_mappings';
 
 describe('IndexMigrator', () => {
   let testOpts: jest.Mocked<MigrationOpts> & {
@@ -60,6 +61,11 @@ describe('IndexMigrator', () => {
       serializer: new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
     };
   });
+
+  // The flags are process-wide, so a test that records them would change every mapping built after.
+  afterEach(() =>
+    setConditionalFieldFlags({ permissionsEnabled: false, workspacesEnabled: false })
+  );
 
   test('creates the index when permission control for saved objects is enabled', async () => {
     const { client } = testOpts;
@@ -206,6 +212,27 @@ describe('IndexMigrator', () => {
       },
       index: '.kibana_1',
     });
+  });
+
+  test('creates the index with the conditional fields recorded by core when no configuration is supplied', async () => {
+    // Reproduces the multi-tenancy tenant index path, which constructs an IndexMigrator without the
+    // raw configuration.
+    const { client } = testOpts;
+
+    testOpts.mappingProperties = { foo: { type: 'long' } as any };
+    testOpts.opensearchDashboardsRawConfig = undefined;
+    setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: true });
+
+    withIndex(client, { index: { statusCode: 404 }, alias: { statusCode: 404 } });
+
+    await new IndexMigrator(testOpts).migrate();
+
+    const { mappings } = (client.indices.create as jest.Mock).mock.calls[0][0].body;
+    expect(mappings.properties).toHaveProperty('workspaces');
+    expect(mappings.properties).toHaveProperty('permissions');
+    // The hashes are what diffMappings compares, so they decide whether a migration is detected.
+    expect(mappings._meta.migrationMappingPropertyHashes).toHaveProperty('workspaces');
+    expect(mappings._meta.migrationMappingPropertyHashes).toHaveProperty('permissions');
   });
 
   test('creates the index if it does not exist', async () => {

--- a/src/core/server/saved_objects/migrations/core/migration_context.ts
+++ b/src/core/server/saved_objects/migrations/core/migration_context.ts
@@ -143,10 +143,7 @@ function createDestContext(
   opensearchDashboardsRawConfig?: Config
 ): Index.FullIndexInfo {
   const targetMappings = deleteTypeMappingsFields(
-    disableUnknownTypeMappingFields(
-      buildActiveMappings(typeMappingDefinitions, opensearchDashboardsRawConfig),
-      source.mappings
-    ),
+    disableUnknownTypeMappingFields(buildActiveMappings(typeMappingDefinitions), source.mappings),
     opensearchDashboardsRawConfig
   );
 

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.test.ts
@@ -38,6 +38,7 @@ import { loggingSystemMock } from '../../../logging/logging_system.mock';
 import { SavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import { SavedObjectsType } from '../../types';
 import { configMock } from '../../../config/mocks';
+import { setConditionalFieldFlags } from '../core/build_active_mappings';
 
 const createRegistry = (types: Array<Partial<SavedObjectsType>>) => {
   const registry = new SavedObjectTypeRegistry();
@@ -55,6 +56,11 @@ const createRegistry = (types: Array<Partial<SavedObjectsType>>) => {
 };
 
 describe('OpenSearchDashboardsMigrator', () => {
+  // The flags are process-wide, so a test that records them would change every mapping built after.
+  afterEach(() =>
+    setConditionalFieldFlags({ permissionsEnabled: false, workspacesEnabled: false })
+  );
+
   describe('getActiveMappings', () => {
     it('returns full index mappings w/ core properties', () => {
       const options = mockOptions();
@@ -79,19 +85,21 @@ describe('OpenSearchDashboardsMigrator', () => {
     });
 
     it('permissions field exists in the mappings when the feature is enabled', () => {
-      const options = mockOptions(false, true);
+      setConditionalFieldFlags({ permissionsEnabled: true, workspacesEnabled: false });
+      const options = mockOptions();
       const mappings = new OpenSearchDashboardsMigrator(options).getActiveMappings();
       expect(mappings).toHaveProperty('properties.permissions');
     });
 
     it('workspaces field exists in the mappings when the feature is enabled', () => {
-      const options = mockOptions(true, false);
+      setConditionalFieldFlags({ permissionsEnabled: false, workspacesEnabled: true });
+      const options = mockOptions();
       const mappings = new OpenSearchDashboardsMigrator(options).getActiveMappings();
       expect(mappings).toHaveProperty('properties.workspaces');
     });
 
     it('text field does not exist in the mappings when the feature is enabled', () => {
-      const options = mockOptions(false, false, { enabled: true, types: ['text'] });
+      const options = mockOptions({ enabled: true, types: ['text'] });
       const mappings = new OpenSearchDashboardsMigrator(options).getActiveMappings();
       expect(mappings).not.toHaveProperty('properties.text');
     });
@@ -165,41 +173,13 @@ type MockedOptions = OpenSearchDashboardsMigratorOptions & {
   client: ReturnType<typeof opensearchClientMock.createOpenSearchClient>;
 };
 
-const mockOptions = (
-  isWorkspaceEnabled?: boolean,
-  isPermissionControlEnabled?: boolean,
-  deleteConfig?: { enabled: boolean; types: string[] }
-) => {
+const mockOptions = (deleteConfig?: { enabled: boolean; types: string[] }) => {
   const rawConfig = configMock.create();
-  rawConfig.get.mockReturnValue(false);
-  if (isWorkspaceEnabled || isPermissionControlEnabled || deleteConfig?.enabled) {
-    rawConfig.get.mockReturnValue(true);
-  }
   rawConfig.get.mockImplementation((path) => {
-    if (path === 'savedObjects.permission.enabled') {
-      if (isPermissionControlEnabled) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (path === 'workspace.enabled') {
-      if (isWorkspaceEnabled) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (path === 'migrations.delete.enabled') {
-      if (deleteConfig?.enabled) {
-        return true;
-      } else {
-        return false;
-      }
+    if (path === 'migrations.delete.enabled') {
+      return !!deleteConfig?.enabled;
     } else if (path === 'migrations.delete.types') {
-      if (deleteConfig?.enabled) {
-        return deleteConfig?.types;
-      } else {
-        return [];
-      }
+      return deleteConfig?.enabled ? deleteConfig?.types : [];
     } else {
       return false;
     }

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.ts
@@ -113,10 +113,7 @@ export class OpenSearchDashboardsMigrator {
     this.opensearchDashboardsRawConfig = opensearchDashboardsRawConfig;
     // Building the active mappings (and associated md5sums) is an expensive
     // operation so we cache the result
-    this.activeMappings = buildActiveMappings(
-      this.mappingProperties,
-      this.opensearchDashboardsRawConfig
-    );
+    this.activeMappings = buildActiveMappings(this.mappingProperties);
   }
 
   /**

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -68,6 +68,8 @@ import { registerRoutes } from './routes';
 import { ServiceStatus, ServiceStatusLevels } from '../status';
 import { calculateStatus$ } from './status';
 import { createMigrationOpenSearchClient } from './migrations/core/';
+// Not via the barrel: this records process-wide state, and the barrel is what plugins deep-import.
+import { setConditionalFieldFlags } from './migrations/core/build_active_mappings';
 import { Config } from '../config';
 import { SqliteSavedObjectsRepository } from './storage/sqlite_repository';
 /**
@@ -357,6 +359,15 @@ export class SavedObjectsService implements CoreService<
       .pipe(first())
       .toPromise();
     this.config = new SavedObjectConfig(savedObjectsConfig, savedObjectsMigrationConfig);
+
+    // Recorded before any plugin runs, for callers that build mappings without the raw
+    // configuration. Permission control comes from the validated config -- the same source
+    // `getPermissionControlEnabled` reports -- so the two cannot drift. Workspaces belongs to the
+    // workspace plugin and has no validated counterpart here.
+    setConditionalFieldFlags({
+      permissionsEnabled: this.config.permission.enabled,
+      workspacesEnabled: !!this.opensearchDashboardsRawConfig.get('workspace.enabled'),
+    });
 
     // Wire up SQLite backend via the existing repository factory provider hook
     if (this.config.storage.backend === 'sqlite') {


### PR DESCRIPTION
### Description

With `savedObjects.permission.enabled`, `opensearch_security.multitenancy.enabled` and `workspace.enabled`, the tenant index was not migrated during service startup, resulting in missing 'permissions' and' workspaces' root fields.

**Root cause.** `buildActiveMappings` decides both fields from an *optional* second parameter read with `?.`, and the tenant paths never pass it, so both fields are silently omitted:

```ts
if (opensearchDashboardsRawConfig?.get('savedObjects.permission.enabled')) { ... }
if (opensearchDashboardsRawConfig?.get('workspace.enabled')) { ... }
```
This is not an oversight in the plugin. Its call was written in April 2020 (security-dashboards-plugin #168), when the function took a single argument; the second parameter arrived in March 2024 with the workspace work (#5949, #5084), and being optional it left the four-year-old caller behind without a word.

### Issues Resolved

Relates to #6314

## Screenshot

Not applicable: no UI change.

## Testing the changes

End to end, against a cluster with the security plugin and:

```yml
savedObjects.permission.enabled: true
opensearch_security.multitenancy.enabled: true
workspace.enabled: true
```

1. Start OpenSearch Dashboards and let the tenant migration run.
2. Check the template and any tenant index:

```
GET _index_template/tenant_template
GET .kibana_<hash>_<tenant>_<n>/_mapping
```

`_meta.migrationMappingPropertyHashes` goes from 31 entries to 33, and `properties` gains
`permissions` and `workspaces`.

3. Confirm the write that used to fail now succeeds:

```
PUT .kibana_<hash>_<tenant>_<n>/_doc/workspace:foo
{ "type": "workspace", "workspace": { "name": "foo" },
  "permissions": { "read": { "users": ["test"] } } }
```

With the features disabled, the mapping is unchanged — the recorded flags default to the previous behaviour, so no migration is triggered and no reindex occurs.

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff