### PR TITLE
Align global banner sidecar offset with EuiFlyout/EuiToast/EuiBottomBar mechanism

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -3001,13 +3001,7 @@ exports[`Header handles visibility and lock changes 1`] = `
     }
   }
 >
-  <HeaderBanner
-    style={
-      Object {
-        "paddingRight": 648,
-      }
-    }
-  />
+  <HeaderBanner />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -10405,13 +10399,7 @@ exports[`Header renders application header without title 1`] = `
     }
   }
 >
-  <HeaderBanner
-    style={
-      Object {
-        "paddingRight": 648,
-      }
-    }
-  />
+  <HeaderBanner />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -14851,13 +14839,7 @@ exports[`Header renders condensed header 1`] = `
     }
   }
 >
-  <HeaderBanner
-    style={
-      Object {
-        "paddingRight": 648,
-      }
-    }
-  />
+  <HeaderBanner />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -20534,13 +20516,7 @@ exports[`Header renders page header with application title 1`] = `
     }
   }
 >
-  <HeaderBanner
-    style={
-      Object {
-        "paddingRight": 648,
-      }
-    }
-  />
+  <HeaderBanner />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"
@@ -25184,13 +25160,7 @@ exports[`Header toggles primary navigation menu when clicked 1`] = `
     }
   }
 >
-  <HeaderBanner
-    style={
-      Object {
-        "paddingRight": 648,
-      }
-    }
-  />
+  <HeaderBanner />
   <header
     className="hide-for-sharing headerGlobalNav"
     data-test-subj="headerGlobalNav"

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -723,7 +723,7 @@ export function Header({
 
   return (
     <>
-      <HeaderBanner globalBanner={globalBanner} style={sidecarPaddingStyle} />
+      <HeaderBanner globalBanner={globalBanner} />
       <header className={className} data-test-subj="headerGlobalNav">
         <div id="globalHeaderBars">
           {!useUpdatedHeader && useExpandedHeader && renderLegacyExpandedHeader()}

--- a/src/core/public/chrome/ui/header/header_banner.tsx
+++ b/src/core/public/chrome/ui/header/header_banner.tsx
@@ -9,26 +9,17 @@
  * GitHub history for details.
  */
 
-import React, { CSSProperties } from 'react';
+import React from 'react';
 import { ChromeGlobalBanner } from '../../chrome_service';
 
 interface HeaderBannerProps {
   globalBanner?: ChromeGlobalBanner;
-  style?: CSSProperties;
 }
 
 /**
  * HeaderBanner component that renders the banner in the header
  * This component is extracted from the Header component for better separation and extensibility
  */
-export const HeaderBanner: React.FC<HeaderBannerProps> = ({ globalBanner, style }) => {
-  return (
-    <>
-      {globalBanner && (
-        <div className="globalBanner" style={style}>
-          {globalBanner.component}
-        </div>
-      )}
-    </>
-  );
+export const HeaderBanner: React.FC<HeaderBannerProps> = ({ globalBanner }) => {
+  return <>{globalBanner && <div className="globalBanner">{globalBanner.component}</div>}</>;
 };

--- a/src/plugins/banner/public/index.scss
+++ b/src/plugins/banner/public/index.scss
@@ -24,9 +24,8 @@ $expandedHeaderWidth: $headerWidth * 2;
   position: fixed;
   top: 0;
   left: 0;
-  right: 0;
+  right: var(--eui-overlay-offset-right, 0);
   z-index: $ouiZHeader - 1; // lower than flyouts
-  width: 100%;
   min-height: var(--global-banner-height);
 }
 


### PR DESCRIPTION
### Description

The global banner (`.globalBanner`) currently avoids the docked chat sidecar via an inline `paddingRight` style (`sidecarPaddingStyle`, added in #11893), computed directly from the sidecar config in `Header`.

Every other sidecar-aware component (`EuiFlyout`, `EuiGlobalToastList`, `EuiBottomBar`) avoids the sidecar through a different, shared mechanism: the `--eui-overlay-offset-right` CSS custom property, kept in sync by the sidecar service. This PR switches the banner to that same mechanism for consistency, so there is one sidecar-offset convention across the codebase instead of two.

- `src/plugins/banner/public/index.scss`: replace `right: 0` + `width: 100%` with `right: var(--eui-overlay-offset-right, 0)`
- `src/core/public/chrome/ui/header/header_banner.tsx` / `header.tsx`: remove the now-unused inline `paddingRight` (`sidecarPaddingStyle`) prop from `HeaderBanner`, since the CSS var now handles the offset
- Updated `header.test.tsx.snap` accordingly

### Issues Resolved

N/A

## Screenshot

Behavior is visually unchanged before/after this PR — the banner still shrinks to avoid the docked chat sidecar, now via CSS var instead of inline padding.

**Sidecar docked, banner correctly offset:**

<img width="877" height="293" alt="image" src="https://github.com/user-attachments/assets/7be5cb24-be6d-4321-9ebf-568b0ab3c941" />



<!-- PASTE SCREENSHOT HERE -->

## Testing the changes

1. Enable the banner plugin locally (`banner.enabled: true` + `banner.content` in `opensearch_dashboards.yml`)
2. Start OSD and open the chat sidecar (docked right)
3. Verify the banner's right edge shrinks to avoid the sidecar
4. Close the sidecar and verify the banner returns to full width

### Check List

- [x] All tests pass
  - [x] `yarn test:jest` (`header.test.tsx`: 15/15 passing)
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
