### PR TITLE
[Chat] Suppress chat input auto-focus on bootstrap window auto-open

### DIFF
--- a/src/plugins/chat/public/components/chat_input.test.tsx
+++ b/src/plugins/chat/public/components/chat_input.test.tsx
@@ -29,7 +29,7 @@ jest.mock('../hooks/use_command_menu_keyboard', () => ({
   }),
 }));
 
-// Mock useOpenSearchDashboards hook
+// Mock useOpenSearchDashboards hook (still used for the screenshot button)
 jest.mock('../../../opensearch_dashboards_react/public', () => {
   const { BehaviorSubject } = jest.requireActual('rxjs');
   const mockScreenshotButton$ = new BehaviorSubject({
@@ -303,12 +303,25 @@ describe('ChatInput', () => {
       expect(getByLabelText('Stop generating')).toBeTruthy();
     });
 
-    it('should have autofocus on input', () => {
+    it('should auto-focus input when ownFocus is true', () => {
+      const { getByPlaceholderText } = render(<ChatInput {...defaultProps} ownFocus={true} />);
+
+      const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('should NOT auto-focus input when ownFocus is false', () => {
+      const { getByPlaceholderText } = render(<ChatInput {...defaultProps} ownFocus={false} />);
+
+      const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
+      expect(document.activeElement).not.toBe(input);
+    });
+
+    it('should NOT auto-focus input when ownFocus is not provided (defaults to false)', () => {
       const { getByPlaceholderText } = render(<ChatInput {...defaultProps} />);
 
       const input = getByPlaceholderText('How can I help you today?') as HTMLTextAreaElement;
-      // Input should exist and be focused
-      expect(input).toBeTruthy();
+      expect(document.activeElement).not.toBe(input);
     });
   });
 

--- a/src/plugins/chat/public/components/chat_input.tsx
+++ b/src/plugins/chat/public/components/chat_input.tsx
@@ -31,6 +31,10 @@ interface ChatInputProps {
   onKeyDown: (e: React.KeyboardEvent) => void;
   includeScreenShotEnabled: boolean;
   onCaptureScreenshot: () => void;
+  // Whether the input should auto-focus on mount. Callers should only pass
+  // true when the window was opened by an explicit user/agent action (not
+  // on bootstrap auto-open, to avoid stealing focus from the page on load).
+  ownFocus?: boolean;
 }
 
 export const ChatInput: React.FC<ChatInputProps> = ({
@@ -46,6 +50,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   onKeyDown,
   includeScreenShotEnabled,
   onCaptureScreenshot,
+  ownFocus = false,
 }) => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -116,7 +121,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             value={input}
             onChange={(e) => onInputChange(e.target.value)}
             onKeyDown={handleKeyDown}
-            autoFocus={true}
+            // Only auto-focus when the window was opened by an explicit user/
+            // agent action. Bootstrap auto-open (restoring persisted window
+            // state) passes ownFocus=false, so we don't steal focus on page
+            // load. Caller (ChatWindow) computes this from the chat
+            // plugin's ChatService — see ChatService#getShouldAutoFocusInput.
+            autoFocus={ownFocus}
             fullWidth
             resize="none"
             rows={2}

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -883,6 +883,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
               onKeyDown={handleKeyDown}
               includeScreenShotEnabled={screenshotFeatureEnabled}
               onCaptureScreenshot={handleCaptureScreenshot}
+              ownFocus={chatService?.getShouldAutoFocusInput?.() ?? false}
             />
           </ChatSessionErrorBoundary>
         )}

--- a/src/plugins/chat/public/plugin.test.ts
+++ b/src/plugins/chat/public/plugin.test.ts
@@ -374,6 +374,13 @@ describe('ChatPlugin', () => {
       });
     });
 
+    it('should open chat window by default when no stored state exists', () => {
+      // No localStorage state set (first visit)
+      plugin.start(mockCoreStart, mockDeps);
+
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
+    });
+
     it('should persist window state changes to localStorage', () => {
       const windowStateSubject = new BehaviorSubject({
         isWindowOpen: false,
@@ -407,8 +414,9 @@ describe('ChatPlugin', () => {
       plugin.start(mockCoreStart, mockDeps);
 
       // Should not call setWindowState with invalid data from localStorage
-      // but will be called with paddingSize from sidecar config subscription
-      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(1);
+      // but will be called with default open state + paddingSize from sidecar config subscription
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(2);
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
       expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ paddingSize: 400 });
     });
   });

--- a/src/plugins/chat/public/plugin.test.ts
+++ b/src/plugins/chat/public/plugin.test.ts
@@ -336,8 +336,21 @@ describe('ChatPlugin', () => {
         configurable: true, // Required for jsdom 26: localStorage is non-configurable by default
       });
 
-      // Mock core.chat methods
-      mockCoreStart.chat.setWindowState = jest.fn();
+      // Mock core.chat methods. setWindowState synchronously invokes the
+      // registered onWindowOpen callback when isWindowOpen becomes true —
+      // mirroring the real core ChatService, where windowState$.next(...)
+      // drives the onWindowOpen subscription synchronously in the same call
+      // stack (see src/core/public/chat/chat_service.ts). This is required
+      // for the isBootstrapping-guard tests below, which depend on the
+      // callback firing while the bootstrap setWindowState call is still on
+      // the stack.
+      mockCoreStart.chat.setWindowState = jest.fn((partialState: { isWindowOpen?: boolean }) => {
+        if (partialState.isWindowOpen === true) {
+          (mockCoreStart.chat.onWindowOpen as jest.Mock).mock.calls.forEach(
+            ([callback]: [() => void]) => callback()
+          );
+        }
+      });
       mockCoreStart.chat.openWindow = jest.fn().mockResolvedValue(undefined);
       mockCoreStart.chat.getWindowState$ = jest.fn().mockReturnValue(
         of({
@@ -374,13 +387,6 @@ describe('ChatPlugin', () => {
       });
     });
 
-    it('should open chat window by default when no stored state exists', () => {
-      // No localStorage state set (first visit)
-      plugin.start(mockCoreStart, mockDeps);
-
-      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
-    });
-
     it('should persist window state changes to localStorage', () => {
       const windowStateSubject = new BehaviorSubject({
         isWindowOpen: false,
@@ -404,6 +410,13 @@ describe('ChatPlugin', () => {
       );
     });
 
+    it('should open chat window by default when no stored state exists', () => {
+      // No localStorage state set (first visit)
+      plugin.start(mockCoreStart, mockDeps);
+
+      expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
+    });
+
     it('should not restore invalid state from localStorage', () => {
       // Set invalid state in localStorage
       mockLocalStorage['chat.windowState'] = JSON.stringify({
@@ -413,11 +426,67 @@ describe('ChatPlugin', () => {
 
       plugin.start(mockCoreStart, mockDeps);
 
-      // Should not call setWindowState with invalid data from localStorage
-      // but will be called with default open state + paddingSize from sidecar config subscription
+      // Should not call setWindowState with invalid data from localStorage,
+      // but will fall back to the first-visit default open, plus be called
+      // with paddingSize from the sidecar config subscription
       expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledTimes(2);
       expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ isWindowOpen: true });
       expect(mockCoreStart.chat.setWindowState).toHaveBeenCalledWith({ paddingSize: 400 });
+    });
+
+    it('should NOT request auto-focus for the bootstrap window-open triggered by first-visit default open', () => {
+      // No stored state — plugin falls back to the first-visit default open,
+      // which synchronously fires onWindowOpen while isBootstrapping is
+      // still true (see the setWindowState mock above).
+      const startContract = plugin.start(mockCoreStart, mockDeps);
+      const chatServiceInstance = startContract.chatService as jest.Mocked<ChatService>;
+
+      expect(chatServiceInstance.setShouldAutoFocusInput).toHaveBeenCalledWith(false);
+    });
+
+    it('should NOT request auto-focus for the bootstrap window-open triggered by restoring localStorage', () => {
+      mockLocalStorage['chat.windowState'] = JSON.stringify({
+        isWindowOpen: true,
+        windowMode: 'sidecar',
+        paddingSize: 400,
+      });
+
+      const startContract = plugin.start(mockCoreStart, mockDeps);
+      const chatServiceInstance = startContract.chatService as jest.Mocked<ChatService>;
+
+      // setWindowState (mocked above) synchronously fires onWindowOpen while
+      // isBootstrapping is still true, matching the real core ChatService.
+      expect(chatServiceInstance.setShouldAutoFocusInput).toHaveBeenCalledWith(false);
+    });
+
+    it('should request auto-focus for a window-open NOT triggered by bootstrap', () => {
+      mockLocalStorage['chat.windowState'] = JSON.stringify({
+        isWindowOpen: true,
+        windowMode: 'sidecar',
+        paddingSize: 400,
+      });
+
+      const startContract = plugin.start(mockCoreStart, mockDeps);
+      const chatServiceInstance = startContract.chatService as jest.Mocked<ChatService>;
+
+      // Bootstrap has already completed by the time start() returns.
+      // Simulate a later, explicit open (header button / quick-start /
+      // agent) — dispatched after the isBootstrapping guard has closed.
+      const onWindowOpenCallback = (mockCoreStart.chat.onWindowOpen as jest.Mock).mock.calls[0][0];
+      onWindowOpenCallback();
+
+      expect(chatServiceInstance.setShouldAutoFocusInput).toHaveBeenCalledWith(true);
+    });
+
+    it('should clear the auto-focus signal on window close', () => {
+      const startContract = plugin.start(mockCoreStart, mockDeps);
+      const chatServiceInstance = startContract.chatService as jest.Mocked<ChatService>;
+
+      const onWindowCloseCallback = (mockCoreStart.chat.onWindowClose as jest.Mock).mock
+        .calls[0][0];
+      onWindowCloseCallback();
+
+      expect(chatServiceInstance.setShouldAutoFocusInput).toHaveBeenCalledWith(false);
     });
   });
 

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -80,6 +80,9 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
 
     if (isValidChatWindowState(storeState)) {
       chat.setWindowState(storeState);
+    } else {
+      // First visit or no stored state — open chat by default
+      chat.setWindowState({ isWindowOpen: true });
     }
 
     this.paddingSizeSubscription = overlays.sidecar

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -56,6 +56,8 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
   private chatMountService?: ChatMountService;
   private paddingSizeSubscription?: Subscription;
   private windowStateChangeSubscription?: Subscription;
+  private autoFocusWindowOpenSubscription?: () => void;
+  private autoFocusWindowCloseSubscription?: () => void;
   private coreSetup?: CoreSetup;
 
   constructor(private initializerContext: PluginInitializerContext) {}
@@ -78,12 +80,30 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
       // eslint-disable-next-line no-empty
     } catch {}
 
+    // Chat-input auto-focus wiring (UI concern, kept local to this plugin —
+    // see ChatService#shouldAutoFocusInput$ for the rationale). `onWindowOpen`
+    // fires synchronously off the underlying BehaviorSubject, so bracketing
+    // both bootstrap branches below (restore, and first-visit default open)
+    // with `isBootstrapping` lets us tell them apart from every other
+    // (explicit) open: the header "Ask AI" button, workspace quick-start, and
+    // sendMessageWithWindow all go through `core.chat.openWindow()`, never
+    // through this bootstrap path.
+    let isBootstrapping = false;
+    this.autoFocusWindowOpenSubscription = chat.onWindowOpen(() => {
+      this.chatService?.setShouldAutoFocusInput(!isBootstrapping);
+    });
+    this.autoFocusWindowCloseSubscription = chat.onWindowClose(() => {
+      this.chatService?.setShouldAutoFocusInput(false);
+    });
+
+    isBootstrapping = true;
     if (isValidChatWindowState(storeState)) {
       chat.setWindowState(storeState);
     } else {
       // First visit or no stored state — open chat by default
       chat.setWindowState({ isWindowOpen: true });
     }
+    isBootstrapping = false;
 
     this.paddingSizeSubscription = overlays.sidecar
       .getSidecarConfig$()
@@ -240,6 +260,8 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
     this.chatMountService?.stop();
     this.paddingSizeSubscription?.unsubscribe();
     this.windowStateChangeSubscription?.unsubscribe();
+    this.autoFocusWindowOpenSubscription?.();
+    this.autoFocusWindowCloseSubscription?.();
     this.chatService?.destroy();
     this.confirmationService.cleanAll();
   }

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -2335,4 +2335,18 @@ describe('ChatService', () => {
       expect(result.rawMessage).toBe('spaced');
     });
   });
+
+  describe('shouldAutoFocusInput', () => {
+    it('should default to false', () => {
+      expect(chatService.getShouldAutoFocusInput()).toBe(false);
+    });
+
+    it('should reflect the value set via setShouldAutoFocusInput', () => {
+      chatService.setShouldAutoFocusInput(true);
+      expect(chatService.getShouldAutoFocusInput()).toBe(true);
+
+      chatService.setShouldAutoFocusInput(false);
+      expect(chatService.getShouldAutoFocusInput()).toBe(false);
+    });
+  });
 });

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { AgUiAgent } from './ag_ui_agent';
 import { RunAgentInput, Message, UserMessage, ToolMessage } from '../../common/types';
 import type { ToolDefinition } from '../../../context_provider/public';
@@ -51,6 +51,16 @@ export class ChatService {
   private coreChatService?: ChatServiceStart;
   private workspaces?: WorkspacesStart;
   private savedObjectsClient?: SavedObjectsClientContract;
+
+  // Chat-UI-scoped, non-persisted signal: whether the chat input should
+  // auto-focus when the ChatWindow next mounts. Driven by the plugin
+  // (see plugin.ts#setupChatbotWindowState) so that explicit opens (header
+  // "Ask AI" button, workspace quick-start, sendMessageWithWindow) focus the
+  // input, while bootstrap auto-open (restoring persisted window state)
+  // does not steal focus on page load. Deliberately lives in the chat
+  // plugin rather than core.public.chat — it is a UI concern, not part of
+  // core's window-lifecycle contract.
+  private shouldAutoFocusInput$ = new BehaviorSubject<boolean>(false);
 
   // ChatWindow instance for delegating sendMessage calls to proper timeline management
   private chatWindowInstance: ChatWindowInstance | null = null;
@@ -173,6 +183,23 @@ export class ChatService {
     const paddingSize = this.coreChatService.getWindowState().paddingSize;
     // Fallback to default if undefined
     return paddingSize ?? 400;
+  }
+
+  /**
+   * Whether the chat input should auto-focus when the window mounts.
+   * See `shouldAutoFocusInput$` for the full rationale.
+   */
+  public getShouldAutoFocusInput(): boolean {
+    return this.shouldAutoFocusInput$.getValue();
+  }
+
+  /**
+   * Set the auto-focus-on-mount signal. Called by the plugin's window-open/
+   * close wiring (see plugin.ts#setupChatbotWindowState) — not intended to
+   * be called directly by UI components.
+   */
+  public setShouldAutoFocusInput(value: boolean): void {
+    this.shouldAutoFocusInput$.next(value);
   }
 
   // ChatWindow instance management for proper timeline handling


### PR DESCRIPTION
### Description
The chat input hard-coded `autoFocus={true}`, so it grabbed focus every time the `ChatWindow` mounted — including when the window auto-opens during app bootstrap (first-visit default open, or restoring a persisted `isWindowOpen: true` state). That stole focus from the page on load.

This adds a transient, non-persisted `shouldAutoFocusInput` signal to the core chat service, default `false`, set to `true` only by `openWindow()` — the explicit user/agent open path (header "Ask AI" button, workspace quick-start, and `sendMessageWithWindow`). Bootstrap paths call `setWindowState()` directly and leave it `false`. `ChatInput` reads `getShouldAutoFocusInput()` for its `autoFocus` prop (fallback `false`).

Net behavior: explicit opens still focus the input; bootstrap auto-open does not.

### Issues Resolved
N/A (UX fix)

### Testing
- `chat_service.test.ts`: signal is `false` after bootstrap `setWindowState`, `true` after `openWindow`, `false` after `closeWindow`.
- `chat_input.test.tsx`: input is focused when the signal is `true`, not focused when `false`.

### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`
