### PR TITLE
[Dashboard Variables] Add usage telemetry for Dashboard Variables

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -117,6 +117,7 @@ export interface DashboardContainerOptions {
   data?: DataPublicPluginStart;
   initialVariables?: Variable[];
   savedObjects?: CoreStart['savedObjects'];
+  telemetry?: CoreStart['telemetry'];
 }
 
 export type DashboardReactContextValue =
@@ -157,7 +158,8 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
     this.variableService = new VariableService(
       options.data,
       initialInput.id,
-      options.savedObjects?.client
+      options.savedObjects?.client,
+      (event) => options.telemetry?.getPluginRecorder().recordEvent(event)
     );
 
     this.variableService.initialize(initialInput.variables);

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container_factory.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container_factory.tsx
@@ -57,6 +57,7 @@ interface StartServices {
   ExitFullScreenButton: React.ComponentType<any>;
   uiActions: UiActionsStart;
   data?: DataPublicPluginStart;
+  telemetry?: CoreStart['telemetry'];
 }
 
 export type DashboardContainerFactory = EmbeddableFactory<

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -289,6 +289,7 @@ export class DashboardPlugin implements Plugin<
         ExitFullScreenButton,
         uiActions: deps.uiActions,
         data: deps.data,
+        telemetry: coreStart.telemetry,
       };
     };
 

--- a/src/plugins/dashboard/public/variables/variable_service.test.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.test.ts
@@ -38,15 +38,18 @@ function createService(initialVariables: Variable[] = [], dashboardId?: string) 
     get: jest.fn().mockResolvedValue({ attributes: {} }),
   };
 
+  const telemetrySink = jest.fn();
+
   const service = new VariableService(
     {} as any, // dataPlugin
     dashboardId,
-    mockSavedObjectsClient as any
+    mockSavedObjectsClient as any,
+    telemetrySink
   );
 
   service.initialize(initialVariables);
 
-  return { service, mockSavedObjectsClient };
+  return { service, mockSavedObjectsClient, telemetrySink };
 }
 
 function makeCustomVariable(overrides: Partial<CustomVariable> = {}): CustomVariable {
@@ -1413,6 +1416,202 @@ describe('VariableService', () => {
       expect(vars[0].options.length).toBe(100);
       expect(vars[0].options[0].value).toBe('option-050');
       expect(vars[0].options[99].value).toBe('option-149');
+    });
+  });
+
+  describe('telemetry', () => {
+    it('should not report anything when no telemetry sink is provided', async () => {
+      // Sink is optional -- consumers like the explore plugin construct the
+      // service without one and must not break.
+      const service = new VariableService({} as any, 'dash-1', {
+        update: jest.fn().mockResolvedValue({}),
+      } as any);
+      service.initialize([makeCustomVariable()]);
+
+      await expect(
+        service.addVariable({
+          name: 'new_var',
+          type: VariableType.Custom,
+          customOptions: ['a'],
+        } as any)
+      ).resolves.toBeUndefined();
+    });
+
+    describe('variables_loaded', () => {
+      it('should report count and distinct types on initialize', () => {
+        const { telemetrySink } = createService([
+          makeCustomVariable({ id: 'c1', name: 'env' }),
+          makeCustomVariable({ id: 'c2', name: 'region' }),
+          makeQueryVariable({ id: 'q1', name: 'service' }),
+        ]);
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variables_loaded',
+          data: { count: 3, types: [VariableType.Custom, VariableType.Query] },
+        });
+      });
+
+      it('should not report when the dashboard has no variables', () => {
+        const { telemetrySink } = createService([]);
+
+        expect(telemetrySink).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'variables_loaded' })
+        );
+      });
+    });
+
+    describe('create', () => {
+      it('should report variable_create_succeeded with the type', async () => {
+        const { service, telemetrySink } = createService([], 'dash-1');
+
+        await service.addVariable({
+          name: 'env',
+          type: VariableType.Custom,
+          customOptions: ['dev'],
+        } as any);
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_create_succeeded',
+          data: { type: VariableType.Custom },
+        });
+      });
+
+      it('should report variable_create_failed and rethrow when persistence fails', async () => {
+        const { service, mockSavedObjectsClient, telemetrySink } = createService([], 'dash-1');
+        mockSavedObjectsClient.update.mockRejectedValue(new TypeError('boom'));
+
+        await expect(
+          service.addVariable({
+            name: 'env',
+            type: VariableType.Custom,
+            customOptions: ['dev'],
+          } as any)
+        ).rejects.toThrow('boom');
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_create_failed',
+          data: { type: VariableType.Custom, errorType: 'TypeError' },
+        });
+        expect(telemetrySink).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'variable_create_succeeded' })
+        );
+      });
+    });
+
+    describe('update', () => {
+      it('should report variable_update_succeeded with the resolved type', async () => {
+        const { service, telemetrySink } = createService([makeCustomVariable()], 'dash-1');
+
+        // A partial update carrying no `type` must still report the real type.
+        await service.updateVariable('custom-1', { name: 'renamed' });
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_update_succeeded',
+          data: { type: VariableType.Custom },
+        });
+      });
+
+      it('should report variable_update_failed and rethrow when persistence fails', async () => {
+        const { service, mockSavedObjectsClient, telemetrySink } = createService(
+          [makeCustomVariable()],
+          'dash-1'
+        );
+        mockSavedObjectsClient.update.mockRejectedValue(new Error('nope'));
+
+        await expect(service.updateVariable('custom-1', { name: 'renamed' })).rejects.toThrow(
+          'nope'
+        );
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_update_failed',
+          data: { type: VariableType.Custom, errorType: 'Error' },
+        });
+      });
+    });
+
+    describe('delete', () => {
+      it('should report variable_deleted with the removed variable type', async () => {
+        const { service, telemetrySink } = createService([makeCustomVariable()], 'dash-1');
+
+        await service.removeVariable('custom-1');
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_deleted',
+          data: { type: VariableType.Custom },
+        });
+      });
+    });
+
+    describe('value change', () => {
+      it('should report variable_value_changed', () => {
+        const { service, telemetrySink } = createService([makeCustomVariable()], 'dash-1');
+
+        service.updateVariableValue('custom-1', ['prod']);
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_value_changed',
+          data: { type: VariableType.Custom },
+        });
+      });
+    });
+
+    describe('variable_query_failed', () => {
+      // Isolate the mock queue so a leftover *Once implementation from an
+      // earlier test cannot shadow the rejection under test, and restore the
+      // module-level default afterwards.
+      beforeEach(() => {
+        mockExecuteVariableQuery.mockReset();
+      });
+      afterEach(() => {
+        mockExecuteVariableQuery.mockResolvedValue(makeQueryResult([]));
+      });
+
+      it('should report the failure with language and error type', async () => {
+        const { service, telemetrySink } = createService([makeQueryVariable()], 'dash-1');
+        mockExecuteVariableQuery.mockRejectedValueOnce(new TypeError('bad query'));
+
+        await service.refreshVariableOptions('query-1');
+
+        expect(telemetrySink).toHaveBeenCalledWith({
+          name: 'variable_query_failed',
+          data: { type: VariableType.Query, language: 'PPL', errorType: 'TypeError' },
+        });
+      });
+
+      it('should not report aborted refreshes', async () => {
+        const { service, telemetrySink } = createService([makeQueryVariable()], 'dash-1');
+        const abortError = new Error('aborted');
+        abortError.name = 'AbortError';
+        mockExecuteVariableQuery.mockRejectedValueOnce(abortError);
+
+        await service.refreshVariableOptions('query-1');
+
+        expect(telemetrySink).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'variable_query_failed' })
+        );
+      });
+    });
+
+    it('should not break the feature when the sink throws', async () => {
+      const throwingSink = jest.fn(() => {
+        throw new Error('sink exploded');
+      });
+      const service = new VariableService(
+        {} as any,
+        'dash-1',
+        { update: jest.fn().mockResolvedValue({}) } as any,
+        throwingSink
+      );
+      service.initialize([]);
+
+      await expect(
+        service.addVariable({
+          name: 'env',
+          type: VariableType.Custom,
+          customOptions: ['dev'],
+        } as any)
+      ).resolves.toBeUndefined();
+      expect(throwingSink).toHaveBeenCalled();
     });
   });
 });

--- a/src/plugins/dashboard/public/variables/variable_service.ts
+++ b/src/plugins/dashboard/public/variables/variable_service.ts
@@ -35,6 +35,14 @@ import { IVariableInterpolationService } from './variable_interpolation_service'
 const MAX_DISPLAY_OPTIONS = 100;
 
 /**
+ * Minimal telemetry sink so this service can report feature usage without
+ * depending on core. Mirrors the pattern used by the query_enhancements plugin.
+ * Callers wire this to core.telemetry's plugin recorder; when omitted, all
+ * reporting is skipped.
+ */
+export type VariableTelemetrySink = (event: { name: string; data: Record<string, any> }) => void;
+
+/**
  * VariableService — a self-contained feature for managing dashboard variables.
  */
 export class VariableService {
@@ -46,20 +54,37 @@ export class VariableService {
   private interpolationService?: IVariableInterpolationService;
   private runtimeState: Map<string, VariableState> = new Map();
   private runtimeStateChange$ = new BehaviorSubject<number>(0);
+  private telemetrySink?: VariableTelemetrySink;
 
   /**
    * @param dataPlugin - Data plugin for executing queries
    * @param dashboardId - Dashboard ID for auto-saving (optional)
    * @param savedObjectsClient - Client for saving to dashboard saved object
+   * @param telemetrySink - Optional sink for feature-usage telemetry
    */
   constructor(
     dataPlugin?: DataPublicPluginStart,
     dashboardId?: string,
-    savedObjectsClient?: SavedObjectsClientContract
+    savedObjectsClient?: SavedObjectsClientContract,
+    telemetrySink?: VariableTelemetrySink
   ) {
     this.dataPlugin = dataPlugin;
     this.dashboardId = dashboardId;
     this.savedObjectsClient = savedObjectsClient;
+    this.telemetrySink = telemetrySink;
+  }
+
+  /**
+   * Report a telemetry event. Never throws -- telemetry must not break the
+   * feature it measures.
+   */
+  private recordTelemetry(name: string, data: Record<string, any> = {}): void {
+    try {
+      this.telemetrySink?.({ name, data });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('[VariableService] Failed to record telemetry:', e);
+    }
   }
 
   public setInterpolationService(service: IVariableInterpolationService): void {
@@ -82,6 +107,14 @@ export class VariableService {
    */
   public initialize(initialVariables: Variable[] = []): void {
     this.variables$.next(initialVariables);
+
+    // Telemetry: reported once per dashboard load that carries variables.
+    if (initialVariables.length > 0) {
+      this.recordTelemetry('variables_loaded', {
+        count: initialVariables.length,
+        types: Array.from(new Set(initialVariables.map((v) => v.type))),
+      });
+    }
   }
 
   /**
@@ -161,7 +194,17 @@ export class VariableService {
     newVariable.current = current;
 
     const updatedVariables = [...this.getVariables(), newVariable];
-    await this.saveVariables(updatedVariables);
+
+    try {
+      await this.saveVariables(updatedVariables);
+    } catch (error) {
+      this.recordTelemetry('variable_create_failed', {
+        type: newVariable.type,
+        errorType: (error as Error)?.name ?? 'Unknown',
+      });
+      throw error;
+    }
+    this.recordTelemetry('variable_create_succeeded', { type: newVariable.type });
     this.updateRuntimeState(id, initialRuntimeState);
 
     if (newVariable.type === VariableType.Query) {
@@ -242,7 +285,17 @@ export class VariableService {
 
     const updatedVariables = [...currentVariables];
     updatedVariables[index] = updatedVariable;
-    await this.saveVariables(updatedVariables);
+
+    try {
+      await this.saveVariables(updatedVariables);
+    } catch (error) {
+      this.recordTelemetry('variable_update_failed', {
+        type: updatedVariable.type,
+        errorType: (error as Error)?.name ?? 'Unknown',
+      });
+      throw error;
+    }
+    this.recordTelemetry('variable_update_succeeded', { type: updatedVariable.type });
 
     // Update runtime state only after successful save
     if (newRuntimeState) {
@@ -258,9 +311,11 @@ export class VariableService {
   }
 
   public async removeVariable(id: string): Promise<void> {
+    const removed = this.getVariables().find((v) => v.id === id);
     const updatedVariables = this.getVariables().filter((v) => v.id !== id);
     this.refreshControllers.get(id)?.abort();
     await this.saveVariables(updatedVariables);
+    this.recordTelemetry('variable_deleted', { type: removed?.type ?? 'unknown' });
 
     this.refreshControllers.delete(id);
     this.runtimeState.delete(id);
@@ -297,6 +352,8 @@ export class VariableService {
     const updatedVariables = [...currentVariables];
     updatedVariables[index] = { ...variable, current: value } as Variable;
     this.variables$.next(updatedVariables);
+    // Telemetry: record variable change.
+    this.recordTelemetry('variable_value_changed', { type: variable.type });
 
     this.refreshDependentVariables(variable.name);
   }
@@ -352,6 +409,11 @@ export class VariableService {
       if (error?.name === 'AbortError') {
         return;
       }
+      this.recordTelemetry('variable_query_failed', {
+        type: queryVariable.type,
+        language: queryVariable.language ?? 'unknown',
+        errorType: error?.name ?? 'Unknown',
+      });
       this.updateRuntimeState(id, {
         loading: false,
         error: error.message || 'Failed to fetch options',


### PR DESCRIPTION
### Description
Add usage telemetry for Dashboard Variables and all events are emitted with `source: 'dashboard'`:

| Event | When | `data` |
|---|---|---|
| `variables_loaded` | A dashboard carrying variables is loaded | `count`, `types[]` |
| `variable_create_succeeded` | A new variable is persisted | `type` |
| `variable_create_failed` | Persisting a new variable throws | `type`, `errorType` |
| `variable_update_succeeded` | An existing variable is persisted | `type` |
| `variable_update_failed` | Persisting an update throws | `type`, `errorType` |
| `variable_deleted` | A variable is removed | `type` |
| `variable_value_changed` | A value is selected from the variables bar | `type` |
| `variable_query_failed` | A query variable fails to fetch options | `type`, `language`, `errorType` |

`variables_loaded` and `variable_value_changed` are the important ones for adoption: they count *consumption* (any viewer opening or interacting with a variable-enabled dashboard), not just authoring. `variable_query_failed` is the only runtime reliability signal — a failed fetch means the user sees an empty dropdown.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
