### PR TITLE
feat(chat): auto-focus input and record telemetry on suggestion click

### DIFF
--- a/src/plugins/chat/public/components/chat_input.tsx
+++ b/src/plugins/chat/public/components/chat_input.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useRef, useMemo } from 'react';
+import React, { useRef, useMemo, forwardRef, useImperativeHandle } from 'react';
 import { EuiButtonIcon, EuiTextColor, EuiTextArea } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { useObservable } from 'react-use';
@@ -37,22 +37,27 @@ interface ChatInputProps {
   ownFocus?: boolean;
 }
 
-export const ChatInput: React.FC<ChatInputProps> = ({
-  layoutMode,
-  input,
-  isCapturing,
-  isStreaming,
-  disabled = false,
-  placeholder,
-  onInputChange,
-  onSend,
-  onStop,
-  onKeyDown,
-  includeScreenShotEnabled,
-  onCaptureScreenshot,
-  ownFocus = false,
-}) => {
+export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(function (
+  {
+    layoutMode,
+    input,
+    isCapturing,
+    isStreaming,
+    disabled = false,
+    placeholder,
+    onInputChange,
+    onSend,
+    onStop,
+    onKeyDown,
+    includeScreenShotEnabled,
+    onCaptureScreenshot,
+    ownFocus = false,
+  },
+  ref
+) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useImperativeHandle(ref, () => inputRef.current!);
 
   const {
     services: {
@@ -161,4 +166,4 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       </div>
     </div>
   );
-};
+});

--- a/src/plugins/chat/public/components/chat_suggestions.test.tsx
+++ b/src/plugins/chat/public/components/chat_suggestions.test.tsx
@@ -151,6 +151,30 @@ describe('ChatSuggestions', () => {
     });
   });
 
+  it('should call onFillInput when an inline suggestion is clicked', async () => {
+    const onFillInput = jest.fn();
+    mockSuggestedActionsService.getCustomSuggestions.mockResolvedValue([]);
+
+    render(
+      <ChatSuggestions
+        messages={mockMessages}
+        currentMessage={{
+          ...mockMessage,
+          content: 'Hi there!\nSUGGESTIONS:["What is OpenSearch?"]',
+        }}
+        onFillInput={onFillInput}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('What is OpenSearch?')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('What is OpenSearch?'));
+
+    expect(onFillInput).toHaveBeenCalledWith('What is OpenSearch?');
+  });
+
   it('should invoke action callback when suggestion is clicked', async () => {
     const mockAction = jest.fn().mockResolvedValue(true);
     const mockSuggestions = [

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -79,6 +79,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     const [isLoading, setIsLoading] = useState(false);
     const handleSendRef = useRef<typeof handleSend>();
     const currentSubscriptionRef = useRef<any>(null);
+    const chatInputRef = useRef<HTMLTextAreaElement>(null);
     const conversationLoadAbortControllerRef = useRef<AbortController | null>(null);
     const { screenshotFeatureEnabled, isCapturing, capturePageContainer } =
       usePageContainerCapture();
@@ -799,7 +800,11 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
               onResendToolResult={handleResendToolResult}
               onApproveConfirmation={handleApproveConfirmation}
               onRejectConfirmation={handleRejectConfirmation}
-              onFillInput={setInput}
+              onFillInput={(content) => {
+                setInput(content);
+                chatInputRef.current?.focus();
+                telemetryRecorder?.recordEvent({ name: 'suggestion_click', data: {} });
+              }}
               inputValue={input}
               onRemoveInput={(content: string) =>
                 setInput((prev) => prev.replace(content, '').trim())
@@ -859,6 +864,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             )}
 
             <ChatInput
+              ref={chatInputRef}
               layoutMode={layoutMode}
               input={input}
               isCapturing={isCapturing}


### PR DESCRIPTION
### Description

Improves the chat suggestion UX and adds telemetry tracking:

- **Auto-focus**: Clicking an inline suggestion now focuses the chat input automatically, so the user can immediately send or edit without an extra click.
- **Ref forwarding**: `ChatInput` is refactored to use `forwardRef<HTMLTextAreaElement>` + `useImperativeHandle`, exposing the underlying textarea DOM node to the parent.
- **Telemetry**: Records a `suggestion_click` event via `telemetryRecorder` whenever an inline suggestion fills the input.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->

## Screenshot

<!-- UI change: suggestion click now focuses the input field -->

## Testing the changes

1. Open the chat panel and send a message that returns inline suggestions (`SUGGESTIONS:[...]` in the response).
2. Click a suggestion bubble — the input should be filled **and** focused (cursor in textarea, ready to type or press Enter).
3. Run unit tests:
   ```
   yarn test:jest src/plugins/chat/public/components/chat_suggestions.test.tsx
   ```

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
