### PR TITLE
[Workspace] Hide horizontal scrollbar on workspace initial page use case cards

### DIFF
--- a/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is OS
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <div
-                class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive eui-xScroll"
+                class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive eui-xScroll workspace-initial__use-case-cards"
               >
                 <div
                   class="euiFlexItem"
@@ -811,7 +811,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is no
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <div
-                class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive eui-xScroll"
+                class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive eui-xScroll workspace-initial__use-case-cards"
               >
                 <div
                   class="euiFlexItem"

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_initial.scss
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_initial.scss
@@ -19,3 +19,12 @@
   padding-right: 48px;
   width: 100%;
 }
+
+// Keep the use case cards horizontally scrollable but hide the scrollbar
+.workspace-initial__use-case-cards {
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
@@ -310,7 +310,11 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
         </EuiFlexItem>
       )}
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup justifyContent="spaceBetween" gutterSize="m" className="eui-xScroll">
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
+          gutterSize="m"
+          className="eui-xScroll workspace-initial__use-case-cards"
+        >
           {useCaseCards}
         </EuiFlexGroup>
       </EuiFlexItem>


### PR DESCRIPTION
### Description
On the workspace initial (home) page, the use case card row shows a visible horizontal scrollbar when the viewport is not wide enough to fit all cards (each card has a 240px min-width). The scrollbar sits directly under the cards and looks visually noisy.

This PR hides the scrollbar while keeping the horizontal scroll behavior, so cards that overflow the viewport are still reachable via trackpad swipe or Shift + mouse wheel

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
Before:
<img width="1165" height="461" alt="image" src="https://github.com/user-attachments/assets/56aa9c8d-66ea-40ed-95dc-4cb798a5272f" />

After:
<img width="1164" height="606" alt="image" src="https://github.com/user-attachments/assets/cf0b1758-bfe7-486e-a787-435f23a67833" />


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
