### PR TITLE
[chat]add Text2Vis tool

### DIFF
--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -313,15 +313,16 @@ export class ChatEventHandler {
 
     // Strategy 1: Use explicitly provided parent message ID
     // This is the most reliable approach when the backend provides it
-    if (parentMessageId) {
-      this.addToolCallToMessage(parentMessageId, toolCall);
+    if (parentMessageId && this.addToolCallToMessage(parentMessageId, toolCall)) {
       return;
     }
 
     // Strategy 2: Determine placement based on message timeline positions
-    // Check if the last assistant message is still the most recent response
+    // Check if the last assistant message is still the most recent response.
+    // Skipped when the backend named a parent: it wants this tool call on a message of
+    // its own, not folded into the text message it has already ended.
     const timelineMessages = this.getTimeline();
-    if (this.lastTextMessageStartId) {
+    if (!parentMessageId && this.lastTextMessageStartId) {
       const lastAssistantTextMessageIndex = timelineMessages.findLastIndex(
         (message) => message.id === this.lastTextMessageStartId
       );
@@ -341,16 +342,18 @@ export class ChatEventHandler {
     // This handles the case where the LLM responds with tool calls but without any text message.
     // Since there's no TEXT_MESSAGE_START event, we need to create a fake assistant message
     // to hold the tool calls so they appear in the correct position in the timeline.
-    const fakeAssistantMessageId = `fake-assistant-message-` + new Date().getTime();
-    this.onTimelineUpdate((prev) => {
-      const newMessage: AssistantMessage = {
-        id: fakeAssistantMessageId,
-        role: 'assistant',
-        toolCalls: [toolCall],
-      };
-      return [...prev, newMessage];
-    });
-    this.lastTextMessageStartId = fakeAssistantMessageId;
+    const newMessageId = parentMessageId ?? `fake-assistant-message-` + new Date().getTime();
+    const newMessage: AssistantMessage = {
+      id: newMessageId,
+      role: 'assistant',
+      toolCalls: [toolCall],
+    };
+    // Register in the active map too, not just the timeline: TEXT_MESSAGE_CONTENT resolves
+    // its target through this map, so a timeline-only insert would silently drop any text
+    // the agent streams onto the same message id afterwards.
+    this.activeAssistantMessages.set(newMessageId, newMessage);
+    this.onTimelineUpdate((prev) => [...prev, newMessage]);
+    this.lastTextMessageStartId = newMessageId;
   }
 
   /**
@@ -403,7 +406,8 @@ export class ChatEventHandler {
             toolCall.function.name,
             args,
             toolCallId,
-            await this.chatService.getCurrentDataSourceInfo()
+            await this.chatService.getCurrentDataSourceInfo(),
+            this.chatService.getCurrentTimeRange()
           );
 
       // Check if tool execution was cancelled (e.g., due to cleanup)
@@ -626,7 +630,7 @@ export class ChatEventHandler {
   /**
    * Add tool call to a specific message in timeline
    */
-  private addToolCallToMessage(messageId: string, toolCall: ToolCall): void {
+  private addToolCallToMessage(messageId: string, toolCall: ToolCall): boolean {
     // Check if message is in active messages
     const activeMessage = this.activeAssistantMessages.get(messageId);
     if (activeMessage) {
@@ -643,8 +647,11 @@ export class ChatEventHandler {
         }
         return prev;
       });
-      return;
+      return true;
     }
+
+    const known = this.getTimeline().find((m) => m.id === messageId);
+    if (!known || known.role !== 'assistant') return false;
 
     // Otherwise find in timeline and update
     this.onTimelineUpdate((prev) => {
@@ -663,6 +670,8 @@ export class ChatEventHandler {
 
       return updated;
     });
+
+    return true;
   }
 
   /**

--- a/src/plugins/dashboard/opensearch_dashboards.json
+++ b/src/plugins/dashboard/opensearch_dashboards.json
@@ -14,5 +14,5 @@
   "optionalPlugins": ["home", "share", "usageCollection"],
   "server": true,
   "ui": true,
-  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home"]
+  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home", "contextProvider"]
 }

--- a/src/plugins/dashboard/public/application/index.tsx
+++ b/src/plugins/dashboard/public/application/index.tsx
@@ -3,15 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Router } from 'react-router-dom';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { OpenSearchDashboardsContextProvider } from '../../../opensearch_dashboards_react/public';
+import { usePageContext } from '../../../context_provider/public';
 import { addHelpMenuToAppChrome } from './utils';
 import { DashboardApp } from './app';
 import { DashboardServices } from '../types';
 export * from './embeddable';
 export * from './actions';
+
+// Parse the dashboard saved-object id
+const getDashboardIdFromHash = (hash: string): string | undefined => {
+  const match = hash.match(/#\/view\/([^/?]+)/);
+  return match ? match[1] : undefined;
+};
+
+// register the dashboard page context
+const DashboardPageContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  usePageContext({
+    description: 'Dashboard application page context',
+    convert: (urlState: any) => ({
+      appId: 'dashboards',
+      dashboardId: getDashboardIdFromHash(urlState.hash || ''),
+      timeRange: urlState._g?.time,
+    }),
+    categories: ['page', 'static'],
+  });
+
+  return <>{children}</>;
+};
 
 export const renderApp = ({ element }: AppMountParameters, services: DashboardServices) => {
   addHelpMenuToAppChrome(services.chrome, services.docLinks);
@@ -20,7 +43,9 @@ export const renderApp = ({ element }: AppMountParameters, services: DashboardSe
     <Router history={services.history}>
       <OpenSearchDashboardsContextProvider services={services}>
         <services.i18n.Context>
-          <DashboardApp />
+          <DashboardPageContextProvider>
+            <DashboardApp />
+          </DashboardPageContextProvider>
         </services.i18n.Context>
       </OpenSearchDashboardsContextProvider>
     </Router>

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -29,7 +29,7 @@
  */
 
 import { NameList } from 'elasticsearch';
-import { Filter, IDataFrame, DataView, IndexPattern, Query } from '../..';
+import { Filter, IDataFrame, DataView, IndexPattern, Query, TimeRange } from '../..';
 import { SearchSource } from './search_source';
 
 /**
@@ -106,6 +106,12 @@ export interface SearchSourceFields {
   df?: IDataFrame;
   skipTimeFilter?: boolean;
   skipFilters?: boolean;
+  /**
+   * An explicit time range for languages that inject a time filter
+   * into the query. When set, it overrides the global timefilter, letting a
+   * caller pin the query to a fixed (absolute) window.
+   */
+  timeRange?: TimeRange;
 }
 
 export interface SearchSourceOptions {

--- a/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
@@ -210,7 +210,7 @@ export const queryExecution = async ({
       throw new Error('Dataset not found for query execution');
     }
 
-    const dataset = services.data.dataViews.convertToDataset(dataView);
+    const dataset = await services.data.dataViews.convertToDataset(dataView);
 
     const preparedQueryObject = {
       ...query,

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -536,7 +536,7 @@ const executeQueryBase = async (
       throw new Error('Dataset not found for query execution');
     }
 
-    const dataset = services.data.dataViews.convertToDataset(dataView);
+    const dataset = await services.data.dataViews.convertToDataset(dataView);
 
     // Create histogram config once for use in both query building and result processing
     let histogramConfig: HistogramConfig | null = null;

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.test.tsx
@@ -1,0 +1,434 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import rison from 'rison-node';
+import {
+  registerAutoVisualizationAction,
+  AUTO_VISUALIZATION_TOOL_NAME,
+} from './auto_visualization_action';
+
+// --- Mocks for heavy / environment-coupled dependencies -------------------
+
+const mockFindRulesByColumns = jest.fn();
+const mockGetAxesMappingByRule = jest.fn();
+const mockGetVisualization = jest.fn();
+
+jest.mock('../../../components/visualizations/visualization_registry', () => ({
+  visualizationRegistry: {
+    findRulesByColumns: (...args: any[]) => mockFindRulesByColumns(...args),
+    getAxesMappingByRule: (...args: any[]) => mockGetAxesMappingByRule(...args),
+    getVisualization: (...args: any[]) => mockGetVisualization(...args),
+  },
+}));
+
+const mockNormalizeResultRows = jest.fn();
+jest.mock('../../../components/visualizations/utils/normalize_result_rows', () => ({
+  normalizeResultRows: (...args: any[]) => mockNormalizeResultRows(...args),
+}));
+
+jest.mock('../../../components/visualizations/visualization_render', () => ({
+  CommonVisualizationRender: () => <div data-test-subj="commonVisRender" />,
+}));
+
+jest.mock('../../../application/in_context_vis_editor/component/vis_editor_no_results', () => ({
+  VisEditorNoResults: () => <div data-test-subj="visEditorNoResults" />,
+}));
+
+jest.mock('./utils', () => ({
+  AUTO_VISUALIZATION_TOOL_NAME: 'auto_create_visualization',
+  AutoVisMeta: {
+    name: 'auto_create_visualization',
+    description: 'desc',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+}));
+
+const baseArgs = {
+  query: 'source=flights | stats avg(price) by carrier',
+  indexName: 'flights',
+  columns: [
+    { name: 'carrier', type: 'keyword' },
+    { name: 'avg(price)', type: 'double' },
+  ],
+};
+
+const createCore = () =>
+  ({
+    uiSettings: { get: jest.fn(() => 500) },
+    http: { basePath: { prepend: (p: string) => `/base${p}` } },
+    savedObjects: {
+      client: { get: jest.fn().mockResolvedValue({ attributes: { title: 'My Dashboard' } }) },
+    },
+    notifications: { toasts: {} },
+    application: { navigateToApp: jest.fn() },
+  }) as unknown as any;
+
+const createData = (bounds?: { min: any; max: any }, globalTime?: any) =>
+  ({
+    query: {
+      timefilter: {
+        timefilter: {
+          getTime: jest.fn(() => globalTime),
+          calculateBounds: jest.fn(() => bounds ?? { min: undefined, max: undefined }),
+        },
+      },
+    },
+    search: { searchSource: { create: jest.fn() } },
+  }) as unknown as any;
+
+const createContextProvider = (dashboardId?: string) =>
+  ({
+    getAssistantContextStore: () => ({
+      getContextsByCategory: (category: string) =>
+        category === 'page' && dashboardId ? [{ value: { appId: 'dashboards', dashboardId } }] : [],
+    }),
+  }) as unknown as any;
+
+const registerAndGetAction = (core: any, data: any, contextProvider?: any): any => {
+  let captured: any;
+  const registerAction = jest.fn((action: any) => {
+    captured = action;
+  });
+  registerAutoVisualizationAction(registerAction, core, data, contextProvider);
+  return captured;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockNormalizeResultRows.mockReturnValue({
+    transformedData: [{ carrier: 'A', 'avg(price)': 1 }],
+    numericalColumns: [{ name: 'avg(price)' }],
+    categoricalColumns: [{ name: 'carrier' }],
+    dateColumns: [],
+    unknownColumns: [],
+  });
+  mockFindRulesByColumns.mockReturnValue({
+    exact: [{ visType: 'bar', rules: [{ priority: 10 }] }],
+    all: [{ visType: 'bar', rules: [{ priority: 10 }] }],
+  });
+  mockGetAxesMappingByRule.mockReturnValue({ x: 'carrier', y: 'avg(price)' });
+  mockGetVisualization.mockReturnValue({ ui: { style: { defaults: { color: 'red' } } } });
+});
+
+describe('registerAutoVisualizationAction', () => {
+  it('does nothing when registerAction is undefined', () => {
+    expect(() =>
+      registerAutoVisualizationAction(undefined as any, createCore(), createData())
+    ).not.toThrow();
+  });
+
+  it('registers an action with the auto visualization tool name and custom renderer', () => {
+    const action = registerAndGetAction(createCore(), createData());
+    expect(action.name).toBe(AUTO_VISUALIZATION_TOOL_NAME);
+    expect(action.useCustomRenderer).toBe(true);
+    expect(typeof action.handler).toBe('function');
+    expect(typeof action.render).toBe('function');
+  });
+});
+
+describe('handler', () => {
+  it('resolves the highest-priority compatible chart and returns a success result', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+
+    expect(result.success).toBe(true);
+    expect(result.chartType).toBe('bar');
+    expect(result.resolvedAxesMapping).toEqual({ x: 'carrier', y: 'avg(price)' });
+    expect(result.visConfig).toEqual({
+      type: 'bar',
+      axesMapping: { x: 'carrier', y: 'avg(price)' },
+      splitField: undefined,
+      styles: { color: 'red' },
+    });
+    expect(result.preparedQuery).toEqual({
+      dataset: expect.objectContaining({ id: 'flights', title: 'flights' }),
+      language: 'PPL',
+      query: baseArgs.query,
+    });
+  });
+
+  it('honors a compatible potentialChartType hint', async () => {
+    mockFindRulesByColumns.mockReturnValue({
+      exact: [
+        { visType: 'bar', rules: [{ priority: 5 }] },
+        { visType: 'pie', rules: [{ priority: 3 }] },
+      ],
+      all: [],
+    });
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler({ ...baseArgs, potentialChartType: 'pie' });
+    expect(result.chartType).toBe('pie');
+  });
+
+  it('falls back to table when no compatible charts are found', async () => {
+    mockFindRulesByColumns.mockReturnValue({ exact: [], all: [] });
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+    expect(result.success).toBe(true);
+    expect(result.chartType).toBe('table');
+    expect(result.resolvedAxesMapping).toEqual({});
+  });
+
+  it('returns a failure result when the chart-type hint is incompatible', async () => {
+    // Only 'bar' is compatible, but the user asked for 'pie'.
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler({ ...baseArgs, potentialChartType: 'pie' });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not compatible');
+    expect(result.message).toContain('bar');
+  });
+
+  it('builds an editor path with encoded _v and _eq params', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+    const result = await action.handler(baseArgs);
+
+    expect(result.editorPath).toEqual(expect.stringContaining('#/?_v='));
+    expect(result.editorPath).toEqual(expect.stringContaining('&_eq='));
+    // No time range / dashboard by default.
+    expect(result.editorPath).not.toContain('_g=');
+    expect(result.editorPath).not.toContain('_c=');
+  });
+
+  it('resolves a relative time range to an absolute window', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    expect(result.resolvedTimeRange).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-08T00:00:00.000Z',
+    });
+    // _g is encoded into the editor path.
+    const gParam = `_g=${encodeURIComponent(
+      rison.encode({
+        time: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-08T00:00:00.000Z' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(gParam);
+  });
+
+  it('prefers the from/to the agent asked for over the injected page time range', async () => {
+    const min = { toISOString: () => '2026-02-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-02-02T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      from: 'now-1d',
+      to: 'now',
+      // chat injects this from the page context on every tool call
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    expect(data.query.timefilter.timefilter.calculateBounds).toHaveBeenCalledWith({
+      from: 'now-1d',
+      to: 'now',
+    });
+    expect(data.query.timefilter.timefilter.getTime).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the global time filter when neither from/to nor a page range is given', async () => {
+    const min = { toISOString: () => '2026-03-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-03-02T00:00:00.000Z' };
+    const data = createData({ min, max }, { from: 'now-15m', to: 'now' });
+    const action = registerAndGetAction(createCore(), data);
+
+    await action.handler({ ...baseArgs, timeFieldName: 'timestamp' });
+
+    expect(data.query.timefilter.timefilter.getTime).toHaveBeenCalled();
+    expect(data.query.timefilter.timefilter.calculateBounds).toHaveBeenCalledWith({
+      from: 'now-15m',
+      to: 'now',
+    });
+  });
+
+  it('ignores a half-specified time range and uses the page range instead', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const data = createData({ min, max });
+    const action = registerAndGetAction(createCore(), data);
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      from: 'now-1d',
+      timeRange: { from: 'now-7d', to: 'now' },
+    });
+
+    // No throw: the resolved range the payload reports is the page one, so the llm can
+    // see its half-range was not used.
+    expect(result.success).toBe(true);
+    expect(data.query.timefilter.timefilter.calculateBounds).toHaveBeenCalledWith({
+      from: 'now-7d',
+      to: 'now',
+    });
+  });
+
+  it('rejects a time range without timeFieldName, since it would be dropped', async () => {
+    const min = { toISOString: () => '2026-01-01T00:00:00.000Z' };
+    const max = { toISOString: () => '2026-01-08T00:00:00.000Z' };
+    const action = registerAndGetAction(createCore(), createData({ min, max }));
+
+    const result = await action.handler({ ...baseArgs, from: 'now-1d', to: 'now' });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('timeFieldName');
+    // Both ways out are offered so an index with no time field cannot trap the llm.
+    expect(result.message).toContain('omit from/to');
+  });
+
+  it('reports no resolved range when the agent time range is unparseable', async () => {
+    // dateMath yields null min/max for anything it cannot parse, e.g. "last tuesday".
+    const action = registerAndGetAction(createCore(), createData());
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      from: 'last tuesday',
+      to: 'now',
+    });
+
+    // The chart still renders, but resolvedTimeRange stays undefined, so nothing claims
+    // the requested range was applied.
+    expect(result.success).toBe(true);
+    expect(result.resolvedTimeRange).toBeUndefined();
+    expect(result.editorPath).not.toContain('_g=');
+  });
+
+  it('keeps rendering without a time range when the page range is unparseable', async () => {
+    const action = registerAndGetAction(createCore(), createData());
+
+    const result = await action.handler({
+      ...baseArgs,
+      timeFieldName: 'timestamp',
+      timeRange: { from: 'bogus', to: 'now' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.resolvedTimeRange).toBeUndefined();
+    expect(result.editorPath).not.toContain('_g=');
+  });
+
+  it('adds dashboard container info (_c) when on a dashboard page', async () => {
+    const core = createCore();
+    const action = registerAndGetAction(core, createData(), createContextProvider('dash-1'));
+    const result = await action.handler(baseArgs);
+
+    expect(core.savedObjects.client.get).toHaveBeenCalledWith('dashboard', 'dash-1');
+    const cParam = `_c=${encodeURIComponent(
+      rison.encode({
+        originatingApp: 'dashboards',
+        containerInfo: { containerId: 'dash-1', containerName: 'My Dashboard' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(cParam);
+  });
+
+  it('omits _c when not on a dashboard page', async () => {
+    const action = registerAndGetAction(createCore(), createData(), createContextProvider());
+    const result = await action.handler(baseArgs);
+    expect(result.editorPath).not.toContain('_c=');
+  });
+
+  it('still succeeds when the dashboard name lookup fails', async () => {
+    const core = createCore();
+    core.savedObjects.client.get = jest.fn().mockRejectedValue(new Error('not found'));
+    const action = registerAndGetAction(core, createData(), createContextProvider('dash-1'));
+    const result = await action.handler(baseArgs);
+
+    // containerId present, containerName omitted.
+    const cParam = `_c=${encodeURIComponent(
+      rison.encode({
+        originatingApp: 'dashboards',
+        containerInfo: { containerId: 'dash-1' },
+      })
+    )}`;
+    expect(result.editorPath).toContain(cParam);
+  });
+});
+
+describe('render', () => {
+  const renderResult = (core: any, data: any, props: any) => {
+    const action = registerAndGetAction(core, data, undefined);
+    return render(action.render(props));
+  };
+
+  it('renders nothing while pending', () => {
+    const { container } = renderResult(createCore(), createData(), {
+      status: 'executing',
+      args: baseArgs,
+      result: undefined,
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the parameters accordion and open-in-editor button on success', () => {
+    // Chart preview kicks off a fetch; make searchSource resolve to empty rows.
+    const data = createData();
+    data.search.searchSource.create = jest.fn().mockResolvedValue({
+      setFields: jest.fn(),
+      fetch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+      getDataFrame: jest.fn(() => ({ schema: [] })),
+    });
+    data.query.queryString = {
+      getLanguageService: () => ({ getLanguage: () => ({}) }),
+    };
+
+    renderResult(createCore(), data, {
+      status: 'complete',
+      args: baseArgs,
+      result: {
+        success: true,
+        preparedQuery: { dataset: { title: 'flights' }, language: 'PPL', query: baseArgs.query },
+        visConfig: { type: 'bar', axesMapping: {}, styles: {} },
+        editorPath: '#/?_v=x',
+      },
+    });
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    expect(screen.getByText('Open in Editor')).toBeInTheDocument();
+  });
+
+  it('shows the resolved window in the parameters, not the raw from/to', () => {
+    const data = createData();
+    data.search.searchSource.create = jest.fn().mockResolvedValue({
+      setFields: jest.fn(),
+      fetch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+      getDataFrame: jest.fn(() => ({ schema: [] })),
+    });
+    data.query.queryString = {
+      getLanguageService: () => ({ getLanguage: () => ({}) }),
+    };
+
+    renderResult(createCore(), data, {
+      status: 'complete',
+      args: { ...baseArgs, timeFieldName: 'timestamp', from: 'now-7d', to: 'now' },
+      result: {
+        success: true,
+        preparedQuery: { dataset: { title: 'flights' }, language: 'PPL', query: baseArgs.query },
+        visConfig: { type: 'bar', axesMapping: {}, styles: {} },
+        editorPath: '#/?_v=x',
+        resolvedTimeRange: {
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-01-08T00:00:00.000Z',
+        },
+      },
+    });
+
+    const paramsJson = screen.getByText(/"timeRange"/).textContent ?? '';
+    expect(paramsJson).toContain('2026-01-01T00:00:00.000Z');
+    expect(paramsJson).not.toContain('now-7d');
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
+++ b/src/plugins/explore/public/components/visualizations/actions/auto_visualization_action.tsx
@@ -1,0 +1,593 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import rison from 'rison-node';
+import {
+  EuiPanel,
+  EuiText,
+  EuiSpacer,
+  EuiButton,
+  EuiAccordion,
+  EuiCodeBlock,
+  EuiLoadingChart,
+  EuiCallOut,
+} from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { RenderProps, ContextProviderStart } from '../../../../../context_provider/public';
+import { DataPublicPluginStart, TimeRange } from '../../../../../data/public';
+import { Dataset, DEFAULT_DATA } from '../../../../../data/common';
+import { ChartType } from '../../../components/visualizations/utils/use_visualization_types';
+import {
+  AxisFieldNameMappings,
+  RenderChartConfig,
+  VisColumn,
+} from '../../../components/visualizations/types';
+import { VisData } from '../../../components/visualizations/visualization_builder.types';
+import { CommonVisualizationRender } from '../../../components/visualizations/visualization_render';
+import { normalizeResultRows } from '../../../components/visualizations/utils/normalize_result_rows';
+import { visualizationRegistry } from '../../../components/visualizations/visualization_registry';
+import { SAMPLE_SIZE_SETTING, VISUALIZATION_EDITOR_APP_ID } from '../../../../common';
+import { VisEditorNoResults } from '../../../application/in_context_vis_editor/component/vis_editor_no_results';
+import { OpenSearchSearchHit } from '../../../types/doc_views_types';
+import { AutoVisMeta } from './utils';
+
+export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+
+export interface AutoVisualizationArgs {
+  query: string;
+  indexName: string;
+  // user intended chart type
+  potentialChartType?: string;
+  columns: Array<{ name: string; type: string }>;
+  splitField?: string;
+  // used to build dataset, without it time range search bar will not show
+  timeFieldName?: string;
+  // injected by chat from the current page context
+  timeRange?: TimeRange;
+  // used to build dataset
+  datasourceId?: string;
+  datasourceTitle?: string;
+  dashboardId?: string;
+  // the time range the llm passed
+  from?: string;
+  to?: string;
+}
+
+export interface PreparedQuery {
+  dataset: Dataset;
+  language: string;
+  query: string;
+}
+
+export interface VisualizationConfigResult {
+  success: true;
+  visConfig: RenderChartConfig;
+  query: PreparedQuery;
+  resolvedChartType: ChartType;
+  resolvedAxesMapping: AxisFieldNameMappings;
+}
+
+const DASHBOARDS_APP_ID = 'dashboards';
+
+function buildEditorPath(
+  visConfig: RenderChartConfig,
+  query: PreparedQuery,
+  timeRange?: TimeRange,
+  dashboardId?: string,
+  dashboardName?: string,
+  originatingApp?: string
+): string {
+  const visState: Record<string, any> = {
+    chartType: visConfig.type,
+    axesMapping: visConfig.axesMapping,
+    styleOptions: visConfig.styles,
+  };
+  if (visConfig.splitField) {
+    visState.splitField = visConfig.splitField;
+  }
+
+  const vParam = rison.encode(visState);
+  const eqParam = rison.encode(query as Record<string, any>);
+
+  const gParam = timeRange
+    ? `&_g=${encodeURIComponent(rison.encode({ time: { from: timeRange.from, to: timeRange.to } }))}`
+    : '';
+
+  // Bind the visualization to the originating dashboard via `_c` (containerInfo),
+  const cParam = originatingApp
+    ? `&_c=${encodeURIComponent(
+        rison.encode({
+          originatingApp,
+          ...(dashboardId && {
+            containerInfo: {
+              containerId: dashboardId,
+              ...(dashboardName && { containerName: dashboardName }),
+            },
+          }),
+        })
+      )}`
+    : '';
+
+  return `#/?_v=${encodeURIComponent(vParam)}&_eq=${encodeURIComponent(eqParam)}${gParam}${cParam}`;
+}
+
+/**
+ * Resolve axes mapping and chart type given the classified columns.
+ */
+function resolveChartFromSchema(
+  numericalColumns: VisColumn[],
+  categoricalColumns: VisColumn[],
+  dateColumns: VisColumn[],
+  potentialChartType?: string
+): {
+  chartType: ChartType;
+  axesMapping: AxisFieldNameMappings;
+} {
+  // 1. find all compatible rules with visualization registry
+  const { all: allMatches, exact: exactMatches } = visualizationRegistry.findRulesByColumns(
+    numericalColumns,
+    categoricalColumns,
+    dateColumns
+  );
+
+  const candidates: Array<{
+    chartType: ChartType;
+    priority: number;
+    axesMapping: AxisFieldNameMappings;
+  }> = [];
+  const seenChartTypes = new Set<string>();
+
+  for (const matches of [exactMatches, allMatches]) {
+    for (const { visType, rules } of matches) {
+      if (seenChartTypes.has(visType)) continue;
+      seenChartTypes.add(visType);
+      // 2. only provide the highest-priority rule for each chart type
+      const bestRule = rules.reduce((best, r) => (r.priority > best.priority ? r : best));
+      const axesMapping = visualizationRegistry.getAxesMappingByRule(
+        bestRule,
+        numericalColumns,
+        categoricalColumns,
+        dateColumns
+      );
+      if (Object.keys(axesMapping).length === 0) continue;
+
+      candidates.push({
+        chartType: visType as ChartType,
+        priority: bestRule.priority,
+        axesMapping,
+      });
+    }
+  }
+
+  // 3. If the user provided a potential chart-type, use it
+  if (potentialChartType) {
+    const matched = candidates.find(
+      (c) => c.chartType.toLowerCase() === potentialChartType.toLowerCase()
+    );
+    if (matched) {
+      return { chartType: matched.chartType, axesMapping: matched.axesMapping };
+    }
+    // chart is incompatible with the columns.
+    // the throw reaches the llm.
+    throw new Error(
+      `Chart type "${potentialChartType}" is not compatible with the query result columns. ` +
+        `Compatible chart types: [${candidates.map((c) => c.chartType).join(', ')}]. ` +
+        `Please adjust ppl query.`
+    );
+  }
+
+  // 4. No potential chart and candidates, use table
+  if (candidates.length === 0) {
+    return { chartType: 'table', axesMapping: {} };
+  }
+
+  // 5. No potential chart, use the chart with highest-priority
+  const best = candidates.reduce((a, b) => (b.priority > a.priority ? b : a));
+  return { chartType: best.chartType, axesMapping: best.axesMapping };
+}
+
+/**
+ * Build the dataset manually + prepared query object from the tool args. The dataset is
+ * built manually and will not be created.
+ */
+export function buildPreparedQuery(args: AutoVisualizationArgs): PreparedQuery {
+  const datasetId = args.datasourceId ? `${args?.datasourceId}_${args.indexName}` : args.indexName;
+  const dataset: Dataset = {
+    id: datasetId,
+    title: args.indexName,
+    type: DEFAULT_DATA.SET_TYPES.INDEX,
+    timeFieldName: args.timeFieldName,
+    ...(args.datasourceId && {
+      dataSource: {
+        id: args.datasourceId,
+        title: args?.datasourceTitle || '',
+        type: 'DATA_SOURCE',
+        version: '',
+      },
+    }),
+  };
+  return { dataset, language: 'PPL', query: args.query };
+}
+
+/**
+ * Read the current dashboard id from the page context,
+ * Read lazily (only when building the editor URL) rather than injected
+ * into every tool call, since most tools don't need it.
+ */
+function getCurrentDashboardContext(contextProvider?: ContextProviderStart): {
+  originatingApp?: string;
+  dashboardId?: string;
+} {
+  const pageContexts = contextProvider?.getAssistantContextStore().getContextsByCategory('page');
+  const dashboardContext = pageContexts?.find((ctx) => {
+    const value = typeof ctx.value === 'string' ? JSON.parse(ctx.value) : ctx.value;
+    return value?.appId === DASHBOARDS_APP_ID;
+  });
+  if (!dashboardContext) return {};
+  const value =
+    typeof dashboardContext.value === 'string'
+      ? JSON.parse(dashboardContext.value)
+      : dashboardContext.value;
+  return { originatingApp: DASHBOARDS_APP_ID, dashboardId: value?.dashboardId };
+}
+
+async function getDashboardName(core: CoreStart, dashboardId: string): Promise<string | undefined> {
+  try {
+    const savedObject = await core.savedObjects.client.get<{ title?: string }>(
+      'dashboard',
+      dashboardId
+    );
+    return savedObject.attributes?.title;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getAbsoluteTimeRange(
+  data: DataPublicPluginStart,
+  args: Pick<AutoVisualizationArgs, 'from' | 'to' | 'timeRange'>
+): TimeRange | undefined {
+  const time = args.from && args.to ? { from: args.from, to: args.to } : undefined;
+
+  // if there is not timeRange in page context use global time filter
+  const range = time ?? args?.timeRange ?? data.query.timefilter.timefilter.getTime();
+  const bounds = data.query.timefilter.timefilter.calculateBounds(range);
+  if (!bounds.min || !bounds.max) return undefined;
+  return { from: bounds.min.toISOString(), to: bounds.max.toISOString() };
+}
+
+/**
+ * Execute the PPL query and normalize the results into VisData.
+ */
+async function executePPLQuery(
+  preparedQueryObject: PreparedQuery,
+  core: CoreStart,
+  data: DataPublicPluginStart,
+  timeRange?: TimeRange,
+  abortSignal?: AbortSignal
+): Promise<{ rawRows: OpenSearchSearchHit[]; rawSchema: Array<{ name?: string; type?: string }> }> {
+  const uiSettings = core.uiSettings;
+  const dataset = preparedQueryObject.dataset;
+
+  await data.query.queryString.getDatasetService().cacheDataset(
+    dataset,
+    {
+      uiSettings: core.uiSettings,
+      savedObjects: core.savedObjects,
+      notifications: core.notifications,
+      http: core.http,
+      data,
+    },
+    false
+  );
+  const dataView = await data.dataViews.get(dataset.id);
+
+  const size = uiSettings.get(SAMPLE_SIZE_SETTING);
+  const searchSource = await data.search.searchSource.create();
+
+  searchSource.setFields({
+    index: dataView,
+    size,
+    query: preparedQueryObject,
+    highlightAll: false,
+    version: false,
+
+    // Pass absolute time range so the PPL search interceptor injects
+    // it into the query instead of using the global timefilter.
+    ...(timeRange && dataset.timeFieldName ? { timeRange } : {}),
+  });
+
+  const languageConfig = data.query.queryString
+    .getLanguageService()
+    .getLanguage(preparedQueryObject.language);
+
+  // Execute query
+  const rawResults = await searchSource.fetch({
+    abortSignal,
+    withLongNumeralsSupport: await uiSettings.get('data:withLongNumerals'),
+    ...(languageConfig?.fields?.formatter ? { formatter: languageConfig.fields.formatter } : {}),
+  });
+
+  return {
+    rawRows: rawResults.hits?.hits ?? [],
+    rawSchema: searchSource.getDataFrame()?.schema ?? [],
+  };
+}
+
+/**
+ * resolve the chart config from ppl execution columns results.
+ */
+export function buildVisConfig(args: AutoVisualizationArgs): VisualizationConfigResult {
+  const preparedQueryObject = buildPreparedQuery(args);
+
+  // 1. get normalized schema — use post-transformation schema when available
+  const originalSchema = (args.columns || []).map((col) => ({ name: col.name, type: col.type }));
+
+  const { numericalColumns, categoricalColumns, dateColumns } = normalizeResultRows(
+    [],
+    originalSchema
+  );
+
+  // 2. resolve axes mapping and chart type
+  const matchChart = resolveChartFromSchema(
+    numericalColumns,
+    categoricalColumns,
+    dateColumns,
+    args.potentialChartType
+  );
+
+  // 3. build vis config
+  const defaultStyles = visualizationRegistry.getVisualization(matchChart.chartType)?.ui.style
+    .defaults;
+
+  const visConfig: RenderChartConfig = {
+    type: matchChart.chartType,
+    axesMapping: matchChart.axesMapping,
+    splitField: args.splitField,
+    styles: defaultStyles || {},
+  };
+
+  return {
+    visConfig,
+    query: preparedQueryObject,
+    success: true,
+    resolvedChartType: matchChart.chartType,
+    resolvedAxesMapping: matchChart.axesMapping,
+  };
+}
+
+/**
+ * Chart preview that executes the PPL query at render time to fetch the row data,
+ */
+export function ChartPreview({
+  query,
+  visConfig,
+  core,
+  data,
+  timeRange,
+  onError,
+}: {
+  query: PreparedQuery;
+  visConfig: RenderChartConfig;
+  core: CoreStart;
+  data: DataPublicPluginStart;
+  timeRange?: TimeRange;
+  onError?: (message: string) => void;
+}) {
+  const [visData, setVisData] = useState<VisData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+
+    executePPLQuery(query, core, data, timeRange, abortController.signal)
+      .then(({ rawRows, rawSchema }) => {
+        if (cancelled) return;
+
+        setVisData(normalizeResultRows(rawRows, rawSchema));
+      })
+      .catch((e) => {
+        if (!cancelled && !abortController.signal.aborted) {
+          const message = e instanceof Error ? e.message : 'Failed to load chart data';
+          setError(message);
+          onError?.(message);
+        }
+      });
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (error) {
+    return (
+      <EuiCallOut size="s" color="danger" title="Could not render chart">
+        <EuiText size="xs">{error}</EuiText>
+      </EuiCallOut>
+    );
+  }
+
+  if (!visData) {
+    return (
+      <div
+        style={{
+          height: 250,
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <EuiLoadingChart size="l" />
+      </div>
+    );
+  }
+
+  if (visData.transformedData.length === 0) {
+    return (
+      <div style={{ height: 250, width: '100%' }}>
+        <VisEditorNoResults />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <CommonVisualizationRender
+        visualizationData={visData}
+        visConfig={visConfig}
+        showRawTable={false}
+      />
+    </div>
+  );
+}
+
+function ArgsParameters({
+  args,
+  absoluteTimeRange,
+}: {
+  args: AutoVisualizationArgs;
+  absoluteTimeRange?: TimeRange;
+}) {
+  const { from, to, ...restArgs } = args;
+  const displayArgs = absoluteTimeRange ? { ...restArgs, timeRange: absoluteTimeRange } : restArgs;
+  return (
+    <EuiAccordion id="auto-vis-args" buttonContent="Parameters" paddingSize="xs">
+      <EuiPanel hasBorder paddingSize="s" style={{ wordBreak: 'break-all' }} hasShadow={false}>
+        <EuiCodeBlock
+          language="json"
+          paddingSize="none"
+          fontSize="s"
+          transparentBackground
+          overflowHeight={150}
+          isCopyable
+        >
+          {JSON.stringify(displayArgs, null, 2)}
+        </EuiCodeBlock>
+      </EuiPanel>
+    </EuiAccordion>
+  );
+}
+
+function getCurrentAppId(core: CoreStart): string | undefined {
+  let appId: string | undefined;
+  const subscription = core.application.currentAppId$.subscribe((id) => {
+    appId = id;
+  });
+  subscription.unsubscribe();
+  return appId;
+}
+
+function openVisualizationEditor(core: CoreStart, editorPath: string) {
+  const visEditorAppBase = core.http.basePath.prepend(`/app/${VISUALIZATION_EDITOR_APP_ID}`);
+  if (getCurrentAppId(core) === VISUALIZATION_EDITOR_APP_ID) {
+    // When already on the vis editor app, navigateToApp only calls history.push without
+    // remounting the page, so the new URL params are ignored by the already-initialized
+    // component. Use window.location.href instead to force a full navigation that
+    // unmounts and remounts the app.
+    window.location.href = `${visEditorAppBase}${editorPath}`;
+  } else {
+    core.application.navigateToApp(VISUALIZATION_EDITOR_APP_ID, { path: editorPath });
+  }
+}
+
+export function checkTimeRangeArgsUsable(args: {
+  from?: string;
+  to?: string;
+  timeFieldName?: string;
+}): void {
+  if (!args.from || !args.to) return;
+
+  if (!args.timeFieldName) {
+    throw new Error(
+      'A time range (from/to) cannot be applied without timeFieldName, so it would be ignored. ' +
+        'Either call the index mapping tool to look up the time field and pass it as ' +
+        'timeFieldName, or omit from/to if this index has no time field.'
+    );
+  }
+}
+
+export function registerAutoVisualizationAction(
+  registerAction: ((action: any) => void) | undefined,
+  core: CoreStart,
+  data: DataPublicPluginStart,
+  contextProvider?: ContextProviderStart
+) {
+  if (!registerAction) return;
+
+  const renderAutoVisualization = ({
+    status,
+    args,
+    result,
+  }: RenderProps<AutoVisualizationArgs>) => {
+    if (status === 'complete' && result?.success) {
+      return (
+        <EuiPanel paddingSize="s" grow={false} hasShadow={false}>
+          {args && <ArgsParameters args={args} absoluteTimeRange={result.resolvedTimeRange} />}
+          <ChartPreview
+            query={result.preparedQuery}
+            visConfig={result.visConfig}
+            core={core}
+            data={data}
+            timeRange={result.resolvedTimeRange}
+          />
+          <EuiSpacer size="s" />
+          <EuiButton size="s" onClick={() => openVisualizationEditor(core, result.editorPath)}>
+            Open in Editor
+          </EuiButton>
+        </EuiPanel>
+      );
+    }
+
+    return null;
+  };
+
+  registerAction({
+    ...AutoVisMeta,
+    useCustomRenderer: true,
+    handler: async (args: AutoVisualizationArgs) => {
+      try {
+        checkTimeRangeArgsUsable(args);
+        const { visConfig, query, resolvedChartType, resolvedAxesMapping } = buildVisConfig(args);
+        const resolvedTimeRange = getAbsoluteTimeRange(data, args);
+        const { originatingApp, dashboardId } = getCurrentDashboardContext(contextProvider);
+
+        const dashboardName = dashboardId ? await getDashboardName(core, dashboardId) : undefined;
+        const editorPath = buildEditorPath(
+          visConfig,
+          query,
+          resolvedTimeRange,
+          dashboardId,
+          dashboardName,
+          originatingApp
+        );
+
+        return {
+          success: true,
+          chartType: resolvedChartType,
+          resolvedAxesMapping,
+          query: args.query,
+          indexName: args.indexName,
+          editorPath,
+          visConfig,
+          preparedQuery: query,
+          resolvedTimeRange,
+          message: `Created ${resolvedChartType} visualization for ${args.indexName}`,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          query: args.query,
+          indexName: args.indexName,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        };
+      }
+    },
+    render: renderAutoVisualization,
+  });
+}

--- a/src/plugins/explore/public/components/visualizations/actions/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/actions/utils.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const AUTO_VISUALIZATION_TOOL_NAME = 'auto_create_visualization';
+export const GET_TRANSFORMATION_SCHEMA_TOOL_NAME = 'get_transformation_schema';
+
+const CHART_TYPE_INFO: Record<string, string> = {
+  line: 'trends over time. Use when user asks about trends, changes over time, or time-series',
+  bar: 'compare values across categories or time buckets. Use for comparisons, rankings, distributions across groups',
+  area: 'stacked/cumulative trends over time. Use for cumulative totals, composition over time',
+  pie: 'proportional breakdown of a whole. Use when user asks about proportions, shares, percentages, breakdown',
+  scatter: 'correlation between two numerical variables. Use color/size to add dimensions',
+  heatmap: 'density or intensity across two categorical dimensions',
+  metric: 'single aggregated number, optionally with sparkline. Use for KPIs, totals, counts',
+  gauge: 'single value against a threshold range',
+  bar_gauge: 'progress bars against threshold range',
+  histogram: 'frequency distribution of a numerical field (auto-binned)',
+  state_timeline: 'discrete status/value changes over time',
+  table: 'raw tabular display',
+};
+
+function buildChartTypeList(): string {
+  return Object.keys(CHART_TYPE_INFO)
+    .map((type) => `"${type}"`)
+    .join(', ');
+}
+function buildChartTypeGuide(): string {
+  return Object.entries(CHART_TYPE_INFO)
+    .map(([type, desc]) => `\n"${type}" — ${desc}`)
+    .join('');
+}
+
+const CHART_GUIDE =
+  '\n\nCHART TYPE GUIDE (choose based on user intent and data shape):' + buildChartTypeGuide();
+
+const VIS_SPEC_PROPERTIES = {
+  query: {
+    type: 'string',
+    description:
+      'The PPL query to visualize (e.g. "source=flights | stats avg(delay) by carrier"). ' +
+      'This must be the same query previously run via ppl_execute.',
+  },
+  indexName: {
+    type: 'string',
+    description: 'The index/dataset name to query',
+  },
+  potentialChartType: {
+    type: 'string',
+    description:
+      'Optional. The chart type you infer the user most likely wants, based on their input. ' +
+      `The chart type must be one of: ${buildChartTypeList()}. ` +
+      'This is only a hint. Omit it when the user does not imply a specific chart type.',
+  },
+  columns: {
+    type: 'array',
+    description:
+      'The result column schema returned by ppl execution. Each column has a name and type ' +
+      '(e.g. "integer", "keyword", "date", "double", "long", "float", "text", "timestamp"). ' +
+      'Used to resolve which chart types and axes mappings are compatible.',
+    items: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Field name' },
+        type: {
+          type: 'string',
+          description: 'Field type from the query result schema',
+        },
+      },
+      required: ['name', 'type'],
+    },
+  },
+  splitField: {
+    type: 'string',
+    description:
+      'Optional categorical or numerical field to split/facet the chart by (small multiples). ' +
+      'Infer the user most likely wants.',
+  },
+  timeFieldName: {
+    type: 'string',
+    description:
+      'The time field name of the index (e.g. "@timestamp", "timestamp"). ' +
+      'Get this from the index mapping. ' +
+      'Required whenever you pass from/to - a time range without it is rejected.',
+  },
+};
+
+const VIS_SPEC_REQUIRED = ['query', 'indexName', 'columns'];
+
+/**
+ * Build the `from`/`to` schema properties for one tool.
+ */
+const buildTimeRangeProperties = (scope: 'visualization' | 'dashboard') => {
+  const placement =
+    scope === 'dashboard'
+      ? 'Pass this at the top level, NOT inside the visualizations array — one range applies ' +
+        'to every panel. '
+      : '';
+
+  return {
+    from: {
+      type: 'string',
+      description:
+        `${placement}Start of the time range. STRONGLY PREFER OpenSearch date math ` +
+        '("now-7d", "now-1h", "now/d") over absolute timestamps: you do not ' +
+        'have access to the current date, so any absolute date you compute ' +
+        'yourself will be wrong. Map relative phrasing directly — ' +
+        '"last 7 days" -> "now-7d", "past hour" -> "now-1h", ' +
+        '"yesterday" -> "now-1d/d". Use an ISO 8601 timestamp ONLY when the ' +
+        'user states an explicit calendar date. Must be provided together with `to`.',
+    },
+    to: {
+      type: 'string',
+      description:
+        `${placement}End of the time range. Use "now" for any query about the recent past ` +
+        '(this is the common case). Use an ISO 8601 timestamp only when the user ' +
+        'states an explicit end date. Must be provided together with `from`.',
+    },
+  };
+};
+
+export const AutoVisMeta = {
+  name: AUTO_VISUALIZATION_TOOL_NAME,
+  description:
+    'Creates a visualization from a PPL query and its result column schema. This tool does NOT ' +
+    'execute the query itself — it resolves the axes mapping from the provided columns, renders a ' +
+    'chart preview, and provides an editor link.' +
+    '\n\nWORKFLOW (follow in order):' +
+    '\n1. timeFieldName is MANDATORY for time-based queries: If the user request ' +
+    'involves any time concept (e.g. "last 7 days", "trends", "over time", "history", ' +
+    'time ranges, or time-series analysis), you MUST call the index mapping tool to get the timeFieldName \n' +
+    '\n2. Call the pplQueryTool tool with the PPL query to run it and obtain the result column schema.' +
+    '\n3. the query must NOT contain time filters — use the from/to parameters to specify the time range, and pass the same from/to you passed to pplQueryTool.' +
+    '\n4. from, to and timeFieldName go together: passing a time range without timeFieldName is rejected.' +
+    CHART_GUIDE,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      ...VIS_SPEC_PROPERTIES,
+      ...buildTimeRangeProperties('visualization'),
+    },
+    required: VIS_SPEC_REQUIRED,
+  },
+};

--- a/src/plugins/explore/public/plugin.test.ts
+++ b/src/plugins/explore/public/plugin.test.ts
@@ -3,11 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { ExplorePlugin } from './plugin';
 import { coreMock } from '../../../core/public/mocks';
 import { AskAIEmbeddableAction } from './actions/ask_ai_embeddable_action';
 import { CONTEXT_MENU_TRIGGER } from '../../embeddable/public';
-import { CoreSetup, CoreStart } from 'opensearch-dashboards/public';
+import {
+  CoreSetup,
+  CoreStart,
+  DEFAULT_NAV_GROUPS,
+  getUseCaseFeatureConfig,
+} from 'opensearch-dashboards/public';
 import { ExplorePluginStart, ExploreSetupDependencies, ExploreStartDependencies } from './types';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../data/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
@@ -28,6 +34,7 @@ import { ContextProviderStart } from '../../context_provider/public';
 import { registerDisabledPPLExecuteQueryAction } from './components/query_panel/actions/ppl_execute_query_action';
 import { registerDisabledPPLLintFixAction } from './components/query_panel/actions/ppl_lint_fix_action';
 import { clearActivePPLLintFixSession } from './components/query_panel/actions/ppl_lint_fix_session';
+import { registerAutoVisualizationAction } from './components/visualizations/actions/auto_visualization_action';
 
 // Mock the action
 jest.mock('./actions/ask_ai_embeddable_action');
@@ -62,6 +69,11 @@ jest.mock('./components/query_panel/actions/ppl_lint_fix_session', () => ({
   clearActivePPLLintFixSession: jest.fn(),
 }));
 
+jest.mock('./components/visualizations/actions/auto_visualization_action', () => ({
+  registerAutoVisualizationAction: jest.fn(),
+  AUTO_VISUALIZATION_TOOL_NAME: 'auto_create_visualization',
+}));
+
 // Mock createOsdUrlTracker
 jest.mock('../../opensearch_dashboards_utils/public', () => ({
   ...jest.requireActual('../../opensearch_dashboards_utils/public'),
@@ -80,6 +92,7 @@ describe('ExplorePlugin', () => {
   let setupDeps: ExploreSetupDependencies;
   let startDeps: ExploreStartDependencies;
   let mockCapabilities: any;
+  let currentWorkspace$: BehaviorSubject<{ features?: string[] } | null>;
 
   function createMockInitializerContext() {
     return {
@@ -231,20 +244,14 @@ describe('ExplorePlugin', () => {
 
     // Mock core start
     coreStart = coreMock.createStart();
-    // Add workspaces mock with proper BehaviorSubject-like structure
+    // A real BehaviorSubject rather than a hand-rolled stub: the plugin both reads it once
+    // (`getIsExploreEnabledWorkspace`) and subscribes to it for the lifetime of start()
+    // (`getIsExploreEnabledWorkspace$`), and tests need to push workspace switches through it.
+    currentWorkspace$ = new BehaviorSubject<{ features?: string[] } | null>({
+      features: ['observability'],
+    });
     Object.defineProperty(coreStart, 'workspaces', {
-      value: {
-        currentWorkspace$: {
-          pipe: jest.fn().mockReturnValue({
-            toPromise: jest.fn().mockResolvedValue({
-              features: ['observability'],
-            }),
-          }),
-          subscribe: jest.fn(),
-          getValue: jest.fn(),
-          next: jest.fn(),
-        },
-      },
+      value: { currentWorkspace$ },
       writable: true,
       configurable: true,
     });
@@ -682,6 +689,71 @@ describe('ExplorePlugin', () => {
       // Verify disabled action is registered before other actions
       const disabledActionIndex = callOrder.indexOf('registerDisabledAction');
       expect(disabledActionIndex).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('visualization assistant tool workspace gating', () => {
+    const mockRegisterAutoVisualizationAction = registerAutoVisualizationAction as jest.Mock;
+    // isNavGroupInFeatureConfigs matches on the prefixed form, not the bare nav group id.
+    const OBSERVABILITY_FEATURE = getUseCaseFeatureConfig(DEFAULT_NAV_GROUPS.observability.id);
+
+    const unregisterCalls = () =>
+      (startDeps.contextProvider!.actions.unregisterAssistantAction as jest.Mock).mock.calls.filter(
+        ([name]) => name === 'auto_create_visualization'
+      );
+
+    beforeEach(() => {
+      mockRegisterAutoVisualizationAction.mockClear();
+    });
+
+    it('registers the tool when start happens inside a workspace', () => {
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledTimes(1);
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledWith(
+        startDeps.contextProvider!.actions.registerAssistantAction,
+        coreStart,
+        startDeps.data,
+        startDeps.contextProvider
+      );
+    });
+
+    it('registers once the workspace loads, not just at start', () => {
+      // currentWorkspace$ is null until the workspace list resolves, which is the state
+      // start() usually observes. A one-shot read here would skip registration for good.
+      currentWorkspace$.next(null);
+
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+      expect(mockRegisterAutoVisualizationAction).not.toHaveBeenCalled();
+
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+      expect(mockRegisterAutoVisualizationAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('unregisters the tool when leaving the workspace', () => {
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+
+      const before = unregisterCalls().length;
+      currentWorkspace$.next(null);
+
+      expect(unregisterCalls().length).toBe(before + 1);
+    });
+
+    it('stops reacting to workspace changes after stop', () => {
+      currentWorkspace$.next(null);
+      plugin.setup(coreSetup, setupDeps);
+      plugin.start(coreStart, startDeps);
+      plugin.stop();
+
+      currentWorkspace$.next({ features: [OBSERVABILITY_FEATURE] });
+
+      expect(mockRegisterAutoVisualizationAction).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -7,8 +7,8 @@ import { i18n } from '@osd/i18n';
 import semver from 'semver';
 import qs from 'query-string';
 import rison from 'rison-node';
-import { BehaviorSubject } from 'rxjs';
-import { filter, map, take } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, map, take } from 'rxjs/operators';
 import {
   App,
   AppMountParameters,
@@ -102,6 +102,11 @@ import {
 } from './components/query_panel/actions/ppl_lint_fix_action';
 import { clearActivePPLLintFixSession } from './components/query_panel/actions/ppl_lint_fix_session';
 
+import {
+  registerAutoVisualizationAction,
+  AUTO_VISUALIZATION_TOOL_NAME,
+} from './components/visualizations/actions/auto_visualization_action';
+
 export class ExplorePlugin implements Plugin<
   ExplorePluginSetup,
   ExplorePluginStart,
@@ -141,6 +146,8 @@ export class ExplorePlugin implements Plugin<
   private editorStopUrlTracking?: () => void;
   private unregisterPPLExecuteQueryAction?: () => void;
   private unregisterPPLLintFixAction?: () => void;
+  private unregisterVisualizationTools?: () => void;
+  private visualizationToolsWorkspaceSubscription?: Subscription;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {}
 
@@ -887,7 +894,16 @@ export class ExplorePlugin implements Plugin<
       plugins.uiActions.addTriggerAction(CONTEXT_MENU_TRIGGER, askAIEmbeddableAction);
     }
 
-    // Register disabled apply_ppl_query action as placeholder
+    // Create saved explore loader so tool can use it
+    const savedExploreLoader = createSavedExploreLoader({
+      savedObjectsClient: core.savedObjects.client,
+      indexPatterns: plugins.data.indexPatterns,
+      search: plugins.data.search,
+      chrome: core.chrome,
+      overlays: core.overlays,
+    });
+
+    // Register disabled execute_ppl_query action as placeholder
     // This will be overridden when query panel mounts and restored when it unmounts
     if (plugins.contextProvider) {
       registerDisabledPPLExecuteQueryAction(
@@ -905,17 +921,31 @@ export class ExplorePlugin implements Plugin<
       const { registerAssistantAction, unregisterAssistantAction } =
         plugins.contextProvider.actions;
 
+      // The tool will only be registered in an explore-enabled workspace as it depends on vis editor
+      this.visualizationToolsWorkspaceSubscription = this.getIsInsideWorkspace$(core).subscribe(
+        (isExploreEnabledWorkspace) => {
+          if (isExploreEnabledWorkspace) {
+            registerAutoVisualizationAction(
+              registerAssistantAction,
+              core,
+              plugins.data,
+              plugins.contextProvider
+            );
+          } else {
+            // Leaving the workspace must take the tool back out of availableTools
+            unregisterAssistantAction(AUTO_VISUALIZATION_TOOL_NAME);
+          }
+        }
+      );
+
+      this.unregisterVisualizationTools = () => {
+        this.visualizationToolsWorkspaceSubscription?.unsubscribe();
+        unregisterAssistantAction(AUTO_VISUALIZATION_TOOL_NAME);
+      };
+
       // Inject contextProvider action helpers into PanelDataService
       PanelDataService.init(registerAssistantAction, unregisterAssistantAction);
     }
-
-    const savedExploreLoader = createSavedExploreLoader({
-      savedObjectsClient: core.savedObjects.client,
-      indexPatterns: plugins.data.indexPatterns,
-      search: plugins.data.search,
-      chrome: core.chrome,
-      overlays: core.overlays,
-    });
 
     return {
       urlGenerator: this.urlGenerator,
@@ -934,6 +964,7 @@ export class ExplorePlugin implements Plugin<
     this.unregisterPPLExecuteQueryAction?.();
     this.unregisterPPLLintFixAction?.();
     clearActivePPLLintFixSession();
+    this.unregisterVisualizationTools?.();
     // cleanup shared panel-data store + fetch_panel_data tool.
     PanelDataService.getInstance().reset();
   }
@@ -1115,6 +1146,16 @@ export class ExplorePlugin implements Plugin<
         (isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.observability.id, features) ||
           isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.all.id, features))) ??
       false
+    );
+  }
+
+  /**
+   * Emits whether the user is inside workspace
+   */
+  private getIsInsideWorkspace$(core: CoreStart): Observable<boolean> {
+    return core.workspaces.currentWorkspace$.pipe(
+      map((workspace) => !!workspace),
+      distinctUntilChanged()
     );
   }
 }

--- a/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/ppl_search_interceptor.ts
@@ -175,9 +175,10 @@ export class PPLSearchInterceptor extends SearchInterceptor {
       // Skip adding time filters if hideDatePicker is false. Let search strategy insert time filters.
       datasetService.getType(dataset.type)?.languageOverrides?.PPL?.hideDatePicker !== false
     ) {
+      // Prefer an explicit time range passed and fall back to the global timefilter.
       const timeFilter = PPLFilterUtils.getTimeFilterWhereClause(
         dataset.timeFieldName,
-        this.queryService.timefilter.timefilter.getTime(),
+        request.params?.body?.timeRange ?? this.queryService.timefilter.timefilter.getTime(),
         dataset.dataSource?.engineType ?? dataset.dataSource?.type
       );
       whereCommands.push(timeFilter);


### PR DESCRIPTION
### Description

This PR adds an AI-driven visualization capability to the chat assistant. Users can describe what they want in natural language (e.g. "show the average ticket price per airport"), and the assistant generates a PPL query, picks a suitable chart type, renders a live chart preview inside the chat window, and offers an "Open in Editor" link that deep-links into the full visualization editor.

The core new tool is auto_create_visualization. And it relies on https://github.com/opensearch-project/opensearch-mcp-server-py/pull/257.

The intended tool-call workflow (encoded in the tool description) is:
Index mapping tool → look up timeFieldName
ppl_execute → run the query, return the result column schema
auto_create_visualization → resolve chart config from columns, render preview, provide editor link

Besides, this pr adds:

fetch_panel_data tool , access panel explore embeddable data
Add dashboard page context and screenshot configuration, revert changes in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11287


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
