### PR TITLE
[Chat] Make Discover AI chat page context language-aware for filters/time range

### DIFF
--- a/src/plugins/context_provider/public/plugin.ts
+++ b/src/plugins/context_provider/public/plugin.ts
@@ -52,6 +52,8 @@ export class ContextProviderPlugin implements Plugin<
         actions: {
           registerAssistantAction: () => undefined,
           unregisterAssistantAction: () => undefined,
+          suppressDefaultPageContext: () => undefined,
+          unsuppressDefaultPageContext: () => undefined,
         },
         hooks: {
           usePageContext: () => '',
@@ -68,6 +70,9 @@ export class ContextProviderPlugin implements Plugin<
       actions: {
         registerAssistantAction: AssistantActionService.getInstance().registerAction,
         unregisterAssistantAction: AssistantActionService.getInstance().unregisterAction,
+        suppressDefaultPageContext: () => this.contextCaptureService!.suppressDefaultPageContext(),
+        unsuppressDefaultPageContext: () =>
+          this.contextCaptureService!.unsuppressDefaultPageContext(),
       },
       hooks: {
         usePageContext,

--- a/src/plugins/context_provider/public/services/context_capture_service.ts
+++ b/src/plugins/context_provider/public/services/context_capture_service.ts
@@ -96,12 +96,12 @@ export class ContextCaptureService {
     });
   }
 
-  private suppressDefaultPageContext(): void {
+  public suppressDefaultPageContext(): void {
     this.defaultContextSuppressed = true;
     this.assistantContextStore.removeContextById(DEFAULT_PAGE_CONTEXT_ID);
   }
 
-  private unsuppressDefaultPageContext(): void {
+  public unsuppressDefaultPageContext(): void {
     this.defaultContextSuppressed = false;
     if (this.cachedAppId) {
       this.registerDefaultPageContext();

--- a/src/plugins/context_provider/public/types.ts
+++ b/src/plugins/context_provider/public/types.ts
@@ -40,6 +40,8 @@ export interface ContextProviderStart {
   actions: {
     registerAssistantAction: (action: AssistantAction) => void;
     unregisterAssistantAction: (id: string) => void;
+    suppressDefaultPageContext: () => void;
+    unsuppressDefaultPageContext: () => void;
   };
   hooks: {
     usePageContext: (options?: any) => string;

--- a/src/plugins/discover/public/application/view_components/context/index.test.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.test.tsx
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render } from '@testing-library/react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import React from 'react';
+import { Subject } from 'rxjs';
 import { ViewProps } from '../../../../../data_explorer/public';
 
 import DiscoverContext from './index';
@@ -15,89 +18,296 @@ jest.mock('../utils/use_search', () => ({
 
 jest.mock('../../../../../opensearch_dashboards_react/public', () => ({
   useOpenSearchDashboards: () => ({ services: {} }),
-  OpenSearchDashboardsContextProvider: () => null,
+  OpenSearchDashboardsContextProvider: ({ children }: any) => children,
 }));
 
-const mockUsePageContext = jest.fn();
+jest.mock('../../../../../data/common', () => ({
+  buildOpenSearchQuery: jest.fn((_index, _queries, filters, _config) => {
+    if ((global as any).__forceEmptyBool) {
+      return { bool: { must: [], filter: [], should: [], must_not: [] } };
+    }
+    return {
+      bool: {
+        must: [],
+        filter: filters.map((f: any) => ({ term: { [f.meta?.key || 'field']: f.meta?.value } })),
+        should: [],
+        must_not: [],
+      },
+    };
+  }),
+  getOpenSearchQueryConfig: jest.fn(() => ({})),
+}));
+
 const mockGetServices = jest.fn();
 jest.mock('../../../opensearch_dashboards_services', () => ({
   getServices: () => mockGetServices(),
 }));
 
-// DiscoverContext is mounted by the router with full ViewProps (AppMountParameters);
-// for these unit tests we only care about the page-context side effect, so we cast a
-// minimal props object and let the mocked hooks handle the rest.
-const renderContext = () =>
-  render(
-    <DiscoverContext {...({} as ViewProps)}>
-      <div>child</div>
-    </DiscoverContext>
-  );
+// Observable subjects to simulate store updates
+const filterUpdates$ = new Subject<void>();
+const timeUpdates$ = new Subject<void>();
+const queryUpdates$ = new Subject<void>();
 
-describe('DiscoverContext page context registration', () => {
+const mockAddContext = jest.fn();
+const mockRemoveContextById = jest.fn();
+const mockSuppressDefaultPageContext = jest.fn();
+const mockUnsuppressDefaultPageContext = jest.fn();
+
+function createMockServices(overrides: any = {}) {
+  return {
+    data: {
+      query: {
+        filterManager: {
+          getFilters: jest.fn(() => overrides.filters ?? []),
+          getUpdates$: () => filterUpdates$,
+        },
+        timefilter: {
+          timefilter: {
+            getTime: jest.fn(() => overrides.timeRange ?? { from: 'now-15m', to: 'now' }),
+            getTimeUpdate$: () => timeUpdates$,
+          },
+        },
+        queryString: {
+          getQuery: jest.fn(
+            () =>
+              overrides.query ?? {
+                query: '',
+                language: overrides.language ?? 'kuery',
+                dataset: overrides.dataset ?? { id: 'test-index' },
+              }
+          ),
+          getLanguageService: jest.fn(() => ({
+            getLanguage: jest.fn((lang: string) => {
+              if (overrides.languageConfig === null) return undefined;
+              if (lang === 'SQL') return { hideDatePicker: true, fields: { filterable: false } };
+              return (
+                overrides.languageConfig ?? { hideDatePicker: false, fields: { filterable: true } }
+              );
+            }),
+          })),
+          getUpdates$: () => queryUpdates$,
+        },
+      },
+    },
+    uiSettings: {
+      get: jest.fn(),
+    },
+    contextProvider:
+      'contextProvider' in overrides
+        ? overrides.contextProvider
+        : {
+            getAssistantContextStore: () => ({
+              addContext: mockAddContext,
+              removeContextById: mockRemoveContextById,
+            }),
+            actions: {
+              suppressDefaultPageContext: mockSuppressDefaultPageContext,
+              unsuppressDefaultPageContext: mockUnsuppressDefaultPageContext,
+            },
+          },
+    ...overrides.extraServices,
+  };
+}
+
+// Minimal ViewProps for rendering
+const renderContext = (container: HTMLElement) => {
+  act(() => {
+    render(
+      React.createElement(DiscoverContext, { onAppLeave: () => {} } as unknown as ViewProps),
+      container
+    );
+  });
+};
+
+describe('DiscoverContext (iteration 3 - direct store subscription)', () => {
+  let container: HTMLElement;
+
   beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
     jest.clearAllMocks();
   });
 
-  it('registers page context with the contextProvider hook when available', () => {
-    mockGetServices.mockReturnValue({
-      contextProvider: { hooks: { usePageContext: mockUsePageContext } },
+  afterEach(() => {
+    act(() => {
+      unmountComponentAtNode(container);
     });
-
-    renderContext();
-
-    expect(mockUsePageContext).toHaveBeenCalledTimes(1);
-    const options = mockUsePageContext.mock.calls[0][0];
-    expect(options.description).toBe('Discover application page context');
-    expect(options.categories).toEqual(['page', 'static']);
-    expect(typeof options.convert).toBe('function');
+    document.body.removeChild(container);
+    delete (global as any).__forceEmptyBool;
   });
 
-  it('maps url state to the expected page context shape via convert', () => {
-    mockGetServices.mockReturnValue({
-      contextProvider: { hooks: { usePageContext: mockUsePageContext } },
-    });
+  it('registers context and suppresses default page context on mount', () => {
+    mockGetServices.mockReturnValue(createMockServices());
+    renderContext(container);
 
-    renderContext();
-
-    const { convert } = mockUsePageContext.mock.calls[0][0];
-
-    const dataset = { id: 'logs-*', title: 'logs-*', type: 'INDEX_PATTERN' };
-    const result = convert({
-      _g: { time: { from: 'now-15m', to: 'now' } },
-      _q: { query: { query: 'status:200', language: 'PPL', dataset } },
-    });
-
-    expect(result).toEqual({
-      appId: 'discover',
-      timeRange: { from: 'now-15m', to: 'now' },
-      query: { query: 'status:200', language: 'PPL' },
-      dataset,
-    });
+    expect(mockSuppressDefaultPageContext).toHaveBeenCalledTimes(1);
+    expect(mockAddContext).toHaveBeenCalledTimes(1);
+    expect(mockAddContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'discover-page-context',
+        description: 'Discover application page context',
+        label: 'Page: Discover',
+        categories: ['page', 'static'],
+      })
+    );
   });
 
-  it('falls back to safe defaults when url state is empty', () => {
-    mockGetServices.mockReturnValue({
-      contextProvider: { hooks: { usePageContext: mockUsePageContext } },
-    });
+  it('includes timeRange and query for DQL/Lucene', () => {
+    mockGetServices.mockReturnValue(
+      createMockServices({
+        language: 'kuery',
+        timeRange: { from: 'now-1h', to: 'now' },
+      })
+    );
+    renderContext(container);
 
-    renderContext();
-
-    const { convert } = mockUsePageContext.mock.calls[0][0];
-    const result = convert({});
-
-    expect(result).toEqual({
-      appId: 'discover',
-      timeRange: undefined,
-      query: { query: '', language: 'kuery' },
-      dataset: undefined,
-    });
+    const contextValue = mockAddContext.mock.calls[0][0].value;
+    expect(contextValue.timeRange).toEqual({ from: 'now-1h', to: 'now' });
+    expect(contextValue.query).toEqual({ query: '', language: 'kuery' });
+    expect(contextValue.appId).toBe('discover');
   });
 
-  it('does not throw when the contextProvider plugin is unavailable (NOOP fallback)', () => {
-    mockGetServices.mockReturnValue({});
+  it('omits timeRange and filters for SQL', () => {
+    mockGetServices.mockReturnValue(
+      createMockServices({
+        language: 'SQL',
+        filters: [{ meta: { key: 'status', value: 'active' } }],
+      })
+    );
+    renderContext(container);
 
-    expect(() => renderContext()).not.toThrow();
-    expect(mockUsePageContext).not.toHaveBeenCalled();
+    const contextValue = mockAddContext.mock.calls[0][0].value;
+    expect(contextValue.timeRange).toBeUndefined();
+    expect(contextValue.filters).toBeUndefined();
+    expect(contextValue.filtersNote).toBeUndefined();
+    expect(contextValue.query.language).toBe('SQL');
+  });
+
+  it('includes filters as OpenSearch DSL with filtersNote for DQL', () => {
+    mockGetServices.mockReturnValue(
+      createMockServices({
+        language: 'kuery',
+        filters: [{ meta: { key: 'status', value: 'active' } }],
+      })
+    );
+    renderContext(container);
+
+    const contextValue = mockAddContext.mock.calls[0][0].value;
+    expect(contextValue.filters).toEqual({
+      must: [],
+      filter: [{ term: { status: 'active' } }],
+      should: [],
+      must_not: [],
+    });
+    expect(contextValue.filtersNote).toContain('already applied');
+  });
+
+  it('omits filters key when rawFilters is empty (timeRange still included)', () => {
+    mockGetServices.mockReturnValue(
+      createMockServices({
+        language: 'kuery',
+        filters: [],
+        timeRange: { from: 'now-7d', to: 'now' },
+      })
+    );
+    renderContext(container);
+
+    const contextValue = mockAddContext.mock.calls[0][0].value;
+    expect(contextValue.filters).toBeUndefined();
+    expect(contextValue.filtersNote).toBeUndefined();
+    expect(contextValue.timeRange).toEqual({ from: 'now-7d', to: 'now' });
+  });
+
+  it('includes filters and filtersNote even when the DSL bool clause is empty (trusts buildOpenSearchQuery as-is)', () => {
+    (global as any).__forceEmptyBool = true;
+    mockGetServices.mockReturnValue(
+      createMockServices({
+        language: 'kuery',
+        filters: [{ meta: { key: 'status', value: 'active', disabled: true } }],
+      })
+    );
+    renderContext(container);
+
+    const contextValue = mockAddContext.mock.calls[0][0].value;
+    expect(contextValue.filters).toEqual({ must: [], filter: [], should: [], must_not: [] });
+    expect(contextValue.filtersNote).toContain('already applied');
+  });
+
+  it('defaults to kuery when language service is unavailable', () => {
+    mockGetServices.mockReturnValue(
+      createMockServices({
+        language: 'unknown-lang',
+        languageConfig: null,
+      })
+    );
+    renderContext(container);
+
+    // With no language config, supportsTimeFilter defaults to true, supportsFilters to true
+    const contextValue = mockAddContext.mock.calls[0][0].value;
+    expect(contextValue.timeRange).toBeDefined();
+    expect(contextValue.query.language).toBe('unknown-lang');
+  });
+
+  it('re-registers context when filterManager emits', () => {
+    mockGetServices.mockReturnValue(createMockServices());
+    renderContext(container);
+
+    mockAddContext.mockClear();
+    act(() => {
+      filterUpdates$.next();
+    });
+
+    expect(mockAddContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-registers context when timefilter emits', () => {
+    mockGetServices.mockReturnValue(createMockServices());
+    renderContext(container);
+
+    mockAddContext.mockClear();
+    act(() => {
+      timeUpdates$.next();
+    });
+
+    expect(mockAddContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-registers context when queryString emits', () => {
+    mockGetServices.mockReturnValue(createMockServices());
+    renderContext(container);
+
+    mockAddContext.mockClear();
+    act(() => {
+      queryUpdates$.next();
+    });
+
+    expect(mockAddContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up on unmount: unsubscribes, removes context, unsuppresses', () => {
+    mockGetServices.mockReturnValue(createMockServices());
+    renderContext(container);
+
+    act(() => {
+      unmountComponentAtNode(container);
+    });
+
+    expect(mockRemoveContextById).toHaveBeenCalledWith('discover-page-context');
+    expect(mockUnsuppressDefaultPageContext).toHaveBeenCalledTimes(1);
+
+    // Verify no further registration after unmount
+    mockAddContext.mockClear();
+    act(() => {
+      filterUpdates$.next();
+    });
+    expect(mockAddContext).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when contextProvider is absent', () => {
+    mockGetServices.mockReturnValue(createMockServices({ contextProvider: undefined }));
+    renderContext(container);
+
+    expect(mockAddContext).not.toHaveBeenCalled();
+    expect(mockSuppressDefaultPageContext).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/discover/public/application/view_components/context/index.tsx
+++ b/src/plugins/discover/public/application/view_components/context/index.tsx
@@ -3,21 +3,67 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { merge } from 'rxjs';
 import { DataExplorerServices, ViewProps } from '../../../../../data_explorer/public';
 import {
   OpenSearchDashboardsContextProvider,
   useOpenSearchDashboards,
 } from '../../../../../opensearch_dashboards_react/public';
+import { buildOpenSearchQuery, getOpenSearchQueryConfig } from '../../../../../data/common';
 import { getServices } from '../../../opensearch_dashboards_services';
 import { useSearch, SearchContextValue } from '../utils/use_search';
 import { useApplyQueryAction } from '../actions/apply_query_action';
 
 const SearchContext = React.createContext<SearchContextValue>({} as SearchContextValue);
+const DISCOVER_PAGE_CONTEXT_ID = 'discover-page-context';
 
-// NOOP fallback used when the contextProvider plugin is not available
-// (e.g. AI features disabled). Keeps the hook call unconditional.
-const NOOP_PAGE_CONTEXT_HOOK = (_options?: any): string => '';
+function buildDiscoverPageContextValue(services: ReturnType<typeof getServices>) {
+  const { filterManager, timefilter, queryString } = services.data.query;
+  const currentQuery = queryString.getQuery();
+  const language = currentQuery.language || 'kuery';
+  const languageConfig = queryString.getLanguageService()?.getLanguage?.(language);
+
+  // SQL expresses time/filter constraints inline, so both are omitted for
+  // languages where hideDatePicker/fields.filterable indicate they're not
+  // used, matching the search bar's own visibility flags.
+  const supportsTimeFilter = !languageConfig?.hideDatePicker;
+  const supportsFilters = languageConfig?.fields?.filterable ?? true;
+
+  let filtersContext: { filters?: unknown; filtersNote?: string } = {};
+  if (supportsFilters) {
+    const rawFilters = filterManager.getFilters();
+    if (rawFilters.length > 0) {
+      // Convert to the same OpenSearch DSL SearchSource.flatten() sends to
+      // the backend. queries=[] is safe here since it makes the
+      // buildOpenSearchQuery 'unsupported' branch unreachable.
+      const opensearchQueryConfig = getOpenSearchQueryConfig({
+        get: services.uiSettings.get.bind(services.uiSettings),
+      });
+      const builtQuery = buildOpenSearchQuery(undefined, [], rawFilters, opensearchQueryConfig);
+      const filtersDsl = 'bool' in builtQuery ? builtQuery.bool : undefined;
+      if (filtersDsl !== undefined) {
+        filtersContext = {
+          filters: filtersDsl,
+          filtersNote:
+            'These filters are already applied as an OpenSearch DSL query on top of the search.',
+        };
+      }
+    }
+  }
+
+  return {
+    appId: 'discover',
+    ...(supportsTimeFilter ? { timeRange: timefilter.timefilter.getTime() } : {}),
+    query: {
+      query: currentQuery.query || '',
+      language,
+      ...(languageConfig?.title ? { languageDisplayName: languageConfig.title } : {}),
+    },
+    dataset: currentQuery.dataset,
+    ...filtersContext,
+  };
+}
 
 // eslint-disable-next-line import/no-default-export
 export default function DiscoverContext({ children }: React.PropsWithChildren<ViewProps>) {
@@ -28,30 +74,39 @@ export default function DiscoverContext({ children }: React.PropsWithChildren<Vi
     ...services,
   });
 
-  // Register page context so the AI chatbot is aware of the current query,
-  // language, dataset and time range in classic Discover. Classic Discover
-  // stores the query one level deeper under `_q.query` (vs `_q` in Explore).
-  const usePageContext = services.contextProvider?.hooks?.usePageContext || NOOP_PAGE_CONTEXT_HOOK;
-  const languageService = services.data?.query?.queryString?.getLanguageService?.();
-  usePageContext({
-    description: 'Discover application page context',
-    convert: (urlState: any) => {
-      const languageKey = urlState?._q?.query?.language || 'kuery';
-      const languageDisplayName = languageService?.getLanguage(languageKey)?.title;
-      const isSql = languageKey.toLowerCase() === 'sql';
-      return {
-        appId: 'discover',
-        ...(isSql ? {} : { timeRange: urlState?._g?.time }),
-        query: {
-          query: urlState?._q?.query?.query || '',
-          language: languageKey,
-          ...(languageDisplayName ? { languageDisplayName } : {}),
-        },
-        dataset: urlState?._q?.query?.dataset,
-      };
-    },
-    categories: ['page', 'static'],
-  });
+  useEffect(() => {
+    const contextStore = services.contextProvider?.getAssistantContextStore?.();
+    if (!contextStore) return;
+
+    const { suppressDefaultPageContext, unsuppressDefaultPageContext } =
+      services.contextProvider?.actions ?? {};
+    suppressDefaultPageContext?.();
+
+    const registerContext = () => {
+      contextStore.addContext({
+        id: DISCOVER_PAGE_CONTEXT_ID,
+        description: 'Discover application page context',
+        value: buildDiscoverPageContextValue(services),
+        label: 'Page: Discover',
+        categories: ['page', 'static'],
+      });
+    };
+    registerContext();
+
+    const { filterManager, timefilter, queryString } = services.data.query;
+    const subscription = merge(
+      filterManager.getUpdates$(),
+      timefilter.timefilter.getTimeUpdate$(),
+      queryString.getUpdates$()
+    ).subscribe(registerContext);
+
+    return () => {
+      subscription.unsubscribe();
+      contextStore.removeContextById(DISCOVER_PAGE_CONTEXT_ID);
+      unsuppressDefaultPageContext?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Register the apply query action for assistant integration
   useApplyQueryAction(


### PR DESCRIPTION
### Description
Classic Discover's page context sent to the AI chatbot previously always included `timeRange` without `filters`, regardless of the active query language. This is misleading for full query languages such as SQL, which express their own temporal and filter constraints inline in the query text — surfacing OSD's separate time-picker/filter-bar state alongside a SQL query would be redundant or confusing to the agent.

This PR:
- Reads query, filters, and time range from the formal data plugin stores (`filterManager`, `timefilter`, `queryString`) instead of parsing Discover's internal URL state.
- Gates `timeRange`/`filters` inclusion on the same `hideDatePicker` / `fields.filterable` flags that already drive the search bar's own UI visibility, so the context always matches what the user sees on screen.
- Converts applied filters to OpenSearch DSL via `buildOpenSearchQuery` (the same conversion `SearchSource.flatten()` uses), with a `filtersNote` telling the agent the filters are already applied so it doesn't try to re-apply them.
- Subscribes directly to `filterManager.getUpdates$()`, `timefilter.getTimeUpdate$()`, and `queryString.getUpdates$()` for reactivity, replacing the URL-change-triggered `usePageContext` hook (which only fired on browser URL changes, correlating with but not contractually tied to the actual store mutations).
- Exposes `suppressDefaultPageContext`/`unsuppressDefaultPageContext` through the typed `ContextProviderStart.actions` contract, so Discover no longer needs to reach into the `window.__defaultPageContextControl` global directly.

### Issues Resolved
N/A

### Testing the changes
- Unit tests: 12/12 passing on `index.test.tsx` (registration, suppression, language-gating for SQL vs DQL/Lucene, empty-filters case, reactivity on each of the 3 store observables independently, cleanup on unmount, contextProvider-absent no-op case).
- `context_provider` plugin test suite: 189/189 passing — no regressions from the `plugin.ts`/`types.ts`/`context_capture_service.ts` contract changes.
- eslint clean on all changed files.
- Manual verification in a running dev server (language switch, filter add/remove, inspecting the outgoing chat request payload) is still pending.