### PR TITLE
fix(explore): guard PanelDataService.getInstance() against uninitialized state

### DIFF
--- a/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
@@ -30,10 +30,10 @@ jest.mock('./explore_embeddable_component', () => ({
   ExploreEmbeddableComponent: jest.fn(() => null),
 }));
 
-// Mock the PanelDataService singleton. The real getInstance() throws unless
-// PanelDataService.init() was called during plugin setup, which never happens
-// in this unit test — so fetch()/destroy() would blow up. Return a stub whose
-// setPanelData/removePanelData are no-ops.
+// Mock the PanelDataService singleton so fetch()/destroy() interactions with the
+// shared panel-data store can be asserted directly, without depending on whether
+// PanelDataService.init() was called (getInstance() now safely returns null when
+// uninitialized, e.g. when contextProvider is disabled).
 jest.mock('./panel_data_service', () => {
   const mockPanelDataInstance = {
     setPanelData: jest.fn(),
@@ -297,6 +297,14 @@ describe('ExploreEmbeddable', () => {
     embeddable.render(mockNode);
     embeddable.destroy();
     expect(mockUnmount).toHaveBeenCalled();
+  });
+
+  test('destroy does not throw when PanelDataService is uninitialized (contextProvider disabled)', () => {
+    const { PanelDataService } = jest.requireMock('./panel_data_service');
+    PanelDataService.getInstance.mockReturnValueOnce(null);
+
+    embeddable.render(mockNode);
+    expect(() => embeddable.destroy()).not.toThrow();
   });
 
   test('updates input correctly', () => {

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -661,7 +661,7 @@ export class ExploreEmbeddable
     // Update shared panel data store so the global fetch_panel_data tool returns fresh data
     const savedExploreId = this.savedExplore.id;
     if (savedExploreId) {
-      PanelDataService.getInstance().setPanelData(savedExploreId, {
+      PanelDataService.getInstance()?.setPanelData(savedExploreId, {
         rows: transformedRows,
         panelTitle: this.panelTitle || this.savedExplore.title,
       });
@@ -735,7 +735,7 @@ export class ExploreEmbeddable
     }
 
     if (this.savedExplore.id) {
-      PanelDataService.getInstance().removePanelData(this.savedExplore.id);
+      PanelDataService.getInstance()?.removePanelData(this.savedExplore.id);
     }
 
     if (this.abortController) {

--- a/src/plugins/explore/public/embeddable/panel_data_service.test.ts
+++ b/src/plugins/explore/public/embeddable/panel_data_service.test.ts
@@ -32,11 +32,17 @@ describe('PanelDataService', () => {
     it('returns the same instance across calls', () => {
       expect(PanelDataService.getInstance()).toBe(PanelDataService.getInstance());
     });
+
+    it('returns null when init() has not been called', () => {
+      (PanelDataService as any).instance = null;
+
+      expect(PanelDataService.getInstance()).toBeNull();
+    });
   });
 
   describe('setPanelData', () => {
     it('registers the shared tool lazily on the first publish', () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       expect(registerAction).not.toHaveBeenCalled();
 
       service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
@@ -46,7 +52,7 @@ describe('PanelDataService', () => {
     });
 
     it('registers the tool only once across multiple publishes', () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
       service.setPanelData('panel-2', { rows: [], panelTitle: 'Panel 2' });
       service.setPanelData('panel-1', { rows: [{ a: 1 }], panelTitle: 'Panel 1' });
@@ -57,7 +63,7 @@ describe('PanelDataService', () => {
 
   describe('fetch_panel_data handler', () => {
     it('returns the formatted rows for a known panel', async () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', {
         rows: [{ _source: { host: 'a' } }, { fields: { host: 'b' } }, { host: 'c' }],
         panelTitle: 'Hosts',
@@ -76,7 +82,7 @@ describe('PanelDataService', () => {
     });
 
     it('returns a not-loaded failure for an unknown panel', async () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
 
       const result = await getRegisteredAction().handler({ savedObjectId: 'missing' });
@@ -86,7 +92,7 @@ describe('PanelDataService', () => {
     });
 
     it('reflects the latest rows after an overwrite', async () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
       service.setPanelData('panel-1', { rows: [{ v: 2 }, { v: 3 }], panelTitle: 'Panel 1' });
 
@@ -99,7 +105,7 @@ describe('PanelDataService', () => {
 
   describe('removePanelData', () => {
     it('drops the panel data so the handler reports it as unavailable', async () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
 
       service.removePanelData('panel-1');
@@ -109,7 +115,7 @@ describe('PanelDataService', () => {
     });
 
     it('leaves the shared tool registered even after the last panel is removed', () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
 
       service.removePanelData('panel-1');
@@ -121,7 +127,7 @@ describe('PanelDataService', () => {
 
   describe('reset', () => {
     it('clears all data and unregisters the tool', async () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [{ v: 1 }], panelTitle: 'Panel 1' });
       service.setPanelData('panel-2', { rows: [{ v: 2 }], panelTitle: 'Panel 2' });
 
@@ -135,7 +141,7 @@ describe('PanelDataService', () => {
     });
 
     it('is a no-op unregister when nothing was ever registered', () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
 
       service.reset();
 
@@ -143,7 +149,7 @@ describe('PanelDataService', () => {
     });
 
     it('re-registers on the next publish after reset', () => {
-      const service = PanelDataService.getInstance();
+      const service = PanelDataService.getInstance()!;
       service.setPanelData('panel-1', { rows: [], panelTitle: 'Panel 1' });
       service.reset();
       registerAction.mockClear();

--- a/src/plugins/explore/public/embeddable/panel_data_service.ts
+++ b/src/plugins/explore/public/embeddable/panel_data_service.ts
@@ -37,12 +37,12 @@ export class PanelDataService {
     PanelDataService.instance.unregisterAction = unregisterAction;
   }
 
-  static getInstance(): PanelDataService {
-    if (!PanelDataService.instance) {
-      throw new Error(
-        'PanelDataService has not been initialized. Call PanelDataService.init() first.'
-      );
-    }
+  /**
+   * Returns the singleton instance, or null if init() has not been called
+   * (e.g. the contextProvider plugin is disabled). Callers must handle the
+   * null case instead of assuming the service is always available.
+   */
+  static getInstance(): PanelDataService | null {
     return PanelDataService.instance;
   }
 

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -935,7 +935,7 @@ export class ExplorePlugin implements Plugin<
     this.unregisterPPLLintFixAction?.();
     clearActivePPLLintFixSession();
     // cleanup shared panel-data store + fetch_panel_data tool.
-    PanelDataService.getInstance().reset();
+    PanelDataService.getInstance()?.reset();
   }
 
   private registerEmbeddable(


### PR DESCRIPTION
## Description
`PanelDataService.getInstance()` throws `'PanelDataService has not been initialized...'` when called before `PanelDataService.init()` runs. `init()` is only called from `plugin.ts`'s `start()` when the `contextProvider` plugin is enabled (`if (plugins.contextProvider) { ... PanelDataService.init(...) }`).

However, `explore_embeddable.tsx` calls `PanelDataService.getInstance()` **unconditionally** in two places:
- On every panel data update (`setPanelData`, in the search-complete handler)
- On every panel removal (`removePanelData`, in `destroy()`)

`plugin.ts`'s `stop()` also calls it unconditionally (`.reset()`).

When `contextProvider` is disabled, `PanelDataService` is never initialized, so every dashboard-embedded Explore panel update or teardown throws an uncaught error, breaking the panel's render/update cycle. This was observed causing CI failures in `download_csv_from_dashboard.spec.js` and `saved_search_in_dashboards.spec.js` (both spec flows embed an Explore panel into a Dashboard and then resubmit a query, which drives a panel-data update through the unguarded call path), traced back to `contextProvider` being disabled in that CI job's plugin config.

## Changes
- `panel_data_service.ts`: `getInstance()` now returns `PanelDataService | null` instead of throwing when uninitialized.
- `explore_embeddable.tsx` / `plugin.ts`: the three call sites use optional chaining (`?.`) and safely no-op when the service isn't initialized.
- Added a regression test in `explore_embeddable.test.tsx` asserting `destroy()` does not throw when `PanelDataService.getInstance()` returns `null`.
- Added a unit test in `panel_data_service.test.ts` asserting `getInstance()` returns `null` before `init()` is called.
- Updated existing `panel_data_service.test.ts` call sites to use the non-null assertion (`!`) since `init()` runs in `beforeEach`.

## Testing
- `npx tsc --noEmit` confirms no new type errors are introduced by this change (verified via diff against the pre-existing whole-repo error baseline).
- Could not run the modified/added Jest tests directly in this checkout — a fresh `yarn osd bootstrap` in this environment produces a pre-existing Babel/TypeScript transform failure affecting unrelated, untouched `.ts` test files as well (confirmed with `decide_client.test.ts`), so this appears to be an environment issue rather than something introduced by this change. Would appreciate a CI run / maintainer verification of the test files.

## Related
This surfaced while investigating CI failures on #12541, which are unrelated to that PR's own changes — root-caused back to this pre-existing gap from #12590.