### PR TITLE
Update inspect query

### DIFF
--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -530,6 +530,7 @@ export {
   useCancelButtonTiming,
   PPLAnalyzePanel,
   runPPLAnalyzeInBackground,
+  cancelPPLAnalyze,
 } from './ui';
 
 /**

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -577,7 +577,6 @@ export {
   validateTimeRange,
   getPPLAnalyzeResult$,
   getPPLAnalyzeLoading$,
-  getPPLAnalyzeOpen$,
   setPPLAnalyzeResult,
   setPPLAnalyzeLoading,
   setPPLAnalyzeOpen,

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -581,6 +581,7 @@ export {
   setPPLAnalyzeResult,
   setPPLAnalyzeLoading,
   setPPLAnalyzeOpen,
+  clearPPLAnalyzeResult,
   isPPLAnalyzeOpen,
   PPLAnalyzeResult,
 } from './query';

--- a/src/plugins/data/public/query/ppl_analyze_state.test.ts
+++ b/src/plugins/data/public/query/ppl_analyze_state.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getPPLAnalyzeResult$,
+  getPPLAnalyzeLoading$,
+  setPPLAnalyzeResult,
+  setPPLAnalyzeLoading,
+  clearPPLAnalyzeResult,
+} from './ppl_analyze_state';
+
+const sampleResult = {
+  query: 'source=accounts',
+  response: { profile: { summary: { total_time_ms: 5 } } },
+};
+
+describe('ppl_analyze_state', () => {
+  afterEach(() => {
+    // Reset the module-level singletons so tests don't leak into each other.
+    clearPPLAnalyzeResult();
+  });
+
+  it('clearPPLAnalyzeResult resets the stored result to null', () => {
+    setPPLAnalyzeResult(sampleResult);
+    expect(getPPLAnalyzeResult$().getValue()).toEqual(sampleResult);
+
+    clearPPLAnalyzeResult();
+    expect(getPPLAnalyzeResult$().getValue()).toBeNull();
+  });
+
+  it('clearPPLAnalyzeResult also turns off loading', () => {
+    setPPLAnalyzeLoading(true);
+    expect(getPPLAnalyzeLoading$().getValue()).toBe(true);
+
+    clearPPLAnalyzeResult();
+    expect(getPPLAnalyzeLoading$().getValue()).toBe(false);
+  });
+
+  it('setPPLAnalyzeResult clears loading when a result arrives', () => {
+    setPPLAnalyzeLoading(true);
+    setPPLAnalyzeResult(sampleResult);
+    expect(getPPLAnalyzeLoading$().getValue()).toBe(false);
+  });
+});

--- a/src/plugins/data/public/query/ppl_analyze_state.ts
+++ b/src/plugins/data/public/query/ppl_analyze_state.ts
@@ -51,7 +51,6 @@ export interface PPLAnalyzeResponse {
   // May be objects or bare strings depending on the backend version; normalize
   // before use rather than assuming the object shape.
   recommendations?: Array<PPLAnalyzeRecommendation | string>;
-  possibleCacheHit?: boolean;
   // Error shape (populated when the backend returns a 4xx/5xx or an error body).
   statusCode?: number;
   error?: string;
@@ -69,7 +68,6 @@ const analyzeOpen$ = new BehaviorSubject<boolean>(false);
 
 export const getPPLAnalyzeResult$ = () => analyzeResult$;
 export const getPPLAnalyzeLoading$ = () => analyzeLoading$;
-export const getPPLAnalyzeOpen$ = () => analyzeOpen$;
 
 export const isPPLAnalyzeOpen = () => analyzeOpen$.getValue();
 

--- a/src/plugins/data/public/query/ppl_analyze_state.ts
+++ b/src/plugins/data/public/query/ppl_analyze_state.ts
@@ -5,18 +5,6 @@
 
 import { BehaviorSubject } from 'rxjs';
 
-/** A single node in the query execution operator tree. */
-export interface PPLAnalyzeOperatorNode {
-  node_type?: string[];
-  source?: string;
-  is_pushed_down?: boolean;
-  estimated_rows?: number;
-  actual_rows?: number;
-  // Backend returns this as a formatted string with a unit (e.g. '2.70 ms');
-  // the panel extracts the numeric value with parseFloat.
-  actual_time_ms?: string;
-}
-
 /** A single optimization recommendation returned by the backend. */
 export interface PPLAnalyzeRecommendation {
   rule?: string;
@@ -26,21 +14,34 @@ export interface PPLAnalyzeRecommendation {
   affected_node?: string;
 }
 
+/**
+ * A single physical-plan node from the backend profile. The panel reconstructs
+ * the execution waterfall from this nested plan tree, where each node's time_ms
+ * is inclusive of its children's time.
+ */
+export interface PPLAnalyzePlanNode {
+  node: string;
+  time_ms?: number;
+  rows?: number;
+  children?: PPLAnalyzePlanNode[];
+}
+
 /** Per-phase timing profile (analyze/optimize/execute/format). */
 export interface PPLAnalyzeProfile {
   phases?: Record<string, { time_ms: number }>;
   summary?: {
     total_time_ms?: number;
   };
+  // The physical execution plan the panel renders the waterfall from.
+  plan?: PPLAnalyzePlanNode;
 }
 
 /**
  * Response body from the PPL analyze backend endpoint. On success it carries the
- * profile and operator tree; on failure the error fields are populated instead.
+ * profile; on failure the error fields are populated instead.
  */
 export interface PPLAnalyzeResponse {
   profile?: PPLAnalyzeProfile;
-  operator_tree?: PPLAnalyzeOperatorNode[];
   recommendations?: PPLAnalyzeRecommendation[];
   possibleCacheHit?: boolean;
   // Error shape (populated when the backend returns a 4xx/5xx or an error body).
@@ -52,7 +53,6 @@ export interface PPLAnalyzeResponse {
 export interface PPLAnalyzeResult {
   query: string;
   response: PPLAnalyzeResponse;
-  injectedTimeFilter?: string;
 }
 
 const analyzeResult$ = new BehaviorSubject<PPLAnalyzeResult | null>(null);

--- a/src/plugins/data/public/query/ppl_analyze_state.ts
+++ b/src/plugins/data/public/query/ppl_analyze_state.ts
@@ -5,7 +5,13 @@
 
 import { BehaviorSubject } from 'rxjs';
 
-/** A single optimization recommendation returned by the backend. */
+/**
+ * A single optimization recommendation returned by the backend. The backend's
+ * contract for `recommendations` has changed over time (it currently declares a
+ * `List<String>`), so a recommendation may arrive either as this object or as a
+ * bare string. Consumers must normalize before reading fields — see
+ * `normalizeRecommendation` in the panel.
+ */
 export interface PPLAnalyzeRecommendation {
   rule?: string;
   severity?: string;
@@ -42,7 +48,9 @@ export interface PPLAnalyzeProfile {
  */
 export interface PPLAnalyzeResponse {
   profile?: PPLAnalyzeProfile;
-  recommendations?: PPLAnalyzeRecommendation[];
+  // May be objects or bare strings depending on the backend version; normalize
+  // before use rather than assuming the object shape.
+  recommendations?: Array<PPLAnalyzeRecommendation | string>;
   possibleCacheHit?: boolean;
   // Error shape (populated when the backend returns a 4xx/5xx or an error body).
   statusCode?: number;
@@ -76,4 +84,14 @@ export const setPPLAnalyzeLoading = (loading: boolean) => {
 
 export const setPPLAnalyzeOpen = (open: boolean) => {
   analyzeOpen$.next(open);
+};
+
+/**
+ * Clears any displayed analyze result and resets loading. Call when the panel is
+ * closed or the page unmounts so a stale result from a previous query doesn't
+ * reappear the next time the panel opens.
+ */
+export const clearPPLAnalyzeResult = () => {
+  analyzeResult$.next(null);
+  analyzeLoading$.next(false);
 };

--- a/src/plugins/data/public/ui/index.ts
+++ b/src/plugins/data/public/ui/index.ts
@@ -59,4 +59,4 @@ export { AdvancedSelector } from './dataset_selector/advanced_selector';
 export { ConfiguratorV2 } from './dataset_selector/configurator/configurator_v2';
 export { useCancelButtonTiming } from './hooks';
 export { PPLAnalyzePanel } from './ppl_analyze_panel/ppl_analyze_panel';
-export { runPPLAnalyzeInBackground } from './ppl_analyze/run_ppl_analyze';
+export { runPPLAnalyzeInBackground, cancelPPLAnalyze } from './ppl_analyze/run_ppl_analyze';

--- a/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.test.ts
+++ b/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.test.ts
@@ -7,7 +7,7 @@
  * @jest-environment node
  */
 
-import { runPPLAnalyzeInBackground } from './run_ppl_analyze';
+import { runPPLAnalyzeInBackground, cancelPPLAnalyze } from './run_ppl_analyze';
 import {
   setPPLAnalyzeLoading,
   setPPLAnalyzeResult,
@@ -30,6 +30,9 @@ const pplQuery = { query: 'source=accounts', language: 'PPL' };
 const sqlQuery = { query: 'SELECT *', language: 'SQL' };
 
 beforeEach(() => {
+  // Drain any request left in-flight by a prior test before resetting call history,
+  // so each test starts with a clean fetch mock and no leftover cancel is fired.
+  cancelPPLAnalyze();
   jest.clearAllMocks();
   mockFetch.mockResolvedValue({ profile: { summary: { total_time_ms: 10 } } });
 });
@@ -103,11 +106,16 @@ describe('runPPLAnalyzeInBackground', () => {
         setTimeout(() => resolve({ profile: {} }), 50)
       );
       const fastFetch = Promise.resolve({ profile: { summary: { total_time_ms: 1 } } });
+      // Make the mock path-aware: cancel requests resolve silently, analyze
+      // requests consume from a queue of pre-configured responses.
+      const analyzeResponses = [slowFetch, fastFetch];
+      mockFetch.mockImplementation((opts: any) => {
+        if (opts.path?.includes('/cancel')) return Promise.resolve({ cancelled: true });
+        return analyzeResponses.shift() || Promise.resolve({});
+      });
       // First call — will resolve slowly (stale)
-      mockFetch.mockReturnValueOnce(slowFetch);
       runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
-      // Second call — resolves immediately (fresh)
-      mockFetch.mockReturnValueOnce(fastFetch);
+      // Second call — resolves immediately (fresh); cancels the first in-flight
       runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
       await fastFetch;
       await Promise.resolve();
@@ -165,6 +173,55 @@ describe('runPPLAnalyzeInBackground', () => {
     });
   });
 
+  describe('queryId and cancellation', () => {
+    it('includes a queryId in the analyze request body', () => {
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      const body = JSON.parse(mockFetch.mock.calls[0][0].body);
+      expect(typeof body.queryId).toBe('string');
+      expect(body.queryId.length).toBeGreaterThan(0);
+    });
+
+    it('cancels the in-flight request when a newer request supersedes it', () => {
+      const cancelCalls = () =>
+        mockFetch.mock.calls.filter((c: any[]) => c[0].path?.includes('/cancel'));
+
+      // First request is now in-flight (fetch never resolves in this test).
+      mockFetch.mockReturnValue(new Promise(() => {}));
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      const firstQueryId = JSON.parse(mockFetch.mock.calls[0][0].body).queryId;
+      expect(cancelCalls()).toHaveLength(0);
+
+      // Second request should cancel the first, posting its queryId to the cancel path.
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      const cancels = cancelCalls();
+      expect(cancels).toHaveLength(1);
+      expect(cancels[0][0]).toEqual(
+        expect.objectContaining({ method: 'POST', path: '/api/enhancements/ppl/cancel' })
+      );
+      expect(JSON.parse(cancels[0][0].body).queryId).toBe(firstQueryId);
+    });
+
+    it('cancelPPLAnalyze posts the in-flight queryId to the cancel path', () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      const queryId = JSON.parse(mockFetch.mock.calls[0][0].body).queryId;
+
+      cancelPPLAnalyze();
+
+      const cancelCall = mockFetch.mock.calls.find((c: any[]) => c[0].path?.includes('/cancel'));
+      expect(cancelCall).toBeDefined();
+      expect(JSON.parse(cancelCall![0].body).queryId).toBe(queryId);
+    });
+
+    it('cancelPPLAnalyze is a no-op when nothing is in flight', () => {
+      // Settle any prior in-flight request from earlier tests, then clear the mock.
+      cancelPPLAnalyze();
+      mockFetch.mockClear();
+      cancelPPLAnalyze();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe('time filter injection', () => {
     it('injects time filter when timeFieldName is present', () => {
       const queryWithTimeField = {
@@ -180,26 +237,6 @@ describe('runPPLAnalyzeInBackground', () => {
       const body = JSON.parse(mockFetch.mock.calls[0][0].body);
       expect(body.query).toContain('WHERE');
       expect(body.query).toContain('@timestamp');
-    });
-
-    it('stores injectedTimeFilter in result', async () => {
-      const queryWithTimeField = {
-        query: 'source=accounts',
-        language: 'PPL',
-        dataset: { timeFieldName: '@timestamp', id: 'accounts', title: 'accounts', type: 'INDEX' },
-      };
-      runPPLAnalyzeInBackground({
-        query: queryWithTimeField,
-        http: mockHttp,
-        timefilter: mockTimefilter,
-      });
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(setPPLAnalyzeResult).toHaveBeenCalledWith(
-        expect.objectContaining({
-          injectedTimeFilter: expect.stringContaining('@timestamp'),
-        })
-      );
     });
 
     it('does not inject time filter when no timeFieldName', () => {

--- a/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.test.ts
+++ b/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.test.ts
@@ -26,6 +26,7 @@ const mockTimefilter = {
   getTime: () => ({ from: 'now-15m', to: 'now' }),
 } as any;
 
+const ANALYZE_PATH = '/api/enhancements/ppl/analyze';
 const pplQuery = { query: 'source=accounts', language: 'PPL' };
 const sqlQuery = { query: 'SELECT *', language: 'SQL' };
 
@@ -219,6 +220,52 @@ describe('runPPLAnalyzeInBackground', () => {
       mockFetch.mockClear();
       cancelPPLAnalyze();
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('passes an abort signal to the analyze fetch', () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      const analyzeCall = mockFetch.mock.calls.find((c: any[]) => c[0].path === ANALYZE_PATH);
+      expect(analyzeCall![0].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('aborts the in-flight fetch when cancelled', () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      const signal = mockFetch.mock.calls.find((c: any[]) => c[0].path === ANALYZE_PATH)![0].signal;
+      expect(signal.aborted).toBe(false);
+
+      cancelPPLAnalyze();
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('does not commit a result when the fetch resolves after cancellation', async () => {
+      // A response that resolves only after we have already cancelled must not
+      // repopulate the panel (would defeat clearPPLAnalyzeResult on close).
+      let resolveFetch: (v: any) => void = () => {};
+      mockFetch.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+      );
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+
+      cancelPPLAnalyze();
+      resolveFetch({ profile: { summary: { total_time_ms: 9 } } });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setPPLAnalyzeResult).not.toHaveBeenCalled();
+    });
+
+    it('does not commit an error result when the fetch rejects with AbortError', async () => {
+      const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+      mockFetch.mockRejectedValue(abortErr);
+      runPPLAnalyzeInBackground({ query: pplQuery, http: mockHttp, timefilter: mockTimefilter });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setPPLAnalyzeResult).not.toHaveBeenCalled();
     });
   });
 

--- a/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.ts
+++ b/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.ts
@@ -26,17 +26,31 @@ let latestRequestId = 0;
 // Tracks the currently in-flight analyze request so it can be cancelled when a
 // newer request supersedes it or the user closes the panel. Cleared once the
 // request settles.
-let inFlight: { queryId: string; dataSourceId?: string; http: HttpStart } | null = null;
+let inFlight: {
+  queryId: string;
+  dataSourceId?: string;
+  http: HttpStart;
+  controller: AbortController;
+} | null = null;
 
 /**
- * Cancels the in-flight analyze request (if any) by asking the backend to cancel
- * the OpenSearch task tagged with our queryId. Best-effort: failures are swallowed
- * since the request may have already completed server-side.
+ * Cancels the in-flight analyze request (if any):
+ *  - aborts the browser fetch so the abandoned response never arrives,
+ *  - bumps latestRequestId so that even if the fetch had already resolved, the
+ *    pending .then/.catch guard discards it instead of repopulating a panel the
+ *    user cancelled,
+ *  - asks the backend to cancel the OpenSearch task tagged with our queryId.
+ * The backend cancel is best-effort: failures are swallowed since the request may
+ * have already completed server-side.
  */
 export function cancelPPLAnalyze() {
   const pending = inFlight;
   if (!pending) return;
   inFlight = null;
+  // Invalidate the in-flight request so a late-arriving (already-buffered) response
+  // can't slip past the requestId guard — abort alone is best-effort on timing.
+  latestRequestId++;
+  pending.controller.abort();
   pending.http
     .fetch({
       method: 'POST',
@@ -98,12 +112,14 @@ export function runPPLAnalyzeInBackground({
   const requestId = ++latestRequestId;
   const queryId = uuidv4();
   const dataSourceId = query.dataset?.dataSource?.id;
-  inFlight = { queryId, dataSourceId, http };
+  const controller = new AbortController();
+  inFlight = { queryId, dataSourceId, http, controller };
   setPPLAnalyzeLoading(true);
   http
     .fetch({
       method: 'POST',
       path: ANALYZE_PATH,
+      signal: controller.signal,
       body: JSON.stringify({
         query: queryString,
         dataSourceId,
@@ -120,7 +136,9 @@ export function runPPLAnalyzeInBackground({
       });
     })
     .catch((err) => {
-      if (requestId !== latestRequestId) return;
+      // Ignore responses from superseded/cancelled requests, and the AbortError
+      // raised when cancelPPLAnalyze() aborts this fetch — neither should surface.
+      if (requestId !== latestRequestId || err?.name === 'AbortError') return;
       inFlight = null;
       // A non-2xx response rejects with an HttpFetchError whose `body` holds the
       // parsed error payload ({ statusCode, error, message }). Commit that as the

--- a/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.ts
+++ b/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.ts
@@ -4,6 +4,7 @@
  */
 
 import dateMath from '@elastic/datemath';
+import { v4 as uuidv4 } from 'uuid';
 import { HttpStart } from '../../../../../core/public';
 import { Query } from '../../index';
 import { TimefilterContract } from '../../query';
@@ -13,10 +14,41 @@ import {
   isPPLAnalyzeOpen,
 } from '../../query/ppl_analyze_state';
 
+const ANALYZE_PATH = '/api/enhancements/ppl/analyze';
+const CANCEL_PATH = '/api/enhancements/ppl/cancel';
+
 // Monotonically increasing counter used to discard out-of-order responses.
 // Each call captures the current value; only the response matching the latest
 // call is committed to analyzeResult$.
 let latestRequestId = 0;
+
+// Tracks the currently in-flight analyze request so it can be cancelled when a
+// newer request supersedes it or the user closes the panel. Cleared once the
+// request settles.
+let inFlight: { queryId: string; dataSourceId?: string; http: HttpStart } | null = null;
+
+/**
+ * Cancels the in-flight analyze request (if any) by asking the backend to cancel
+ * the OpenSearch task tagged with our queryId. Best-effort: failures are swallowed
+ * since the request may have already completed server-side.
+ */
+export function cancelPPLAnalyze() {
+  const pending = inFlight;
+  if (!pending) return;
+  inFlight = null;
+  pending.http
+    .fetch({
+      method: 'POST',
+      path: CANCEL_PATH,
+      body: JSON.stringify({
+        queryId: pending.queryId,
+        dataSourceId: pending.dataSourceId,
+      }),
+    })
+    .catch(() => {
+      // Task may have already finished or never started — nothing to clean up.
+    });
+}
 
 export function runPPLAnalyzeInBackground({
   query,
@@ -33,7 +65,6 @@ export function runPPLAnalyzeInBackground({
   if (onlyIfOpen && !isPPLAnalyzeOpen()) return;
 
   let queryString = query.query as string;
-  let injectedTimeFilter: string | undefined;
   const timeFieldName = query.dataset?.timeFieldName;
 
   // Only inject a time filter for search queries (source=... or search source=...).
@@ -52,35 +83,44 @@ export function runPPLAnalyzeInBackground({
       const toStr = toMoment.utc().format('YYYY-MM-DD HH:mm:ss.SSS');
       // Escape backticks in the field name to prevent PPL injection via identifier quoting
       const safeFieldName = timeFieldName.replace(/`/g, '``');
-      injectedTimeFilter = `WHERE \`${safeFieldName}\` >= '${fromStr}' AND \`${safeFieldName}\` <= '${toStr}'`;
+      const timeFilter = `WHERE \`${safeFieldName}\` >= '${fromStr}' AND \`${safeFieldName}\` <= '${toStr}'`;
       const commands = queryString.split('|');
-      commands.splice(1, 0, ` ${injectedTimeFilter} `);
+      commands.splice(1, 0, ` ${timeFilter} `);
       queryString = commands.map((cmd) => cmd.trim()).join(' | ');
     }
   }
 
+  // A newer request supersedes any in-flight one — cancel it server-side so we
+  // don't leave an orphaned OpenSearch task running.
+  cancelPPLAnalyze();
+
   const requestId = ++latestRequestId;
+  const queryId = uuidv4();
+  const dataSourceId = query.dataset?.dataSource?.id;
+  inFlight = { queryId, dataSourceId, http };
   setPPLAnalyzeLoading(true);
   http
     .fetch({
       method: 'POST',
-      path: '/api/enhancements/ppl/analyze',
+      path: ANALYZE_PATH,
       body: JSON.stringify({
         query: queryString,
-        dataSourceId: query.dataset?.dataSource?.id,
+        dataSourceId,
+        queryId,
       }),
     })
     .then((result) => {
       // Discard stale responses from superseded requests
       if (requestId !== latestRequestId) return;
+      inFlight = null;
       setPPLAnalyzeResult({
         query: query.query as string,
         response: result,
-        injectedTimeFilter,
       });
     })
     .catch((err) => {
       if (requestId !== latestRequestId) return;
+      inFlight = null;
       // A non-2xx response rejects with an HttpFetchError whose `body` holds the
       // parsed error payload ({ statusCode, error, message }). Commit that as the
       // result so the panel can surface the error; fall back to a synthetic body
@@ -93,7 +133,6 @@ export function runPPLAnalyzeInBackground({
       setPPLAnalyzeResult({
         query: query.query as string,
         response,
-        injectedTimeFilter,
       });
     });
 }

--- a/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.ts
+++ b/src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.ts
@@ -5,6 +5,7 @@
 
 import dateMath from '@elastic/datemath';
 import { v4 as uuidv4 } from 'uuid';
+import { i18n } from '@osd/i18n';
 import { HttpStart } from '../../../../../core/public';
 import { Query } from '../../index';
 import { TimefilterContract } from '../../query';
@@ -126,8 +127,16 @@ export function runPPLAnalyzeInBackground({
       // result so the panel can surface the error; fall back to a synthetic body
       // when no structured payload is available (e.g. a network failure).
       const response = err?.body ?? {
-        error: err?.response?.statusText || 'Request failed',
-        message: err?.message || 'The analyze request could not be completed.',
+        error:
+          err?.response?.statusText ||
+          i18n.translate('data.pplAnalyze.error.requestFailed', {
+            defaultMessage: 'Request failed',
+          }),
+        message:
+          err?.message ||
+          i18n.translate('data.pplAnalyze.error.couldNotComplete', {
+            defaultMessage: 'The analyze request could not be completed.',
+          }),
         statusCode: err?.response?.status,
       };
       setPPLAnalyzeResult({

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
@@ -202,6 +202,57 @@ describe('PPLAnalyzePanel', () => {
       render(<PPLAnalyzePanel analyzeResult={result} />);
       expect(screen.getByText('Execution Phase Profiling unavailable')).toBeInTheDocument();
     });
+
+    it('notes concurrent operations when expanding a node with siblings', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      // First post-order row is one of the two sibling index scans (they run
+      // concurrently under the merge join).
+      fireEvent.click(screen.getAllByRole('button')[0]);
+      expect(
+        screen.getByText(/Ran concurrently with 1 other operation \(CalciteEnumerableIndexScan\)/)
+      ).toBeInTheDocument();
+    });
+
+    it('does not note concurrency for a node without siblings', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      // The EnumerableCalc (second-to-last row, above the overhead row) has no
+      // siblings; expanding it shows no concurrency note.
+      const rows = screen.getAllByRole('button');
+      fireEvent.click(rows[rows.length - 2]);
+      expect(screen.queryByText(/Ran concurrently with/)).not.toBeInTheDocument();
+    });
+
+    it('renders a trailing overhead stage for execute time outside the operators', () => {
+      // execute 259.53ms vs root inclusive 258.0ms -> ~1.53ms of overhead.
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      expect(screen.getByText('Result composition')).toBeInTheDocument();
+      // The synthetic stage is excluded from the operator count: the plan has 4 real
+      // operators (Calc, MergeJoin, 2 index scans), not 5.
+      expect(screen.getByText(/Operators:/i).closest('div')).toHaveTextContent('Operators: 4');
+    });
+
+    it('explains the overhead stage when expanded, with dashed row counts', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      // The overhead stage is the last row.
+      const rows = screen.getAllByRole('button');
+      fireEvent.click(rows[rows.length - 1]);
+      expect(screen.getByText('OVERHEAD TIME')).toBeInTheDocument();
+      expect(screen.getByText(/outside any operator/)).toBeInTheDocument();
+    });
+
+    it('omits the overhead stage when execute time equals operator time', () => {
+      const noOverhead = {
+        ...complexResult,
+        response: {
+          profile: {
+            ...complexResult.response.profile,
+            phases: { ...complexResult.response.profile.phases, execute: { time_ms: 258.0 } },
+          },
+        },
+      };
+      render(<PPLAnalyzePanel analyzeResult={noOverhead} />);
+      expect(screen.queryByText('Result composition')).not.toBeInTheDocument();
+    });
   });
 
   describe('recommendations', () => {

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PPLAnalyzePanel } from './ppl_analyze_panel';
 
+// The panel renders the physical plan (profile.plan).
 const mockAnalyzeResult = {
   query: 'source=accounts | where age < 30',
   response: {
@@ -18,25 +19,19 @@ const mockAnalyzeResult = {
         execute: { time_ms: 3.68 },
         format: { time_ms: 0.19 },
       },
+      plan: {
+        node: 'EnumerableCalc',
+        time_ms: 3.68,
+        rows: 3,
+        children: [
+          {
+            node: 'CalciteEnumerableIndexScan',
+            time_ms: 2.7,
+            rows: 3,
+          },
+        ],
+      },
     },
-    operator_tree: [
-      {
-        source: 'source=accounts | where age < 30',
-        node_type: ['SearchFrom', 'WhereCommand'],
-        estimated_rows: 5000,
-        actual_rows: 3,
-        actual_time_ms: '2.70 ms',
-        is_pushed_down: true,
-      },
-      {
-        source: 'eval full_name = firstname + " " + lastname | fields full_name, email, age',
-        node_type: ['EvalCommand', 'FieldsCommand'],
-        estimated_rows: 5000,
-        actual_rows: 3,
-        actual_time_ms: '0.11 ms',
-        is_pushed_down: false,
-      },
-    ],
     recommendations: [
       {
         serverity: 'INFO',
@@ -92,36 +87,120 @@ describe('PPLAnalyzePanel', () => {
     });
   });
 
-  describe('operator tree', () => {
+  describe('physical plan (all queries)', () => {
     it('renders Execution Phase Profiling title', () => {
       render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
       expect(screen.getByText('Execution Phase Profiling')).toBeInTheDocument();
     });
 
-    it('renders pushed-down stage row', () => {
+    it('renders physical-plan operator rows with convention prefixes stripped', () => {
       render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
-      expect(screen.getByText(/Pushed down to OpenSearch/i)).toBeInTheDocument();
+      expect(screen.getByText('Calc')).toBeInTheDocument();
+      expect(screen.getByText('IndexScan')).toBeInTheDocument();
+      // Undecorated names should not leak into the row labels.
+      expect(screen.queryByText('EnumerableCalc')).not.toBeInTheDocument();
     });
 
-    it('renders coordinator stage rows', () => {
-      render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
-      expect(screen.getByText('EVAL')).toBeInTheDocument();
-    });
-
-    it('shows fallback callout when operator_tree is empty', () => {
+    it('shows fallback callout when the plan is absent', () => {
       const result = {
         ...mockAnalyzeResult,
-        response: { ...mockAnalyzeResult.response, operator_tree: [] },
+        response: {
+          ...mockAnalyzeResult.response,
+          profile: { ...mockAnalyzeResult.response.profile, plan: undefined },
+        },
       };
       render(<PPLAnalyzePanel analyzeResult={result} />);
       expect(screen.getByText('Execution Phase Profiling unavailable')).toBeInTheDocument();
     });
 
-    it('expands stage on click to show operations sub-table', () => {
+    it('expands a stage on click to show operator detail', () => {
       render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
-      const expandButton = screen.getAllByRole('button')[0];
-      fireEvent.click(expandButton);
-      expect(screen.getByText('OPERATIONS IN THIS STAGE')).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole('button')[0]);
+      expect(screen.getByText('SOURCE NODES')).toBeInTheDocument();
+    });
+  });
+
+  describe('physical plan (complex queries)', () => {
+    // A complex query (e.g. JOIN) returns a nested physical plan under
+    // profile.plan.
+    const complexResult = {
+      query:
+        'source=test_data | join left=l right=r on l.city=r.city test_data | head 1 | fields city',
+      response: {
+        profile: {
+          summary: { total_time_ms: 279.93 },
+          phases: {
+            analyze: { time_ms: 3.52 },
+            optimize: { time_ms: 16.39 },
+            execute: { time_ms: 259.53 },
+            format: { time_ms: 0.38 },
+          },
+          plan: {
+            node: 'EnumerableCalc',
+            time_ms: 258.0,
+            rows: 1,
+            children: [
+              {
+                node: 'EnumerableMergeJoin',
+                time_ms: 257.91,
+                rows: 2,
+                children: [
+                  { node: 'CalciteEnumerableIndexScan', time_ms: 133.17, rows: 3 },
+                  { node: 'CalciteEnumerableIndexScan', time_ms: 123.63, rows: 3 },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    it('renders the physical plan waterfall with convention prefixes stripped', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      expect(screen.getByText('Execution Phase Profiling')).toBeInTheDocument();
+      // Convention tokens (Enumerable, Calcite, ...) are stripped for display.
+      expect(screen.getByText('Calc')).toBeInTheDocument();
+      expect(screen.getByText('MergeJoin')).toBeInTheDocument();
+      expect(screen.getAllByText('IndexScan').length).toBe(2);
+      // Undecorated names should not leak into the row labels.
+      expect(screen.queryByText('EnumerableCalc')).not.toBeInTheDocument();
+    });
+
+    it('shows the full undecorated operator name when a node is expanded', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      // First row (post-order) is a leaf index scan.
+      fireEvent.click(screen.getAllByRole('button')[0]);
+      expect(screen.getByText('CalciteEnumerableIndexScan')).toBeInTheDocument();
+    });
+
+    it('does not show the unavailable callout when a plan tree is present', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      expect(screen.queryByText('Execution Phase Profiling unavailable')).not.toBeInTheDocument();
+    });
+
+    it('expands a physical plan node to show operator detail', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      fireEvent.click(screen.getAllByRole('button')[0]);
+      // TIME appears both as the column header and the detail label.
+      expect(screen.getAllByText('TIME').length).toBeGreaterThan(1);
+      expect(screen.queryByText('TIME (INCLUSIVE)')).not.toBeInTheDocument();
+      expect(screen.getByText('SOURCE NODES')).toBeInTheDocument();
+    });
+
+    it('reports the operator count in the summary row', () => {
+      render(<PPLAnalyzePanel analyzeResult={complexResult} />);
+      expect(screen.getByText(/Operators:/i)).toBeInTheDocument();
+    });
+
+    it('still shows the unavailable callout when neither tree nor plan exists', () => {
+      const result = {
+        ...complexResult,
+        response: {
+          profile: { ...complexResult.response.profile, plan: undefined },
+        },
+      };
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      expect(screen.getByText('Execution Phase Profiling unavailable')).toBeInTheDocument();
     });
   });
 
@@ -160,6 +239,95 @@ describe('PPLAnalyzePanel', () => {
     });
   });
 
+  describe('recommendations filtering', () => {
+    // Execute phase = 100 ms. In this plan the sort's self-time is
+    // 50 - 48 = 2 ms (2% of execute, below the 5% floor) and the leaf scan's is
+    // 48 ms (48%, above the floor).
+    const buildResult = (recommendations: any[]) => ({
+      query: 'source=accounts | sort age',
+      response: {
+        profile: {
+          summary: { total_time_ms: 100 },
+          phases: {
+            analyze: { time_ms: 0 },
+            optimize: { time_ms: 0 },
+            execute: { time_ms: 100 },
+            format: { time_ms: 0 },
+          },
+          plan: {
+            node: 'EnumerableSort',
+            time_ms: 50,
+            rows: 3,
+            children: [{ node: 'CalciteEnumerableIndexScan', time_ms: 48, rows: 100000 }],
+          },
+        },
+        recommendations,
+      },
+    });
+
+    it('drops recommendations for nodes below 5% of the execute phase', () => {
+      const result = buildResult([
+        {
+          severity: 'WARNING',
+          rule: 'Tiny sort rule',
+          message: 'sort is small',
+          affected_node: 'EnumerableSort', // 2% of execute -> dropped
+        },
+        {
+          severity: 'WARNING',
+          rule: 'Big scan rule',
+          message: 'scan is large',
+          affected_node: 'CalciteEnumerableIndexScan', // 48% of execute -> kept
+        },
+      ]);
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      expect(screen.getByText('Big scan rule')).toBeInTheDocument();
+      expect(screen.queryByText('Tiny sort rule')).not.toBeInTheDocument();
+    });
+
+    it('keeps recommendations whose affected_node is not a plan node', () => {
+      // An unmatched affected_node can't be weighed, so it passes the share filter.
+      const result = buildResult([
+        {
+          severity: 'INFO',
+          rule: 'Phase-level rule',
+          message: 'planning dominates',
+          affected_node: 'source=accounts | sort age',
+        },
+      ]);
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      expect(screen.getByText('Phase-level rule')).toBeInTheDocument();
+    });
+
+    it('shows at most three recommendations, most critical first', () => {
+      const result = buildResult([
+        { severity: 'INFO', rule: 'Info one', message: 'i1' },
+        { severity: 'CRITICAL', rule: 'Crit one', message: 'c1' },
+        { severity: 'INFO', rule: 'Info two', message: 'i2' },
+        { severity: 'WARNING', rule: 'Warn one', message: 'w1' },
+      ]);
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      // Top 3 by severity: CRITICAL, WARNING, then the first INFO; the second INFO drops.
+      expect(screen.getByText('Crit one')).toBeInTheDocument();
+      expect(screen.getByText('Warn one')).toBeInTheDocument();
+      expect(screen.getByText('Info one')).toBeInTheDocument();
+      expect(screen.queryByText('Info two')).not.toBeInTheDocument();
+    });
+
+    it('hides the section when every recommendation is filtered out', () => {
+      const result = buildResult([
+        {
+          severity: 'WARNING',
+          rule: 'Tiny sort rule',
+          message: 'sort is small',
+          affected_node: 'EnumerableSort',
+        },
+      ]);
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      expect(screen.queryByText('RECOMMENDATIONS')).not.toBeInTheDocument();
+    });
+  });
+
   describe('cache hit detection', () => {
     it('does not show cache callout when possibleCacheHit is false', () => {
       render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
@@ -182,14 +350,14 @@ describe('PPLAnalyzePanel', () => {
       expect(screen.getByText(/Total Execution Phase:/i)).toBeInTheDocument();
     });
 
-    it('renders on data nodes time', () => {
+    it('renders the operator count', () => {
       render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
-      expect(screen.getByText(/On data nodes:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Operators:/i)).toBeInTheDocument();
     });
 
-    it('renders on coordinator time', () => {
+    it('renders the result row count', () => {
       render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
-      expect(screen.getByText(/On coordinator:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Result:/i)).toBeInTheDocument();
     });
   });
 });

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
@@ -34,7 +34,7 @@ const mockAnalyzeResult = {
     },
     recommendations: [
       {
-        serverity: 'INFO',
+        severity: 'INFO',
         rule: 'Bottleneck stage',
         message: '73% of time is in the *SearchFrom, WhereCommand* stage',
         affected_node: 'source=accounts | where age < 30',
@@ -327,7 +327,7 @@ describe('PPLAnalyzePanel', () => {
       expect(screen.getByText('Phase-level rule')).toBeInTheDocument();
     });
 
-    it('shows at most three recommendations, most critical first', () => {
+    it('shows at most three recommendations by default, most critical first', () => {
       const result = buildResult([
         { severity: 'INFO', rule: 'Info one', message: 'i1' },
         { severity: 'CRITICAL', rule: 'Crit one', message: 'c1' },
@@ -335,11 +335,39 @@ describe('PPLAnalyzePanel', () => {
         { severity: 'WARNING', rule: 'Warn one', message: 'w1' },
       ]);
       render(<PPLAnalyzePanel analyzeResult={result} />);
-      // Top 3 by severity: CRITICAL, WARNING, then the first INFO; the second INFO drops.
+      // Top 3 by severity: CRITICAL, WARNING, then the first INFO; the second INFO
+      // is hidden behind the show-all toggle, not rendered initially.
       expect(screen.getByText('Crit one')).toBeInTheDocument();
       expect(screen.getByText('Warn one')).toBeInTheDocument();
       expect(screen.getByText('Info one')).toBeInTheDocument();
       expect(screen.queryByText('Info two')).not.toBeInTheDocument();
+    });
+
+    it('shows a "show all" toggle that reveals the remaining recommendations', () => {
+      const result = buildResult([
+        { severity: 'INFO', rule: 'Info one', message: 'i1' },
+        { severity: 'CRITICAL', rule: 'Crit one', message: 'c1' },
+        { severity: 'INFO', rule: 'Info two', message: 'i2' },
+        { severity: 'WARNING', rule: 'Warn one', message: 'w1' },
+      ]);
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      const toggle = screen.getByTestId('analyzeShowAllRecommendations');
+      expect(toggle).toHaveTextContent('Showing 3 of 4');
+      expect(screen.queryByText('Info two')).not.toBeInTheDocument();
+
+      fireEvent.click(toggle);
+      expect(screen.getByText('Info two')).toBeInTheDocument();
+      // Once expanded, the toggle is gone.
+      expect(screen.queryByTestId('analyzeShowAllRecommendations')).not.toBeInTheDocument();
+    });
+
+    it('does not show the toggle when three or fewer recommendations survive', () => {
+      const result = buildResult([
+        { severity: 'CRITICAL', rule: 'Crit one', message: 'c1' },
+        { severity: 'WARNING', rule: 'Warn one', message: 'w1' },
+      ]);
+      render(<PPLAnalyzePanel analyzeResult={result} />);
+      expect(screen.queryByTestId('analyzeShowAllRecommendations')).not.toBeInTheDocument();
     });
 
     it('hides the section when every recommendation is filtered out', () => {
@@ -353,22 +381,6 @@ describe('PPLAnalyzePanel', () => {
       ]);
       render(<PPLAnalyzePanel analyzeResult={result} />);
       expect(screen.queryByText('RECOMMENDATIONS')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('cache hit detection', () => {
-    it('does not show cache callout when possibleCacheHit is false', () => {
-      render(<PPLAnalyzePanel analyzeResult={mockAnalyzeResult} />);
-      expect(screen.queryByText('Possible cache hit detected')).not.toBeInTheDocument();
-    });
-
-    it('shows cache callout when possibleCacheHit is true', () => {
-      const result = {
-        ...mockAnalyzeResult,
-        response: { ...mockAnalyzeResult.response, possibleCacheHit: true },
-      };
-      render(<PPLAnalyzePanel analyzeResult={result} />);
-      expect(screen.getByText('Possible cache hit detected')).toBeInTheDocument();
     });
   });
 

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx
@@ -237,6 +237,34 @@ describe('PPLAnalyzePanel', () => {
       render(<PPLAnalyzePanel analyzeResult={result} />);
       expect(screen.queryByText('RECOMMENDATIONS')).not.toBeInTheDocument();
     });
+
+    it('renders string recommendations without throwing (backend List<String> shape)', () => {
+      // The backend may return recommendations as bare strings rather than objects;
+      // the panel must coerce them instead of calling String.split on a missing field.
+      const result = {
+        ...mockAnalyzeResult,
+        response: {
+          ...mockAnalyzeResult.response,
+          recommendations: ['Consider adding a filter to reduce scanned rows.'],
+        },
+      };
+      expect(() => render(<PPLAnalyzePanel analyzeResult={result} />)).not.toThrow();
+      expect(
+        screen.getByText('Consider adding a filter to reduce scanned rows.')
+      ).toBeInTheDocument();
+    });
+
+    it('ignores malformed recommendation entries (null / number)', () => {
+      const result = {
+        ...mockAnalyzeResult,
+        response: {
+          ...mockAnalyzeResult.response,
+          recommendations: [null, 42, { message: 'A valid one' }] as any,
+        },
+      };
+      expect(() => render(<PPLAnalyzePanel analyzeResult={result} />)).not.toThrow();
+      expect(screen.getByText('A valid one')).toBeInTheDocument();
+    });
   });
 
   describe('recommendations filtering', () => {

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
@@ -40,12 +40,6 @@ const PHASE_COLORS: Record<string, string> = {
   format: '#D6BF57',
 };
 
-const OPERATOR_COLORS = {
-  pushedDown: '#7DE2D1',
-  inMemory: '#FFCE7A',
-  bottleneck: '#FF6666',
-};
-
 const PHASE_DESCRIPTIONS: Record<string, string> = {
   analyze: i18n.translate('data.pplAnalyze.phaseDescription.analyze', {
     defaultMessage: 'Parsing and validating the query syntax and semantics.',
@@ -199,8 +193,13 @@ function formatMs(ms: number): string {
 // Measure rendered text width with a shared canvas — no DOM node, no reflow. Falls
 // back to a rough per-character estimate when canvas is unavailable (e.g. in jsdom).
 let measureCtx: CanvasRenderingContext2D | null = null;
+// Track whether we've already tried to create the context: getContext('2d') can
+// return null, so a `measureCtx === null` guard alone would re-allocate a canvas on
+// every call. This latches the attempt so we only create one canvas, ever.
+let measureCtxAttempted = false;
 function measureTextWidth(text: string, font: string): number {
-  if (measureCtx === null && typeof document !== 'undefined') {
+  if (!measureCtxAttempted && typeof document !== 'undefined') {
+    measureCtxAttempted = true;
     measureCtx = document.createElement('canvas').getContext('2d');
   }
   if (measureCtx) {
@@ -295,23 +294,25 @@ function PhysicalPlanSection({
     return () => observer.disconnect();
   }, []);
 
-  const nodes = flattenPlan(plan);
-  // Scale the timeline to the sum of self-times rather than the root's reported
-  // time_ms — the root isn't guaranteed to have the largest inclusive time, so
-  // summing the self-times is the only value the bars are certain to tile into.
-  const totalTimeMs = nodes.reduce((sum, n) => sum + n.selfTimeMs, 0);
-  const maxSelfTimeMs = Math.max(...nodes.map((n) => n.selfTimeMs), 0);
-  const bottleneckIdx = nodes.findIndex((n) => n.selfTimeMs === maxSelfTimeMs);
-
-  // Lay the self-time slices end-to-end so each bar starts where the previous
-  // one ended. Self-times sum to the total, so the bars tile the full timeline
-  // instead of every bar starting at 0.
-  let cursor = 0;
-  const nodeStarts: number[] = [];
-  nodes.forEach((n) => {
-    nodeStarts.push(cursor);
-    cursor += n.selfTimeMs;
-  });
+  // Flatten the plan and derive the layout geometry once per plan, not on every
+  // hover/expand re-render.
+  const { nodes, totalTimeMs, nodeStarts } = React.useMemo(() => {
+    const flat = flattenPlan(plan);
+    // Scale the timeline to the sum of self-times rather than the root's reported
+    // time_ms — the root isn't guaranteed to have the largest inclusive time, so
+    // summing the self-times is the only value the bars are certain to tile into.
+    const total = flat.reduce((sum, n) => sum + n.selfTimeMs, 0);
+    // Lay the self-time slices end-to-end so each bar starts where the previous
+    // one ended. Self-times sum to the total, so the bars tile the full timeline
+    // instead of every bar starting at 0.
+    let cursor = 0;
+    const starts: number[] = [];
+    flat.forEach((n) => {
+      starts.push(cursor);
+      cursor += n.selfTimeMs;
+    });
+    return { nodes: flat, totalTimeMs: total, nodeStarts: starts };
+  }, [plan]);
 
   const tickInterval = totalTimeMs > 0 ? totalTimeMs / (TICK_COUNT - 1) : 1;
   const ticks = Array.from({ length: TICK_COUNT }, (_, i) => i * tickInterval);
@@ -418,7 +419,6 @@ function PhysicalPlanSection({
         </div>
         {/* Node rows */}
         {nodes.map((n, idx) => {
-          const isBottleneck = idx === bottleneckIdx && n.selfTimeMs > 0;
           const isExpanded = expandedIdx === idx;
           const isHovered = hoveredIdx === idx;
           const startPct = totalTimeMs > 0 ? (nodeStarts[idx] / totalTimeMs) * 100 : 0;
@@ -492,20 +492,6 @@ function PhysicalPlanSection({
                   >
                     <strong>{displayNodeName(n.node)}</strong>
                   </EuiText>
-                  {isBottleneck && (
-                    <span
-                      style={{
-                        flexShrink: 0,
-                        fontSize: 12,
-                        color: OPERATOR_COLORS.bottleneck,
-                      }}
-                      title={i18n.translate('data.pplAnalyze.bottleneckTooltip', {
-                        defaultMessage: 'Bottleneck',
-                      })}
-                    >
-                      ⚠
-                    </span>
-                  )}
                 </div>
                 {/* Stats column */}
                 <div
@@ -763,13 +749,15 @@ const MIN_NODE_EXECUTE_SHARE = 0.05;
 const MAX_RECOMMENDATIONS = 3;
 const SEVERITY_RANK: Record<string, number> = { CRITICAL: 0, WARNING: 1, INFO: 2 };
 
-// Filter incoming recommendations to the ones worth showing:
+// Filter and order the recommendations worth showing:
 //  1. drop any whose `affected_node` maps to a plan node using less than
 //     MIN_NODE_EXECUTE_SHARE of the execute phase (small operators aren't the
 //     right thing to tell customers to optimize),
-//  2. keep at most MAX_RECOMMENDATIONS, preferring higher severities.
+//  2. order by severity so the most important ones come first.
 // Recs with no `affected_node` (phase-level advice) or an unmatched name pass
 // through the share filter — we can't judge their weight, so we don't drop them.
+// The display cap (MAX_RECOMMENDATIONS) is applied in the component so the full
+// list stays available behind a "show all" affordance.
 function filterRecommendations(
   recs: Array<PPLAnalyzeRecommendation | string> | undefined,
   nodes: FlatPlanNode[],
@@ -794,12 +782,11 @@ function filterRecommendations(
     if (selfMs === undefined) return true;
     return selfMs >= minSelfMs;
   });
-  const ranked = [...kept].sort((a, b) => {
-    const sa = SEVERITY_RANK[((a as any).serverity || a.severity || 'INFO').toUpperCase()] ?? 2;
-    const sb = SEVERITY_RANK[((b as any).serverity || b.severity || 'INFO').toUpperCase()] ?? 2;
+  return [...kept].sort((a, b) => {
+    const sa = SEVERITY_RANK[(a.severity || 'INFO').toUpperCase()] ?? 2;
+    const sb = SEVERITY_RANK[(b.severity || 'INFO').toUpperCase()] ?? 2;
     return sa - sb;
   });
-  return ranked.slice(0, MAX_RECOMMENDATIONS);
 }
 
 function RecommendationsSection({
@@ -807,6 +794,11 @@ function RecommendationsSection({
 }: {
   recommendations: PPLAnalyzeRecommendation[];
 }) {
+  const [showAll, setShowAll] = useState(false);
+  // Cap the list by default; the rest stay reachable via the "show all" toggle so
+  // nothing is silently hidden.
+  const isCapped = recommendations.length > MAX_RECOMMENDATIONS;
+  const visible = showAll ? recommendations : recommendations.slice(0, MAX_RECOMMENDATIONS);
   return (
     <div>
       <EuiTitle size="xxs">
@@ -826,8 +818,8 @@ function RecommendationsSection({
           />
         </EuiText>
       ) : (
-        recommendations.map((rec: any, idx: number) => {
-          const severity = (rec.serverity || rec.severity || 'INFO').toUpperCase();
+        visible.map((rec: PPLAnalyzeRecommendation, idx: number) => {
+          const severity = (rec.severity || 'INFO').toUpperCase();
           const color = SEVERITY_COLORS[severity] || SEVERITY_COLORS.INFO;
           return (
             <React.Fragment key={idx}>
@@ -872,10 +864,27 @@ function RecommendationsSection({
                   </>
                 )}
               </EuiPanel>
-              {idx < recommendations.length - 1 && <EuiSpacer size="s" />}
+              {idx < visible.length - 1 && <EuiSpacer size="s" />}
             </React.Fragment>
           );
         })
+      )}
+      {isCapped && !showAll && (
+        <>
+          <EuiSpacer size="xs" />
+          <EuiButtonEmpty
+            size="xs"
+            flush="left"
+            onClick={() => setShowAll(true)}
+            data-test-subj="analyzeShowAllRecommendations"
+          >
+            <FormattedMessage
+              id="data.pplAnalyze.recommendations.showAll"
+              defaultMessage="Showing {shown} of {total} — Show all"
+              values={{ shown: MAX_RECOMMENDATIONS, total: recommendations.length }}
+            />
+          </EuiButtonEmpty>
+        </>
       )}
     </div>
   );
@@ -914,7 +923,6 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
   // (profile.plan).
   const planTree = response.profile?.plan;
   const hasPlanTree = !!planTree;
-  const possibleCacheHit = !!response.possibleCacheHit;
   const executePhaseMs = response.profile?.phases?.execute?.time_ms || 0;
   // Drop recs on tiny operators and cap to the most critical few. Recomputes only
   // when the plan or execute-phase timing changes, not on hover/expand state.
@@ -978,25 +986,6 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
         </EuiCallOut>
       ) : (
         <>
-          {possibleCacheHit && (
-            <>
-              <EuiCallOut
-                title={i18n.translate('data.pplAnalyze.cacheHit.title', {
-                  defaultMessage: 'Possible cache hit detected',
-                })}
-                iconType="iInCircle"
-                color="primary"
-              >
-                <EuiText size="s">
-                  <FormattedMessage
-                    id="data.pplAnalyze.cacheHit.body"
-                    defaultMessage="This query may have been previously cached, which can produce a much faster execution phase time than normal. Cache hits can make profiling results inaccurate. This behavior can be toggled in Settings."
-                  />
-                </EuiText>
-              </EuiCallOut>
-              <EuiSpacer size="m" />
-            </>
-          )}
           {response.profile?.phases && (
             <TimingBar phases={response.profile.phases} totalTimeMs={totalTimeMs} />
           )}

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -17,7 +17,7 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
-import { PPLAnalyzeResult } from '../../query/ppl_analyze_state';
+import { PPLAnalyzeResult, PPLAnalyzePlanNode } from '../../query/ppl_analyze_state';
 
 // Theme-reactive colors that resolve to light/dark values automatically.
 const { euiColorEmptyShade, euiColorLightShade, euiColorMediumShade } = euiThemeVars;
@@ -153,241 +153,138 @@ const LABEL_COL_WIDTH = 200;
 const STATS_COL_WIDTH = 210;
 const TICK_COUNT = 6;
 
+// The in-bar label style is `font: 600 11px`; measure text against that. The bar has
+// 6px of left padding, so a label needs (textWidth + 6 + a small right margin) px of
+// bar to sit inside without clipping.
+const BAR_LABEL_FONT = '600 11px sans-serif';
+const BAR_LABEL_PADDING_PX = 6;
+const BAR_LABEL_RIGHT_MARGIN_PX = 4;
+
 function formatMs(ms: number): string {
   return `${ms.toFixed(1)} ms`;
 }
 
-function StageBadge({ isPushedDown }: { isPushedDown: boolean }) {
-  return (
-    <span
-      style={{
-        display: 'inline-block',
-        fontSize: 10,
-        fontWeight: 600,
-        padding: '1px 5px',
-        borderRadius: 3,
-        backgroundColor: isPushedDown
-          ? `${OPERATOR_COLORS.pushedDown}33`
-          : `${OPERATOR_COLORS.inMemory}33`,
-        color: isPushedDown ? OPERATOR_COLORS.pushedDown : OPERATOR_COLORS.inMemory,
-        border: `1px solid ${isPushedDown ? OPERATOR_COLORS.pushedDown : OPERATOR_COLORS.inMemory}`,
-        marginLeft: 6,
-        verticalAlign: 'middle',
-      }}
-    >
-      {isPushedDown ? 'data' : 'coord'}
-    </span>
-  );
+// Measure rendered text width with a shared canvas — no DOM node, no reflow. Falls
+// back to a rough per-character estimate when canvas is unavailable (e.g. in jsdom).
+let measureCtx: CanvasRenderingContext2D | null = null;
+function measureTextWidth(text: string, font: string): number {
+  if (measureCtx === null && typeof document !== 'undefined') {
+    measureCtx = document.createElement('canvas').getContext('2d');
+  }
+  if (measureCtx) {
+    measureCtx.font = font;
+    return measureCtx.measureText(text).width;
+  }
+  // ~6px/char is a reasonable estimate for 11px sans-serif when we can't measure.
+  return text.length * 6;
 }
 
-// Split a PPL source fragment into one command string per node_type entry.
-function splitSourceCommands(source: string, count: number): string[] {
-  const parts = source.split('|').map((s) => s.trim());
-  if (parts.length >= count) return parts.slice(0, count);
-  while (parts.length < count) parts.push(parts[parts.length - 1] || source);
-  return parts;
+// Calcite decorates physical operator names with their calling convention
+// (e.g. "CalciteEnumerableIndexScan", "EnumerableMergeJoin"). Strip those tokens
+// for display so only the operator itself shows; the full name stays available
+// in the tooltip and expanded detail. Falls back to the original if stripping
+// leaves nothing.
+const CONVENTION_TOKENS = ['Calcite', 'Logical', 'OpenSearch', 'Enumerable', 'Bindable'];
+function displayNodeName(node: string): string {
+  let name = node;
+  for (const token of CONVENTION_TOKENS) {
+    name = name.split(token).join('');
+  }
+  return name.trim() || node;
 }
 
-// Extract the command keyword — stop at space, =, (, |, or comma
-function parseCommand(cmd: string): { keyword: string; args: string } {
-  const match = cmd.match(/^([^=\s(|,]+)/);
-  return { keyword: match?.[1] || cmd, args: cmd };
+// A physical-plan node flattened for tabular display. `selfTimeMs` is the node's
+// own time excluding children, used for the waterfall bar so the bars sum to the
+// total rather than double-counting nested inclusive times.
+interface FlatPlanNode {
+  node: string;
+  depth: number;
+  inclusiveTimeMs: number;
+  selfTimeMs: number;
+  rows?: number;
+  rowsIn?: number;
+  childNames: string[];
 }
 
-function OperationSubTable({
-  op,
-  nodeTimeMs,
-  barColor,
-  injectedTimeFilter,
+// Flatten the nested physical plan into a post-order list (children before their
+// parent). Physical plans execute bottom-up — leaf scans run first, the root last
+// — so post-order puts rows in execution order top-to-bottom. Each node's reported
+// time_ms is inclusive of its children, and children are pipelined rather than run
+// sequentially, so self-time = time_ms - max(child time_ms) — the parent can only
+// start after its slowest child (clamped at 0 to absorb rounding). rowsIn is the sum
+// of direct children's rows.
+function flattenPlan(root: PPLAnalyzePlanNode): FlatPlanNode[] {
+  const out: FlatPlanNode[] = [];
+  const walk = (node: PPLAnalyzePlanNode, depth: number) => {
+    const children = node.children || [];
+    children.forEach((c) => walk(c, depth + 1));
+    const childTime = children.reduce((max, c) => Math.max(max, c.time_ms || 0), 0);
+    const inclusiveTimeMs = node.time_ms || 0;
+    const childRows = children.reduce((sum, c) => sum + (c.rows || 0), 0);
+    out.push({
+      node: node.node,
+      depth,
+      inclusiveTimeMs,
+      selfTimeMs: Math.max(inclusiveTimeMs - childTime, 0),
+      rows: node.rows,
+      rowsIn: children.length > 0 ? childRows : undefined,
+      childNames: children.map((c) => c.node),
+    });
+  };
+  walk(root, 0);
+  return out;
+}
+
+// Waterfall reconstruction from the physical plan tree (profile.plan). Stages are
+// physical-plan operators; timing/rows come straight from the profile. There is no
+// PPL-op mapping, push-down location, estimated rows, or cost share — only what the
+// profile reports, which keeps this correct for any plan shape.
+function PhysicalPlanSection({
+  plan,
+  executePhaseMs,
 }: {
-  op: any;
-  nodeTimeMs: number;
-  barColor: string;
-  injectedTimeFilter?: string;
-}) {
-  const commands = splitSourceCommands(op.source || '', (op.node_type || ['Stage']).length);
-  const types: string[] = op.node_type || ['Stage'];
-
-  const nodeColor = op.is_pushed_down ? OPERATOR_COLORS.pushedDown : OPERATOR_COLORS.inMemory;
-
-  return (
-    <div style={{ borderTop: `1px solid ${euiColorLightShade}` }}>
-      {/* Sub-header */}
-      <div
-        style={{
-          display: 'flex',
-          padding: '6px 12px 6px 36px',
-          borderBottom: `1px solid ${euiColorLightShade}`,
-          backgroundColor: euiColorEmptyShade,
-          gap: 8,
-        }}
-      >
-        {['OPERATIONS IN THIS STAGE', 'ESTIMATED TIME', 'SHARE OF STAGE'].map((h, i) => (
-          <span
-            key={h}
-            style={{
-              fontSize: 10,
-              color: euiColorMediumShade,
-              flex: i === 0 ? 3 : i === 2 ? 2 : 1,
-              textAlign: i === 0 ? 'left' : 'center',
-            }}
-          >
-            {h}
-          </span>
-        ))}
-      </div>
-      {/* Operation rows */}
-      {types.map((type, typeIdx) => {
-        const { keyword, args } = parseCommand(commands[typeIdx]);
-        const sharePct = types.length > 0 ? 100 / types.length : 100;
-        const isDatePickerFilter =
-          !!injectedTimeFilter && args.trim() === injectedTimeFilter.trim();
-        return (
-          <div
-            key={typeIdx}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              padding: '6px 12px 6px 8px',
-              borderBottom: typeIdx < types.length - 1 ? `1px solid ${euiColorLightShade}` : 'none',
-              backgroundColor: euiColorEmptyShade,
-              gap: 8,
-            }}
-          >
-            <div style={{ width: 20, flexShrink: 0, display: 'flex', alignItems: 'center' }}>
-              {isDatePickerFilter && (
-                <EuiToolTip
-                  position="right"
-                  content="This filter was automatically added from the date picker, not written by you."
-                >
-                  <EuiIcon
-                    type="iInCircle"
-                    size="s"
-                    color="subdued"
-                    style={{ cursor: 'default' }}
-                  />
-                </EuiToolTip>
-              )}
-            </div>
-            <EuiText size="xs" style={{ flex: 3 }}>
-              <span style={{ fontFamily: 'monospace' }}>
-                <strong>{keyword}</strong>{' '}
-                <span style={{ color: euiColorMediumShade }}>
-                  {args.replace(keyword, '').trim()}
-                </span>
-              </span>
-            </EuiText>
-            <EuiText size="xs" style={{ flex: 1, textAlign: 'center' }}>
-              {formatMs(nodeTimeMs)}
-            </EuiText>
-            <div style={{ flex: 2, paddingRight: 8 }}>
-              <div
-                style={{
-                  height: 8,
-                  borderRadius: 2,
-                  backgroundColor: barColor,
-                  width: `${sharePct}%`,
-                  minWidth: 4,
-                }}
-              />
-            </div>
-          </div>
-        );
-      })}
-      {/* Detail panel below the operation breakdown */}
-      <div
-        style={{
-          padding: '12px 16px',
-          borderTop: `1px solid ${euiColorLightShade}`,
-          backgroundColor: euiColorEmptyShade,
-        }}
-      >
-        <EuiFlexGroup gutterSize="l" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued">
-              LOCATION
-            </EuiText>
-            <EuiText size="s">
-              {op.is_pushed_down ? 'OpenSearch data nodes' : 'Coordinator'}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued">
-              ESTIMATED ROWS
-            </EuiText>
-            <EuiText size="s">
-              <strong>{op.estimated_rows?.toLocaleString() ?? '—'}</strong>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued">
-              ACTUAL ROWS
-            </EuiText>
-            <EuiText size="s">
-              <strong>{op.actual_rows?.toLocaleString() ?? '—'}</strong>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued">
-              EXECUTION TIME
-            </EuiText>
-            <EuiText size="s">
-              <strong>{formatMs(nodeTimeMs)}</strong>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="s" />
-        <div
-          style={{
-            height: 4,
-            borderRadius: 2,
-            backgroundColor: nodeColor,
-            width: '100%',
-          }}
-        />
-        <EuiSpacer size="xs" />
-        <EuiText size="xs" color="subdued">
-          {/* <em>Detailed per-operation metrics are not yet available.</em> */}
-        </EuiText>
-      </div>
-    </div>
-  );
-}
-
-function OperatorPlanSection({
-  operatorTree,
-  executionPhaseMs,
-  injectedTimeFilter,
-}: {
-  operatorTree: any[];
-  executionPhaseMs: number;
-  injectedTimeFilter?: string;
+  plan: PPLAnalyzePlanNode;
+  executePhaseMs: number;
 }) {
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  // Pixel width of the bar column, measured at runtime so we can decide whether each
+  // label actually fits inside its bar rather than guessing from a fixed percentage.
+  const barTrackRef = useRef<HTMLDivElement | null>(null);
+  const [barTrackWidth, setBarTrackWidth] = useState(0);
 
-  const timings = operatorTree.map((op) => parseFloat(op.actual_time_ms) || 0);
-  const totalTimeMs = timings.reduce((a, b) => a + b, 0);
-  const maxTimeMs = Math.max(...timings);
-  const bottleneckNodeIdx = timings.indexOf(maxTimeMs);
-  const execBase = executionPhaseMs > 0 ? executionPhaseMs : totalTimeMs;
+  useEffect(() => {
+    const el = barTrackRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      setBarTrackWidth(entries[0].contentRect.width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
-  // Compute cumulative start times per node
+  const nodes = flattenPlan(plan);
+  // Scale the timeline to the sum of self-times rather than the root's reported
+  // time_ms — the root isn't guaranteed to have the largest inclusive time, so
+  // summing the self-times is the only value the bars are certain to tile into.
+  const totalTimeMs = nodes.reduce((sum, n) => sum + n.selfTimeMs, 0);
+  const maxSelfTimeMs = Math.max(...nodes.map((n) => n.selfTimeMs), 0);
+  const bottleneckIdx = nodes.findIndex((n) => n.selfTimeMs === maxSelfTimeMs);
+
+  // Lay the self-time slices end-to-end so each bar starts where the previous
+  // one ended. Self-times sum to the total, so the bars tile the full timeline
+  // instead of every bar starting at 0.
   let cursor = 0;
   const nodeStarts: number[] = [];
-  operatorTree.forEach((_, i) => {
+  nodes.forEach((n) => {
     nodeStarts.push(cursor);
-    cursor += timings[i];
+    cursor += n.selfTimeMs;
   });
-
-  const pushedDownMs = operatorTree.reduce(
-    (sum, op, i) => (op.is_pushed_down ? sum + timings[i] : sum),
-    0
-  );
-  const coordMs = totalTimeMs - pushedDownMs;
 
   const tickInterval = totalTimeMs > 0 ? totalTimeMs / (TICK_COUNT - 1) : 1;
   const ticks = Array.from({ length: TICK_COUNT }, (_, i) => i * tickInterval);
+
+  const barColor = PHASE_COLORS.execute;
 
   return (
     <div>
@@ -396,34 +293,9 @@ function OperatorPlanSection({
       </EuiTitle>
       <EuiSpacer size="xs" />
       <EuiText size="xs" color="subdued">
-        Each row is one execution stage. Click a stage to see the individual operations inside it.
+        Stages below are the physical-plan operators reported by the profiler (not PPL commands).
+        Each row&apos;s bar shows the time spent in that operator alone. Click a stage for details.
       </EuiText>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
-        {[
-          { color: OPERATOR_COLORS.pushedDown, label: 'Optimized by OpenSearch' },
-          { color: OPERATOR_COLORS.inMemory, label: 'Ran on coordinator' },
-        ].map(({ color, label }) => (
-          <EuiFlexItem key={label} grow={false}>
-            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <span
-                  style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: 2,
-                    backgroundColor: color,
-                    display: 'inline-block',
-                  }}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="xs">{label}</EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        ))}
-      </EuiFlexGroup>
       <EuiSpacer size="m" />
       <div
         style={{
@@ -433,12 +305,7 @@ function OperatorPlanSection({
         }}
       >
         {/* Column header row */}
-        <div
-          style={{
-            display: 'flex',
-            backgroundColor: euiColorEmptyShade,
-          }}
-        >
+        <div style={{ display: 'flex', backgroundColor: euiColorEmptyShade }}>
           <div
             style={{
               width: LABEL_COL_WIDTH,
@@ -475,6 +342,7 @@ function OperatorPlanSection({
             ))}
           </div>
           <div
+            ref={barTrackRef}
             style={{
               flex: 1,
               position: 'relative',
@@ -504,40 +372,37 @@ function OperatorPlanSection({
           </div>
         </div>
         {/* Node rows */}
-        {operatorTree.map((op, nodeIdx) => {
-          const timeMs = timings[nodeIdx];
-          const startMs = nodeStarts[nodeIdx];
-          const isBottleneck = nodeIdx === bottleneckNodeIdx;
-          const isPushedDown = !!op.is_pushed_down;
-          const isExpanded = expandedIdx === nodeIdx;
-          const isHovered = hoveredIdx === nodeIdx;
-          const barColor = PHASE_COLORS.execute;
-          const nodeColor = isPushedDown ? OPERATOR_COLORS.pushedDown : OPERATOR_COLORS.inMemory;
-          const startPct = totalTimeMs > 0 ? (startMs / totalTimeMs) * 100 : 0;
-          const widthPct = totalTimeMs > 0 ? (timeMs / totalTimeMs) * 100 : 0;
-          const pctOfExec = ((timeMs / execBase) * 100).toFixed(0);
-          const rowBg = isHovered || isExpanded ? `${nodeColor}28` : 'transparent';
+        {nodes.map((n, idx) => {
+          const isBottleneck = idx === bottleneckIdx && n.selfTimeMs > 0;
+          const isExpanded = expandedIdx === idx;
+          const isHovered = hoveredIdx === idx;
+          const startPct = totalTimeMs > 0 ? (nodeStarts[idx] / totalTimeMs) * 100 : 0;
+          const widthPct = totalTimeMs > 0 ? (n.selfTimeMs / totalTimeMs) * 100 : 0;
+          const rowBg = isHovered || isExpanded ? `${barColor}28` : 'transparent';
+          // Bar widths tile the plan-tree timeline (totalTimeMs) so there is no trailing
+          // gap, but the label shows the operator's share of the execute phase.
+          const sharePct = executePhaseMs > 0 ? (n.selfTimeMs / executePhaseMs) * 100 : 0;
 
-          // Label for the node
-          const types: string[] = op.node_type || ['Stage'];
-          const commands = splitSourceCommands(op.source || '', types.length);
-          const nodeTitle = isPushedDown
-            ? `Pushed down to OpenSearch (${types.length} op${types.length > 1 ? 's' : ''})`
-            : parseCommand(commands[0]).keyword.toUpperCase();
-          const nodeSublabel = isPushedDown
-            ? types.map((t, i) => parseCommand(commands[i]).keyword).join(' › ')
-            : commands[0];
+          // Decide inside vs. outside by measuring the label against the bar's actual
+          // pixel width instead of a fixed percentage. Until the track width is known
+          // (first paint / no ResizeObserver) keep every label outside so nothing clips.
+          const label = `${formatMs(n.selfTimeMs)} (${sharePct.toFixed(0)}%)`;
+          const barPx = (Math.max(widthPct, 0.5) / 100) * barTrackWidth;
+          const labelPx = measureTextWidth(label, BAR_LABEL_FONT);
+          const labelFitsInside =
+            barTrackWidth > 0 &&
+            barPx >= labelPx + BAR_LABEL_PADDING_PX + BAR_LABEL_RIGHT_MARGIN_PX;
 
           return (
-            <React.Fragment key={nodeIdx}>
+            <React.Fragment key={idx}>
               <div
                 role="button"
                 tabIndex={0}
-                onMouseEnter={() => setHoveredIdx(nodeIdx)}
+                onMouseEnter={() => setHoveredIdx(idx)}
                 onMouseLeave={() => setHoveredIdx(null)}
-                onClick={() => setExpandedIdx(isExpanded ? null : nodeIdx)}
+                onClick={() => setExpandedIdx(isExpanded ? null : idx)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') setExpandedIdx(isExpanded ? null : nodeIdx);
+                  if (e.key === 'Enter') setExpandedIdx(isExpanded ? null : idx);
                 }}
                 style={{
                   display: 'flex',
@@ -558,6 +423,7 @@ function OperatorPlanSection({
                     display: 'flex',
                     alignItems: 'center',
                     gap: 6,
+                    overflow: 'hidden',
                   }}
                 >
                   <span style={{ flexShrink: 0 }}>
@@ -567,46 +433,32 @@ function OperatorPlanSection({
                       color="subdued"
                     />
                   </span>
-                  <div style={{ minWidth: 0 }}>
-                    <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
-                      <EuiFlexItem grow={false}>
-                        <EuiText size="s">
-                          <strong>{nodeTitle}</strong>
-                        </EuiText>
-                      </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <StageBadge isPushedDown={isPushedDown} />
-                      </EuiFlexItem>
-                      {isBottleneck && (
-                        <EuiFlexItem grow={false}>
-                          <span
-                            style={{
-                              marginLeft: 4,
-                              fontSize: 12,
-                              color: OPERATOR_COLORS.bottleneck,
-                            }}
-                            title="Bottleneck"
-                          >
-                            ⚠
-                          </span>
-                        </EuiFlexItem>
-                      )}
-                    </EuiFlexGroup>
-                    <EuiText
-                      size="xs"
-                      color="subdued"
+                  <EuiText
+                    size="s"
+                    style={{
+                      minWidth: 0,
+                      flex: 1,
+                      fontFamily: 'monospace',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={n.node}
+                  >
+                    <strong>{displayNodeName(n.node)}</strong>
+                  </EuiText>
+                  {isBottleneck && (
+                    <span
                       style={{
-                        marginTop: 2,
-                        fontFamily: 'monospace',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
+                        flexShrink: 0,
+                        fontSize: 12,
+                        color: OPERATOR_COLORS.bottleneck,
                       }}
-                      title={nodeSublabel}
+                      title="Bottleneck"
                     >
-                      {nodeSublabel}
-                    </EuiText>
-                  </div>
+                      ⚠
+                    </span>
+                  )}
                 </div>
                 {/* Stats column */}
                 <div
@@ -618,11 +470,9 @@ function OperatorPlanSection({
                   }}
                 >
                   {[
-                    formatMs(timeMs),
-                    nodeIdx === 0
-                      ? '—'
-                      : (operatorTree[nodeIdx - 1]?.actual_rows?.toLocaleString() ?? '—'),
-                    op.actual_rows?.toLocaleString() ?? '—',
+                    formatMs(n.selfTimeMs),
+                    n.rowsIn?.toLocaleString() ?? '—',
+                    n.rows?.toLocaleString() ?? '—',
                   ].map((val, i) => (
                     <EuiText
                       key={i}
@@ -638,7 +488,7 @@ function OperatorPlanSection({
                     </EuiText>
                   ))}
                 </div>
-                {/* Bar column */}
+                {/* Bar column — self-time waterfall */}
                 <div
                   style={{
                     flex: 1,
@@ -679,11 +529,7 @@ function OperatorPlanSection({
                       minWidth: 4,
                     }}
                   >
-                    {isBottleneck ? (
-                      <span style={{ fontSize: 11, color: '#000', whiteSpace: 'nowrap' }}>
-                        {formatMs(timeMs)} ({pctOfExec}% of Execution Phase)
-                      </span>
-                    ) : widthPct > 10 ? (
+                    {labelFitsInside && (
                       <span
                         style={{
                           fontSize: 11,
@@ -692,11 +538,11 @@ function OperatorPlanSection({
                           whiteSpace: 'nowrap',
                         }}
                       >
-                        {formatMs(timeMs)}
+                        {label}
                       </span>
-                    ) : null}
+                    )}
                   </div>
-                  {!isBottleneck && widthPct <= 10 && startPct + widthPct < 85 && (
+                  {!labelFitsInside && startPct + widthPct < 85 && (
                     <span
                       style={{
                         position: 'absolute',
@@ -705,28 +551,73 @@ function OperatorPlanSection({
                         transform: 'translateY(-50%)',
                         paddingLeft: 4,
                         fontSize: 11,
-                        // Kept as a fixed dark color on purpose. This label sits just
-                        // outside the bar, but a theme-reactive euiTextColor renders
-                        // near-white in dark mode and is actually harder to read here
-                        // against the surrounding bar/gridline area, so black stays
-                        // the most legible option across themes.
+                        // Fixed dark color: sits just outside the bar and stays the
+                        // most legible option across light/dark themes.
                         color: '#000',
                         whiteSpace: 'nowrap',
                       }}
                     >
-                      {formatMs(timeMs)}
+                      {label}
                     </span>
                   )}
                 </div>
               </div>
-              {/* Expanded sub-table */}
+              {/* Expanded detail */}
               {isExpanded && (
-                <OperationSubTable
-                  op={op}
-                  nodeTimeMs={timeMs}
-                  barColor={barColor}
-                  injectedTimeFilter={injectedTimeFilter}
-                />
+                <div
+                  style={{
+                    padding: '12px 16px',
+                    borderTop: `1px solid ${euiColorLightShade}`,
+                    backgroundColor: euiColorEmptyShade,
+                  }}
+                >
+                  <EuiFlexGroup gutterSize="l" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        OPERATOR
+                      </EuiText>
+                      <EuiText size="s">
+                        <strong>{n.node}</strong>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        TIME
+                      </EuiText>
+                      <EuiText size="s">
+                        <strong>{formatMs(n.selfTimeMs)}</strong>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        ROWS IN
+                      </EuiText>
+                      <EuiText size="s">
+                        <strong>{n.rowsIn?.toLocaleString() ?? '—'}</strong>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        ROWS OUT
+                      </EuiText>
+                      <EuiText size="s">
+                        <strong>{n.rows?.toLocaleString() ?? '—'}</strong>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        SOURCE NODES
+                      </EuiText>
+                      <EuiText size="s">
+                        <strong>
+                          {n.childNames.length > 0
+                            ? n.childNames.map(displayNodeName).join(', ')
+                            : 'None'}
+                        </strong>
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </div>
               )}
             </React.Fragment>
           );
@@ -741,17 +632,14 @@ function OperatorPlanSection({
           }}
         >
           <EuiText size="xs">
-            Total Execution Phase: <strong>{formatMs(totalTimeMs)}</strong>
+            Total Execution Phase: <strong>{formatMs(executePhaseMs)}</strong>
           </EuiText>
           <EuiText size="xs">
-            On data nodes: <strong>{formatMs(pushedDownMs)}</strong>
+            Operators: <strong>{nodes.length}</strong>
           </EuiText>
-          <EuiText size="xs">
-            On coordinator: <strong>{formatMs(coordMs)}</strong>
-          </EuiText>
-          {operatorTree[0]?.actual_rows !== undefined && (
+          {plan.rows !== undefined && (
             <EuiText size="xs">
-              Result: <strong>{operatorTree[0].actual_rows?.toLocaleString()} rows</strong>
+              Result: <strong>{plan.rows?.toLocaleString()} rows</strong>
             </EuiText>
           )}
         </div>
@@ -769,6 +657,47 @@ const SEVERITY_COLORS: Record<string, string> = {
 function parseRecommendationMessage(message: string): React.ReactNode {
   const parts = message.split(/\*([^*]+)\*/g);
   return parts.map((part, i) => (i % 2 === 1 ? <strong key={i}>{part}</strong> : part));
+}
+
+// Fraction of the execute phase below which a node isn't worth surfacing a
+// recommendation for — small contributors are noise, not opportunities.
+const MIN_NODE_EXECUTE_SHARE = 0.05;
+// Cap on the number of recommendations shown; the highest-severity ones win.
+const MAX_RECOMMENDATIONS = 3;
+const SEVERITY_RANK: Record<string, number> = { CRITICAL: 0, WARNING: 1, INFO: 2 };
+
+// Filter incoming recommendations to the ones worth showing:
+//  1. drop any whose `affected_node` maps to a plan node using less than
+//     MIN_NODE_EXECUTE_SHARE of the execute phase (small operators aren't the
+//     right thing to tell customers to optimize),
+//  2. keep at most MAX_RECOMMENDATIONS, preferring higher severities.
+// Recs with no `affected_node` (phase-level advice) or an unmatched name pass
+// through the share filter — we can't judge their weight, so we don't drop them.
+function filterRecommendations(
+  recs: any[] | undefined,
+  nodes: FlatPlanNode[],
+  executePhaseMs: number
+): any[] {
+  if (!recs || recs.length === 0) return [];
+  const selfTimeByNode = new Map<string, number>();
+  nodes.forEach((n) => {
+    // Multiple plan nodes can share a raw name (e.g. two IndexScans on a join);
+    // sum their self-times so the filter reflects the operator's total weight.
+    selfTimeByNode.set(n.node, (selfTimeByNode.get(n.node) || 0) + n.selfTimeMs);
+  });
+  const minSelfMs = executePhaseMs * MIN_NODE_EXECUTE_SHARE;
+  const kept = recs.filter((rec) => {
+    if (!rec?.affected_node) return true;
+    const selfMs = selfTimeByNode.get(rec.affected_node);
+    if (selfMs === undefined) return true;
+    return selfMs >= minSelfMs;
+  });
+  const ranked = [...kept].sort((a, b) => {
+    const sa = SEVERITY_RANK[(a.serverity || a.severity || 'INFO').toUpperCase()] ?? 2;
+    const sb = SEVERITY_RANK[(b.serverity || b.severity || 'INFO').toUpperCase()] ?? 2;
+    return sa - sb;
+  });
+  return ranked.slice(0, MAX_RECOMMENDATIONS);
 }
 
 function RecommendationsSection({ recommendations }: { recommendations: any[] }) {
@@ -859,12 +788,27 @@ function parseAnalyzeError(response: any): { title: string; message: string } | 
 }
 
 export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult, onClose }) => {
-  const { response, injectedTimeFilter } = analyzeResult;
+  const { response } = analyzeResult;
   const analyzeError = parseAnalyzeError(response);
   const hasProfile = !!response.profile;
   const totalTimeMs = response.profile?.summary?.total_time_ms || 0;
-  const hasOperatorTree = response.operator_tree && response.operator_tree.length > 0;
+  // The waterfall is reconstructed from the physical plan reported by the profiler
+  // (profile.plan).
+  const planTree = response.profile?.plan;
+  const hasPlanTree = !!planTree;
   const possibleCacheHit = !!response.possibleCacheHit;
+  const executePhaseMs = response.profile?.phases?.execute?.time_ms || 0;
+  // Drop recs on tiny operators and cap to the most critical few. Recomputes only
+  // when the plan or execute-phase timing changes, not on hover/expand state.
+  const filteredRecommendations = React.useMemo(
+    () =>
+      filterRecommendations(
+        response.recommendations,
+        planTree ? flattenPlan(planTree) : [],
+        executePhaseMs
+      ),
+    [response.recommendations, planTree, executePhaseMs]
+  );
 
   return (
     <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
@@ -928,12 +872,8 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
           <EuiSpacer size="l" />
           <EuiFlexGroup gutterSize="l">
             <EuiFlexItem grow={3}>
-              {hasOperatorTree ? (
-                <OperatorPlanSection
-                  operatorTree={response.operator_tree}
-                  executionPhaseMs={response.profile?.phases?.execute?.time_ms || 0}
-                  injectedTimeFilter={injectedTimeFilter}
-                />
+              {hasPlanTree ? (
+                <PhysicalPlanSection plan={planTree!} executePhaseMs={executePhaseMs} />
               ) : (
                 <EuiCallOut
                   title="Execution Phase Profiling unavailable"
@@ -941,17 +881,16 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
                   color="warning"
                 >
                   <EuiText size="s">
-                    The per-stage execution breakdown is only available for queries with a linear
-                    execution plan. Queries that produce non-linear plans (e.g. JOINs) are not yet
-                    supported and fall back to profile-only output. The phase timing bar above
-                    reflects the full query profile.
+                    The per-stage execution breakdown is unavailable because the query profile did
+                    not include a physical plan. The phase timing bar above reflects the full query
+                    profile.
                   </EuiText>
                 </EuiCallOut>
               )}
             </EuiFlexItem>
-            {response.recommendations && response.recommendations.length > 0 && (
+            {filteredRecommendations.length > 0 && (
               <EuiFlexItem grow={2}>
-                <RecommendationsSection recommendations={response.recommendations} />
+                <RecommendationsSection recommendations={filteredRecommendations} />
               </EuiFlexItem>
             )}
           </EuiFlexGroup>

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
@@ -40,6 +40,13 @@ const PHASE_COLORS: Record<string, string> = {
   format: '#D6BF57',
 };
 
+// Display name for the synthetic trailing stage that accounts for execute-phase time
+// spent outside the operators (e.g. composing the result set).
+const OVERHEAD_NODE = i18n.translate('data.pplAnalyze.overheadStageName', {
+  defaultMessage: 'Result composition',
+});
+const OVERHEAD_BAR_COLOR = '#98A2B3';
+
 const PHASE_DESCRIPTIONS: Record<string, string> = {
   analyze: i18n.translate('data.pplAnalyze.phaseDescription.analyze', {
     defaultMessage: 'Parsing and validating the query syntax and semantics.',
@@ -225,44 +232,63 @@ function displayNodeName(node: string): string {
 }
 
 // A physical-plan node flattened for tabular display. `selfTimeMs` is the node's
-// own time excluding children, used for the waterfall bar so the bars sum to the
-// total rather than double-counting nested inclusive times.
+// own time excluding children (the bar width); `startMs` is where its bar begins on
+// the timeline — the max of its children's inclusive times, since a node can only
+// begin once its slowest child has finished (0 for leaves). `concurrentWith` holds
+// the full names of the node's siblings (nodes sharing a parent), which run
+// concurrently with it.
 interface FlatPlanNode {
   node: string;
   depth: number;
   inclusiveTimeMs: number;
   selfTimeMs: number;
+  startMs: number;
   rows?: number;
   rowsIn?: number;
   childNames: string[];
+  concurrentWith: string[];
+  // Marks the synthetic trailing row that accounts for execute-phase time not
+  // attributed to any operator (e.g. composing the result set). Rendered grey.
+  isOverhead?: boolean;
 }
 
 // Flatten the nested physical plan into a post-order list (children before their
 // parent). Physical plans execute bottom-up — leaf scans run first, the root last
 // — so post-order puts rows in execution order top-to-bottom. Each node's reported
-// time_ms is inclusive of its children, and children are pipelined rather than run
-// sequentially, so self-time = time_ms - max(child time_ms) — the parent can only
-// start after its slowest child (clamped at 0 to absorb rounding). rowsIn is the sum
-// of direct children's rows.
+// time_ms is inclusive of its children, so its bar starts at max(child time_ms) —
+// when its slowest child finished — and its width (self-time) is time_ms minus that
+// start (clamped at 0 to absorb rounding). Sibling bars overlap in real time; that
+// is expected and rendered as-is. rowsIn is the sum of direct children's rows.
 function flattenPlan(root: PPLAnalyzePlanNode): FlatPlanNode[] {
   const out: FlatPlanNode[] = [];
-  const walk = (node: PPLAnalyzePlanNode, depth: number) => {
+  // `siblingNames` is the full (undecorated) names of every node sharing this node's
+  // parent (excluding itself) — those operators overlap in time with this one.
+  const walk = (node: PPLAnalyzePlanNode, depth: number, siblingNames: string[]) => {
     const children = node.children || [];
-    children.forEach((c) => walk(c, depth + 1));
-    const childTime = children.reduce((max, c) => Math.max(max, c.time_ms || 0), 0);
+    const childNames = children.map((c) => c.node);
+    children.forEach((c, i) =>
+      walk(
+        c,
+        depth + 1,
+        childNames.filter((_, j) => j !== i)
+      )
+    );
+    const startMs = children.reduce((max, c) => Math.max(max, c.time_ms || 0), 0);
     const inclusiveTimeMs = node.time_ms || 0;
     const childRows = children.reduce((sum, c) => sum + (c.rows || 0), 0);
     out.push({
       node: node.node,
       depth,
       inclusiveTimeMs,
-      selfTimeMs: Math.max(inclusiveTimeMs - childTime, 0),
+      selfTimeMs: Math.max(inclusiveTimeMs - startMs, 0),
+      startMs,
       rows: node.rows,
       rowsIn: children.length > 0 ? childRows : undefined,
       childNames: children.map((c) => c.node),
+      concurrentWith: siblingNames,
     });
   };
-  walk(root, 0);
+  walk(root, 0, []);
   return out;
 }
 
@@ -294,27 +320,39 @@ function PhysicalPlanSection({
     return () => observer.disconnect();
   }, []);
 
-  // Flatten the plan and derive the layout geometry once per plan, not on every
-  // hover/expand re-render.
-  const { nodes, totalTimeMs, nodeStarts } = React.useMemo(() => {
+  // Flatten the plan, then append a synthetic "overhead" row for execute-phase time
+  // not attributed to any operator (result-set composition, etc.). It spans from the
+  // end of operator work (the root's inclusive time) to the end of the execute phase.
+  // Memoized per plan/phase, not per hover/expand re-render.
+  const nodes = React.useMemo(() => {
     const flat = flattenPlan(plan);
-    // Scale the timeline to the sum of self-times rather than the root's reported
-    // time_ms — the root isn't guaranteed to have the largest inclusive time, so
-    // summing the self-times is the only value the bars are certain to tile into.
-    const total = flat.reduce((sum, n) => sum + n.selfTimeMs, 0);
-    // Lay the self-time slices end-to-end so each bar starts where the previous
-    // one ended. Self-times sum to the total, so the bars tile the full timeline
-    // instead of every bar starting at 0.
-    let cursor = 0;
-    const starts: number[] = [];
-    flat.forEach((n) => {
-      starts.push(cursor);
-      cursor += n.selfTimeMs;
-    });
-    return { nodes: flat, totalTimeMs: total, nodeStarts: starts };
-  }, [plan]);
+    const operatorEndMs = flat.reduce((max, n) => Math.max(max, n.startMs + n.selfTimeMs), 0);
+    const overheadMs = executePhaseMs - operatorEndMs;
+    // Only surface it when it's a meaningful slice (avoids a sliver from rounding).
+    if (overheadMs > 0.05) {
+      flat.push({
+        node: OVERHEAD_NODE,
+        depth: 0,
+        inclusiveTimeMs: overheadMs,
+        selfTimeMs: overheadMs,
+        startMs: operatorEndMs,
+        rows: undefined,
+        rowsIn: undefined,
+        childNames: [],
+        concurrentWith: [],
+        isOverhead: true,
+      });
+    }
+    return flat;
+  }, [plan, executePhaseMs]);
 
-  const tickInterval = totalTimeMs > 0 ? totalTimeMs / (TICK_COUNT - 1) : 1;
+  // The whole waterfall — axis ticks, bar start offsets, bar widths, and the label
+  // percentage — is scaled to the execute phase, so every number shares one
+  // denominator. Each bar starts at its slowest child's inclusive time (0 for
+  // leaves), so sibling bars may overlap and bars stop short of the right edge
+  // where operator time doesn't fill the whole execute phase.
+  const scaleMs = executePhaseMs;
+  const tickInterval = scaleMs > 0 ? scaleMs / (TICK_COUNT - 1) : 1;
   const ticks = Array.from({ length: TICK_COUNT }, (_, i) => i * tickInterval);
 
   const barColor = PHASE_COLORS.execute;
@@ -333,7 +371,7 @@ function PhysicalPlanSection({
       <EuiText size="xs" color="subdued">
         <FormattedMessage
           id="data.pplAnalyze.executionProfiling.description"
-          defaultMessage="Stages below are the physical-plan operators reported by the profiler (not PPL commands). Each row's bar shows the time spent in that operator alone. Click a stage for details."
+          defaultMessage="Each stage is a physical-plan operator produced by the query optimizer, which may not correspond directly to the commands in your PPL query. A stage's bar is positioned on the execution timeline and sized by the time attributed to that operator; operators whose bars overlap ran concurrently. Select a stage to view more information."
         />
       </EuiText>
       <EuiSpacer size="m" />
@@ -396,14 +434,14 @@ function PhysicalPlanSection({
               borderLeft: `1px solid ${euiColorLightShade}`,
             }}
           >
-            {totalTimeMs > 0 &&
+            {scaleMs > 0 &&
               ticks.map((t, i) =>
                 i === 0 || i === ticks.length - 1 ? null : (
                   <span
                     key={i}
                     style={{
                       position: 'absolute',
-                      left: `${(t / totalTimeMs) * 100}%`,
+                      left: `${(t / scaleMs) * 100}%`,
                       transform: 'translateX(-50%)',
                       fontSize: 10,
                       color: euiColorMediumShade,
@@ -421,17 +459,25 @@ function PhysicalPlanSection({
         {nodes.map((n, idx) => {
           const isExpanded = expandedIdx === idx;
           const isHovered = hoveredIdx === idx;
-          const startPct = totalTimeMs > 0 ? (nodeStarts[idx] / totalTimeMs) * 100 : 0;
-          const widthPct = totalTimeMs > 0 ? (n.selfTimeMs / totalTimeMs) * 100 : 0;
-          const rowBg = isHovered || isExpanded ? `${barColor}28` : 'transparent';
-          // Bar widths tile the plan-tree timeline (totalTimeMs) so there is no trailing
-          // gap, but the label shows the operator's share of the execute phase.
-          const sharePct = executePhaseMs > 0 ? (n.selfTimeMs / executePhaseMs) * 100 : 0;
+          // Everything is scaled to the execute phase: start offset, width, and the
+          // label percentage all share one denominator, so a bar's width matches the
+          // percentage it prints.
+          const startPct = scaleMs > 0 ? (n.startMs / scaleMs) * 100 : 0;
+          const widthPct = scaleMs > 0 ? (n.selfTimeMs / scaleMs) * 100 : 0;
+          // The synthetic overhead row is greyed to distinguish it from real operators.
+          const rowBarColor = n.isOverhead ? OVERHEAD_BAR_COLOR : barColor;
+          const rowBg = isHovered || isExpanded ? `${rowBarColor}28` : 'transparent';
 
+          // Concurrent operators (those with siblings) overlap in time, so their
+          // widths don't add up to a meaningful share of the timeline — omit the
+          // percentage for them and show only the duration.
+          const isConcurrent = n.concurrentWith.length > 0;
+          const label = isConcurrent
+            ? formatMs(n.selfTimeMs)
+            : `${formatMs(n.selfTimeMs)} (${widthPct.toFixed(0)}%)`;
           // Decide inside vs. outside by measuring the label against the bar's actual
           // pixel width instead of a fixed percentage. Until the track width is known
           // (first paint / no ResizeObserver) keep every label outside so nothing clips.
-          const label = `${formatMs(n.selfTimeMs)} (${sharePct.toFixed(0)}%)`;
           const barPx = (Math.max(widthPct, 0.5) / 100) * barTrackWidth;
           const labelPx = measureTextWidth(label, BAR_LABEL_FONT);
           const labelFitsInside =
@@ -531,13 +577,13 @@ function PhysicalPlanSection({
                     borderLeft: `1px solid ${euiColorLightShade}`,
                   }}
                 >
-                  {totalTimeMs > 0 &&
+                  {scaleMs > 0 &&
                     ticks.slice(1, -1).map((t, i) => (
                       <div
                         key={i}
                         style={{
                           position: 'absolute',
-                          left: `${(t / totalTimeMs) * 100}%`,
+                          left: `${(t / scaleMs) * 100}%`,
                           top: 0,
                           bottom: 0,
                           width: 1,
@@ -553,7 +599,7 @@ function PhysicalPlanSection({
                       transform: 'translateY(-50%)',
                       width: `${Math.max(widthPct, 0.5)}%`,
                       height: 20,
-                      backgroundColor: barColor,
+                      backgroundColor: rowBarColor,
                       borderRadius: 3,
                       display: 'flex',
                       alignItems: 'center',
@@ -596,7 +642,34 @@ function PhysicalPlanSection({
                 </div>
               </div>
               {/* Expanded detail */}
-              {isExpanded && (
+              {isExpanded && n.isOverhead && (
+                <div
+                  style={{
+                    padding: '12px 16px',
+                    borderTop: `1px solid ${euiColorLightShade}`,
+                    backgroundColor: euiColorEmptyShade,
+                  }}
+                >
+                  <EuiText size="xs" color="subdued">
+                    <FormattedMessage
+                      id="data.pplAnalyze.detail.overheadTime"
+                      defaultMessage="OVERHEAD TIME"
+                    />
+                  </EuiText>
+                  <EuiText size="s">
+                    <strong>{formatMs(n.selfTimeMs)}</strong>
+                  </EuiText>
+                  <EuiSpacer size="s" />
+                  <EuiText size="xs" color="subdued">
+                    <FormattedMessage
+                      id="data.pplAnalyze.detail.overheadExplanation"
+                      defaultMessage="The execute phase ({execute}) is longer than the time spent in the plan's operators. This stage accounts for the difference — work done during execution but outside any operator, such as composing the individual operator outputs into the final result set. It is expected and generally small."
+                      values={{ execute: formatMs(executePhaseMs) }}
+                    />
+                  </EuiText>
+                </div>
+              )}
+              {isExpanded && !n.isOverhead && (
                 <div
                   style={{
                     padding: '12px 16px',
@@ -664,6 +737,21 @@ function PhysicalPlanSection({
                       </EuiText>
                     </EuiFlexItem>
                   </EuiFlexGroup>
+                  {n.concurrentWith.length > 0 && (
+                    <>
+                      <EuiSpacer size="s" />
+                      <EuiText size="xs" color="subdued">
+                        <FormattedMessage
+                          id="data.pplAnalyze.detail.concurrent"
+                          defaultMessage="Ran concurrently with {count, plural, one {# other operation} other {# other operations}} ({operations})"
+                          values={{
+                            count: n.concurrentWith.length,
+                            operations: n.concurrentWith.join(', '),
+                          }}
+                        />
+                      </EuiText>
+                    </>
+                  )}
                 </div>
               )}
             </React.Fragment>
@@ -689,7 +777,7 @@ function PhysicalPlanSection({
             <FormattedMessage
               id="data.pplAnalyze.summary.operators"
               defaultMessage="Operators: {count}"
-              values={{ count: <strong>{nodes.length}</strong> }}
+              values={{ count: <strong>{nodes.filter((n) => !n.isOverhead).length}</strong> }}
             />
           </EuiText>
           {plan.rows !== undefined && (

--- a/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
+++ b/src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.tsx
@@ -17,7 +17,13 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
-import { PPLAnalyzeResult, PPLAnalyzePlanNode } from '../../query/ppl_analyze_state';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+import {
+  PPLAnalyzeResult,
+  PPLAnalyzePlanNode,
+  PPLAnalyzeRecommendation,
+} from '../../query/ppl_analyze_state';
 
 // Theme-reactive colors that resolve to light/dark values automatically.
 const { euiColorEmptyShade, euiColorLightShade, euiColorMediumShade } = euiThemeVars;
@@ -41,10 +47,18 @@ const OPERATOR_COLORS = {
 };
 
 const PHASE_DESCRIPTIONS: Record<string, string> = {
-  analyze: 'Parsing and validating the query syntax and semantics.',
-  optimize: 'Determining the most efficient execution plan and push-down strategy.',
-  execute: 'Running the query against OpenSearch and processing results.',
-  format: 'Formatting the final result set for output.',
+  analyze: i18n.translate('data.pplAnalyze.phaseDescription.analyze', {
+    defaultMessage: 'Parsing and validating the query syntax and semantics.',
+  }),
+  optimize: i18n.translate('data.pplAnalyze.phaseDescription.optimize', {
+    defaultMessage: 'Determining the most efficient execution plan and push-down strategy.',
+  }),
+  execute: i18n.translate('data.pplAnalyze.phaseDescription.execute', {
+    defaultMessage: 'Running the query against OpenSearch and processing results.',
+  }),
+  format: i18n.translate('data.pplAnalyze.phaseDescription.format', {
+    defaultMessage: 'Formatting the final result set for output.',
+  }),
 };
 
 function TimingBar({
@@ -60,7 +74,13 @@ function TimingBar({
   return (
     <div>
       <EuiText size="s">
-        <strong>Query completed in {totalTimeMs.toFixed(1)}ms</strong>
+        <strong>
+          <FormattedMessage
+            id="data.pplAnalyze.timingBar.queryCompleted"
+            defaultMessage="Query completed in {time}ms"
+            values={{ time: totalTimeMs.toFixed(1) }}
+          />
+        </strong>
       </EuiText>
       <EuiSpacer size="s" />
       <EuiFlexGroup gutterSize="s" alignItems="center" wrap responsive={false}>
@@ -82,7 +102,15 @@ function TimingBar({
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText size="xs">
-                    {name.charAt(0).toUpperCase() + name.slice(1)} {timeMs.toFixed(1)}ms ({pct}%)
+                    <FormattedMessage
+                      id="data.pplAnalyze.timingBar.phaseLegend"
+                      defaultMessage="{phase} {time}ms ({pct}%)"
+                      values={{
+                        phase: name.charAt(0).toUpperCase() + name.slice(1),
+                        time: timeMs.toFixed(1),
+                        pct,
+                      }}
+                    />
                   </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
@@ -97,7 +125,11 @@ function TimingBar({
           if (pct === 0) return null;
           const displayPct = Math.max(pct, 0.5);
           const label = name.charAt(0).toUpperCase() + name.slice(1);
-          const description = PHASE_DESCRIPTIONS[name] || 'No details available.';
+          const description =
+            PHASE_DESCRIPTIONS[name] ||
+            i18n.translate('data.pplAnalyze.phaseDescription.fallback', {
+              defaultMessage: 'No details available.',
+            });
           return (
             <div key={name} style={{ width: `${displayPct}%`, height: 20 }}>
               <EuiToolTip
@@ -289,12 +321,19 @@ function PhysicalPlanSection({
   return (
     <div>
       <EuiTitle size="s">
-        <h3>Execution Phase Profiling</h3>
+        <h3>
+          <FormattedMessage
+            id="data.pplAnalyze.executionProfiling.title"
+            defaultMessage="Execution Phase Profiling"
+          />
+        </h3>
       </EuiTitle>
       <EuiSpacer size="xs" />
       <EuiText size="xs" color="subdued">
-        Stages below are the physical-plan operators reported by the profiler (not PPL commands).
-        Each row&apos;s bar shows the time spent in that operator alone. Click a stage for details.
+        <FormattedMessage
+          id="data.pplAnalyze.executionProfiling.description"
+          defaultMessage="Stages below are the physical-plan operators reported by the profiler (not PPL commands). Each row's bar shows the time spent in that operator alone. Click a stage for details."
+        />
       </EuiText>
       <EuiSpacer size="m" />
       <div
@@ -314,7 +353,9 @@ function PhysicalPlanSection({
               padding: '6px 12px',
             }}
           >
-            <span style={{ fontSize: 10, color: euiColorMediumShade }}>STAGE</span>
+            <span style={{ fontSize: 10, color: euiColorMediumShade }}>
+              {i18n.translate('data.pplAnalyze.column.stage', { defaultMessage: 'STAGE' })}
+            </span>
           </div>
           <div
             style={{
@@ -326,7 +367,11 @@ function PhysicalPlanSection({
               paddingBottom: 6,
             }}
           >
-            {['TIME', 'ROWS IN', 'ROWS OUT'].map((h) => (
+            {[
+              i18n.translate('data.pplAnalyze.column.time', { defaultMessage: 'TIME' }),
+              i18n.translate('data.pplAnalyze.column.rowsIn', { defaultMessage: 'ROWS IN' }),
+              i18n.translate('data.pplAnalyze.column.rowsOut', { defaultMessage: 'ROWS OUT' }),
+            ].map((h) => (
               <span
                 key={h}
                 style={{
@@ -454,7 +499,9 @@ function PhysicalPlanSection({
                         fontSize: 12,
                         color: OPERATOR_COLORS.bottleneck,
                       }}
-                      title="Bottleneck"
+                      title={i18n.translate('data.pplAnalyze.bottleneckTooltip', {
+                        defaultMessage: 'Bottleneck',
+                      })}
                     >
                       ⚠
                     </span>
@@ -574,7 +621,10 @@ function PhysicalPlanSection({
                   <EuiFlexGroup gutterSize="l" responsive={false}>
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
-                        OPERATOR
+                        <FormattedMessage
+                          id="data.pplAnalyze.detail.operator"
+                          defaultMessage="OPERATOR"
+                        />
                       </EuiText>
                       <EuiText size="s">
                         <strong>{n.node}</strong>
@@ -582,7 +632,7 @@ function PhysicalPlanSection({
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
-                        TIME
+                        <FormattedMessage id="data.pplAnalyze.column.time" defaultMessage="TIME" />
                       </EuiText>
                       <EuiText size="s">
                         <strong>{formatMs(n.selfTimeMs)}</strong>
@@ -590,7 +640,10 @@ function PhysicalPlanSection({
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
-                        ROWS IN
+                        <FormattedMessage
+                          id="data.pplAnalyze.column.rowsIn"
+                          defaultMessage="ROWS IN"
+                        />
                       </EuiText>
                       <EuiText size="s">
                         <strong>{n.rowsIn?.toLocaleString() ?? '—'}</strong>
@@ -598,7 +651,10 @@ function PhysicalPlanSection({
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
-                        ROWS OUT
+                        <FormattedMessage
+                          id="data.pplAnalyze.column.rowsOut"
+                          defaultMessage="ROWS OUT"
+                        />
                       </EuiText>
                       <EuiText size="s">
                         <strong>{n.rows?.toLocaleString() ?? '—'}</strong>
@@ -606,13 +662,18 @@ function PhysicalPlanSection({
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
-                        SOURCE NODES
+                        <FormattedMessage
+                          id="data.pplAnalyze.detail.sourceNodes"
+                          defaultMessage="SOURCE NODES"
+                        />
                       </EuiText>
                       <EuiText size="s">
                         <strong>
                           {n.childNames.length > 0
                             ? n.childNames.map(displayNodeName).join(', ')
-                            : 'None'}
+                            : i18n.translate('data.pplAnalyze.detail.noSourceNodes', {
+                                defaultMessage: 'None',
+                              })}
                         </strong>
                       </EuiText>
                     </EuiFlexItem>
@@ -632,14 +693,36 @@ function PhysicalPlanSection({
           }}
         >
           <EuiText size="xs">
-            Total Execution Phase: <strong>{formatMs(executePhaseMs)}</strong>
+            <FormattedMessage
+              id="data.pplAnalyze.summary.totalExecutionPhase"
+              defaultMessage="Total Execution Phase: {time}"
+              values={{ time: <strong>{formatMs(executePhaseMs)}</strong> }}
+            />
           </EuiText>
           <EuiText size="xs">
-            Operators: <strong>{nodes.length}</strong>
+            <FormattedMessage
+              id="data.pplAnalyze.summary.operators"
+              defaultMessage="Operators: {count}"
+              values={{ count: <strong>{nodes.length}</strong> }}
+            />
           </EuiText>
           {plan.rows !== undefined && (
             <EuiText size="xs">
-              Result: <strong>{plan.rows?.toLocaleString()} rows</strong>
+              <FormattedMessage
+                id="data.pplAnalyze.summary.result"
+                defaultMessage="Result: {rows}"
+                values={{
+                  rows: (
+                    <strong>
+                      <FormattedMessage
+                        id="data.pplAnalyze.summary.resultRows"
+                        defaultMessage="{count} rows"
+                        values={{ count: plan.rows?.toLocaleString() }}
+                      />
+                    </strong>
+                  ),
+                }}
+              />
             </EuiText>
           )}
         </div>
@@ -654,9 +737,23 @@ const SEVERITY_COLORS: Record<string, string> = {
   INFO: '#7DE2D1',
 };
 
-function parseRecommendationMessage(message: string): React.ReactNode {
+function parseRecommendationMessage(message: unknown): React.ReactNode {
+  // The backend has shipped recommendations as both objects and bare strings, so
+  // `message` isn't guaranteed to be a string. Coerce non-strings rather than
+  // calling String.prototype.split on something that lacks it (which would throw).
+  if (typeof message !== 'string') return message == null ? null : String(message);
   const parts = message.split(/\*([^*]+)\*/g);
   return parts.map((part, i) => (i % 2 === 1 ? <strong key={i}>{part}</strong> : part));
+}
+
+// A recommendation may arrive as a structured object or as a bare string (the
+// backend's `recommendations` contract has been both). Coerce to the object shape
+// the UI expects so every downstream field read is safe. Anything that isn't a
+// usable object or string is dropped.
+function normalizeRecommendation(rec: unknown): PPLAnalyzeRecommendation | null {
+  if (typeof rec === 'string') return { message: rec };
+  if (rec && typeof rec === 'object') return rec as PPLAnalyzeRecommendation;
+  return null;
 }
 
 // Fraction of the execute phase below which a node isn't worth surfacing a
@@ -674,11 +771,16 @@ const SEVERITY_RANK: Record<string, number> = { CRITICAL: 0, WARNING: 1, INFO: 2
 // Recs with no `affected_node` (phase-level advice) or an unmatched name pass
 // through the share filter — we can't judge their weight, so we don't drop them.
 function filterRecommendations(
-  recs: any[] | undefined,
+  recs: Array<PPLAnalyzeRecommendation | string> | undefined,
   nodes: FlatPlanNode[],
   executePhaseMs: number
-): any[] {
+): PPLAnalyzeRecommendation[] {
   if (!recs || recs.length === 0) return [];
+  // Coerce mixed string/object input to a uniform object shape up front, dropping
+  // anything unusable, so the rest of the pipeline reads fields safely.
+  const normalized = recs
+    .map(normalizeRecommendation)
+    .filter((rec): rec is PPLAnalyzeRecommendation => rec !== null);
   const selfTimeByNode = new Map<string, number>();
   nodes.forEach((n) => {
     // Multiple plan nodes can share a raw name (e.g. two IndexScans on a join);
@@ -686,30 +788,42 @@ function filterRecommendations(
     selfTimeByNode.set(n.node, (selfTimeByNode.get(n.node) || 0) + n.selfTimeMs);
   });
   const minSelfMs = executePhaseMs * MIN_NODE_EXECUTE_SHARE;
-  const kept = recs.filter((rec) => {
-    if (!rec?.affected_node) return true;
+  const kept = normalized.filter((rec) => {
+    if (!rec.affected_node) return true;
     const selfMs = selfTimeByNode.get(rec.affected_node);
     if (selfMs === undefined) return true;
     return selfMs >= minSelfMs;
   });
   const ranked = [...kept].sort((a, b) => {
-    const sa = SEVERITY_RANK[(a.serverity || a.severity || 'INFO').toUpperCase()] ?? 2;
-    const sb = SEVERITY_RANK[(b.serverity || b.severity || 'INFO').toUpperCase()] ?? 2;
+    const sa = SEVERITY_RANK[((a as any).serverity || a.severity || 'INFO').toUpperCase()] ?? 2;
+    const sb = SEVERITY_RANK[((b as any).serverity || b.severity || 'INFO').toUpperCase()] ?? 2;
     return sa - sb;
   });
   return ranked.slice(0, MAX_RECOMMENDATIONS);
 }
 
-function RecommendationsSection({ recommendations }: { recommendations: any[] }) {
+function RecommendationsSection({
+  recommendations,
+}: {
+  recommendations: PPLAnalyzeRecommendation[];
+}) {
   return (
     <div>
       <EuiTitle size="xxs">
-        <h4>RECOMMENDATIONS</h4>
+        <h4>
+          <FormattedMessage
+            id="data.pplAnalyze.recommendations.title"
+            defaultMessage="RECOMMENDATIONS"
+          />
+        </h4>
       </EuiTitle>
       <EuiSpacer size="s" />
       {!recommendations || recommendations.length === 0 ? (
         <EuiText size="s" color="subdued">
-          No recommendations for this query.
+          <FormattedMessage
+            id="data.pplAnalyze.recommendations.empty"
+            defaultMessage="No recommendations for this query."
+          />
         </EuiText>
       ) : (
         recommendations.map((rec: any, idx: number) => {
@@ -741,7 +855,11 @@ function RecommendationsSection({ recommendations }: { recommendations: any[] })
                   <>
                     <EuiSpacer size="xs" />
                     <EuiText size="xs" color="subdued">
-                      Affects: {rec.affected_node}
+                      <FormattedMessage
+                        id="data.pplAnalyze.recommendations.affects"
+                        defaultMessage="Affects: {node}"
+                        values={{ node: rec.affected_node }}
+                      />
                     </EuiText>
                   </>
                 )}
@@ -823,7 +941,10 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
                 onClick={onClose}
                 data-test-subj="analyzeCloseButton"
               >
-                Return to query results
+                <FormattedMessage
+                  id="data.pplAnalyze.returnToResults"
+                  defaultMessage="Return to query results"
+                />
               </EuiButtonEmpty>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -841,26 +962,36 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
         </EuiCallOut>
       ) : !hasProfile ? (
         <EuiCallOut
-          title="Query Profiling Unavailable - Error"
+          title={i18n.translate('data.pplAnalyze.profileUnavailable.title', {
+            defaultMessage: 'Query Profiling Unavailable - Error',
+          })}
           iconType="iInCircle"
           color="danger"
           data-test-subj="analyzeProfileUnavailable"
         >
           <EuiText size="s">
-            There was an error retrieving your query analysis from the backend. Typically, this is
-            the result of an outdated version of the backend that does not support analyzing
-            queries.
+            <FormattedMessage
+              id="data.pplAnalyze.profileUnavailable.body"
+              defaultMessage="There was an error retrieving your query analysis from the backend. Typically, this is the result of an outdated version of the backend that does not support analyzing queries."
+            />
           </EuiText>
         </EuiCallOut>
       ) : (
         <>
           {possibleCacheHit && (
             <>
-              <EuiCallOut title="Possible cache hit detected" iconType="iInCircle" color="primary">
+              <EuiCallOut
+                title={i18n.translate('data.pplAnalyze.cacheHit.title', {
+                  defaultMessage: 'Possible cache hit detected',
+                })}
+                iconType="iInCircle"
+                color="primary"
+              >
                 <EuiText size="s">
-                  This query may have been previously cached, which can produce a much faster
-                  execution phase time than normal. Cache hits can make profiling results
-                  inaccurate. This behavior can be toggled in Settings.
+                  <FormattedMessage
+                    id="data.pplAnalyze.cacheHit.body"
+                    defaultMessage="This query may have been previously cached, which can produce a much faster execution phase time than normal. Cache hits can make profiling results inaccurate. This behavior can be toggled in Settings."
+                  />
                 </EuiText>
               </EuiCallOut>
               <EuiSpacer size="m" />
@@ -876,14 +1007,17 @@ export const PPLAnalyzePanel: React.FC<PPLAnalyzePanelProps> = ({ analyzeResult,
                 <PhysicalPlanSection plan={planTree!} executePhaseMs={executePhaseMs} />
               ) : (
                 <EuiCallOut
-                  title="Execution Phase Profiling unavailable"
+                  title={i18n.translate('data.pplAnalyze.executionUnavailable.title', {
+                    defaultMessage: 'Execution Phase Profiling unavailable',
+                  })}
                   iconType="iInCircle"
                   color="warning"
                 >
                   <EuiText size="s">
-                    The per-stage execution breakdown is unavailable because the query profile did
-                    not include a physical plan. The phase timing bar above reflects the full query
-                    profile.
+                    <FormattedMessage
+                      id="data.pplAnalyze.executionUnavailable.body"
+                      defaultMessage="The per-stage execution breakdown is unavailable because the query profile did not include a physical plan. The phase timing bar above reflects the full query profile."
+                    />
                   </EuiText>
                 </EuiCallOut>
               )}

--- a/src/plugins/discover/common/index.ts
+++ b/src/plugins/discover/common/index.ts
@@ -16,20 +16,3 @@ export const CONTEXT_STEP_SETTING = 'context:step';
 export const CONTEXT_TIE_BREAKER_FIELDS_SETTING = 'context:tieBreakerFields';
 export const MODIFY_COLUMNS_ON_SWITCH = 'discover:modifyColumnsOnSwitch';
 export const QUERY_ENHANCEMENT_ENABLED_SETTING = 'query:enhancements:enabled';
-export const PPL_ANALYZE_ENABLED_SETTING = 'discover:pplAnalyze:enabled';
-export const PPL_ANALYZE_SHOW_BOTTLENECK_SETTING = 'discover:pplAnalyze:showBottleneck';
-export const PPL_ANALYZE_SHOW_PUSHDOWN_SETTING = 'discover:pplAnalyze:showPushdown';
-export const PPL_ANALYZE_SHOW_LOW_SELECTIVITY_SETTING = 'discover:pplAnalyze:showLowSelectivity';
-export const PPL_ANALYZE_LOW_SELECTIVITY_THRESHOLD_SETTING =
-  'discover:pplAnalyze:lowSelectivityThreshold';
-export const PPL_ANALYZE_SHOW_MISSING_TIME_FILTER_SETTING =
-  'discover:pplAnalyze:showMissingTimeFilter';
-export const PPL_ANALYZE_MAX_PLAN_DEPTH_SETTING = 'discover:pplAnalyze:maxPlanDepth';
-export const PPL_ANALYZE_EXECUTE_RECOMMENDATIONS_SETTING =
-  'discover:pplAnalyze:executeRecommendations';
-export const PPL_ANALYZE_PER_SHARD_ANALYSIS_SETTING = 'discover:pplAnalyze:perShardAnalysis';
-export const PPL_ANALYZE_PER_INDEX_STATISTICS_SETTING = 'discover:pplAnalyze:perIndexStatistics';
-export const PPL_ANALYZE_ANALYZE_RECOMMENDATIONS_SETTING =
-  'discover:pplAnalyze:analyzeRecommendations';
-export const PPL_ANALYZE_OPTIMIZE_RECOMMENDATIONS_SETTING =
-  'discover:pplAnalyze:optimizeRecommendations';

--- a/src/plugins/explore/public/application/pages/logs/logs_page.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { FC } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
@@ -380,6 +380,21 @@ describe('LogsPage', () => {
 
       expect(screen.getByTestId('bottom-container')).toBeInTheDocument();
       expect(screen.queryByText('Running query analysis…')).not.toBeInTheDocument();
+    });
+
+    it('renders a Cancel button while loading that closes the analyze panel', () => {
+      setupServices({ pplAnalyzeEnabled: true, logsQueryBuilderEnabled: false });
+      mockAnalyzeState.isOpen = true;
+      mockAnalyzeState.isLoading = true;
+
+      renderPage();
+
+      const cancelButton = screen.getByTestId('analyzeCancelButton');
+      expect(cancelButton).toBeInTheDocument();
+
+      fireEvent.click(cancelButton);
+      // Cancelling closes the panel (also cancels/clears the in-flight analysis).
+      expect(mockAnalyzeState.setIsOpen).toHaveBeenCalledWith(false);
     });
   });
 

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -27,6 +27,7 @@ import {
   getPPLAnalyzeResult$,
   runPPLAnalyzeInBackground,
   cancelPPLAnalyze,
+  clearPPLAnalyzeResult,
   setPPLAnalyzeOpen,
 } from '../../../../../data/public';
 import { useInitialQueryExecution } from '../../utils/hooks/use_initial_query_execution';
@@ -109,8 +110,10 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
     const sub = getPPLAnalyzeResult$().subscribe(setAnalyzeResult);
     return () => {
       sub.unsubscribe();
-      // Cancel any in-flight analysis when leaving the page.
+      // Cancel any in-flight analysis and clear the stored result when leaving the
+      // page, so a stale result can't reappear on the next mount.
       cancelPPLAnalyze();
+      clearPPLAnalyzeResult();
     };
   }, []);
   const queryState = useSelector((state: RootState) => state.query);
@@ -145,8 +148,10 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
       setIsOpen(true);
       setPPLAnalyzeOpen(true);
     } else {
-      // Closing the panel abandons any in-flight analysis — cancel it server-side.
+      // Closing the panel abandons any in-flight analysis — cancel it server-side
+      // and clear the stored result so it doesn't flash back on reopen.
       cancelPPLAnalyze();
+      clearPPLAnalyzeResult();
       setIsOpen(false);
       setPPLAnalyzeOpen(false);
     }
@@ -203,6 +208,7 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
                       iconType="cross"
                       onClick={() => {
                         cancelPPLAnalyze();
+                        clearPPLAnalyzeResult();
                         setIsOpen(false);
                         setPPLAnalyzeOpen(false);
                       }}
@@ -217,6 +223,7 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
                       analyzeResult={analyzeResult!}
                       onClose={() => {
                         cancelPPLAnalyze();
+                        clearPPLAnalyzeResult();
                         setIsOpen(false);
                         setPPLAnalyzeOpen(false);
                       }}

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -17,6 +17,7 @@ import {
 import { AppMountParameters, HeaderVariant } from 'opensearch-dashboards/public';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
 import { RootState } from '../../utils/state_management/store';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../../types';
@@ -200,7 +201,10 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
                   >
                     <EuiLoadingSpinner size="xl" />
                     <EuiText size="s" color="subdued">
-                      Running query analysis…
+                      <FormattedMessage
+                        id="explore.logsPage.analyze.running"
+                        defaultMessage="Running query analysis…"
+                      />
                     </EuiText>
                     <EuiButtonEmpty
                       size="s"
@@ -214,7 +218,10 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
                       }}
                       data-test-subj="analyzeCancelButton"
                     >
-                      Cancel
+                      <FormattedMessage
+                        id="explore.logsPage.analyze.cancel"
+                        defaultMessage="Cancel"
+                      />
                     </EuiButtonEmpty>
                   </div>
                 ) : (

--- a/src/plugins/explore/public/application/pages/logs/logs_page.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_page.tsx
@@ -6,7 +6,14 @@
 import '../explore_page.scss';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiErrorBoundary, EuiLoadingSpinner, EuiPage, EuiPageBody, EuiText } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiErrorBoundary,
+  EuiLoadingSpinner,
+  EuiPage,
+  EuiPageBody,
+  EuiText,
+} from '@elastic/eui';
 import { AppMountParameters, HeaderVariant } from 'opensearch-dashboards/public';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@osd/i18n';
@@ -19,6 +26,7 @@ import {
   PPLAnalyzePanel,
   getPPLAnalyzeResult$,
   runPPLAnalyzeInBackground,
+  cancelPPLAnalyze,
   setPPLAnalyzeOpen,
 } from '../../../../../data/public';
 import { useInitialQueryExecution } from '../../utils/hooks/use_initial_query_execution';
@@ -99,7 +107,11 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
   const [analyzeResult, setAnalyzeResult] = useState(() => getPPLAnalyzeResult$().getValue());
   useEffect(() => {
     const sub = getPPLAnalyzeResult$().subscribe(setAnalyzeResult);
-    return () => sub.unsubscribe();
+    return () => {
+      sub.unsubscribe();
+      // Cancel any in-flight analysis when leaving the page.
+      cancelPPLAnalyze();
+    };
   }, []);
   const queryState = useSelector((state: RootState) => state.query);
 
@@ -133,6 +145,8 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
       setIsOpen(true);
       setPPLAnalyzeOpen(true);
     } else {
+      // Closing the panel abandons any in-flight analysis — cancel it server-side.
+      cancelPPLAnalyze();
       setIsOpen(false);
       setPPLAnalyzeOpen(false);
     }
@@ -183,12 +197,26 @@ export const LogsPage: React.FC<Partial<Pick<AppMountParameters, 'setHeaderActio
                     <EuiText size="s" color="subdued">
                       Running query analysis…
                     </EuiText>
+                    <EuiButtonEmpty
+                      size="s"
+                      color="danger"
+                      iconType="cross"
+                      onClick={() => {
+                        cancelPPLAnalyze();
+                        setIsOpen(false);
+                        setPPLAnalyzeOpen(false);
+                      }}
+                      data-test-subj="analyzeCancelButton"
+                    >
+                      Cancel
+                    </EuiButtonEmpty>
                   </div>
                 ) : (
                   <div style={{ overflowY: 'auto', height: '100%' }}>
                     <PPLAnalyzePanel
                       analyzeResult={analyzeResult!}
                       onClose={() => {
+                        cancelPPLAnalyze();
                         setIsOpen(false);
                         setPPLAnalyzeOpen(false);
                       }}

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_widgets.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_widgets.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
+import { FormattedMessage } from '@osd/i18n/react';
 import { useSelector } from 'react-redux';
 import { DatasetSelectWidget } from './dataset_select';
 import { SaveQueryButton } from './save_query';
@@ -75,7 +76,10 @@ export const QueryPanelWidgets = ({
               data-test-subj="exploreAnalyzeButton"
               iconType="inspect"
             >
-              Inspect Query
+              <FormattedMessage
+                id="explore.queryPanel.inspectQueryButton"
+                defaultMessage="Inspect Query"
+              />
             </EuiButtonEmpty>
             <div className="exploreQueryPanelWidgets__verticalSeparator" />
           </>

--- a/src/plugins/explore/public/components/top_nav/top_nav.tsx
+++ b/src/plugins/explore/public/components/top_nav/top_nav.tsx
@@ -9,7 +9,11 @@ import { useObservable } from 'react-use';
 import { AppMountParameters } from 'opensearch-dashboards/public';
 import { useSelector as useNewStateSelector, useDispatch } from 'react-redux';
 import { useOpenOnUrlMarker } from '../../../../opensearch_dashboards_utils/public';
-import { useSyncQueryStateWithUrl, runPPLAnalyzeInBackground } from '../../../../data/public';
+import {
+  useSyncQueryStateWithUrl,
+  runPPLAnalyzeInBackground,
+  cancelPPLAnalyze,
+} from '../../../../data/public';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { TopNavMenuItemRenderType } from '../../../../navigation/public';
 import { PLUGIN_ID } from '../../../common';
@@ -180,6 +184,8 @@ export const TopNav = ({ setHeaderActionMenu = () => {}, savedExplore }: TopNavP
 
   const handleQueryCancel = useCallback(() => {
     abortAllActiveQueries();
+    // Also cancel any in-flight PPL analyze request tied to this query.
+    cancelPPLAnalyze();
     dispatch(setHasUserInitiatedQuery(false));
     // Clear all cached results to ensure refresh works properly after cancel
     dispatch(clearResults());

--- a/src/plugins/query_enhancements/server/routes/ppl_analyze.test.ts
+++ b/src/plugins/query_enhancements/server/routes/ppl_analyze.test.ts
@@ -140,6 +140,20 @@ describe('registerPPLAnalyzeRoute', () => {
     expect(res.ok).toHaveBeenCalledWith({ body: { profile: {} } });
   });
 
+  it('returns 400 when a dataSourceId is given but the data source plugin is unavailable', async () => {
+    const transportRequest = jest.fn();
+    const context = createContext(transportRequest);
+    // Simulate the data source plugin being disabled/absent.
+    context.dataSource = {};
+    const req = { body: { query: 'source=accounts', dataSourceId: 'ds-1' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(transportRequest).not.toHaveBeenCalled();
+    expect(res.custom).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+  });
+
   it('unwraps result.body into the response', async () => {
     const transportRequest = jest.fn().mockResolvedValue({ body: { profile: { plan: {} } } });
     const context = createContext(transportRequest);

--- a/src/plugins/query_enhancements/server/routes/ppl_analyze.test.ts
+++ b/src/plugins/query_enhancements/server/routes/ppl_analyze.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { loggingSystemMock } from '../../../../core/server/mocks';
+import { registerPPLAnalyzeRoute } from './ppl_analyze';
+
+describe('registerPPLAnalyzeRoute', () => {
+  let handler: any;
+  let logger: ReturnType<typeof loggingSystemMock.create>['get'];
+
+  const createResponse = () => ({
+    ok: jest.fn((v) => v),
+    custom: jest.fn((v) => v),
+  });
+
+  // sampleSize is what `discover:sampleSize` resolves to; pass a number, or `undefined`
+  // to simulate the setting being unset. Defaults to 500 when the arg is omitted.
+  const createContext = (transportRequestMock: jest.Mock, ...rest: Array<number | undefined>) =>
+    ({
+      core: {
+        opensearch: {
+          client: {
+            asCurrentUser: {
+              transport: { request: transportRequestMock },
+            },
+          },
+        },
+        uiSettings: {
+          client: {
+            get: jest.fn().mockResolvedValue(rest.length > 0 ? rest[0] : 500),
+          },
+        },
+      },
+      dataSource: {
+        opensearch: {
+          getClient: jest.fn().mockResolvedValue({
+            transport: { request: transportRequestMock },
+          }),
+        },
+      },
+    }) as any;
+
+  beforeEach(() => {
+    const router = {
+      post: jest.fn((_, h) => {
+        handler = h;
+      }),
+    } as any;
+    // @ts-expect-error TS2322 TODO(ts-error): fixme
+    logger = loggingSystemMock.create().get();
+    // @ts-expect-error TS2345 TODO(ts-error): fixme
+    registerPPLAnalyzeRoute(router, logger);
+  });
+
+  it('sends fetch_size from discover:sampleSize when the query has no head', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: {} } });
+    const context = createContext(transportRequest, 500);
+    const req = { body: { query: 'source=accounts' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(context.core.uiSettings.client.get).toHaveBeenCalledWith('discover:sampleSize');
+    expect(transportRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/_plugins/_ppl',
+        querystring: { fetch_size: 500 },
+        body: expect.objectContaining({ query: 'source=accounts', analyze: true }),
+      })
+    );
+  });
+
+  it('omits fetch_size when the query already ends with a head command', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: {} } });
+    const context = createContext(transportRequest, 500);
+    const req = { body: { query: 'source=accounts | head 10' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    // No sample-size lookup and no fetch_size when the user set an explicit limit.
+    expect(context.core.uiSettings.client.get).not.toHaveBeenCalled();
+    expect(transportRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/_plugins/_ppl', querystring: undefined })
+    );
+  });
+
+  it('omits fetch_size when the sample-size setting is unset', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: {} } });
+    const context = createContext(transportRequest, undefined);
+    const req = { body: { query: 'source=accounts' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(transportRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ querystring: undefined })
+    );
+  });
+
+  it('forwards queryId in the request body when provided', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: {} } });
+    const context = createContext(transportRequest);
+    const req = { body: { query: 'source=accounts', queryId: 'uuid-123' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(transportRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ analyze: true, queryId: 'uuid-123' }),
+      })
+    );
+  });
+
+  it('does not include queryId in the body when it is absent', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: {} } });
+    const context = createContext(transportRequest);
+    const req = { body: { query: 'source=accounts' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    const sentBody = transportRequest.mock.calls[0][0].body;
+    expect(sentBody).not.toHaveProperty('queryId');
+  });
+
+  it('uses the data source client when dataSourceId is provided', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: {} } });
+    const context = createContext(transportRequest);
+    const req = { body: { query: 'source=accounts', dataSourceId: 'ds-1' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(context.dataSource.opensearch.getClient).toHaveBeenCalledWith('ds-1');
+    expect(res.ok).toHaveBeenCalledWith({ body: { profile: {} } });
+  });
+
+  it('unwraps result.body into the response', async () => {
+    const transportRequest = jest.fn().mockResolvedValue({ body: { profile: { plan: {} } } });
+    const context = createContext(transportRequest);
+    const req = { body: { query: 'source=accounts' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(res.ok).toHaveBeenCalledWith({ body: { profile: { plan: {} } } });
+  });
+
+  it('coerces a 500-class error to 503', async () => {
+    const transportRequest = jest
+      .fn()
+      .mockRejectedValue({ statusCode: 500, message: 'boom', body: { error: 'boom' } });
+    const context = createContext(transportRequest);
+    const req = { body: { query: 'source=accounts' } } as any;
+    const res = createResponse();
+
+    await handler(context, req, res);
+
+    expect(res.custom).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 503, body: JSON.stringify('boom') })
+    );
+  });
+});

--- a/src/plugins/query_enhancements/server/routes/ppl_analyze.ts
+++ b/src/plugins/query_enhancements/server/routes/ppl_analyze.ts
@@ -7,6 +7,7 @@ import { schema } from '@osd/config-schema';
 import { IRouter, Logger } from 'opensearch-dashboards/server';
 import { API, URI } from '../../common';
 import { queryEndsWithHead } from '../../common/utils';
+import { coerceStatusCode, DATASOURCE_UNAVAILABLE_MESSAGE, resolveOpenSearchClient } from '.';
 
 // The Discover UI sample-size setting caps how many rows the query fetches. We reuse
 // it for analyze so profiling scans the same row budget as a normal query run.
@@ -18,7 +19,10 @@ export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
       path: API.PPL_ANALYZE,
       validate: {
         body: schema.object({
-          query: schema.string(),
+          // maxLength is belt-and-suspenders: OSD's server.maxPayload (1 MiB default)
+          // already bounds the body. 64 KB is 2-4x the largest realistic interactive
+          // PPL pipeline, and makes the cap explicit + independent of global config.
+          query: schema.string({ minLength: 1, maxLength: 65536 }),
           dataSourceId: schema.maybe(schema.nullable(schema.string())),
           queryId: schema.maybe(schema.string()),
         }),
@@ -27,9 +31,10 @@ export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
     async (context, request, response) => {
       const { query, dataSourceId, queryId } = request.body;
       try {
-        const client = dataSourceId
-          ? await context.dataSource.opensearch.getClient(dataSourceId)
-          : context.core.opensearch.client.asCurrentUser;
+        const client = await resolveOpenSearchClient(context, dataSourceId ?? undefined);
+        if (!client) {
+          return response.custom({ statusCode: 400, body: DATASOURCE_UNAVAILABLE_MESSAGE });
+        }
 
         // Cap the scanned rows at the Discover sample size, mirroring a normal PPL run
         // (see ppl_search_strategy.ts). Sent as the `?fetch_size=` query param, which
@@ -59,7 +64,6 @@ export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
         logger.error(`PPL analyze failed: ${error.message}`);
         const errorBody = error.body || error.meta?.body;
         logger.error(`PPL analyze error detail: ${JSON.stringify(errorBody)}`);
-        const statusCode = error.statusCode || error.meta?.statusCode || 500;
         let parsedBody: any = errorBody;
         if (typeof errorBody === 'string') {
           try {
@@ -71,7 +75,7 @@ export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
         }
         const detail = parsedBody?.error || error.message || 'PPL analyze request failed';
         return response.custom({
-          statusCode: statusCode === 500 ? 503 : statusCode,
+          statusCode: coerceStatusCode(error.statusCode ?? error.meta?.statusCode),
           body: JSON.stringify(detail),
         });
       }

--- a/src/plugins/query_enhancements/server/routes/ppl_analyze.ts
+++ b/src/plugins/query_enhancements/server/routes/ppl_analyze.ts
@@ -6,6 +6,11 @@
 import { schema } from '@osd/config-schema';
 import { IRouter, Logger } from 'opensearch-dashboards/server';
 import { API, URI } from '../../common';
+import { queryEndsWithHead } from '../../common/utils';
+
+// The Discover UI sample-size setting caps how many rows the query fetches. We reuse
+// it for analyze so profiling scans the same row budget as a normal query run.
+const SAMPLE_SIZE_SETTING = 'discover:sampleSize';
 
 export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
   router.post(
@@ -15,22 +20,36 @@ export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
         body: schema.object({
           query: schema.string(),
           dataSourceId: schema.maybe(schema.nullable(schema.string())),
+          queryId: schema.maybe(schema.string()),
         }),
       },
     },
     async (context, request, response) => {
-      const { query, dataSourceId } = request.body;
+      const { query, dataSourceId, queryId } = request.body;
       try {
         const client = dataSourceId
           ? await context.dataSource.opensearch.getClient(dataSourceId)
           : context.core.opensearch.client.asCurrentUser;
 
+        // Cap the scanned rows at the Discover sample size, mirroring a normal PPL run
+        // (see ppl_search_strategy.ts). Sent as the `?fetch_size=` query param, which
+        // the backend pushes down into the scan. Skipped when the query already ends
+        // with an explicit `head` so a user-written limit still wins.
+        const hasHead = queryEndsWithHead(query);
+        const fetchSize = hasHead
+          ? undefined
+          : await context.core.uiSettings.client.get<number>(SAMPLE_SIZE_SETTING);
+
         const result = await client.transport.request({
           method: 'POST',
           path: URI.PPL,
+          querystring: fetchSize ? { fetch_size: fetchSize } : undefined,
           body: {
             query,
             analyze: true,
+            // Forwarded so the spawned task carries `queryId=<uuid>` in its
+            // description, letting the PPL cancel route find and cancel it.
+            ...(queryId && { queryId }),
           },
         });
 

--- a/src/plugins/query_enhancements/server/routes/ppl_analyze.ts
+++ b/src/plugins/query_enhancements/server/routes/ppl_analyze.ts
@@ -24,7 +24,8 @@ export function registerPPLAnalyzeRoute(router: IRouter, logger: Logger) {
           // PPL pipeline, and makes the cap explicit + independent of global config.
           query: schema.string({ minLength: 1, maxLength: 65536 }),
           dataSourceId: schema.maybe(schema.nullable(schema.string())),
-          queryId: schema.maybe(schema.string()),
+          // queryId is a client-generated UUID (36 chars); 128 is ample headroom.
+          queryId: schema.maybe(schema.string({ maxLength: 128 })),
         }),
       },
     },


### PR DESCRIPTION
### Description

- Follow up PR to #12399 
- Updates inspect query panel to reflect backend changes in https://github.com/opensearch-project/sql/pull/5568
- Physical-plan-only rendering: Waterfall graph is now built from profile.plan for all queries
- operator_tree path and estimated-time/share columns were removed
- Waterfall timing model changes to show concurrent execution
- Added synthetic overhead stage to show time in execution phase not attributed to operators
- fetch_size cap on the analyze requests, mirroring normal PPL queries
- Added cancellation functionality for analyze requests (queryId + cancelPPLAnalyze with AbortController + request-id invalidation; clear-on-close so stale results don't reappear)
- Added rendering logic for new recommendation functionality from backend
- Removed the bottleneck marker
- Removed dead code
- i18n-wrapped all user facing strings
- Added tests for new functionality

### Issues Resolved

Related to https://github.com/opensearch-project/sql/issues/5500
Related to https://github.com/opensearch-project/sql/pull/5568
Follow up to #12399

## Screenshot

<img width="3448" height="1898" alt="image" src="https://github.com/user-attachments/assets/3229eb4e-e384-4de1-9946-e6d6a11225db" />

<img width="3442" height="1916" alt="image" src="https://github.com/user-attachments/assets/125be99f-7a19-4a66-a800-d6ed74e6d384" />


## Testing the changes

To view the Analyze panel locally, temporarily enable the feature flag in `config/opensearch_dashboard.yml":
```
explore.pplAnalyze.enabled: true
```

Then restart the server with `yarn start --opensearch.ignoreVersionMismatch=true --no-base-path` and navigate to the Explore > Logs page. The Inspect Query button will appear in the top right of the query bar. Note: These are only for local development testing, do not deploy these changes.

To run tests from the terminal, use these commands:
```
yarn test:jest \
        src/plugins/data/public/ui/ppl_analyze_panel/ppl_analyze_panel.test.tsx \
        src/plugins/data/public/ui/ppl_analyze/run_ppl_analyze.test.ts \
        src/plugins/query_enhancements/server/routes/ppl_analyze.test.ts \
        src/plugins/explore/server/plugin.test.ts \
        src/plugins/explore/public/application/pages/logs/logs_page.test.tsx \
        src/plugins/explore/public/application/pages/logs/logs_query_panel.test.tsx \
        src/plugins/data/public/query/ppl_analyze_state.test.tsx \
        src/plugins/explore/public/components/query_panel/query_panel_widgets/query_panel_widgets.test.tsx
```

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
