### PR TITLE
Add unit tests for HeaderLogo onClick force-navigation paths

### DIFF
--- a/src/core/public/chrome/ui/header/header_logo.test.tsx
+++ b/src/core/public/chrome/ui/header/header_logo.test.tsx
@@ -96,8 +96,40 @@ describe('Header logo', () => {
       expect(props.navigateToApp).toHaveBeenCalledWith('home');
     });
 
-    // ToDo: Add tests for onClick
-    // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4692
-    it.todo('performs all the complications');
+    it('reloads the page when the target URL matches the current URL and has a hash', () => {
+      // jsdom 26: spy on location.reload rather than replacing the location object.
+      const reloadSpy = jest.spyOn(window.location, 'reload').mockImplementation(jest.fn());
+
+      const props = {
+        ...mockProps(),
+        href: `${document.location.href}#section`,
+        forceNavigation$: new BehaviorSubject(true),
+      };
+      const component = mountWithIntl(<HeaderLogo {...props} />);
+      component.find('.logoContainer img').simulate('click');
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+      expect(props.navigateToApp).not.toHaveBeenCalled();
+
+      reloadSpy.mockRestore();
+    });
+
+    it('does not reload or navigate to the app when the target URL matches the current URL without a hash', () => {
+      // jsdom 26: spy on location.reload rather than replacing the location object.
+      const reloadSpy = jest.spyOn(window.location, 'reload').mockImplementation(jest.fn());
+
+      const props = {
+        ...mockProps(),
+        href: document.location.href,
+        forceNavigation$: new BehaviorSubject(true),
+      };
+      const component = mountWithIntl(<HeaderLogo {...props} />);
+      component.find('.logoContainer img').simulate('click');
+
+      expect(reloadSpy).not.toHaveBeenCalled();
+      expect(props.navigateToApp).not.toHaveBeenCalled();
+
+      reloadSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Description

`HeaderLogo`'s `onClick` handler only had test coverage for the
`forceNavigation = false` path. As noted on the issue, two other exit
paths were untested when `forceNavigation` is `true`:

1. Reload: when the target URL matches the current URL (same
   protocol/host/path) and has a hash, `document.location.reload()`
   is called.
2. No intervention: when the target URL matches the current URL
   without a hash, neither `reload()` nor `navigateToApp()` is
   called, letting the browser load the URL natively.

This replaces the `it.todo(...)` placeholder with tests for both
paths.

Note: `window.location.reload` is non-configurable under jsdom 26, so
the tests spy on it rather than replacing the location object,
following the same pattern already used in
`reload_button.test.tsx`.

## Issues Resolved

Fixes #4692

## Testing the changes

Ran the existing test conventions for this file (`mountWithIntl` +
enzyme `simulate('click')`); relying on CI's `yarn test:jest` to
execute since I don't have a working Node 22 / bootstrapped
environment locally.

- [x] Unit tests added