### PR TITLE
ci: disable security plugin via config in S3 cypress workflow

### DIFF
--- a/.github/workflows/cypress_workflow_with_s3.yml
+++ b/.github/workflows/cypress_workflow_with_s3.yml
@@ -85,9 +85,9 @@ jobs:
           rm -f opensearch-*.tar.gz
         shell: bash
 
-      - name: Remove security plugin
+      - name: Disable security plugin
         run: |
-          /bin/bash -c "yes | ./opensearch-${{ env.LATEST_VERSION }}/bin/opensearch-plugin remove opensearch-security"
+          echo "plugins.security.disabled: true" >> ./opensearch-${{ env.LATEST_VERSION }}/config/opensearch.yml
         shell: bash
 
       - name: Run OpenSearch

--- a/.github/workflows/cypress_workflow_with_s3.yml
+++ b/.github/workflows/cypress_workflow_with_s3.yml
@@ -2,9 +2,6 @@ name: Run cypress tests with S3
 
 # trigger once PR has been merged
 on:
-  # TEMP: verification-only trigger, revert before merge
-  pull_request:
-    branches: ['**']
   push:
     branches: ['main', '[0-9]+\.x', '[0-9]+\.[0-9]+']
     paths-ignore:

--- a/.github/workflows/cypress_workflow_with_s3.yml
+++ b/.github/workflows/cypress_workflow_with_s3.yml
@@ -2,6 +2,9 @@ name: Run cypress tests with S3
 
 # trigger once PR has been merged
 on:
+  # TEMP: verification-only trigger, revert before merge
+  pull_request:
+    branches: ['**']
   push:
     branches: ['main', '[0-9]+\.x', '[0-9]+\.[0-9]+']
     paths-ignore:


### PR DESCRIPTION
### Description

The `Run cypress tests with S3` workflow fails at the **Remove security plugin** step with exit code 11:

```
ERROR: plugin [opensearch-security] cannot be removed because it is extended by
other plugins: [opensearch-flow-framework, opensearch-anomaly-detection, opensearch-ml]
```

`opensearch-plugin remove opensearch-security` cannot run while other bundled plugins still declare it as an extended dependency.

Instead of removing plugins in dependency order (which is brittle across OpenSearch versions as the set of security-dependent plugins changes), this PR disables the security plugin via the `plugins.security.disabled: true` config flag in `opensearch.yml`. The security plugin honours this flag at startup and disables itself without requiring removal of its dependents.

### Verification

- **CI:** the full `Run cypress tests with S3` job passed — including the **Disable security plugin** step (previously failing with exit code 11) and the **Run Dashboards Cypress tests with query enhancements** step — https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/32103828755/job/95609307039

A temporary `pull_request` trigger was used to run the workflow on this PR for verification and has since been reverted — the workflow trigger is back to `push` / `workflow_dispatch` only.

### Check List
- [x] All tests pass
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff
