### PR TITLE
fix(explore): Show metric graph with selected time range

### DIFF
--- a/src/plugins/explore/public/application/pages/metrics/explore/components/metric_card.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/metric_card.tsx
@@ -63,7 +63,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
 
   const type = inferMetricType(name, metadata?.type || MetricType.UNKNOWN);
 
-  const { onTimeRangeChange } = useExploration();
+  const { onTimeRangeChange, timeBounds } = useExploration();
 
   const sparklineLabel =
     type === MetricType.COUNTER ? 'sum(rate)' : type === MetricType.HISTOGRAM ? 'p95' : 'avg';
@@ -104,6 +104,8 @@ export const MetricCard: React.FC<MetricCardProps> = ({
           label={sparklineLabel}
           isDarkMode={darkMode}
           onTimeRangeChange={onTimeRangeChange}
+          timeFrom={timeBounds?.min}
+          timeTo={timeBounds?.max}
         />
       );
     return <EuiLoadingChart size="m" />;

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/metric_detail.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/metric_detail.tsx
@@ -88,6 +88,7 @@ const BreakdownPanel: React.FC<{
   metricType: MetricType;
   onVisibilityChange: (key: string, visible: boolean) => void;
   onTimeRangeChange?: (from: string, to: string) => void;
+  timeBounds?: { min: number; max: number };
 }> = ({
   labelName,
   data,
@@ -98,6 +99,7 @@ const BreakdownPanel: React.FC<{
   metricType,
   onVisibilityChange,
   onTimeRangeChange,
+  timeBounds,
 }) => {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -189,6 +191,8 @@ const BreakdownPanel: React.FC<{
                   stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
                   isDarkMode={darkMode}
                   onTimeRangeChange={onTimeRangeChange}
+                  timeFrom={timeBounds?.min}
+                  timeTo={timeBounds?.max}
                   {...breakdownYRange}
                 />
               ) : (
@@ -231,6 +235,8 @@ const BreakdownPanel: React.FC<{
               label={data.label}
               isDarkMode={darkMode}
               onTimeRangeChange={onTimeRangeChange}
+              timeFrom={timeBounds?.min}
+              timeTo={timeBounds?.max}
               {...breakdownYRange}
             />
           ) : (
@@ -254,6 +260,7 @@ export const MetricDetail: React.FC = () => {
     executePromQL,
     refreshCounter,
     onTimeRangeChange,
+    timeBounds,
   } = useExploration();
   const [chartData, setChartData] = useState<Array<[number, string]>>([]);
   const [labels, setLabels] = useState<LabelInfo[]>([]);
@@ -470,6 +477,8 @@ export const MetricDetail: React.FC = () => {
             label="value"
             isDarkMode={darkMode}
             onTimeRangeChange={onTimeRangeChange}
+            timeFrom={timeBounds?.min}
+            timeTo={timeBounds?.max}
           />
         ) : (
           <EuiText size="s" color="subdued">
@@ -550,6 +559,7 @@ export const MetricDetail: React.FC = () => {
                 metricType={metricType}
                 onVisibilityChange={onVisibilityChange}
                 onTimeRangeChange={onTimeRangeChange}
+                timeBounds={timeBounds}
               />
             ))}
           </div>

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
@@ -223,7 +223,18 @@ export const SparklineChart: React.FC<ChartProps> = ({
     }
 
     return baseOption;
-  }, [hasData, parsed, allSeries, isDarkMode, yMin, yMax, getColor, onTimeRangeChange]);
+  }, [
+    hasData,
+    parsed,
+    allSeries,
+    isDarkMode,
+    yMin,
+    yMax,
+    getColor,
+    onTimeRangeChange,
+    timeFrom,
+    timeTo,
+  ]);
 
   // Init / dispose
   useEffect(() => {

--- a/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/components/sparkline.tsx
@@ -23,6 +23,8 @@ interface ChartProps {
   series?: SeriesData[];
   yMin?: number;
   yMax?: number;
+  timeFrom?: number;
+  timeTo?: number;
   isDarkMode?: boolean;
   onTimeRangeChange?: (from: string, to: string) => void;
 }
@@ -70,6 +72,8 @@ export const SparklineChart: React.FC<ChartProps> = ({
   series: multiSeries,
   yMin,
   yMax,
+  timeFrom,
+  timeTo,
   isDarkMode = false,
   onTimeRangeChange,
 }) => {
@@ -180,6 +184,8 @@ export const SparklineChart: React.FC<ChartProps> = ({
       },
       xAxis: {
         type: 'time',
+        min: timeFrom,
+        max: timeTo,
         axisLabel: { fontSize: 10, color: textColor },
         axisLine: { show: false },
         axisTick: { show: false },

--- a/src/plugins/explore/public/application/pages/metrics/explore/contexts/exploration_context.ts
+++ b/src/plugins/explore/public/application/pages/metrics/explore/contexts/exploration_context.ts
@@ -84,6 +84,7 @@ interface ExplorationContextValue {
   executePromQL: (promql: string) => void;
   refreshCounter: number;
   onTimeRangeChange?: (from: string, to: string) => void;
+  timeBounds?: { min: number; max: number };
 }
 
 export const ExplorationContext = createContext<ExplorationContextValue | null>(null);

--- a/src/plugins/explore/public/application/pages/metrics/explore/index.tsx
+++ b/src/plugins/explore/public/application/pages/metrics/explore/index.tsx
@@ -73,6 +73,17 @@ export const MetricsExploreTab = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [services.data?.query?.timefilter?.timefilter, refreshCounter]);
 
+  // Absolute time bounds (epoch ms) for anchoring sparkline x-axis to the full
+  // time picker range. Recomputed alongside stepSec on every refresh.
+  const timeBounds = useMemo(() => {
+    const timefilter = services.data?.query?.timefilter?.timefilter;
+    if (!timefilter) return undefined;
+    const bounds = timefilter.getBounds();
+    if (!bounds?.min || !bounds?.max) return undefined;
+    return { min: bounds.min.valueOf(), max: bounds.max.valueOf() };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [services.data?.query?.timefilter?.timefilter, refreshCounter]);
+
   // Sync local state → Redux (for URL persistence)
   const prevStateRef = useRef(state);
   useEffect(() => {
@@ -211,6 +222,7 @@ export const MetricsExploreTab = () => {
         executePromQL,
         refreshCounter,
         onTimeRangeChange: handleTimeRangeChange,
+        timeBounds,
       }}
     >
       <CursorContext.Provider value={cursorBus}>

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
@@ -86,7 +86,7 @@ const defaultAreaChartStyles: AreaChartStyle = {
 
   standardAxes: [],
 
-  showFullTimeRange: false,
+  showFullTimeRange: true,
 };
 
 export const createAreaConfig = (): VisualizationType<'area'> => ({

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.test.tsx
@@ -128,7 +128,7 @@ describe('AreaVisStyleControls', () => {
           axisRole: AxisRole.Y,
         },
       ],
-      showFullTimeRange: false,
+      showFullTimeRange: true,
     },
     onStyleChange: jest.fn(),
     axisColumnMappings: {
@@ -309,7 +309,7 @@ describe('AreaVisStyleControls', () => {
     await userEvent.click(screen.getByTestId('showFullTimeRangeSwitch'));
 
     expect(defaultProps.onStyleChange).toHaveBeenCalledWith({
-      showFullTimeRange: true, // Default is false, so toggling sets it to true
+      showFullTimeRange: false, // Default is true, so toggling sets it to false
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/to_expression.test.ts
@@ -66,7 +66,7 @@ describe('Area Chart to_expression', () => {
       thresholdStyle: ThresholdMode.Solid,
     },
     standardAxes: [],
-    showFullTimeRange: false,
+    showFullTimeRange: true,
   };
 
   describe('createSimpleAreaChart', () => {

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
@@ -98,7 +98,7 @@ export const defaultBarChartStyles: BarChartStyle = {
     aggregationType: AggregationType.SUM,
     bucketTimeUnit: TimeUnit.AUTO,
   },
-  showFullTimeRange: false,
+  showFullTimeRange: true,
 };
 
 export const createBarConfig = (): VisualizationType<'bar'> => ({

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
@@ -81,7 +81,7 @@ describe('line_vis_config', () => {
           tooltipOptions: { mode: 'all' } as TooltipOptions,
           grid: {} as GridOptions,
           standardAxes: [],
-          showFullTimeRange: false,
+          showFullTimeRange: true,
         },
         onStyleChange: jest.fn(),
         numericalColumns: [],

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
@@ -92,7 +92,7 @@ export const defaultLineChartStyles: LineChartStyle = {
 
   standardAxes: [],
 
-  showFullTimeRange: false,
+  showFullTimeRange: true,
 };
 
 export const createLineConfig = (): VisualizationType<'line'> => ({

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.test.tsx
@@ -203,7 +203,7 @@ describe('LineVisStyleControls', () => {
       },
       tooltipOptions: defaultTooltipOptions,
       standardAxes: [defaultCategoryAxis, defaultValueAxis],
-      showFullTimeRange: false,
+      showFullTimeRange: true,
     },
     onStyleChange: jest.fn(),
     numericalColumns: [mockNumericalColumn],

--- a/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/to_expression.test.ts
@@ -65,7 +65,7 @@ describe('Line Chart to_expression', () => {
       thresholds: [],
       thresholdStyle: ThresholdMode.Off,
     },
-    showFullTimeRange: false,
+    showFullTimeRange: true,
   };
 
   describe('createSimpleLineChart', () => {


### PR DESCRIPTION
### Description

Changes the default value of `showFullTimeRange` from `false` to `true` for line, area, and bar chart visualizations in the Explore plugin so the X-axis always reflects the full time picker range rather than auto-fitting to the data extent alone.

Additionally, for the Explore Metrics sparkline charts, passes `timeFrom`/`timeTo` props (sourced from `timefilter.getBounds()`) into the xAxis `min`/`max` configuration so sparklines also honor the selected time window.

The existing "Show full time range" toggle in the Axes settings panel remains available for users who prefer auto-fit behavior.

This code was fully generated by AI. But I was at least able to run and test it locally.

### Issues Resolved

fixes #12607

## Screenshot

### graph showing full 30 days
<img width="2974" height="1710" alt="image" src="https://github.com/user-attachments/assets/c9859f9f-116f-4273-91f5-9f4c792f0dbe" />

### query showing full 15 days
<img width="2938" height="1792" alt="image" src="https://github.com/user-attachments/assets/2b458813-9585-48e9-a9ce-bba3634fc8b1" />

### switch off "show full time range" (only showing visible data points)

<img width="2958" height="1840" alt="image" src="https://github.com/user-attachments/assets/29d30cfc-e045-4af5-a6ff-8b029e49fc02" />


## Testing the changes

1. Start OpenSearch Dashboards with a connected OpenSearch instance containing time-series data
2. Navigate to **Explore > Metrics**
3. In the **Query Metrics** tab, run a PromQL query that returns data spanning only a few days
4. Set the time picker to "Last 1 year"
5. Verify the chart X-axis now spans the full year (from/to matches the time picker)
6. Open the style panel > Axes accordion and toggle off "Show full time range" — the chart should revert to auto-fitting to data extent
7. Switch to the **Explore Metrics** tab, select a metric, and verify the sparkline X-axis also spans the full time picker range

### Check List

- [] All tests pass
  - [] `yarn test:jest`
  - [] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

Currently, my test system is quite exhausted. Still need to run the yarn tests.