### PR TITLE
[Explore] Add 'View surrounding documents' support for PPL queries

### DIFF
--- a/src/plugins/data/common/data_frames/utils.ts
+++ b/src/plugins/data/common/data_frames/utils.ts
@@ -121,8 +121,22 @@ export const convertResult = ({
         hit[field.name] = processField(field, field.values[index]);
       });
 
+      // Metadata fields returned by PPL when include_metadata=true belong at the hit top level,
+      // not inside _source, matching the structure of DSL hits. Lift them out so that code
+      // reading hit._id (e.g. "View surrounding documents") works the same way for both.
+      const topLevelMeta: Record<string, unknown> = {};
+      for (const metaKey of ['_id', '_index', '_score', '_sort', '_routing']) {
+        if (metaKey in hit) {
+          topLevelMeta[metaKey] = hit[metaKey];
+          delete hit[metaKey];
+        }
+      }
+
       hits.push({
-        _index: data.name,
+        _index: (topLevelMeta._index as string | undefined) ?? data.name,
+        ...(topLevelMeta._id !== undefined && { _id: topLevelMeta._id as string }),
+        ...(topLevelMeta._score !== undefined && { _score: topLevelMeta._score as number }),
+        ...(topLevelMeta._sort !== undefined && { sort: [topLevelMeta._sort as number] }),
         _source: hit,
         ...(highlightData?.[index] && { highlight: highlightData[index] }),
       });

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/ppl_context.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/api/ppl_context.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import { IndexPattern } from '../../../../../opensearch_dashboards_services';
+import { getServices } from '../../../../../opensearch_dashboards_services';
+import { SurrDocType, OpenSearchHitRecord, OpenSearchHitRecordList } from './context';
+import { SortDirection } from './utils/sorting';
+import { generateIntervals } from './utils/generate_intervals';
+import { convertIsoToMillis, extractNanos, convertTimeValueToIso } from './utils/date_conversion';
+
+const DAY_MILLIS = 24 * 60 * 60 * 1000;
+const LOOKUP_OFFSETS = [0, 1, 7, 30, 365, 10000].map((days) => days * DAY_MILLIS);
+
+const PPL_SEARCH_PATH = '/api/enhancements/search/ppl';
+
+// Metadata fields returned by PPL when include_metadata=true; excluded from _source.
+const META_FIELDS = new Set(['_id', '_index', '_score', '_maxscore', '_sort', '_routing']);
+
+interface PPLSearchResponse {
+  body?: {
+    fields?: Array<{ name: string; type: string; values: unknown[] }>;
+    size?: number;
+  };
+}
+
+/**
+ * Convert a PPL IDataFrame response (with include_metadata=true) into OpenSearchHitRecord objects.
+ * PPL returns columnar data: fields[i].values[rowIndex] gives the value for row `rowIndex`.
+ */
+function pplResponseToHitRecords(response: PPLSearchResponse): OpenSearchHitRecordList {
+  const fields = response.body?.fields;
+  if (!fields || !fields.length) return [];
+
+  const rowCount = response.body?.size ?? fields[0].values.length;
+  const records: OpenSearchHitRecordList = [];
+
+  for (let row = 0; row < rowCount; row++) {
+    const _source: Record<string, unknown> = {};
+    let _id = '';
+    let sortValue: number | undefined;
+
+    for (const field of fields) {
+      const val = field.values[row];
+      if (field.name === '_id') {
+        _id = String(val ?? '');
+      } else if (field.name === '_sort') {
+        sortValue = Array.isArray(val) ? (val[0] as number) : (val as number);
+      } else if (!META_FIELDS.has(field.name)) {
+        _source[field.name] = val;
+      }
+    }
+
+    records.push({ _id, _source, fields: {}, sort: sortValue !== undefined ? [sortValue] : [] });
+  }
+
+  return records;
+}
+
+/**
+ * Fetch the anchor document by _id using PPL with include_metadata=true.
+ */
+export async function fetchPPLAnchor(
+  anchorId: string,
+  indexPattern: IndexPattern
+): Promise<OpenSearchHitRecord> {
+  const { http, data } = getServices();
+  const pplQuery = `source=\`${indexPattern.title}\` | where _id = '${anchorId}' | head 1`;
+
+  const response = (await http.post(PPL_SEARCH_PATH, {
+    body: JSON.stringify({
+      query: {
+        query: pplQuery,
+        language: 'PPL',
+        dataset: data.query.queryString.getQuery().dataset,
+        format: 'jdbc',
+      },
+      includeMetadata: true,
+    }),
+  })) as PPLSearchResponse;
+
+  const records = pplResponseToHitRecords(response);
+  if (!records.length) {
+    throw new Error(
+      i18n.translate('explore.discover.context.ppl.failedToLoadAnchorDocumentErrorDescription', {
+        defaultMessage: 'Failed to load anchor document.',
+      })
+    );
+  }
+
+  return { ...records[0], isAnchor: true };
+}
+
+/**
+ * Fetch successor or predecessor documents around the anchor using PPL with include_metadata=true.
+ * Uses the same expanding-interval strategy as the DSL fetchSurroundingDocs.
+ */
+export async function fetchPPLSurroundingDocs(
+  type: SurrDocType,
+  indexPattern: IndexPattern,
+  anchor: OpenSearchHitRecord,
+  sortDir: SortDirection,
+  size: number
+): Promise<OpenSearchHitRecordList> {
+  if (!anchor || !size) return [];
+
+  const { http, data } = getServices();
+  const timeField = indexPattern.timeFieldName!;
+
+  const nanos = indexPattern.isTimeNanosBased() ? extractNanos(anchor._source[timeField]) : '';
+  const timeValueMillis =
+    nanos !== '' ? convertIsoToMillis(anchor._source[timeField]) : anchor.sort[0];
+
+  const sortDirToApply = type === SurrDocType.SUCCESSORS ? sortDir : reverseSortDir(sortDir);
+  const intervals = generateIntervals(LOOKUP_OFFSETS, timeValueMillis, type, sortDir);
+
+  let documents: OpenSearchHitRecordList = [];
+
+  for (const [start, stop] of intervals) {
+    const remainingSize = size - documents.length;
+    if (remainingSize <= 0) break;
+
+    const where = buildWhereClause(timeField, anchor._id, start, stop, sortDir, type);
+    const sortOrder = sortDirToApply === SortDirection.asc ? '+' : '-';
+    const pplQuery =
+      `source=\`${indexPattern.title}\` | where ${where} | ` +
+      `sort ${sortOrder} \`${timeField}\` | head ${remainingSize}`;
+
+    const response = (await http.post(PPL_SEARCH_PATH, {
+      body: JSON.stringify({
+        query: {
+          query: pplQuery,
+          language: 'PPL',
+          dataset: data.query.queryString.getQuery().dataset,
+          format: 'jdbc',
+        },
+        includeMetadata: true,
+        skipTimeFilter: true,
+        skipFilters: true,
+      }),
+    })) as PPLSearchResponse;
+
+    const hits = pplResponseToHitRecords(response);
+
+    documents =
+      type === SurrDocType.SUCCESSORS
+        ? [...documents, ...hits]
+        : [...hits.slice().reverse(), ...documents];
+  }
+
+  return documents;
+}
+
+function reverseSortDir(dir: SortDirection): SortDirection {
+  return dir === SortDirection.asc ? SortDirection.desc : SortDirection.asc;
+}
+
+/**
+ * Build a PPL WHERE clause mirroring DSL's time-range interval logic.
+ * `generateIntervals` produces interval bounds with the correct sign for the type/sort combination;
+ * ascending sort + successors → start is lower bound (>=), stop is upper bound (<).
+ */
+function buildWhereClause(
+  timeField: string,
+  anchorId: string,
+  start: number | null,
+  stop: number | null,
+  sortDir: SortDirection,
+  type: SurrDocType
+): string {
+  const conditions: string[] = [`_id != '${anchorId}'`];
+
+  const ascending =
+    (sortDir === SortDirection.asc && type === SurrDocType.SUCCESSORS) ||
+    (sortDir === SortDirection.desc && type === SurrDocType.PREDECESSORS);
+
+  const lowerMs = ascending ? start : stop;
+  const upperMs = ascending ? stop : start;
+
+  if (lowerMs !== null) {
+    const iso = convertTimeValueToIso(lowerMs, '');
+    if (iso) conditions.push(`\`${timeField}\` >= '${iso}'`);
+  }
+  if (upperMs !== null) {
+    const iso = convertTimeValueToIso(upperMs, '');
+    if (iso) conditions.push(`\`${timeField}\` < '${iso}'`);
+  }
+
+  return conditions.join(' AND ');
+}

--- a/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/utils/use_query_actions.ts
+++ b/src/plugins/explore/public/application/legacy/discover/application/components/doc_views/context/utils/use_query_actions.ts
@@ -9,6 +9,7 @@ import { useMemo, useCallback, useState } from 'react';
 import { Filter } from '../../../../../../../../../../data/public';
 import { fetchAnchor } from '../api/anchor';
 import { OpenSearchHitRecord, fetchSurroundingDocs } from '../api/context';
+import { fetchPPLAnchor, fetchPPLSurroundingDocs } from '../api/ppl_context';
 import { ExploreServices } from '../../../../../../../../types';
 import { useOpenSearchDashboards } from '../../../../../../../../../../opensearch_dashboards_react/public';
 import { CONTEXT_TIE_BREAKER_FIELDS_SETTING } from '../../../../../../../../../common/legacy/discover';
@@ -38,28 +39,37 @@ export function useQueryActions(anchorId: string, indexPattern: IndexPattern) {
   );
   const [contextQueryState, setContextQueryState] = useState<ContextQueryState>(initialState);
 
-  const fetchAnchorRow = useCallback(async () => {
-    if (!tieBreakerField) {
-      setContextQueryState((prevState) => ({
-        ...prevState,
-        anchorStatus: {
-          value: LOADING_STATUS.FAILED,
-          reason: FAILURE_REASONS.INVALID_TIEBREAKER,
-        },
-      }));
-      return;
-    }
+  const isPPL = data.query.queryString.getQuery().language === 'PPL';
 
+  const fetchAnchorRow = useCallback(async () => {
     try {
       setContextQueryState((prevState) => ({
         ...prevState,
         anchorStatus: { value: LOADING_STATUS.LOADING },
       }));
-      const sort = [
-        { [indexPattern.timeFieldName!]: SortDirection.desc },
-        { [tieBreakerField]: SortDirection.desc },
-      ];
-      const fetchAnchorResult = await fetchAnchor(anchorId, indexPattern, searchSource, sort);
+
+      let fetchAnchorResult: OpenSearchHitRecord;
+
+      if (isPPL) {
+        fetchAnchorResult = await fetchPPLAnchor(anchorId, indexPattern);
+      } else {
+        if (!tieBreakerField) {
+          setContextQueryState((prevState) => ({
+            ...prevState,
+            anchorStatus: {
+              value: LOADING_STATUS.FAILED,
+              reason: FAILURE_REASONS.INVALID_TIEBREAKER,
+            },
+          }));
+          return;
+        }
+        const sort = [
+          { [indexPattern.timeFieldName!]: SortDirection.desc },
+          { [tieBreakerField]: SortDirection.desc },
+        ];
+        fetchAnchorResult = await fetchAnchor(anchorId, indexPattern, searchSource, sort);
+      }
+
       setContextQueryState((prevState) => ({
         ...prevState,
         anchor: fetchAnchorResult,
@@ -78,7 +88,7 @@ export function useQueryActions(anchorId: string, indexPattern: IndexPattern) {
         text: 'fail',
       });
     }
-  }, [anchorId, indexPattern, searchSource, tieBreakerField, toastNotifications]);
+  }, [anchorId, indexPattern, isPPL, searchSource, tieBreakerField, toastNotifications]);
 
   const fetchSurroundingRows = useCallback(
     async (type: SurrDocType, count: number, filters: Filter[], anchor?: OpenSearchHitRecord) => {
@@ -96,15 +106,23 @@ export function useQueryActions(anchorId: string, indexPattern: IndexPattern) {
         }
         const fetchedAchor = anchor || contextQueryState.anchor;
 
-        const rows = await fetchSurroundingDocs(
-          type,
-          indexPattern,
-          fetchedAchor as OpenSearchHitRecord,
-          tieBreakerField,
-          SortDirection.desc,
-          count,
-          filters
-        );
+        const rows = isPPL
+          ? await fetchPPLSurroundingDocs(
+              type,
+              indexPattern,
+              fetchedAchor as OpenSearchHitRecord,
+              SortDirection.desc,
+              count
+            )
+          : await fetchSurroundingDocs(
+              type,
+              indexPattern,
+              fetchedAchor as OpenSearchHitRecord,
+              tieBreakerField,
+              SortDirection.desc,
+              count,
+              filters
+            );
         if (type === SurrDocType.PREDECESSORS) {
           setContextQueryState((prevState) => ({
             ...prevState,
@@ -141,7 +159,7 @@ export function useQueryActions(anchorId: string, indexPattern: IndexPattern) {
         });
       }
     },
-    [contextQueryState.anchor, indexPattern, tieBreakerField, toastNotifications]
+    [contextQueryState.anchor, indexPattern, isPPL, tieBreakerField, toastNotifications]
   );
 
   const fetchContextRows = useCallback(

--- a/src/plugins/explore/public/application/utils/state_management/actions/utils.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/utils.ts
@@ -107,6 +107,25 @@ export function fillMissingTimestamps(
  * Checks if the main query ends with a head command (optionally followed by `from N` or `| where`).
  * Subquery brackets [...] are masked so that head inside subqueries is ignored.
  */
+// Commands whose presence means the query produces buckets/aggregations rather than raw documents.
+// Mirrors the same list in query_enhancements/common/utils.ts — keep in sync.
+const PPL_AGGREGATING_COMMANDS = [
+  'stats',
+  'rare',
+  'top',
+  'eventstats',
+  'trendline',
+  'transpose',
+  'xyseries',
+  'timewrap',
+  'patterns',
+];
+
+export const isPPLAggregationQuery = (queryString: string): boolean => {
+  const masked = queryString.replace(/\[.*?\]/g, (match) => '\0'.repeat(match.length));
+  return new RegExp(`\\|\\s*(${PPL_AGGREGATING_COMMANDS.join('|')})\\b`, 'i').test(masked);
+};
+
 export const queryEndsWithHead = (queryString: string): boolean => {
   const masked = queryString.replace(/\[.*?\]/g, (match) => '\0'.repeat(match.length));
   return /\|\s*head\b(\s+\d+)?(\s+from\s+\d+)?\s*(\|\s*where\b.*)?\s*$/i.test(masked);

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -101,6 +101,7 @@ import {
   registerDisabledPPLLintFixAction,
 } from './components/query_panel/actions/ppl_lint_fix_action';
 import { clearActivePPLLintFixSession } from './components/query_panel/actions/ppl_lint_fix_session';
+import { isPPLAggregationQuery } from './application/utils/state_management/actions/utils';
 
 import {
   registerAutoVisualizationAction,
@@ -230,9 +231,23 @@ export class ExplorePlugin implements Plugin<
       }),
       generateCb: (renderProps: Record<string, unknown>) => {
         const queryString = getServices().data.query.queryString;
+        const currentQuery = queryString.getQuery();
+        const language = currentQuery.language;
         const showDocLinks =
-          queryString.getLanguageService().getLanguage(queryString.getQuery().language)
-            ?.showDocLinks ?? undefined;
+          queryString.getLanguageService().getLanguage(language)?.showDocLinks ?? undefined;
+
+        const hit = (renderProps as any).hit;
+        const indexPattern = (renderProps as any).indexPattern;
+
+        // PPL-specific hide conditions in addition to the common checks below.
+        const isPPL = language === 'PPL';
+        const isPPLHidden =
+          isPPL && // Aggregation results are buckets, not documents — no document to surround.
+          (isPPLAggregationQuery(String(currentQuery.query ?? '')) ||
+            // _id absent means the backend didn't return metadata (old cluster / non-Calcite engine).
+            !hit._id ||
+            // S3/async datasets use a different search path; context queries don't support it.
+            currentQuery.dataset?.type === 'S3');
 
         // Note: Explore uses Redux for filter management, not filterManager
         // So we don't include filter state in URLs for context links
@@ -248,14 +263,15 @@ export class ExplorePlugin implements Plugin<
         );
 
         const contextUrl = `#/context/${encodeURIComponent(
-          (renderProps as any).indexPattern.id
-        )}/${encodeURIComponent((renderProps as any).hit._id)}?${hash}`;
+          indexPattern.id
+        )}/${encodeURIComponent(hit._id)}?${hash}`;
 
         return {
           url: generateDocViewsUrl(contextUrl),
           hide:
+            isPPLHidden ||
             (showDocLinks !== undefined ? !showDocLinks : false) ||
-            !(renderProps as any).indexPattern.isTimeBased(),
+            !indexPattern.isTimeBased(),
         };
       },
       order: 1,

--- a/src/plugins/query_enhancements/public/plugin.tsx
+++ b/src/plugins/query_enhancements/public/plugin.tsx
@@ -131,7 +131,7 @@ export class QueryEnhancementsPlugin implements Plugin<
         }),
         url: 'https://opensearch.org/docs/latest/search-plugins/sql/ppl/syntax/',
       },
-      showDocLinks: false,
+      showDocLinks: true,
       editor: createEditor(SingleLineInput, null, pplControls, DefaultInput),
       editorSupportedAppNames: ['discover', 'explore', 'agentTraces'],
       supportedAppNames: [

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
@@ -63,6 +63,13 @@ export const pplSearchStrategyProvider = (
           request.body = { ...request.body, fetchSize };
         }
 
+        // Request metadata fields (_id, _index, _score, _sort) for non-aggregation queries so
+        // that document-level features like "View surrounding documents" can use the _id.
+        // Aggregation results are buckets, not documents, so metadata is not applicable.
+        if (!aggregates && !request.body.includeMetadata) {
+          request.body = { ...request.body, includeMetadata: true };
+        }
+
         const rawResponse: any = await pplFacet.describeQuery(context, request);
 
         if (!rawResponse.success) throwFacetError(rawResponse);

--- a/src/plugins/query_enhancements/server/utils/facet.ts
+++ b/src/plugins/query_enhancements/server/utils/facet.ts
@@ -96,7 +96,7 @@ export class Facet {
       // shape when `format=jdbc` is sent; `/_plugins/_sql` defaults to JDBC so this was previously
       // a no-op there.
       const format = request.body?.query?.format ?? request.body?.format;
-      const { lang, fetchSize, queryId } = request.body;
+      const { lang, fetchSize, queryId, includeMetadata } = request.body;
       const compressionHeaders = this.getCompressionHeaders();
       const { highlight } = request.body;
       const params = {
@@ -111,6 +111,7 @@ export class Facet {
           ...(highlight && { highlight }),
           ...(queryId && { queryId }),
           ...(query.profile && { profile: true }),
+          ...(includeMetadata && { include_metadata: true }),
         },
         ...(format && { format }),
         ...(Object.keys(compressionHeaders).length > 0 && { headers: compressionHeaders }),


### PR DESCRIPTION
### Description

Enables the **View surrounding documents** feature for PPL queries in Explore, bringing it to parity with DQL/Lucene. This feature lets users navigate to the time-context view for a specific log row when using PPL as the query language.

The implementation leverages the new `include_metadata` parameter from [opensearch-project/sql#5412](https://github.com/opensearch-project/sql/pull/5412) to expose `_id`, `_sort`, and other metadata fields in PPL responses, which are required for the context query to identify and exclude the anchor document.

**Key changes:**

| Layer | File | Change |
|---|---|---|
| Server search strategy | `ppl_search_strategy.ts` | Auto-sets `include_metadata: true` for non-aggregation PPL queries so `_id` is available in every result row |
| Server facet | `facet.ts` | Forwards `includeMetadata` from request body to `/_plugins/_ppl` as `include_metadata` |
| Data layer | `data_frames/utils.ts` | Lifts `_id`, `_index`, `_score`, `_sort` from `_source` to hit top-level, matching DSL hit structure |
| New API | `ppl_context.ts` | `fetchPPLAnchor` and `fetchPPLSurroundingDocs` — PPL queries with `_id` filtering + `include_metadata: true`, using the same expanding-interval strategy as DSL |
| Query hook | `use_query_actions.ts` | Routes anchor/context fetches to PPL-specific functions when language is PPL; DSL path unchanged |
| Link visibility | `explore/plugin.ts` | Enables `showDocLinks` for PPL; hides the link for aggregations, missing `_id`, and S3 datasets |
| Utils | `explore/.../utils.ts` | Adds `isPPLAggregationQuery` helper |

**Graceful degradation:** On older clusters where `include_metadata` is not supported, `_id` will be absent from the response and the link is automatically hidden.

### Issues Resolved

Closes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12609

## Screenshot

<!-- TODO: attach screenshot of "View surrounding documents" link appearing on PPL result rows -->

## Testing the changes

1. Start a cluster with [opensearch-project/sql#5412](https://github.com/opensearch-project/sql/pull/5412) applied (Calcite engine enabled).
2. In Explore, select an index with a time field and switch the query language to **PPL**.
3. Run a plain document query (e.g. `source=<index>`).
4. Expand a row — confirm the **"View surrounding documents"** link appears.
5. Click the link — confirm the context view loads with predecessor/successor documents.
6. Run an aggregation query (e.g. `source=<index> | stats count() by status`) — confirm the link is **hidden**.
7. Switch to **DQL** — confirm the existing surrounding-docs behavior is unchanged.
8. Test against an older cluster (without sql#5412) — confirm the link is hidden gracefully.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff