### PR TITLE
fix: preserve opposite dashboard and visualization filters

### DIFF
--- a/src/plugins/data/common/query/filter_manager/uniq_filters.test.ts
+++ b/src/plugins/data/common/query/filter_manager/uniq_filters.test.ts
@@ -76,5 +76,24 @@ describe('filter manager utilities', () => {
 
       expect(results).toHaveLength(1);
     });
+
+    test('should respect comparator options', () => {
+      const includedFilter = buildQueryFilter(
+        { _type: { match: { query: 'apache', type: 'phrase' } } },
+        'index',
+        ''
+      );
+      const excludedFilter = {
+        ...buildQueryFilter({ _type: { match: { query: 'apache', type: 'phrase' } } }, 'index', ''),
+        meta: {
+          ...includedFilter.meta,
+          negate: true,
+        },
+      };
+
+      const results = uniqFilters([includedFilter, excludedFilter], { negate: true });
+
+      expect(results).toEqual([includedFilter, excludedFilter]);
+    });
   });
 });

--- a/src/plugins/data/common/query/filter_manager/uniq_filters.ts
+++ b/src/plugins/data/common/query/filter_manager/uniq_filters.ts
@@ -30,6 +30,7 @@
 
 import { each, union } from 'lodash';
 import { Filter } from '../../opensearch_query';
+import { FilterCompareOptions } from './compare_filters';
 import { dedupFilters } from './dedup_filters';
 
 /**
@@ -40,11 +41,11 @@ import { dedupFilters } from './dedup_filters';
 
  * @returns {object} The original filters array with duplicates removed
  */
-export const uniqFilters = (filters: Filter[], comparatorOptions: any = {}) => {
+export const uniqFilters = (filters: Filter[], comparatorOptions: FilterCompareOptions = {}) => {
   let results: Filter[] = [];
 
   each(filters, (filter: Filter) => {
-    results = union(results, dedupFilters(results, [filter]), comparatorOptions);
+    results = union(results, dedupFilters(results, [filter], comparatorOptions));
   });
 
   return results;

--- a/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards_context.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/opensearch_dashboards_context.ts
@@ -129,7 +129,10 @@ export const opensearchDashboardsContextFunction: ExpressionFunctionOpenSearchDa
     return {
       type: 'opensearch_dashboards_context',
       query: queries,
-      filters: uniqFilters(filters.filter((f: any) => !f.meta?.disabled)),
+      filters: uniqFilters(
+        filters.filter((f: any) => !f.meta?.disabled),
+        { negate: true }
+      ),
       timeRange,
     };
   },

--- a/src/plugins/expressions/common/expression_functions/specs/tests/opensearch_dashboards_context.test.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/tests/opensearch_dashboards_context.test.ts
@@ -8,12 +8,12 @@ import { OpenSearchDashboardsContext } from '../../../expression_types';
 import { opensearchDashboardsContextFunction } from '../opensearch_dashboards_context';
 import { functionWrapper } from './utils';
 
-const createFilter = (alias: string, disabled: boolean): Filter =>
+const createFilter = (alias: string, disabled: boolean, negate = false): Filter =>
   ({
     meta: {
       alias,
       disabled,
-      negate: false,
+      negate,
     },
     query: {
       match_phrase: {
@@ -49,5 +49,31 @@ describe('interpreter/functions#opensearch-dashboards-context', () => {
     const actual = await fn(input, { filters: JSON.stringify([visualizationFilter]) });
 
     expect(actual.filters).toEqual([dashboardFilter]);
+  });
+
+  it('keeps a negated visualization filter when the matching dashboard filter is enabled', async () => {
+    const dashboardFilter = createFilter('dashboard filter', false);
+    const visualizationFilter = createFilter('visualization filter', false, true);
+    const input: OpenSearchDashboardsContext = {
+      type: 'opensearch_dashboards_context',
+      filters: [dashboardFilter],
+    };
+
+    const actual = await fn(input, { filters: JSON.stringify([visualizationFilter]) });
+
+    expect(actual.filters).toEqual([dashboardFilter, visualizationFilter]);
+  });
+
+  it('keeps a visualization filter when the matching dashboard filter is negated', async () => {
+    const dashboardFilter = createFilter('dashboard filter', false, true);
+    const visualizationFilter = createFilter('visualization filter', false);
+    const input: OpenSearchDashboardsContext = {
+      type: 'opensearch_dashboards_context',
+      filters: [dashboardFilter],
+    };
+
+    const actual = await fn(input, { filters: JSON.stringify([visualizationFilter]) });
+
+    expect(actual.filters).toEqual([dashboardFilter, visualizationFilter]);
   });
 });


### PR DESCRIPTION
### Description
Fixes #12599.

Dashboard and visualization filters with the same query were deduplicated without considering their negation state. As a result, an include filter and an equivalent exclude filter were treated as duplicates, causing the dashboard filter to replace the visualization filter.

This change:

- Includes `meta.negate` when deduplicating expression-context filters.
- Correctly forwards filter comparison options through `uniqFilters`.
- Preserves both `A` and `NOT A`, producing the expected empty result.
- Continues deduplicating filters with matching queries and negation states.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
