### PR TITLE
feat(dashboard): add shared crosshair to time-series panels

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/options.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/options.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { OptionsMenu } from './options';
+
+describe('OptionsMenu', () => {
+  it('updates the shared crosshair setting', () => {
+    const onUseSharedCrosshairChange = jest.fn();
+
+    render(
+      <OptionsMenu
+        useMargins={true}
+        onUseMarginsChange={jest.fn()}
+        hidePanelTitles={false}
+        onHidePanelTitlesChange={jest.fn()}
+        useSharedCrosshair={false}
+        onUseSharedCrosshairChange={onUseSharedCrosshairChange}
+      />
+    );
+
+    const switches = screen.getAllByRole('switch');
+    fireEvent.click(switches[2]);
+
+    expect(onUseSharedCrosshairChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/options.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/options.tsx
@@ -38,17 +38,21 @@ interface Props {
   onUseMarginsChange: (useMargins: boolean) => void;
   hidePanelTitles: boolean;
   onHidePanelTitlesChange: (hideTitles: boolean) => void;
+  useSharedCrosshair: boolean;
+  onUseSharedCrosshairChange: (useSharedCrosshair: boolean) => void;
 }
 
 interface State {
   useMargins: boolean;
   hidePanelTitles: boolean;
+  useSharedCrosshair: boolean;
 }
 
 export class OptionsMenu extends Component<Props, State> {
   state = {
     useMargins: this.props.useMargins,
     hidePanelTitles: this.props.hidePanelTitles,
+    useSharedCrosshair: this.props.useSharedCrosshair,
   };
 
   constructor(props: Props) {
@@ -65,6 +69,12 @@ export class OptionsMenu extends Component<Props, State> {
     const isChecked = !evt.target.checked;
     this.props.onHidePanelTitlesChange(isChecked);
     this.setState({ hidePanelTitles: isChecked });
+  };
+
+  handleUseSharedCrosshairChange = (evt: any) => {
+    const isChecked = evt.target.checked;
+    this.props.onUseSharedCrosshairChange(isChecked);
+    this.setState({ useSharedCrosshair: isChecked });
   };
 
   render() {
@@ -89,6 +99,17 @@ export class OptionsMenu extends Component<Props, State> {
             checked={!this.state.hidePanelTitles}
             onChange={this.handleHidePanelTitlesChange}
             data-test-subj="dashboardPanelTitlesCheckbox"
+          />
+        </EuiCompressedFormRow>
+
+        <EuiCompressedFormRow>
+          <EuiCompressedSwitch
+            label={i18n.translate('dashboard.topNav.options.useSharedCrosshairSwitchLabel', {
+              defaultMessage: 'Sync crosshair across panels',
+            })}
+            checked={this.state.useSharedCrosshair}
+            onChange={this.handleUseSharedCrosshairChange}
+            data-test-subj="dashboardSharedCrosshairCheckbox"
           />
         </EuiCompressedFormRow>
       </EuiForm>

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/show_options_popover.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/show_options_popover.tsx
@@ -53,12 +53,16 @@ export function showOptionsPopover({
   onUseMarginsChange,
   hidePanelTitles,
   onHidePanelTitlesChange,
+  useSharedCrosshair,
+  onUseSharedCrosshairChange,
 }: {
   anchorElement: HTMLElement;
   useMargins: boolean;
   onUseMarginsChange: (useMargins: boolean) => void;
   hidePanelTitles: boolean;
   onHidePanelTitlesChange: (hideTitles: boolean) => void;
+  useSharedCrosshair: boolean;
+  onUseSharedCrosshairChange: (useSharedCrosshair: boolean) => void;
 }) {
   if (isOpen) {
     onClose();
@@ -77,6 +81,8 @@ export function showOptionsPopover({
           onUseMarginsChange={onUseMarginsChange}
           hidePanelTitles={hidePanelTitles}
           onHidePanelTitlesChange={onHidePanelTitlesChange}
+          useSharedCrosshair={useSharedCrosshair}
+          onUseSharedCrosshairChange={onUseSharedCrosshairChange}
         />
       </EuiWrappingPopover>
     </I18nProvider>

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.test.tsx
@@ -76,6 +76,29 @@ beforeEach(() => {
   options.embeddable = doStart();
 });
 
+class TestDashboardContainer extends DashboardContainer {
+  public getInheritedInputForTest(id: string) {
+    return this.getInheritedInput(id);
+  }
+}
+
+test('DashboardContainer inherits the shared crosshair setting', () => {
+  const disabledContainer = new TestDashboardContainer(
+    getSampleDashboardInput({ id: 'dashboard-123', useSharedCrosshair: false }),
+    options
+  );
+  const enabledContainer = new TestDashboardContainer(
+    getSampleDashboardInput({ id: 'dashboard-123', useSharedCrosshair: true }),
+    options
+  );
+
+  expect(disabledContainer.getInheritedInputForTest('panel-1').useSharedCrosshair).toBe(false);
+  expect(enabledContainer.getInheritedInputForTest('panel-1').useSharedCrosshair).toBe(true);
+
+  disabledContainer.destroy();
+  enabledContainer.destroy();
+});
+
 test('DashboardContainer initializes embeddables', (done) => {
   const initialInput = getSampleDashboardInput({
     panels: {

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -79,6 +79,7 @@ export interface DashboardContainerInput extends ContainerInput {
   refreshConfig?: RefreshInterval;
   expandedPanelId?: string;
   useMargins: boolean;
+  useSharedCrosshair?: boolean;
   title: string;
   description?: string;
   isEmbeddedExternally?: boolean;
@@ -101,6 +102,7 @@ export interface InheritedChildInput extends IndexSignature {
   refreshConfig?: RefreshInterval;
   viewMode: ViewMode;
   hidePanelTitles?: boolean;
+  useSharedCrosshair?: boolean;
   id: string;
 }
 
@@ -371,10 +373,19 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
   }
 
   protected getInheritedInput(id: string): InheritedChildInput {
-    const { viewMode, refreshConfig, timeRange, query, hidePanelTitles, filters } = this.input;
+    const {
+      viewMode,
+      refreshConfig,
+      timeRange,
+      query,
+      hidePanelTitles,
+      filters,
+      useSharedCrosshair,
+    } = this.input;
     return {
       filters,
       hidePanelTitles,
+      useSharedCrosshair,
       query,
       timeRange,
       refreshConfig,

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container_factory.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container_factory.tsx
@@ -95,6 +95,7 @@ export class DashboardContainerFactoryDefinition implements EmbeddableFactoryDef
       isEmbeddedExternally: false,
       isFullScreenMode: false,
       useMargins: true,
+      useSharedCrosshair: false,
     };
   }
 

--- a/src/plugins/dashboard/public/application/test_helpers/get_sample_dashboard_input.ts
+++ b/src/plugins/dashboard/public/application/test_helpers/get_sample_dashboard_input.ts
@@ -38,6 +38,7 @@ export function getSampleDashboardInput(
     id: '123',
     filters: [],
     useMargins: false,
+    useSharedCrosshair: false,
     isEmbeddedExternally: false,
     isFullScreenMode: false,
     title: 'My Dashboard',

--- a/src/plugins/dashboard/public/application/utils/create_dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/utils/create_dashboard_container.tsx
@@ -369,6 +369,7 @@ const getDashboardInputFromAppState = (
     id: savedDashboardId || '',
     filters: data.query.filterManager.getFilters(),
     hidePanelTitles: appStateData.options.hidePanelTitles,
+    useSharedCrosshair: appStateData.options.useSharedCrosshair ?? false,
     query: data.query.queryString.getQuery(),
     timeRange: data.query.timefilter.timefilter.getTime(),
     refreshConfig: data.query.timefilter.timefilter.getRefreshInterval(),

--- a/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
@@ -235,6 +235,10 @@ export const getNavActions = (
       onHidePanelTitlesChange: (isChecked: boolean) => {
         stateContainer.transitions.setOption('hidePanelTitles', isChecked);
       },
+      useSharedCrosshair: appState.options.useSharedCrosshair ?? false,
+      onUseSharedCrosshairChange: (isChecked: boolean) => {
+        stateContainer.transitions.setOption('useSharedCrosshair', isChecked);
+      },
     });
   };
 
@@ -371,6 +375,7 @@ export const getNavActions = (
       newStateContainer.options = {
         hidePanelTitles: dashboard.options.hidePanelTitles,
         useMargins: dashboard.options.useMargins,
+        useSharedCrosshair: dashboard.options.useSharedCrosshair,
       };
       newStateContainer.timeRestore = dashboard.timeRestore;
       stateContainer.transitions.setDashboard(newStateContainer);

--- a/src/plugins/dashboard/public/application/utils/stubs.ts
+++ b/src/plugins/dashboard/public/application/utils/stubs.ts
@@ -15,6 +15,7 @@ export const dashboardAppStateStub: DashboardAppState = {
   options: {
     hidePanelTitles: false,
     useMargins: true,
+    useSharedCrosshair: false,
   },
   query: { query: '', language: 'kuery' },
   filters: [],

--- a/src/plugins/dashboard/public/application/utils/stubs.ts
+++ b/src/plugins/dashboard/public/application/utils/stubs.ts
@@ -15,7 +15,6 @@ export const dashboardAppStateStub: DashboardAppState = {
   options: {
     hidePanelTitles: false,
     useMargins: true,
-    useSharedCrosshair: false,
   },
   query: { query: '', language: 'kuery' },
   filters: [],

--- a/src/plugins/dashboard/public/dashboard.ts
+++ b/src/plugins/dashboard/public/dashboard.ts
@@ -23,6 +23,7 @@ export interface SerializedDashboard {
   options?: {
     hidePanelTitles: boolean;
     useMargins: boolean;
+    useSharedCrosshair?: boolean;
   };
   uiState?: string;
   lastSavedTitle: string;

--- a/src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts
@@ -112,6 +112,7 @@ export function createSavedDashboardClass(
             // for BWC reasons we can't default dashboards that already exist without this setting to true.
             useMargins: !id,
             hidePanelTitles: false,
+            useSharedCrosshair: false,
           }),
           variablesJSON: undefined,
           version: 1,

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -118,6 +118,7 @@ export interface DashboardAppState {
   options: {
     hidePanelTitles: boolean;
     useMargins: boolean;
+    useSharedCrosshair?: boolean;
   };
   query: Query | string;
   filters: Filter[];

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.test.ts
@@ -5,9 +5,16 @@
 
 import React from 'react';
 import { createAreaConfig } from './area_vis_config';
-import { Positions, ThresholdMode } from '../types';
+import { AxisRole, Positions, ThresholdMode, VisFieldType } from '../types';
 import { AreaVisStyleControls } from './area_vis_options';
 import { DEFAULT_POINT_SIZE } from '../style_panel/share';
+
+jest.mock('./to_expression', () => ({
+  createSimpleAreaChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createMultiAreaChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createCategoryAreaChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createStackedAreaChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+}));
 
 describe('area_vis_config', () => {
   const defaultAreaChartStyles = createAreaConfig().ui.style.defaults;
@@ -52,6 +59,31 @@ describe('area_vis_config', () => {
 
       expect(typeof config.getRules).toBe('function');
       expect(Array.isArray(config.getRules())).toBe(true);
+    });
+
+    test('should only pass the shared crosshair group to rules with a date x-axis', () => {
+      const config = createAreaConfig();
+      const crosshairGroup = 'dashboard';
+
+      config.getRules().forEach((rule) => {
+        const rendered = rule.render({
+          data: [],
+          allData: [],
+          styleOptions: config.ui.style.defaults,
+          axisColumnMappings: {
+            x: [{}],
+            y: [{}],
+            color: [{}],
+          },
+          timeRange: { from: 'now-1h', to: 'now' },
+          renderContext: { crosshairGroup },
+        } as any) as React.ReactElement<{ group?: string }>;
+        const hasDateXAxis = rule.mappings.some(
+          (mapping) => mapping[AxisRole.X]?.type === VisFieldType.Date
+        );
+
+        expect(rendered.props.group).toBe(hasDateXAxis ? crosshairGroup : undefined);
+      });
     });
 
     test('render function should create an AreaVisStyleControls component', () => {

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
@@ -171,6 +171,7 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -204,6 +205,7 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -237,6 +239,7 @@ export const createAreaConfig = (): VisualizationType<'area'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.test.ts
@@ -5,8 +5,23 @@
 
 import React from 'react';
 import { createBarConfig, defaultBarChartStyles } from './bar_vis_config';
-import { Positions, ThresholdMode, AxisRole, AggregationType, TimeUnit } from '../types';
+import {
+  Positions,
+  ThresholdMode,
+  AxisRole,
+  AggregationType,
+  TimeUnit,
+  VisFieldType,
+} from '../types';
 import { BarVisStyleControls } from './bar_vis_options';
+
+jest.mock('./to_expression', () => ({
+  createBarSpec: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createDoubleNumericalBarChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createGroupedTimeBarChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createStackedBarSpec: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createTimeBarChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+}));
 
 describe('bar_vis_config', () => {
   describe('defaultBarChartStyles', () => {
@@ -63,6 +78,31 @@ describe('bar_vis_config', () => {
 
       expect(typeof config.getRules).toBe('function');
       expect(Array.isArray(config.getRules())).toBe(true);
+    });
+
+    test('should only pass the shared crosshair group to rules with a date x-axis', () => {
+      const config = createBarConfig();
+      const crosshairGroup = 'dashboard';
+
+      config.getRules().forEach((rule) => {
+        const rendered = rule.render({
+          data: [],
+          allData: [],
+          styleOptions: config.ui.style.defaults,
+          axisColumnMappings: {
+            x: [{}],
+            y: [{}],
+            color: [{}],
+          },
+          timeRange: { from: 'now-1h', to: 'now' },
+          renderContext: { crosshairGroup },
+        } as any) as React.ReactElement<{ group?: string }>;
+        const hasDateXAxis = rule.mappings.some(
+          (mapping) => mapping[AxisRole.X]?.type === VisFieldType.Date
+        );
+
+        expect(rendered.props.group).toBe(hasDateXAxis ? crosshairGroup : undefined);
+      });
     });
 
     test('render function should create a BarVisStyleControls component', () => {

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
@@ -219,6 +219,7 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -282,6 +283,7 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -348,6 +350,7 @@ export const createBarConfig = (): VisualizationType<'bar'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}

--- a/src/plugins/explore/public/components/visualizations/echarts_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/echarts_render.test.tsx
@@ -8,25 +8,65 @@ import { BehaviorSubject } from 'rxjs';
 import { EchartsRender } from './echarts_render';
 import { LegendTarget } from './utils/legend';
 
-const mockEchartsInstance = {
-  resize: jest.fn(),
-  dispose: jest.fn(),
-  isDisposed: jest.fn(() => false),
-  on: jest.fn(),
-  off: jest.fn(),
-  setOption: jest.fn(),
-  setTheme: jest.fn(),
-  dispatchAction: jest.fn(),
-};
-
 jest.mock('echarts', () => ({
-  init: jest.fn(() => mockEchartsInstance),
+  init: jest.fn(),
   registerTheme: jest.fn(),
 }));
 
+const createMockEchartsInstance = () => {
+  const handlers = new Map<string, (params: any) => void>();
+  const zrenderHandlers = new Map<string, () => void>();
+
+  return {
+    resize: jest.fn(),
+    dispose: jest.fn(),
+    isDisposed: jest.fn(() => false),
+    on: jest.fn((event: string, handler: (params: any) => void) => {
+      handlers.set(event, handler);
+    }),
+    off: jest.fn((event: string) => {
+      handlers.delete(event);
+    }),
+    emit: (event: string, params: any) => handlers.get(event)?.(params),
+    emitZrender: (event: string) => zrenderHandlers.get(event)?.(),
+    getZr: jest.fn(() => ({
+      on: jest.fn((event: string, handler: () => void) => {
+        zrenderHandlers.set(event, handler);
+      }),
+      off: jest.fn((event: string) => {
+        zrenderHandlers.delete(event);
+      }),
+    })),
+    setOption: jest.fn(),
+    setTheme: jest.fn(),
+    dispatchAction: jest.fn(),
+    convertToPixel: jest.fn(() => 180),
+    getWidth: jest.fn(() => 400),
+    getHeight: jest.fn(() => 300),
+    getModel: jest.fn(() => ({
+      getComponent: jest.fn(() => ({
+        axis: {
+          grid: {
+            getRect: () => ({ x: 20, y: 30, width: 320, height: 180 }),
+          },
+        },
+      })),
+    })),
+    group: '',
+  };
+};
+
 describe('EchartsRender', () => {
+  let mockEchartsInstances: Array<ReturnType<typeof createMockEchartsInstance>>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEchartsInstances = [];
+    jest.requireMock('echarts').init.mockImplementation(() => {
+      const instance = createMockEchartsInstance();
+      mockEchartsInstances.push(instance);
+      return instance;
+    });
     global.ResizeObserver = jest.fn().mockImplementation(() => ({
       observe: jest.fn(),
       disconnect: jest.fn(),
@@ -47,7 +87,7 @@ describe('EchartsRender', () => {
       highlightedLegendTarget$.next({ type: 'series', name: 'seriesA' });
     });
 
-    expect(mockEchartsInstance.dispatchAction).toHaveBeenCalledWith({
+    expect(mockEchartsInstances[0].dispatchAction).toHaveBeenCalledWith({
       type: 'highlight',
       seriesName: 'seriesA',
     });
@@ -67,10 +107,134 @@ describe('EchartsRender', () => {
       highlightedLegendTarget$.next({ type: 'data', name: 'sliceA', seriesIndex: 0 });
     });
 
-    expect(mockEchartsInstance.dispatchAction).toHaveBeenCalledWith({
+    expect(mockEchartsInstances[0].dispatchAction).toHaveBeenCalledWith({
       type: 'highlight',
       seriesIndex: 0,
       name: 'sliceA',
+    });
+  });
+
+  it('stops synchronizing after the group is removed', () => {
+    const spec = { series: [{ type: 'line' as const, data: [1, 2] }] };
+    const { rerender } = render(
+      <>
+        <EchartsRender spec={spec} group="dashboard-123" />
+        <EchartsRender spec={spec} group="dashboard-123" />
+      </>
+    );
+    const [source, target] = mockEchartsInstances;
+    const axesInfo = [{ axisDim: 'x', axisIndex: 0, value: 1234 }];
+
+    act(() => {
+      source.emitZrender('mousemove');
+      source.emit('updateAxisPointer', { axesInfo });
+    });
+    expect(target.dispatchAction).toHaveBeenCalledTimes(1);
+
+    target.dispatchAction.mockClear();
+    rerender(
+      <>
+        <EchartsRender spec={spec} group="dashboard-123" />
+        <EchartsRender spec={spec} />
+      </>
+    );
+    expect(target.dispatchAction).toHaveBeenCalledWith({ type: 'hideTip' });
+    expect(target.dispatchAction).toHaveBeenCalledWith({
+      type: 'updateAxisPointer',
+      currTrigger: 'leave',
+    });
+
+    target.dispatchAction.mockClear();
+    act(() => {
+      source.emit('updateAxisPointer', { axesInfo });
+    });
+    expect(target.dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it('synchronizes an axis pointer using the target chart coordinates', () => {
+    const spec = { series: [{ type: 'line' as const, data: [1, 2] }] };
+    render(
+      <>
+        <EchartsRender spec={spec} group="dashboard-123" />
+        <EchartsRender spec={spec} group="dashboard-123" />
+      </>
+    );
+
+    const [source, target] = mockEchartsInstances;
+    const axesInfo = [{ axisDim: 'x', axisIndex: 0, value: 1234 }];
+
+    act(() => {
+      source.emitZrender('mousemove');
+      source.emit('updateAxisPointer', { axesInfo });
+    });
+
+    expect(target.convertToPixel).toHaveBeenCalledWith({ xAxisIndex: 0 }, 1234);
+    expect(target.dispatchAction).toHaveBeenCalledWith({
+      type: 'updateAxisPointer',
+      axesInfo,
+      x: 180,
+      y: 120,
+    });
+
+    source.dispatchAction.mockClear();
+    act(() => {
+      target.emit('updateAxisPointer', { axesInfo });
+    });
+    expect(source.dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it('clears a target when the shared axis value is outside its visible range', () => {
+    const spec = { series: [{ type: 'line' as const, data: [1, 2] }] };
+    render(
+      <>
+        <EchartsRender spec={spec} group="dashboard-123" />
+        <EchartsRender spec={spec} group="dashboard-123" />
+      </>
+    );
+
+    const [source, target] = mockEchartsInstances;
+    const axesInfo = [{ axisDim: 'x', axisIndex: 0, value: 1234 }];
+
+    act(() => {
+      source.emitZrender('mousemove');
+      source.emit('updateAxisPointer', { axesInfo });
+    });
+    expect(target.dispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'updateAxisPointer' })
+    );
+
+    target.dispatchAction.mockClear();
+    target.convertToPixel.mockReturnValue(500);
+    act(() => {
+      source.emit('updateAxisPointer', { axesInfo });
+    });
+
+    expect(target.dispatchAction).toHaveBeenCalledWith({ type: 'hideTip' });
+    expect(target.dispatchAction).toHaveBeenCalledWith({
+      type: 'updateAxisPointer',
+      currTrigger: 'leave',
+    });
+  });
+
+  it('hides synchronized tooltips and pointers when the source pointer leaves', () => {
+    const spec = { series: [{ type: 'line' as const, data: [1, 2] }] };
+    render(
+      <>
+        <EchartsRender spec={spec} group="dashboard-123" />
+        <EchartsRender spec={spec} group="dashboard-123" />
+      </>
+    );
+
+    const [source, target] = mockEchartsInstances;
+    act(() => {
+      source.emitZrender('mousemove');
+      source.emitZrender('globalout');
+    });
+
+    expect(target.dispatchAction).toHaveBeenCalledWith({ type: 'hideTip' });
+    expect(target.dispatchAction).toHaveBeenCalledWith({
+      type: 'updateAxisPointer',
+      currTrigger: 'leave',
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/echarts_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/echarts_render.tsx
@@ -106,6 +106,7 @@ const syncAxisPointerByValue = (
     ({ axisDim, value }) => (axisDim === 'x' || axisDim === 'y') && value != null
   );
   if (!axisInfo) {
+    hideSharedCrosshair(group, source);
     return;
   }
 

--- a/src/plugins/explore/public/components/visualizations/echarts_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/echarts_render.tsx
@@ -14,13 +14,137 @@ import { LegendTarget } from './utils/legend';
 
 interface Props {
   spec: echarts.EChartsOption;
+  group?: string;
   onSelectTimeRange?: (range: TimeRange) => void;
   legendSelected$?: BehaviorSubject<Record<string, boolean>>;
   highlightedLegendTarget$?: BehaviorSubject<LegendTarget | undefined>;
 }
 
+interface SharedAxisInfo {
+  axisDim?: string;
+  axisIndex?: number;
+  value?: unknown;
+}
+
+interface SharedAxisPointerEvent {
+  axesInfo?: SharedAxisInfo[];
+}
+
+const sharedCrosshairGroups = new Map<string, Set<echarts.ECharts>>();
+let activePointerChart: echarts.ECharts | undefined;
+
+/**
+ * Converts the shared axis value into coordinates local to the target chart.
+ * The orthogonal coordinate is placed inside the target grid so ECharts can
+ * resolve its own nearest data point, while values outside the grid are ignored.
+ */
+const getTargetAxisPoint = (
+  instance: echarts.ECharts,
+  axisInfo: SharedAxisInfo
+): { x: number; y: number } | undefined => {
+  const { axisDim, value } = axisInfo;
+  if ((axisDim !== 'x' && axisDim !== 'y') || value == null) {
+    return;
+  }
+
+  const axisIndex = axisInfo.axisIndex ?? 0;
+  // Project the value through the target axis because each panel has its own
+  // scale, dimensions, and grid position.
+  const pixel = instance.convertToPixel(
+    { [`${axisDim}AxisIndex`]: axisIndex },
+    value as string | number
+  );
+  if (typeof pixel !== 'number' || !Number.isFinite(pixel)) {
+    return;
+  }
+
+  const axisModel = (instance as any).getModel()?.getComponent(`${axisDim}Axis`, axisIndex);
+  const gridRect = axisModel?.axis?.grid?.getRect?.();
+  const gridStart = gridRect?.[axisDim];
+  const gridSize = gridRect?.[axisDim === 'x' ? 'width' : 'height'];
+
+  // Do not render a shared pointer when the value is outside the target's
+  // visible axis range.
+  if (
+    typeof gridStart === 'number' &&
+    typeof gridSize === 'number' &&
+    (pixel < gridStart || pixel > gridStart + gridSize)
+  ) {
+    return;
+  }
+
+  const gridCenterX = gridRect ? gridRect.x + gridRect.width / 2 : instance.getWidth() / 2;
+  const gridCenterY = gridRect ? gridRect.y + gridRect.height / 2 : instance.getHeight() / 2;
+
+  // ECharts requires a two-dimensional point to resolve the tooltip. Keep the
+  // synchronized coordinate on the shared axis and center the other coordinate.
+  return {
+    x: axisDim === 'x' ? pixel : gridCenterX,
+    y: axisDim === 'y' ? pixel : gridCenterY,
+  };
+};
+
+/**
+ * Replays the active chart's axis value across the group using each target's
+ * coordinate system. Only the chart under the pointer may publish, preventing
+ * target update events from being relayed back through the group.
+ */
+const syncAxisPointerByValue = (
+  group: string,
+  source: echarts.ECharts,
+  event: SharedAxisPointerEvent
+) => {
+  // A dispatched target update emits the same ECharts event. Only the chart
+  // currently under the mouse may relay it, which prevents synchronization loops.
+  if (activePointerChart !== source) {
+    return;
+  }
+
+  // Synchronize by the semantic axis value instead of a source data index,
+  // which may refer to a different or missing row in another panel.
+  const axisInfo = event.axesInfo?.find(
+    ({ axisDim, value }) => (axisDim === 'x' || axisDim === 'y') && value != null
+  );
+  if (!axisInfo) {
+    return;
+  }
+
+  sharedCrosshairGroups.get(group)?.forEach((target) => {
+    if (target === source || target.isDisposed()) {
+      return;
+    }
+
+    // Recompute the pointer position in the target chart before dispatching so
+    // its native axis pointer and tooltip resolve against the target data.
+    const point = getTargetAxisPoint(target, axisInfo);
+    if (!point) {
+      // Clear any previous synchronized state when the shared value cannot be
+      // represented in this target's visible axis range.
+      target.dispatchAction({ type: 'hideTip' });
+      target.dispatchAction({ type: 'updateAxisPointer', currTrigger: 'leave' });
+      return;
+    }
+
+    target.dispatchAction({
+      type: 'updateAxisPointer',
+      axesInfo: event.axesInfo,
+      ...point,
+    });
+  });
+};
+
+const hideSharedCrosshair = (group: string, source: echarts.ECharts) => {
+  sharedCrosshairGroups.get(group)?.forEach((target) => {
+    if (target === source || target.isDisposed()) {
+      return;
+    }
+    target.dispatchAction({ type: 'hideTip' });
+    target.dispatchAction({ type: 'updateAxisPointer', currTrigger: 'leave' });
+  });
+};
+
 export const EchartsRender = React.memo(
-  ({ spec, onSelectTimeRange, legendSelected$, highlightedLegendTarget$ }: Props) => {
+  ({ spec, group, onSelectTimeRange, legendSelected$, highlightedLegendTarget$ }: Props) => {
     const [instance, setInstance] = useState<echarts.ECharts | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const instanceRef = useRef<echarts.ECharts | null>(null);
@@ -55,6 +179,52 @@ export const EchartsRender = React.memo(
         }
       };
     }, [containerResizeObserver]);
+
+    useEffect(() => {
+      if (!instance) return;
+
+      if (group) {
+        const instances = sharedCrosshairGroups.get(group) ?? new Set<echarts.ECharts>();
+        instances.add(instance);
+        sharedCrosshairGroups.set(group, instances);
+
+        const onAxisPointerUpdate = (...args: unknown[]) => {
+          const [event] = args;
+          if (typeof event !== 'object' || event === null) {
+            return;
+          }
+          syncAxisPointerByValue(group, instance, event as SharedAxisPointerEvent);
+        };
+        const onMouseMove = () => {
+          activePointerChart = instance;
+        };
+        const onGlobalOut = () => {
+          if (activePointerChart === instance) {
+            activePointerChart = undefined;
+            hideSharedCrosshair(group, instance);
+          }
+        };
+        const zrender = instance.getZr();
+        zrender.on('mousemove', onMouseMove);
+        zrender.on('globalout', onGlobalOut);
+        instance.on('updateAxisPointer', onAxisPointerUpdate);
+
+        return () => {
+          if (!instance.isDisposed()) {
+            instance.off('updateAxisPointer', onAxisPointerUpdate);
+            zrender.off('mousemove', onMouseMove);
+            zrender.off('globalout', onGlobalOut);
+            instance.dispatchAction({ type: 'hideTip' });
+            instance.dispatchAction({ type: 'updateAxisPointer', currTrigger: 'leave' });
+          }
+          onGlobalOut();
+          instances.delete(instance);
+          if (instances.size === 0) {
+            sharedCrosshairGroups.delete(group);
+          }
+        };
+      }
+    }, [group, instance]);
 
     useEffect(() => {
       function onBrushEnd(params: any) {

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.test.ts
@@ -6,16 +6,33 @@
 import React from 'react';
 import { createLineConfig, defaultLineChartStyles } from './line_vis_config';
 import { LineVisStyleControls } from './line_vis_options';
-import { GridOptions, ThresholdMode, Positions, TooltipOptions, LineStyle } from '../types';
+import {
+  GridOptions,
+  ThresholdMode,
+  Positions,
+  TooltipOptions,
+  LineStyle,
+  VisFieldType,
+  AxisRole,
+} from '../types';
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   createElement: jest.fn(),
 }));
 
+jest.mock('./to_expression', () => ({
+  createSimpleLineChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createLineBarChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createMultiLineChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createCategoryLineChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+  createCategoryMultiLineChart: jest.fn(() => ({ spec: {}, legendItems: [] })),
+}));
+
 describe('line_vis_config', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (React.createElement as jest.Mock).mockImplementation((type, props) => ({ type, props }));
   });
 
   describe('createLineConfig', () => {
@@ -58,6 +75,32 @@ describe('line_vis_config', () => {
       const rules = config.getRules();
       expect(Array.isArray(rules)).toBe(true);
       expect(rules.length).toBeGreaterThan(0);
+    });
+
+    it('should only pass the shared crosshair group to rules with a date x-axis', () => {
+      const config = createLineConfig();
+      const crosshairGroup = 'dashboard';
+
+      config.getRules().forEach((rule) => {
+        const rendered = rule.render({
+          data: [],
+          allData: [],
+          styleOptions: config.ui.style.defaults,
+          axisColumnMappings: {
+            x: [{}],
+            y: [{}],
+            y2: [{}],
+            color: [{}],
+          },
+          timeRange: { from: 'now-1h', to: 'now' },
+          renderContext: { crosshairGroup },
+        } as any) as React.ReactElement<{ group?: string }>;
+        const hasDateXAxis = rule.mappings.some(
+          (mapping) => mapping[AxisRole.X]?.type === VisFieldType.Date
+        );
+
+        expect(rendered.props.group).toBe(hasDateXAxis ? crosshairGroup : undefined);
+      });
     });
 
     it('should render the LineVisStyleControls component with the provided props', () => {

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
@@ -147,6 +147,7 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -181,6 +182,7 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -214,6 +216,7 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}
@@ -247,6 +250,7 @@ export const createLineConfig = (): VisualizationType<'line'> => ({
           return (
             <EchartsRender
               spec={spec}
+              group={props.renderContext?.crosshairGroup}
               onSelectTimeRange={props.onSelectTimeRange}
               legendSelected$={props.legendSelected$}
               highlightedLegendTarget$={props.highlightedLegendTarget$}

--- a/src/plugins/explore/public/components/visualizations/theme/default.ts
+++ b/src/plugins/explore/public/components/visualizations/theme/default.ts
@@ -65,11 +65,11 @@ function createEchartsTheme(colors: ReturnType<typeof getColors>) {
     tooltip: {
       axisPointer: {
         lineStyle: {
-          color: colors.grid,
+          color: colors.subText,
           width: 1,
         },
         crossStyle: {
-          color: colors.grid,
+          color: colors.subText,
           width: 1,
         },
       },

--- a/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
@@ -77,6 +77,8 @@ interface EChartsSpecInput<T extends BaseChartStyle = BaseChartStyle> {
   timeRange?: { from: string; to: string };
 }
 
+export type AxisType = 'category' | 'value' | 'time';
+
 /**
  * State object that flows through the pipeline
  */
@@ -123,7 +125,7 @@ export function pipe<T extends BaseChartStyle>(
 /**
  * Get ECharts axis type from VisColumn schema
  */
-export function getAxisType(axis: Axis | Axis[] | undefined): 'category' | 'value' | 'time' {
+export function getAxisType(axis: Axis | Axis[] | undefined): AxisType {
   const effectiveAxis = Array.isArray(axis) ? axis[0] : axis;
   if (!effectiveAxis) return 'value';
 
@@ -161,7 +163,7 @@ export const createBaseConfig =
         confine: true, // for x direction
         show: styles.tooltipOptions?.mode !== 'hidden',
         ...(axisConfig && addTrigger && { trigger: 'axis' as const }),
-        axisPointer: { type: 'shadow' as const },
+        axisPointer: { type: 'line' as const },
         ...(hasUnit && {
           valueFormatter: (value: unknown) =>
             typeof value === 'number'
@@ -209,10 +211,10 @@ export const buildAxisConfigs = <T extends BaseChartStyle>(
     isValueAxis: boolean = false,
     addSplitLineStyle: boolean = false
   ) => {
-    const axisStyling = applyAxisStyling({ axisStyle, addSplitLineStyle });
-    const type = getAxisType(axis);
+    const axisType = getAxisType(axis);
+    const axisStyling = applyAxisStyling({ axisType, axisStyle, addSplitLineStyle });
     return {
-      type,
+      type: axisType,
       ...axisStyling,
       nameGap: 8,
       ...(isValueAxis &&
@@ -285,17 +287,22 @@ const POSITION_MAP = {
 };
 
 export const applyAxisStyling = ({
+  axisType,
   axisStyle,
   addSplitLineStyle,
 }: {
   axisStyle?: StandardAxes;
   addSplitLineStyle?: boolean;
+  axisType?: AxisType;
 }): XAXisComponentOption | YAXisComponentOption => {
   const echartsAxisConfig: XAXisComponentOption | YAXisComponentOption = {
     name: axisStyle?.title?.text || '',
     nameLocation: 'middle',
     nameGap: 35,
     axisLine: { show: true },
+    axisPointer: {
+      snap: axisType === 'time' ? false : true,
+    },
   };
 
   // Apply axis visibility

--- a/src/plugins/explore/public/components/visualizations/utils/use_visualization_types.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/use_visualization_types.ts
@@ -86,6 +86,7 @@ export interface StyleControlsProps<T extends ChartStyles> {
 
 export interface VisualizationRenderContext {
   seriesName?: string;
+  crosshairGroup?: string;
 }
 
 export interface VisRenderProps<T extends ChartType> {

--- a/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.test.tsx
@@ -12,6 +12,7 @@ import { VisFieldType, Positions, RenderChartConfig } from './types';
 import { defaultBarChartStyles } from './bar/bar_vis_config';
 import { defaultTableChartStyles } from './table/table_vis_config';
 import { defaultMetricChartStyles } from './metric/metric_vis_config';
+import { defaultLineChartStyles } from './line/line_vis_config';
 import { ChartType } from './utils/use_visualization_types';
 
 const mockRender = jest.fn(() => <div data-test-subj="echartsRender">Echarts Render</div>);
@@ -187,6 +188,29 @@ describe('VisualizationRender', () => {
     expect(screen.getByTestId('echartsRender')).toBeInTheDocument();
   });
 
+  it('passes the crosshair group through the visualization render context', () => {
+    const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
+    const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>(mockChartConfig);
+    const showRawTable$ = new BehaviorSubject<boolean>(false);
+
+    render(
+      <VisualizationRender
+        data$={data$}
+        config$={visConfig$}
+        showRawTable$={showRawTable$}
+        crosshairGroup="dashboard-123"
+      />
+    );
+
+    expect(mockRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renderContext: expect.objectContaining({
+          crosshairGroup: 'dashboard-123',
+        }),
+      })
+    );
+  });
+
   it('renders empty state when there is no selection mapping', () => {
     const data$ = new BehaviorSubject<VisData | undefined>(mockVisData);
     const visConfig$ = new BehaviorSubject<RenderChartConfig | undefined>({
@@ -270,6 +294,68 @@ describe('VisualizationRender', () => {
     ]);
     expect(splitRender.mock.calls[0][0].allData).toBe(mockSplitVisData.transformedData);
     expect(splitRender.mock.calls[1][0].allData).toBe(mockSplitVisData.transformedData);
+  });
+
+  it('does not mutate split data when shared crosshair is enabled', () => {
+    const splitRender = jest.fn(() => <div data-test-subj="splitChart">Split Chart</div>);
+    mockFindRuleByAxesMapping.mockReturnValue({
+      render: splitRender,
+    });
+
+    const splitTimeData: VisData = {
+      transformedData: [
+        { timestamp: '2026-08-12T08:00:00.000Z', os: 'linux', count: 1 },
+        { timestamp: '2026-08-12T09:00:00.000Z', os: 'windows', count: 2 },
+      ],
+      numericalColumns: [
+        {
+          id: 1,
+          name: 'count',
+          schema: VisFieldType.Numerical,
+          column: 'count',
+        },
+      ],
+      categoricalColumns: [
+        {
+          id: 2,
+          name: 'os',
+          schema: VisFieldType.Categorical,
+          column: 'os',
+        },
+      ],
+      dateColumns: [
+        {
+          id: 3,
+          name: 'timestamp',
+          schema: VisFieldType.Date,
+          column: 'timestamp',
+        },
+      ],
+      unknownColumns: [],
+    };
+    const splitConfig: RenderChartConfig = {
+      type: 'line',
+      styles: defaultLineChartStyles,
+      axesMapping: { x: 'timestamp', y: 'count' },
+      splitField: 'os',
+    };
+
+    render(
+      <CommonVisualizationRender
+        visualizationData={splitTimeData}
+        visConfig={splitConfig}
+        showRawTable={false}
+        crosshairGroup="dashboard-123"
+      />
+    );
+
+    expect(splitRender).toHaveBeenCalledTimes(2);
+    expect(splitRender.mock.calls[0][0].data).toEqual([
+      { timestamp: '2026-08-12T08:00:00.000Z', os: 'linux', count: 1 },
+    ]);
+    expect(splitRender.mock.calls[1][0].data).toEqual([
+      { timestamp: '2026-08-12T09:00:00.000Z', os: 'windows', count: 2 },
+    ]);
   });
 
   it('returns null when data has no columns', () => {

--- a/src/plugins/explore/public/components/visualizations/visualization_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/visualization_render.tsx
@@ -30,6 +30,7 @@ interface Props {
   timeRange?: TimeRange;
   onSelectTimeRange?: (timeRange?: TimeRange) => void;
   onStyleChange?: (updatedStyle: Partial<TableChartStyle>) => void;
+  crosshairGroup?: string;
 }
 
 interface CommonProps {
@@ -39,6 +40,7 @@ interface CommonProps {
   timeRange?: TimeRange;
   onSelectTimeRange?: (timeRange?: TimeRange) => void;
   onStyleChange?: (updatedStyle: Partial<TableChartStyle>) => void;
+  crosshairGroup?: string;
 }
 
 const defaultStyleOptions: TableChartStyle = {
@@ -58,6 +60,7 @@ export const CommonVisualizationRender = ({
   timeRange: inputTimeRange,
   onSelectTimeRange,
   onStyleChange,
+  crosshairGroup,
 }: CommonProps) => {
   const { from, to } = inputTimeRange || {};
   const legendSelected$ = useRef(new BehaviorSubject<Record<string, boolean>>({})).current;
@@ -195,6 +198,7 @@ export const CommonVisualizationRender = ({
                   config={visConfig}
                   renderContext={{
                     seriesName: groupKey,
+                    crosshairGroup,
                   }}
                   onLegend={(legend) => onLegend(groupKey, legend, groups)}
                   timeRange={timeRange}
@@ -227,6 +231,7 @@ export const CommonVisualizationRender = ({
           <ChartRender
             data={visualizationData}
             config={visConfig}
+            renderContext={{ crosshairGroup }}
             onLegend={(legend) => onLegend('__default__', legend, ['__default__'])}
             timeRange={timeRange}
             onSelectTimeRange={onSelectTimeRange}
@@ -249,6 +254,7 @@ export const VisualizationRender = ({
   timeRange: inputTimeRange,
   onSelectTimeRange,
   onStyleChange,
+  crosshairGroup,
 }: Props) => {
   const visualizationData = useObservable(data$);
   const visConfig = useObservable(config$);
@@ -261,6 +267,7 @@ export const VisualizationRender = ({
       timeRange={inputTimeRange}
       onSelectTimeRange={onSelectTimeRange}
       onStyleChange={onStyleChange}
+      crosshairGroup={crosshairGroup}
     />
   );
 };

--- a/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
@@ -5,7 +5,7 @@
 
 import { BehaviorSubject } from 'rxjs';
 import { skip } from 'rxjs/operators';
-import { ExploreEmbeddable } from './explore_embeddable';
+import { ExploreEmbeddable, getCrosshairGroup } from './explore_embeddable';
 import { ExploreInput } from './types';
 import { EXPLORE_EMBEDDABLE_TYPE } from './constants';
 import { discoverPluginMock } from '../application/legacy/discover/mocks';
@@ -45,6 +45,20 @@ jest.mock('./panel_data_service', () => {
       init: jest.fn(),
     },
   };
+});
+
+describe('getCrosshairGroup', () => {
+  it('returns no group when shared crosshair is disabled', () => {
+    expect(getCrosshairGroup(false, 'dashboard-123')).toBeUndefined();
+  });
+
+  it('uses the container id when shared crosshair is enabled', () => {
+    expect(getCrosshairGroup(true, 'dashboard-123')).toBe('dashboard-123');
+  });
+
+  it('uses the static id for an unsaved dashboard', () => {
+    expect(getCrosshairGroup(true, '')).toBe('dashboard-unsaved');
+  });
 });
 
 // Mock the services

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -132,6 +132,13 @@ const getVisualizationMetadata = (visualization?: string): VisualizationMetadata
   }
 };
 
+const UNSAVED_DASHBOARD_CROSSHAIR_GROUP = 'dashboard-unsaved';
+
+export const getCrosshairGroup = (
+  useSharedCrosshair: boolean | undefined,
+  containerId: string | undefined
+) => (useSharedCrosshair ? containerId || UNSAVED_DASHBOARD_CROSSHAIR_GROUP : undefined);
+
 export class ExploreEmbeddable
   extends Embeddable<ExploreInput, ExploreOutput>
   implements IEmbeddable<ExploreInput, ExploreOutput>
@@ -681,6 +688,10 @@ export class ExploreEmbeddable
               showRawTable={false}
               timeRange={searchContext.timeRange}
               onSelectTimeRange={this.searchProps?.onSelectTimeRange}
+              crosshairGroup={getCrosshairGroup(
+                this.input.useSharedCrosshair,
+                this.parent?.getInput().id
+              )}
             />
           );
           this.searchProps.chartRender = chartRender;

--- a/src/plugins/explore/public/embeddable/types.ts
+++ b/src/plugins/explore/public/embeddable/types.ts
@@ -14,6 +14,7 @@ export interface ExploreInput extends EmbeddableInput {
   query?: QueryState;
   filters?: Filter[];
   hidePanelTitles?: boolean;
+  useSharedCrosshair?: boolean;
   columns?: string[];
   sort?: SortOrder[];
   // attributes and references are used to create embeddables without storing saved object


### PR DESCRIPTION
### Description
Adds an opt-in dashboard setting to synchronize crosshairs across Explore time-series panels. The shared crosshair will not work for legacy visualizations.

This change:

- Adds a **Sync crosshair across panels** dashboard setting, disabled by default.
- Persists the setting with the dashboard and passes it to Explore embeddables.
- Supports line, area, and bar charts with a time-based X-axis.
- Leaves categorical and other unsupported visualizations unchanged.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/cfa00f8a-ac87-46f6-8931-ca0a93169cb1


<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
