### PR TITLE
feat(dashboard): Add panel description

### DIFF
--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/21/rule_matching_vis_area.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/21/rule_matching_vis_area.spec.js
@@ -87,10 +87,11 @@ export const runCreateVisTests = () => {
       // Open thresholds setting
       cy.get('[aria-controls="thresholdSection"]').click();
       // Change threshold mode from default 'Off' to enable threshold functionality
+      cy.get('.visStylePanelOuter').scrollTo('bottom');
+      // The accordion's overflow clips the select at its lower edge according to Cypress.
       cy.getElementByTestId('thresholdModeSelect')
-        .scrollIntoView()
-        .should('be.visible')
-        .select('Solid lines');
+        .select('Solid lines', { force: true })
+        .should('have.value', 'solid');
       cy.getElementByTestId('exploreVisAddThreshold').click();
       // compare with new canvas
       cy.get('.exploreVisContainer canvas').then((canvas) => {

--- a/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/21/rule_matching_vis_area.spec.js
+++ b/cypress/integration/core_opensearch_dashboards/opensearch_dashboards/apps/explore/21/rule_matching_vis_area.spec.js
@@ -87,7 +87,10 @@ export const runCreateVisTests = () => {
       // Open thresholds setting
       cy.get('[aria-controls="thresholdSection"]').click();
       // Change threshold mode from default 'Off' to enable threshold functionality
-      cy.getElementByTestId('thresholdModeSelect').should('be.visible').select('Solid lines');
+      cy.getElementByTestId('thresholdModeSelect')
+        .scrollIntoView()
+        .should('be.visible')
+        .select('Solid lines');
       cy.getElementByTestId('exploreVisAddThreshold').click();
       // compare with new canvas
       cy.get('.exploreVisContainer canvas').then((canvas) => {

--- a/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
+++ b/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
@@ -66,6 +66,7 @@
 
   .embPanel__titleText {
     @include euiTextTruncate;
+
     padding-right: $euiSizeS;
   }
 

--- a/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
+++ b/src/plugins/embeddable/public/lib/panel/_embeddable_panel.scss
@@ -66,6 +66,7 @@
 
   .embPanel__titleText {
     @include euiTextTruncate;
+    padding-right: $euiSizeS;
   }
 
   .embPanel__placeholderTitleText {

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_button.test.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_button.test.tsx
@@ -13,6 +13,7 @@ import { useVisualizationBuilder } from '../hooks/use_visualization_builder';
 import { useCurrentExploreId } from '../../../application/utils/hooks/use_current_explore_id';
 import { useSavedExplore } from '../../utils/hooks/use_saved_explore';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { ChartConfig } from '../../../components/visualizations/visualization_builder.types';
 
 jest.mock('../hooks/use_query_builder_state', () => ({
   useQueryBuilderState: jest.fn(),
@@ -82,16 +83,19 @@ const buildServices = () => ({
 const mockSavedExplore = {
   id: 'explore-1',
   title: 'My Explore',
+  visualization: '',
   save: jest.fn().mockResolvedValue('explore-1'),
 };
 
-const buildVisualizationBuilder = () => ({
+const buildVisualizationBuilder = (
+  visConfig: ChartConfig = {
+    type: 'bar',
+    styles: {},
+    axesMapping: { x: 'field' },
+  }
+) => ({
   visualizationBuilderForEditor: {
-    visConfig$: new BehaviorSubject({
-      type: 'bar',
-      styles: {},
-      axesMapping: { x: 'field' },
-    }),
+    visConfig$: new BehaviorSubject(visConfig),
     isVisDirty$: new BehaviorSubject(false),
     getTransformationService: jest.fn().mockReturnValue({ pipeline$: new BehaviorSubject([]) }),
   },
@@ -152,9 +156,22 @@ describe('SaveVisButton', () => {
     });
   });
 
-  it('saves directly without modal for existing explore when dirty', async () => {
+  it('serializes panel settings when saving an existing visualization', async () => {
+    const savedExplore = {
+      ...mockSavedExplore,
+      save: jest.fn().mockResolvedValue('explore-1'),
+    };
     (useCurrentExploreId as jest.Mock).mockReturnValue('explore-1');
-    (useSavedExplore as jest.Mock).mockReturnValue({ savedExplore: mockSavedExplore });
+    (useSavedExplore as jest.Mock).mockReturnValue({ savedExplore });
+    (useVisualizationBuilder as jest.Mock).mockReturnValue(
+      buildVisualizationBuilder({
+        type: 'bar',
+        styles: {},
+        axesMapping: { x: 'field' },
+        title: 'Panel title',
+        description: 'Panel description',
+      })
+    );
     (useQueryBuilderState as jest.Mock).mockReturnValue({
       queryEditorState: {
         isQueryEditorDirty: true,
@@ -168,8 +185,14 @@ describe('SaveVisButton', () => {
     fireEvent.click(screen.getByTestId('saveVisualizationEditorButton'));
 
     await waitFor(() => {
-      expect(mockSavedExplore.save).toHaveBeenCalled();
+      expect(savedExplore.save).toHaveBeenCalled();
     });
+    expect(JSON.parse(savedExplore.visualization)).toEqual(
+      expect.objectContaining({
+        title: 'Panel title',
+        description: 'Panel description',
+      })
+    );
   });
 
   it('discards and navigates to originatingApp when originatingApp is set', () => {

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_button.test.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_button.test.tsx
@@ -87,7 +87,11 @@ const mockSavedExplore = {
 
 const buildVisualizationBuilder = () => ({
   visualizationBuilderForEditor: {
-    visConfig$: { value: { type: 'bar', styles: {}, axesMapping: { x: 'field' } } },
+    visConfig$: new BehaviorSubject({
+      type: 'bar',
+      styles: {},
+      axesMapping: { x: 'field' },
+    }),
     isVisDirty$: new BehaviorSubject(false),
     getTransformationService: jest.fn().mockReturnValue({ pipeline$: new BehaviorSubject([]) }),
   },

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_button.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_button.tsx
@@ -48,7 +48,7 @@ const saveButtonText = i18n.translate('explore.topNav.saveVisButton.save', {
 export const SaveVisButton = () => {
   const { queryEditorState, datasetView, resultState } = useQueryBuilderState();
   const { visualizationBuilderForEditor: visualizationBuilder } = useVisualizationBuilder();
-  const visConfig = visualizationBuilder.visConfig$.value;
+  const visConfig = useObservable(visualizationBuilder.visConfig$);
   const transformationService = visualizationBuilder.getTransformationService();
 
   const { services } = useOpenSearchDashboards<ExploreServices>();
@@ -138,7 +138,8 @@ export const SaveVisButton = () => {
       savedExploreToSave.title = newTitle;
       savedExploreToSave.type = undefined; // save explores created in in-context editor don't have flavor
       savedExploreToSave.visualization = JSON.stringify({
-        title: '',
+        title: visConfig?.title,
+        description: visConfig?.description,
         chartType: visConfig?.type ?? 'line',
         params: visConfig?.styles ?? {},
         axesMapping,
@@ -272,6 +273,7 @@ export const SaveVisButton = () => {
       {showModal && (
         <SaveVisModal
           savedExploreId={exploreId}
+          initialTitle={visConfig?.title}
           onCancel={() => setShowModal(false)}
           onConfirm={handleSave}
           showComplexQueryWarning={resultState?.profile?.isComplex ?? false}

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_modal.test.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_modal.test.tsx
@@ -21,9 +21,10 @@ jest.mock('@osd/i18n/react', () => ({
 }));
 
 jest.mock('../../../components/visualizations/style_panel/utils', () => ({
-  DebouncedFieldText: ({ onChange, placeholder }: any) => (
+  DebouncedFieldText: ({ value, onChange, placeholder }: any) => (
     <input
       data-test-subj="title-input"
+      value={value}
       placeholder={placeholder}
       onChange={(e) => onChange(e.target.value)}
     />
@@ -39,10 +40,14 @@ beforeEach(() => {
   (useSavedExplore as jest.Mock).mockReturnValue({ savedExplore: mockSavedExplore });
 });
 
-const renderModal = (savedExploreId: string | undefined = undefined) =>
+const renderModal = (
+  savedExploreId: string | undefined = undefined,
+  initialTitle: string | undefined = undefined
+) =>
   render(
     <SaveVisModal
       savedExploreId={savedExploreId}
+      initialTitle={initialTitle}
       onConfirm={mockOnConfirm}
       onCancel={mockOnCancel}
     />
@@ -66,6 +71,13 @@ describe('SaveVisModal', () => {
     (useSavedExplore as jest.Mock).mockReturnValue({ savedExplore: { id: undefined, title: '' } });
     renderModal();
     expect(screen.getByTestId('saveVisandBackToDashboardConfirmButton')).toBeDisabled();
+  });
+
+  it('initializes the saved object title from the visualization title', () => {
+    renderModal(undefined, 'Panel title');
+
+    expect(screen.getByTestId('title-input')).toHaveValue('Panel title');
+    expect(screen.getByTestId('saveVisandBackToDashboardConfirmButton')).toBeEnabled();
   });
 
   it('calls onConfirm when save button is clicked', async () => {

--- a/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_modal.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/save_vis_modal.tsx
@@ -36,11 +36,13 @@ interface SaveVisModalProps {
   onConfirm: (props: OnSaveProps) => Promise<void>;
   onCancel: () => void;
   savedExploreId: string | undefined;
+  initialTitle?: string;
   showComplexQueryWarning?: boolean;
 }
 
 export const SaveVisModal: React.FC<SaveVisModalProps> = ({
   savedExploreId,
+  initialTitle,
   onConfirm,
   onCancel,
   showComplexQueryWarning,
@@ -51,7 +53,7 @@ export const SaveVisModal: React.FC<SaveVisModalProps> = ({
 
   const { savedExplore } = useSavedExplore(savedExploreId);
 
-  const [title, setTitle] = useState<string>(savedExplore?.title ?? '');
+  const [title, setTitle] = useState<string>(initialTitle ?? '');
 
   const enableButton = title !== '';
 
@@ -137,7 +139,7 @@ export const SaveVisModal: React.FC<SaveVisModalProps> = ({
               })}
             >
               <DebouncedFieldText
-                value={savedExplore?.title ?? ''}
+                value={title}
                 placeholder="Enter save search name"
                 onChange={(text: string) => {
                   setIsTitleDuplicate(false);

--- a/src/plugins/explore/public/application/in_context_vis_editor/visualization_editor_page.test.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/visualization_editor_page.test.tsx
@@ -162,7 +162,11 @@ describe('VisualizationEditorPage', () => {
       isLoading: false,
       error: undefined,
       savedQueryState: undefined,
-      savedVisConfig: { chartType: 'bar' },
+      savedVisConfig: {
+        chartType: 'bar',
+        title: 'Panel title',
+        description: 'Panel description',
+      },
     });
 
     renderPage();
@@ -170,6 +174,8 @@ describe('VisualizationEditorPage', () => {
     await waitFor(() => {
       expect(mockVisualizationBuilder.setVisConfig).toHaveBeenCalledWith({
         type: 'bar',
+        title: 'Panel title',
+        description: 'Panel description',
       });
     });
   });

--- a/src/plugins/explore/public/application/in_context_vis_editor/visualization_editor_page.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/visualization_editor_page.tsx
@@ -97,6 +97,8 @@ export const VisualizationEditorPage = ({
       if (savedVisConfig) {
         visualizationBuilderForEditor.setVisConfig({
           type: savedVisConfig.chartType,
+          title: savedVisConfig.title,
+          description: savedVisConfig.description,
           styles: savedVisConfig.params,
           axesMapping: savedVisConfig.axesMapping,
           splitField: savedVisConfig.splitField,

--- a/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
+++ b/src/plugins/explore/public/application/utils/hooks/use_page_initialization.ts
@@ -71,6 +71,8 @@ export const useInitPage = () => {
         const uiState = savedExplore.uiState;
         if (visualization) {
           const {
+            title: visualizationTitle,
+            description: visualizationDescription,
             chartType,
             params,
             axesMapping,
@@ -81,6 +83,8 @@ export const useInitPage = () => {
           } = JSON.parse(visualization);
           visualizationBuilder.setVisConfig({
             type: chartType,
+            title: visualizationTitle,
+            description: visualizationDescription,
             styles: params,
             axesMapping,
             splitField,

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_button.tsx
@@ -108,6 +108,8 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
       undefined,
       tabDefinition,
       {
+        title: chartConfig?.title,
+        description: chartConfig?.description,
         chartType: chartConfig?.type,
         axesMapping: chartConfig?.axesMapping,
         styleOptions: chartConfig?.styles,
@@ -239,6 +241,7 @@ export const SaveAndAddButtonWithModal = ({ dataset }: { dataset?: IndexPattern 
       {showAddToDashboardModal && (
         <AddToDashboardModal
           savedExploreId={savedExploreIdFromUrl}
+          initialTitle={chartConfig?.title}
           savedObjectsClient={saveObjectsClient}
           onCancel={() => setShowAddToDashboardModal(false)}
           onConfirm={handleSave}

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.test.tsx
@@ -183,6 +183,22 @@ describe('AddToDashboardModal', () => {
     expect(addButton).toBeDisabled();
   });
 
+  it('initializes the saved object title from the visualization title', async () => {
+    await act(async () => {
+      render(
+        <AddToDashboardModal
+          savedObjectsClient={mockSavedObjectsClient}
+          onConfirm={mockOnConfirm}
+          onCancel={mockOnCancel}
+          savedExploreId="explore-1"
+          initialTitle="Panel title"
+        />
+      );
+    });
+
+    expect(await screen.findByPlaceholderText('Enter save search name')).toHaveValue('Panel title');
+  });
+
   it('calls onCancel when cancel button is clicked', async () => {
     await act(async () => {
       render(

--- a/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.tsx
+++ b/src/plugins/explore/public/components/visualizations/add_to_dashboard_modal.tsx
@@ -33,6 +33,7 @@ interface AddToDashboardModalProps {
   onConfirm: (props: OnSaveProps) => void;
   onCancel: () => void;
   savedExploreId: string | undefined;
+  initialTitle?: string;
   showComplexQueryWarning?: boolean;
 }
 
@@ -45,6 +46,7 @@ export const AddToDashboardModal: React.FC<AddToDashboardModalProps> = ({
   savedObjectsClient,
   onConfirm,
   onCancel,
+  initialTitle,
   showComplexQueryWarning,
 }) => {
   const [selectedOption, setSelectedOption] = useState<'existing' | 'new'>('existing');
@@ -108,7 +110,7 @@ export const AddToDashboardModal: React.FC<AddToDashboardModalProps> = ({
 
   const { savedExplore } = useSavedExplore(savedExploreId);
 
-  const [title, setTitle] = useState<string>('');
+  const [title, setTitle] = useState<string>(initialTitle ?? '');
 
   // Dashboard-related state managed by custom hook
   const {

--- a/src/plugins/explore/public/components/visualizations/panel_settings_accordion.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/panel_settings_accordion.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PanelSettingsAccordion } from './panel_settings_accordion';
+
+describe('PanelSettingsAccordion', () => {
+  it('renders the current title and description', () => {
+    render(
+      <PanelSettingsAccordion
+        title="Panel title"
+        description="Panel description"
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('panelSettingsTitle')).toHaveValue('Panel title');
+    expect(screen.getByTestId('panelSettingsDescription')).toHaveValue('Panel description');
+  });
+
+  it('reports title and description changes independently', () => {
+    const onChange = jest.fn();
+    render(<PanelSettingsAccordion onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId('panelSettingsTitle'), {
+      target: { value: 'Updated title' },
+    });
+    fireEvent.change(screen.getByTestId('panelSettingsDescription'), {
+      target: { value: 'Updated description' },
+    });
+
+    expect(onChange).toHaveBeenNthCalledWith(1, { title: 'Updated title' });
+    expect(onChange).toHaveBeenNthCalledWith(2, { description: 'Updated description' });
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/panel_settings_accordion.tsx
+++ b/src/plugins/explore/public/components/visualizations/panel_settings_accordion.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFieldText, EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { StyleAccordion } from './style_panel/style_accordion';
+
+interface PanelSettingsAccordionProps {
+  title?: string;
+  description?: string;
+  onChange: (settings: { title?: string; description?: string }) => void;
+}
+
+export const PanelSettingsAccordion: React.FC<PanelSettingsAccordionProps> = ({
+  title,
+  description,
+  onChange,
+}) => {
+  return (
+    <StyleAccordion
+      id="panelSettings"
+      accordionLabel={i18n.translate('explore.stylePanel.panelSettings.title', {
+        defaultMessage: 'Panel settings',
+      })}
+      initialIsOpen={false}
+    >
+      <EuiFormRow
+        label={i18n.translate('explore.stylePanel.panelSettings.titleLabel', {
+          defaultMessage: 'Title',
+        })}
+      >
+        <EuiFieldText
+          compressed
+          value={title ?? ''}
+          onChange={(event) => onChange({ title: event.target.value })}
+          data-test-subj="panelSettingsTitle"
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label={i18n.translate('explore.stylePanel.panelSettings.descriptionLabel', {
+          defaultMessage: 'Description',
+        })}
+      >
+        <EuiTextArea
+          compressed
+          value={description ?? ''}
+          onChange={(event) => onChange({ description: event.target.value })}
+          data-test-subj="panelSettingsDescription"
+        />
+      </EuiFormRow>
+    </StyleAccordion>
+  );
+};

--- a/src/plugins/explore/public/components/visualizations/style_panel_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel_render.tsx
@@ -17,6 +17,7 @@ import { visualizationRegistry } from './visualization_registry';
 import { SplitConfig, VisData } from './visualization_builder.types';
 import { getAxisConfigByColumnMapping } from './utils/axis';
 import { AxesSelectPanel } from './style_panel/axes/axes_selector';
+import { PanelSettingsAccordion } from './panel_settings_accordion';
 
 interface StylePanelProps<T> {
   data$: Observable<VisData | undefined>;
@@ -25,6 +26,7 @@ interface StylePanelProps<T> {
   onChartTypeChange: (type: ChartType) => void;
   onAxesMappingChange: (mappings: AxisFieldNameMappings) => void;
   onSplitConfigChange: (config: Partial<SplitConfig>) => void;
+  onPanelSettingsChange: (settings: { title?: string; description?: string }) => void;
   className?: string;
 }
 
@@ -35,6 +37,7 @@ export const StylePanelRender = <T extends ChartType>({
   onChartTypeChange,
   onAxesMappingChange,
   onSplitConfigChange,
+  onPanelSettingsChange,
   className,
 }: StylePanelProps<T>) => {
   const visualizationData = useObservable(data$);
@@ -97,6 +100,11 @@ export const StylePanelRender = <T extends ChartType>({
         currentMapping={axisColumnMappings}
         updateVisualization={updateVisualization}
         chartType={chartConfig.type}
+      />
+      <PanelSettingsAccordion
+        title={chartConfig.title}
+        description={chartConfig.description}
+        onChange={onPanelSettingsChange}
       />
       {chartConfig?.type !== 'table' && (
         <SplitSettingsAccordion

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
@@ -640,6 +640,20 @@ describe('VisualizationBuilder', () => {
     expect(builder.visConfig$.value?.type).toBe('heatmap');
   });
 
+  test('should preserve panel settings when chart type changes', () => {
+    const builder = new VisualizationBuilder({});
+    builder.setVisConfig({
+      type: 'bar',
+      title: 'Panel title',
+      description: 'Panel description',
+    });
+
+    builder.setCurrentChartType('line');
+
+    expect(builder.visConfig$.value?.title).toBe('Panel title');
+    expect(builder.visConfig$.value?.description).toBe('Panel description');
+  });
+
   test('should reset vis state', () => {
     const builder = new VisualizationBuilder({});
     builder.setVisConfig({

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.test.ts
@@ -609,6 +609,21 @@ describe('VisualizationBuilder', () => {
     });
   });
 
+  test('should update panel settings and mark the visualization dirty', () => {
+    const builder = new VisualizationBuilder({});
+    builder.setVisConfig({ type: 'table' });
+
+    builder.updatePanelSettings({ title: 'Panel title' });
+    builder.updatePanelSettings({ description: 'Panel description' });
+
+    expect(builder.visConfig$.value).toEqual({
+      type: 'table',
+      title: 'Panel title',
+      description: 'Panel description',
+    });
+    expect(builder.isVisDirty$.value).toBe(true);
+  });
+
   test('should set axes mapping', () => {
     const builder = new VisualizationBuilder({});
     // initial vis config
@@ -687,6 +702,21 @@ describe('VisualizationBuilder', () => {
       expect(builder.visConfig$.value?.splitField).toBe('category');
       expect(builder.visConfig$.value?.splitLayout).toBe('horizontal');
       expect(builder.visConfig$.value?.showSplitLabel).toBe(true);
+    });
+
+    test('should preserve panel settings', () => {
+      const builder = new VisualizationBuilder({});
+      builder.visConfig$.next({
+        type: 'bar',
+        title: 'Panel title',
+        description: 'Panel description',
+      });
+
+      const result = (builder as any).applyVisConfig('line', { x: 'field0', y: 'field1' }, false);
+
+      expect(result).toBe(true);
+      expect(builder.visConfig$.value?.title).toBe('Panel title');
+      expect(builder.visConfig$.value?.description).toBe('Panel description');
     });
 
     test('should preserve styles when preserveStyles is true', () => {

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.ts
@@ -27,6 +27,8 @@ import { ITransformationService } from '../data_transformations/types';
 import { createNoOpTransformationService } from '../data_transformations/transformation_service';
 
 interface VisState {
+  title?: string;
+  description?: string;
   styleOptions?: StyleOptions;
   chartType?: string;
   axesMapping?: AxisFieldNameMappings;
@@ -110,6 +112,13 @@ export class VisualizationBuilder {
         initialVisConfig.styles = state.styleOptions;
       }
 
+      if (state.title !== undefined) {
+        initialVisConfig.title = state.title;
+      }
+      if (state.description !== undefined) {
+        initialVisConfig.description = state.description;
+      }
+
       if (state.axesMapping) {
         initialVisConfig.axesMapping = state.axesMapping;
       }
@@ -151,6 +160,8 @@ export class VisualizationBuilder {
         .subscribe(([visConfig, isVisDirty]) =>
           this.syncToUrl(
             {
+              title: visConfig?.title,
+              description: visConfig?.description,
               chartType: visConfig?.type,
               axesMapping: visConfig?.axesMapping,
               styleOptions: visConfig?.styles,
@@ -190,7 +201,11 @@ export class VisualizationBuilder {
     }
 
     const currentVisConfig = this.visConfig$.value;
-    const newVisConfig: ChartConfig = { type: chartType };
+    const newVisConfig: ChartConfig = {
+      type: chartType,
+      title: currentVisConfig?.title,
+      description: currentVisConfig?.description,
+    };
 
     const visConfig = visualizationRegistry.getVisualization(chartType);
     if (!visConfig) {
@@ -317,6 +332,8 @@ export class VisualizationBuilder {
           ? currentConfig.styles
           : chartTypeConfig.ui.style.defaults,
       axesMapping,
+      title: currentConfig?.title,
+      description: currentConfig?.description,
       splitField: currentConfig?.splitField,
       splitLayout: currentConfig?.splitLayout,
       showSplitLabel: currentConfig?.showSplitLabel,
@@ -428,6 +445,19 @@ export class VisualizationBuilder {
     }
   }
 
+  updatePanelSettings(settings: { title?: string; description?: string }) {
+    const currentVisConfig = this.visConfig$.value;
+    if (!currentVisConfig) {
+      return;
+    }
+
+    const nextConfig = { ...currentVisConfig, ...settings };
+    if (!isEqual(currentVisConfig, nextConfig)) {
+      this.setIsVisDirty(true);
+      this.visConfig$.next(nextConfig);
+    }
+  }
+
   setVisConfig(config?: ChartConfig) {
     const newConfig = adaptLegacyData(config);
     this.visConfig$.next(newConfig);
@@ -534,7 +564,13 @@ export class VisualizationBuilder {
   }
 
   clearUrl() {
-    this.syncToUrl({ axesMapping: {}, styleOptions: undefined, chartType: undefined });
+    this.syncToUrl({
+      title: undefined,
+      description: undefined,
+      axesMapping: {},
+      styleOptions: undefined,
+      chartType: undefined,
+    });
   }
 
   getRenderConfig$(): Observable<RenderChartConfig | undefined> {
@@ -545,6 +581,8 @@ export class VisualizationBuilder {
           if (vis) {
             const styles: ChartStyles = mergeStyles(vis.ui.style.defaults, config.styles);
             return {
+              title: config.title,
+              description: config.description,
               styles,
               type: config.type,
               axesMapping: config.axesMapping,
@@ -585,6 +623,7 @@ export class VisualizationBuilder {
       onAxesMappingChange: this.setAxesMapping.bind(this),
       onChartTypeChange: this.setCurrentChartType.bind(this),
       onSplitConfigChange: this.updateSplitConfig.bind(this),
+      onPanelSettingsChange: this.updatePanelSettings.bind(this),
     });
   }
 }

--- a/src/plugins/explore/public/components/visualizations/visualization_builder.types.ts
+++ b/src/plugins/explore/public/components/visualizations/visualization_builder.types.ts
@@ -25,6 +25,8 @@ export interface SplitConfig {
 
 export interface ChartConfig extends SplitConfig {
   type: ChartType;
+  title?: string;
+  description?: string;
   styles?: StyleOptions;
   axesMapping?: AxisFieldNameMappings;
   dataTransformations?: UrlTransformationState[];

--- a/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
@@ -991,12 +991,19 @@ describe('ExploreEmbeddable', () => {
       );
 
       expect(emb.getDescription()).toBe('Logs for initial');
+      const outputListener = jest.fn();
+      const outputSubscription = emb.getOutput$().subscribe(outputListener);
+      outputListener.mockClear();
 
       environment = 'production';
       parent.variables$.next([{ id: 'env', value: 'production' }]);
 
       expect(emb.getDescription()).toBe('Logs for production');
+      expect(outputListener).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Logs for production' })
+      );
 
+      outputSubscription.unsubscribe();
       emb.destroy();
       parent.destroy();
     });

--- a/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.test.tsx
@@ -277,6 +277,43 @@ describe('ExploreEmbeddable', () => {
     expect(embeddable.type).toBe(EXPLORE_EMBEDDABLE_TYPE);
   });
 
+  test('uses visualization metadata for the default panel title and description', () => {
+    const services = createMockServices();
+    const metadataContainer = createTestContainer('metadata-embeddable');
+    const metadataEmbeddable = new ExploreEmbeddable(
+      {
+        savedExplore: {
+          ...mockSavedExplore,
+          visualization: JSON.stringify({
+            chartType: 'bar',
+            title: 'Visualization title',
+            description: 'Visualization description',
+          }),
+        },
+        editUrl: '/app/explore/logs/test',
+        editPath: 'test',
+        indexPatterns: [],
+        editable: true,
+        filterManager: services.filterManager,
+        services,
+        editApp: 'explore/logs',
+      },
+      { ...mockInput, id: 'metadata-embeddable' },
+      mockExecuteTriggerActions,
+      metadataContainer
+    );
+
+    expect(metadataEmbeddable.getTitle()).toBe('Visualization title');
+    expect(metadataEmbeddable.getDescription()).toBe('Visualization description');
+
+    metadataEmbeddable.destroy();
+    metadataContainer.destroy();
+  });
+
+  test('falls back to the saved object title when visualization title is empty', () => {
+    expect(embeddable.getTitle()).toBe('Test Explore');
+  });
+
   test('should have return inspector adaptors', () => {
     expect(embeddable.getInspectorAdapters()).not.toBeUndefined();
     expect(embeddable.getInspectorAdapters().data).toBeDefined();
@@ -721,7 +758,7 @@ describe('ExploreEmbeddable', () => {
     expect(adaptLegacyDataSpy).toHaveBeenCalled();
   });
 
-  describe('variable interpolation in panel title', () => {
+  describe('variable interpolation in panel metadata', () => {
     test('interpolates input.title when it contains variables', () => {
       const mockInterpolation: Partial<IVariableInterpolationService> = {
         hasVariables: jest.fn((str: string) => str.includes('$')),
@@ -760,7 +797,7 @@ describe('ExploreEmbeddable', () => {
       );
 
       // @ts-ignore
-      emb.handleTitleVariables();
+      emb.handlePanelMetadataVariables();
 
       expect(mockInterpolation.interpolate).toHaveBeenCalledWith('Sales for $region');
       expect(emb.getOutput().title).toBe('Sales for Region-A');
@@ -796,7 +833,7 @@ describe('ExploreEmbeddable', () => {
       );
 
       // @ts-ignore
-      emb.handleTitleVariables();
+      emb.handlePanelMetadataVariables();
 
       expect(mockInterpolation.interpolate).toHaveBeenCalledWith('Logs for $env');
       expect(emb.getOutput().title).toBe('Logs for prod');
@@ -832,8 +869,47 @@ describe('ExploreEmbeddable', () => {
       );
 
       // @ts-ignore
-      emb.handleTitleVariables();
+      emb.handlePanelMetadataVariables();
       expect(mockInterpolation.interpolate).not.toHaveBeenCalled();
+
+      emb.destroy();
+      parent.destroy();
+    });
+
+    test('interpolates visualization description when it contains variables', () => {
+      const mockInterpolation: Partial<IVariableInterpolationService> = {
+        hasVariables: jest.fn((str: string) => str.includes('$')),
+        interpolate: jest.fn((str: string) => str.replace('$env', 'production')),
+        getCurrentValues: jest.fn().mockReturnValue({}),
+        getVariables: jest.fn().mockReturnValue([]),
+      };
+      const parent = createTestContainer('description-var-emb', {}, mockInterpolation);
+      const mockServices = createMockServices();
+
+      const emb = new ExploreEmbeddable(
+        {
+          savedExplore: {
+            ...mockSavedExplore,
+            visualization: JSON.stringify({
+              chartType: 'bar',
+              description: 'Logs for $env',
+            }),
+          },
+          editUrl: '/app/explore/logs/test',
+          editPath: 'test',
+          indexPatterns: [],
+          editable: true,
+          filterManager: mockServices.filterManager,
+          services: mockServices,
+          editApp: 'explore/logs',
+        },
+        { ...mockInput, id: 'description-var-emb' },
+        mockExecuteTriggerActions,
+        parent
+      );
+
+      expect(mockInterpolation.interpolate).toHaveBeenCalledWith('Logs for $env');
+      expect(emb.getDescription()).toBe('Logs for production');
 
       emb.destroy();
       parent.destroy();
@@ -879,6 +955,50 @@ describe('ExploreEmbeddable', () => {
         });
 
       parent.variables$.next([{ id: 'env', value: 'production' }]);
+    });
+
+    test('re-interpolates description when variables$ emits new values', () => {
+      let environment = 'initial';
+      const mockInterpolation: Partial<IVariableInterpolationService> = {
+        hasVariables: jest.fn((str: string) => str.includes('$')),
+        interpolate: jest.fn((str: string) => str.replace('$env', environment)),
+        getCurrentValues: jest.fn().mockReturnValue({}),
+        getVariables: jest.fn().mockReturnValue([]),
+      };
+      const parent = createTestContainer('reactive-description-emb', {}, mockInterpolation);
+      const mockServices = createMockServices();
+
+      const emb = new ExploreEmbeddable(
+        {
+          savedExplore: {
+            ...mockSavedExplore,
+            visualization: JSON.stringify({
+              chartType: 'bar',
+              description: 'Logs for $env',
+            }),
+          },
+          editUrl: '/app/explore/logs/test',
+          editPath: 'test',
+          indexPatterns: [],
+          editable: true,
+          filterManager: mockServices.filterManager,
+          services: mockServices,
+          editApp: 'explore/logs',
+        },
+        { ...mockInput, id: 'reactive-description-emb' },
+        mockExecuteTriggerActions,
+        parent
+      );
+
+      expect(emb.getDescription()).toBe('Logs for initial');
+
+      environment = 'production';
+      parent.variables$.next([{ id: 'env', value: 'production' }]);
+
+      expect(emb.getDescription()).toBe('Logs for production');
+
+      emb.destroy();
+      parent.destroy();
     });
   });
 

--- a/src/plugins/explore/public/embeddable/explore_embeddable.tsx
+++ b/src/plugins/explore/public/embeddable/explore_embeddable.tsx
@@ -114,6 +114,24 @@ interface ExploreEmbeddableConfig {
   editApp: string;
 }
 
+interface VisualizationMetadata {
+  title?: string;
+  description?: string;
+}
+
+const getVisualizationMetadata = (visualization?: string): VisualizationMetadata => {
+  if (!visualization) {
+    return {};
+  }
+
+  try {
+    const { title, description } = JSON.parse(visualization);
+    return { title, description };
+  } catch {
+    return {};
+  }
+};
+
 export class ExploreEmbeddable
   extends Embeddable<ExploreInput, ExploreOutput>
   implements IEmbeddable<ExploreInput, ExploreOutput>
@@ -125,7 +143,7 @@ export class ExploreEmbeddable
   private filtersSearchSource?: ISearchSource;
   private subscription: Subscription;
   private autoRefreshFetchSubscription?: Subscription;
-  private titleVariableSubscription?: Subscription;
+  private panelMetadataVariableSubscription?: Subscription;
   public readonly type = EXPLORE_EMBEDDABLE_TYPE;
   private panelTitle: string = '';
   private filterManager: FilterManager;
@@ -147,6 +165,7 @@ export class ExploreEmbeddable
 
   // Data transformation support
   private transformationService: TransformationService;
+  private readonly visualizationMetadata: VisualizationMetadata;
 
   constructor(
     {
@@ -163,10 +182,12 @@ export class ExploreEmbeddable
     private readonly executeTriggerActions: UiActionsStart['executeTriggerActions'],
     parent?: Container
   ) {
+    const visualizationMetadata = getVisualizationMetadata(savedExplore.visualization);
     super(
       initialInput,
       {
-        defaultTitle: savedExplore.title,
+        defaultTitle: visualizationMetadata.title || savedExplore.title,
+        description: visualizationMetadata.description,
         editUrl,
         editPath,
         editApp,
@@ -178,6 +199,7 @@ export class ExploreEmbeddable
     this.services = services;
     this.filterManager = filterManager;
     this.savedExplore = savedExplore;
+    this.visualizationMetadata = visualizationMetadata;
     // manage data adapters for CSV export
     this.inspectorAdaptors = {
       requests: new RequestAdapter(),
@@ -208,17 +230,17 @@ export class ExploreEmbeddable
         }
       });
     // Must include output$ here: when a panel title is edited, the base Embeddable.onResetInput()
-    // fires input$.next() (which triggers handleTitleVariables correctly) but then immediately
+    // fires input$.next() (which triggers handlePanelMetadataVariables correctly) but then immediately
     // overwrites the output title with the raw un-interpolated input.title via getPanelTitle().
-    // Subscribing to output$ ensures handleTitleVariables re-applies variable interpolation
+    // Subscribing to output$ ensures handlePanelMetadataVariables re-applies variable interpolation
     // after that overwrite. The isEqual guard in updateOutput() prevents infinite loops.
     if (parent && 'variableService' in parent) {
       const dashboardContainer = parent as unknown as DashboardContainer;
-      this.titleVariableSubscription = merge(
+      this.panelMetadataVariableSubscription = merge(
         this.getInput$(),
         this.getOutput$(),
         dashboardContainer.variableService.getVariables$()
-      ).subscribe(this.handleTitleVariables);
+      ).subscribe(this.handlePanelMetadataVariables);
     }
   }
 
@@ -238,16 +260,30 @@ export class ExploreEmbeddable
     }
   }
 
-  private handleTitleVariables = () => {
+  private handlePanelMetadataVariables = () => {
     let panelTitle = this.output.title ?? '';
     if (this.input.title && this.interpolationService.hasVariables(this.input.title)) {
       panelTitle = this.interpolationService.interpolate(this.input.title);
-    } else if (this.interpolationService.hasVariables(this.savedExplore.title)) {
-      panelTitle = this.interpolationService.interpolate(this.savedExplore.title);
+    } else {
+      const defaultTitle = this.visualizationMetadata.title || this.savedExplore.title;
+      if (this.interpolationService.hasVariables(defaultTitle)) {
+        panelTitle = this.interpolationService.interpolate(defaultTitle);
+      }
     }
-    this.updateOutput({ title: panelTitle });
+
+    const description = this.visualizationMetadata.description;
+    const panelDescription =
+      description && this.interpolationService.hasVariables(description)
+        ? this.interpolationService.interpolate(description)
+        : description;
+
+    this.updateOutput({ title: panelTitle, description: panelDescription });
     this.panelTitle = panelTitle;
   };
+
+  public getDescription() {
+    return this.output.description;
+  }
 
   /**
    * Initialize variable interpolation service and subscription
@@ -725,8 +761,8 @@ export class ExploreEmbeddable
       this.variableSubscription.unsubscribe();
     }
 
-    if (this.titleVariableSubscription) {
-      this.titleVariableSubscription.unsubscribe();
+    if (this.panelMetadataVariableSubscription) {
+      this.panelMetadataVariableSubscription.unsubscribe();
     }
 
     // Cleanup transformation service

--- a/src/plugins/explore/public/embeddable/types.ts
+++ b/src/plugins/explore/public/embeddable/types.ts
@@ -22,6 +22,7 @@ export interface ExploreInput extends EmbeddableInput {
 }
 
 export interface ExploreOutput extends EmbeddableOutput {
+  description?: string;
   editUrl: string;
   indexPatterns?: IIndexPattern[];
   editable: boolean;

--- a/src/plugins/explore/public/saved_explore/transforms.test.ts
+++ b/src/plugins/explore/public/saved_explore/transforms.test.ts
@@ -17,6 +17,22 @@ const createMockSavedExplore = (): SavedExplore =>
   }) as unknown as SavedExplore;
 
 describe('saveStateToSavedObject', () => {
+  it('serializes panel settings into the visualization config', () => {
+    const obj = createMockSavedExplore();
+
+    saveStateToSavedObject(obj, undefined, undefined, {
+      title: 'Panel title',
+      description: 'Panel description',
+    });
+
+    expect(JSON.parse(obj.visualization!)).toEqual(
+      expect.objectContaining({
+        title: 'Panel title',
+        description: 'Panel description',
+      })
+    );
+  });
+
   describe('activeTab in uiState', () => {
     it('uses activeTabId when tabDefinition exists', () => {
       const obj = createMockSavedExplore();

--- a/src/plugins/explore/public/saved_explore/transforms.ts
+++ b/src/plugins/explore/public/saved_explore/transforms.ts
@@ -23,6 +23,8 @@ export interface ExploreState {
 }
 
 interface VisState {
+  title?: string;
+  description?: string;
   chartType?: ChartType;
   styleOptions?: StyleOptions;
   axesMapping?: AxisFieldNameMappings;
@@ -43,9 +45,8 @@ export const saveStateToSavedObject = (
   // Serialize the state into the saved object
   obj.type = flavorId;
   obj.visualization = JSON.stringify({
-    // TODO: Add title to saved object
-    // Visualization has an independent title?
-    title: '',
+    title: visState?.title ?? '',
+    description: visState?.description,
     chartType: visState?.chartType ?? 'line',
     params: visState?.styleOptions ?? {},
     axesMapping: visState?.axesMapping,


### PR DESCRIPTION
### Description

This PR adds optional panel title and description settings to Explore visualizations across Logs Explore, Metrics Explore, and the standalone visualization editor. The metadata is stored in the visualization configuration and preserved across chart changes. When saving a new visualization, its panel title prepopulates the save modal while remaining independent from the saved-object name.

On dashboards, the visualization title is used as the default panel title, with the saved-object title as a fallback. The visualization description appears in the panel tooltip. Both titles and descriptions support dashboard variable interpolation.

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<img width="1474" height="841" alt="Screenshot 2026-08-19 at 18 10 30" src="https://github.com/user-attachments/assets/6e7d0fe0-57d1-4dc5-996e-cef319a03091" />

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
