### PR TITLE
[Backport 2.19] fix(security): add AST-based validation for Vega expressions to prevent XSS (#12422)

### DIFF
--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -185,7 +185,7 @@ export default {
   transformIgnorePatterns: [
     // ignore all node_modules except those which require babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios|vega-expression|vega-util))[/\\\\].+\\.js$',
     'packages/osd-pm/dist/index.js',
   ],
   snapshotSerializers: [

--- a/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_parser.ts
@@ -62,6 +62,7 @@ import {
   OpenSearchDashboards,
 } from './types';
 import { PPLQueryParser } from './ppl_parser';
+import { validateVegaExpression } from './vega_validation';
 
 // Set default single color to match other OpenSearch Dashboards visualizations
 const defaultColor: string = euiPaletteColorBlind()[0];
@@ -162,6 +163,22 @@ The URL is an identifier only. OpenSearch Dashboards and your browser will never
         })
       );
     }
+
+    const validationResults = validateVegaExpression(this.spec);
+    if (validationResults.length > 0) {
+      const reason = validationResults
+        .map((r) => `${r.reason} in "${r.expression}" at ${r.location}`)
+        .join('\n');
+      throw new Error(
+        i18n.translate('visTypeVega.vegaParser.unexpectedVegaExpression', {
+          defaultMessage: 'Unexpected Vega expression: {reason}',
+          values: {
+            reason,
+          },
+        })
+      );
+    }
+
     this.isVegaLite = this.parseSchema(this.spec).isVegaLite;
     this.useHover = !this.isVegaLite;
 

--- a/src/plugins/vis_type_vega/public/data_model/vega_validation.test.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_validation.test.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { validateVegaExpression } from './vega_validation';
+
+describe('validateVegaExpression', () => {
+  describe('legitimate expressions', () => {
+    it('allows basic data access expressions', () => {
+      const spec = {
+        signals: [{ name: 'tooltip', update: 'datum.x' }],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('allows scale and signal references', () => {
+      const spec = {
+        marks: [{ encode: { update: { x: { signal: "scale('x', datum.value)" } } } }],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('allows tree/hierarchy data fields', () => {
+      const spec = {
+        marks: [
+          {
+            encode: {
+              update: {
+                x: { signal: 'datum.children' },
+                y: { signal: 'datum.parent' },
+              },
+            },
+          },
+        ],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('allows conditional expressions', () => {
+      const spec = {
+        signals: [{ name: 'color', update: "datum.value > 0 ? 'green' : 'red'" }],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('allows object literals with non-computed keys matching blocked names', () => {
+      const spec = {
+        signals: [{ name: 'config', update: '{constructor: 1, self: 2}' }],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('allows array access with numeric index', () => {
+      const spec = {
+        signals: [{ name: 'item', update: 'data[0].value' }],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('allows computed member access with simple identifiers', () => {
+      const spec = {
+        signals: [{ name: 'val', update: 'datum[field]' }],
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+  });
+
+  describe('blocked property access', () => {
+    it('blocks ownerDocument access via dot notation', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: 'el.ownerDocument' }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].reason).toContain('ownerDocument');
+    });
+
+    it('blocks ownerDocument access via bracket notation', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "el['ownerDocument']" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].reason).toContain('ownerDocument');
+    });
+
+    it('blocks defaultView access', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "doc['defaultView']" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].reason).toContain('defaultView');
+    });
+
+    it('blocks constructor access', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: 'datum.constructor.constructor("return this")()' }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].reason).toContain('constructor');
+    });
+
+    it('blocks innerHTML access', () => {
+      const spec = {
+        marks: [{ encode: { update: { text: { signal: 'el.innerHTML' } } } }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].reason).toContain('innerHTML');
+    });
+
+    it('blocks event.view access', () => {
+      const spec = {
+        signals: [{ name: 'xss', on: [{ events: 'click', update: 'event.view' }] }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].reason).toContain('view');
+    });
+  });
+
+  describe('blocked identifiers', () => {
+    it('blocks window identifier', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: 'window.location' }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('window'))).toBe(true);
+    });
+
+    it('blocks document identifier', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: 'document.cookie' }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('document'))).toBe(true);
+    });
+
+    it('blocks globalThis identifier', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: 'globalThis.fetch' }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('globalThis'))).toBe(true);
+    });
+  });
+
+  describe('blocked function calls', () => {
+    it('blocks eval calls', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "eval('alert(1)')" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('eval'))).toBe(true);
+    });
+
+    it('blocks Function constructor calls', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "Function('return this')()" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('Function'))).toBe(true);
+    });
+
+    it('blocks setTimeout calls', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "setTimeout('alert(1)', 0)" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('setTimeout'))).toBe(true);
+    });
+
+    it('blocks method-style dangerous calls', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "obj.eval('code')" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('eval'))).toBe(true);
+    });
+
+    it('blocks atob calls used for obfuscation', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "atob('b3duZXJEb2N1bWVudA==')" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('atob'))).toBe(true);
+    });
+  });
+
+  describe('dynamic computed property access', () => {
+    it('blocks string concatenation in computed properties', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "el['owner' + 'Document']" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.some((r) => r.reason.includes('dynamic computed property'))).toBe(true);
+    });
+
+    it('blocks function calls in computed properties', () => {
+      const spec = {
+        signals: [{ name: 'xss', update: "el[atob('b3duZXJEb2N1bWVudA==')]" }],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('spec traversal', () => {
+    it('checks expressions in nested marks', () => {
+      const spec = {
+        marks: [
+          {
+            type: 'rect',
+            encode: {
+              enter: {
+                x: { signal: 'el.ownerDocument' },
+              },
+            },
+          },
+        ],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].location).toContain('marks');
+    });
+
+    it('checks calculate transforms', () => {
+      const spec = {
+        data: [
+          {
+            name: 'source',
+            transform: [{ type: 'formula', expr: 'window.location', as: 'url' }],
+          },
+        ],
+      };
+      const results = validateVegaExpression(spec);
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('returns empty results for non-expression fields', () => {
+      const spec = {
+        description: 'window.document is fine in non-expression fields',
+        title: 'eval(this) is also fine here',
+      };
+      expect(validateVegaExpression(spec)).toHaveLength(0);
+    });
+
+    it('handles malformed specs gracefully', () => {
+      expect(validateVegaExpression(null as any)).toHaveLength(0);
+      expect(validateVegaExpression(undefined as any)).toHaveLength(0);
+      expect(validateVegaExpression({} as any)).toHaveLength(0);
+    });
+  });
+});

--- a/src/plugins/vis_type_vega/public/data_model/vega_validation.ts
+++ b/src/plugins/vis_type_vega/public/data_model/vega_validation.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parseExpression } from 'vega-expression';
+
+interface ValidationResult {
+  expression: string;
+  reason: string;
+  location: string;
+}
+
+/**
+ * Properties that should never be accessed in Vega expressions.
+ * These allow DOM traversal from the Vega dataflow to the window object.
+ *
+ * Note: We intentionally exclude common data field names like 'children',
+ * 'parentNode', 'firstChild', 'lastChild' which are used in Vega tree/hierarchy
+ * data transforms. The critical exploit chain requires 'ownerDocument' → 'defaultView'
+ * to reach the window object, so blocking those is sufficient.
+ */
+const BLOCKED_PROPERTIES = new Set([
+  // DOM traversal to window (critical exploit path)
+  'ownerDocument',
+  'defaultView',
+  'contentDocument',
+  'contentWindow',
+  'view', // event.view → window
+  // DOM manipulation methods
+  'innerHTML',
+  'outerHTML',
+  'insertAdjacentHTML',
+  'createElement',
+  'createElementNS',
+  'getElementById',
+  'getElementsByClassName',
+  'getElementsByTagName',
+  'querySelector',
+  'querySelectorAll',
+  // Prototype pollution
+  '__proto__',
+  'prototype',
+  'constructor',
+]);
+
+/**
+ * Global identifiers that should never be accessed directly in expressions.
+ */
+const BLOCKED_IDENTIFIERS = new Set([
+  'window',
+  'document',
+  'global',
+  'globalThis',
+  'top',
+  'parent',
+  'frames',
+  'self',
+  'constructor',
+]);
+
+/**
+ * Function names that should never be called in expressions.
+ */
+const BLOCKED_FUNCTIONS = new Set([
+  'eval',
+  'Function',
+  'setTimeout',
+  'setInterval',
+  'setImmediate',
+  'execScript',
+  'atob',
+  'btoa',
+]);
+
+interface ASTNode {
+  type: string;
+  name?: string;
+  value?: any;
+  object?: ASTNode;
+  property?: ASTNode;
+  computed?: boolean;
+  callee?: ASTNode;
+  arguments?: ASTNode[];
+  elements?: ASTNode[];
+  properties?: ASTNode[];
+  key?: ASTNode;
+  test?: ASTNode;
+  consequent?: ASTNode;
+  alternate?: ASTNode;
+  left?: ASTNode;
+  right?: ASTNode;
+  argument?: ASTNode;
+  operator?: string;
+}
+
+/**
+ * Extract the property name from a MemberExpression node.
+ * Handles both dot notation (node.property.name) and bracket notation with literals (node.property.value).
+ */
+function getPropertyName(node: ASTNode): string | null {
+  if (!node.property) return null;
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name || null;
+  }
+  if (
+    node.computed &&
+    node.property.type === 'Literal' &&
+    typeof node.property.value === 'string'
+  ) {
+    return node.property.value;
+  }
+  return null;
+}
+
+/**
+ * Recursively walk all nodes in the AST and invoke the visitor function on each.
+ */
+function walkAst(node: ASTNode | null | undefined, visitor: (n: ASTNode) => void): void {
+  if (!node || typeof node !== 'object') return;
+
+  visitor(node);
+
+  switch (node.type) {
+    case 'MemberExpression':
+      walkAst(node.object, visitor);
+      if (node.computed) {
+        walkAst(node.property, visitor);
+      }
+      break;
+    case 'CallExpression':
+      walkAst(node.callee, visitor);
+      node.arguments?.forEach((arg) => walkAst(arg, visitor));
+      break;
+    case 'ArrayExpression':
+      node.elements?.forEach((el) => walkAst(el, visitor));
+      break;
+    case 'ObjectExpression':
+      node.properties?.forEach((prop) => walkAst(prop, visitor));
+      break;
+    case 'Property':
+      if (node.computed) {
+        walkAst(node.key, visitor);
+      }
+      walkAst(node.value, visitor);
+      break;
+    case 'BinaryExpression':
+    case 'LogicalExpression':
+      walkAst(node.left, visitor);
+      walkAst(node.right, visitor);
+      break;
+    case 'UnaryExpression':
+      walkAst(node.argument, visitor);
+      break;
+    case 'ConditionalExpression':
+      walkAst(node.test, visitor);
+      walkAst(node.consequent, visitor);
+      walkAst(node.alternate, visitor);
+      break;
+    // Identifier and Literal are leaf nodes — no children to walk
+    default:
+      break;
+  }
+}
+
+/**
+ * Check if an expression string contains dangerous patterns by parsing it into an AST
+ * and walking the tree to detect blocked property access, identifiers, and function calls.
+ */
+function checkExpressionAst(expression: string, location: string): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  let ast: ASTNode;
+  try {
+    ast = parseExpression(expression) as unknown as ASTNode;
+  } catch (e) {
+    // If the expression doesn't parse, Vega will reject it at render time anyway
+    return results;
+  }
+
+  walkAst(ast, (node: ASTNode) => {
+    // Check MemberExpression for blocked property access
+    if (node.type === 'MemberExpression') {
+      const propName = getPropertyName(node);
+      if (propName && BLOCKED_PROPERTIES.has(propName)) {
+        results.push({
+          expression,
+          reason: `Blocked property access: "${propName}"`,
+          location,
+        });
+      }
+      // Block computed member access with non-literal expressions (e.g., string
+      // concatenation or function calls used to obfuscate property names)
+      if (node.computed && propName === null) {
+        const prop = node.property;
+        if (prop && prop.type !== 'Literal' && prop.type !== 'Identifier') {
+          results.push({
+            expression,
+            reason: `Blocked dynamic computed property access`,
+            location,
+          });
+        }
+      }
+    }
+
+    // Check Identifier nodes for blocked globals
+    // Only block top-level identifiers — property names in non-computed
+    // MemberExpressions are no longer visited (fixed in walkAst above)
+    if (node.type === 'Identifier' && node.name && BLOCKED_IDENTIFIERS.has(node.name)) {
+      results.push({
+        expression,
+        reason: `Blocked identifier: "${node.name}"`,
+        location,
+      });
+    }
+
+    // Check CallExpression for blocked function calls
+    if (node.type === 'CallExpression' && node.callee) {
+      let calleeName: string | null = null;
+      if (node.callee.type === 'Identifier') {
+        calleeName = node.callee.name || null;
+      }
+      // Also check method-style calls like obj.eval(...) or obj.setTimeout(...)
+      if (node.callee.type === 'MemberExpression') {
+        calleeName = getPropertyName(node.callee);
+      }
+      if (calleeName && BLOCKED_FUNCTIONS.has(calleeName)) {
+        results.push({
+          expression,
+          reason: `Blocked function call: "${calleeName}"`,
+          location,
+        });
+      }
+    }
+  });
+
+  return results;
+}
+
+/**
+ * Validate Vega spec expressions using AST-based analysis to block dangerous patterns
+ * that could lead to XSS or code execution.
+ *
+ * This function traverses the spec object, finds all expression fields, parses them
+ * into ASTs, and checks for dangerous property access chains regardless of dot vs
+ * bracket notation.
+ */
+export function validateVegaExpression(spec: Record<string, any>): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  // Fields that typically contain Vega expressions
+  const expressionFields = ['expr', 'update', 'test', 'calculate', 'filter', 'signal'];
+
+  function traverse(obj: Record<string, any>, path = '') {
+    if (!obj || typeof obj !== 'object') return;
+
+    if (Array.isArray(obj)) {
+      obj.forEach((item, index) => {
+        traverse(item, `${path}[${index}]`);
+      });
+      return;
+    }
+
+    for (const [key, value] of Object.entries(obj)) {
+      const currentPath = path ? `${path}.${key}` : key;
+
+      // Check if this is an expression field
+      if (expressionFields.includes(key) && typeof value === 'string') {
+        const expressionResults = checkExpressionAst(value, currentPath);
+        results.push(...expressionResults);
+      }
+
+      // Recursively check nested objects
+      traverse(value, currentPath);
+    }
+  }
+
+  traverse(spec);
+  return results;
+}


### PR DESCRIPTION
Backport of #12422 to `2.19`.

### Description

Adds expression-level validation to Vega visualizations that blocks dangerous property access, identifiers, and function calls that could enable DOM traversal XSS attacks. The validator parses Vega expressions into ASTs using `vega-expression` and walks the tree to detect:
- Blocked property access (`ownerDocument`, `defaultView`, `innerHTML`, etc.) regardless of dot vs bracket notation
- Blocked global identifiers (`window`, `document`, `globalThis`, etc.)
- Blocked function calls (`eval`, `Function`, `setTimeout`, `atob`, etc.)
- Dynamic computed property access used to obfuscate property names

Legitimate Vega expressions (data access, scales, signals, tree/hierarchy fields like `datum.children`, `datum.parent`) remain unaffected.

### Backport notes

Cherry-picked from `d1cac5ddb700b870458519d6c3e51919ccbbdbb8`. One conflict in `src/dev/jest/config.js` (`transformIgnorePatterns`) was resolved by adding only the `vega-expression` and `vega-util` exclusions this change requires on top of the 2.19 base list; the other entries from the main-branch version reference dependencies not present in 2.19. Both packages are already available in 2.19 as transitive deps of `vega` (no `package.json` change needed, matching the original PR).

### Check List
- [x] All tests pass
- [ ] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commit changes are listed out in CHANGELOG.md file (N/A for backport)
- [x] Commits are signed per the DCO using `--signoff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)