### PR TITLE
fix: permission match logic in translatePermissionsToRole

### DIFF
--- a/src/plugins/workspace/server/utils.test.ts
+++ b/src/plugins/workspace/server/utils.test.ts
@@ -12,6 +12,7 @@ import { PermissionModeId, UiSettingScope } from '../../../core/server';
 import {
   generateRandomId,
   getPermissionMode,
+  translatePermissionsToRole,
   updateDashboardAdminStateForRequest,
   transferCurrentUserInPermissions,
   getDataSourcesList,
@@ -359,6 +360,120 @@ describe('getPermissionMode', () => {
       permissionControlClient: mockPermissionControlClient,
       permissions: { read: { users: ['user1'] } },
     });
+
+    expect(result).toBe(PermissionModeId.Read);
+  });
+});
+
+describe('translatePermissionsToRole', () => {
+  it('should return Owner when permission control is disabled', () => {
+    const result = translatePermissionsToRole(
+      false,
+      { write: { users: ['user1'] }, library_write: { users: ['user1'] } },
+      { users: ['user1'], groups: [] }
+    );
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should return Read when permission control is enabled but permissions are undefined', () => {
+    const result = translatePermissionsToRole(true, undefined, { users: ['user1'], groups: [] });
+
+    expect(result).toBe(PermissionModeId.Read);
+  });
+
+  it('should return Owner when the user matches both write and library_write permissions', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { write: { users: ['user1'] }, library_write: { users: ['user1'] } },
+      { users: ['user1'], groups: [] }
+    );
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should return ReadAndWrite when the user only matches library_write permission', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { library_write: { users: ['user1'] } },
+      { users: ['user1'], groups: [] }
+    );
+
+    expect(result).toBe(PermissionModeId.ReadAndWrite);
+  });
+
+  it('should return Read when the user only matches read permission', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { read: { users: ['user1'] } },
+      { users: ['user1'], groups: [] }
+    );
+
+    expect(result).toBe(PermissionModeId.Read);
+  });
+
+  it('should return Read when none of the principals match any permission', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { write: { users: ['user1'] }, library_write: { users: ['user1'] } },
+      { users: ['user2'], groups: ['group2'] }
+    );
+
+    expect(result).toBe(PermissionModeId.Read);
+  });
+
+  it('should match when a permission uses the "*" wildcard for users', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { write: { users: ['*'] }, library_write: { users: ['*'] } },
+      { users: ['anyUser'], groups: [] }
+    );
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should match when a permission uses the "*" wildcard for groups', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { write: { groups: ['*'] }, library_write: { groups: ['*'] } },
+      { users: [], groups: ['anyGroup'] }
+    );
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should match against any of the principal groups, not only the first one', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { write: { groups: ['group2'] }, library_write: { groups: ['group2'] } },
+      { users: [], groups: ['group1', 'group2'] }
+    );
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should match against any of the principal users, not only the first one', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { write: { users: ['user2'] }, library_write: { users: ['user2'] } },
+      { users: ['user1', 'user2'], groups: [] }
+    );
+
+    expect(result).toBe(PermissionModeId.Owner);
+  });
+
+  it('should match via group permission when the user does not match directly', () => {
+    const result = translatePermissionsToRole(
+      true,
+      { library_write: { groups: ['group1'] } },
+      { users: ['user1'], groups: ['group1'] }
+    );
+
+    expect(result).toBe(PermissionModeId.ReadAndWrite);
+  });
+
+  it('should handle undefined principals gracefully', () => {
+    const result = translatePermissionsToRole(true, { write: { users: ['user1'] } }, undefined);
 
     expect(result).toBe(PermissionModeId.Read);
   });

--- a/src/plugins/workspace/server/utils.ts
+++ b/src/plugins/workspace/server/utils.ts
@@ -165,38 +165,56 @@ export const translatePermissionsToRole = (
   principals?: Principals
 ): PermissionModeId => {
   let permissionMode = PermissionModeId.Owner;
-  if (isPermissionControlEnabled && permissions) {
-    const modes = [] as WorkspacePermissionMode[];
-    const currentUserId = principals?.users?.[0] || '';
-    const currentGroupId = principals?.groups?.[0] || '';
-    [
-      WorkspacePermissionMode.Write,
-      WorkspacePermissionMode.LibraryWrite,
-      WorkspacePermissionMode.LibraryRead,
-      WorkspacePermissionMode.Read,
-    ].forEach((mode) => {
-      if (
-        permissions[mode] &&
-        (permissions[mode].users?.includes(currentUserId) ||
-          permissions[mode].groups?.includes(currentGroupId))
-      ) {
-        modes.push(mode);
-      }
-    });
+  if (isPermissionControlEnabled) {
+    if (permissions) {
+      const modes = [] as WorkspacePermissionMode[];
+      [
+        WorkspacePermissionMode.Write,
+        WorkspacePermissionMode.LibraryWrite,
+        WorkspacePermissionMode.LibraryRead,
+        WorkspacePermissionMode.Read,
+      ].forEach((mode) => {
+        if (permissions[mode]) {
+          if (permissions[mode].users?.includes('*') || permissions[mode].groups?.includes('*')) {
+            modes.push(mode);
+            return;
+          }
 
-    if (
-      modes.includes(WorkspacePermissionMode.LibraryWrite) &&
-      modes.includes(WorkspacePermissionMode.Write)
-    ) {
-      permissionMode = PermissionModeId.Owner;
-    } else if (modes.includes(WorkspacePermissionMode.LibraryWrite)) {
-      permissionMode = PermissionModeId.ReadAndWrite;
+          const isGroupMatched = (principals?.groups || []).find((group) =>
+            permissions[mode].groups?.includes(group)
+          );
+
+          if (isGroupMatched) {
+            modes.push(mode);
+            return;
+          }
+
+          const isUserMatched = (principals?.users || []).find((user) =>
+            permissions[mode].users?.includes(user)
+          );
+
+          if (isUserMatched) {
+            modes.push(mode);
+            return;
+          }
+        }
+      });
+
+      if (
+        modes.includes(WorkspacePermissionMode.LibraryWrite) &&
+        modes.includes(WorkspacePermissionMode.Write)
+      ) {
+        permissionMode = PermissionModeId.Owner;
+      } else if (modes.includes(WorkspacePermissionMode.LibraryWrite)) {
+        permissionMode = PermissionModeId.ReadAndWrite;
+      } else {
+        permissionMode = PermissionModeId.Read;
+      }
     } else {
       permissionMode = PermissionModeId.Read;
     }
-  } else {
-    permissionMode = PermissionModeId.Read;
   }
+
   return permissionMode;
 };
 


### PR DESCRIPTION
### Description

Fixes the permission-matching logic in `translatePermissionsToRole` (`src/plugins/workspace/server/utils.ts`), which determines a user's effective workspace role (`Owner` / `ReadAndWrite` / `Read`) from a workspace's ACL permissions.

Previously the function only compared the workspace permissions against the **first** principal returned for the request:

```ts
const currentUserId = principals?.users?.[0] || '';
const currentGroupId = principals?.groups?.[0] || '';
```

This meant a user who was granted access via their 2nd (or later) group — or any non-first principal — was incorrectly evaluated and could be denied the role they should have had.

This change:

- **Matches against all principals**, iterating over every entry in `principals.users` and `principals.groups` instead of only index `[0]`.
- **Adds `*` wildcard support** — a permission entry whose `users` or `groups` contains `*` now matches any requesting principal (shared-with-everyone semantics).
- **Restructures the control flow** so permission control being enabled and permissions being present are handled as separate cases:
  - permission control **disabled** → defaults to `Owner`,
  - permission control **enabled** but no permissions object → `Read`,
  - permission control **enabled** with permissions → role computed from matched modes.

### Issues Resolved

<!-- Replace with the actual issue this resolves, e.g. `fixes #1234` -->
N/A

## Screenshot

N/A — server-side logic change, no UI impact.

## Testing the changes

Added a dedicated `translatePermissionsToRole` describe block in `utils.test.ts` (the function previously had no direct coverage) covering:

- permission control disabled → `Owner`; enabled with undefined permissions → `Read`,
- `Owner` when matched on both `write` + `library_write`; `ReadAndWrite` when only `library_write`; `Read` for read-only and no-match cases,
- `*` wildcard matching for both `users` and `groups`,
- matching against a non-first principal group and a non-first principal user,
- group-based match when the user does not match directly, and graceful handling of undefined `principals`.

Run locally:

```bash
yarn test:jest src/plugins/workspace/server/utils.test.ts
```

All 41 tests in the file pass.

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
