### PR TITLE
[Explore Vis]add unit enhancement+ min/max support

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
@@ -152,8 +152,19 @@ export const createAreaSeries =
         name,
         type: 'line',
         ...pointSymbol,
-        ...(styles.lineStyle === 'line' ? { showSymbol: false } : {}),
-        ...buildValueLabel(styles.showValues, item),
+        ...(styles.lineStyle === 'line'
+          ? styles.showValues
+            ? { showSymbol: true, symbolSize: 0 }
+            : { showSymbol: false }
+          : {}),
+        ...buildValueLabel(
+          styles.showValues,
+          item,
+          styles.decimals,
+          styles.unitId,
+          styles.unitSuffix,
+          resolveStackMode(styles) === 'percentage'
+        ),
         // TODO remove it for connection/disconnection
         connectNulls: true,
         ...stackConfig,

--- a/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
@@ -157,14 +157,15 @@ export const createAreaSeries =
             ? { showSymbol: true, symbolSize: 0 }
             : { showSymbol: false }
           : {}),
-        ...buildValueLabel(
-          styles.showValues,
-          item,
-          styles.decimals,
-          styles.unitId,
-          styles.unitSuffix,
-          resolveStackMode(styles) === 'percentage'
-        ),
+        ...buildValueLabel({
+          showValues: styles.showValues,
+          valueField: item,
+          decimals: styles.decimals,
+          unitId: styles.unitId,
+          unitSuffix: styles.unitSuffix,
+          isPercentage: resolveStackMode(styles) === 'percentage',
+          isStack: resolveStackMode(styles) !== 'none',
+        }),
         // TODO remove it for connection/disconnection
         connectNulls: true,
         ...stackConfig,

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
@@ -80,6 +80,13 @@ export interface AreaChartStyleOptions {
   showFullTimeRange?: boolean;
   stackMode?: StackMode;
   lineStyle?: LineStyle;
+
+  // Standard options
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
+  min?: number;
+  max?: number;
 }
 
 export type AreaChartStyle = Required<
@@ -92,9 +99,25 @@ export type AreaChartStyle = Required<
     | 'lineWidth'
     | 'pointSize'
     | 'areaOpacity'
+    | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
+    | 'min'
+    | 'max'
   >
 > &
-  Pick<AreaChartStyleOptions, 'legendTitle' | 'lineWidth' | 'pointSize' | 'areaOpacity'>;
+  Pick<
+    AreaChartStyleOptions,
+    | 'legendTitle'
+    | 'lineWidth'
+    | 'pointSize'
+    | 'areaOpacity'
+    | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
+    | 'min'
+    | 'max'
+  >;
 
 export const defaultAreaChartStyles: AreaChartStyle = {
   // Basic controls

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_config.tsx
@@ -21,6 +21,7 @@ import {
   LineDashStyle,
   LineMode,
   LineStyle,
+  StandardOptions,
 } from '../types';
 import { getColors } from '../theme/default_colors';
 import {
@@ -40,7 +41,7 @@ export const DEFAULT_FILL_OPACITY = 0.5;
 export type GradientMode = 'none' | 'opacity' | 'hue';
 
 // Complete area chart style controls interface
-export interface AreaChartStyleOptions {
+export interface AreaChartStyleOptions extends StandardOptions {
   // Basic controls
   addLegend?: boolean;
   legendPosition?: Positions;
@@ -80,13 +81,6 @@ export interface AreaChartStyleOptions {
   showFullTimeRange?: boolean;
   stackMode?: StackMode;
   lineStyle?: LineStyle;
-
-  // Standard options
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
-  min?: number;
-  max?: number;
 }
 
 export type AreaChartStyle = Required<

--- a/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/area/area_vis_options.tsx
@@ -14,6 +14,7 @@ import { AxisRole, VisFieldType } from '../types';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
 import { AllAxesOptions } from '../style_panel/axes/standard_axes_options';
 import { AreaExclusiveVisOptions } from './area_exclusive_vis_options';
+import { StandardOptionsPanel } from '../style_panel/standard_options/standard_options_panel';
 
 export type AreaVisStyleControlsProps = StyleControlsProps<AreaChartStyle>;
 
@@ -83,6 +84,20 @@ export const AreaVisStyleControls: React.FC<AreaVisStyleControlsProps> = ({
               thresholdsOptions={styleOptions.thresholdOptions}
               onChange={(options) => updateStyleOption('thresholdOptions', options)}
               showThresholdStyle={true}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <StandardOptionsPanel
+              min={styleOptions.min}
+              max={styleOptions.max}
+              onMinChange={(value) => updateStyleOption('min', value)}
+              onMaxChange={(value) => updateStyleOption('max', value)}
+              unit={styleOptions.unitId}
+              onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.test.ts
@@ -88,7 +88,7 @@ describe('bar_chart_utils', () => {
         headers: ['category', 'count'],
       }) as any;
 
-      expect(label.formatter({ value: ['a', 23.456] })).toBe('23.46%');
+      expect(label.formatter({ value: ['a', 0.23456] })).toBe('23.46%');
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.test.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { buildBarRadius, buildValueLabel, inferTimeIntervals } from './bar_chart_utils';
+import { buildBarRadius, inferTimeIntervals } from './bar_chart_utils';
 import { TimeUnit } from '../types';
-import { BarChartStyle } from './bar_vis_config';
 
 describe('bar_chart_utils', () => {
   describe('inferTimeIntervals', () => {
@@ -52,43 +51,6 @@ describe('bar_chart_utils', () => {
       expect(
         buildBarRadius({ barRadius: 8, seriesEncode: 'y', isStacked: true, isTopSegment: true })
       ).toEqual({ borderRadius: [8, 8, 0, 0] });
-    });
-  });
-
-  describe('buildValueLabel', () => {
-    const styles = (overrides: Partial<BarChartStyle>) =>
-      ({ showValues: true, ...overrides }) as BarChartStyle;
-
-    it('returns nothing when showValues is off', () => {
-      expect(
-        buildValueLabel({
-          styles: { showValues: false } as unknown as BarChartStyle,
-          seriesField: 'count',
-          headers: ['category', 'count'],
-        })
-      ).toEqual({});
-    });
-
-    it('formats the value of its own column', () => {
-      const { label } = buildValueLabel({
-        styles: styles({}),
-        seriesField: 'count',
-        headers: ['category', 'count'],
-      }) as any;
-
-      expect(label.show).toBe(true);
-      expect(label.position).toBe('inside');
-      expect(label.formatter({ value: ['a', 12.345] })).toBe('12.35');
-    });
-
-    it('adds a percent unit when stacking to 100%', () => {
-      const { label } = buildValueLabel({
-        styles: styles({ stackMode: 'percentage' }),
-        seriesField: 'count',
-        headers: ['category', 'count'],
-      }) as any;
-
-      expect(label.formatter({ value: ['a', 0.23456] })).toBe('23.46%');
     });
   });
 });

--- a/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.ts
@@ -5,8 +5,7 @@
 
 import { BarSeriesOption } from 'echarts';
 import { TimeUnit } from '../types';
-import { formatSeriesValueLabel, generateThresholdLines } from '../utils/utils';
-import { formatUnitValue } from '../style_panel/unit/collection';
+import { generateThresholdLines } from '../utils/utils';
 import { BarChartStyle, DEFAULT_BAR_FILL_OPACITY } from './bar_vis_config';
 import { BaseChartStyle, PipelineFn } from '../utils/echarts_spec';
 import { getSeriesDisplayName } from '../utils/series';
@@ -17,6 +16,7 @@ import {
   getLegendNameDomain,
   LegendItem,
 } from '../utils/legend';
+import { buildValueLabel } from '../style_panel/share/value_label_options';
 import { resolveStackMode } from '../utils/data_transformation';
 
 export const buildStackConfig = (styles: BarChartStyle) =>
@@ -42,40 +42,6 @@ export const buildBarRadius = ({
   const radius = seriesEncode === 'x' ? [0, barRadius, barRadius, 0] : [barRadius, barRadius, 0, 0];
 
   return { borderRadius: radius };
-};
-
-export const buildValueLabelLayout = (isStacked: boolean) =>
-  isStacked ? { hideOverlap: true } : {};
-
-export const buildValueLabel = ({
-  styles,
-  seriesField,
-  headers,
-}: {
-  styles: BarChartStyle;
-  seriesField: string;
-  headers?: string[];
-}) => {
-  if (!styles.showValues) return {};
-
-  const isPercentage = resolveStackMode(styles) === 'percentage';
-  const isStacked = resolveStackMode(styles) !== 'none';
-  const valueIndex = headers?.indexOf(seriesField) ?? -1;
-
-  return {
-    label: {
-      show: true,
-      position: 'inside' as const,
-      formatter: (params: any) => {
-        const value =
-          Array.isArray(params.value) && valueIndex >= 0 ? params.value[valueIndex] : params.value;
-        // Percentage stack will keep the % label; otherwise apply unit.
-        if (isPercentage) return formatSeriesValueLabel(value, true, styles.decimals);
-        return formatUnitValue(value, styles.unitId, styles.decimals, styles.unitSuffix);
-      },
-    },
-    labelLayout: buildValueLabelLayout(isStacked),
-  };
 };
 
 export const inferTimeIntervals = (data: Array<Record<string, any>>, field: string | undefined) => {
@@ -162,7 +128,6 @@ export const createBarSeries =
     const isStacked = 'stack' in stackConfig;
     // Series are stacked in order, so assume the last one sits on top of the stack
     const topSegmentIndex = seriesFields.length - 1;
-    const headers: string[] | undefined = transformedData[0];
 
     const series = seriesFields.map((seriesField, index) => {
       const name = getSeriesDisplayName(seriesField, allColumns);
@@ -197,9 +162,14 @@ export const createBarSeries =
         },
         // apply value labels based on showValues
         ...buildValueLabel({
-          styles,
-          seriesField,
-          headers,
+          showValues: styles.showValues,
+          valueField: seriesField,
+          decimals: styles.decimals,
+          unitId: styles.unitId,
+          unitSuffix: styles.unitSuffix,
+          isPercentage: resolveStackMode(styles) === 'percentage',
+          isStack: resolveStackMode(styles) !== 'none',
+          chartType: 'bar',
         }),
         // Apply stack configuration based on stackMode
         ...stackConfig,

--- a/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_chart_utils.ts
@@ -6,6 +6,7 @@
 import { BarSeriesOption } from 'echarts';
 import { TimeUnit } from '../types';
 import { formatSeriesValueLabel, generateThresholdLines } from '../utils/utils';
+import { formatUnitValue } from '../style_panel/unit/collection';
 import { BarChartStyle, DEFAULT_BAR_FILL_OPACITY } from './bar_vis_config';
 import { BaseChartStyle, PipelineFn } from '../utils/echarts_spec';
 import { getSeriesDisplayName } from '../utils/series';
@@ -68,7 +69,9 @@ export const buildValueLabel = ({
       formatter: (params: any) => {
         const value =
           Array.isArray(params.value) && valueIndex >= 0 ? params.value[valueIndex] : params.value;
-        return formatSeriesValueLabel(value, isPercentage);
+        // Percentage stack will keep the % label; otherwise apply unit.
+        if (isPercentage) return formatSeriesValueLabel(value, true, styles.decimals);
+        return formatUnitValue(value, styles.unitId, styles.decimals, styles.unitSuffix);
       },
     },
     labelLayout: buildValueLabelLayout(isStacked),

--- a/src/plugins/explore/public/components/visualizations/bar/bar_exclusive_vis_options.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_exclusive_vis_options.test.tsx
@@ -265,10 +265,8 @@ describe('BarExclusiveVisOptions', () => {
     expect(defaultProps.onShowValuesChange).toHaveBeenCalledWith(true);
   });
 
-  test('does not render radius or show values for histogram type', () => {
+  test('should show values for histogram type', () => {
     render(<BarExclusiveVisOptions {...defaultProps} type="histogram" />);
-
-    expect(screen.queryByTestId('barRadiusRange')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('barShowValuesSwitch')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('barShowValuesSwitch')).toBeInTheDocument();
   });
 });

--- a/src/plugins/explore/public/components/visualizations/bar/bar_exclusive_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_exclusive_vis_options.tsx
@@ -192,7 +192,6 @@ export const BarExclusiveVisOptions = ({
           />
         </>
       )}
-
       {renderManualSizeOptions(type)}
       {type === 'bar' && (
         <>
@@ -215,20 +214,20 @@ export const BarExclusiveVisOptions = ({
             />
           </EuiFormRow>
           <EuiSpacer size="s" />
-          <EuiFormRow>
-            <EuiSwitch
-              compressed
-              label={i18n.translate('explore.stylePanel.bar.showValues', {
-                defaultMessage: 'Show values',
-              })}
-              checked={showValues ?? false}
-              onChange={(e) => onShowValuesChange?.(e.target.checked)}
-              data-test-subj="barShowValuesSwitch"
-            />
-          </EuiFormRow>
-          <EuiSpacer size="s" />
         </>
       )}
+      <EuiFormRow>
+        <EuiSwitch
+          compressed
+          label={i18n.translate('explore.stylePanel.bar.showValues', {
+            defaultMessage: 'Show values',
+          })}
+          checked={showValues ?? false}
+          onChange={(e) => onShowValuesChange?.(e.target.checked)}
+          data-test-subj="barShowValuesSwitch"
+        />
+      </EuiFormRow>
+      <EuiSpacer size="s" />
       <EuiFormRow>
         <EuiSwitch
           compressed

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
@@ -19,6 +19,7 @@ import {
   TimeUnit,
   ThresholdOptions,
   StackMode,
+  StandardOptions,
 } from '../types';
 import { BarVisStyleControls } from './bar_vis_options';
 import { DEFAULT_X_AXIS_CONFIG } from '../constants';
@@ -34,7 +35,7 @@ import { EchartsRender } from '../echarts_render';
 
 export const DEFAULT_BAR_FILL_OPACITY = 1;
 
-export interface BarChartStyleOptions {
+export interface BarChartStyleOptions extends StandardOptions {
   // Basic controls
   addLegend?: boolean;
   legendPosition?: Positions;
@@ -68,13 +69,6 @@ export interface BarChartStyleOptions {
   useThresholdColor?: boolean;
   showFullTimeRange?: boolean;
   fillOpacity?: number;
-
-  // Standard options
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
-  min?: number;
-  max?: number;
 }
 
 export type BarChartStyle = Required<

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_config.tsx
@@ -68,15 +68,42 @@ export interface BarChartStyleOptions {
   useThresholdColor?: boolean;
   showFullTimeRange?: boolean;
   fillOpacity?: number;
+
+  // Standard options
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
+  min?: number;
+  max?: number;
 }
 
 export type BarChartStyle = Required<
   Omit<
     BarChartStyleOptions,
-    'legendShape' | 'thresholdLines' | 'legendTitle' | 'barRadius' | 'fillOpacity'
+    | 'legendShape'
+    | 'thresholdLines'
+    | 'legendTitle'
+    | 'barRadius'
+    | 'fillOpacity'
+    | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
+    | 'min'
+    | 'max'
   >
 > &
-  Pick<BarChartStyleOptions, 'legendShape' | 'legendTitle' | 'barRadius' | 'fillOpacity'>;
+  Pick<
+    BarChartStyleOptions,
+    | 'legendShape'
+    | 'legendTitle'
+    | 'barRadius'
+    | 'fillOpacity'
+    | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
+    | 'min'
+    | 'max'
+  >;
 
 export const MIN_BAR_RADIUS = 0;
 export const MAX_BAR_RADIUS = 20;

--- a/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar/bar_vis_options.tsx
@@ -15,6 +15,7 @@ import { AllAxesOptions } from '../style_panel/axes/standard_axes_options';
 import { AxisRole, VisFieldType } from '../types';
 import { BucketOptionsPanel } from './bucket_options';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
+import { StandardOptionsPanel } from '../style_panel/standard_options/standard_options_panel';
 
 export type BarVisStyleControlsProps = StyleControlsProps<BarChartStyle>;
 
@@ -104,6 +105,20 @@ export const BarVisStyleControls: React.FC<BarVisStyleControlsProps> = ({
               thresholdsOptions={styleOptions.thresholdOptions}
               onChange={(options) => updateStyleOption('thresholdOptions', options)}
               showThresholdStyle={true}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <StandardOptionsPanel
+              min={styleOptions.min}
+              max={styleOptions.max}
+              onMinChange={(value) => updateStyleOption('min', value)}
+              onMaxChange={(value) => updateStyleOption('max', value)}
+              unit={styleOptions.unitId}
+              onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
@@ -235,7 +235,10 @@ describe('bar to_expression', () => {
         }
       );
 
-      expect(spec.series[0].label.formatter({ value: ['A', 1, null, null] })).toBe('100%');
+      const dimensionNames = spec.dataset.source[0];
+      expect(spec.series[0].label.formatter({ value: ['A', 1, null, null], dimensionNames })).toBe(
+        '100%'
+      );
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
@@ -235,8 +235,7 @@ describe('bar to_expression', () => {
         }
       );
 
-      // The first segment of the first row is normalized to 100% of that row
-      expect(spec.series[0].label.formatter({ value: ['A', 100, null, null] })).toBe('100%');
+      expect(spec.series[0].label.formatter({ value: ['A', 1, null, null] })).toBe('100%');
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.test.tsx
@@ -33,6 +33,11 @@ jest.mock('./bar_gauge_item', () => ({
 
 jest.mock('../style_panel/unit/collection', () => ({
   getUnitById: jest.fn(() => undefined),
+  appendUnitSuffix: jest.fn((text: string | number, suffix?: string) => {
+    const base = String(text);
+    if (!suffix) return base;
+    return suffix.startsWith('/') ? `${base}${suffix}` : `${base} ${suffix}`;
+  }),
 }));
 
 const defaultStyles = defaultBarGaugeChartStyles;

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.tsx
@@ -8,7 +8,8 @@ import { debounce } from 'lodash';
 import { Threshold } from '../types';
 import { BarGaugeChartStyle } from './bar_gauge_vis_config';
 import { DEFAULT_GREY, getColors } from '../theme/default_colors';
-import { getUnitById } from '../style_panel/unit/collection';
+import { getUnitById, appendUnitSuffix } from '../style_panel/unit/collection';
+import { formatDecimal } from '../utils/data_transformation';
 import { BarGaugeItem, BarGaugeItemData } from './bar_gauge_item';
 import './bar_gauge_component.scss';
 
@@ -90,14 +91,14 @@ export const BarGaugeRender = ({ data, styles, isHorizontal }: BarGaugeRenderPro
   const formatValue = useCallback(
     (value: number | null): string => {
       if (value === null) return '-';
-      if (selectedUnit?.display) {
-        return String(selectedUnit.display(value, selectedUnit.symbol).label);
-      }
-      return `${Math.round(value * 100) / 100}${
-        selectedUnit?.symbol ? ` ${selectedUnit.symbol}` : ''
-      }`;
+      const base = selectedUnit?.display
+        ? String(selectedUnit.display(value, selectedUnit.symbol, styles.decimals).label)
+        : `${formatDecimal(value, styles.decimals)}${
+            selectedUnit?.symbol ? ` ${selectedUnit.symbol}` : ''
+          }`;
+      return appendUnitSuffix(base, styles.unitSuffix);
     },
-    [selectedUnit]
+    [selectedUnit, styles.decimals, styles.unitSuffix]
   );
 
   const getFontColor = useCallback(

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_config.tsx
@@ -26,12 +26,14 @@ export interface BarGaugeChartStyleOptions {
   min?: number;
   max?: number;
   unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
 }
 
 export type BarGaugeChartStyle = Required<
-  Omit<BarGaugeChartStyleOptions, 'min' | 'max' | 'unitId'>
+  Omit<BarGaugeChartStyleOptions, 'min' | 'max' | 'unitId' | 'unitSuffix' | 'decimals'>
 > &
-  Pick<BarGaugeChartStyleOptions, 'min' | 'max' | 'unitId'>;
+  Pick<BarGaugeChartStyleOptions, 'min' | 'max' | 'unitId' | 'unitSuffix' | 'decimals'>;
 
 export const defaultBarGaugeChartStyles: BarGaugeChartStyle = {
   tooltipOptions: {

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_config.tsx
@@ -6,7 +6,13 @@
 import React from 'react';
 import { VisRule, VisualizationType } from '../utils/use_visualization_types';
 import { BarGaugeVisStyleControls } from './bar_gauge_vis_options';
-import { AxisRole, VisFieldType, ThresholdOptions, TooltipOptions } from '../types';
+import {
+  AxisRole,
+  VisFieldType,
+  ThresholdOptions,
+  TooltipOptions,
+  StandardOptions,
+} from '../types';
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
 import { BarGaugeRender } from './bar_gauge_render';
@@ -18,16 +24,11 @@ export interface ExclusiveBarGaugeConfig {
   showUnfilledArea: boolean;
 }
 
-export interface BarGaugeChartStyleOptions {
+export interface BarGaugeChartStyleOptions extends StandardOptions {
   tooltipOptions?: TooltipOptions;
   exclusive?: ExclusiveBarGaugeConfig;
   thresholdOptions?: ThresholdOptions;
   valueCalculation?: CalculationMethod;
-  min?: number;
-  max?: number;
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
 }
 
 export type BarGaugeChartStyle = Required<

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_vis_options.tsx
@@ -76,6 +76,10 @@ export const BarGaugeVisStyleControls: React.FC<BarGaugeVisStyleControlsProps> =
               onMaxChange={(value) => updateStyleOption('max', value)}
               unit={styleOptions.unitId}
               onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
 

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_chart_utils.ts
@@ -59,7 +59,13 @@ export const createGaugeSeries =
 
       const selectedUnit = getUnitById(styles?.unitId);
 
-      const displayValue = showDisplayValue(isValidNumber, selectedUnit, calculatedValue);
+      const displayValue = showDisplayValue(
+        isValidNumber,
+        selectedUnit,
+        calculatedValue,
+        styles?.decimals,
+        styles?.unitSuffix
+      );
 
       const { minBase, maxBase } = getMaxAndMinBase(
         minNumber,

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
@@ -6,17 +6,15 @@
 import React from 'react';
 import { VisRule, VisualizationType } from '../utils/use_visualization_types';
 import { GaugeVisStyleControls } from './gauge_vis_options';
-import { ThresholdOptions, AxisRole, VisFieldType, Threshold } from '../types';
+import { ThresholdOptions, AxisRole, VisFieldType, Threshold, StandardOptions } from '../types';
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
 import { createGauge } from './to_expression';
 import { EchartsRender } from '../echarts_render';
 
-export interface GaugeChartStyleOptions {
+export interface GaugeChartStyleOptions extends StandardOptions {
   showTitle?: boolean;
   title?: string;
-  min?: number;
-  max?: number;
 
   /**
    * @deprecated - use thresholdOptions instead
@@ -27,9 +25,6 @@ export interface GaugeChartStyleOptions {
    */
   thresholds?: Threshold[];
   valueCalculation?: CalculationMethod;
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
   thresholdOptions?: ThresholdOptions;
   useThresholdColor?: boolean;
 }

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_config.tsx
@@ -28,14 +28,19 @@ export interface GaugeChartStyleOptions {
   thresholds?: Threshold[];
   valueCalculation?: CalculationMethod;
   unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
   thresholdOptions?: ThresholdOptions;
   useThresholdColor?: boolean;
 }
 
 export type GaugeChartStyle = Required<
-  Omit<GaugeChartStyleOptions, 'min' | 'max' | 'unitId' | 'baseColor' | 'thresholds'>
+  Omit<
+    GaugeChartStyleOptions,
+    'min' | 'max' | 'unitId' | 'unitSuffix' | 'decimals' | 'baseColor' | 'thresholds'
+  >
 > &
-  Pick<GaugeChartStyleOptions, 'min' | 'max' | 'unitId'>;
+  Pick<GaugeChartStyleOptions, 'min' | 'max' | 'unitId' | 'unitSuffix' | 'decimals'>;
 
 export const defaultGaugeChartStyles: GaugeChartStyle = {
   showTitle: true,

--- a/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/gauge/gauge_vis_options.tsx
@@ -126,6 +126,10 @@ export const GaugeVisStyleControls: React.FC<GaugeVisStyleControlsProps> = ({
               onMaxChange={(value) => updateStyleOption('max', value)}
               unit={styleOptions.unitId}
               onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
         </>

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_chart_utils.ts
@@ -11,6 +11,7 @@ import { getColors, DEFAULT_GREY } from '../theme/default_colors';
 import { BaseChartStyle, EChartsSpecState, PipelineFn } from '../utils/echarts_spec';
 import { rgbToHex, hexToRgb } from '../theme/color_utils';
 import { getSeriesDisplayName } from '../utils/series';
+import { formatUnitValue } from '../style_panel/unit/collection';
 import { DEFAULT_GRID } from '../constants';
 
 // Uses Interquartile Range method to find robust min/max values by excluding statistical outliers
@@ -163,7 +164,9 @@ export const createHeatmapSeries =
           ...(styles.exclusive.label.rotate && { rotate: 45 }),
           formatter: (params: any) => {
             const v = Array.isArray(params.value) ? params.value[seriesIndex] : params.value;
-            return typeof v === 'number' ? v.toFixed(2) : v; // trim to 2 decimals
+            return typeof v === 'number'
+              ? formatUnitValue(v, styles.unitId, styles.decimals, styles.unitSuffix)
+              : v;
           },
         },
         tooltip: {
@@ -190,11 +193,17 @@ export const createHeatmapSeries =
             const categoryIndex = transformedData[0].indexOf(categoryFields[0]);
             const category2Index = transformedData[0].indexOf(categoryFields[1]);
 
+            const rawSeriesValue = params.value[seriesIndex];
+            const seriesValue =
+              typeof rawSeriesValue === 'number'
+                ? formatUnitValue(rawSeriesValue, styles.unitId, styles.decimals, styles.unitSuffix)
+                : (rawSeriesValue ?? '');
+
             const message = `<strong>${categoryDisplayName}</strong>: ${
               params.value[categoryIndex] ?? ''
             }<br/><strong>${categoryDisplayName2}</strong>: ${
               params.value[category2Index] ?? ''
-            }<br/><strong>${seriesDisplayName}</strong>: ${params.value[seriesIndex] ?? ''}`;
+            }<br/><strong>${seriesDisplayName}</strong>: ${seriesValue}`;
 
             return DOMPurify.sanitize(message);
           },

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.tsx
@@ -64,10 +64,17 @@ export interface HeatmapChartStyleOptions {
 
   useThresholdColor?: boolean;
   thresholdOptions?: ThresholdOptions;
+
+  // Standard options
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
 }
 
-export type HeatmapChartStyle = Required<Omit<HeatmapChartStyleOptions, 'legendTitle'>> &
-  Pick<HeatmapChartStyleOptions, 'legendTitle'>;
+export type HeatmapChartStyle = Required<
+  Omit<HeatmapChartStyleOptions, 'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals'>
+> &
+  Pick<HeatmapChartStyleOptions, 'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals'>;
 
 export const defaultHeatmapChartStyles: HeatmapChartStyle = {
   // Basic controls

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_config.tsx
@@ -17,6 +17,7 @@ import {
   AggregationType,
   VisFieldType,
   ThresholdOptions,
+  StandardOptions,
 } from '../types';
 import { getColors } from '../theme/default_colors';
 import { DEFAULT_X_AXIS_CONFIG, DEFAULT_Y_AXIS_CONFIG } from '../constants';
@@ -49,7 +50,7 @@ export interface ExclusiveHeatmapConfig {
   customRanges?: RangeValue[];
 }
 // Complete heatmap chart style options interface
-export interface HeatmapChartStyleOptions {
+export interface HeatmapChartStyleOptions extends StandardOptions {
   // Basic controls
   tooltipOptions?: TooltipOptions;
   addLegend?: boolean;
@@ -64,15 +65,13 @@ export interface HeatmapChartStyleOptions {
 
   useThresholdColor?: boolean;
   thresholdOptions?: ThresholdOptions;
-
-  // Standard options
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
 }
 
 export type HeatmapChartStyle = Required<
-  Omit<HeatmapChartStyleOptions, 'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals'>
+  Omit<
+    HeatmapChartStyleOptions,
+    'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals' | 'min' | 'max'
+  >
 > &
   Pick<HeatmapChartStyleOptions, 'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals'>;
 

--- a/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/heatmap/heatmap_vis_options.tsx
@@ -14,6 +14,7 @@ import { AllAxesOptions } from '../style_panel/axes/standard_axes_options';
 import { StyleControlsProps } from '../utils/use_visualization_types';
 import { AxisRole } from '../types';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
+import { StandardOptionsPanel } from '../style_panel/standard_options/standard_options_panel';
 
 export type HeatmapVisStyleControlsProps = StyleControlsProps<HeatmapChartStyle>;
 
@@ -59,6 +60,16 @@ export const HeatmapVisStyleControls: React.FC<HeatmapVisStyleControlsProps> = (
             <ThresholdPanel
               thresholdsOptions={styleOptions.thresholdOptions}
               onChange={(options) => updateStyleOption('thresholdOptions', options)}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <StandardOptionsPanel
+              unit={styleOptions.unitId}
+              onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.test.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.test.ts
@@ -13,6 +13,7 @@ jest.mock('../theme/default_colors', () => ({
     categories: ['#00BFB3'],
     backgroundShade: '#F5F7FA',
     statusGreen: '#00BFB3',
+    text: '#000000',
   }),
 }));
 
@@ -21,6 +22,7 @@ jest.mock('../utils/series', () => ({
 }));
 
 jest.mock('../utils/utils', () => ({
+  formatSeriesValueLabel: jest.fn((value: unknown) => String(value)),
   generateThresholdLines: jest.fn(() => ({})),
   getValueColorByThreshold: jest.fn(() => '#00BFB3'),
 }));
@@ -363,6 +365,45 @@ describe('createHistogramSeries', () => {
 
       expect(series.encode.x).toBe('start');
       expect(series.encode.y).toBe('count');
+    });
+
+    it('should render value labels', () => {
+      const options = {
+        styles: {
+          ...mockStyles,
+          showValue: true,
+          unitSuffix: 'ms',
+        },
+        binStartField: 'start',
+        binEndField: 'end',
+        seriesFields: ['count'],
+      };
+
+      const state = {
+        data: [],
+        styles: mockStyles,
+        transformedData: [
+          ['start', 'end', 'count'],
+          [0, 10, 5],
+        ],
+        axisColumnMappings: {},
+      } as any;
+
+      const result = createHistogramSeries(options)(state);
+      const series = result.series![0] as any;
+      const mockApi = {
+        value: jest.fn((index: number) => [0, 10, 5][index]),
+        coord: jest.fn((point: number[]) => {
+          if (point[1] === 0) return [100, 200];
+          return [150, 150];
+        }),
+      };
+      const renderResult = series.renderItem({}, mockApi);
+      const textNode = renderResult.children[1];
+
+      expect(renderResult.children).toHaveLength(2);
+      expect(textNode.type).toBe('text');
+      expect(textNode.style.text).toBe('5');
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
@@ -6,7 +6,11 @@
 import { CustomSeriesOption, EChartsOption, format } from 'echarts';
 import { BaseChartStyle, PipelineFn } from '../utils/echarts_spec';
 import { getSeriesDisplayName } from '../utils/series';
-import { generateThresholdLines, getValueColorByThreshold } from '../utils/utils';
+import {
+  formatSeriesValueLabel,
+  generateThresholdLines,
+  getValueColorByThreshold,
+} from '../utils/utils';
 import { HistogramChartStyle } from './histogram_vis_config';
 import { getColors } from '../theme/default_colors';
 import { getDecimalPrecision, roundToPrecision } from '../utils/data_transformation';
@@ -36,6 +40,16 @@ export const formatHistogramBucketValue = (
     return formatUnitValue(rounded, unit.unitId, unit.decimals, unit.unitSuffix);
   }
   return rounded.toString();
+};
+
+export const formatBucketValue = (value: unknown, unit?: { decimals?: number }): string => {
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue)) {
+    return String(value);
+  }
+
+  return formatSeriesValueLabel(numericValue, undefined, unit?.decimals);
 };
 
 export const createHistogramSeries =
@@ -91,10 +105,12 @@ export const createHistogramSeries =
           x: binStartField,
           y: seriesField,
         },
+
         ...(index === 0 && thresholdLines),
         renderItem(params, api) {
           const xValue = api.value(binStartIndex) as number;
           const yValue = api.value(seriesFieldIndex) as number;
+          const valueLabel = formatSeriesValueLabel(yValue, false, styles.decimals);
 
           // Convert data coordinates to pixel coordinates
           const start = api.coord([xValue, 0]);
@@ -125,6 +141,22 @@ export const createHistogramSeries =
                     : { lineWidth: 1 }),
                 },
               },
+              ...(styles.showValue
+                ? [
+                    {
+                      type: 'text',
+                      silent: true,
+                      style: {
+                        x: start[0] + width / 2,
+                        y: end[1],
+                        text: valueLabel,
+                        textAlign: 'center',
+                        textVerticalAlign: 'bottom',
+                        fill: getColors().text,
+                      },
+                    },
+                  ]
+                : []),
             ],
           };
         },
@@ -162,7 +194,7 @@ export const createHistogramSeries =
             ) ?? '-';
           return `${bucketStart} - ${bucketEnd}<p><span>${
             params.seriesName ?? 'value'
-          }</span> <b>${value}</b></p>`;
+          }</span> <b>${formatBucketValue(value, styles)}</b></p>`;
         }
         return '-';
       },
@@ -182,7 +214,10 @@ export const createHistogramSeries =
     if (newState.xAxisConfig) {
       const xAxisConfig = { ...newState.xAxisConfig };
 
-      const isMinMaxInValid = styles.min != null && styles.max != null && styles.min >= styles.max;
+      const isMinMaxInValid =
+        (styles.min != null && styles.max != null && styles.min >= styles.max) ||
+        (styles.min != null && styles.min >= max) ||
+        (styles.max != null && styles.max <= min);
       xAxisConfig.min = (isMinMaxInValid ? undefined : styles.min) ?? min;
       xAxisConfig.max = (isMinMaxInValid ? undefined : styles.max) ?? max;
       xAxisConfig.interval = bucketSize;

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_chart_utils.ts
@@ -10,6 +10,7 @@ import { generateThresholdLines, getValueColorByThreshold } from '../utils/utils
 import { HistogramChartStyle } from './histogram_vis_config';
 import { getColors } from '../theme/default_colors';
 import { getDecimalPrecision, roundToPrecision } from '../utils/data_transformation';
+import { formatUnitValue } from '../style_panel/unit/collection';
 
 interface Options {
   styles: HistogramChartStyle;
@@ -18,14 +19,23 @@ interface Options {
   seriesFields: string[] | ((headers?: string[]) => string[]);
 }
 
-export const formatHistogramBucketValue = (value: unknown, bucketPrecision: number): string => {
+// Histogram applies unit on bucket value
+export const formatHistogramBucketValue = (
+  value: unknown,
+  bucketPrecision: number,
+  unit?: { unitId?: string; decimals?: number; unitSuffix?: string }
+): string => {
   const numericValue = Number(value);
 
   if (!Number.isFinite(numericValue)) {
     return String(value);
   }
 
-  return roundToPrecision(numericValue, bucketPrecision).toString();
+  const rounded = roundToPrecision(numericValue, bucketPrecision);
+  if (unit && (unit.unitId || unit.decimals != null || unit.unitSuffix)) {
+    return formatUnitValue(rounded, unit.unitId, unit.decimals, unit.unitSuffix);
+  }
+  return rounded.toString();
 };
 
 export const createHistogramSeries =
@@ -76,6 +86,7 @@ export const createHistogramSeries =
         type: 'custom',
         id: seriesField,
         name,
+        clip: true,
         encode: {
           x: binStartField,
           y: seriesField,
@@ -133,14 +144,16 @@ export const createHistogramSeries =
             format.encodeHTML(
               formatHistogramBucketValue(
                 params.value[dimensionNames.indexOf(binStartField)],
-                bucketPrecision
+                bucketPrecision,
+                styles
               )
             ) ?? '-';
           const bucketEnd =
             format.encodeHTML(
               formatHistogramBucketValue(
                 params.value[dimensionNames.indexOf(binEndField)],
-                bucketPrecision
+                bucketPrecision,
+                styles
               )
             ) ?? '-';
           const value =
@@ -168,14 +181,28 @@ export const createHistogramSeries =
     // Histogram axis config
     if (newState.xAxisConfig) {
       const xAxisConfig = { ...newState.xAxisConfig };
-      xAxisConfig.min = min;
-      xAxisConfig.max = max;
+
+      const isMinMaxInValid = styles.min != null && styles.max != null && styles.min >= styles.max;
+      xAxisConfig.min = (isMinMaxInValid ? undefined : styles.min) ?? min;
+      xAxisConfig.max = (isMinMaxInValid ? undefined : styles.max) ?? max;
       xAxisConfig.interval = bucketSize;
       xAxisConfig.axisLabel = {
         ...xAxisConfig.axisLabel,
-        formatter: (value: unknown) => formatHistogramBucketValue(value, bucketPrecision),
+        formatter: (value: unknown) => formatHistogramBucketValue(value, bucketPrecision, styles),
       };
       newState.xAxisConfig = xAxisConfig;
+    }
+
+    // The Y axis is the bucket count, not the measured field.
+    // Delete any unit formatter or value label
+    if (newState.yAxisConfig && !Array.isArray(newState.yAxisConfig)) {
+      const yAxisConfig = { ...newState.yAxisConfig };
+      if (yAxisConfig.axisLabel?.formatter) {
+        yAxisConfig.axisLabel = { ...yAxisConfig.axisLabel, formatter: undefined };
+      }
+      delete yAxisConfig.min;
+      delete yAxisConfig.max;
+      newState.yAxisConfig = yAxisConfig;
     }
 
     return newState;

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_config.tsx
@@ -15,6 +15,7 @@ import {
   AggregationType,
   BucketOptions,
   ThresholdOptions,
+  StandardOptions,
 } from '../types';
 import { HistogramVisStyleControls } from './histogram_vis_options';
 import { DEFAULT_X_AXIS_CONFIG } from '../constants';
@@ -22,7 +23,7 @@ import { getColors } from '../theme/default_colors';
 import { createNumericalHistogramChart, createSingleHistogramChart } from './to_expression';
 import { EchartsRender } from '../echarts_render';
 
-export interface HistogramChartStyleOptions {
+export interface HistogramChartStyleOptions extends StandardOptions {
   // Basic controls
   tooltipOptions?: TooltipOptions;
 
@@ -42,13 +43,7 @@ export interface HistogramChartStyleOptions {
   thresholdOptions?: ThresholdOptions;
 
   useThresholdColor?: boolean;
-
-  // Standard options
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
-  min?: number;
-  max?: number;
+  showValue?: boolean;
 }
 
 export type HistogramChartStyle = Required<
@@ -87,6 +82,7 @@ export const defaultHistogramChartStyles: HistogramChartStyle = {
   bucket: {
     aggregationType: AggregationType.SUM,
   },
+  showValue: false,
 };
 
 export const createHistogramConfig = (): VisualizationType<'histogram'> => ({

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_config.tsx
@@ -42,9 +42,19 @@ export interface HistogramChartStyleOptions {
   thresholdOptions?: ThresholdOptions;
 
   useThresholdColor?: boolean;
+
+  // Standard options
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
+  min?: number;
+  max?: number;
 }
 
-export type HistogramChartStyle = Required<HistogramChartStyleOptions>;
+export type HistogramChartStyle = Required<
+  Omit<HistogramChartStyleOptions, 'unitId' | 'unitSuffix' | 'decimals' | 'min' | 'max'>
+> &
+  Pick<HistogramChartStyleOptions, 'unitId' | 'unitSuffix' | 'decimals' | 'min' | 'max'>;
 
 export const defaultHistogramChartStyles: HistogramChartStyle = {
   tooltipOptions: {

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.tsx
@@ -101,6 +101,7 @@ export const HistogramVisStyleControls: React.FC<HistogramVisStyleControlsProps>
               barBorderWidth={styleOptions.barBorderWidth}
               barBorderColor={styleOptions.barBorderColor}
               useThresholdColor={styleOptions?.useThresholdColor}
+              showValues={styleOptions?.showValue}
               onBarSizeModeChange={(barSizeMode) => updateStyleOption('barSizeMode', barSizeMode)}
               onBarWidthChange={(barWidth) => updateStyleOption('barWidth', barWidth)}
               onBarPaddingChange={(barPadding) => updateStyleOption('barPadding', barPadding)}
@@ -116,6 +117,7 @@ export const HistogramVisStyleControls: React.FC<HistogramVisStyleControlsProps>
               onUseThresholdColorChange={(useThresholdColor) =>
                 updateStyleOption('useThresholdColor', useThresholdColor)
               }
+              onShowValuesChange={(showValue) => updateStyleOption('showValue', showValue)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/histogram/histogram_vis_options.tsx
@@ -14,6 +14,7 @@ import { AllAxesOptions } from '../style_panel/axes/standard_axes_options';
 import { AxisRole, VisFieldType } from '../types';
 import { BucketOptionsPanel } from '../bar/bucket_options';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
+import { StandardOptionsPanel } from '../style_panel/standard_options/standard_options_panel';
 
 export type HistogramVisStyleControlsProps = StyleControlsProps<HistogramChartStyle>;
 
@@ -47,7 +48,7 @@ export const HistogramVisStyleControls: React.FC<HistogramVisStyleControlsProps>
   // The mapping object will be an empty object if no fields are selected on the axes selector. No
   // visualization is generated in this case so we shouldn't display style option panels.
   const hasMappingSelected = !isEmpty(axisColumnMappings);
-  const hasColorMapping = !!axisColumnMappings?.[AxisRole.COLOR];
+
   return (
     <EuiFlexGroup direction="column" gutterSize="none">
       {hasMappingSelected && (
@@ -59,12 +60,25 @@ export const HistogramVisStyleControls: React.FC<HistogramVisStyleControlsProps>
               onChange={(bucket) => updateStyleOption('bucket', bucket)}
             />
           </EuiFlexItem>
-
           <EuiFlexItem>
             <ThresholdPanel
               thresholdsOptions={styleOptions.thresholdOptions}
               onChange={(options) => updateStyleOption('thresholdOptions', options)}
               showThresholdStyle={true}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <StandardOptionsPanel
+              min={styleOptions.min}
+              max={styleOptions.max}
+              onMinChange={(value) => updateStyleOption('min', value)}
+              onMaxChange={(value) => updateStyleOption('max', value)}
+              unit={styleOptions.unitId}
+              onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -102,10 +116,8 @@ export const HistogramVisStyleControls: React.FC<HistogramVisStyleControlsProps>
               onUseThresholdColorChange={(useThresholdColor) =>
                 updateStyleOption('useThresholdColor', useThresholdColor)
               }
-              shouldDisableUseThresholdColor={hasColorMapping}
             />
           </EuiFlexItem>
-
           <EuiFlexItem grow={false}>
             <TooltipOptionsPanel
               tooltipOptions={styleOptions.tooltipOptions}

--- a/src/plugins/explore/public/components/visualizations/line/line_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_chart_utils.ts
@@ -25,8 +25,18 @@ const generateLineStyles = (styles: LineChartStyle, valueField?: string) => {
   // other modes keep drawing their symbols at the size ECharts picks and stay unlabelled
   return {
     ...getPointSymbol(styles.pointSize, styles.showValues),
-    ...(styles.lineStyle === 'line' ? { showSymbol: false } : {}),
-    ...(valueField ? buildValueLabel(styles.showValues, valueField) : {}),
+    ...(styles.lineStyle === 'line'
+      ? styles.showValues
+        ? { showSymbol: true, symbolSize: 0 }
+        : { showSymbol: false }
+      : {}),
+    ...buildValueLabel(
+      styles.showValues,
+      valueField,
+      styles.decimals,
+      styles.unitId,
+      styles.unitSuffix
+    ),
     lineStyle: {
       width: lineWidth,
       type: getLineDashType(styles.lineDashStyle),

--- a/src/plugins/explore/public/components/visualizations/line/line_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/line/line_chart_utils.ts
@@ -30,13 +30,13 @@ const generateLineStyles = (styles: LineChartStyle, valueField?: string) => {
         ? { showSymbol: true, symbolSize: 0 }
         : { showSymbol: false }
       : {}),
-    ...buildValueLabel(
-      styles.showValues,
+    ...buildValueLabel({
+      showValues: styles.showValues,
       valueField,
-      styles.decimals,
-      styles.unitId,
-      styles.unitSuffix
-    ),
+      decimals: styles.decimals,
+      unitId: styles.unitId,
+      unitSuffix: styles.unitSuffix,
+    }),
     lineStyle: {
       width: lineWidth,
       type: getLineDashType(styles.lineDashStyle),
@@ -190,6 +190,16 @@ export const createLineBarSeries =
             x: categoryField,
             y: field,
           },
+          ...buildValueLabel({
+            showValues: styles.showValues,
+            valueField: field,
+            decimals: styles.decimals,
+            unitId: styles.unitId,
+            unitSuffix: styles.unitSuffix,
+            // force the value label to be positioned inside the bar
+            isStack: true,
+            chartType: 'bar',
+          }),
           emphasis: {
             focus: 'self',
           },

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
@@ -69,15 +69,34 @@ export interface LineChartStyleOptions {
   pointSize?: number;
   // Renders each data point's value
   showValues?: boolean;
+
+  // Standard options
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
+  min?: number;
+  max?: number;
 }
 
 export type LineChartStyle = Required<
   Omit<
     LineChartStyleOptions,
-    'thresholdLines' | 'legendTitle' | 'categoryAxes' | 'valueAxes' | 'pointSize'
+    | 'thresholdLines'
+    | 'legendTitle'
+    | 'categoryAxes'
+    | 'valueAxes'
+    | 'pointSize'
+    | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
+    | 'min'
+    | 'max'
   >
 > &
-  Pick<LineChartStyleOptions, 'legendTitle' | 'pointSize'>;
+  Pick<
+    LineChartStyleOptions,
+    'legendTitle' | 'pointSize' | 'unitId' | 'unitSuffix' | 'decimals' | 'min' | 'max'
+  >;
 
 export const defaultLineChartStyles: LineChartStyle = {
   addLegend: true,

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_config.tsx
@@ -19,7 +19,7 @@ import {
   LineDashStyle,
   LineStyle,
 } from '../types';
-import { TooltipOptions } from '../types';
+import { TooltipOptions, StandardOptions } from '../types';
 import { getColors } from '../theme/default_colors';
 import {
   createSimpleLineChart,
@@ -33,7 +33,7 @@ import { EchartsRender } from '../echarts_render';
 export type LineMode = 'straight' | 'smooth' | 'stepped';
 
 // Complete line chart style controls interface
-export interface LineChartStyleOptions {
+export interface LineChartStyleOptions extends StandardOptions {
   addLegend?: boolean;
   legendPosition?: Positions;
   // @deprecated - removed this once migrated to echarts
@@ -69,13 +69,6 @@ export interface LineChartStyleOptions {
   pointSize?: number;
   // Renders each data point's value
   showValues?: boolean;
-
-  // Standard options
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
-  min?: number;
-  max?: number;
 }
 
 export type LineChartStyle = Required<

--- a/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx
@@ -14,6 +14,7 @@ import { TooltipOptionsPanel } from '../style_panel/tooltip/tooltip';
 import { AxisRole, VisFieldType } from '../types';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
 import { AllAxesOptions } from '../style_panel/axes/standard_axes_options';
+import { StandardOptionsPanel } from '../style_panel/standard_options/standard_options_panel';
 
 export type LineVisStyleControlsProps = StyleControlsProps<LineChartStyle>;
 
@@ -77,6 +78,20 @@ export const LineVisStyleControls: React.FC<LineVisStyleControlsProps> = ({
               thresholdsOptions={styleOptions.thresholdOptions}
               onChange={(options) => updateStyleOption('thresholdOptions', options)}
               showThresholdStyle={true}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <StandardOptionsPanel
+              min={styleOptions.min}
+              max={styleOptions.max}
+              onMinChange={(value) => updateStyleOption('min', value)}
+              onMaxChange={(value) => updateStyleOption('max', value)}
+              unit={styleOptions.unitId}
+              onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
@@ -23,6 +23,7 @@ interface MetricTextData {
   numericValue: string;
   unitText: string;
   unitFirst: boolean; // True if unit should be displayed before value (e.g., currency)
+  unitSuffix: string;
   fillColor: string;
   changeText: string;
   changeColor: string;
@@ -202,6 +203,7 @@ function calculateMetricTextData(
   let valueText = '';
   let unitText = '';
   let unitFirst = false;
+  let unitSuffix = '';
 
   if (showValue) {
     if (isValidNumber && calculatedValue !== undefined) {
@@ -240,7 +242,9 @@ function calculateMetricTextData(
         unitText = selectedUnit?.symbol || '';
         unitFirst = false;
       }
-      unitText = appendUnitSuffix(unitText, styles.unitSuffix);
+      if (styles?.unitSuffix) {
+        unitSuffix = styles?.unitSuffix;
+      }
     } else {
       valueText = '-';
       unitText = '';
@@ -257,6 +261,7 @@ function calculateMetricTextData(
     changeColor,
     backgroundColor,
     backgroundGradient,
+    unitSuffix,
   };
 }
 
@@ -381,10 +386,11 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
     }
 
     // Build the full text string for each element
-    const fullValueText = textData.unitFirst
+    let fullValueText = textData.unitFirst
       ? `${textData.unitText}${textData.numericValue}`
       : `${textData.numericValue}${textData.unitText}`;
 
+    fullValueText = appendUnitSuffix(fullValueText, styles.unitSuffix);
     const titleText = title || '';
     const changeText = textData.changeText || '';
 
@@ -427,6 +433,7 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
     styles.showPercentage,
     title,
     textData,
+    styles.unitSuffix,
   ]);
 
   if (!s || !textData) {
@@ -504,6 +511,19 @@ export const MetricChartRender: React.FC<MetricChartRenderProps> = ({
               }}
             >
               {textData.unitText}
+            </span>
+          )}
+
+          {textData.unitSuffix && (
+            <span
+              className="metric-unit-suffix"
+              style={{
+                fontSize: valueFontSize * 0.45,
+                color: textData.fillColor,
+                marginLeft: textData.unitSuffix.startsWith('/') ? '0' : '0.2em',
+              }}
+            >
+              {textData.unitSuffix}
             </span>
           )}
         </div>

--- a/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_component.tsx
@@ -10,7 +10,8 @@ import { MetricChartStyle } from './metric_vis_config';
 import { AxisRole, RendererSpecConfig } from '../types';
 import { MetricAxisMapping } from './to_expression';
 import { calculatePercentage, calculateValue } from '../utils/calculation';
-import { getUnitById } from '../style_panel/unit/collection';
+import { getUnitById, appendUnitSuffix } from '../style_panel/unit/collection';
+import { formatDecimal } from '../utils/data_transformation';
 import { getColors, DEFAULT_GREY } from '../theme/default_colors';
 import { EchartsRender } from '../echarts_render';
 import { darkenHexColor, getContrastTextColor, normalizeHexColor } from '../utils/color';
@@ -206,7 +207,11 @@ function calculateMetricTextData(
     if (isValidNumber && calculatedValue !== undefined) {
       // Format the numeric value
       if (selectedUnit?.display) {
-        const unitDisplay = selectedUnit.display(calculatedValue, selectedUnit.symbol);
+        const unitDisplay = selectedUnit.display(
+          calculatedValue,
+          selectedUnit.symbol,
+          styles.decimals
+        );
 
         // Check if we have segments to extract value and unit separately
         if (unitDisplay.segments) {
@@ -231,10 +236,11 @@ function calculateMetricTextData(
         }
       } else {
         // Simple formatting without custom display
-        valueText = `${Math.round(calculatedValue * 100) / 100}`;
+        valueText = formatDecimal(calculatedValue, styles.decimals);
         unitText = selectedUnit?.symbol || '';
         unitFirst = false;
       }
+      unitText = appendUnitSuffix(unitText, styles.unitSuffix);
     } else {
       valueText = '-';
       unitText = '';

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.tsx
@@ -13,6 +13,7 @@ import {
   VisFieldType,
   PercentageColor,
   ThresholdOptions,
+  StandardOptions,
 } from '../types';
 import { CalculationMethod } from '../utils/calculation';
 import { getColors } from '../theme/default_colors';
@@ -24,7 +25,7 @@ export type LayoutType = 'horizontal' | 'vertical' | 'auto';
 export type TextMode = 'value' | 'name' | 'value_and_name' | 'none';
 export type ColorMode = 'none' | 'value' | 'background_gradient' | 'background_solid';
 
-export interface MetricChartStyleOptions {
+export interface MetricChartStyleOptions extends StandardOptions {
   showTitle?: boolean;
   title?: string;
   fontSize?: number;
@@ -45,12 +46,7 @@ export interface MetricChartStyleOptions {
    * @deprecated - use global thresholdOptions instead
    */
   customRanges?: RangeValue[];
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
   thresholdOptions?: ThresholdOptions;
-  min?: number;
-  max?: number;
   useThresholdColor?: boolean;
   layoutType?: LayoutType;
   textMode?: TextMode;

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_config.tsx
@@ -46,6 +46,8 @@ export interface MetricChartStyleOptions {
    */
   customRanges?: RangeValue[];
   unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
   thresholdOptions?: ThresholdOptions;
   min?: number;
   max?: number;
@@ -62,6 +64,8 @@ export type MetricChartStyle = Required<
     | 'titleSize'
     | 'percentageSize'
     | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
     | 'colorSchema'
     | 'customRanges'
     | 'useColor'
@@ -78,6 +82,8 @@ export type MetricChartStyle = Required<
     | 'titleSize'
     | 'percentageSize'
     | 'unitId'
+    | 'unitSuffix'
+    | 'decimals'
     | 'min'
     | 'max'
     | 'layoutType'

--- a/src/plugins/explore/public/components/visualizations/metric/metric_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/metric/metric_vis_options.tsx
@@ -191,6 +191,10 @@ export const MetricVisStyleControls: React.FC<MetricVisStyleControlsProps> = ({
               onMaxChange={(value) => updateStyleOption('max', value)}
               unit={styleOptions.unitId}
               onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem>

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.tsx
@@ -44,10 +44,25 @@ export interface ScatterChartStyleOptions {
 
   useThresholdColor?: boolean;
   thresholdOptions?: ThresholdOptions;
+
+  // Standard options
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
+  min?: number;
+  max?: number;
 }
 
-export type ScatterChartStyle = Required<Omit<ScatterChartStyleOptions, 'legendTitle'>> &
-  Pick<ScatterChartStyleOptions, 'legendTitle'>;
+export type ScatterChartStyle = Required<
+  Omit<
+    ScatterChartStyleOptions,
+    'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals' | 'min' | 'max'
+  >
+> &
+  Pick<
+    ScatterChartStyleOptions,
+    'legendTitle' | 'unitId' | 'unitSuffix' | 'decimals' | 'min' | 'max'
+  >;
 
 export const defaultScatterChartStyles: ScatterChartStyle = {
   // Basic controls

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_config.tsx
@@ -15,6 +15,7 @@ import {
   VisFieldType,
   ThresholdMode,
   ThresholdOptions,
+  StandardOptions,
 } from '../types';
 import { getColors } from '../theme/default_colors';
 import {
@@ -30,7 +31,7 @@ export interface ExclusiveScatterConfig {
   filled: boolean;
 }
 // Complete line chart style controls interface
-export interface ScatterChartStyleOptions {
+export interface ScatterChartStyleOptions extends StandardOptions {
   // Basic controls
   tooltipOptions?: TooltipOptions;
   addLegend?: boolean;
@@ -44,13 +45,6 @@ export interface ScatterChartStyleOptions {
 
   useThresholdColor?: boolean;
   thresholdOptions?: ThresholdOptions;
-
-  // Standard options
-  unitId?: string;
-  unitSuffix?: string;
-  decimals?: number;
-  min?: number;
-  max?: number;
 }
 
 export type ScatterChartStyle = Required<

--- a/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/scatter/scatter_vis_options.tsx
@@ -14,6 +14,7 @@ import { LegendOptionsWrapper } from '../style_panel/legend/legend_options_wrapp
 import { TooltipOptionsPanel } from '../style_panel/tooltip/tooltip';
 import { AxisRole } from '../types';
 import { ThresholdPanel } from '../style_panel/threshold/threshold_panel';
+import { StandardOptionsPanel } from '../style_panel/standard_options/standard_options_panel';
 
 export type ScatterVisStyleControlsProps = StyleControlsProps<ScatterChartStyle>;
 
@@ -59,6 +60,20 @@ export const ScatterVisStyleControls: React.FC<ScatterVisStyleControlsProps> = (
               thresholdsOptions={styleOptions.thresholdOptions}
               onChange={(options) => updateStyleOption('thresholdOptions', options)}
               showThresholdStyle={true}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <StandardOptionsPanel
+              min={styleOptions.min}
+              max={styleOptions.max}
+              onMinChange={(value) => updateStyleOption('min', value)}
+              onMaxChange={(value) => updateStyleOption('max', value)}
+              unit={styleOptions.unitId}
+              onUnitChange={(value) => updateStyleOption('unitId', value)}
+              decimals={styleOptions.decimals}
+              onDecimalsChange={(value) => updateStyleOption('decimals', value)}
+              unitSuffix={styleOptions.unitSuffix}
+              onUnitSuffixChange={(value) => updateStyleOption('unitSuffix', value)}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/src/plugins/explore/public/components/visualizations/style_panel/share/value_label_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/share/value_label_options.tsx
@@ -34,33 +34,44 @@ export const ShowValuesSwitch = ({
   );
 };
 
+interface BuildValueLabelProps {
+  showValues: boolean | undefined;
+  valueField?: string;
+  decimals?: number;
+  unitId?: string;
+  unitSuffix?: string;
+  isPercentage?: boolean;
+  isStack?: boolean;
+  chartType?: 'non_bar' | 'bar';
+}
 /**
  * Builds the ECharts label config that prints each data point's value.
  */
-export const buildValueLabel = (
-  showValues: boolean | undefined,
-  valueField?: string,
-  decimals?: number,
-  unitId?: string,
-  unitSuffix?: string,
-  isPercentage = false
-) => {
+export const buildValueLabel = ({
+  showValues,
+  valueField,
+  decimals,
+  unitId,
+  unitSuffix,
+  isStack = false,
+  isPercentage = false,
+  chartType = 'non_bar',
+}: BuildValueLabelProps) => {
   if (!showValues || !valueField) return {};
+  const isBar = chartType === 'bar';
   return {
     label: {
       show: showValues ?? false,
-      position: 'top' as const,
+      position: !isStack || !isBar ? 'top' : 'inside',
       formatter: (params: { value?: unknown; dimensionNames?: string[] }) => {
-        if (!Array.isArray(params.value)) {
-          return '';
-        }
         const valueIndex = params.dimensionNames?.indexOf(valueField) ?? -1;
-        const value = valueIndex >= 0 ? params.value[valueIndex] : undefined;
+        const value =
+          Array.isArray(params.value) && valueIndex >= 0 ? params.value[valueIndex] : params.value;
         // stack:Percentage won't consider unit display
         if (isPercentage) return formatSeriesValueLabel(value, true, decimals);
         return formatUnitValue(value, unitId, decimals, unitSuffix);
       },
     },
-    labelLayout: { hideOverlap: true },
+    labelLayout: isStack ? { hideOverlap: true } : {},
   };
 };

--- a/src/plugins/explore/public/components/visualizations/style_panel/share/value_label_options.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/share/value_label_options.tsx
@@ -5,6 +5,8 @@
 
 import { i18n } from '@osd/i18n';
 import { EuiSwitch } from '@elastic/eui';
+import { formatUnitValue } from '../unit/collection';
+import { formatSeriesValueLabel } from '../../utils/utils';
 
 interface ShowValuesSwitchProps {
   showValues?: boolean;
@@ -35,19 +37,30 @@ export const ShowValuesSwitch = ({
 /**
  * Builds the ECharts label config that prints each data point's value.
  */
-export const buildValueLabel = (showValues: boolean | undefined, valueField: string) => ({
-  label: {
-    show: showValues ?? false,
-    position: 'top' as const,
-    formatter: (params: { value?: unknown; dimensionNames?: string[] }) => {
-      if (!Array.isArray(params.value)) {
-        return '';
-      }
-      const valueIndex = params.dimensionNames?.indexOf(valueField) ?? -1;
-      const value = valueIndex >= 0 ? params.value[valueIndex] : undefined;
-      // TODO apply unit
-      return typeof value === 'number' ? String(Math.round(value * 100) / 100) : '';
+export const buildValueLabel = (
+  showValues: boolean | undefined,
+  valueField?: string,
+  decimals?: number,
+  unitId?: string,
+  unitSuffix?: string,
+  isPercentage = false
+) => {
+  if (!showValues || !valueField) return {};
+  return {
+    label: {
+      show: showValues ?? false,
+      position: 'top' as const,
+      formatter: (params: { value?: unknown; dimensionNames?: string[] }) => {
+        if (!Array.isArray(params.value)) {
+          return '';
+        }
+        const valueIndex = params.dimensionNames?.indexOf(valueField) ?? -1;
+        const value = valueIndex >= 0 ? params.value[valueIndex] : undefined;
+        // stack:Percentage won't consider unit display
+        if (isPercentage) return formatSeriesValueLabel(value, true, decimals);
+        return formatUnitValue(value, unitId, decimals, unitSuffix);
+      },
     },
-  },
-  labelLayout: { hideOverlap: true },
-});
+    labelLayout: { hideOverlap: true },
+  };
+};

--- a/src/plugins/explore/public/components/visualizations/style_panel/standard_options/standard_options_panel.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/standard_options/standard_options_panel.tsx
@@ -4,19 +4,24 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 
 import { MinMaxControls } from './min_max_control';
 import { StyleAccordion } from '../style_accordion';
 import { UnitPanel } from '../unit/unit_panel';
+import { DebouncedFieldNumber, DebouncedFieldText } from '../utils';
 
 export interface StandardOptionsPanelProps {
   min?: number;
   max?: number;
-  onMinChange: (min: number | undefined) => void;
-  onMaxChange: (max: number | undefined) => void;
+  onMinChange?: (min: number | undefined) => void;
+  onMaxChange?: (max: number | undefined) => void;
   unit?: string;
   onUnitChange: (unit: string | undefined) => void;
+  decimals?: number;
+  onDecimalsChange?: (decimals: number | undefined) => void;
+  unitSuffix?: string;
+  onUnitSuffixChange?: (unitSuffix: string | undefined) => void;
   initialIsOpen?: boolean;
 }
 
@@ -27,6 +32,10 @@ export const StandardOptionsPanel = ({
   onMinChange,
   unit,
   onUnitChange,
+  decimals,
+  onDecimalsChange,
+  unitSuffix,
+  onUnitSuffixChange,
   initialIsOpen = false,
 }: StandardOptionsPanelProps) => {
   return (
@@ -39,18 +48,62 @@ export const StandardOptionsPanel = ({
       initialIsOpen={initialIsOpen}
     >
       <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiFlexItem>
-          <MinMaxControls
-            min={min}
-            max={max}
-            onMaxChange={onMaxChange}
-            onMinChange={onMinChange}
-          />{' '}
-        </EuiFlexItem>
+        {onMaxChange && onMinChange && (
+          <EuiFlexItem>
+            <MinMaxControls
+              min={min}
+              max={max}
+              onMaxChange={onMaxChange}
+              onMinChange={onMinChange}
+            />
+          </EuiFlexItem>
+        )}
 
         <EuiFlexItem>
           <UnitPanel unit={unit} onUnitChange={onUnitChange} />
         </EuiFlexItem>
+
+        {onUnitSuffixChange && (
+          <EuiFlexItem>
+            <EuiFormRow
+              label={i18n.translate('explore.stylePanel.standardOptions.unitSuffix', {
+                defaultMessage: 'Unit suffix',
+              })}
+              helpText={i18n.translate('explore.stylePanel.standardOptions.unitSuffix.help', {
+                defaultMessage: 'Appended after the unit or use a customized unit.',
+              })}
+            >
+              <DebouncedFieldText
+                value={unitSuffix ?? ''}
+                onChange={(value) => onUnitSuffixChange(value === '' ? undefined : value)}
+                placeholder="e.g. /sec"
+                data-test-subj="standardOptionsUnitSuffix"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        )}
+
+        {onDecimalsChange && (
+          <EuiFlexItem>
+            <EuiFormRow
+              label={i18n.translate('explore.stylePanel.standardOptions.decimals', {
+                defaultMessage: 'Decimals',
+              })}
+              helpText={i18n.translate('explore.stylePanel.standardOptions.decimals.help', {
+                defaultMessage: 'Leave empty for automatic precision',
+              })}
+            >
+              <DebouncedFieldNumber
+                min={0}
+                max={10}
+                value={decimals}
+                onChange={(value) => onDecimalsChange(value == null ? undefined : value)}
+                placeholder="auto"
+                data-test-subj="standardOptionsDecimals"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </StyleAccordion>
   );

--- a/src/plugins/explore/public/components/visualizations/style_panel/unit/collection.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/unit/collection.tsx
@@ -5,6 +5,7 @@
 
 import { i18n } from '@osd/i18n';
 import { Unit, UnitDisplay, UnitItem } from '../../types';
+import { formatDecimal } from '../../utils/data_transformation/utils/number';
 
 export const dataUnits = [
   { symbol: 'b', value: 1 }, // 1 bit
@@ -48,25 +49,25 @@ export const lengthUnits = [
   { symbol: 'mi', value: 1609.344 }, // 1 mile = 1609.344 meters
 ];
 
-export const shortNumber = (num: number) => {
+export const shortNumber = (num: number, decimals?: number) => {
   const units = ['', 'K', 'M', 'B', 'T', 'Q'];
   let unitIndex = 0;
   let n = num;
 
-  while (n >= 1000 && unitIndex < units.length - 1) {
+  while (Math.abs(n) >= 1000 && unitIndex < units.length - 1) {
     n /= 1000;
     unitIndex++;
   }
 
-  return `${Math.round(n * 100) / 100} ${units[unitIndex]}`;
+  return `${formatDecimal(n, decimals)} ${units[unitIndex]}`;
 };
 
-export const currencyFormat = (num: number, symbol?: string): UnitDisplay => {
+export const currencyFormat = (num: number, symbol?: string, decimals?: number): UnitDisplay => {
   return {
-    label: `${symbol ? symbol : ''} ${Math.round(num * 100) / 100}`,
+    label: `${symbol ? symbol : ''} ${formatDecimal(num, decimals)}`,
     segments: [
       { type: 'unit', value: symbol || '' },
-      { type: 'value', value: Math.round(num * 100) / 100 },
+      { type: 'value', value: formatDecimal(num, decimals) },
     ],
   };
 };
@@ -74,23 +75,24 @@ export const currencyFormat = (num: number, symbol?: string): UnitDisplay => {
 export const computing = (
   num: number,
   units: Array<{ symbol: string; value: number }>,
-  symbol?: string
+  symbol?: string,
+  decimals?: number
 ): UnitDisplay => {
   // target the base unit symbol
   const startUnit = symbol && units.find((u) => u.symbol === symbol);
-  if (!symbol || !startUnit) return { label: `${Math.round(num * 100) / 100}` };
+  if (!symbol || !startUnit) return { label: formatDecimal(num, decimals) };
 
   const finalNum = num * startUnit.value;
   let i = units.findIndex((u) => u.symbol === symbol);
 
-  while (i < units.length - 1 && finalNum >= units[i + 1].value) {
+  while (i < units.length - 1 && Math.abs(finalNum) >= units[i + 1].value) {
     i++;
   }
   const displayNum = finalNum / units[i].value;
   return {
-    label: `${Math.round(displayNum * 100) / 100} ${units[i].symbol}`,
+    label: `${formatDecimal(displayNum, decimals)} ${units[i].symbol}`,
     segments: [
-      { type: 'value', value: Math.round(displayNum * 100) / 100 },
+      { type: 'value', value: formatDecimal(displayNum, decimals) },
       { type: 'unit', value: units[i].symbol },
     ],
   };
@@ -143,11 +145,12 @@ export const UnitsCollection: Record<string, Unit> = {
       {
         id: 'short',
         name: i18n.translate('explore.stylePanel.unit.short', { defaultMessage: 'Short' }),
-        display: (val: number) => ({ label: shortNumber(val) }),
+        display: (val: number, sy?: string, decimals?: number) => ({
+          label: shortNumber(val, decimals),
+        }),
       },
     ],
   },
-
   acceleration: {
     name: i18n.translate('explore.stylePanel.unit.acceleration', {
       defaultMessage: 'Acceleration',
@@ -257,19 +260,19 @@ export const UnitsCollection: Record<string, Unit> = {
         id: 'dollars',
         name: i18n.translate('explore.stylePanel.unit.dollars', { defaultMessage: 'Dollars ($)' }),
         symbol: '$',
-        display: (val, sy) => currencyFormat(val, sy),
+        display: (val, sy, decimals) => currencyFormat(val, sy, decimals),
       },
       {
         id: 'pounds',
         name: i18n.translate('explore.stylePanel.unit.pounds', { defaultMessage: 'Pounds (£)' }),
         symbol: '£',
-        display: (val, sy) => currencyFormat(val, sy),
+        display: (val, sy, decimals) => currencyFormat(val, sy, decimals),
       },
       {
         id: 'euro',
         name: i18n.translate('explore.stylePanel.unit.euro', { defaultMessage: 'Euros (€)' }),
         symbol: '€',
-        display: (val, sy) => currencyFormat(val, sy),
+        display: (val, sy, decimals) => currencyFormat(val, sy, decimals),
       },
       {
         id: 'yuan',
@@ -277,19 +280,19 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'Chinese Yuan (¥)',
         }),
         symbol: '¥',
-        display: (val, sy) => currencyFormat(val, sy),
+        display: (val, sy, decimals) => currencyFormat(val, sy, decimals),
       },
       {
         id: 'yen',
         name: i18n.translate('explore.stylePanel.unit.yen', { defaultMessage: 'Yen (¥)' }),
         symbol: '¥',
-        display: (val, sy) => currencyFormat(val, sy),
+        display: (val, sy, decimals) => currencyFormat(val, sy, decimals),
       },
       {
         id: 'rubles',
         name: i18n.translate('explore.stylePanel.unit.rubles', { defaultMessage: 'Rubles (₽)' }),
         symbol: '₽',
-        display: (val, sy) => currencyFormat(val, sy),
+        display: (val, sy, decimals) => currencyFormat(val, sy, decimals),
       },
     ],
   },
@@ -324,13 +327,13 @@ export const UnitsCollection: Record<string, Unit> = {
         id: 'bits',
         name: i18n.translate('explore.stylePanel.unit.bits', { defaultMessage: 'bits(b)' }),
         symbol: 'b',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'bytes',
         name: i18n.translate('explore.stylePanel.unit.bytes', { defaultMessage: 'bytes(B)' }),
         symbol: 'B',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'kilobytes',
@@ -338,7 +341,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'kilobytes(kB)',
         }),
         symbol: 'kB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'kibibytes',
@@ -346,7 +349,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'kibibytes(KiB)',
         }),
         symbol: 'KiB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'megabytes',
@@ -354,7 +357,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'megabytes(MB)',
         }),
         symbol: 'MB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'mebibytes',
@@ -362,7 +365,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'mebibytes(MiB)',
         }),
         symbol: 'MiB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'gigabytes',
@@ -370,7 +373,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'gigabytes(GB)',
         }),
         symbol: 'GB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'gibibytes',
@@ -378,7 +381,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'gibibytes(GiB)',
         }),
         symbol: 'GiB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'terabytes',
@@ -386,7 +389,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'terabytes(TB)',
         }),
         symbol: 'TB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'tebibytes',
@@ -394,7 +397,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'tebibytes(TiB)',
         }),
         symbol: 'TiB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'petabytes',
@@ -402,7 +405,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'petabytes(PB)',
         }),
         symbol: 'PB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
       {
         id: 'pebibytes',
@@ -410,7 +413,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'pebibytes(PiB)',
         }),
         symbol: 'PiB',
-        display: (val, sy) => computing(val, dataUnits, sy),
+        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
       },
     ],
   },
@@ -422,43 +425,43 @@ export const UnitsCollection: Record<string, Unit> = {
         id: 'year',
         name: i18n.translate('explore.stylePanel.unit.year', { defaultMessage: 'Year' }),
         symbol: 'years',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'month',
         name: i18n.translate('explore.stylePanel.unit.month', { defaultMessage: 'Month' }),
         symbol: 'months',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'week',
         name: i18n.translate('explore.stylePanel.unit.week', { defaultMessage: 'Week' }),
         symbol: 'weeks',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'day',
         name: i18n.translate('explore.stylePanel.unit.day', { defaultMessage: 'Day' }),
         symbol: 'days',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'hour',
         name: i18n.translate('explore.stylePanel.unit.hour', { defaultMessage: 'Hour' }),
         symbol: 'hours',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'minute',
         name: i18n.translate('explore.stylePanel.unit.minute', { defaultMessage: 'Minute' }),
         symbol: 'minutes',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'second',
         name: i18n.translate('explore.stylePanel.unit.second', { defaultMessage: 'Second' }),
         symbol: 'seconds',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
       {
         id: 'millisecond',
@@ -466,7 +469,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'Millisecond',
         }),
         symbol: 'milliseconds',
-        display: (val, sy) => computing(val, timeUnits, sy),
+        display: (val, sy, decimals) => computing(val, timeUnits, sy, decimals),
       },
     ],
   },
@@ -501,13 +504,13 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'milligram (mg)',
         }),
         symbol: 'mg',
-        display: (val, sy) => computing(val, massUnits, sy),
+        display: (val, sy, decimals) => computing(val, massUnits, sy, decimals),
       },
       {
         id: 'gram',
         name: i18n.translate('explore.stylePanel.unit.gram', { defaultMessage: 'gram (g)' }),
         symbol: 'g',
-        display: (val, sy) => computing(val, massUnits, sy),
+        display: (val, sy, decimals) => computing(val, massUnits, sy, decimals),
       },
       {
         id: 'kilogram',
@@ -515,7 +518,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'kilogram (kg)',
         }),
         symbol: 'kg',
-        display: (val, sy) => computing(val, massUnits, sy),
+        display: (val, sy, decimals) => computing(val, massUnits, sy, decimals),
       },
       {
         id: 'metric',
@@ -523,7 +526,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'metric ton (t)',
         }),
         symbol: 't',
-        display: (val, sy) => computing(val, massUnits, sy),
+        display: (val, sy, decimals) => computing(val, massUnits, sy, decimals),
       },
     ],
   },
@@ -536,25 +539,25 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'millimeter (mm)',
         }),
         symbol: 'mm',
-        display: (val, sy) => computing(val, lengthUnits, sy),
+        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
       },
       {
         id: 'inch',
         name: i18n.translate('explore.stylePanel.unit.inch', { defaultMessage: 'inch (in)' }),
         symbol: 'in',
-        display: (val, sy) => computing(val, lengthUnits, sy),
+        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
       },
       {
         id: 'feet',
         name: i18n.translate('explore.stylePanel.unit.feet', { defaultMessage: 'feet (ft)' }),
         symbol: 'ft',
-        display: (val, sy) => computing(val, lengthUnits, sy),
+        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
       },
       {
         id: 'meter',
         name: i18n.translate('explore.stylePanel.unit.meter', { defaultMessage: 'meter (m)' }),
         symbol: 'm',
-        display: (val, sy) => computing(val, lengthUnits, sy),
+        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
       },
       {
         id: 'kilometer',
@@ -562,13 +565,13 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'kilometer (km)',
         }),
         symbol: 'km',
-        display: (val, sy) => computing(val, lengthUnits, sy),
+        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
       },
       {
         id: 'mile',
         name: i18n.translate('explore.stylePanel.unit.mile', { defaultMessage: 'mile (mi)' }),
         symbol: 'mi',
-        display: (val, sy) => computing(val, lengthUnits, sy),
+        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
       },
     ],
   },
@@ -588,17 +591,46 @@ Object.values(UnitsCollection).forEach((category) => {
 // get unit by ID
 export const getUnitById = (id?: string) => (id ? UnitsLookup[id] : undefined);
 
+/**
+ * Appends a user-defined unit suffix
+ * A rate-style suffix ("/sec") appends directly (100 b/sec)
+ * anything else gets a separating space (100 meter)
+ */
+export const appendUnitSuffix = (text: string | number, suffix?: string): string => {
+  const base = String(text);
+  if (!suffix) return base;
+  return suffix.startsWith('/') ? `${base}${suffix}` : `${base} ${suffix}`;
+};
+
 export function showDisplayValue(
   isValidNumber: boolean,
   selectedUnit: UnitItem | undefined,
-  calculatedValue: number | undefined
+  calculatedValue: number | undefined,
+  decimals?: number,
+  suffix?: string
 ) {
-  const displayValue =
-    isValidNumber && calculatedValue
-      ? selectedUnit && selectedUnit?.display
-        ? selectedUnit?.display(calculatedValue, selectedUnit?.symbol).label
-        : `${Math.round(calculatedValue * 100) / 100} ${selectedUnit?.symbol ?? ''}`
-      : '-';
+  if (!isValidNumber || calculatedValue == null) return '-';
+  const base =
+    selectedUnit && selectedUnit?.display
+      ? selectedUnit?.display(calculatedValue, selectedUnit?.symbol, decimals).label
+      : `${formatDecimal(calculatedValue, decimals)} ${selectedUnit?.symbol ?? ''}`;
 
-  return displayValue;
+  return appendUnitSuffix(base, suffix);
 }
+
+/**
+ * Formats a numeric value into unit + decimals + optional suffix
+ */
+export const formatUnitValue = (
+  value: number,
+  unitId?: string,
+  decimals?: number,
+  suffix?: string
+): string => {
+  if (!Number.isFinite(value)) return String(value);
+  const unit = getUnitById(unitId);
+  const base = unit?.display
+    ? String(unit.display(value, unit.symbol, decimals).label)
+    : `${formatDecimal(value, decimals)}${unit?.symbol ? ` ${unit.symbol}` : ''}`;
+  return appendUnitSuffix(base, suffix);
+};

--- a/src/plugins/explore/public/components/visualizations/types.ts
+++ b/src/plugins/explore/public/components/visualizations/types.ts
@@ -249,7 +249,7 @@ export interface UnitItem {
   id: string;
   name: string;
   symbol?: string;
-  display?: (value: number, symbol?: string) => UnitDisplay;
+  display?: (value: number, symbol?: string, decimals?: number) => UnitDisplay;
   fontScale?: number;
 }
 

--- a/src/plugins/explore/public/components/visualizations/types.ts
+++ b/src/plugins/explore/public/components/visualizations/types.ts
@@ -67,6 +67,14 @@ export interface TooltipOptions {
   mode: 'all' | 'hidden';
 }
 
+export interface StandardOptions {
+  unitId?: string;
+  unitSuffix?: string;
+  decimals?: number;
+  min?: number;
+  max?: number;
+}
+
 // Styling: Grid configuration
 export interface GridOptions {
   xLines: boolean;

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/index.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/index.ts
@@ -16,7 +16,7 @@ export type { TransformFn } from './transform';
 export { aggregateValues } from './utils/aggregation';
 export { roundToTimeUnit } from './utils/time';
 export { normalizeEmptyValue } from './utils/normalization';
-export { getDecimalPrecision, roundToPrecision } from './utils/number';
+export { getDecimalPrecision, roundToPrecision, formatDecimal } from './utils/number';
 
 export { map, pick } from './common';
 export * from './normalize_percentage';

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/normalize_percentage.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/normalize_percentage.ts
@@ -32,7 +32,7 @@ export const normalizeToPercentage =
         if (newRow[field] === null || newRow[field] === undefined || !Number.isFinite(value)) {
           return;
         }
-        newRow[field] = total === 0 ? 0 : (value / total) * 100;
+        newRow[field] = total === 0 ? 0 : value / total;
       });
       return newRow;
     });

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/number.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/number.ts
@@ -27,3 +27,9 @@ export const roundToPrecision = (value: number, precision: number): number => {
   const factor = Math.pow(10, precision);
   return Number((Math.round(value * factor) / factor).toFixed(precision));
 };
+
+/**
+ * Formats a number for display, auto(default) is 2
+ */
+export const formatDecimal = (value: number, decimals?: number): string =>
+  decimals == null ? String(roundToPrecision(value, 2)) : value.toFixed(decimals);

--- a/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
@@ -29,6 +29,7 @@ import {
 import { convertThresholds } from './utils';
 import { DEFAULT_OPACITY } from '../constants';
 import { LegendItem } from './legend';
+import { formatUnitValue } from '../style_panel/unit/collection';
 
 /**
  * Base style interface that all chart styles should extend
@@ -47,6 +48,13 @@ export interface BaseChartStyle {
   addLegend?: boolean;
   legendPosition?: Positions;
   showFullTimeRange?: boolean;
+  // standard options in cartesian charts
+  decimals?: number;
+  unitId?: string;
+  // Free-text suffix appended after the unit ("/sec" glues, "meter" gets a space).
+  unitSuffix?: string;
+  min?: number;
+  max?: number;
 }
 
 interface Axis {
@@ -150,6 +158,8 @@ export const createBaseConfig =
   (state: EChartsSpecState<T>): EChartsSpecState<T> => {
     const { styles, axisConfig } = state;
 
+    const hasUnit = !!styles.unitId || styles.decimals != null || !!styles.unitSuffix;
+
     const baseConfig = {
       tooltip: {
         extraCssText: `overflow: auto; max-height: 50%; max-width: 80%;`,
@@ -158,6 +168,12 @@ export const createBaseConfig =
         show: styles.tooltipOptions?.mode !== 'hidden',
         ...(axisConfig && addTrigger && { trigger: 'axis' as const }),
         axisPointer: { type: 'shadow' as const },
+        ...(hasUnit && {
+          valueFormatter: (value: unknown) =>
+            typeof value === 'number'
+              ? formatUnitValue(value, styles.unitId, styles.decimals, styles.unitSuffix)
+              : String(value ?? ''),
+        }),
       },
       legend: {
         show: false,
@@ -183,15 +199,38 @@ export const buildAxisConfigs = <T extends BaseChartStyle>(
 
   const hasY2 = axisColumnMappings.y2 !== undefined;
 
+  const { styles } = state;
+  const hasUnit = !!styles.unitId || styles.decimals != null || !!styles?.unitSuffix;
+
+  // when both x and y are numerical, prefer Y
+  const yIsValueAxis = getAxisType(axisColumnMappings.y) === 'value';
+  const xIsValueAxis = getAxisType(axisColumnMappings.x) === 'value' && !yIsValueAxis;
+
+  const isMinMaxInValid = styles.min != null && styles.max != null && styles.min >= styles.max;
+
   const getConfig = (
     axis: Axis | Axis[] | undefined,
     axisStyle: StandardAxes | undefined,
+    isValueAxis: boolean = false,
     addSplitLineStyle: boolean = false
   ) => {
+    const axisStyling = applyAxisStyling({ axisStyle, addSplitLineStyle });
+    const type = getAxisType(axis);
     return {
-      type: getAxisType(axis),
-      ...applyAxisStyling({ axisStyle, addSplitLineStyle }),
+      type,
+      ...axisStyling,
       nameGap: 8,
+      ...(isValueAxis &&
+        hasUnit && {
+          axisLabel: {
+            ...axisStyling.axisLabel,
+            formatter: (value: number) =>
+              formatUnitValue(value, styles.unitId, styles.decimals, styles.unitSuffix),
+          },
+        }),
+      // if min and max are not valid, ignore
+      ...(isValueAxis && !isMinMaxInValid && { min: styles.min }),
+      ...(isValueAxis && !isMinMaxInValid && { max: styles.max }),
     };
   };
 
@@ -199,11 +238,17 @@ export const buildAxisConfigs = <T extends BaseChartStyle>(
     throw new Error('axisConfig must be derived before buildAxisConfigs');
   }
 
-  const xAxisConfig = getConfig(axisColumnMappings.x, axisConfig.xAxisStyle);
-  let yAxisConfig: any = getConfig(axisColumnMappings.y, axisConfig.yAxisStyle);
+  const xAxisConfig = getConfig(axisColumnMappings.x, axisConfig.xAxisStyle, xIsValueAxis);
+  let yAxisConfig: any = getConfig(axisColumnMappings.y, axisConfig.yAxisStyle, yIsValueAxis);
 
   if (hasY2) {
-    const y2AxisConfig = getConfig(axisColumnMappings.y2, axisConfig.y2AxisStyle, true);
+    const y2IsValueAxis = getAxisType(axisColumnMappings.y2) === 'value';
+    const y2AxisConfig = getConfig(
+      axisColumnMappings.y2,
+      axisConfig.y2AxisStyle,
+      y2IsValueAxis,
+      true
+    );
     yAxisConfig = [yAxisConfig, y2AxisConfig];
   }
 
@@ -269,9 +314,10 @@ export const applyAxisStyling = ({
     echartsAxisConfig.splitLine = {
       show: axisStyle.grid.showLines ?? true,
       ...(addSplitLineStyle && {
+        // only for y2
         lineStyle: {
           type: 'dotted',
-          opacity: DEFAULT_OPACITY / 2,
+          opacity: (DEFAULT_OPACITY * 100) / 2,
         },
       }),
     };

--- a/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/echarts_spec.ts
@@ -25,6 +25,7 @@ import {
   ThresholdOptions,
   AxisRole,
   VisColumn,
+  StandardOptions,
 } from '../types';
 import { convertThresholds } from './utils';
 import { DEFAULT_OPACITY } from '../constants';
@@ -34,7 +35,7 @@ import { formatUnitValue } from '../style_panel/unit/collection';
 /**
  * Base style interface that all chart styles should extend
  */
-export interface BaseChartStyle {
+export interface BaseChartStyle extends StandardOptions {
   tooltipOptions?: {
     mode: string;
   };
@@ -48,13 +49,6 @@ export interface BaseChartStyle {
   addLegend?: boolean;
   legendPosition?: Positions;
   showFullTimeRange?: boolean;
-  // standard options in cartesian charts
-  decimals?: number;
-  unitId?: string;
-  // Free-text suffix appended after the unit ("/sec" glues, "meter" gets a space).
-  unitSuffix?: string;
-  min?: number;
-  max?: number;
 }
 
 interface Axis {
@@ -206,6 +200,7 @@ export const buildAxisConfigs = <T extends BaseChartStyle>(
   const yIsValueAxis = getAxisType(axisColumnMappings.y) === 'value';
   const xIsValueAxis = getAxisType(axisColumnMappings.x) === 'value' && !yIsValueAxis;
 
+  // TODO apply data range
   const isMinMaxInValid = styles.min != null && styles.max != null && styles.min >= styles.max;
 
   const getConfig = (
@@ -317,7 +312,7 @@ export const applyAxisStyling = ({
         // only for y2
         lineStyle: {
           type: 'dotted',
-          opacity: (DEFAULT_OPACITY * 100) / 2,
+          opacity: DEFAULT_OPACITY,
         },
       }),
     };

--- a/src/plugins/explore/public/components/visualizations/utils/utils.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/utils.ts
@@ -17,7 +17,7 @@ import {
 } from '../types';
 import { ChartStyles, StyleOptions } from './use_visualization_types';
 import { BaseChartStyle, PipelineFn } from './echarts_spec';
-import { resolveStackMode } from './data_transformation';
+import { resolveStackMode, formatDecimal } from './data_transformation';
 
 export const applyAxisStyling = ({
   axis,
@@ -337,9 +337,13 @@ export const applyPercentageAxis =
 
     const toPercentageAxis = (axisConfig: any) => ({
       ...axisConfig,
-      min: hasNegativeValue ? -100 : 0,
-      max: 100,
-      axisLabel: { ...axisConfig?.axisLabel, formatter: '{value}%' },
+      // Respect a user-set min/max
+      min: axisConfig?.min ?? (hasNegativeValue ? -1 : 0),
+      max: axisConfig?.max ?? 1,
+      axisLabel: {
+        ...axisConfig?.axisLabel,
+        formatter: (value: unknown) => formatSeriesValueLabel(value, true),
+      },
     });
 
     // multi y series
@@ -367,17 +371,23 @@ export const applyPercentageAxis =
 /**
  * Format a series value for display as a label drawn on a mark (e.g. on a bar).
  */
-export const formatSeriesValueLabel = (value: unknown, isPercentage = false): string => {
+export const formatSeriesValueLabel = (
+  value: unknown,
+  isPercentage = false,
+  decimals?: number
+): string => {
   if (value === null || value === undefined || value === '') return '';
 
   const numericValue = Number(value);
   // Non numeric values are shown as-is rather than as `NaN`
   if (!Number.isFinite(numericValue)) return String(value);
 
-  // TODO apply unit decimals
-  const trimmed = Math.round(numericValue * Math.pow(10, 2)) / Math.pow(10, 2);
+  const valueWithDecimals = formatDecimal(
+    isPercentage ? numericValue * 100 : numericValue,
+    decimals
+  );
 
-  return isPercentage ? `${trimmed}%` : String(trimmed);
+  return isPercentage ? `${valueWithDecimals}%` : valueWithDecimals;
 };
 
 export const getNormalizedAxisConfig = (


### PR DESCRIPTION
### Description

This pr add unit enhancement and min/max support to all charts(except statetimeline), including:
 * Min / Max: bound the value axis. For most charts this is the Y axis; for histogram it is the binned X axis.
 * Unit: pick a display unit from the unit collection. Units auto-scale to a readable tier (e.g. a value in MB renders as GB) — the query is unchanged.
 * Decimals: displayed precision, 0–10 or empty for "auto" ( default is 2).
 * Unit suffix: free text appended after the unit; a leading "/" glues it (e.g. "/sec" -> "12 MB/sec"), otherwise it is space-separated ("100 meter").

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


https://github.com/user-attachments/assets/31e0a016-134b-4d55-b89d-b73b018433d2


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
