### PR TITLE
fix(visualization): support language sql in vis editor

### DIFF
--- a/src/plugins/explore/public/application/in_context_vis_editor/component/lauguage_toggle.tsx
+++ b/src/plugins/explore/public/application/in_context_vis_editor/component/lauguage_toggle.tsx
@@ -13,6 +13,8 @@ import { EditorMode } from '../../utils/state_management/types';
 import { SupportLanguageType } from '../query_builder/query_builder';
 import { useEditorOperations } from '../hooks/use_editor_operations';
 import { useQueryBuilderState } from '../hooks/use_query_builder_state';
+import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import { ExploreServices } from '../../../types';
 
 const promptOptionText = i18n.translate('explore.queryPanelFooter.languageToggle.promptOption', {
   defaultMessage: 'AI',
@@ -26,6 +28,10 @@ const pplOptionText = i18n.translate('explore.queryPanelFooter.languageToggle.pp
   defaultMessage: 'PPL',
 });
 
+const sqlOptionText = i18n.translate('explore.queryPanelFooter.languageToggle.sqlOption', {
+  defaultMessage: 'OpenSearch SQL',
+});
+
 const getLanguageDisplayLabel = (languageType: SupportLanguageType): string => {
   switch (languageType) {
     case SupportLanguageType.promQL:
@@ -34,12 +40,15 @@ const getLanguageDisplayLabel = (languageType: SupportLanguageType): string => {
       return pplOptionText;
     case SupportLanguageType.ai:
       return promptOptionText;
+    case SupportLanguageType.sql:
+      return sqlOptionText;
     default:
       return languageType;
   }
 };
 
 export const LanguageToggle = () => {
+  const { services } = useOpenSearchDashboards<ExploreServices>();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { focusEditor, switchEditorMode } = useEditorOperations();
   const { queryBuilder, queryEditorState } = useQueryBuilderState();
@@ -80,8 +89,10 @@ export const LanguageToggle = () => {
 
         if (option === promQLOptionText) {
           languageType = SupportLanguageType.promQL;
-        } else {
+        } else if (option === pplOptionText) {
           languageType = SupportLanguageType.ppl;
+        } else {
+          languageType = SupportLanguageType.sql;
         }
 
         clearEditor();
@@ -116,6 +127,19 @@ export const LanguageToggle = () => {
       </EuiContextMenuItem>,
     ];
 
+    if (services.sqlSupportEnabled) {
+      output.push(
+        <EuiContextMenuItem
+          key={sqlOptionText}
+          onClick={() => onLanguageItemClick(sqlOptionText)}
+          disabled={!isPromptMode && language === 'SQL'}
+          data-test-subj={`queryPanelFooterLanguageToggle-${sqlOptionText}`}
+        >
+          {sqlOptionText}
+        </EuiContextMenuItem>
+      );
+    }
+
     // whether to display AI needs to check dataset first
     if (promptModeIsAvailable) {
       output.push(
@@ -131,7 +155,13 @@ export const LanguageToggle = () => {
     }
 
     return output;
-  }, [onLanguageItemClick, isPromptMode, language, promptModeIsAvailable]);
+  }, [
+    onLanguageItemClick,
+    isPromptMode,
+    language,
+    promptModeIsAvailable,
+    services.sqlSupportEnabled,
+  ]);
 
   return (
     // This div is needed to allow for the gradient styling

--- a/src/plugins/explore/public/application/in_context_vis_editor/query_builder/query_builder.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/query_builder/query_builder.ts
@@ -60,6 +60,7 @@ export enum SupportLanguageType {
   ppl = 'PPL',
   promQL = 'PROMQL',
   ai = 'AI',
+  sql = 'SQL',
 }
 
 export interface QueryState {

--- a/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
+++ b/src/plugins/explore/public/application/in_context_vis_editor/query_builder/utils.ts
@@ -107,13 +107,14 @@ export const getPreloadedQueryState = async (
   if (minimalDataset) {
     const initialQueryByDataset = services.data.query.queryString.getInitialQueryByDataset({
       ...minimalDataset,
-      language: minimalDataset.language || 'PPL',
+      language: minimalDataset.language || languageType || 'PPL',
     });
 
     // override the initial query to be an empty string
     return {
       ...initialQueryByDataset,
-      query: '',
+      // SQL needs a base query (SELECT * FROM ...) to be valid; PPL works with empty
+      ...(languageType !== SupportLanguageType.sql ? { query: '' } : {}),
       // Ensure we use the minimal dataset
       dataset: minimalDataset,
     };

--- a/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
+++ b/src/plugins/query_enhancements/public/search/sql_search_interceptor.ts
@@ -29,7 +29,11 @@ import { SQLFilterUtils } from './filters';
 
 export class SQLSearchInterceptor extends SearchInterceptor {
   private static readonly filterManagerSupportedAppNames = ['dashboards'];
-  private static readonly timeFilterSupportedAppNames = ['dashboards', 'explore/logs'];
+  private static readonly timeFilterSupportedAppNames = [
+    'dashboards',
+    'explore/logs',
+    'visualization-editor',
+  ];
 
   protected queryService!: DataPublicPluginStart['query'];
   protected notifications!: CoreStart['notifications'];


### PR DESCRIPTION
### Description

Pr https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12061 enables language sql inside Explore Logs.
This pr syncs the feature to vis editor

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot


https://github.com/user-attachments/assets/41776846-9dad-4805-8be3-4c89eb80893e


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
