### PR TITLE
[fix]Normalize grouped unit conversion

### DIFF
--- a/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
+++ b/src/plugins/explore/public/components/visualizations/area/area_chart_utils.ts
@@ -5,6 +5,7 @@
 
 import * as echarts from 'echarts';
 import type { LineSeriesOption } from 'echarts';
+import { darkMode } from '@osd/ui-shared-deps/theme';
 import { getSeriesDisplayName } from '../utils/series';
 import { AreaChartStyle, DEFAULT_FILL_OPACITY } from './area_vis_config';
 
@@ -58,6 +59,9 @@ export const lightenHexColor = (hexColor: string, ratio: number): string => {
   return rgbToHex(blend(r), blend(g), blend(b));
 };
 
+export const getOpacityGradientBaselineColor = () =>
+  darkMode ? 'rgba(0, 0, 0, 0)' : 'rgba(255, 255, 255, 0)';
+
 export const buildAreaStyle = (styles: AreaChartStyle, seriesColor: string) => {
   const opacity = styles.areaOpacity ?? DEFAULT_FILL_OPACITY;
 
@@ -70,7 +74,7 @@ export const buildAreaStyle = (styles: AreaChartStyle, seriesColor: string) => {
   // The gradient's far end: transparent for `opacity` mode, a lighter hue for `hue` mode.
   const baselineColor =
     gradientMode === 'opacity'
-      ? 'rgba(0, 0, 0, 0)'
+      ? getOpacityGradientBaselineColor()
       : lightenHexColor(seriesColor, HUE_GRADIENT_LIGHTEN_RATIO);
 
   return {

--- a/src/plugins/explore/public/components/visualizations/style_panel/share/opacity_range.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/share/opacity_range.tsx
@@ -23,16 +23,18 @@ export const OpacityRange = ({
   const label = i18n.translate('explore.stylePanel.area.areaOpacity', {
     defaultMessage: 'Fill opacity',
   });
+  const defaultOpacityPercent = Math.round(defaultOpacity * 100);
+  const opacityPercent = Math.round((fillOpacity ?? defaultOpacity) * 100);
 
   return (
     <EuiFormRow label={label}>
       <DebouncedFieldRange
         // Value is stored as a 0-1 fraction but shown on a 0-100 scale
-        value={(fillOpacity ?? defaultOpacity) * 100}
-        onChange={(value) => onOpacityChange((value ?? defaultOpacity * 100) / 100)}
+        value={opacityPercent}
+        onChange={(value) => onOpacityChange((value ?? defaultOpacityPercent) / 100)}
         min={0}
         max={100}
-        defaultValue={defaultOpacity * 100}
+        defaultValue={defaultOpacityPercent}
         step={1}
         aria-label={label}
         data-test-subj={testsubj}

--- a/src/plugins/explore/public/components/visualizations/style_panel/unit/collection.test.ts
+++ b/src/plugins/explore/public/components/visualizations/style_panel/unit/collection.test.ts
@@ -10,7 +10,11 @@ import {
   computingDate,
   currencyFormat,
   computing,
-  dataUnits,
+  decimalDataUnits,
+  binaryDataUnits,
+  metricLengthUnits,
+  imperialLengthUnits,
+  timeUnits,
 } from './collection';
 
 // Mock Date.now for consistent testing
@@ -164,30 +168,32 @@ describe('UnitsCollection', () => {
   it('should add proper unit for data values using display function', () => {
     const bits = getUnitById('bits');
     expect(bits?.display?.(100.12, 'b').label).toBe('12.52 B');
+    expect(bits?.display?.(8000, 'b').label).toBe('1 KB');
 
-    const kbits = getUnitById('bytes');
-    expect(kbits?.display?.(100.12, 'B').label).toBe('100.12 B');
+    const bytes = getUnitById('bytes');
+    expect(bytes?.display?.(100.12, 'B').label).toBe('100.12 B');
+    expect(bytes?.display?.(1024, 'B').label).toBe('1.02 KB');
 
     const kilobytes = getUnitById('kilobytes');
-    expect(kilobytes?.display?.(100.12, 'kB').label).toBe('97.77 KiB');
+    expect(kilobytes?.display?.(100.12, 'KB').label).toBe('100.12 KB');
 
     const kibibytes = getUnitById('kibibytes');
     expect(kibibytes?.display?.(100.12, 'KiB').label).toBe('100.12 KiB');
 
     const megabytes = getUnitById('megabytes');
-    expect(megabytes?.display?.(100.12, 'MB').label).toBe('95.48 MiB');
+    expect(megabytes?.display?.(100.12, 'MB').label).toBe('100.12 MB');
 
     const mebibytes = getUnitById('mebibytes');
     expect(mebibytes?.display?.(100.12, 'MiB').label).toBe('100.12 MiB');
 
     const gigabytes = getUnitById('gigabytes');
-    expect(gigabytes?.display?.(100.12, 'GB').label).toBe('93.24 GiB');
+    expect(gigabytes?.display?.(100.12, 'GB').label).toBe('100.12 GB');
 
     const gibibytes = getUnitById('gibibytes');
     expect(gibibytes?.display?.(100.12, 'GiB').label).toBe('100.12 GiB');
 
     const terabytes = getUnitById('terabytes');
-    expect(terabytes?.display?.(100.12, 'TB').label).toBe('91.06 TiB');
+    expect(terabytes?.display?.(100.12, 'TB').label).toBe('100.12 TB');
 
     const tebibytes = getUnitById('tebibytes');
     expect(tebibytes?.display?.(100.12, 'TiB').label).toBe('100.12 TiB');
@@ -216,6 +222,20 @@ describe('UnitsCollection', () => {
     expect(second?.display?.(1000, 'seconds').label).toBe('16.67 minutes');
     const millisecond = getUnitById('millisecond');
     expect(millisecond?.display?.(1000, 'milliseconds').label).toBe('1 seconds');
+  });
+
+  it('should keep length values in the same measurement system', () => {
+    const meter = getUnitById('meter');
+    expect(meter?.display?.(2000, 'm').label).toBe('2 km');
+
+    const kilometer = getUnitById('kilometer');
+    expect(kilometer?.display?.(0.5, 'km').label).toBe('500 m');
+
+    const feet = getUnitById('feet');
+    expect(feet?.display?.(6000, 'ft').label).toBe('1.14 mi');
+
+    const mile = getUnitById('mile');
+    expect(mile?.display?.(0.5, 'mi').label).toBe('2640 ft');
   });
 });
 
@@ -379,7 +399,42 @@ describe('currencyFormat', () => {
 
 describe('computing', () => {
   it('should compute the decent unit with the base unit', () => {
-    const result = computing(1000, dataUnits, 'B');
-    expect(result.label).toBe('1 kB');
+    const result = computing(1000, decimalDataUnits, 'B');
+    expect(result.label).toBe('1 KB');
+  });
+
+  it('should compute downward when the value is smaller than the current unit', () => {
+    const result = computing(0.5, timeUnits, 'hours');
+    expect(result.label).toBe('30 minutes');
+  });
+});
+
+describe('data unit groups', () => {
+  it('should keep decimal data units in the decimal system', () => {
+    expect(computing(1024, decimalDataUnits, 'KB').label).toBe('1.02 MB');
+    expect(computing(1000, decimalDataUnits, 'MB').label).toBe('1 GB');
+  });
+
+  it('should keep binary data units in the binary system', () => {
+    expect(computing(1024, binaryDataUnits, 'KiB').label).toBe('1 MiB');
+    expect(computing(1024, binaryDataUnits, 'MiB').label).toBe('1 GiB');
+  });
+
+  it('should scale data units downward within the same system', () => {
+    expect(computing(0.5, decimalDataUnits, 'MB').label).toBe('500 KB');
+    expect(computing(0.5, binaryDataUnits, 'KiB').label).toBe('512 B');
+    expect(computing(0.5, decimalDataUnits, 'B').label).toBe('4 b');
+  });
+});
+
+describe('length unit groups', () => {
+  it('should keep metric length units in the metric system', () => {
+    expect(computing(2000, metricLengthUnits, 'm').label).toBe('2 km');
+    expect(computing(0.5, metricLengthUnits, 'km').label).toBe('500 m');
+  });
+
+  it('should keep imperial length units in the imperial system', () => {
+    expect(computing(6000, imperialLengthUnits, 'ft').label).toBe('1.14 mi');
+    expect(computing(0.5, imperialLengthUnits, 'mi').label).toBe('2640 ft');
   });
 });

--- a/src/plugins/explore/public/components/visualizations/style_panel/unit/collection.tsx
+++ b/src/plugins/explore/public/components/visualizations/style_panel/unit/collection.tsx
@@ -7,18 +7,25 @@ import { i18n } from '@osd/i18n';
 import { Unit, UnitDisplay, UnitItem } from '../../types';
 import { formatDecimal } from '../../utils/data_transformation/utils/number';
 
-export const dataUnits = [
+type UnitScale = Array<{ symbol: string; value: number }>;
+
+export const decimalDataUnits = [
   { symbol: 'b', value: 1 }, // 1 bit
   { symbol: 'B', value: 8 }, // 1 byte = 8 bits
-  { symbol: 'kB', value: 8 * 1000 }, // 1 kB = 1000 bytes = 1000*8 bits
-  { symbol: 'KiB', value: 8 * 1024 }, // 1 KiB = 1024 bytes = 1024*8 bits
-  { symbol: 'MB', value: 8 * 1000 ** 2 }, // 1 MB = 1024^2 bytes
-  { symbol: 'MiB', value: 8 * 1024 ** 2 }, // 1 MiB = 1024^2 bytes
+  { symbol: 'KB', value: 8 * 1000 }, // 1 kB = 1000 bytes = 1000*8 bits
+  { symbol: 'MB', value: 8 * 1000 ** 2 }, // 1 MB = 1000^2 bytes
   { symbol: 'GB', value: 8 * 1000 ** 3 }, // 1 GB = 1000^3 bytes
-  { symbol: 'GiB', value: 8 * 1024 ** 3 }, // 1 GiB = 1024^3 bytes
   { symbol: 'TB', value: 8 * 1000 ** 4 }, // 1 TB = 1000^4 bytes
-  { symbol: 'TiB', value: 8 * 1024 ** 4 }, // 1 TiB = 1024^4 bytes
   { symbol: 'PB', value: 8 * 1000 ** 5 }, // 1 PB = 1000^5 bytes
+];
+
+export const binaryDataUnits = [
+  { symbol: 'b', value: 1 }, // 1 bit
+  { symbol: 'B', value: 8 }, // 1 byte = 8 bits
+  { symbol: 'KiB', value: 8 * 1024 }, // 1 KiB = 1024 bytes = 1024*8 bits
+  { symbol: 'MiB', value: 8 * 1024 ** 2 }, // 1 MiB = 1024^2 bytes
+  { symbol: 'GiB', value: 8 * 1024 ** 3 }, // 1 GiB = 1024^3 bytes
+  { symbol: 'TiB', value: 8 * 1024 ** 4 }, // 1 TiB = 1024^4 bytes
   { symbol: 'PiB', value: 8 * 1024 ** 5 }, // 1 PiB = 1024^5 bytes
 ];
 
@@ -40,12 +47,15 @@ export const massUnits = [
   { symbol: 't', value: 1000000 }, // 1 metric ton = 1,000,000 grams
 ];
 
-export const lengthUnits = [
+export const metricLengthUnits = [
   { symbol: 'mm', value: 0.001 }, // 1 millimeter = 0.001 meters
-  { symbol: 'in', value: 0.0254 }, // 1 inch = 0.0254 meters
-  { symbol: 'ft', value: 0.3048 }, // 1 foot = 0.3048 meters
   { symbol: 'm', value: 1 }, // 1 meter = 1 meter
   { symbol: 'km', value: 1000 }, // 1 kilometer = 1000 meters
+];
+
+export const imperialLengthUnits = [
+  { symbol: 'in', value: 0.0254 }, // 1 inch = 0.0254 meters
+  { symbol: 'ft', value: 0.3048 }, // 1 foot = 0.3048 meters
   { symbol: 'mi', value: 1609.344 }, // 1 mile = 1609.344 meters
 ];
 
@@ -74,7 +84,7 @@ export const currencyFormat = (num: number, symbol?: string, decimals?: number):
 
 export const computing = (
   num: number,
-  units: Array<{ symbol: string; value: number }>,
+  units: UnitScale,
   symbol?: string,
   decimals?: number
 ): UnitDisplay => {
@@ -88,6 +98,10 @@ export const computing = (
   while (i < units.length - 1 && Math.abs(finalNum) >= units[i + 1].value) {
     i++;
   }
+  while (finalNum !== 0 && i > 0 && Math.abs(finalNum) < units[i].value) {
+    i--;
+  }
+
   const displayNum = finalNum / units[i].value;
   return {
     label: `${formatDecimal(displayNum, decimals)} ${units[i].symbol}`,
@@ -97,6 +111,13 @@ export const computing = (
     ],
   };
 };
+
+const computingInUnitGroup = (
+  num: number,
+  units: UnitScale,
+  symbol?: string,
+  decimals?: number
+): UnitDisplay => computing(num, units, symbol, decimals);
 
 export const computingDate = (num: number, symbol?: string): UnitDisplay => {
   const numDate = new Date(num);
@@ -327,21 +348,21 @@ export const UnitsCollection: Record<string, Unit> = {
         id: 'bits',
         name: i18n.translate('explore.stylePanel.unit.bits', { defaultMessage: 'bits(b)' }),
         symbol: 'b',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'bytes',
         name: i18n.translate('explore.stylePanel.unit.bytes', { defaultMessage: 'bytes(B)' }),
         symbol: 'B',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'kilobytes',
         name: i18n.translate('explore.stylePanel.unit.kilobytes', {
-          defaultMessage: 'kilobytes(kB)',
+          defaultMessage: 'kilobytes(KB)',
         }),
-        symbol: 'kB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        symbol: 'KB',
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'kibibytes',
@@ -349,7 +370,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'kibibytes(KiB)',
         }),
         symbol: 'KiB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, binaryDataUnits, sy, decimals),
       },
       {
         id: 'megabytes',
@@ -357,7 +378,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'megabytes(MB)',
         }),
         symbol: 'MB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'mebibytes',
@@ -365,7 +386,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'mebibytes(MiB)',
         }),
         symbol: 'MiB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, binaryDataUnits, sy, decimals),
       },
       {
         id: 'gigabytes',
@@ -373,7 +394,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'gigabytes(GB)',
         }),
         symbol: 'GB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'gibibytes',
@@ -381,7 +402,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'gibibytes(GiB)',
         }),
         symbol: 'GiB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, binaryDataUnits, sy, decimals),
       },
       {
         id: 'terabytes',
@@ -389,7 +410,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'terabytes(TB)',
         }),
         symbol: 'TB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'tebibytes',
@@ -397,7 +418,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'tebibytes(TiB)',
         }),
         symbol: 'TiB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, binaryDataUnits, sy, decimals),
       },
       {
         id: 'petabytes',
@@ -405,7 +426,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'petabytes(PB)',
         }),
         symbol: 'PB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, decimalDataUnits, sy, decimals),
       },
       {
         id: 'pebibytes',
@@ -413,7 +434,7 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'pebibytes(PiB)',
         }),
         symbol: 'PiB',
-        display: (val, sy, decimals) => computing(val, dataUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, binaryDataUnits, sy, decimals),
       },
     ],
   },
@@ -539,25 +560,27 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'millimeter (mm)',
         }),
         symbol: 'mm',
-        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, metricLengthUnits, sy, decimals),
       },
       {
         id: 'inch',
         name: i18n.translate('explore.stylePanel.unit.inch', { defaultMessage: 'inch (in)' }),
         symbol: 'in',
-        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
+        display: (val, sy, decimals) =>
+          computingInUnitGroup(val, imperialLengthUnits, sy, decimals),
       },
       {
         id: 'feet',
         name: i18n.translate('explore.stylePanel.unit.feet', { defaultMessage: 'feet (ft)' }),
         symbol: 'ft',
-        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
+        display: (val, sy, decimals) =>
+          computingInUnitGroup(val, imperialLengthUnits, sy, decimals),
       },
       {
         id: 'meter',
         name: i18n.translate('explore.stylePanel.unit.meter', { defaultMessage: 'meter (m)' }),
         symbol: 'm',
-        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, metricLengthUnits, sy, decimals),
       },
       {
         id: 'kilometer',
@@ -565,13 +588,14 @@ export const UnitsCollection: Record<string, Unit> = {
           defaultMessage: 'kilometer (km)',
         }),
         symbol: 'km',
-        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
+        display: (val, sy, decimals) => computingInUnitGroup(val, metricLengthUnits, sy, decimals),
       },
       {
         id: 'mile',
         name: i18n.translate('explore.stylePanel.unit.mile', { defaultMessage: 'mile (mi)' }),
         symbol: 'mi',
-        display: (val, sy, decimals) => computing(val, lengthUnits, sy, decimals),
+        display: (val, sy, decimals) =>
+          computingInUnitGroup(val, imperialLengthUnits, sy, decimals),
       },
     ],
   },


### PR DESCRIPTION
### Description

This change improves style panel formatting behavior in two areas:
1. Unit conversion now stays within the same measurement system.
2. Opacity sliders now display clean integer percentages instead of floating point artifacts.
3. Apply opacity based on dark mode

#### Grouped unit conversion
Updated unit conversion logic so automatic scaling only happens within the same unit family.
For data units:
- Decimal units scale within b / B / kB / MB / GB / TB / PB
- Binary units scale within b / B / KiB / MiB / GiB / TiB / PiB

For length units:
- Metric units scale within mm / m / km
- Imperial units scale within in / ft / mi

This prevents cross-system conversions such as:
- MB -> MiB
- m -> ft
- mi -> km

## Screenshot

Apply unit MiB

<img width="2895" height="1174" alt="截屏2026-08-24 16 40 44" src="https://github.com/user-attachments/assets/682aeb73-9ebf-494a-b49e-cf9525a16112" />


Apply unit MB

<img width="2895" height="1174" alt="截屏2026-08-24 16 40 44" src="https://github.com/user-attachments/assets/1d38a5bb-ad78-4ea9-9caf-56c14b79184c" />


Opacity:
<img width="2386" height="1139" alt="截屏2026-08-24 17 16 47" src="https://github.com/user-attachments/assets/ee67d047-f27d-4a6f-9afe-54ed87483df8" />


<img width="2393" height="1134" alt="截屏2026-08-24 17 17 25" src="https://github.com/user-attachments/assets/bc0cddc2-e83a-4066-9b75-786f606fc4f6" />



## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
