### PR TITLE
feat(visualization): remove workspace gating from explore visualization editor flows

### DIFF
--- a/src/plugins/dashboard/public/application/components/dashboard_editor.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import { OpenSearchDashboardsContextProvider } from '../../../../opensearch_dashboards_react/public';
+import { createDashboardServicesMock } from '../utils/mocks';
+import { DashboardEditor } from './dashboard_editor';
+
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({ id: 'dashboard-id' })),
+}));
+
+jest.mock('../components/dashboard_top_nav', () => {
+  return {
+    DashboardTopNav: jest.fn(() => null),
+  };
+});
+
+jest.mock('./dashboard_variables', () => {
+  return {
+    DashboardVariables: jest.fn(() => null),
+  };
+});
+
+jest.mock('../utils/use/use_chrome_visibility', () => ({
+  useChromeVisibility: jest.fn(() => true),
+}));
+
+jest.mock('../utils/use/use_saved_dashboard_instance', () => ({
+  useSavedDashboardInstance: jest.fn(),
+}));
+
+jest.mock('../utils/use/use_dashboard_app_state', () => ({
+  useDashboardAppAndGlobalState: jest.fn(),
+}));
+
+jest.mock('../utils/use/use_editor_updates', () => ({
+  useEditorUpdates: jest.fn(),
+}));
+
+describe('DashboardEditor dashboard variables', () => {
+  const { useSavedDashboardInstance } = jest.requireMock(
+    '../utils/use/use_saved_dashboard_instance'
+  );
+  const { useDashboardAppAndGlobalState } = jest.requireMock(
+    '../utils/use/use_dashboard_app_state'
+  );
+  const { useEditorUpdates } = jest.requireMock('../utils/use/use_editor_updates');
+  const { DashboardVariables } = jest.requireMock('./dashboard_variables');
+
+  const variableService = { getVariables: jest.fn() };
+  const variableInterpolationService = {};
+  const currentContainer = {
+    variableService,
+    variableInterpolationService,
+    getPanelQueries: jest.fn(() => []),
+  };
+  const appState = {
+    transitions: {
+      set: jest.fn(),
+    },
+  };
+  const savedDashboardInstance = { id: 'dashboard-id' };
+  const dashboard = {};
+
+  const renderDashboardEditor = ({
+    variablesEnabled = true,
+    exploreEnabled = true,
+  }: {
+    variablesEnabled?: boolean;
+    exploreEnabled?: boolean;
+  } = {}) => {
+    const services = {
+      ...createDashboardServicesMock(),
+      pluginInitializerContext: {
+        config: {
+          get: jest.fn(() => ({ variables: { enabled: variablesEnabled } })),
+        },
+      },
+    };
+    services.uiSettings.get = jest.fn(() => false);
+    services.application.capabilities = {
+      ...services.application.capabilities,
+      ...(exploreEnabled ? { explore: { show: true } } : {}),
+    };
+
+    return render(
+      <OpenSearchDashboardsContextProvider services={services}>
+        <DashboardEditor />
+      </OpenSearchDashboardsContextProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useSavedDashboardInstance.mockReturnValue({
+      savedDashboard: savedDashboardInstance,
+      dashboard,
+    });
+    useDashboardAppAndGlobalState.mockReturnValue({
+      appState,
+      currentContainer,
+      indexPatterns: [],
+    });
+    useEditorUpdates.mockReturnValue({
+      isEmbeddableRendered: true,
+      currentAppState: { viewMode: 'edit' },
+    });
+  });
+
+  it('renders variables when the feature and Explore are enabled', async () => {
+    renderDashboardEditor();
+
+    await waitFor(() => {
+      expect(DashboardVariables).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variableService,
+          interpolationService: variableInterpolationService,
+          isEditMode: true,
+          dashboardId: 'dashboard-id',
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it('does not render variables when the feature is disabled', async () => {
+    renderDashboardEditor({ variablesEnabled: false });
+
+    await waitFor(() => {
+      expect(DashboardVariables).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not render variables when Explore is disabled', async () => {
+    renderDashboardEditor({ exploreEnabled: false });
+
+    await waitFor(() => {
+      expect(DashboardVariables).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_editor.tsx
@@ -6,7 +6,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { EventEmitter } from 'events';
-import { take } from 'rxjs/operators';
 import { i18n } from '@osd/i18n';
 import { DashboardTopNav } from '../components/dashboard_top_nav';
 import { useChromeVisibility } from '../utils/use/use_chrome_visibility';
@@ -15,22 +14,19 @@ import { useSavedDashboardInstance } from '../utils/use/use_saved_dashboard_inst
 import { DashboardServices } from '../../types';
 import { useDashboardAppAndGlobalState } from '../utils/use/use_dashboard_app_state';
 import { useEditorUpdates } from '../utils/use/use_editor_updates';
-import {
-  DEFAULT_NAV_GROUPS,
-  HeaderVariant,
-  isNavGroupInFeatureConfigs,
-} from '../../../../../core/public';
+import { HeaderVariant } from '../../../../../core/public';
 import { ViewMode } from '../../../../embeddable/public';
 import { DashboardVariables } from './dashboard_variables';
 
 export const DashboardEditor = () => {
   const { id: dashboardIdFromUrl } = useParams<{ id: string }>();
   const { services } = useOpenSearchDashboards<DashboardServices>();
-  const { chrome, uiSettings, keyboardShortcut, workspaces, chat } = services;
+  const { chrome, uiSettings, keyboardShortcut, chat } = services;
   // Master switch for the Dashboard Variables feature (dashboard.variables.enabled, default false).
   const variablesEnabled =
     services.pluginInitializerContext.config.get<{ variables?: { enabled?: boolean } }>()?.variables
       ?.enabled ?? false;
+  const exploreEnabled = services.application.capabilities.explore?.show === true;
   const { setHeaderVariant } = chrome;
   const isChromeVisible = useChromeVisibility({ chrome });
   const [eventEmitter] = useState(new EventEmitter());
@@ -98,20 +94,6 @@ export const DashboardEditor = () => {
     execute: handleFullScreen,
   });
 
-  const [isExploreWorkspace, setIsExploreWorkspace] = useState(false);
-  useEffect(() => {
-    workspaces.currentWorkspace$
-      .pipe(take(1))
-      .toPromise()
-      .then((ws) => {
-        const features = ws?.features;
-        setIsExploreWorkspace(
-          (features && isNavGroupInFeatureConfigs(DEFAULT_NAV_GROUPS.observability.id, features)) ??
-            false
-        );
-      });
-  }, [workspaces.currentWorkspace$]);
-
   return (
     <div>
       <div>
@@ -129,9 +111,8 @@ export const DashboardEditor = () => {
               dashboardIdFromUrl={dashboardIdFromUrl}
               eventEmitter={eventEmitter}
             />
-            {/* Variables are only available when the feature flag is enabled and in
-                observability workspaces */}
-            {variablesEnabled && isExploreWorkspace && currentContainer.variableService && (
+            {/* Dashboard Variables are controlled by dashboard.variables.enabled and require Explore. */}
+            {variablesEnabled && exploreEnabled && currentContainer.variableService && (
               <DashboardVariables
                 variableService={currentContainer.variableService}
                 interpolationService={currentContainer.variableInterpolationService}

--- a/src/plugins/explore/public/plugin.test.ts
+++ b/src/plugins/explore/public/plugin.test.ts
@@ -180,6 +180,7 @@ describe('ExplorePlugin', () => {
         registerTrigger: jest.fn(),
         getTrigger: jest.fn(),
         getTriggers: jest.fn(),
+        getTriggerActions: jest.fn().mockReturnValue([]),
         unregisterAction: jest.fn(),
         attachAction: jest.fn(),
         getAction: jest.fn(),
@@ -578,6 +579,24 @@ describe('ExplorePlugin', () => {
       // Verify both are enabled
       expect(coreStart.application.capabilities.explore?.discoverTracesEnabled).toBe(true);
       expect(coreStart.application.capabilities.explore?.discoverMetricsEnabled).toBe(true);
+    });
+
+    it('keeps the visualization editor alias visible outside Explore-enabled workspaces', async () => {
+      currentWorkspace$.next(null);
+      const discoverAlias = { name: 'DiscoverVisualization', hidden: false };
+      const metricsAlias = { name: 'MetricsVisualization', hidden: false };
+      const editorAlias = { name: 'VisualizationEditor', hidden: false };
+      (startDeps.visualizations.getAliases as jest.Mock).mockReturnValue([
+        discoverAlias,
+        metricsAlias,
+        editorAlias,
+      ]);
+
+      await (plugin as any).configureExploreVisualizationVisibility(coreStart, startDeps);
+
+      expect(discoverAlias.hidden).toBe(true);
+      expect(metricsAlias.hidden).toBe(true);
+      expect(editorAlias.hidden).toBe(false);
     });
   });
 

--- a/src/plugins/explore/public/plugin.ts
+++ b/src/plugins/explore/public/plugin.ts
@@ -1126,11 +1126,11 @@ export class ExplorePlugin implements Plugin<
         .filter(
           (v) =>
             v.name === this.DISCOVER_VISUALIZATION_NAME ||
-            v.name === this.METRICS_VISUALIZATION_NAME ||
-            v.name === this.VISUALIZATION_EDITOR_NAME
+            v.name === this.METRICS_VISUALIZATION_NAME
         )
         .forEach((visAlias) => {
-          // if current workspace has NO explore enabled, the explore visualization ingress should be hidden
+          // Hide aliases that route into the normal Explore apps. The standalone
+          // visualization editor remains available for dashboard create flows.
           visAlias.hidden = true;
         });
     }


### PR DESCRIPTION
### Description
Keep the standalone Visualization Editor  and Dashboard Variables available when explore is enabled, previously, it is visible only when in observability workspace, now these feature accessible in all types workspaces, and it is also available when workspace is not enabled but explore enabled.

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
